### PR TITLE
Split DocFX workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/docfx-build-publish.yml
+++ b/.github/workflows/docfx-build-publish.yml
@@ -8,6 +8,7 @@ on:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
+  contents: read
   actions: read
   pages: write
   id-token: write
@@ -17,12 +18,9 @@ permissions:
 concurrency:
   group: "pages"
   cancel-in-progress: false
-  
+
 jobs:
-  publish-docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+  build-docs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -40,7 +38,15 @@ jobs:
       with:
         # Upload entire repository
         path: 'docs/_site'
+
+  deploy-docs:
+    needs: build-docs
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
-


### PR DESCRIPTION
PR runs were failing instantly on publish-docs because the single job was bound to the github-pages environment, which only permits deployments from master. Pull request runs from feature branches were blocked by the environment protection rule before any step could run.

Split into:
- build-docs: runs on push and pull_request, builds the DocFX site and uploads the pages artifact. No environment binding, so PRs validate the docs build without tripping the deployment protection rule.
- deploy-docs: depends on build-docs and only runs on push to master, retains the github-pages environment binding and performs the actions/deploy-pages step.

Also adds an explicit contents: read permission for clarity.

https://claude.ai/code/session_01Hp1rQuuveDTDjM6A14NxgE