### PR TITLE
Fix cryptography namespace breaking issues and extract BlockCipherTransform base

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTransform.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    using System;
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Provides a reusable base implementation of <see cref="ICryptoTransform" /> for block cipher algorithms that
+    /// combine an <see cref="IBlockCipher" /> engine with a <see cref="IBlockCipherModeTransform" /> and an
+    /// <see cref="IPaddingStrategy" />.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Block-aligned streaming data is processed via <see cref="TransformBlock" />, and the final (potentially
+    /// partial) block — including padding application or removal — is handled by <see cref="TransformFinalBlock" />.
+    /// </para>
+    /// <para>
+    /// When decrypting with a strippable padding mode (for example <see cref="PaddingMode.PKCS7" />), the last
+    /// complete block of input is deferred until <see cref="TransformFinalBlock" /> is called to allow correct
+    /// padding validation and removal at the boundary of the stream.
+    /// </para>
+    /// <para>
+    /// Derived classes need only provide a constructor that calls
+    /// <see cref="BlockCipherTransform(IBlockCipher, CipherBlockMode, PaddingMode, byte[], bool)" /> with the
+    /// appropriate arguments. All transform logic is handled by this base class.
+    /// </para>
+    /// </remarks>
+    public abstract class BlockCipherTransform : ICryptoTransform
+    {
+        private readonly IBlockCipher cipher;
+        private readonly bool encrypt;
+        private readonly IBlockCipherModeTransform mode;
+        private readonly IPaddingStrategy padding;
+
+        private byte[]? deferredInput;
+        private bool disposed;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="BlockCipherTransform" /> class using the specified cipher
+        /// engine, mode, padding scheme, initialisation vector, and transform direction.
+        /// </summary>
+        /// <param name="cipher">
+        /// The configured <see cref="IBlockCipher" /> engine to use. Must not be <see langword="null" />.
+        /// </param>
+        /// <param name="cipherMode">The block cipher mode of operation (for example, <see cref="CipherBlockMode.CBC" />).</param>
+        /// <param name="paddingMode">The padding scheme to apply to the final block.</param>
+        /// <param name="iv">The initialisation vector for the cipher mode. Must match the cipher block size.</param>
+        /// <param name="encrypt">
+        /// <see langword="true" /> to configure for encryption; <see langword="false" /> for decryption.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
+        protected BlockCipherTransform(IBlockCipher cipher, CipherBlockMode cipherMode, PaddingMode paddingMode, byte[] iv, bool encrypt)
+        {
+            this.cipher = cipher ?? throw new ArgumentNullException(nameof(cipher));
+            this.encrypt = encrypt;
+            this.mode = BlockCipherModeFactory.Create(cipherMode, cipher, iv);
+            this.padding = PaddingFactory.Create(paddingMode);
+        }
+
+        /// <inheritdoc />
+        public bool CanReuseTransform => false;
+
+        /// <inheritdoc />
+        public bool CanTransformMultipleBlocks => true;
+
+        /// <inheritdoc />
+        public int InputBlockSize => this.cipher.BlockSize;
+
+        /// <inheritdoc />
+        public int OutputBlockSize => this.cipher.BlockSize;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            if (this.disposed)
+                return;
+
+            if (this.deferredInput is not null)
+            {
+                CryptographicOperations.ZeroMemory(this.deferredInput);
+                this.deferredInput = null;
+            }
+
+            this.cipher.Dispose();
+            this.disposed = true;
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Transforms a block-aligned region of the input byte array and writes the result to the output buffer.
+        /// </summary>
+        /// <param name="inputBuffer">The input data buffer. Must not be <see langword="null" />.</param>
+        /// <param name="inputOffset">The byte offset within <paramref name="inputBuffer" /> at which to begin reading.</param>
+        /// <param name="inputCount">The number of bytes to process. Must be a multiple of <see cref="InputBlockSize" />.</param>
+        /// <param name="outputBuffer">The buffer to write the transformed data into. Must not be <see langword="null" />.</param>
+        /// <param name="outputOffset">The byte offset within <paramref name="outputBuffer" /> at which to begin writing.</param>
+        /// <returns>The number of bytes written to <paramref name="outputBuffer" />.</returns>
+        /// <exception cref="ObjectDisposedException">This instance has been disposed.</exception>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="inputBuffer" /> or <paramref name="outputBuffer" /> is <see langword="null" />.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// The input or output buffer span is invalid or insufficient in length for the requested operation.
+        /// </exception>
+        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount,
+                                  byte[] outputBuffer, int outputOffset)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+            ThrowHelper.ThrowIfNull(inputBuffer);
+            ThrowHelper.ThrowIfNull(outputBuffer);
+
+            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
+            Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
+
+            if (this.encrypt)
+            {
+                return this.mode.Transform(input, output, true);
+            }
+            else
+            {
+                bool stripPadding = this.padding is Pkcs7Padding;
+
+                if (stripPadding && input.Length <= this.cipher.BlockSize)
+                {
+                    this.deferredInput = input.ToArray();
+                    return 0;
+                }
+
+                int bytesToProcess = input.Length;
+                if (stripPadding)
+                {
+                    bytesToProcess -= this.cipher.BlockSize;
+                    this.deferredInput = input.Slice(bytesToProcess).ToArray();
+                }
+
+                return this.mode.Transform(input.Slice(0, bytesToProcess), output.Slice(0, bytesToProcess), false);
+            }
+        }
+
+        /// <summary>
+        /// Transforms the final block of data, applying or removing padding as appropriate, and returns the result.
+        /// </summary>
+        /// <param name="inputBuffer">The final input data buffer. Must not be <see langword="null" />.</param>
+        /// <param name="inputOffset">The byte offset within <paramref name="inputBuffer" /> at which to begin reading.</param>
+        /// <param name="inputCount">The number of bytes to process from <paramref name="inputBuffer" />.</param>
+        /// <returns>A new byte array containing the transformed and padded (or depadded) final block.</returns>
+        /// <exception cref="ObjectDisposedException">This instance has been disposed.</exception>
+        /// <exception cref="ArgumentNullException"><paramref name="inputBuffer" /> is <see langword="null" />.</exception>
+        /// <exception cref="CryptographicException">The padding is invalid or cannot be removed during decryption.</exception>
+        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+            ThrowHelper.ThrowIfNull(inputBuffer);
+
+            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
+
+            if (this.encrypt)
+            {
+                byte[] padded = this.padding.Pad(input, this.cipher.BlockSize);
+                byte[] output = new byte[padded.Length];
+                this.mode.Transform(padded, output, true);
+                return output;
+            }
+            else
+            {
+                byte[] combined = Combine(this.deferredInput, input);
+                byte[] decrypted = new byte[combined.Length];
+                this.mode.Transform(combined, decrypted, false);
+                return this.padding.Unpad(decrypted, this.cipher.BlockSize);
+            }
+        }
+
+        /// <summary>
+        /// Concatenates an optional deferred byte array with an incoming input span into a single contiguous byte array.
+        /// </summary>
+        /// <param name="first">The previously cached partial or complete block, or <see langword="null" /> if none was deferred.</param>
+        /// <param name="second">The newly arriving data to append.</param>
+        /// <returns>
+        /// A new byte array containing <paramref name="first" /> followed by <paramref name="second" />, or a copy of
+        /// <paramref name="second" /> alone if <paramref name="first" /> is <see langword="null" /> or empty.
+        /// </returns>
+        private static byte[] Combine(byte[]? first, ReadOnlySpan<byte> second)
+        {
+            if (first == null || first.Length == 0)
+                return second.ToArray();
+
+            byte[] result = new byte[first.Length + second.Length];
+            Buffer.BlockCopy(first, 0, result, 0, first.Length);
+            second.CopyTo(result.AsSpan(first.Length));
+            return result;
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishTransform.cs
@@ -44,6 +44,8 @@ namespace Bodu.Security.Cryptography
         // deferred until TransformFinalBlock can confirm and remove padding correctly.
         private byte[]? deferredInput;
 
+        private bool disposed;
+
         /// <summary>
         /// Initialises a new instance of the <see cref="BlowfishTransform" /> class.
         /// </summary>
@@ -97,6 +99,9 @@ namespace Bodu.Security.Cryptography
         /// </summary>
         public void Dispose()
         {
+            if (this.disposed)
+                return;
+
             if (this.deferredInput is not null)
             {
                 CryptographicOperations.ZeroMemory(this.deferredInput);
@@ -104,6 +109,7 @@ namespace Bodu.Security.Cryptography
             }
 
             this.cipher.Dispose();
+            this.disposed = true;
             GC.SuppressFinalize(this);
         }
 
@@ -133,6 +139,12 @@ namespace Bodu.Security.Cryptography
             byte[] outputBuffer,
             int outputOffset)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
+            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
+            ThrowHelper.ThrowIfNull(inputBuffer);
+            ThrowHelper.ThrowIfNull(outputBuffer);
+
             ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
             Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
 
@@ -182,6 +194,11 @@ namespace Bodu.Security.Cryptography
         /// </remarks>
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
+            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
+            ThrowHelper.ThrowIfNull(inputBuffer);
+
             ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
 
             if (this.encrypt)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishTransform.cs
@@ -4,53 +4,27 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System;
-using System.Security.Cryptography;
-
 namespace Bodu.Security.Cryptography
 {
+    using System.Security.Cryptography;
+
     /// <summary>
     /// Performs a cryptographic transformation of data using the <see cref="Blowfish" /> algorithm. This class cannot be inherited.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Using this class directly is not recommended. The preferred approach is to use <see cref="Blowfish" /> with a
-    /// <see cref="CryptoStream" />, which handles padding and block alignment automatically.
-    /// </para>
-    /// <para>
-    /// Both <see cref="Blowfish.CreateEncryptor(byte[], byte[])" /> and <see cref="Blowfish.CreateDecryptor(byte[], byte[])" /> return an
-    /// instance of this class configured with the appropriate key material, cipher mode, padding scheme, and transform direction. To
-    /// encrypt or decrypt data, pass the returned <see cref="BlowfishTransform" /> instance to a <see cref="CryptoStream" />.
-    /// </para>
-    /// <para>
-    /// This class integrates a <see cref="BlowfishBlockCipher" /> engine with an <see cref="IBlockCipherModeTransform" /> and an
-    /// <see cref="IPaddingStrategy" />. Block-aligned streaming data is processed via <see cref="TransformBlock" />, and the final
-    /// (potentially partial) block — including padding application or removal — is handled by <see cref="TransformFinalBlock" />.
-    /// </para>
-    /// <para>
-    /// When decrypting, the final ciphertext block is deferred until <see cref="TransformFinalBlock" /> is called to allow correct
-    /// padding validation and removal.
+    /// Instances of this class are returned by <see cref="Blowfish.CreateEncryptor(byte[], byte[])" /> and
+    /// <see cref="Blowfish.CreateDecryptor(byte[], byte[])" />. Using this class directly is not recommended; prefer using
+    /// <see cref="Blowfish" /> with a <see cref="CryptoStream" />, which handles padding and block alignment automatically.
     /// </para>
     /// </remarks>
-    public sealed partial class BlowfishTransform
-        : System.Security.Cryptography.ICryptoTransform
+    public sealed class BlowfishTransform : BlockCipherTransform
     {
-        private readonly IBlockCipher cipher;
-        private readonly bool encrypt;
-        private readonly IBlockCipherModeTransform mode;
-        private readonly IPaddingStrategy padding;
-
-        // Holds the last complete ciphertext block when decrypting with strippable padding,
-        // deferred until TransformFinalBlock can confirm and remove padding correctly.
-        private byte[]? deferredInput;
-
-        private bool disposed;
-
         /// <summary>
         /// Initialises a new instance of the <see cref="BlowfishTransform" /> class.
         /// </summary>
         /// <param name="cipher">
-        /// The configured <see cref="BlowfishBlockCipher" /> engine to use. Must not be <see langword="null" />.
+        /// The configured <see cref="IBlockCipher" /> engine to use. Must not be <see langword="null" />.
         /// </param>
         /// <param name="cipherMode">The block cipher mode of operation (e.g., CBC, ECB, CFB).</param>
         /// <param name="paddingMode">The padding scheme to apply to the final block.</param>
@@ -59,182 +33,10 @@ namespace Bodu.Security.Cryptography
         /// than ECB.
         /// </param>
         /// <param name="encrypt"><see langword="true" /> to configure for encryption; <see langword="false" /> for decryption.</param>
-        /// <exception cref="ArgumentNullException">
-        /// <paramref name="cipher" /> is <see langword="null" />.
-        /// </exception>
-        /// <exception cref="ArgumentException">
-        /// <paramref name="iv" /> is required but <see langword="null" />, or its length does not match the cipher block size.
-        /// </exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
         internal BlowfishTransform(IBlockCipher cipher, CipherBlockMode cipherMode, PaddingMode paddingMode, byte[] iv, bool encrypt)
+            : base(cipher, cipherMode, paddingMode, iv, encrypt)
         {
-            this.cipher = cipher ?? throw new ArgumentNullException(nameof(cipher));
-            this.encrypt = encrypt;
-            this.mode = BlockCipherModeFactory.Create(cipherMode, cipher, iv);
-            this.padding = PaddingFactory.Create(paddingMode);
-        }
-
-        /// <inheritdoc />
-        /// <remarks>
-        /// <para>
-        /// Returns <see langword="false" />. Each <see cref="BlowfishTransform" /> instance is intended for a single-use transform
-        /// lifetime. Create a new instance for each independent encryption or decryption operation.
-        /// </para>
-        /// </remarks>
-        public bool CanReuseTransform => false;
-
-        /// <inheritdoc />
-        public bool CanTransformMultipleBlocks => true;
-
-        /// <inheritdoc />
-        /// <value>The Blowfish block size in bytes (8).</value>
-        public int InputBlockSize => this.cipher.BlockSize;
-
-        /// <inheritdoc />
-        /// <value>The Blowfish block size in bytes (8).</value>
-        public int OutputBlockSize => this.cipher.BlockSize;
-
-        /// <summary>
-        /// Releases all resources used by the current instance of the <see cref="BlowfishTransform" /> class, including the underlying
-        /// cipher engine.
-        /// </summary>
-        public void Dispose()
-        {
-            if (this.disposed)
-                return;
-
-            if (this.deferredInput is not null)
-            {
-                CryptographicOperations.ZeroMemory(this.deferredInput);
-                this.deferredInput = null;
-            }
-
-            this.cipher.Dispose();
-            this.disposed = true;
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Transforms a block-aligned region of the input byte array and writes the result to the output buffer.
-        /// </summary>
-        /// <param name="inputBuffer">The input data buffer. Must not be <see langword="null" />.</param>
-        /// <param name="inputOffset">The byte offset within <paramref name="inputBuffer" /> at which to begin reading.</param>
-        /// <param name="inputCount">The number of bytes to process. Must be a multiple of <see cref="InputBlockSize" />.</param>
-        /// <param name="outputBuffer">The buffer to write transformed data into. Must not be <see langword="null" />.</param>
-        /// <param name="outputOffset">The byte offset within <paramref name="outputBuffer" /> at which to begin writing.</param>
-        /// <returns>The number of bytes written to <paramref name="outputBuffer" />.</returns>
-        /// <exception cref="ArgumentException">
-        /// The input or output buffer span is invalid or insufficient in length for the requested operation.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// When decrypting with a strippable padding mode (e.g., <see cref="PaddingMode.PKCS7" />), the last complete block of input is
-        /// deferred and not written to the output until <see cref="TransformFinalBlock" /> is called. This allows correct padding removal
-        /// at the boundary of the stream.
-        /// </para>
-        /// </remarks>
-        public int TransformBlock(
-            byte[] inputBuffer,
-            int inputOffset,
-            int inputCount,
-            byte[] outputBuffer,
-            int outputOffset)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-            ThrowHelper.ThrowIfNull(outputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-            Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                return this.mode.Transform(input, output, true);
-            }
-            else
-            {
-                // When decrypting, defer the last block to enable padding removal at finalization.
-                bool stripPadding = this.padding is Pkcs7Padding;
-
-                if (stripPadding && input.Length <= this.cipher.BlockSize)
-                {
-                    // Buffer this block; it may carry the padding.
-                    this.deferredInput = input.ToArray();
-                    return 0;
-                }
-
-                int bytesToProcess = input.Length;
-                if (stripPadding)
-                {
-                    // Retain the final block for deferred inspection.
-                    bytesToProcess -= this.cipher.BlockSize;
-                    this.deferredInput = input.Slice(bytesToProcess).ToArray();
-                }
-
-                return this.mode.Transform(input.Slice(0, bytesToProcess), output.Slice(0, bytesToProcess), false);
-            }
-        }
-
-        /// <summary>
-        /// Transforms the final block of data, applying or removing padding as appropriate, and returns the result.
-        /// </summary>
-        /// <param name="inputBuffer">The final input data buffer. Must not be <see langword="null" />.</param>
-        /// <param name="inputOffset">The byte offset within <paramref name="inputBuffer" /> at which to begin reading.</param>
-        /// <param name="inputCount">The number of bytes to process from <paramref name="inputBuffer" />.</param>
-        /// <returns>A new byte array containing the transformed and padded (or depadded) final block.</returns>
-        /// <exception cref="CryptographicException">
-        /// The padding is invalid or cannot be removed during decryption.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// When encrypting, padding is applied to the final block before transformation. When decrypting, any previously deferred block is
-        /// prepended to <paramref name="inputBuffer" />, the combined data is decrypted, and the padding is then stripped.
-        /// </para>
-        /// </remarks>
-        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                byte[] padded = this.padding.Pad(input, this.cipher.BlockSize);
-                byte[] output = new byte[padded.Length];
-                this.mode.Transform(padded, output, true);
-                return output;
-            }
-            else
-            {
-                byte[] combined = Combine(this.deferredInput, input);
-                byte[] decrypted = new byte[combined.Length];
-                this.mode.Transform(combined, decrypted, false);
-                return this.padding.Unpad(decrypted, this.cipher.BlockSize);
-            }
-        }
-
-        /// <summary>
-        /// Concatenates an optional deferred byte array with an incoming input span into a single contiguous byte array.
-        /// </summary>
-        /// <param name="first">The previously cached partial or complete block, or <see langword="null" /> if none was deferred.</param>
-        /// <param name="second">The newly arriving data to append.</param>
-        /// <returns>
-        /// A new byte array containing <paramref name="first" /> followed by <paramref name="second" />, or a copy of
-        /// <paramref name="second" /> alone if <paramref name="first" /> is <see langword="null" /> or empty.
-        /// </returns>
-        private static byte[] Combine(byte[]? first, ReadOnlySpan<byte> second)
-        {
-            if (first == null || first.Length == 0)
-                return second.ToArray();
-
-            byte[] result = new byte[first.Length + second.Length];
-            Buffer.BlockCopy(first, 0, result, 0, first.Length);
-            second.CopyTo(result.AsSpan(first.Length));
-            return result;
         }
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackTransform.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="SkipjackTransform.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -6,7 +6,6 @@
 
 namespace Bodu.Security.Cryptography
 {
-    using System;
     using System.Security.Cryptography;
 
     /// <summary>
@@ -14,26 +13,13 @@ namespace Bodu.Security.Cryptography
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This class integrates a <see cref="SkipjackBlockCipher" /> engine with an <see cref="IBlockCipherModeTransform" /> and an
-    /// <see cref="IPaddingStrategy" />. Block-aligned streaming data is processed via <see cref="TransformBlock" />, and the final
-    /// (potentially partial) block, including padding application or removal, is handled by <see cref="TransformFinalBlock" />.
-    /// </para>
-    /// <para>
     /// Instances of this class are returned by <see cref="Skipjack.CreateEncryptor(byte[], byte[])" /> and
     /// <see cref="Skipjack.CreateDecryptor(byte[], byte[])" />. Using this class directly is not recommended; prefer using
     /// <see cref="Skipjack" /> with a <see cref="CryptoStream" />, which handles padding and block alignment automatically.
     /// </para>
     /// </remarks>
-    public sealed class SkipjackTransform : ICryptoTransform
+    public sealed class SkipjackTransform : BlockCipherTransform
     {
-        private readonly IBlockCipher cipher;
-        private readonly bool encrypt;
-        private readonly IBlockCipherModeTransform mode;
-        private readonly IPaddingStrategy padding;
-        private byte[]? deferredInput;
-
-        private bool disposed;
-
         /// <summary>
         /// Initialises a new instance of the <see cref="SkipjackTransform" /> class using the specified cipher, mode, padding, and
         /// initialisation vector.
@@ -43,151 +29,10 @@ namespace Bodu.Security.Cryptography
         /// <param name="paddingMode">The padding scheme to apply to the final block.</param>
         /// <param name="iv">The initialisation vector for the cipher mode. Must match the cipher block size.</param>
         /// <param name="encrypt"><see langword="true" /> to configure for encryption; <see langword="false" /> for decryption.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
         public SkipjackTransform(IBlockCipher cipher, CipherBlockMode cipherMode, PaddingMode paddingMode, byte[] iv, bool encrypt)
+            : base(cipher, cipherMode, paddingMode, iv, encrypt)
         {
-            this.cipher = cipher ?? throw new ArgumentNullException(nameof(cipher));
-            this.encrypt = encrypt;
-            this.mode = BlockCipherModeFactory.Create(cipherMode, cipher, iv);
-            this.padding = PaddingFactory.Create(paddingMode);
-        }
-
-        /// <inheritdoc />
-        public bool CanReuseTransform => false;
-
-        /// <inheritdoc />
-        public bool CanTransformMultipleBlocks => true;
-
-        /// <inheritdoc />
-        public int InputBlockSize => this.cipher.BlockSize;
-
-        /// <inheritdoc />
-        public int OutputBlockSize => this.cipher.BlockSize;
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if (this.disposed)
-                return;
-
-            if (this.deferredInput is not null)
-            {
-                CryptographicOperations.ZeroMemory(this.deferredInput);
-                this.deferredInput = null;
-            }
-
-            this.cipher.Dispose();
-            this.disposed = true;
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Transforms a block-aligned region of the input byte array and writes the result to the output buffer.
-        /// </summary>
-        /// <param name="inputBuffer">The input data buffer. Must not be <see langword="null" />.</param>
-        /// <param name="inputOffset">The byte offset within <paramref name="inputBuffer" /> at which to begin reading.</param>
-        /// <param name="inputCount">The number of bytes to process. Must be a multiple of <see cref="InputBlockSize" />.</param>
-        /// <param name="outputBuffer">The buffer to write the transformed data into. Must not be <see langword="null" />.</param>
-        /// <param name="outputOffset">The byte offset within <paramref name="outputBuffer" /> at which to begin writing.</param>
-        /// <returns>The number of bytes written to <paramref name="outputBuffer" />.</returns>
-        /// <exception cref="ArgumentException">
-        /// The input or output buffer span is invalid or insufficient in length for the requested operation.
-        /// </exception>
-        /// <remarks>
-        /// When decrypting with a strippable padding mode (for example <see cref="PaddingMode.PKCS7" />), the last complete block of input
-        /// is deferred and not written to the output until <see cref="TransformFinalBlock" /> is called. This allows correct padding
-        /// removal at the end of the stream.
-        /// </remarks>
-        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount,
-                                  byte[] outputBuffer, int outputOffset)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-            ThrowHelper.ThrowIfNull(outputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-            Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                // ENCRYPTION: transform all blocks immediately
-                return this.mode.Transform(input, output, true);
-            }
-            else
-            {
-                // DECRYPTION: defer final block to allow padding validation
-                bool stripPadding = this.padding is Pkcs7Padding; // Extend with other depaddable schemes
-
-                if (stripPadding && input.Length <= this.cipher.BlockSize)
-                {
-                    // Buffer the last block until finalization
-                    this.deferredInput = input.ToArray();
-                    return 0;
-                }
-
-                int bytesToProcess = input.Length;
-                if (stripPadding)
-                {
-                    // Retain last block for padding removal later
-                    bytesToProcess -= this.cipher.BlockSize;
-                    this.deferredInput = input.Slice(bytesToProcess).ToArray();
-                }
-
-                return this.mode.Transform(input.Slice(0, bytesToProcess), output.Slice(0, bytesToProcess), false);
-            }
-        }
-
-        /// <inheritdoc />
-        /// <summary>
-        /// Transforms the final block of data, applying padding (or removing it, if decrypting).
-        /// </summary>
-        /// <param name="inputBuffer">The final portion of input data to transform.</param>
-        /// <param name="inputOffset">The byte offset in the input buffer to begin reading from.</param>
-        /// <param name="inputCount">The number of bytes to read from <paramref name="inputBuffer" />.</param>
-        /// <returns>A new array containing the transformed final block.</returns>
-        /// <exception cref="CryptographicException">Thrown if the padding is invalid during decryption.</exception>
-        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                byte[] padded = this.padding.Pad(input, this.cipher.BlockSize);
-                byte[] output = new byte[padded.Length];
-                this.mode.Transform(padded, output, true);
-                return output;
-            }
-            else
-            {
-                byte[] combined = Combine(this.deferredInput, input);
-                byte[] decrypted = new byte[combined.Length];
-                this.mode.Transform(combined, decrypted, false);
-                return this.padding.Unpad(decrypted, this.cipher.BlockSize);
-            }
-        }
-
-        /// <summary>
-        /// Combines a deferred block with a new input span to produce a single contiguous byte array.
-        /// </summary>
-        /// <param name="first">The previously cached partial block or <see langword="null" />.</param>
-        /// <param name="second">The incoming data to append.</param>
-        /// <returns>A new array containing the concatenated data.</returns>
-        private static byte[] Combine(byte[]? first, ReadOnlySpan<byte> second)
-        {
-            if (first == null || first.Length == 0)
-                return second.ToArray();
-
-            byte[] result = new byte[first.Length + second.Length];
-            Buffer.BlockCopy(first, 0, result, 0, first.Length);
-            second.CopyTo(result.AsSpan(first.Length));
-            return result;
         }
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackTransform.cs
@@ -1,4 +1,10 @@
-﻿namespace Bodu.Security.Cryptography
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkipjackTransform.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
 {
     using System;
     using System.Security.Cryptography;
@@ -25,6 +31,8 @@
         private readonly IBlockCipherModeTransform mode;
         private readonly IPaddingStrategy padding;
         private byte[]? deferredInput;
+
+        private bool disposed;
 
         /// <summary>
         /// Initialises a new instance of the <see cref="SkipjackTransform" /> class using the specified cipher, mode, padding, and
@@ -59,6 +67,9 @@
         /// <inheritdoc />
         public void Dispose()
         {
+            if (this.disposed)
+                return;
+
             if (this.deferredInput is not null)
             {
                 CryptographicOperations.ZeroMemory(this.deferredInput);
@@ -66,6 +77,7 @@
             }
 
             this.cipher.Dispose();
+            this.disposed = true;
             GC.SuppressFinalize(this);
         }
 
@@ -89,6 +101,12 @@
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount,
                                   byte[] outputBuffer, int outputOffset)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
+            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
+            ThrowHelper.ThrowIfNull(inputBuffer);
+            ThrowHelper.ThrowIfNull(outputBuffer);
+
             ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
             Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
 
@@ -132,6 +150,11 @@
         /// <exception cref="CryptographicException">Thrown if the padding is invalid during decryption.</exception>
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
+            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
+            ThrowHelper.ThrowIfNull(inputBuffer);
+
             ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
 
             if (this.encrypt)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishTransform.cs
@@ -38,6 +38,8 @@ namespace Bodu.Security.Cryptography
 
         private byte[]? deferredInput;
 
+        private bool disposed;
+
         /// <summary>
         /// Initialises a new instance of the <see cref="ThreefishTransform" /> class using the specified cipher, mode, padding, and
         /// initialisation vector.
@@ -71,6 +73,9 @@ namespace Bodu.Security.Cryptography
         /// <inheritdoc />
         public void Dispose()
         {
+            if (this.disposed)
+                return;
+
             if (this.deferredInput is not null)
             {
                 CryptographicOperations.ZeroMemory(this.deferredInput);
@@ -78,6 +83,7 @@ namespace Bodu.Security.Cryptography
             }
 
             this.cipher.Dispose();
+            this.disposed = true;
             GC.SuppressFinalize(this);
         }
 
@@ -95,6 +101,8 @@ namespace Bodu.Security.Cryptography
         public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount,
                                   byte[] outputBuffer, int outputOffset)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
             // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
             ThrowHelper.ThrowIfNull(inputBuffer);
             ThrowHelper.ThrowIfNull(outputBuffer);
@@ -142,6 +150,8 @@ namespace Bodu.Security.Cryptography
         /// <exception cref="CryptographicException">Thrown if the padding is invalid during decryption.</exception>
         public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
         {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+
             // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
             ThrowHelper.ThrowIfNull(inputBuffer);
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishTransform.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="ThreefishTransform.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -6,7 +6,6 @@
 
 namespace Bodu.Security.Cryptography
 {
-    using System;
     using System.Security.Cryptography;
 
     /// <summary>
@@ -15,31 +14,13 @@ namespace Bodu.Security.Cryptography
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This class integrates an <see cref="IBlockCipher" /> engine with an <see cref="IBlockCipherModeTransform" /> and an
-    /// <see cref="IPaddingStrategy" /> to implement the <see cref="ICryptoTransform" /> contract. Block-aligned streaming data is
-    /// processed via <see cref="TransformBlock" />, and the final (potentially partial) block — including padding application or
-    /// removal — is handled by <see cref="TransformFinalBlock" />.
-    /// </para>
-    /// <para>
     /// Instances of this class are returned by <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> and
     /// <see cref="Threefish.CreateDecryptor(byte[], byte[], byte[])" />. Using this class directly is not recommended; prefer using a
     /// concrete <see cref="Threefish" /> algorithm with a <see cref="CryptoStream" />.
     /// </para>
     /// </remarks>
-    public sealed class ThreefishTransform : ICryptoTransform
+    public sealed class ThreefishTransform : BlockCipherTransform
     {
-        private readonly IBlockCipher cipher;
-
-        private readonly bool encrypt;
-
-        private readonly IBlockCipherModeTransform mode;
-
-        private readonly IPaddingStrategy padding;
-
-        private byte[]? deferredInput;
-
-        private bool disposed;
-
         /// <summary>
         /// Initialises a new instance of the <see cref="ThreefishTransform" /> class using the specified cipher, mode, padding, and
         /// initialisation vector.
@@ -49,145 +30,10 @@ namespace Bodu.Security.Cryptography
         /// <param name="paddingMode">The padding scheme to apply to the final block.</param>
         /// <param name="iv">The initialisation vector for the cipher mode. Must match the cipher block size.</param>
         /// <param name="encrypt"><see langword="true" /> to configure for encryption; <see langword="false" /> for decryption.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
+        /// <exception cref="System.ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
         public ThreefishTransform(IBlockCipher cipher, CipherBlockMode cipherMode, PaddingMode paddingMode, byte[] iv, bool encrypt)
+            : base(cipher, cipherMode, paddingMode, iv, encrypt)
         {
-            this.cipher = cipher ?? throw new ArgumentNullException(nameof(cipher));
-            this.encrypt = encrypt;
-            this.mode = BlockCipherModeFactory.Create(cipherMode, cipher, iv);
-            this.padding = PaddingFactory.Create(paddingMode);
-        }
-
-        /// <inheritdoc />
-        public bool CanReuseTransform => false;
-
-        /// <inheritdoc />
-        public bool CanTransformMultipleBlocks => true;
-
-        /// <inheritdoc />
-        public int InputBlockSize => this.cipher.BlockSize;
-
-        /// <inheritdoc />
-        public int OutputBlockSize => this.cipher.BlockSize;
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-            if (this.disposed)
-                return;
-
-            if (this.deferredInput is not null)
-            {
-                CryptographicOperations.ZeroMemory(this.deferredInput);
-                this.deferredInput = null;
-            }
-
-            this.cipher.Dispose();
-            this.disposed = true;
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Transforms a block of bytes and writes the output to the specified buffer.
-        /// </summary>
-        /// <param name="inputBuffer">The input data buffer.</param>
-        /// <param name="inputOffset">The byte offset into <paramref name="inputBuffer" /> to begin reading from.</param>
-        /// <param name="inputCount">The number of bytes to read from <paramref name="inputBuffer" />.</param>
-        /// <param name="outputBuffer">The buffer to write the transformed data to.</param>
-        /// <param name="outputOffset">The byte offset into <paramref name="outputBuffer" /> to begin writing at.</param>
-        /// <returns>The number of bytes written to <paramref name="outputBuffer" />.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="inputBuffer" /> or <paramref name="outputBuffer" /> is <see langword="null" />.</exception>
-        /// <exception cref="ArgumentException">Thrown if the input or output spans are invalid or insufficient in length.</exception>
-        public int TransformBlock(byte[] inputBuffer, int inputOffset, int inputCount,
-                                  byte[] outputBuffer, int outputOffset)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-            ThrowHelper.ThrowIfNull(outputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-            Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                // ENCRYPTION: transform all blocks immediately
-                return this.mode.Transform(input, output, true);
-            }
-            else
-            {
-                // DECRYPTION: defer final block to allow padding validation
-                bool stripPadding = this.padding is Pkcs7Padding; // Extend with other depaddable schemes
-
-                if (stripPadding && input.Length <= this.cipher.BlockSize)
-                {
-                    // Buffer the last block until finalization
-                    this.deferredInput = input.ToArray();
-                    return 0;
-                }
-
-                int bytesToProcess = input.Length;
-                if (stripPadding)
-                {
-                    // Retain last block for padding removal later
-                    bytesToProcess -= this.cipher.BlockSize;
-                    this.deferredInput = input.Slice(bytesToProcess).ToArray();
-                }
-
-                return this.mode.Transform(input.Slice(0, bytesToProcess), output.Slice(0, bytesToProcess), false);
-            }
-        }
-
-        /// <summary>
-        /// Transforms the final block of data, applying padding (or removing it, if decrypting).
-        /// </summary>
-        /// <param name="inputBuffer">The final portion of input data to transform.</param>
-        /// <param name="inputOffset">The byte offset in the input buffer to begin reading from.</param>
-        /// <param name="inputCount">The number of bytes to read from <paramref name="inputBuffer" />.</param>
-        /// <returns>A new array containing the transformed final block.</returns>
-        /// <exception cref="ArgumentNullException"><paramref name="inputBuffer" /> is <see langword="null" />.</exception>
-        /// <exception cref="CryptographicException">Thrown if the padding is invalid during decryption.</exception>
-        public byte[] TransformFinalBlock(byte[] inputBuffer, int inputOffset, int inputCount)
-        {
-            ObjectDisposedException.ThrowIf(this.disposed, this);
-
-            // Fix: enforce ICryptoTransform null-argument contract (previously threw NullReferenceException via .AsSpan).
-            ThrowHelper.ThrowIfNull(inputBuffer);
-
-            ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-
-            if (this.encrypt)
-            {
-                byte[] padded = this.padding.Pad(input, this.cipher.BlockSize);
-                byte[] output = new byte[padded.Length];
-                this.mode.Transform(padded, output, true);
-                return output;
-            }
-            else
-            {
-                byte[] combined = Combine(this.deferredInput, input);
-                byte[] decrypted = new byte[combined.Length];
-                this.mode.Transform(combined, decrypted, false);
-                return this.padding.Unpad(decrypted, this.cipher.BlockSize);
-            }
-        }
-
-        /// <summary>
-        /// Combines a deferred block with a new input span to produce a single contiguous byte array.
-        /// </summary>
-        /// <param name="first">The previously cached partial block or <see langword="null" />.</param>
-        /// <param name="second">The incoming data to append.</param>
-        /// <returns>A new array containing the concatenated data.</returns>
-        private static byte[] Combine(byte[]? first, ReadOnlySpan<byte> second)
-        {
-            if (first == null || first.Length == 0)
-                return second.ToArray();
-
-            byte[] result = new byte[first.Length + second.Length];
-            Buffer.BlockCopy(first, 0, result, 0, first.Length);
-            second.CopyTo(result.AsSpan(first.Length));
-            return result;
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.TransformBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.TransformBlock.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTransformTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography
+{
+    public abstract partial class BlockCipherTransformTests<TCryptoTransform>
+    {
+        /// <summary>
+        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
+        /// </summary>
+        [TestMethod]
+        public void TransformBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
+        {
+            using var transform = this.CreateTransform();
+            byte[] output = new byte[transform.OutputBlockSize];
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformBlock(null!, 0, 0, output, 0);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>outputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
+        /// </summary>
+        [TestMethod]
+        public void TransformBlock_WhenOutputBufferIsNull_ShouldThrowArgumentNullException_fix()
+        {
+            using var transform = this.CreateTransform();
+            byte[] input = new byte[transform.InputBlockSize];
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformBlock(input, 0, input.Length, null!, 0);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="BlockCipherTransform.InputBlockSize" /> is greater than zero.
+        /// </summary>
+        [TestMethod]
+        public void InputBlockSize_ShouldBeGreaterThanZero()
+        {
+            using var transform = this.CreateTransform();
+            Assert.IsTrue(transform.InputBlockSize > 0);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="BlockCipherTransform.InputBlockSize" /> equals
+        /// <see cref="BlockCipherTransform.OutputBlockSize" />.
+        /// </summary>
+        [TestMethod]
+        public void InputBlockSize_ShouldEqualOutputBlockSize()
+        {
+            using var transform = this.CreateTransform();
+            Assert.AreEqual(transform.InputBlockSize, transform.OutputBlockSize);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="BlockCipherTransform.CanReuseTransform" /> returns <see langword="false" />.
+        /// </summary>
+        [TestMethod]
+        public void CanReuseTransform_ShouldReturnFalse()
+        {
+            using var transform = this.CreateTransform();
+            Assert.IsFalse(transform.CanReuseTransform);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="BlockCipherTransform.CanTransformMultipleBlocks" /> returns <see langword="true" />.
+        /// </summary>
+        [TestMethod]
+        public void CanTransformMultipleBlocks_ShouldReturnTrue()
+        {
+            using var transform = this.CreateTransform();
+            Assert.IsTrue(transform.CanTransformMultipleBlocks);
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.TransformFinalBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.TransformFinalBlock.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTransformTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography
+{
+    public abstract partial class BlockCipherTransformTests<TCryptoTransform>
+    {
+        /// <summary>
+        /// Verifies that <see cref="ICryptoTransform.TransformFinalBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
+        /// </summary>
+        [TestMethod]
+        public void TransformFinalBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
+        {
+            using var transform = this.CreateTransform();
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformFinalBlock(null!, 0, 0);
+            });
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.cs
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTransformTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    /// <summary>
+    /// Base class for testing <see cref="BlockCipherTransform" /> implementations. Extends
+    /// <see cref="CryptoTransformTests{TCryptoTransform}" /> with tests specific to block cipher transforms,
+    /// including null-argument validation and property invariants.
+    /// </summary>
+    /// <typeparam name="TCryptoTransform">The concrete block cipher transform type under test.</typeparam>
+    public abstract partial class BlockCipherTransformTests<TCryptoTransform>
+        : CryptoTransformTests<TCryptoTransform>
+        where TCryptoTransform : BlockCipherTransform
+    {
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTransformTests.cs
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------------------------------------------
-// <copyright file="ThreefishTransformTests.cs" company="PlaceholderCompany">
+// <copyright file="BlowfishTransformTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
@@ -8,20 +8,19 @@ namespace Bodu.Security.Cryptography
 {
     /// <summary>
     /// Concrete test class that exercises the <see cref="CryptoTransformTests{TCryptoTransform}" /> base tests
-    /// against the <see cref="ThreefishTransform" /> implementation.
+    /// against the <see cref="BlowfishTransform" /> implementation.
     /// </summary>
     [TestClass]
-    public sealed class ThreefishTransformTests
-        : CryptoTransformTests<ThreefishTransform>
+    public sealed class BlowfishTransformTests
+        : CryptoTransformTests<BlowfishTransform>
     {
         /// <inheritdoc />
-        protected override ThreefishTransform CreateTransform()
+        protected override BlowfishTransform CreateTransform()
         {
-            var algorithm = new Threefish256();
+            var algorithm = new Blowfish();
             algorithm.GenerateKey();
             algorithm.GenerateIV();
-            algorithm.GenerateTweak();
-            return (ThreefishTransform)algorithm.CreateEncryptor(algorithm.Key, algorithm.IV, algorithm.Tweak);
+            return (BlowfishTransform)algorithm.CreateEncryptor(algorithm.Key, algorithm.IV);
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTransformTests.cs
@@ -7,12 +7,12 @@
 namespace Bodu.Security.Cryptography
 {
     /// <summary>
-    /// Concrete test class that exercises the <see cref="CryptoTransformTests{TCryptoTransform}" /> base tests
+    /// Concrete test class that exercises the <see cref="BlockCipherTransformTests{TCryptoTransform}" /> base tests
     /// against the <see cref="BlowfishTransform" /> implementation.
     /// </summary>
     [TestClass]
     public sealed class BlowfishTransformTests
-        : CryptoTransformTests<BlowfishTransform>
+        : BlockCipherTransformTests<BlowfishTransform>
     {
         /// <inheritdoc />
         protected override BlowfishTransform CreateTransform()

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformBlock.cs
@@ -1,28 +1,64 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="CryptoTransformTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using Bodu.Security.Cryptography;
 using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography
 {
-    public abstract partial class CryptoTransformTests<TAlgorithm>
+    public abstract partial class CryptoTransformTests<TCryptoTransform>
     {
         /// <summary>
         /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws an <see cref="ObjectDisposedException" /> after the
-        /// algorithm is disposed.
+        /// transform is disposed.
         /// </summary>
         [TestMethod]
         public void TransformBlock_WhenDisposed_ShouldThrowExactly()
         {
-            using var algorithm = this.CreateAlgorithm();
-            algorithm.Dispose();
+            using var transform = this.CreateTransform();
+            transform.Dispose();
+
+            byte[] buffer = new byte[transform.InputBlockSize];
+
             Assert.ThrowsExactly<ObjectDisposedException>(() =>
             {
-                algorithm.TransformBlock(Array.Empty<byte>(), 0, 0, null, 0);
+                transform.TransformBlock(buffer, 0, buffer.Length, buffer, 0);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
+        /// </summary>
+        [TestMethod]
+        public void TransformBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
+        {
+            using var transform = this.CreateTransform();
+            byte[] output = new byte[transform.OutputBlockSize];
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformBlock(null!, 0, 0, output, 0);
+            });
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>outputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
+        /// </summary>
+        [TestMethod]
+        public void TransformBlock_WhenOutputBufferIsNull_ShouldThrowArgumentNullException_fix()
+        {
+            using var transform = this.CreateTransform();
+            byte[] input = new byte[transform.InputBlockSize];
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformBlock(input, 0, input.Length, null!, 0);
             });
         }
     }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformBlock.cs
@@ -27,39 +27,5 @@ namespace Bodu.Security.Cryptography
                 transform.TransformBlock(buffer, 0, buffer.Length, buffer, 0);
             });
         }
-
-        /// <summary>
-        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
-        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
-        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
-        /// </summary>
-        [TestMethod]
-        public void TransformBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
-        {
-            using var transform = this.CreateTransform();
-            byte[] output = new byte[transform.OutputBlockSize];
-
-            Assert.ThrowsExactly<ArgumentNullException>(() =>
-            {
-                _ = transform.TransformBlock(null!, 0, 0, output, 0);
-            });
-        }
-
-        /// <summary>
-        /// Verifies that <see cref="ICryptoTransform.TransformBlock" /> throws
-        /// <see cref="ArgumentNullException" /> when <c>outputBuffer</c> is <see langword="null" />.
-        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
-        /// </summary>
-        [TestMethod]
-        public void TransformBlock_WhenOutputBufferIsNull_ShouldThrowArgumentNullException_fix()
-        {
-            using var transform = this.CreateTransform();
-            byte[] input = new byte[transform.InputBlockSize];
-
-            Assert.ThrowsExactly<ArgumentNullException>(() =>
-            {
-                _ = transform.TransformBlock(input, 0, input.Length, null!, 0);
-            });
-        }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformFinalBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformFinalBlock.cs
@@ -1,42 +1,45 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="CryptoTransformTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using Bodu.Security.Cryptography;
 using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography
 {
-    public abstract partial class CryptoTransformTests<TAlgorithm>
+    public abstract partial class CryptoTransformTests<TCryptoTransform>
     {
         /// <summary>
         /// Verifies that <see cref="ICryptoTransform.TransformFinalBlock" /> throws an <see cref="ObjectDisposedException" /> after the
-        /// algorithm has been disposed.
+        /// transform has been disposed.
         /// </summary>
         [TestMethod]
         public void TransformFinalBlock_WhenDisposed_ShouldThrowExactly()
         {
-            using var algorithm = this.CreateAlgorithm();
-            algorithm.Dispose();
+            using var transform = this.CreateTransform();
+            transform.Dispose();
 
             Assert.ThrowsExactly<ObjectDisposedException>(() =>
             {
-                algorithm.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
+                transform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             });
         }
 
         /// <summary>
-        /// Verifies that <see cref="ICryptoTransform.TransformFinalBlock" /> returns the input unchanged when passed a valid byte array.
+        /// Verifies that <see cref="ICryptoTransform.TransformFinalBlock" /> throws
+        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
+        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
         /// </summary>
         [TestMethod]
-        public void TransformFinalBlock_WhenCalledWithValidInput_ShouldReturnInputUnchanged()
+        public void TransformFinalBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
         {
-            byte[] input = CryptoTestUtilities.ByteSequence256;
-            using var algorithm = this.CreateAlgorithm();
-            byte[] result = algorithm.TransformFinalBlock(input, 0, input.Length);
-            CollectionAssert.AreEqual(input, result);
+            using var transform = this.CreateTransform();
+
+            Assert.ThrowsExactly<ArgumentNullException>(() =>
+            {
+                _ = transform.TransformFinalBlock(null!, 0, 0);
+            });
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformFinalBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.TransformFinalBlock.cs
@@ -25,21 +25,5 @@ namespace Bodu.Security.Cryptography
                 transform.TransformFinalBlock(Array.Empty<byte>(), 0, 0);
             });
         }
-
-        /// <summary>
-        /// Verifies that <see cref="ICryptoTransform.TransformFinalBlock" /> throws
-        /// <see cref="ArgumentNullException" /> when <c>inputBuffer</c> is <see langword="null" />.
-        /// Regression guard for transforms that previously threw <see cref="NullReferenceException" /> via <c>.AsSpan</c>.
-        /// </summary>
-        [TestMethod]
-        public void TransformFinalBlock_WhenInputBufferIsNull_ShouldThrowArgumentNullException_fix()
-        {
-            using var transform = this.CreateTransform();
-
-            Assert.ThrowsExactly<ArgumentNullException>(() =>
-            {
-                _ = transform.TransformFinalBlock(null!, 0, 0);
-            });
-        }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoTransformTests.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="CryptoTransformTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -7,40 +7,18 @@
 namespace Bodu.Security.Cryptography
 {
     /// <summary>
-    /// Base class for testing types implementing <see cref="ICryptoTransform" />.
+    /// Base class for testing types implementing <see cref="System.Security.Cryptography.ICryptoTransform" />.
     /// </summary>
-    /// <typeparam name="TAlgorithm">The crypto transform type under test.</typeparam>
-    public abstract partial class CryptoTransformTests<TAlgorithm>
-        where TAlgorithm : System.Security.Cryptography.ICryptoTransform
+    /// <typeparam name="TCryptoTransform">The crypto transform type under test.</typeparam>
+    public abstract partial class CryptoTransformTests<TCryptoTransform>
+        where TCryptoTransform : System.Security.Cryptography.ICryptoTransform
     {
         /// <summary>
-        /// Creates a new instance of the cryptographic hash algorithm under test.
+        /// Creates a new instance of the cryptographic transform under test.
         /// </summary>
         /// <returns>
-        /// A newly constructed and fully initialized instance of <typeparamref name="TAlgorithm" />, ready for use in hash test scenarios.
+        /// A newly constructed and fully initialised instance of <typeparamref name="TCryptoTransform" />, ready for use in test scenarios.
         /// </returns>
-        /// <remarks>
-        /// <para>
-        /// This method is used as the factory method for producing clean instances of the algorithm under test. Implementations may
-        /// configure the instance with default settings, keys, or parameters as appropriate for the test context.
-        /// </para>
-        /// </remarks>
-        protected abstract TAlgorithm CreateAlgorithm();
-
-        /// <summary>
-        /// Gets the expected hash result when computing the hash of an empty byte array using the default algorithm variant.
-        /// </summary>
-        /// <value>A non-null <see cref="byte" /> array containing the expected hash value for an empty input.</value>
-        /// <exception cref="KeyNotFoundException">
-        /// Thrown if the expected hash for the "Empty" input is not defined in the test vector data for the default variant.
-        /// </exception>
-        /// <remarks>
-        /// <para>
-        /// This property is used in unit tests to validate that the algorithm produces the correct and consistent result when hashing an
-        /// empty input sequence. The value must match the reference hash from an authoritative source (e.g., test vectors from RFCs or
-        /// specification suites).
-        /// </para>
-        /// </remarks>
-        protected abstract byte[] ExpectedEmptyInputHash { get; }
+        protected abstract TCryptoTransform CreateTransform();
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackTransformTests.cs
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------------------------------------------
-// <copyright file="ThreefishTransformTests.cs" company="PlaceholderCompany">
+// <copyright file="SkipjackTransformTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
@@ -8,20 +8,19 @@ namespace Bodu.Security.Cryptography
 {
     /// <summary>
     /// Concrete test class that exercises the <see cref="CryptoTransformTests{TCryptoTransform}" /> base tests
-    /// against the <see cref="ThreefishTransform" /> implementation.
+    /// against the <see cref="SkipjackTransform" /> implementation.
     /// </summary>
     [TestClass]
-    public sealed class ThreefishTransformTests
-        : CryptoTransformTests<ThreefishTransform>
+    public sealed class SkipjackTransformTests
+        : CryptoTransformTests<SkipjackTransform>
     {
         /// <inheritdoc />
-        protected override ThreefishTransform CreateTransform()
+        protected override SkipjackTransform CreateTransform()
         {
-            var algorithm = new Threefish256();
+            var algorithm = new Skipjack();
             algorithm.GenerateKey();
             algorithm.GenerateIV();
-            algorithm.GenerateTweak();
-            return (ThreefishTransform)algorithm.CreateEncryptor(algorithm.Key, algorithm.IV, algorithm.Tweak);
+            return (SkipjackTransform)algorithm.CreateEncryptor(algorithm.Key, algorithm.IV);
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackTransformTests.cs
@@ -7,12 +7,12 @@
 namespace Bodu.Security.Cryptography
 {
     /// <summary>
-    /// Concrete test class that exercises the <see cref="CryptoTransformTests{TCryptoTransform}" /> base tests
+    /// Concrete test class that exercises the <see cref="BlockCipherTransformTests{TCryptoTransform}" /> base tests
     /// against the <see cref="SkipjackTransform" /> implementation.
     /// </summary>
     [TestClass]
     public sealed class SkipjackTransformTests
-        : CryptoTransformTests<SkipjackTransform>
+        : BlockCipherTransformTests<SkipjackTransform>
     {
         /// <inheritdoc />
         protected override SkipjackTransform CreateTransform()

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishTransformTests.cs
@@ -7,12 +7,12 @@
 namespace Bodu.Security.Cryptography
 {
     /// <summary>
-    /// Concrete test class that exercises the <see cref="CryptoTransformTests{TCryptoTransform}" /> base tests
+    /// Concrete test class that exercises the <see cref="BlockCipherTransformTests{TCryptoTransform}" /> base tests
     /// against the <see cref="ThreefishTransform" /> implementation.
     /// </summary>
     [TestClass]
     public sealed class ThreefishTransformTests
-        : CryptoTransformTests<ThreefishTransform>
+        : BlockCipherTransformTests<ThreefishTransform>
     {
         /// <inheritdoc />
         protected override ThreefishTransform CreateTransform()


### PR DESCRIPTION
## Summary

- **Threefish.Validate** — add null-argument guards (`ThrowHelper.ThrowIfNull`) and normalise IV length failure to `CryptographicException` (was `ArgumentException`, inconsistent with key/tweak branches and Skipjack)
- **SipHash.OnKeyChanged** — switch key reads from host-endian `BitConverter.ToUInt64` to `BinaryPrimitives.ReadUInt64LittleEndian`, matching the SipHash specification and the existing `ProcessBlock` loader
- **BlockCipherTransform** — extract common `TransformBlock`/`TransformFinalBlock`/`Dispose` logic from `ThreefishTransform`, `SkipjackTransform`, and `BlowfishTransform` into a shared abstract base class; add `ObjectDisposedException` tracking and `ThrowHelper.ThrowIfNull` guards to all three transforms
- **CryptoTransformTests** — rename `TAlgorithm` → `TCryptoTransform`, remove hash-specific members; introduce `BlockCipherTransformTests<T>` middle layer with null-arg `_fix` regression tests and property invariant assertions; create concrete `ThreefishTransformTests`, `SkipjackTransformTests`, `BlowfishTransformTests`
- Add `_fix`-suffixed regression tests to `SymmetricAlgorithmTests`, `TweakableSymmetricAlgorithmTests`, and `KeyedBlockHashAlgorithmTests` base partials
- Add missing file-header banners on `Threefish.cs`, `ThreefishTransform.cs`, `SkipjackTransform.cs`

## Test plan

- [ ] `dotnet build Bodu.sln` compiles without errors or new warnings
- [ ] `dotnet test Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj --settings test.runsettings` — all existing and new `_fix` tests pass
- [ ] Verify `ThreefishTransformTests`, `SkipjackTransformTests`, `BlowfishTransformTests` each inherit 9 tests (2 disposal + 7 block-cipher)
- [ ] Verify null-argument tests for `CreateEncryptor`/`CreateDecryptor` run for Skipjack and SimpleReversingTweakableSymmetricAlgorithm

https://claude.ai/code/session_01UU5w91mXCMhznY3zzryMiM