### PR TITLE
Fix hashing extension defects and restore lost tests

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.AppendData.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.AppendData.cs
@@ -27,7 +27,9 @@ namespace Bodu.Security.Cryptography.Extensions
         /// </para>
         /// <para>
         /// An <see cref="ArrayPool{T}" /> buffer is used internally to bridge the span into the array-based
-        /// <see cref="HashAlgorithm.TransformBlock" /> API. The buffer is always returned to the pool, even if an exception occurs.
+        /// <see cref="HashAlgorithm.TransformBlock" /> API. The buffer is cleared and returned to the pool in a <c>finally</c>
+        /// block so the input data cannot be observed by a subsequent pool consumer even if
+        /// <see cref="HashAlgorithm.TransformBlock" /> throws.
         /// </para>
         /// <para>
         /// If <paramref name="data" /> is empty, this method returns without performing any work.
@@ -49,8 +51,10 @@ namespace Bodu.Security.Cryptography.Extensions
             }
             finally
             {
-                // Always return the rented buffer so it is not permanently lost if TransformBlock throws.
-                ArrayPool<byte>.Shared.Return(buffer);
+                // The rented buffer may contain a copy of the caller's input (potentially sensitive, e.g. a password).
+                // Clear the used region before returning the array to the shared pool so a subsequent renter cannot
+                // observe the plaintext. 'clearArray: true' also zeros the entire rented array.
+                ArrayPool<byte>.Shared.Return(buffer, clearArray: true);
             }
         }
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.VerifyHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.VerifyHash.cs
@@ -71,10 +71,9 @@ namespace Bodu.Security.Cryptography.Extensions
             ThrowHelper.ThrowIfNull(input);
             ThrowHelper.ThrowIfNull(expectedHex);
 
-            byte[] actualHash = algorithm.ComputeHash(input);
-
-            // Decode the expected hex to bytes for a constant-time binary comparison.
-            // A malformed hex string cannot represent a valid hash, so treat it as a non-match.
+            // Decode the expected hex to bytes BEFORE computing the hash so a malformed hex string fails fast
+            // without wasting work hashing the input. A malformed hex string cannot represent a valid hash,
+            // so treat it as a non-match.
             byte[] expectedBytes;
             try
             {
@@ -84,6 +83,8 @@ namespace Bodu.Security.Cryptography.Extensions
             {
                 return false;
             }
+
+            byte[] actualHash = algorithm.ComputeHash(input);
 
             return CryptographicOperations.FixedTimeEquals(actualHash, expectedBytes);
         }
@@ -148,10 +149,10 @@ namespace Bodu.Security.Cryptography.Extensions
             ThrowHelper.ThrowIfNull(stream);
             ThrowHelper.ThrowIfNull(expectedHex);
 
-            byte[] actualHash = algorithm.ComputeHash(stream);
-
-            // Decode the expected hex to bytes for a constant-time binary comparison.
-            // A malformed hex string cannot represent a valid hash, so treat it as a non-match.
+            // Decode the expected hex to bytes BEFORE reading and hashing the stream so a malformed hex string
+            // fails fast without consuming stream data or wasting the hash computation. A malformed hex string
+            // cannot represent a valid hash, so treat it as a non-match. This matches the behavior of the
+            // asynchronous stream overload.
             byte[] expectedBytes;
             try
             {
@@ -161,6 +162,8 @@ namespace Bodu.Security.Cryptography.Extensions
             {
                 return false;
             }
+
+            byte[] actualHash = algorithm.ComputeHash(stream);
 
             return CryptographicOperations.FixedTimeEquals(actualHash, expectedBytes);
         }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.TryVerifyHash.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.TryVerifyHash.cs
@@ -1,302 +1,210 @@
-// --------------------------------------------------------------------------------------------------------------- //
-// <copyright file="HashAlgorithmExtensions_TryVerifyHash.cs" company="PlaceholderCompany">
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmExtensionsTests_TryVerifyHash.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace Bodu.Security.Cryptography.Extensions
 {
-    using System;
-    using System.IO;
-    using System.Security.Cryptography;
-    using System.Text;
-
-    public static partial class HashAlgorithmExtensions
+    public partial class HashAlgorithmExtensionsTests
     {
         /// <summary>
-        /// Attempts to compute and verify the hash of a byte array, reporting both whether the operation succeeded and whether the hash
-        /// matched.
+        /// Verifies that TryVerifyHash returns true when span input matches the expected hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">
-        /// The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
-        /// </param>
-        /// <param name="expectedHash">
-        /// The expected hash value to compare against. A <see langword="null" /> value causes the method to return
-        /// <see langword="false" />.
-        /// </param>
-        /// <param name="result">
-        /// When this method returns <see langword="true" />, contains <see langword="true" /> if the computed hash matched
-        /// <paramref name="expectedHash" />; otherwise, <see langword="false" />. Always <see langword="false" /> when the method itself
-        /// returns <see langword="false" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the hash computation and comparison completed without error; <see langword="false" /> if
-        /// <paramref name="input" /> or <paramref name="expectedHash" /> is <see langword="null" />, or an internal exception occurred.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
-        /// <remarks>
-        /// Unlike <see cref="VerifyHash(HashAlgorithm, byte[], byte[])" />, this overload distinguishes between a failed operation
-        /// (return value <see langword="false" />) and a successful but non-matching comparison (<paramref name="result" /> =
-        /// <see langword="false" />). Both <see langword="null" /> inputs are treated as an operation failure rather than an error,
-        /// making this overload suitable for defensive validation where inputs may be absent.
-        /// </remarks>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, byte[] input, byte[] expectedHash, out bool result)
+        [TestMethod]
+        public void TryVerifyHash_WhenSpanMatches_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-
-            result = false;
-
-            // Treat absent inputs as an operation failure rather than a programming error.
-            if (input == null || expectedHash == null)
-                return false;
-
-            try
-            {
-                result = algorithm.VerifyHash(input, expectedHash);
-                return true;
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            ReadOnlySpan<byte> spanInput = SampleData;
+            ReadOnlySpan<byte> expected = SampleHash;
+            Assert.IsTrue(algorithm.TryVerifyHash(spanInput, expected));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a byte array against the expected hash value.
+        /// Verifies that TryVerifyHash returns true when memory input matches the expected hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.</param>
-        /// <param name="expectedHash">
-        /// The expected hash value to compare against. Must not be <see langword="null" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHash" /> is <see langword="null" />.
-        /// </exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, byte[] input, byte[] expectedHash)
+        [TestMethod]
+        public void TryVerifyHash_WhenMemoryMatches_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(expectedHash);
-
-            if (input == null)
-                return false;
-
-            try
-            {
-                return algorithm.VerifyHash(input, expectedHash);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            ReadOnlyMemory<byte> memory = SampleData;
+            Assert.IsTrue(algorithm.TryVerifyHash(memory, SampleHash));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a byte array against an expected hexadecimal hash string.
+        /// Verifies that TryVerifyHash returns true when the stream content matches the expected hex string.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.</param>
-        /// <param name="expectedHex">
-        /// The expected hash as a hexadecimal string. Must not be <see langword="null" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />; otherwise, <see langword="false" />.
-        /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHex" /> is <see langword="null" />.
-        /// </exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, byte[] input, string expectedHex)
+        [TestMethod]
+        public void TryVerifyHash_WhenStreamMatchesHex_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(expectedHex);
-
-            if (input == null)
-                return false;
-
-            try
-            {
-                return algorithm.VerifyHash(input, expectedHex);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            Assert.IsTrue(algorithm.TryVerifyHash(stream, SampleHex));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of an encoded string against the expected hash value.
+        /// Verifies that TryVerifyHash returns true when the stream matches the expected hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">
-        /// The plain-text string to encode and hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="encoding">
-        /// The encoding used to convert <paramref name="input" /> to bytes. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="expectedHash">
-        /// The expected hash value as a byte array. Must not be <see langword="null" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, <paramref name="encoding" />, or
-        /// <paramref name="expectedHash" /> is <see langword="null" />.
-        /// </exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, string input, Encoding encoding, byte[] expectedHash)
+        [TestMethod]
+        public void TryVerifyHash_WhenStreamMatchesByteArray_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(input);
-            ThrowHelper.ThrowIfNull(encoding);
-            ThrowHelper.ThrowIfNull(expectedHash);
-
-            try
-            {
-                return algorithm.VerifyHash(input, encoding, expectedHash);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            Assert.IsTrue(algorithm.TryVerifyHash(stream, SampleHash));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a span of bytes against the expected hash span.
+        /// Verifies that TryVerifyHash returns true when the byte array input matches the expected hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">The span of input bytes to hash.</param>
-        /// <param name="expectedHash">The expected hash as a read-only byte span.</param>
-        /// <returns>
-        /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, ReadOnlySpan<byte> input, ReadOnlySpan<byte> expectedHash)
+        [TestMethod]
+        public void TryVerifyHash_WhenByteArrayMatches_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-
-            try
-            {
-                return algorithm.VerifyHash(input, expectedHash);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            Assert.IsTrue(algorithm.TryVerifyHash(SampleData, SampleHash));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a memory buffer against the expected hash value.
+        /// Verifies that TryVerifyHash returns true when the byte array input matches the expected hex string.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="input">The memory buffer containing the input data to hash.</param>
-        /// <param name="expectedHash">
-        /// The expected hash value as a byte array. Must not be <see langword="null" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHash" /> is <see langword="null" />.
-        /// </exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, ReadOnlyMemory<byte> input, byte[] expectedHash)
+        [TestMethod]
+        public void TryVerifyHash_WhenByteArrayMatchesHex_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(expectedHash);
-
-            try
-            {
-                return algorithm.VerifyHash(input, expectedHash);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            Assert.IsTrue(algorithm.TryVerifyHash(SampleData, SampleHex));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a stream against the expected hash value.
+        /// Verifies that TryVerifyHash returns true when string and encoding match the expected hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="stream">
-        /// The input stream to read and hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
-        /// </param>
-        /// <param name="expectedHash">
-        /// The expected hash value as a byte array. A <see langword="null" /> value causes the method to return <see langword="false" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the stream produces a matching hash; otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, Stream stream, byte[] expectedHash)
+        [TestMethod]
+        public void TryVerifyHash_WhenStringEncodedMatches_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-
-            if (stream == null || expectedHash == null)
-                return false;
-
-            try
-            {
-                return algorithm.VerifyHash(stream, expectedHash);
-            }
-            catch
-            {
-                return false;
-            }
+            using var algorithm = CreateAlgorithm();
+            Assert.IsTrue(algorithm.TryVerifyHash(SampleString, SampleEncoding, SampleStringHash));
         }
 
         /// <summary>
-        /// Attempts to compute and verify the hash of a stream against the expected hexadecimal hash string.
+        /// Verifies that the out-variant TryVerifyHash returns true and reports a match when inputs agree.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="stream">
-        /// The input stream to read and hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
-        /// </param>
-        /// <param name="expectedHex">
-        /// The expected hash value as a hexadecimal string. Must not be <see langword="null" />.
-        /// </param>
-        /// <returns>
-        /// <see langword="true" /> if the stream hash matches <paramref name="expectedHex" />; otherwise, <see langword="false" />.
-        /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHex" /> is <see langword="null" />.
-        /// </exception>
-        public static bool TryVerifyHash(this HashAlgorithm algorithm, Stream stream, string expectedHex)
+        [TestMethod]
+        public void TryVerifyHash_OutVariant_WhenByteArrayMatches_ShouldReturnTrueAndSetResult()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(expectedHex);
+            using var algorithm = CreateAlgorithm();
+            bool ok = algorithm.TryVerifyHash(SampleData, SampleHash, out bool result);
+            Assert.IsTrue(ok);
+            Assert.IsTrue(result);
+        }
 
-            if (stream == null)
-                return false;
+        /// <summary>
+        /// Verifies that TryVerifyHash returns false for empty input.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenInputIsEmpty_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.IsFalse(algorithm.TryVerifyHash(Array.Empty<byte>(), SampleHash));
+        }
 
-            try
+        /// <summary>
+        /// Verifies that TryVerifyHash returns false for mismatched hash values.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenHashDoesNotMatch_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            byte[] badHash = BitConverter.GetBytes((uint)999);
+            Assert.IsFalse(algorithm.TryVerifyHash(SampleData, badHash));
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash throws ArgumentNullException when the algorithm is null and the expected hash is also null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenAlgorithmAndExpectedHashAreNull_ShouldThrowArgumentNullException()
+        {
+            HashAlgorithm? algorithm = null;
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
             {
-                return algorithm.VerifyHash(stream, expectedHex);
-            }
-            catch
+                algorithm!.TryVerifyHash(SampleData, (byte[])null!);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash returns false when the input byte array is null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenInputIsNull_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.IsFalse(algorithm.TryVerifyHash((byte[])null!, SampleHash));
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash throws ArgumentNullException when the algorithm is null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+        {
+            HashAlgorithm? algorithm = null;
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
             {
-                return false;
-            }
+                algorithm!.TryVerifyHash(SampleData, SampleHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash throws ArgumentNullException when the string input is null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenStringInputIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                algorithm.TryVerifyHash(null!, SampleEncoding, SampleStringHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash throws ArgumentNullException when the encoding is null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenEncodingIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                algorithm.TryVerifyHash(SampleString, null!, SampleStringHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash throws ArgumentNullException when the expected hash for string+encoding is null.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenStringExpectedHashIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                algorithm.TryVerifyHash(SampleString, SampleEncoding, null!);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHash returns false when the expected hex is not a valid hex string.
+        /// </summary>
+        [TestMethod]
+        public void TryVerifyHash_WhenHexIsMalformed_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            Assert.IsFalse(algorithm.TryVerifyHash(SampleData, "ZZZZ"));
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.TryVerifyHashAsync.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.TryVerifyHashAsync.cs
@@ -1,0 +1,187 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmExtensionsTests_TryVerifyHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Security.Cryptography.Extensions
+{
+    public partial class HashAlgorithmExtensionsTests
+    {
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for matching byte array and expected hash.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenByteArrayMatches_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            bool result = await algorithm.TryVerifyHashAsync(SampleData, SampleHash);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for matching byte array and expected hex string.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenByteArrayMatchesHex_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            bool result = await algorithm.TryVerifyHashAsync(SampleData, SampleHex);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for string input encoded with encoding and matching hash.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenEncodedStringMatches_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            bool result = await algorithm.TryVerifyHashAsync(SampleString, SampleEncoding, SampleStringHash);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for stream content matching expected hex string.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStreamMatchesHex_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            bool result = await algorithm.TryVerifyHashAsync(stream, SampleHex);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for stream content matching expected byte array.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStreamMatchesByteArray_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            bool result = await algorithm.TryVerifyHashAsync(stream, SampleHash);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns true for stream content matching expected ReadOnlyMemory hash.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStreamMatchesMemory_ShouldReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            ReadOnlyMemory<byte> expected = SampleHash;
+            bool result = await algorithm.TryVerifyHashAsync(stream, expected);
+            Assert.IsTrue(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns false for a mismatched hash.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenHashDoesNotMatch_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            byte[] badHash = BitConverter.GetBytes((uint)1234);
+            bool result = await algorithm.TryVerifyHashAsync(SampleData, badHash);
+            Assert.IsFalse(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns false when the stream argument is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStreamIsNull_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            bool result = await algorithm.TryVerifyHashAsync((Stream)null!, SampleHash);
+            Assert.IsFalse(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync returns false when the stream expected hash is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStreamExpectedHashIsNull_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            bool result = await algorithm.TryVerifyHashAsync(stream, (byte[])null!);
+            Assert.IsFalse(result);
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync throws ArgumentNullException when the byte array input is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenByteArrayInputIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.TryVerifyHashAsync((byte[])null!, SampleHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync throws ArgumentNullException when the byte array expected hash is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenByteArrayExpectedHashIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.TryVerifyHashAsync(SampleData, (byte[])null!);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync throws ArgumentNullException when the string input is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStringInputIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.TryVerifyHashAsync(null!, SampleEncoding, SampleStringHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync throws ArgumentNullException when the encoding is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenEncodingIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.TryVerifyHashAsync(SampleString, null!, SampleStringHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that TryVerifyHashAsync throws ArgumentNullException when the string+encoding expected hash is null.
+        /// </summary>
+        [TestMethod]
+        public async Task TryVerifyHashAsync_WhenStringExpectedHashIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.TryVerifyHashAsync(SampleString, SampleEncoding, null!);
+            });
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.VerifyHashAsync.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.VerifyHashAsync.cs
@@ -1,167 +1,170 @@
-// --------------------------------------------------------------------------------------------------------------- //
-// <copyright file="HashAlgorithmExtensions_VerifyHashAsync.cs" company="PlaceholderCompany">
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmExtensionsTests_VerifyHashAsync.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Bodu.Infrastructure;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
 namespace Bodu.Security.Cryptography.Extensions
 {
-    using System;
-    using System.IO;
-    using System.Security.Cryptography;
-    using System.Threading;
-    using System.Threading.Tasks;
-
-    public static partial class HashAlgorithmExtensions
+    public partial class HashAlgorithmExtensionsTests
     {
         /// <summary>
-        /// Asynchronously verifies that the computed hash of a stream matches the expected hash value.
+        /// Verifies that VerifyHashAsync returns true when stream content matches the expected hex string.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="stream">
-        /// The stream to read and hash asynchronously. Must not be <see langword="null" /> and must be readable.
-        /// </param>
-        /// <param name="expectedHash">
-        /// The expected hash value as a byte array. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>
-        /// A task that evaluates to <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />;
-        /// otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHash" /> is
-        /// <see langword="null" />.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// Comparison is performed using <see cref="CryptographicOperations.FixedTimeEquals" /> to mitigate timing side-channel attacks.
-        /// </para>
-        /// <para>
-        /// If <paramref name="cancellationToken" /> is already cancelled on entry, an <see cref="OperationCanceledException" /> is thrown
-        /// immediately before any I/O begins.
-        /// </para>
-        /// </remarks>
-        public static async Task<bool> VerifyHashAsync(this HashAlgorithm algorithm, Stream stream, byte[] expectedHash, CancellationToken cancellationToken = default)
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenStreamMatchesHex_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(stream);
-            ThrowHelper.ThrowIfNull(expectedHash);
-
-            // Throw OperationCanceledException directly for an already-cancelled token.
-            // ComputeHashAsync would otherwise throw the derived TaskCanceledException.
-            cancellationToken.ThrowIfCancellationRequested();
-
-            byte[] actualHash = await algorithm.ComputeHashAsync(stream, cancellationToken).ConfigureAwait(false);
-
-            return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash);
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            Assert.IsTrue(await algorithm.VerifyHashAsync(stream, SampleHex));
         }
 
         /// <summary>
-        /// Asynchronously verifies that the computed hash of a stream matches the expected hexadecimal hash string.
+        /// Verifies that VerifyHashAsync returns true when stream content matches the expected byte array.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="stream">
-        /// The readable stream to hash asynchronously. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="expectedHex">
-        /// The expected hash as a hexadecimal string. Case-insensitive. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>
-        /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />;
-        /// otherwise, <see langword="false" />.
-        /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHex" /> is
-        /// <see langword="null" />.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// <paramref name="expectedHex" /> is decoded to bytes before comparison. The comparison is then performed using
-        /// <see cref="CryptographicOperations.FixedTimeEquals" /> to mitigate timing side-channel attacks.
-        /// </para>
-        /// <para>
-        /// A malformed <paramref name="expectedHex" /> string is treated as a non-match and returns <see langword="false" />.
-        /// </para>
-        /// <para>
-        /// If <paramref name="cancellationToken" /> is already cancelled on entry, an <see cref="OperationCanceledException" /> is thrown
-        /// immediately before any I/O begins.
-        /// </para>
-        /// </remarks>
-        public static async Task<bool> VerifyHashAsync(this HashAlgorithm algorithm, Stream stream, string expectedHex, CancellationToken cancellationToken = default)
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenStreamMatchesByteArray_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(stream);
-            ThrowHelper.ThrowIfNull(expectedHex);
-
-            // Throw OperationCanceledException directly for an already-cancelled token.
-            // ComputeHashAsync would otherwise throw the derived TaskCanceledException.
-            cancellationToken.ThrowIfCancellationRequested();
-
-            // Decode the expected hex to bytes for a constant-time binary comparison.
-            // A malformed hex string cannot represent a valid hash, so treat it as a non-match.
-            byte[] expectedBytes;
-            try
-            {
-                expectedBytes = Convert.FromHexString(expectedHex);
-            }
-            catch (FormatException)
-            {
-                return false;
-            }
-
-            byte[] actualHash = await algorithm.ComputeHashAsync(stream, cancellationToken).ConfigureAwait(false);
-
-            return CryptographicOperations.FixedTimeEquals(actualHash, expectedBytes);
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            Assert.IsTrue(await algorithm.VerifyHashAsync(stream, SampleHash));
         }
 
         /// <summary>
-        /// Asynchronously verifies that the computed hash of a stream matches the expected hash value held in a memory buffer.
+        /// Verifies that VerifyHashAsync returns true when stream content matches the expected ReadOnlyMemory hash.
         /// </summary>
-        /// <param name="algorithm">
-        /// The <see cref="HashAlgorithm" /> instance used to compute the hash. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="stream">
-        /// The readable stream to hash asynchronously. Must not be <see langword="null" />.
-        /// </param>
-        /// <param name="expectedHash">The expected hash value as a <see cref="ReadOnlyMemory{T}" /> of bytes.</param>
-        /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
-        /// <returns>
-        /// A task that evaluates to <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />;
-        /// otherwise, <see langword="false" />.
-        /// </returns>
-        /// <exception cref="ArgumentNullException">
-        /// Thrown if <paramref name="algorithm" /> or <paramref name="stream" /> is <see langword="null" />.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This overload supports allocation-reduced verification when the expected hash is already held in a
-        /// <see cref="ReadOnlyMemory{T}" /> buffer. Comparison is performed using
-        /// <see cref="CryptographicOperations.FixedTimeEquals" /> to mitigate timing side-channel attacks.
-        /// </para>
-        /// <para>
-        /// If <paramref name="cancellationToken" /> is already cancelled on entry, an <see cref="OperationCanceledException" /> is thrown
-        /// immediately before any I/O begins.
-        /// </para>
-        /// </remarks>
-        public static async Task<bool> VerifyHashAsync(this HashAlgorithm algorithm, Stream stream, ReadOnlyMemory<byte> expectedHash, CancellationToken cancellationToken = default)
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenStreamMatchesMemory_ShouldReturnTrue()
         {
-            ThrowHelper.ThrowIfNull(algorithm);
-            ThrowHelper.ThrowIfNull(stream);
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            ReadOnlyMemory<byte> expected = SampleHash;
+            Assert.IsTrue(await algorithm.VerifyHashAsync(stream, expected));
+        }
 
-            // Throw OperationCanceledException directly for an already-cancelled token.
-            // ComputeHashAsync would otherwise throw the derived TaskCanceledException.
-            cancellationToken.ThrowIfCancellationRequested();
+        /// <summary>
+        /// Verifies that VerifyHashAsync returns false for mismatched hash values.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenHashDoesNotMatch_ShouldReturnFalse()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            byte[] badHash = BitConverter.GetBytes((uint)9999);
+            Assert.IsFalse(await algorithm.VerifyHashAsync(stream, badHash));
+        }
 
-            byte[] actualHash = await algorithm.ComputeHashAsync(stream, cancellationToken).ConfigureAwait(false);
+        /// <summary>
+        /// Verifies that VerifyHashAsync returns false when the expected hex string is malformed, without consuming the stream.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenHexIsMalformed_ShouldReturnFalseWithoutReadingStream()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var baseStream = new MemoryStream(SampleData);
+            using var monitored = new MonitoringStream(baseStream);
 
-            return CryptographicOperations.FixedTimeEquals(actualHash, expectedHash.Span);
+            bool result = await algorithm.VerifyHashAsync(monitored, "ZZZZ");
+
+            Assert.IsFalse(result);
+            Assert.AreEqual(0, monitored.Reads.Count);
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync throws ArgumentNullException when the algorithm is null.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+        {
+            HashAlgorithm? algorithm = null;
+            using var stream = new MemoryStream(SampleData);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm!.VerifyHashAsync(stream, SampleHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync throws ArgumentNullException when the stream is null.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.VerifyHashAsync((Stream)null!, SampleHash);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync throws ArgumentNullException when the expected byte array is null.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenExpectedHashIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.VerifyHashAsync(stream, (byte[])null!);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync throws ArgumentNullException when the expected hex string is null.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenExpectedHexIsNull_ShouldThrowArgumentNullException()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            await Assert.ThrowsExceptionAsync<ArgumentNullException>(async () =>
+            {
+                await algorithm.VerifyHashAsync(stream, (string)null!);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync throws OperationCanceledException when the token is already cancelled.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenTokenAlreadyCancelled_ShouldThrow()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var stream = new MemoryStream(SampleData);
+            using var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(async () =>
+            {
+                await algorithm.VerifyHashAsync(stream, SampleHash, cts.Token);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that VerifyHashAsync tracks stream reads via MonitoringStream when computing the hash.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyHashAsync_WhenUsingMonitoringStream_ShouldTrackReadsAndReturnTrue()
+        {
+            using var algorithm = CreateAlgorithm();
+            using var baseStream = new MemoryStream(new byte[] { 2, 3 });
+            using var monitored = new MonitoringStream(baseStream);
+            byte[] expected = BitConverter.GetBytes((uint)5);
+
+            bool result = await algorithm.VerifyHashAsync(monitored, expected);
+
+            Assert.IsTrue(result);
+            Assert.IsTrue(monitored.Reads.Count > 0);
         }
     }
 }


### PR DESCRIPTION
- AppendData: clear the rented ArrayPool buffer on return so the caller's (potentially sensitive) input bytes cannot be observed by a subsequent pool consumer, even if TransformBlock throws.
- VerifyHash(byte[], string) and VerifyHash(Stream, string): decode the expected hex string BEFORE computing the hash so malformed hex fails fast without wasting work (and, for streams, without consuming stream data). This matches the behavior of the async stream overload.
- Restore HashAlgorithmExtensionsTests.TryVerifyHash, TryVerifyHashAsync, and VerifyHashAsync, which had been accidentally replaced with source content (or left empty) and no longer compiled. Added coverage for the malformed-hex fast-fail paths.