### PR TITLE
Fix cancellation handling in ParallelMerkleTreeHash and flaky test

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -84,6 +84,10 @@ namespace Bodu.Security.Cryptography
         private byte[]? _rootHash;
         private bool _disposed;
 
+        // Set per-call by ComputeHash* methods; links the disposal token with any user-supplied
+        // cancellation token so that level workers respond to external cancellation.
+        private CancellationToken _activeToken;
+
         /// <summary>
         /// Initialises a new <see cref="ParallelMerkleTreeHash"/> instance with the specified hash
         /// algorithm factory, block size, and fan-out.
@@ -130,8 +134,8 @@ namespace Bodu.Security.Cryptography
         ///   Supplying a fresh instance per call ensures each computation's trace is isolated.
         /// </param>
         /// <param name="cancellationToken">
-        ///   Token used to cancel the read loop. Cancellation stops further reads but does not
-        ///   interrupt level workers already in progress; those are cancelled via <see cref="Dispose"/>.
+        ///   Token used to cancel the operation. When signalled, the read loop is stopped and all
+        ///   active level workers are drained before the exception is propagated.
         /// </param>
         /// <returns>
         ///   A byte array containing the Merkle root hash of all data read from <paramref name="input"/>.
@@ -150,25 +154,38 @@ namespace Bodu.Security.Cryptography
             CancellationToken cancellationToken = default)
         {
             ArgumentNullException.ThrowIfNull(input);
-            this.Reset(diagnostics);
+            ObjectDisposedException.ThrowIf(this._disposed, this);
 
-            using var linked = CancellationTokenSource.CreateLinkedTokenSource(this._cts.Token, cancellationToken);
-
-            // Read in chunks larger than one block so that a single ReadAsync can feed several leaves,
-            // keeping the I/O system ahead of the hashing pipeline.
-            byte[] readBuffer = ArrayPool<byte>.Shared.Rent(this._blockSize * 8);
+            var linked = CancellationTokenSource.CreateLinkedTokenSource(this._cts.Token, cancellationToken);
             try
             {
-                int bytesRead;
-                while ((bytesRead = await input.ReadAsync(readBuffer.AsMemory(0, readBuffer.Length), linked.Token)) > 0)
-                    this.ProcessBytes(readBuffer.AsSpan(0, bytesRead));
+                this.Reset(diagnostics, linked.Token);
+
+                // Read in chunks larger than one block so that a single ReadAsync can feed several leaves,
+                // keeping the I/O system ahead of the hashing pipeline.
+                byte[] readBuffer = ArrayPool<byte>.Shared.Rent(this._blockSize * 8);
+                try
+                {
+                    int bytesRead;
+                    while ((bytesRead = await input.ReadAsync(readBuffer.AsMemory(0, readBuffer.Length), linked.Token)) > 0)
+                        this.ProcessBytes(readBuffer.AsSpan(0, bytesRead));
+                }
+                catch (OperationCanceledException)
+                {
+                    await this.DrainWorkersAsync();
+                    throw;
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(readBuffer, clearArray: true);
+                }
+
+                return await this.FinalizeAsync();
             }
             finally
             {
-                ArrayPool<byte>.Shared.Return(readBuffer, clearArray: true);
+                linked.Dispose();
             }
-
-            return await this.FinalizeAsync();
         }
 
         /// <summary>
@@ -186,7 +203,7 @@ namespace Bodu.Security.Cryptography
         /// <exception cref="InvalidOperationException">No input data was provided.</exception>
         public byte[] ComputeHash(ReadOnlySpan<byte> data, MerkleTreeDiagnostics? diagnostics = null)
         {
-            this.Reset(diagnostics);
+            this.Reset(diagnostics, this._cts.Token);
             this.ProcessBytes(data);
             return this.FinalizeAsync().GetAwaiter().GetResult();
         }
@@ -251,7 +268,7 @@ namespace Bodu.Security.Cryptography
         /// constructor.
         /// </para>
         /// </remarks>
-        private void Reset(MerkleTreeDiagnostics? diagnostics)
+        private void Reset(MerkleTreeDiagnostics? diagnostics, CancellationToken activeToken)
         {
             ObjectDisposedException.ThrowIf(this._disposed, this);
 
@@ -265,6 +282,7 @@ namespace Bodu.Security.Cryptography
             this._leafIndex = 0;
             this._rootHash = null;
             this._diagnostics = diagnostics;
+            this._activeToken = activeToken;
 
             // Recreate level 0 immediately so the producer can submit leaves without waiting.
             this.EnsureLevelExists(0);
@@ -345,7 +363,7 @@ namespace Bodu.Security.Cryptography
 
                 var channel = Channel.CreateUnbounded<byte[]>(options);
                 this._levelChannels[level] = channel;
-                this._levelWorkers[level] = Task.Run(() => this.RunLevelWorkerAsync(level, channel, this._cts.Token));
+                this._levelWorkers[level] = Task.Run(() => this.RunLevelWorkerAsync(level, channel, this._activeToken));
             }
         }
 
@@ -457,6 +475,22 @@ namespace Bodu.Security.Cryptography
             }
 
             return this._rootHash ?? throw new InvalidOperationException("No input data was provided.");
+        }
+
+        /// <summary>
+        /// Completes all level channels and awaits their workers, suppressing any exceptions that
+        /// arise from cancelled tokens or completed channels during cancellation teardown.
+        /// </summary>
+        private async Task DrainWorkersAsync()
+        {
+            foreach (var channel in this._levelChannels.Values)
+                channel.Writer.TryComplete();
+
+            foreach (var worker in this._levelWorkers.Values)
+            {
+                try { await worker; }
+                catch { }
+            }
         }
 
         // -----------------------------------------------------------------------------------------

--- a/Bodu.Security.Cryptography/test/Infrastructure/CancellationTriggerStream.cs
+++ b/Bodu.Security.Cryptography/test/Infrastructure/CancellationTriggerStream.cs
@@ -1,0 +1,84 @@
+using System;
+using System.IO;
+using System.Threading;
+
+namespace Bodu.Infrastructure
+{
+    /// <summary>
+    /// A stream wrapper that cancels a <see cref="CancellationTokenSource" /> after a specified
+    /// number of successful reads, enabling deterministic cancellation testing without relying
+    /// on timing.
+    /// </summary>
+    public sealed class CancellationTriggerStream : Stream
+    {
+        private readonly Stream _inner;
+        private readonly CancellationTokenSource _cts;
+        private readonly int _cancelAfterRead;
+        private int _readCount;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="CancellationTriggerStream" /> class.
+        /// </summary>
+        /// <param name="inner">The underlying stream to read from.</param>
+        /// <param name="cts">The cancellation token source to cancel after the specified number of reads.</param>
+        /// <param name="cancelAfterRead">
+        ///   The number of successful reads (returning &gt; 0 bytes) after which <paramref name="cts" />
+        ///   is cancelled. The cancellation fires after the read completes, so subsequent calls to
+        ///   <c>ReadAsync</c> detect the cancelled token before invoking the next synchronous read.
+        /// </param>
+        public CancellationTriggerStream(Stream inner, CancellationTokenSource cts, int cancelAfterRead)
+        {
+            _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+            _cts = cts ?? throw new ArgumentNullException(nameof(cts));
+            _cancelAfterRead = cancelAfterRead;
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead => _inner.CanRead;
+
+        /// <inheritdoc />
+        public override bool CanSeek => _inner.CanSeek;
+
+        /// <inheritdoc />
+        public override bool CanWrite => _inner.CanWrite;
+
+        /// <inheritdoc />
+        public override long Length => _inner.Length;
+
+        /// <inheritdoc />
+        public override long Position
+        {
+            get => _inner.Position;
+            set => _inner.Position = value;
+        }
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            int result = _inner.Read(buffer, offset, count);
+            if (result > 0 && ++_readCount == _cancelAfterRead && !_cts.IsCancellationRequested)
+                _cts.Cancel();
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override void Flush() => _inner.Flush();
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+
+        /// <inheritdoc />
+        public override void SetLength(long value) => _inner.SetLength(value);
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+
+        /// <inheritdoc />
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+                _inner.Dispose();
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/ParallelMerkleTreeHashTests.ComputeHashAsync.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/ParallelMerkleTreeHashTests.ComputeHashAsync.cs
@@ -143,23 +143,18 @@ namespace Bodu.Security.Cryptography
         {
             using var cts = new CancellationTokenSource();
 
-            // A large stream ensures at least one Read completes before cancellation fires.
             const int length = 1_000_000;
             using var hasher = new ParallelMerkleTreeHash(Factory, blockSize: 256, fanOut: 2);
 
-            // Cancel after a short delay.
-            var cancel = Task.Run(async () =>
-            {
-                await Task.Delay(15);
-                cts.Cancel();
-            });
+            // CancellationTriggerStream cancels the CTS after exactly 3 successful reads,
+            // making the test deterministic — the next ReadAsync detects the cancelled token.
+            using var stream = new CancellationTriggerStream(
+                new IncrementingByteStream(length), cts, cancelAfterRead: 3);
 
-            var compute = Assert.ThrowsExactlyAsync<TaskCanceledException>(async () =>
+            await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () =>
             {
-                await hasher.ComputeHashAsync(new IncrementingByteStream(length), cancellationToken: cts.Token);
+                await hasher.ComputeHashAsync(stream, cancellationToken: cts.Token);
             });
-
-            await Task.WhenAll(cancel, compute);
         }
 
         // -----------------------------------------------------------------------------------------


### PR DESCRIPTION
Two issues fixed:

1. Production code: When ComputeHashAsync was cancelled via the user's CancellationToken, level workers were left dangling because they used the disposal-only _cts.Token rather than a token linked to the user's cancellation. Workers now receive _activeToken (linked to both the disposal and user tokens), and a new DrainWorkersAsync method properly completes channels and awaits workers on cancellation before re-throwing.

2. Test: The mid-stream cancellation test relied on a 15ms Task.Delay race against a fast synchronous stream, making it flaky on fast machines. Replaced with CancellationTriggerStream that deterministically cancels the CTS after a fixed number of successful reads.

https://claude.ai/code/session_015h96eXUkSFFC4ZN64TU6Nv