### PR TITLE
Add test parity between CircularBuffer and ConcurrentCircularBuffer

### DIFF
--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -226,6 +226,9 @@ public sealed partial class ConcurrentCircularBuffer<T>
     /// producers after this point are not removed. This bounding prevents an indefinite loop when <see cref="AllowOverwrite"/> is
     /// <see langword="true"/> and producers are continuously enqueueing.
     /// </para>
+    /// <para>
+    /// The <see cref="ItemEvicted"/> event is not raised by this operation, as clearing the buffer is not considered an eviction.
+    /// </para>
     /// </remarks>
     public void Clear()
     {

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Clear.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Clear.cs
@@ -407,5 +407,51 @@ namespace Bodu.Collections.Generic.Concurrent
             Assert.IsTrue(peekEmptyCount >= 0);
             Assert.IsTrue(indexerRaceCount >= 0);
         }
+
+    /// <summary>
+    /// Verifies that enqueuing items after clearing a previously full buffer behaves correctly
+    /// and maintains FIFO order.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenBufferWasFullAndNewItemsEnqueued_ShouldMaintainFifoOrder()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3, allowOverwrite: true);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+        buffer.Enqueue(3);
+
+        Assert.AreEqual(3, buffer.Count);
+        buffer.Clear();
+        Assert.AreEqual(0, buffer.Count);
+
+        buffer.Enqueue(10);
+        buffer.Enqueue(20);
+        buffer.Enqueue(30);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, buffer.ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that draining all items via TryDequeue and then refilling the buffer preserves
+    /// FIFO order across the cycle.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenDrainedViaTryDequeueAndRefilled_ShouldPreserveFifoOrder()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+        buffer.Enqueue(3);
+
+        buffer.TryDequeue(out _);
+        buffer.TryDequeue(out _);
+        buffer.TryDequeue(out _);
+
+        Assert.AreEqual(0, buffer.Count);
+
+        buffer.Enqueue(10);
+        buffer.Enqueue(20);
+
+        CollectionAssert.AreEqual(new[] { 10, 20 }, buffer.ToArray());
     }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Contains.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Contains.cs
@@ -287,4 +287,19 @@ public partial class ConcurrentCircularBufferTests
         Assert.IsTrue(buffer.Contains(d));
         Assert.IsFalse(buffer.Contains(a)); // was dequeued
     }
+
+    /// <summary>
+    /// Verifies that Contains uses the default equality comparer for value types.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenUsingValueTypes_ShouldUseDefaultEquality()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(5);
+        buffer.Enqueue(10);
+        buffer.Enqueue(20);
+        buffer.Enqueue(30);
+
+        Assert.IsTrue(buffer.Contains(20));
+        Assert.IsFalse(buffer.Contains(99));
+    }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Ctor.cs
@@ -224,4 +224,30 @@ public partial class ConcurrentCircularBufferTests
         CollectionAssert.AreEqual(new[] { 6, 7, 8, 9, 10 }, buffer.ToArray().Select(x => x.Value).ToArray());
         Assert.AreEqual(0, evicted);
     }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="ConcurrentCircularBuffer{T}"/> with an empty collection and a negative
+    /// capacity throws <see cref="ArgumentOutOfRangeException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenEmptyCollectionAndInvalidCapacity_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new ConcurrentCircularBuffer<int>(Array.Empty<int>(), -1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="ConcurrentCircularBuffer{T}"/> with an empty collection and a valid capacity
+    /// creates an empty buffer with the specified capacity.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenEmptyCollectionAndValidCapacity_ShouldCreateEmptyBuffer()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(Array.Empty<int>(), 5);
+
+        Assert.AreEqual(0, buffer.Count);
+        Assert.AreEqual(5, buffer.Capacity);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.StructureOf.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.StructureOf.cs
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.Enumerator.StructureOf.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that the ConcurrentCircularBuffer enumerator is defined as a value type (struct).
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Structural")]
+    public void StructureOf_ConcurrentCircularBufferEnumerator_ShouldBeStructType()
+    {
+        var enumeratorType = typeof(ConcurrentCircularBuffer<int>.Enumerator);
+        Assert.IsTrue(enumeratorType.IsValueType, "Enumerator must be a value type (struct).");
+    }
+
+    /// <summary>
+    /// Verifies that all public instance properties of the ConcurrentCircularBuffer enumerator are
+    /// immutable, meaning none expose a public setter.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Structural")]
+    public void StructureOf_ConcurrentCircularBufferEnumerator_ShouldExposeOnlyImmutablePublicProperties()
+    {
+        var enumeratorType = typeof(ConcurrentCircularBuffer<int>.Enumerator);
+
+        var mutableProperties = enumeratorType
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(p => p.SetMethod != null && p.SetMethod.IsPublic)
+            .ToList();
+
+        Assert.AreEqual(0, mutableProperties.Count,
+            $"Enumerator exposes mutable public properties: {string.Join(", ", mutableProperties.Select(p => p.Name))}");
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.cs
@@ -133,4 +133,67 @@ public partial class ConcurrentCircularBufferTests
         var result = buffer.ToArray().Select(x => x.Value).ToArray();
         CollectionAssert.AreEqual(new[] { 2, 3, 4 }, result);
     }
+
+    /// <summary>
+    /// Verifies that accessing <see cref="ConcurrentCircularBuffer{T}.Enumerator.Current"/> before the first call to
+    /// <see cref="ConcurrentCircularBuffer{T}.Enumerator.MoveNext"/> returns the default value for the element type.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenCurrentAccessedBeforeMoveNext_ShouldReturnDefault()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(10);
+        buffer.Enqueue(20);
+
+        var enumerator = buffer.GetEnumerator();
+        Assert.AreEqual(default(int), enumerator.Current);
+    }
+
+    /// <summary>
+    /// Verifies that accessing <see cref="ConcurrentCircularBuffer{T}.Enumerator.Current"/> after the enumerator has been
+    /// fully exhausted returns the default value for the element type.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenCurrentAccessedAfterExhaustion_ShouldReturnDefault()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+        buffer.Enqueue(3);
+
+        var enumerator = buffer.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+            // Consume all items.
+        }
+
+        Assert.AreEqual(default(int), enumerator.Current);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="ConcurrentCircularBuffer{T}.Enumerator.Reset"/> after full enumeration allows the
+    /// enumerator to iterate over the same snapshot again, yielding identical items in the same order.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetCalled_ShouldRestartIteration()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(4);
+        buffer.Enqueue(100);
+        buffer.Enqueue(200);
+        buffer.Enqueue(300);
+
+        var enumerator = buffer.GetEnumerator();
+
+        var firstPass = new List<int>();
+        while (enumerator.MoveNext())
+            firstPass.Add(enumerator.Current);
+
+        enumerator.Reset();
+
+        var secondPass = new List<int>();
+        while (enumerator.MoveNext())
+            secondPass.Add(enumerator.Current);
+
+        CollectionAssert.AreEqual(firstPass, secondPass);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Equals.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Equals.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.Equals.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that Equals returns <see langword="true"/> when comparing the buffer instance with itself.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparingSameReference_ShouldReturnTrue()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+
+        Assert.IsTrue(buffer.Equals(buffer));
+    }
+
+    /// <summary>
+    /// Verifies that Equals returns <see langword="false"/> when comparing the buffer with <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparingWithNull_ShouldReturnFalse()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(1);
+
+        Assert.IsFalse(buffer.Equals(null));
+    }
+
+    /// <summary>
+    /// Verifies that Equals returns <see langword="false"/> when comparing the buffer with an object of a different type.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparingDifferentType_ShouldReturnFalse()
+    {
+        var buffer = new ConcurrentCircularBuffer<string>(2);
+        buffer.Enqueue("A");
+
+        Assert.IsFalse(buffer.Equals("not a buffer"));
+    }
+
+    /// <summary>
+    /// Verifies that Equals returns <see langword="false"/> when comparing two distinct buffer instances,
+    /// even if they contain the same elements, because default reference equality is used.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparingTwoDistinctInstancesWithSameContents_ShouldReturnFalse()
+    {
+        var buffer1 = new ConcurrentCircularBuffer<string>(3);
+        var buffer2 = new ConcurrentCircularBuffer<string>(3);
+
+        buffer1.Enqueue("A");
+        buffer2.Enqueue("A");
+
+        Assert.IsFalse(buffer1.Equals(buffer2));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.GetHashCode.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.GetHashCode.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.GetHashCode.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that GetHashCode returns a stable value when called multiple times on the same instance.
+    /// </summary>
+    [TestMethod]
+    public void GetHashCode_WhenCalledMultipleTimes_ShouldReturnStableValue()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(2);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+
+        int hash1 = buffer.GetHashCode();
+        int hash2 = buffer.GetHashCode();
+
+        Assert.AreEqual(hash1, hash2);
+    }
+
+    /// <summary>
+    /// Verifies that GetHashCode returns different values for two distinct instances, as expected
+    /// from reference-based hash code semantics.
+    /// </summary>
+    [TestMethod]
+    public void GetHashCode_WhenCalledOnDistinctInstances_ShouldLikelyDiffer()
+    {
+        var buffer1 = new ConcurrentCircularBuffer<int>(2);
+        var buffer2 = new ConcurrentCircularBuffer<int>(2);
+
+        buffer1.Enqueue(1);
+        buffer2.Enqueue(1);
+
+        Assert.AreNotEqual(buffer1.GetHashCode(), buffer2.GetHashCode(),
+            "Hash codes matched but should ideally differ for different instances.");
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.IEnumerable.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.IEnumerable.cs
@@ -117,4 +117,46 @@ public partial class ConcurrentCircularBufferTests
         var values = buffer.Select(x => x?.Value).ToArray();
         CollectionAssert.AreEqual(new[] { 1, 2, 3 }, values);
     }
+
+    /// <summary>
+    /// Verifies that the enumerator output from <see cref="Enumerable.ToArray{TSource}"/> matches the output from
+    /// <see cref="ConcurrentCircularBuffer{T}.CopyTo"/> when the buffer is in a contiguous (non-wrapped) state.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenContiguous_ShouldMatchCopyToOutput()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(5);
+        buffer.Enqueue(10);
+        buffer.Enqueue(20);
+        buffer.Enqueue(30);
+
+        int[] fromToArray = buffer.ToArray();
+
+        int[] fromCopyTo = new int[buffer.Count];
+        buffer.CopyTo(fromCopyTo, 0);
+
+        CollectionAssert.AreEqual(fromToArray, fromCopyTo);
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator output from <see cref="Enumerable.ToArray{TSource}"/> matches the output from
+    /// <see cref="ConcurrentCircularBuffer{T}.CopyTo"/> when the internal buffer has wrapped around.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenWrapped_ShouldMatchCopyToOutput()
+    {
+        var buffer = new ConcurrentCircularBuffer<int>(3);
+        buffer.Enqueue(1);
+        buffer.Enqueue(2);
+        buffer.Enqueue(3);
+        buffer.Dequeue();       // removes 1
+        buffer.Enqueue(4);      // wraps: logical order is [2, 3, 4]
+
+        int[] fromToArray = buffer.ToArray();
+
+        int[] fromCopyTo = new int[buffer.Count];
+        buffer.CopyTo(fromCopyTo, 0);
+
+        CollectionAssert.AreEqual(fromToArray, fromCopyTo);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.Clear.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.Clear.cs
@@ -150,5 +150,97 @@ namespace Bodu.Collections.Generic
             Assert.AreEqual(0, buffer.Count);
             CollectionAssert.AreEqual(Array.Empty<int>(), buffer.ToArray());
         }
+
+        /// <summary>
+        /// Verifies that clearing a full buffer does not raise any eviction events.
+        /// </summary>
+        [TestMethod]
+        public void Clear_WhenBufferFull_ShouldNotRaiseEvictionEvents()
+        {
+            int evictingCount = 0;
+            int evictedCount = 0;
+
+            var buffer = new CircularBuffer<int>(3, allowOverwrite: true);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3);
+
+            buffer.ItemEvicting += _ => evictingCount++;
+            buffer.ItemEvicted += _ => evictedCount++;
+
+            buffer.Clear();
+
+            Assert.AreEqual(0, evictingCount);
+            Assert.AreEqual(0, evictedCount);
+        }
+
+        /// <summary>
+        /// Verifies that clearing and immediately reusing the buffer preserves its capacity and maintains
+        /// correct FIFO ordering for subsequently enqueued items.
+        /// </summary>
+        [TestMethod]
+        public void Clear_WhenCalledAndImmediatelyReused_ShouldPreserveCapacityAndMaintainFifoOrder()
+        {
+            var buffer = new CircularBuffer<int>(3);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3);
+
+            buffer.Clear();
+
+            buffer.Enqueue(10);
+            buffer.Enqueue(20);
+
+            Assert.AreEqual(3, buffer.Capacity);
+            Assert.AreEqual(2, buffer.Count);
+            CollectionAssert.AreEqual(new[] { 10, 20 }, buffer.ToArray());
+        }
+
+        /// <summary>
+        /// Verifies that enqueuing items after clearing a previously full buffer behaves correctly
+        /// and maintains FIFO order.
+        /// </summary>
+        [TestMethod]
+        public void Clear_WhenBufferWasFullAndNewItemsEnqueued_ShouldMaintainFifoOrder()
+        {
+            var buffer = new CircularBuffer<int>(3, allowOverwrite: true);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3);
+
+            Assert.AreEqual(3, buffer.Count);
+            buffer.Clear();
+            Assert.AreEqual(0, buffer.Count);
+
+            buffer.Enqueue(10);
+            buffer.Enqueue(20);
+            buffer.Enqueue(30);
+
+            CollectionAssert.AreEqual(new[] { 10, 20, 30 }, buffer.ToArray());
+        }
+
+        /// <summary>
+        /// Verifies that draining all items and then refilling the buffer preserves FIFO order
+        /// across the cycle.
+        /// </summary>
+        [TestMethod]
+        public void Clear_WhenDrainedAndRefilled_ShouldPreserveFifoOrder()
+        {
+            var buffer = new CircularBuffer<int>(3);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3);
+
+            buffer.Dequeue();
+            buffer.Dequeue();
+            buffer.Dequeue();
+
+            Assert.AreEqual(0, buffer.Count);
+
+            buffer.Enqueue(10);
+            buffer.Enqueue(20);
+
+            CollectionAssert.AreEqual(new[] { 10, 20 }, buffer.ToArray());
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.Contains.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.Contains.cs
@@ -136,5 +136,53 @@ namespace Bodu.Collections.Generic
             Assert.IsTrue(buffer.Contains(40));
             Assert.IsFalse(buffer.Contains(99));
         }
+
+        /// <summary>
+        /// Verifies that Contains returns false for previously present items after the buffer has been cleared.
+        /// </summary>
+        [TestMethod]
+        public void Contains_AfterClear_ShouldReturnFalseForPreviouslyPresentItems()
+        {
+            var buffer = new CircularBuffer<string>(3);
+            buffer.Enqueue("A");
+            buffer.Enqueue("B");
+
+            buffer.Clear();
+
+            Assert.IsFalse(buffer.Contains("A"));
+            Assert.IsFalse(buffer.Contains("B"));
+        }
+
+        /// <summary>
+        /// Verifies that Contains returns false for an item that has been evicted by an overwrite and true
+        /// for the item that replaced it.
+        /// </summary>
+        [TestMethod]
+        public void Contains_WhenItemEvictedByOverwrite_ShouldReturnFalse()
+        {
+            var buffer = new CircularBuffer<int>(2, allowOverwrite: true);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3); // evicts 1
+
+            Assert.IsFalse(buffer.Contains(1));
+            Assert.IsTrue(buffer.Contains(3));
+        }
+
+        /// <summary>
+        /// Verifies that Contains returns true when duplicate items are present and at least one instance remains
+        /// after a dequeue.
+        /// </summary>
+        [TestMethod]
+        public void Contains_WhenDuplicatesPresent_ShouldReturnTrueWhileAnyInstanceExists()
+        {
+            var buffer = new CircularBuffer<string>(3);
+            buffer.Enqueue("X");
+            buffer.Enqueue("X");
+
+            buffer.Dequeue(); // removes first "X"
+
+            Assert.IsTrue(buffer.Contains("X"));
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.CopyTo.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.CopyTo.cs
@@ -258,5 +258,25 @@ namespace Bodu.Collections.Generic
             Assert.AreEqual(2, verify[1]?.Value,
                 "Buffer's second element should be unaffected as only the first element's property was mutated.");
         }
+
+        /// <summary>
+        /// Verifies that CopyTo with a non-zero destination offset places elements at the correct position.
+        /// </summary>
+        [TestMethod]
+        public void CopyTo_WhenDestinationHasNonZeroOffset_ShouldPlaceElementsAtIndex()
+        {
+            var buffer = new CircularBuffer<int>(3);
+            buffer.Enqueue(10);
+            buffer.Enqueue(20);
+
+            var array = new int[5];
+            buffer.CopyTo(array, 2);
+
+            Assert.AreEqual(0, array[0]);
+            Assert.AreEqual(0, array[1]);
+            Assert.AreEqual(10, array[2]);
+            Assert.AreEqual(20, array[3]);
+            Assert.AreEqual(0, array[4]);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.Ctor.cs
@@ -280,5 +280,35 @@ namespace Bodu.Collections.Generic
             var buffer = new CircularBuffer<int>(source, 5);
             CollectionAssert.AreEqual(new[] { 10, 20, 30 }, buffer.ToArray());
         }
+
+        /// <summary>
+        /// Verifies that constructing from a collection containing null elements retains nulls at the correct positions.
+        /// </summary>
+        [TestMethod]
+        public void Constructor_WhenCollectionContainsNulls_ShouldRetainNulls()
+        {
+            var source = new string?[] { "A", null, "B" };
+            var buffer = new CircularBuffer<string?>(source, 5);
+
+            Assert.AreEqual(3, buffer.Count);
+
+            string?[] result = buffer.ToArray();
+            Assert.AreEqual("A", result[0]);
+            Assert.IsNull(result[1]);
+            Assert.AreEqual("B", result[2]);
+        }
+
+        /// <summary>
+        /// Verifies that constructing from an empty collection with a valid capacity creates an empty buffer
+        /// with the specified capacity.
+        /// </summary>
+        [TestMethod]
+        public void Constructor_WhenEmptyCollectionAndValidCapacity_ShouldCreateEmptyBuffer()
+        {
+            var buffer = new CircularBuffer<int>(Array.Empty<int>(), 5);
+
+            Assert.AreEqual(0, buffer.Count);
+            Assert.AreEqual(5, buffer.Capacity);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.ItemEvicted.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.ItemEvicted.cs
@@ -116,5 +116,52 @@
 
             CollectionAssert.AreEqual(new[] { "X" }, evictedItems);
         }
+
+        /// <summary>
+        /// Verifies that an unsubscribed ItemEvicted handler does not receive further eviction events.
+        /// </summary>
+        [TestMethod]
+        public void ItemEvicted_WhenHandlerUnsubscribed_ShouldNotReceiveFurtherEvents()
+        {
+            int callCount = 0;
+            var buffer = new CircularBuffer<int>(1, allowOverwrite: true);
+
+            Action<int> handler = _ => callCount++;
+            buffer.ItemEvicted += handler;
+
+            buffer.Enqueue(1);
+            buffer.Enqueue(2); // evicts 1 — handler fires
+
+            Assert.AreEqual(1, callCount);
+
+            buffer.ItemEvicted -= handler;
+
+            buffer.Enqueue(3); // evicts 2 — handler should not fire
+
+            Assert.AreEqual(1, callCount);
+        }
+
+        /// <summary>
+        /// Verifies that the ItemEvicted handler receives a null argument when a null item is evicted.
+        /// </summary>
+        [TestMethod]
+        public void ItemEvicted_WhenNullItemIsEvicted_ShouldReceiveNullArgument()
+        {
+            string? received = "sentinel";
+            bool handlerCalled = false;
+
+            var buffer = new CircularBuffer<string?>(1, allowOverwrite: true);
+            buffer.ItemEvicted += item =>
+            {
+                received = item;
+                handlerCalled = true;
+            };
+
+            buffer.Enqueue(null);
+            buffer.Enqueue("X"); // evicts null
+
+            Assert.IsTrue(handlerCalled);
+            Assert.IsNull(received);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.Peek.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.Peek.cs
@@ -47,5 +47,43 @@ namespace Bodu.Collections.Generic
                 _ = buffer.Peek();
             });
         }
+
+        /// <summary>
+        /// Verifies that calling Peek repeatedly does not change the count of the buffer.
+        /// </summary>
+        [TestMethod]
+        public void Peek_WhenCalledRepeatedly_ShouldNotChangeCount()
+        {
+            var buffer = new CircularBuffer<int>(5);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+            buffer.Enqueue(3);
+
+            int expectedCount = buffer.Count;
+
+            for (int i = 0; i < 100; i++)
+            {
+                buffer.Peek();
+            }
+
+            Assert.AreEqual(expectedCount, buffer.Count);
+        }
+
+        /// <summary>
+        /// Verifies that Peek reflects the new oldest item after a dequeue operation.
+        /// </summary>
+        [TestMethod]
+        public void Peek_WhenOldestChangesDueToDequeue_ShouldReflectNewOldest()
+        {
+            var buffer = new CircularBuffer<string>(3);
+            buffer.Enqueue("A");
+            buffer.Enqueue("B");
+
+            Assert.AreEqual("A", buffer.Peek());
+
+            buffer.Dequeue();
+
+            Assert.AreEqual("B", buffer.Peek());
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.ToArray.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.ToArray.cs
@@ -43,5 +43,23 @@ namespace Bodu.Collections.Generic
 
             CollectionAssert.AreEqual(new[] { 20, 30, 40 }, buffer.ToArray());
         }
+
+        /// <summary>
+        /// Verifies that modifying the array returned by ToArray does not affect the contents of the buffer.
+        /// </summary>
+        [TestMethod]
+        public void ToArray_WhenSnapshotIsModified_ShouldNotAffectBuffer()
+        {
+            var buffer = new CircularBuffer<int>(3);
+            buffer.Enqueue(10);
+            buffer.Enqueue(20);
+            buffer.Enqueue(30);
+
+            int[] snapshot = buffer.ToArray();
+            snapshot[0] = 999;
+
+            int[] actual = buffer.ToArray();
+            Assert.AreEqual(10, actual[0]);
+        }
     }
 }

--- a/Bodu.Core/test/Collections.Generic/CircularBufferTests.TryDequeue.cs
+++ b/Bodu.Core/test/Collections.Generic/CircularBufferTests.TryDequeue.cs
@@ -88,5 +88,26 @@ namespace Bodu.Collections.Generic
             CollectionAssert.AreEqual(Array.Empty<string>(), events);
             CollectionAssert.AreEqual(new[] { "B" }, buffer.ToArray());
         }
+
+        /// <summary>
+        /// Verifies that TryDequeue returns false after all items have been removed from the buffer.
+        /// </summary>
+        [TestMethod]
+        public void TryDequeue_WhenBufferTransitionsToEmpty_ShouldReturnFalseAfterLastItem()
+        {
+            var buffer = new CircularBuffer<int>(3);
+            buffer.Enqueue(1);
+            buffer.Enqueue(2);
+
+            bool first = buffer.TryDequeue(out int value1);
+            bool second = buffer.TryDequeue(out int value2);
+            bool third = buffer.TryDequeue(out int value3);
+
+            Assert.IsTrue(first);
+            Assert.AreEqual(1, value1);
+            Assert.IsTrue(second);
+            Assert.AreEqual(2, value2);
+            Assert.IsFalse(third);
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Systematic comparison of `CircularBuffer<T>` and `ConcurrentCircularBuffer<T>` test suites identified ~30 scenarios tested on one type but not the other. This PR closes those gaps.
- Added `<remarks>` to `ConcurrentCircularBuffer.Clear()` documenting that `ItemEvicted` is not raised during clear operations (matching the existing `CircularBuffer.Clear()` documentation).

### CircularBuffer (13 new tests)
- **Constructor**: null elements in collection preserved, empty collection + valid capacity
- **Contains**: after Clear returns false, evicted item returns false, duplicates still found after partial dequeue
- **Clear**: no eviction events fired, reuse preserves FIFO, enqueue after clear on full buffer, drain-and-refill cycle
- **CopyTo**: non-zero destination offset
- **Peek**: repeated calls do not change Count, reflects new oldest after dequeue
- **TryDequeue**: transition to empty returns false
- **ItemEvicted**: handler unsubscribe stops further events, null item eviction delivers null to handler
- **ToArray**: snapshot isolation (modifying returned array does not affect buffer)

### ConcurrentCircularBuffer (17 new tests)
- **Equals**: same reference, null, different type, distinct instances with same contents
- **GetHashCode**: stable across calls, distinct instances likely differ
- **Enumerator edge cases**: Current before MoveNext returns default, Current after exhaustion returns default, Reset re-iterates
- **Enumerator structural**: is value type (struct), only immutable public properties
- **Constructor**: empty collection + invalid capacity throws, empty collection + valid capacity succeeds
- **IEnumerable**: contiguous layout matches CopyTo output, wrapped layout matches CopyTo output
- **Contains**: value-type default equality
- **Clear**: enqueue after clear on full buffer, drain-via-TryDequeue-and-refill cycle

## Test plan

- [ ] `dotnet build Bodu.sln` succeeds
- [ ] `dotnet test Bodu.Core/test/Bodu.Core.Test.csproj --settings test.runsettings` — all new and existing tests pass
- [ ] No existing tests broken by the addition

https://claude.ai/code/session_014qfaGUtBUyApyrWiFfLNCi