### PR TITLE
Fix EvictingDictionary correctness, re-entrancy, enumeration safety, and Key/Value views

### DIFF
--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.CacheItem.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.CacheItem.cs
@@ -21,9 +21,9 @@ public partial class EvictingDictionary<TKey, TValue>
 #endif
     {
         /// <summary>
-        /// Gets the value associated with the cache entry.
+        /// Gets or sets the value associated with the cache entry.
         /// </summary>
-        public TValue Value { get; private set; }
+        public TValue Value { get; set; }
 
         /// <summary>
         /// Gets or sets the linked list node that represents the key in the ordering structure. Used by recency- and access-order-based

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.ICollection.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.ICollection.cs
@@ -13,7 +13,6 @@ namespace Bodu.Collections.Generic;
 public partial class EvictingDictionary<TKey, TValue> :
     System.Collections.ICollection
 {
-    [NonSerialized]
     private object? _syncRoot;
 
     /// <inheritdoc />

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.IDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.IDictionary.cs
@@ -179,19 +179,23 @@ public partial class EvictingDictionary<TKey, TValue> :
     /// </param>
     /// <returns><see langword="true"/> if the dictionary contains an element with the specified key; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// If the eviction policy is <see cref="EvictingDictionaryPolicy.LeastRecentlyUsed"/> or
-    /// <see cref="EvictingDictionaryPolicy.LeastFrequentlyUsed"/>, accessing a key through this method will update its usage metadata.
+    /// <para>
+    /// A successful read counts as an access for the configured <see cref="EvictingDictionaryPolicy"/>: recency-tracked policies
+    /// ( <see cref="EvictingDictionaryPolicy.LeastRecentlyUsed"/> and <see cref="EvictingDictionaryPolicy.MostRecentlyUsed"/>) reposition the key,
+    /// <see cref="EvictingDictionaryPolicy.LeastFrequentlyUsed"/> increments its frequency, and <see cref="EvictingDictionaryPolicy.SecondChance"/>
+    /// sets its reference flag. <see cref="EvictingDictionaryPolicy.FirstInFirstOut"/> and <see cref="EvictingDictionaryPolicy.RandomReplacement"/>
+    /// are unaffected by reads.
+    /// </para>
+    /// <para>
+    /// <see cref="EvictingDictionary{TKey, TValue}.TotalTouches"/> is incremented on every successful lookup regardless of policy.
+    /// </para>
     /// </remarks>
     public bool TryGetValue(TKey key, out TValue value)
     {
         if (_store.TryGetValue(key, out CacheItem? item))
         {
             value = item.Value;
-
-            if (_evictingPolicy is EvictingDictionaryPolicy.LeastRecentlyUsed
-                or EvictingDictionaryPolicy.LeastFrequentlyUsed)
-                TouchInternal(key, item);
-
+            TouchInternal(key, item);
             _totalTouches++;
             return true;
         }

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.IDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.IDictionary.cs
@@ -7,7 +7,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Bodu.Collections.Generic;
 
@@ -22,10 +21,18 @@ public partial class EvictingDictionary<TKey, TValue> :
     public bool IsReadOnly => false;
 
     /// <inheritdoc />
-    public ICollection<TKey> Keys => GetOrderedItems().Select(kvp => kvp.Key).ToList();
+    /// <remarks>
+    /// Returns a live, order-preserving view of the dictionary's keys. The collection is cached per instance, so repeated reads of
+    /// <see cref="Keys"/> do not allocate; enumeration is in the order defined by the current <see cref="EvictingDictionaryPolicy"/>.
+    /// </remarks>
+    public ICollection<TKey> Keys => _keys ??= new KeyCollection(this);
 
     /// <inheritdoc />
-    public ICollection<TValue> Values => GetOrderedItems().Select(item => item.Value).ToList();
+    /// <remarks>
+    /// Returns a live, order-preserving view of the dictionary's values. The collection is cached per instance, so repeated reads of
+    /// <see cref="Values"/> do not allocate; enumeration is in the order defined by the current <see cref="EvictingDictionaryPolicy"/>.
+    /// </remarks>
+    public ICollection<TValue> Values => _values ??= new ValueCollection(this);
 
     /// <inheritdoc />
     bool IDictionary.IsFixedSize => false;
@@ -67,20 +74,32 @@ public partial class EvictingDictionary<TKey, TValue> :
     }
 
     /// <summary>
-    /// Adds the specified key and value to the dictionary. If the dictionary has reached its capacity, an existing entry will be evicted
-    /// according to the configured <see cref="EvictingDictionaryPolicy"/>.
+    /// Adds the specified key and value to the dictionary, or replaces the value if the key already exists. If the dictionary has
+    /// reached its capacity and the key is new, an existing entry will be evicted according to the configured
+    /// <see cref="EvictingDictionaryPolicy"/>.
     /// </summary>
-    /// <param name="key">The key of the element to add.</param>
-    /// <param name="value">The value of the element to add.</param>
+    /// <param name="key">The key of the element to add or update.</param>
+    /// <param name="value">The value to associate with <paramref name="key"/>.</param>
     /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if invoked from within an <see cref="ItemEvicting"/> or <see cref="ItemEvicted"/> event handler.
+    /// </exception>
+    /// <remarks>
+    /// When an entry for <paramref name="key"/> already exists its value is updated in place without disturbing eviction metadata:
+    /// position in the order list, LFU frequency, and the SecondChance reference flag are all preserved. This differs from
+    /// <see cref="System.Collections.Generic.Dictionary{TKey, TValue}.Add(TKey, TValue)"/>, which throws on duplicate keys.
+    /// </remarks>
     public void Add(TKey key, TValue value)
     {
         ThrowHelper.ThrowIfNull(key);
+        ThrowIfEvicting();
 
-        // Remove an existing entry for this key so that the replacement is tracked correctly
-        // by the eviction policy (position and frequency are reset on re-insertion).
-        if (_store.ContainsKey(key))
-            Remove(key);
+        if (_store.TryGetValue(key, out CacheItem? existing))
+        {
+            existing.Value = value;
+            _version++;
+            return;
+        }
 
         if (_store.Count >= _capacity)
             EvictOne();
@@ -88,15 +107,16 @@ public partial class EvictingDictionary<TKey, TValue> :
         CacheItem item = new CacheItem(value);
 
         if (_evictingPolicy is EvictingDictionaryPolicy.FirstInFirstOut
-            || _evictingPolicy is EvictingDictionaryPolicy.LeastRecentlyUsed
-            || _evictingPolicy is EvictingDictionaryPolicy.MostRecentlyUsed
-            || _evictingPolicy is EvictingDictionaryPolicy.SecondChance)
+            or EvictingDictionaryPolicy.LeastRecentlyUsed
+            or EvictingDictionaryPolicy.MostRecentlyUsed
+            or EvictingDictionaryPolicy.SecondChance)
             item.Node = _order.AddLast(key);
 
         if (_evictingPolicy == EvictingDictionaryPolicy.LeastFrequentlyUsed)
             AddToFrequencyList(item.Frequency, key);
 
         _store[key] = item;
+        _version++;
     }
 
     /// <summary>
@@ -110,6 +130,9 @@ public partial class EvictingDictionary<TKey, TValue> :
     /// <summary>
     /// Removes all entries from the dictionary and resets internal tracking counters.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if invoked from within an <see cref="ItemEvicting"/> or <see cref="ItemEvicted"/> event handler.
+    /// </exception>
     /// <remarks>
     /// Clears the dictionary and resets all internal eviction metadata, including access order (for LeastRecentlyUsed and MostRecentlyUsed),
     /// frequency tracking (for LeastFrequentlyUsed), and counters such as <see cref="EvictingDictionary{TKey, TValue}.TotalTouches"/> and
@@ -117,10 +140,13 @@ public partial class EvictingDictionary<TKey, TValue> :
     /// </remarks>
     public void Clear()
     {
+        ThrowIfEvicting();
+
         _store.Clear();
         _order?.Clear();
         _frequencyList?.Clear();
         _totalTouches = _evictionCount = 0;
+        _version++;
     }
 
     /// <inheritdoc />
@@ -147,12 +173,15 @@ public partial class EvictingDictionary<TKey, TValue> :
     public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() => GetOrderedItems().GetEnumerator();
 
     /// <inheritdoc />
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if invoked from within an <see cref="ItemEvicting"/> or <see cref="ItemEvicted"/> event handler.
+    /// </exception>
     public bool Remove(TKey key)
     {
+        ThrowIfEvicting();
+
         if (_store.TryGetValue(key, out CacheItem? item))
         {
-            // Use the stored node reference for O(1) removal from the order list for all
-            // order-tracked policies (FIFO, LRU, MRU, SecondChance).
             if (_order is not null && item.Node is not null)
                 _order.Remove(item.Node);
 
@@ -160,6 +189,7 @@ public partial class EvictingDictionary<TKey, TValue> :
                 RemoveFromFrequencyList(item.Frequency, key);
 
             _store.Remove(key);
+            _version++;
             return true;
         }
 

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.KeyCollection.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.KeyCollection.cs
@@ -1,0 +1,106 @@
+// --------------------------------------------------------------------------------------------------------------- //
+// <copyright file="EvictingDictionary.KeyCollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------- //
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public partial class EvictingDictionary<TKey, TValue>
+{
+    /// <summary>
+    /// Represents a live, order-preserving view of the keys contained in an <see cref="EvictingDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// The collection reflects subsequent mutations to the underlying dictionary. Enumeration order follows the current
+    /// <see cref="EvictingDictionaryPolicy"/>. The collection is read-only; <see cref="Add"/>, <see cref="Clear"/>, and
+    /// <see cref="Remove"/> throw <see cref="NotSupportedException"/>.
+    /// </remarks>
+    public sealed class KeyCollection :
+        ICollection<TKey>,
+        IReadOnlyCollection<TKey>,
+        ICollection
+    {
+        private readonly EvictingDictionary<TKey, TValue> _dictionary;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KeyCollection"/> class bound to the specified dictionary.
+        /// </summary>
+        /// <param name="dictionary">The dictionary whose keys this collection exposes. Must not be <see langword="null"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <see langword="null"/>.</exception>
+        internal KeyCollection(EvictingDictionary<TKey, TValue> dictionary)
+        {
+            ThrowHelper.ThrowIfNull(dictionary);
+
+            _dictionary = dictionary;
+        }
+
+        /// <inheritdoc />
+        public int Count => _dictionary._store.Count;
+
+        /// <inheritdoc />
+        bool ICollection<TKey>.IsReadOnly => true;
+
+        /// <inheritdoc />
+        bool ICollection.IsSynchronized => false;
+
+        /// <inheritdoc />
+        object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+        /// <inheritdoc />
+        public bool Contains(TKey item) => _dictionary.ContainsKey(item);
+
+        /// <inheritdoc />
+        public void CopyTo(TKey[] array, int arrayIndex)
+        {
+            ThrowHelper.ThrowIfNull(array);
+            ThrowHelper.ThrowIfLessThan(arrayIndex, 0);
+            ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, arrayIndex, Count);
+
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                array[arrayIndex++] = kvp.Key;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<TKey> GetEnumerator()
+        {
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                yield return kvp.Key;
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ThrowHelper.ThrowIfNull(array);
+            ThrowHelper.ThrowIfArrayIsNotSingleDimension(array);
+            ThrowHelper.ThrowIfArrayIsNotZeroBased(array);
+            ThrowHelper.ThrowIfLessThan(index, 0);
+            ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, index, Count);
+
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                array.SetValue(kvp.Key, index++);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Keys cannot be added directly; modify the owning dictionary instead.</exception>
+        void ICollection<TKey>.Add(TKey item) =>
+            throw new NotSupportedException("Mutating the dictionary through the Keys collection is not supported.");
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Keys cannot be cleared directly; call <see cref="EvictingDictionary{TKey, TValue}.Clear"/> instead.</exception>
+        void ICollection<TKey>.Clear() =>
+            throw new NotSupportedException("Mutating the dictionary through the Keys collection is not supported.");
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Keys cannot be removed directly; call <see cref="EvictingDictionary{TKey, TValue}.Remove(TKey)"/> instead.</exception>
+        bool ICollection<TKey>.Remove(TKey item) =>
+            throw new NotSupportedException("Mutating the dictionary through the Keys collection is not supported.");
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.ValueCollection.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.ValueCollection.cs
@@ -1,0 +1,117 @@
+// --------------------------------------------------------------------------------------------------------------- //
+// <copyright file="EvictingDictionary.ValueCollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// --------------------------------------------------------------------------------------------------------------- //
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public partial class EvictingDictionary<TKey, TValue>
+{
+    /// <summary>
+    /// Represents a live, order-preserving view of the values contained in an <see cref="EvictingDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// The collection reflects subsequent mutations to the underlying dictionary. Enumeration order follows the current
+    /// <see cref="EvictingDictionaryPolicy"/>. The collection is read-only; <see cref="Add"/>, <see cref="Clear"/>, and
+    /// <see cref="Remove"/> throw <see cref="NotSupportedException"/>.
+    /// </remarks>
+    public sealed class ValueCollection :
+        ICollection<TValue>,
+        IReadOnlyCollection<TValue>,
+        ICollection
+    {
+        private readonly EvictingDictionary<TKey, TValue> _dictionary;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ValueCollection"/> class bound to the specified dictionary.
+        /// </summary>
+        /// <param name="dictionary">The dictionary whose values this collection exposes. Must not be <see langword="null"/>.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <see langword="null"/>.</exception>
+        internal ValueCollection(EvictingDictionary<TKey, TValue> dictionary)
+        {
+            ThrowHelper.ThrowIfNull(dictionary);
+
+            _dictionary = dictionary;
+        }
+
+        /// <inheritdoc />
+        public int Count => _dictionary._store.Count;
+
+        /// <inheritdoc />
+        bool ICollection<TValue>.IsReadOnly => true;
+
+        /// <inheritdoc />
+        bool ICollection.IsSynchronized => false;
+
+        /// <inheritdoc />
+        object ICollection.SyncRoot => ((ICollection)_dictionary).SyncRoot;
+
+        /// <inheritdoc />
+        public bool Contains(TValue item)
+        {
+            EqualityComparer<TValue> comparer = EqualityComparer<TValue>.Default;
+
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+            {
+                if (comparer.Equals(kvp.Value, item))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public void CopyTo(TValue[] array, int arrayIndex)
+        {
+            ThrowHelper.ThrowIfNull(array);
+            ThrowHelper.ThrowIfLessThan(arrayIndex, 0);
+            ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, arrayIndex, Count);
+
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                array[arrayIndex++] = kvp.Value;
+        }
+
+        /// <inheritdoc />
+        public IEnumerator<TValue> GetEnumerator()
+        {
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                yield return kvp.Value;
+        }
+
+        /// <inheritdoc />
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        /// <inheritdoc />
+        void ICollection.CopyTo(Array array, int index)
+        {
+            ThrowHelper.ThrowIfNull(array);
+            ThrowHelper.ThrowIfArrayIsNotSingleDimension(array);
+            ThrowHelper.ThrowIfArrayIsNotZeroBased(array);
+            ThrowHelper.ThrowIfLessThan(index, 0);
+            ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, index, Count);
+
+            foreach (KeyValuePair<TKey, TValue> kvp in _dictionary.GetOrderedItems())
+                array.SetValue(kvp.Value, index++);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Values cannot be added directly; modify the owning dictionary instead.</exception>
+        void ICollection<TValue>.Add(TValue item) =>
+            throw new NotSupportedException("Mutating the dictionary through the Values collection is not supported.");
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Values cannot be cleared directly; call <see cref="EvictingDictionary{TKey, TValue}.Clear"/> instead.</exception>
+        void ICollection<TValue>.Clear() =>
+            throw new NotSupportedException("Mutating the dictionary through the Values collection is not supported.");
+
+        /// <inheritdoc />
+        /// <exception cref="NotSupportedException">Values cannot be removed directly; modify the owning dictionary instead.</exception>
+        bool ICollection<TValue>.Remove(TValue item) =>
+            throw new NotSupportedException("Mutating the dictionary through the Values collection is not supported.");
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
@@ -65,7 +65,6 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 [DebuggerDisplay("Count: {Count}, Capacity: {_capacity}, Policy: {_evictingPolicy}")]
 [DebuggerTypeProxy(typeof(EvictingDictionaryDebugView<,>))]
-[Serializable]
 public partial class EvictingDictionary<TKey, TValue>
     where TKey : notnull
 {
@@ -78,8 +77,15 @@ public partial class EvictingDictionary<TKey, TValue>
     private readonly SortedDictionary<int, LinkedList<TKey>> _frequencyList = null!;
     private readonly Dictionary<TKey, CacheItem> _store;
     private long _evictionCount;
+    private bool _isEvicting;
+    private KeyCollection? _keys;
     private LinkedList<TKey> _order = null!;
     private long _totalTouches;
+    private ValueCollection? _values;
+
+    // Incremented on every mutation (Add, Remove, Clear, in-place replace) so enumerators can detect
+    // concurrent modification and fail fast rather than produce undefined ordering.
+    private int _version;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="EvictingDictionary{TKey, TValue}"/> class, with the default capacity and eviction policy.
@@ -509,10 +515,31 @@ public partial class EvictingDictionary<TKey, TValue>
 
         if (found && _store.TryGetValue(keyToRemove, out CacheItem? item))
         {
-            ItemEvicting?.Invoke(keyToRemove, item.Value);
+            // Mark eviction in progress around each event so a handler attempting to mutate the dictionary
+            // fails fast via ThrowIfEvicting rather than corrupting internal state mid-eviction.
+            try
+            {
+                _isEvicting = true;
+                ItemEvicting?.Invoke(keyToRemove, item.Value);
+            }
+            finally
+            {
+                _isEvicting = false;
+            }
+
             _evictionCount++;
             Remove(keyToRemove);
-            ItemEvicted?.Invoke(keyToRemove, item.Value);
+
+            try
+            {
+                _isEvicting = true;
+                ItemEvicted?.Invoke(keyToRemove, item.Value);
+            }
+            finally
+            {
+                _isEvicting = false;
+            }
+
             return;
         }
 
@@ -521,6 +548,17 @@ public partial class EvictingDictionary<TKey, TValue>
         if (_store.Count >= _capacity)
             throw new InvalidOperationException(
                 $"Eviction policy '{_evictingPolicy}' produced no candidate while the dictionary is at capacity.");
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> if called while an eviction event is being dispatched. Prevents handlers from
+    /// re-entering the dictionary and corrupting its state.
+    /// </summary>
+    private void ThrowIfEvicting()
+    {
+        if (_isEvicting)
+            throw new InvalidOperationException(
+                "The dictionary cannot be mutated from within an ItemEvicting or ItemEvicted event handler.");
     }
 
     /// <summary>
@@ -536,6 +574,8 @@ public partial class EvictingDictionary<TKey, TValue>
     /// </remarks>
     private IEnumerable<KeyValuePair<TKey, TValue>> GetOrderedItems()
     {
+        int version = _version;
+
         switch (_evictingPolicy)
         {
             case EvictingDictionaryPolicy.FirstInFirstOut:
@@ -546,6 +586,8 @@ public partial class EvictingDictionary<TKey, TValue>
 
                 foreach (TKey key in _order)
                 {
+                    ThrowIfVersionChanged(version);
+
                     if (_store.TryGetValue(key, out CacheItem? item))
                         yield return new KeyValuePair<TKey, TValue>(key, item.Value);
                 }
@@ -556,9 +598,10 @@ public partial class EvictingDictionary<TKey, TValue>
                 if (_order is null)
                     yield break;
 
-                // MRU: iterate from most recently used (tail) to least (head).
                 for (LinkedListNode<TKey>? node = _order.Last; node is not null; node = node.Previous)
                 {
+                    ThrowIfVersionChanged(version);
+
                     if (_store.TryGetValue(node.Value, out CacheItem? item))
                         yield return new KeyValuePair<TKey, TValue>(node.Value, item.Value);
                 }
@@ -569,11 +612,12 @@ public partial class EvictingDictionary<TKey, TValue>
                 if (_frequencyList is null)
                     yield break;
 
-                // SortedDictionary is already in ascending key order; no secondary sort is required.
                 foreach (KeyValuePair<int, LinkedList<TKey>> freq in _frequencyList)
                 {
                     foreach (TKey key in freq.Value)
                     {
+                        ThrowIfVersionChanged(version);
+
                         if (_store.TryGetValue(key, out CacheItem? item))
                             yield return new KeyValuePair<TKey, TValue>(key, item.Value);
                     }
@@ -584,16 +628,33 @@ public partial class EvictingDictionary<TKey, TValue>
             case EvictingDictionaryPolicy.RandomReplacement:
 #if NETSTANDARD2_0
                 foreach (var pair in _store)
+                {
+                    ThrowIfVersionChanged(version);
                     yield return new KeyValuePair<TKey, TValue>(pair.Key, pair.Value.Value);
+                }
 #else
                 foreach ((TKey key, CacheItem item) in _store)
+                {
+                    ThrowIfVersionChanged(version);
                     yield return new KeyValuePair<TKey, TValue>(key, item.Value);
+                }
 #endif
                 break;
 
             default:
                 throw new InvalidOperationException($"Unknown eviction policy: {_evictingPolicy}");
         }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException"/> if <paramref name="capturedVersion"/> no longer matches the current
+    /// <see cref="_version"/>, signalling that the dictionary was modified during enumeration.
+    /// </summary>
+    /// <param name="capturedVersion">The version observed at the start of enumeration.</param>
+    private void ThrowIfVersionChanged(int capturedVersion)
+    {
+        if (_version != capturedVersion)
+            throw new InvalidOperationException("Collection was modified; enumeration operation may not execute.");
     }
 
     /// <summary>
@@ -607,8 +668,6 @@ public partial class EvictingDictionary<TKey, TValue>
         if (_order is null || _order.Count == 0)
             throw new InvalidOperationException("No eviction candidate available: the order list is empty.");
 
-        // Walk the list using explicit node references so we can perform O(1) removal and re-insertion
-        // without allocating a snapshot copy via ToList().
         LinkedListNode<TKey>? node = _order.First;
         while (node is not null)
         {
@@ -622,13 +681,12 @@ public partial class EvictingDictionary<TKey, TValue>
             if (!item.SecondChance)
                 return key;
 
-            // Give the item a second chance: clear the flag and cycle it to the tail.
+            // Clock algorithm: clear the reference bit and cycle the item to the tail, giving it one extra pass before eviction.
             item.SecondChance = false;
             _order.Remove(current);
             item.Node = _order.AddLast(key);
         }
 
-        // All items had their second-chance flag set; fall back to the oldest remaining entry.
         if (_order.First is not null)
             return _order.First.Value;
 

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
@@ -24,8 +24,17 @@ namespace Bodu.Collections.Generic;
 /// queue, an access-order cache, or a frequency-based cache.
 /// </para>
 /// <para>
-/// <see cref="EvictingDictionary{TKey, TValue}"/> allows <see langword="null"/> keys and values (for reference types) and supports
-/// custom key equality via <see cref="System.Collections.Generic.IEqualityComparer{T}"/>.
+/// Keys must be non-null (the type parameter is constrained by <see langword="notnull"/>). Values may be <see langword="null"/> when
+/// <typeparamref name="TValue"/> is a reference type. Custom key equality is supported via <see cref="System.Collections.Generic.IEqualityComparer{T}"/>.
+/// </para>
+/// <para>
+/// Calling <see cref="EvictingDictionary{TKey, TValue}.Add(TKey, TValue)"/> (or assigning via the indexer) with a key that already
+/// exists replaces the existing entry rather than throwing — this differs from <see cref="System.Collections.Generic.Dictionary{TKey, TValue}"/>'s
+/// strict <c>Add</c> semantics, and resets the entry's eviction metadata.
+/// </para>
+/// <para>
+/// <see cref="EvictingDictionary{TKey, TValue}"/> is not thread-safe. Concurrent reads and writes (including reads, which mutate
+/// eviction metadata for some policies) require external synchronisation.
 /// </para>
 /// <example>
 /// <code language="csharp">
@@ -437,36 +446,81 @@ public partial class EvictingDictionary<TKey, TValue>
     /// Removes the next item to be evicted based on the current eviction policy. Raises the <see cref="ItemEvicting"/> and
     /// <see cref="ItemEvicted"/> events and updates eviction metrics.
     /// </summary>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the configured eviction policy fails to produce a candidate while the dictionary is at or above its capacity. This
+    /// indicates that the internal tracking structures have become desynchronised from the underlying store.
+    /// </exception>
     private void EvictOne()
     {
-        TKey? keyToRemove = _evictingPolicy switch
+        // Track success explicitly: relying on `keyToRemove is not null` is unreliable when TKey is a value type
+        // because default(TKey) (e.g. 0) may itself be a valid key.
+        bool found = false;
+        TKey keyToRemove = default!;
+
+        switch (_evictingPolicy)
         {
-            EvictingDictionaryPolicy.FirstInFirstOut or EvictingDictionaryPolicy.LeastRecentlyUsed
-                when _order?.First is not null => _order.First.Value,
+            case EvictingDictionaryPolicy.FirstInFirstOut:
+            case EvictingDictionaryPolicy.LeastRecentlyUsed:
+                if (_order?.First is { } firstNode)
+                {
+                    keyToRemove = firstNode.Value;
+                    found = true;
+                }
 
-            EvictingDictionaryPolicy.MostRecentlyUsed
-                when _order?.Last is not null => _order.Last.Value,
+                break;
 
-            EvictingDictionaryPolicy.LeastFrequentlyUsed
-                when _frequencyList?.Count > 0 &&
-                     _frequencyList.First().Value?.First is LinkedListNode<TKey> node => node.Value,
+            case EvictingDictionaryPolicy.MostRecentlyUsed:
+                if (_order?.Last is { } lastNode)
+                {
+                    keyToRemove = lastNode.Value;
+                    found = true;
+                }
 
-            EvictingDictionaryPolicy.RandomReplacement
-                when _store.Count > 0 => _store.Keys.First(),
+                break;
 
-            EvictingDictionaryPolicy.SecondChance when _order is not null =>
-                GetSecondChanceCandidate(),
+            case EvictingDictionaryPolicy.LeastFrequentlyUsed:
+                if (_frequencyList?.Count > 0
+                    && _frequencyList.First().Value?.First is LinkedListNode<TKey> lfuNode)
+                {
+                    keyToRemove = lfuNode.Value;
+                    found = true;
+                }
 
-            _ => default
-        };
+                break;
 
-        if (keyToRemove is not null && _store.TryGetValue(keyToRemove, out CacheItem? item))
+            case EvictingDictionaryPolicy.RandomReplacement:
+                if (_store.Count > 0)
+                {
+                    keyToRemove = _store.Keys.ElementAt(Random.Shared.Next(_store.Count));
+                    found = true;
+                }
+
+                break;
+
+            case EvictingDictionaryPolicy.SecondChance:
+                if (_order is not null && _order.Count > 0)
+                {
+                    keyToRemove = GetSecondChanceCandidate();
+                    found = true;
+                }
+
+                break;
+        }
+
+        if (found && _store.TryGetValue(keyToRemove, out CacheItem? item))
         {
             ItemEvicting?.Invoke(keyToRemove, item.Value);
             _evictionCount++;
             Remove(keyToRemove);
             ItemEvicted?.Invoke(keyToRemove, item.Value);
+            return;
         }
+
+        // No candidate was produced. If the store is still at capacity the caller (Add) will exceed the limit, so fail loudly
+        // rather than silently corrupting the invariant.
+        if (_store.Count >= _capacity)
+            throw new InvalidOperationException(
+                $"Eviction policy '{_evictingPolicy}' produced no candidate while the dictionary is at capacity.");
     }
 
     /// <summary>

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.IEnumerable.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.IEnumerable.cs
@@ -55,5 +55,57 @@ namespace Bodu.Collections.Generic
 
             Assert.IsFalse(enumerator.MoveNext());
         }
+
+        /// <summary>
+        /// Verifies that mutating the dictionary via Add during enumeration invalidates the active enumerator and
+        /// causes the next <c>MoveNext</c> to throw <see cref="InvalidOperationException"/>.
+        /// </summary>
+        [TestMethod]
+        public void GetEnumerator_WhenDictionaryIsMutatedByAddDuringEnumeration_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<int, int>(10);
+            for (int i = 0; i < 5; i++)
+                dictionary.Add(i, i);
+
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
+            {
+                foreach (KeyValuePair<int, int> kvp in dictionary)
+                    dictionary.Add(kvp.Key + 100, kvp.Value);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that mutating the dictionary via Remove during enumeration invalidates the active enumerator.
+        /// </summary>
+        [TestMethod]
+        public void GetEnumerator_WhenDictionaryIsMutatedByRemoveDuringEnumeration_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<int, int>(10);
+            for (int i = 0; i < 5; i++)
+                dictionary.Add(i, i);
+
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
+            {
+                foreach (KeyValuePair<int, int> kvp in dictionary)
+                    dictionary.Remove(kvp.Key);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that mutating the dictionary via Clear during enumeration invalidates the active enumerator.
+        /// </summary>
+        [TestMethod]
+        public void GetEnumerator_WhenDictionaryIsClearedDuringEnumeration_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<int, int>(10);
+            for (int i = 0; i < 3; i++)
+                dictionary.Add(i, i);
+
+            Assert.ThrowsExactly<InvalidOperationException>(() =>
+            {
+                foreach (KeyValuePair<int, int> _ in dictionary)
+                    dictionary.Clear();
+            });
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.ItemEvicting.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.ItemEvicting.cs
@@ -41,5 +41,72 @@ namespace Bodu.Collections.Generic
             dictionary.Clear();
             Assert.IsFalse(eventFired);
         }
+
+        /// <summary>
+        /// Verifies that calling Add from an ItemEvicting handler throws InvalidOperationException to prevent
+        /// re-entrant mutation from corrupting internal state mid-eviction.
+        /// </summary>
+        [TestMethod]
+        public void Add_WhenCalledFromItemEvictingHandler_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            Exception? captured = null;
+            dictionary.ItemEvicting += (_, _) =>
+            {
+                try { dictionary.Add("Z", 99); }
+                catch (Exception ex) { captured = ex; }
+            };
+
+            dictionary.Add("C", 3); // triggers eviction → handler attempts re-entrant Add.
+
+            Assert.IsInstanceOfType<InvalidOperationException>(captured);
+        }
+
+        /// <summary>
+        /// Verifies that calling Remove from an ItemEvicting handler throws InvalidOperationException.
+        /// </summary>
+        [TestMethod]
+        public void Remove_WhenCalledFromItemEvictingHandler_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            Exception? captured = null;
+            dictionary.ItemEvicting += (_, _) =>
+            {
+                try { dictionary.Remove("B"); }
+                catch (Exception ex) { captured = ex; }
+            };
+
+            dictionary.Add("C", 3);
+
+            Assert.IsInstanceOfType<InvalidOperationException>(captured);
+        }
+
+        /// <summary>
+        /// Verifies that calling Clear from an ItemEvicted handler throws InvalidOperationException.
+        /// </summary>
+        [TestMethod]
+        public void Clear_WhenCalledFromItemEvictedHandler_ShouldThrowInvalidOperationException()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            Exception? captured = null;
+            dictionary.ItemEvicted += (_, _) =>
+            {
+                try { dictionary.Clear(); }
+                catch (Exception ex) { captured = ex; }
+            };
+
+            dictionary.Add("C", 3);
+
+            Assert.IsInstanceOfType<InvalidOperationException>(captured);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Keys.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Keys.cs
@@ -91,5 +91,49 @@ namespace Bodu.Collections.Generic
 
             Assert.AreEqual(1, dictionary.Keys.Count);
         }
+
+        /// <summary>
+        /// Verifies that the Keys property returns the same cached instance on successive reads, so callers
+        /// observing only the reference do not pay an allocation per access.
+        /// </summary>
+        [TestMethod]
+        public void Keys_Get_WhenReadTwice_ShouldReturnSameInstance()
+        {
+            var dictionary = new EvictingDictionary<string, int>(3);
+            dictionary.Add("A", 1);
+
+            var first = dictionary.Keys;
+            var second = dictionary.Keys;
+
+            Assert.AreSame(first, second);
+        }
+
+        /// <summary>
+        /// Verifies that the Keys view reflects mutations to the owning dictionary without requiring a fresh property read.
+        /// </summary>
+        [TestMethod]
+        public void Keys_WhenDictionaryIsMutatedAfterRead_ShouldReflectLiveState()
+        {
+            var dictionary = new EvictingDictionary<string, int>(5);
+            dictionary.Add("A", 1);
+
+            var keys = dictionary.Keys;
+            dictionary.Add("B", 2);
+
+            Assert.AreEqual(2, keys.Count);
+            CollectionAssert.Contains(keys.ToList(), "B");
+        }
+
+        /// <summary>
+        /// Verifies that mutating the dictionary through the Keys collection is not supported and throws.
+        /// </summary>
+        [TestMethod]
+        public void Keys_Add_ShouldThrowNotSupportedException()
+        {
+            var dictionary = new EvictingDictionary<string, int>(3);
+            ICollection<string> keys = dictionary.Keys;
+
+            Assert.ThrowsExactly<NotSupportedException>(() => keys.Add("Z"));
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Policy.LFU.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Policy.LFU.cs
@@ -181,5 +181,33 @@ namespace Bodu.Collections.Generic
 
             Assert.IsFalse(eventFired);
         }
+
+        /// <summary>
+        /// Verifies that replacing an existing key under LeastFrequentlyUsed preserves its accumulated frequency,
+        /// so a well-used key is not knocked back to a cold state by a subsequent value update.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("LFU")]
+        public void Add_WhenReplacingExistingKeyUnderLFU_ShouldPreserveFrequency()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2, EvictingDictionaryPolicy.LeastFrequentlyUsed);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            // Accumulate frequency on "A".
+            for (int i = 0; i < 5; i++)
+                _ = dictionary["A"];
+
+            // Replace "A"'s value. Under the old behaviour this reset its frequency, making it a cold candidate.
+            dictionary.Add("A", 999);
+
+            // Adding a new key should evict "B" (low frequency), not "A" (which retained its high frequency).
+            dictionary.Add("C", 3);
+
+            Assert.IsTrue(dictionary.ContainsKey("A"));
+            Assert.IsFalse(dictionary.ContainsKey("B"));
+            Assert.IsTrue(dictionary.ContainsKey("C"));
+            Assert.AreEqual(999, dictionary["A"]);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Policy.RND.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Policy.RND.cs
@@ -122,5 +122,41 @@ namespace Bodu.Collections.Generic
             Assert.AreEqual(2, dictionary.Keys.Count);
             Assert.IsTrue(dictionary.ContainsKey("c"));
         }
+
+        /// <summary>
+        /// Verifies that RandomReplacement actually selects different victims across many independent runs,
+        /// rather than deterministically evicting the same key each time.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("Random")]
+        public void Add_WhenPolicyIsRandomAndCapacityExceededAcrossManyRuns_ShouldEvictDifferentKeysOverTime()
+        {
+            const int trials = 200;
+            var evictedKeys = new HashSet<string>();
+
+            for (int i = 0; i < trials; i++)
+            {
+                var dictionary = new EvictingDictionary<string, int>(3, EvictingDictionaryPolicy.RandomReplacement);
+                dictionary.Add("A", 1);
+                dictionary.Add("B", 2);
+                dictionary.Add("C", 3);
+
+                string? evicted = null;
+                dictionary.ItemEvicted += (key, _) => evicted = key;
+
+                dictionary.Add("D", 4);
+
+                Assert.IsNotNull(evicted);
+                evictedKeys.Add(evicted!);
+
+                // Once we have observed at least two distinct victims we are confident the selection is non-deterministic.
+                if (evictedKeys.Count >= 2)
+                    return;
+            }
+
+            Assert.Fail(
+                $"RandomReplacement evicted the same key in all {trials} trials (observed: {string.Join(',', evictedKeys)}); " +
+                "expected non-deterministic victim selection.");
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.TryGet.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.TryGet.cs
@@ -135,5 +135,47 @@ namespace Bodu.Collections.Generic
             Assert.IsFalse(result);
             Assert.IsNull(value);
         }
+
+        /// <summary>
+        /// Verifies that TryGetValue repositions the accessed key to the most-recently-used end under
+        /// MostRecentlyUsed policy, so the next eviction targets it rather than an older entry.
+        /// </summary>
+        [TestMethod]
+        public void TryGetValue_WhenPolicyIsMRUAndKeyAccessed_ShouldUpdateRecencyAndBeNextEvictionCandidate()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2, EvictingDictionaryPolicy.MostRecentlyUsed);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            // Access "A" — under MRU this should make it the most recently used and the next eviction candidate.
+            _ = dictionary.TryGetValue("A", out _);
+
+            dictionary.Add("C", 3); // Should evict "A" (most recently used).
+
+            Assert.IsFalse(dictionary.ContainsKey("A"));
+            Assert.IsTrue(dictionary.ContainsKey("B"));
+            Assert.IsTrue(dictionary.ContainsKey("C"));
+        }
+
+        /// <summary>
+        /// Verifies that TryGetValue sets the second-chance flag on the accessed key under SecondChance
+        /// policy, sparing it from eviction on the next pass.
+        /// </summary>
+        [TestMethod]
+        public void TryGetValue_WhenPolicyIsSecondChanceAndKeyAccessed_ShouldSpareKeyFromEviction()
+        {
+            var dictionary = new EvictingDictionary<string, int>(2, EvictingDictionaryPolicy.SecondChance);
+            dictionary.Add("A", 1);
+            dictionary.Add("B", 2);
+
+            // Access "A" so its second-chance flag is set; the algorithm should spare it and evict "B" instead.
+            _ = dictionary.TryGetValue("A", out _);
+
+            dictionary.Add("C", 3);
+
+            Assert.IsTrue(dictionary.ContainsKey("A"));
+            Assert.IsFalse(dictionary.ContainsKey("B"));
+            Assert.IsTrue(dictionary.ContainsKey("C"));
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Values.cs
+++ b/Bodu.Core/test/Collections.Generic/EvictingDictionaryTests.Values.cs
@@ -107,5 +107,46 @@ namespace Bodu.Collections.Generic
 
             Assert.AreEqual(2, values.Count(v => v == 42));
         }
+
+        /// <summary>
+        /// Verifies that the Values property returns the same cached instance on successive reads.
+        /// </summary>
+        [TestMethod]
+        public void Values_Get_WhenReadTwice_ShouldReturnSameInstance()
+        {
+            var dictionary = new EvictingDictionary<string, int>(3);
+            dictionary.Add("A", 1);
+
+            var first = dictionary.Values;
+            var second = dictionary.Values;
+
+            Assert.AreSame(first, second);
+        }
+
+        /// <summary>
+        /// Verifies that Values.Contains uses the default equality comparer for the value type.
+        /// </summary>
+        [TestMethod]
+        public void Values_Contains_WhenValuePresent_ShouldReturnTrue()
+        {
+            var dictionary = new EvictingDictionary<string, int>(3);
+            dictionary.Add("A", 10);
+            dictionary.Add("B", 20);
+
+            Assert.IsTrue(dictionary.Values.Contains(20));
+            Assert.IsFalse(dictionary.Values.Contains(99));
+        }
+
+        /// <summary>
+        /// Verifies that mutating the dictionary through the Values collection is not supported.
+        /// </summary>
+        [TestMethod]
+        public void Values_Add_ShouldThrowNotSupportedException()
+        {
+            var dictionary = new EvictingDictionary<string, int>(3);
+            ICollection<int> values = dictionary.Values;
+
+            Assert.ThrowsExactly<NotSupportedException>(() => values.Add(42));
+        }
     }
 }


### PR DESCRIPTION
## Summary

Addresses correctness, safety, and performance issues found while reviewing `EvictingDictionary<TKey, TValue>` in `Bodu.Core`.

### Correctness fixes
- **`TryGetValue` now updates eviction metadata for MRU and SecondChance** (previously only LRU and LFU). Without this, MRU could not select recently-read keys for eviction, and SecondChance reference bits were never set on reads — degenerating the algorithm into FIFO.
- **`EvictOne` tracks candidate selection via an explicit `found` flag** rather than `keyToRemove is not null`, which is unreliable when `TKey` is a value type (`default(int) == 0` is itself a valid key). When the policy fails to produce a candidate while the store is at capacity, `EvictOne` now throws `InvalidOperationException` rather than silently allowing the store to exceed its capacity.
- **`RandomReplacement` now selects a victim uniformly at random** via `Random.Shared`, instead of always returning the first key from the underlying store.
- **`Add` updates existing entries in place** rather than `Remove` + re-insert. This preserves LFU frequency, linked-list position (FIFO/LRU/MRU/SecondChance), and the SecondChance reference flag on replace. The divergence from `Dictionary<K,V>`'s strict `Add` contract is documented in the class-level remarks.

### Re-entrancy and enumeration safety
- **`EvictOne` sets an `_isEvicting` flag** (try/finally) around each `ItemEvicting`/`ItemEvicted` invocation. A new `ThrowIfEvicting` helper at the entry of `Add`, `Remove`, and `Clear` causes re-entrant mutation from event handlers to fail fast with `InvalidOperationException` instead of silently corrupting state.
- **`_version` counter** bumped on every mutation. `GetOrderedItems` captures the version at start and calls `ThrowIfVersionChanged` before each yield, matching BCL `Dictionary<K,V>` concurrent-modification semantics.

### Performance and polish
- **`Keys`/`Values` now return cached, lazy `KeyCollection`/`ValueCollection` views** (new nested public types). Previously each read allocated a fresh `List<T>` and an O(n) copy. Views are read-only; `Add`/`Clear`/`Remove` throw `NotSupportedException`.
- **Removed the non-functional `[Serializable]` attribute** and `[NonSerialized]` on `_syncRoot`. The type uses events and policy-conditional non-null fields and is not round-trippable via the default serializer; declaring `Serializable` without `ISerializable` was misleading.
- Trimmed a narrative comment in `GetSecondChanceCandidate` so the remaining one explains the clock-algorithm intent rather than the mechanics.
- Corrected XML docs: removed the false claim that null keys are allowed, documented the add-or-replace semantics of `Add`, noted the type is not thread-safe, and expanded `TryGetValue` remarks to describe per-policy access behaviour.

## Test plan

- [ ] `dotnet build Bodu.sln` succeeds (could not be verified locally — `dotnet` was not available in the dev environment).
- [ ] `dotnet test Bodu.Core/test/Bodu.Core.Test.csproj --settings test.runsettings` passes.
- [ ] New tests pass:
  - `TryGetValue_WhenPolicyIsMRUAndKeyAccessed_ShouldUpdateRecencyAndBeNextEvictionCandidate`
  - `TryGetValue_WhenPolicyIsSecondChanceAndKeyAccessed_ShouldSpareKeyFromEviction`
  - `Add_WhenPolicyIsRandomAndCapacityExceededAcrossManyRuns_ShouldEvictDifferentKeysOverTime`
  - `Add_WhenCalledFromItemEvictingHandler_ShouldThrowInvalidOperationException`
  - `Remove_WhenCalledFromItemEvictingHandler_ShouldThrowInvalidOperationException`
  - `Clear_WhenCalledFromItemEvictedHandler_ShouldThrowInvalidOperationException`
  - `GetEnumerator_WhenDictionaryIsMutatedByAdd/Remove/ClearDuringEnumeration_ShouldThrowInvalidOperationException`
  - `Keys_Get_WhenReadTwice_ShouldReturnSameInstance` (and the `Values` equivalent)
  - `Keys_WhenDictionaryIsMutatedAfterRead_ShouldReflectLiveState`
  - `Keys_Add_ShouldThrowNotSupportedException` (and `Values_Add_ShouldThrowNotSupportedException`)
  - `Add_WhenReplacingExistingKeyUnderLFU_ShouldPreserveFrequency`
- [ ] Existing test suite continues to pass (none rely on the dropped reset-on-replace metadata behaviour).

https://claude.ai/code/session_014qfaGUtBUyApyrWiFfLNCi