### PR TITLE
docs: add cryptography usage guides with worked encrypt/decrypt examples

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Adler.Adler32.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Adler.Adler32.cs
@@ -20,6 +20,7 @@ namespace Bodu.Security.Cryptography
     /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password hashing,
     /// digital signatures, or integrity validation in security-sensitive applications.</note>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-1--a-non-cryptographic-checksum">Non-cryptographic checksum guide</seealso>
     public sealed class Adler32
         : Adler32Base
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
@@ -33,6 +33,10 @@ namespace Bodu.Security.Cryptography
     /// encrypted under the same key. For new applications, a cipher with a 128-bit or larger block size (such as AES) should be preferred.
     /// </note>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/blowfish.html">Using Blowfish (guide with full encrypt / decrypt examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public sealed class Blowfish
         : SymmetricAlgorithm
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
@@ -21,6 +21,7 @@
     /// successive calls to <see cref="Transform" /> continue the stream.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html#cbc--the-default">CBC walk-through in the cipher-modes guide</seealso>
     public sealed class CbcModeTransform
         : IBlockCipherModeTransform
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -21,6 +21,7 @@
     /// The initialisation vector must equal the cipher block size in length and should be unique and unpredictable per message under a given key.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html#cfb--self-synchronising-stream-cipher">CFB walk-through in the cipher-modes guide</seealso>
     public sealed class CfbModeTransform : IBlockCipherModeTransform
     {
         private readonly IBlockCipher cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CipherBlockMode.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CipherBlockMode.cs
@@ -32,6 +32,9 @@ namespace Bodu.Security.Cryptography
     /// <see cref="IBlockCipherModeTransform" /> for a given value.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes (guide with per-mode worked examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public enum CipherBlockMode
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
@@ -35,6 +35,7 @@ namespace Bodu.Security.Cryptography
     /// most once per key.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html#ctr--parallel-seekable-stream-shaped">CTR walk-through in the cipher-modes guide</seealso>
     public sealed class CtrModeTransform : IBlockCipherModeTransform
     {
         private readonly IBlockCipher cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -21,6 +21,7 @@
     /// authenticated mode unless ECB is required as a primitive inside a larger construction.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html#ecb--almost-never">ECB walk-through in the cipher-modes guide</seealso>
     public sealed class EcbModeTransform : IBlockCipherModeTransform
     {
         private readonly IBlockCipher cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Fletcher.32.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Fletcher.32.cs
@@ -19,6 +19,7 @@ namespace Bodu.Security.Cryptography
     /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password hashing,
     /// digital signatures, or integrity validation in security-sensitive applications.</note>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-1--a-non-cryptographic-checksum">Non-cryptographic checksum guide</seealso>
     public sealed class Fletcher32
         : Security.Cryptography.Fletcher<Fletcher32>
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Fnv.Fnv1a32.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Fnv.Fnv1a32.cs
@@ -22,6 +22,7 @@ namespace Bodu.Security.Cryptography
     /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password hashing,
     /// digital signatures, or integrity validation in security-sensitive applications.</note>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-1--a-non-cryptographic-checksum">Non-cryptographic checksum guide</seealso>
     public sealed class Fnv1a32
         : Fnv
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -38,6 +38,7 @@
     /// <see cref="ParallelMerkleTreeHash" />.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-6--merkle-trees">Merkle-tree recipes in the hashing guide</seealso>
     public sealed class MerkleTreeHash : IDisposable
     {
         private readonly int blockSize;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -22,6 +22,7 @@
     /// key, otherwise keystreams collide and confidentiality is lost.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/cipher-modes.html#ofb--synchronous-stream-cipher">OFB walk-through in the cipher-modes guide</seealso>
     public sealed class OfbModeTransform : IBlockCipherModeTransform
     {
         private readonly IBlockCipher cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
@@ -10,6 +10,7 @@
     /// <summary>
     /// Creates <see cref="IPaddingStrategy" /> instances for the standard <see cref="PaddingMode" /> values.
     /// </summary>
+    /// <seealso href="../guides/cryptography/padding.html">Padding guide — PKCS7, Zeros, and None with worked examples</seealso>
     public static class PaddingFactory
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -88,6 +88,7 @@ namespace Bodu.Security.Cryptography
     /// is closed, eliminating the lost-node race that would otherwise cause finalisation to deadlock.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-6--merkle-trees">Merkle-tree recipes in the hashing guide</seealso>
     public sealed class ParallelMerkleTreeHash : IDisposable
     {
         private readonly int _blockSize;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
@@ -22,6 +22,7 @@ namespace Bodu.Security.Cryptography
     /// </para>
     /// <para>See <see cref="SipHash{T}" /> for a description of the round structure.</para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-2--a-keyed-hash-siphash">Keyed-hash (SipHash) guide</seealso>
     public sealed class SipHash64
         : SipHash<SipHash64>
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -30,6 +30,10 @@ namespace Bodu.Security.Cryptography
     /// are encrypted under the same key. Prefer a modern cipher such as AES.
     /// </note>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/skipjack.html">Using Skipjack (guide with full encrypt / decrypt examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public sealed class Skipjack
         : SymmetricAlgorithm
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
@@ -16,6 +16,10 @@
     /// </para>
     /// <para>For other block sizes, see <see cref="Threefish256" /> and <see cref="Threefish512" />.</para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/threefish-1024.html">Using Threefish-1024 (guide with full encrypt / decrypt examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public sealed class Threefish1024
         : Threefish
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
@@ -16,6 +16,10 @@
     /// </para>
     /// <para>For other block sizes, see <see cref="Threefish512" /> and <see cref="Threefish1024" />.</para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/threefish-256.html">Using Threefish-256 (guide with full encrypt / decrypt examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public sealed class Threefish256
         : Threefish
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
@@ -16,6 +16,10 @@
     /// </para>
     /// <para>For other block sizes, see <see cref="Threefish256" /> and <see cref="Threefish1024" />.</para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/threefish-512.html">Using Threefish-512 (guide with full encrypt / decrypt examples)</seealso>
+    /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
+    /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>
     public sealed class Threefish512
         : Threefish
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -38,6 +38,7 @@ namespace Bodu.Security.Cryptography
     /// byte[] digest = tiger.ComputeHash(message);
     /// </code>
     /// </example>
+    /// <seealso href="../guides/cryptography/hashing.html#pattern-3--a-cryptographic-digest">Cryptographic digest guide</seealso>
     public sealed partial class Tiger
         : BlockHashAlgorithm<Tiger>
     {

--- a/docs/guides/cryptography/blowfish.md
+++ b/docs/guides/cryptography/blowfish.md
@@ -1,0 +1,101 @@
+---
+title: Using Blowfish
+---
+
+# Using Blowfish
+
+<xref:Bodu.Security.Cryptography.Blowfish> is Bruce Schneier's 1993 Feistel cipher. It operates on **64-bit (8-byte) blocks** with a **variable-length key from 32 to 448 bits (4 to 56 bytes)**, chosen in 8-bit increments.
+
+> [!NOTE]
+> Blowfish has a 64-bit block size, which makes it vulnerable to birthday-bound attacks (SWEET32) when more than a few gigabytes are encrypted under the same key. For new work, prefer a 128-bit-block cipher such as AES or Threefish-256.
+
+## Sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 64 bits (8 bytes) | Fixed. |
+| Key size | 32 – 448 bits (4 – 56 bytes), 8-bit steps | Default is 128 bits. Set via `KeySize` before `GenerateKey()`. |
+| IV size | 64 bits (8 bytes) | Matches the block size. |
+
+## Encrypt and decrypt — CBC + PKCS7 (default 128-bit key)
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = Encoding.UTF8.GetBytes("message under Blowfish");
+
+byte[] key, iv, ciphertext;
+using (var alg = new Blowfish { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 })
+{
+    alg.GenerateKey();    // 16 bytes at the default 128-bit key size
+    alg.GenerateIV();     // 8 bytes
+
+    key = alg.Key;
+    iv  = alg.IV;
+
+    ciphertext = alg.Encrypt(plaintext);
+}
+
+byte[] recovered;
+using (var alg = new Blowfish { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7,
+                                 Key = key, IV = iv })
+{
+    recovered = alg.Decrypt(ciphertext);
+}
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+## Using a longer key
+
+Blowfish accepts keys up to 448 bits. Set `KeySize` *before* generating the key, because `GenerateKey()` sizes its output from that property:
+
+```csharp
+using var alg = new Blowfish
+{
+    KeySize   = 256,              // 32-byte key
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+};
+alg.GenerateKey();                // 32 bytes
+alg.GenerateIV();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+```
+
+Any byte length from 4 to 56 is valid; longer keys only strengthen the cipher up to the point where the key schedule is the attack vector rather than the round function.
+
+## Encrypt and decrypt — CTR (stream mode)
+
+```csharp
+using var alg = new Blowfish
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();                  // 8-byte counter block, unique per message
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+As with Skipjack, the 8-byte counter means you should not encrypt more than a few gigabytes under the same key in CTR mode.
+
+## A note on the key schedule
+
+Blowfish's key schedule is intentionally expensive: it derives the P-array and four S-boxes from the key by running the cipher thousands of times over itself. This makes brute-force searches meaningfully harder at the cost of a slow setup — roughly a few milliseconds for a one-off key.
+
+The practical implication is that you should **not** build a new `Blowfish` instance per message if you're re-using the same key. Cache the instance and call `CreateEncryptor()` / `CreateDecryptor()` per message instead.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key/IV lifecycle.
+- [Cipher block modes](cipher-modes.md) — CFB, OFB, ECB also work with Blowfish.
+- [Padding](padding.md) — which padding scheme pairs with which mode.
+- [Using Skipjack](skipjack.md) — the other 64-bit-block cipher in the library.

--- a/docs/guides/cryptography/cipher-modes.md
+++ b/docs/guides/cryptography/cipher-modes.md
@@ -1,0 +1,151 @@
+---
+title: Cipher block modes
+---
+
+# Cipher block modes
+
+This page walks through each of the five classic block cipher modes exposed via <xref:Bodu.Security.Cryptography.CipherBlockMode>, shows a complete encrypt-and-decrypt round-trip for each, and calls out the IV rules and security trade-offs.
+
+For the data-flow visualisation, see the panels on the [CipherBlockMode API page](../../api/Bodu.Security.Cryptography.CipherBlockMode.html). Each panel in that diagram corresponds to one section below.
+
+## CBC — the default
+
+**Use for:** general-purpose encryption of a whole message where you care about confidentiality only, and the IV is generated fresh per message.
+
+**IV:** same length as the block, **unpredictable** (not just unique).
+
+**Padding:** required for non-block-aligned plaintext. PKCS7 is the safe default.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("confidential payload");
+
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+The IV must travel with the ciphertext so the receiver can decrypt. Don't put it in a predictable field (a counter, a timestamp) — that breaks CBC's security argument. `GenerateIV()` pulls from the platform CSPRNG, which is fine.
+
+## CTR — parallel, seekable, stream-shaped
+
+**Use for:** random-access scenarios (disk-like), high-throughput pipelines where you want to parallelise encryption per block, or when the plaintext length isn't known up front and you don't want padding.
+
+**IV (counter):** same length as the block. **Must be unique per message under a given key.** Reuse is catastrophic.
+
+**Padding:** not required — `PaddingMode.None` is valid, because CTR turns the block cipher into a stream cipher. The ciphertext is the same length as the plaintext.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,   // CTR is a stream cipher
+};
+alg.GenerateKey();
+alg.GenerateIV();                    // used as the initial counter block
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+**Design note.** The counter wraps after 2^(block_size) encryptions. `CtrModeTransform` detects this and throws <xref:System.Security.Cryptography.CryptographicException> rather than silently reusing keystream. In practice the block sizes on this library (64 to 1024 bits) are more than enough for any real workload, but this guard is your safety net.
+
+## CFB — self-synchronising stream cipher
+
+**Use for:** byte-streamed encryption where a small transmission error should self-heal within a block or two.
+
+**IV:** same length as the block, unique per message. Unpredictability helps but is not strictly required.
+
+**Padding:** not required if the plaintext is block-aligned, but PKCS7 works.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CFB,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+Both directions use the cipher's *encryption* primitive — the decryptor never calls `Decrypt` on the underlying block cipher. That's a property of all CFB/OFB/CTR modes and matters if you've only implemented the encrypt path on a custom engine.
+
+## OFB — synchronous stream cipher
+
+**Use for:** stream encryption where bit-level error propagation must not happen (a single flipped bit in the ciphertext produces a single flipped bit in the plaintext — no cascade).
+
+**IV:** same length as the block, **unique per message**. IV reuse under the same key is catastrophic because the keystream becomes identical.
+
+**Padding:** not required.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.OFB,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+OFB is rarely the best choice today — CTR gives you the same stream-cipher behaviour *plus* random access. Reach for OFB only when you have a specific interoperability requirement.
+
+## ECB — almost never
+
+**Use for:** a primitive inside a higher-level construction (a custom AEAD, a MAC), and nothing else.
+
+**IV:** none.
+
+**Padding:** required for non-block-aligned plaintext; PKCS7.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.ECB,
+    Padding   = PaddingMode.PKCS7,
+};
+alg.GenerateKey();
+alg.GenerateTweak();
+// No IV is needed for ECB.
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+ECB encrypts every block independently. That means identical plaintext blocks encrypt to identical ciphertext blocks — an attacker can see the structure of your message without breaking the cipher. The classic *Tux the penguin* demonstration shows why this matters. Do not use ECB for real messages.
+
+## Choosing a mode — quick guide
+
+| If you need… | Use | Why |
+|---|---|---|
+| A safe default for a single message with a random IV | **CBC** | Confidentiality with simple assumptions. |
+| Seekable, parallelisable, stream-shaped encryption | **CTR** | Keystream depends only on counter; blocks are independent. |
+| Byte-level streaming with self-healing on errors | **CFB** | Error propagates for one block then resynchronises. |
+| Bit-exact error isolation on an unreliable channel | **OFB** | Keystream is plaintext-independent. |
+| A cipher primitive for something you're building | **ECB** | The lowest level; you must add your own chaining. |
+
+## Where to go next
+
+- [Padding](padding.md) — which padding scheme to pair with which mode.
+- [Encryption basics](encryption-basics.md) — Key/IV/Tweak lifecycle, disposal, and common pitfalls.
+- Per-algorithm: [Threefish-256](threefish-256.md) · [Skipjack](skipjack.md) · [Blowfish](blowfish.md).

--- a/docs/guides/cryptography/encryption-basics.md
+++ b/docs/guides/cryptography/encryption-basics.md
@@ -1,0 +1,136 @@
+---
+title: Encryption basics
+---
+
+# Encryption basics
+
+This page introduces the mental model that every cipher in the library follows. If you know `System.Security.Cryptography.SymmetricAlgorithm` from the BCL, most of this will feel familiar — with three twists:
+
+1. **`BlockMode`** replaces `Mode`. The inherited `Mode` property (type <xref:System.Security.Cryptography.CipherMode>) only knows about the modes the BCL defined. Bodu ciphers expose a new `BlockMode` property of type <xref:Bodu.Security.Cryptography.CipherBlockMode>, which adds `CTR`, `OFB`, and friends. *Set `BlockMode`, not `Mode`.*
+2. **Tweak** is a first-class input for Threefish. Threefish is a *tweakable* block cipher; each call is parameterised by a key, an IV, **and** a 128-bit tweak that acts as a domain-separation label.
+3. **Key / IV / Tweak are lazily generated.** If you never set them, they are materialised on first read from a cryptographically secure RNG. Read the property, or call `GenerateKey()` / `GenerateIV()` / `GenerateTweak()` explicitly.
+
+## Anatomy of an encryption
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+// 1. Choose and configure the algorithm.
+using var alg = new Threefish256();
+alg.BlockMode = CipherBlockMode.CBC;   // how blocks chain
+alg.Padding   = PaddingMode.PKCS7;     // how the last (partial) block is filled
+
+// 2. Produce key material. This is cryptographically random.
+alg.GenerateKey();                     // 32 bytes for Threefish-256
+alg.GenerateIV();                      // 32 bytes, matches the block size
+alg.GenerateTweak();                   // 16 bytes, Threefish-specific
+
+// 3. Encrypt.
+byte[] plaintext  = System.Text.Encoding.UTF8.GetBytes("hello, world");
+byte[] ciphertext;
+using (ICryptoTransform enc = alg.CreateEncryptor())
+    ciphertext = enc.TransformFinalBlock(plaintext, 0, plaintext.Length);
+
+// 4. Decrypt using the same Key, IV, and Tweak.
+byte[] recovered;
+using (ICryptoTransform dec = alg.CreateDecryptor())
+    recovered = dec.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+The four numbered steps above are the shape of **every** encryption in the library.
+
+## Key, IV, Tweak — what each is for
+
+| Input | Role | Secret? | Reuse across messages? |
+|---|---|---|---|
+| **Key** | Selects which permutation family to use. | **Yes.** Never transmit or log in the clear. | Yes, within a rotation policy (e.g. rotate per month / per volume). |
+| **IV** (initialisation vector) | Randomises the ciphertext so two messages with the same key and plaintext encrypt to different ciphertexts. | No — the IV travels with the ciphertext. | **No.** Must be unique per message under a given key. For `CBC` it must also be *unpredictable*. For `CTR` / `OFB` reuse is catastrophic. |
+| **Tweak** (Threefish only) | Domain separator. Encrypting the same plaintext under the same key but a different tweak yields unrelated ciphertext. | No — treat like an IV. | Depends on use. For generic encryption, it behaves like an auxiliary IV; for disk encryption-style uses, it encodes the sector/record number. |
+
+## Using the extension methods
+
+The repetitive `CreateEncryptor()` / `TransformFinalBlock()` dance can be collapsed to one call with the `Encrypt` / `Decrypt` extension methods in `Bodu.Security.Cryptography.Extensions`:
+
+```csharp
+using Bodu.Security.Cryptography.Extensions;
+
+using var alg = new Threefish256 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 };
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+Both extension methods also have overloads for `Stream` sources and destinations, so you can encrypt a file in one call:
+
+```csharp
+using var src = File.OpenRead("plaintext.bin");
+using var dst = File.Create("cipher.bin");
+int bytesRead = alg.Encrypt(src, dst, bufferSize: 4096);
+```
+
+## Lazy material generation
+
+Reading the `Key`, `IV`, or `Tweak` property on an un-initialised algorithm **allocates random bytes**. That is usually what you want for a fresh encryption, but it means that:
+
+- Reading `alg.Key` once and then encrypting is safe — the same bytes are cached in `KeyValue` and used on the next access.
+- Reading `alg.Key` *before* decrypting a previously-encrypted message will silently generate a **different** key. Decryption will then fail with garbled output or a padding error. Always re-assign the exact bytes used at encryption time.
+
+```csharp
+// ✗ Wrong — this generates a NEW key for decryption.
+byte[] cipher = alg.Encrypt(plaintext);
+using var fresh = new Threefish256();
+byte[] recovered = fresh.Decrypt(cipher);  // fails: wrong key
+
+// ✓ Right — carry Key/IV/Tweak across the boundary.
+byte[] key = alg.Key, iv = alg.IV, tweak = alg.Tweak;
+byte[] cipher = alg.Encrypt(plaintext);
+// …store (cipher, iv, tweak) next to the message; keep key in a vault.
+
+using var fresh = new Threefish256 { Key = key, IV = iv, Tweak = tweak };
+byte[] recovered = fresh.Decrypt(cipher);
+```
+
+## Storage layout
+
+A common convention, used by many protocols, is to prepend the IV (and, for Threefish, the tweak) to the ciphertext:
+
+```text
+┌────────┬──────────┬──────────────────┐
+│   IV   │  tweak   │    ciphertext    │
+│ B bytes│ 16 bytes │        …         │
+└────────┴──────────┴──────────────────┘
+```
+
+The receiver knows the cipher's block size, so it can slice the fixed-width prefix off and then pass the remaining ciphertext through the decryptor with the recovered IV and tweak. The key is **not** in this envelope — it lives separately in a secrets store.
+
+## Disposal
+
+Every `SymmetricAlgorithm` holds sensitive material (the expanded key schedule, the IV, intermediate buffers). Always wrap in `using`:
+
+```csharp
+using var alg = new Threefish256();
+// …
+// alg is disposed here; its internal state is zeroed.
+```
+
+`ICryptoTransform` instances returned from `CreateEncryptor()` / `CreateDecryptor()` are also `IDisposable` — wrap them too, unless you're using the extension methods which already do.
+
+## Common pitfalls
+
+- **Reusing a `(Key, IV)` pair** in CTR / OFB / CFB completely breaks confidentiality: the XOR of two ciphertexts recovers the XOR of the plaintexts.
+- **Reusing a `Key` in ECB** makes identical plaintext blocks produce identical ciphertext blocks — structure leaks.
+- **Using `PaddingMode.None` with an unpadded plaintext** will throw if the plaintext length is not a multiple of the block size. See [Padding](padding.md) for details.
+- **Logging the key** (e.g. via `Convert.ToHexString(alg.Key)`) makes the key available to anyone with log access. Don't.
+- **Holding the algorithm instance alive longer than needed** keeps the expanded key schedule in memory. Dispose as soon as encryption finishes.
+
+## Where to go next
+
+- [Cipher block modes](cipher-modes.md) — ECB, CBC, CFB, OFB, CTR side by side.
+- [Padding](padding.md) — which scheme for which situation.
+- Per-algorithm: [Threefish-256](threefish-256.md) · [Threefish-512](threefish-512.md) · [Threefish-1024](threefish-1024.md) · [Skipjack](skipjack.md) · [Blowfish](blowfish.md).

--- a/docs/guides/cryptography/hashing.md
+++ b/docs/guides/cryptography/hashing.md
@@ -1,0 +1,125 @@
+---
+title: Using hashes and checksums
+---
+
+# Using hashes and checksums
+
+**Bodu.Security.Cryptography** ships a broad family of hashes and checksums that plug into the standard <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contract. This page sorts them by use-case and shows a minimal recipe for each.
+
+## Pick the right tool
+
+| If you need… | Use | Why |
+|---|---|---|
+| A fast error-detection checksum for network framing, file integrity, etc. | <xref:Bodu.Security.Cryptography.Fletcher32>, <xref:Bodu.Security.Cryptography.Adler32>, <xref:Bodu.Security.Cryptography.Fnv1a32>, <xref:Bodu.Security.Cryptography.Crc> | Cheap, well-spread, **not** cryptographic. |
+| A hash-table key or a short fingerprint, resistant to collision DoS | <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.SipHash128> | Keyed, collision-resistant for short inputs. |
+| A cryptographic digest for signatures, fingerprints, or content addressing | <xref:Bodu.Security.Cryptography.Tiger>, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> (BCL) | Collision-resistant against active attackers. |
+| A rolling integrity check over a long stream or file, with partial re-verification | <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Subtree recomputation without rehashing the whole input. |
+
+The library also includes a number of classic non-cryptographic hashes (<xref:Bodu.Security.Cryptography.Bernstein>, <xref:Bodu.Security.Cryptography.BKDR>, <xref:Bodu.Security.Cryptography.SDBM>, <xref:Bodu.Security.Cryptography.JSHash>, <xref:Bodu.Security.Cryptography.Elf64>) which follow the same `HashAlgorithm` pattern shown below.
+
+## Pattern 1 — a non-cryptographic checksum
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var hash = new Fletcher32();
+byte[] digest = hash.ComputeHash(data);
+string hex    = Convert.ToHexString(digest);   // 4-byte value as 8 hex characters
+```
+
+The same shape works for `Adler32`, `Adler64`, `Fletcher16`, `Fletcher32`, `Fletcher64`, `Fnv1a32`, `Fnv1a64`, `CityHash64`, `CrcStandard`, and the classic hashes listed above. They all derive from `HashAlgorithm`, so any API that accepts a `HashAlgorithm` accepts them.
+
+**What they're not.** These are error-detection and distribution tools. An attacker who can freely modify a message can trivially forge the checksum. Pair them with a signature or a MAC if you need integrity against an adversary.
+
+## Pattern 2 — a keyed hash (SipHash)
+
+SipHash was designed to keep hash tables safe from collision-DoS attacks. It takes a secret key, and a knowledge-of-the-key adversary still cannot produce collisions efficiently.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+// 128-bit key — generated once, stored in your process / vault.
+byte[] key = new byte[16];
+RandomNumberGenerator.Fill(key);
+
+using var sip = new SipHash64 { Key = key };
+byte[] digest = sip.ComputeHash(keyBytes);
+ulong slotHash = BitConverter.ToUInt64(digest);
+
+// Use the output as a stable 64-bit hash for routing / bucketing.
+```
+
+`SipHash128` gives you a 128-bit output for use cases that care about longer collision resistance. Both types expose `CompressionRounds` and `FinalizationRounds` if you need to trade speed for margin (defaults are the standard 2-4 SipHash).
+
+## Pattern 3 — a cryptographic digest
+
+<xref:Bodu.Security.Cryptography.Tiger> is a classic 192-bit cryptographic hash optimised for 64-bit platforms. Use it for interoperability with existing Tiger-based systems, or when you want a digest in the same family as SHA-2 without pulling in a second dependency.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var tiger = new Tiger();     // 192-bit default; set HashSize for 128/160
+byte[] digest = tiger.ComputeHash(data);
+```
+
+For brand-new work, prefer the BCL's <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> or <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType> — they are hardware-accelerated on most modern CPUs.
+
+## Pattern 4 — verifying a hash
+
+Computing a hash is half the job; comparing it in constant time is the other half. The `HashAlgorithmExtensions` class (in `Bodu.Security.Cryptography.Extensions`) provides a `VerifyHash` helper that does the comparison with <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*>:
+
+```csharp
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] expected = LoadExpectedDigestForFile("report.pdf");
+
+using var hash = new Tiger();
+bool match = hash.VerifyHash(new ReadOnlySpan<byte>(fileBytes), expected);
+```
+
+A direct `SequenceEqual` comparison leaks timing information to an observer and is unsafe for authentication decisions.
+
+## Pattern 5 — streaming hash over a file
+
+Every `HashAlgorithm` accepts a `Stream`, which lets you fingerprint a file without loading it into memory:
+
+```csharp
+using var hash = new Fnv1a64();
+using var stream = File.OpenRead("archive.bin");
+byte[] fingerprint = hash.ComputeHash(stream);
+```
+
+For a larger file where you want partial verifiability — "the first megabyte's digest is X; the second megabyte's digest is Y" — use a Merkle tree instead (next section).
+
+## Pattern 6 — Merkle trees
+
+<xref:Bodu.Security.Cryptography.MerkleTreeHash> lets you compute a single root digest over a stream by hashing it in fixed-size blocks and reducing the leaves level-by-level. The intermediate hashes can later prove integrity of an individual chunk without rehashing the whole stream.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+using var merkle = new MerkleTreeHash(
+    algorithmFactory: () => SHA256.Create(),
+    blockSize: 4096,
+    fanOut: 2);
+
+using var stream = File.OpenRead("archive.bin");
+byte[] root = merkle.ComputeHash(stream);
+```
+
+Each leaf is a SHA-256 of a 4 KiB block; each internal node is a SHA-256 of two concatenated child hashes. The root changes if any byte of the input changes.
+
+For large inputs where you want to overlap leaf hashing with tree reduction, use <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> — see the [class documentation](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html) for the swim-lane diagram of how its dispatcher and level-workers interact.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — symmetric encryption in this library.
+- [Cipher block modes](cipher-modes.md) — ECB / CBC / CFB / OFB / CTR with worked examples.
+- [MerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) · [ParallelMerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -1,0 +1,60 @@
+---
+title: Cryptography guides
+---
+
+# Cryptography guides
+
+Recipe-style walk-throughs for using **Bodu.Security.Cryptography** in real applications — encrypting and decrypting data with the right mode, padding, and IV; and choosing the right hash for the job.
+
+If you're looking for the generated API reference, see the [Bodu.Security.Cryptography namespace page](../../api/Bodu.Security.Cryptography.html).
+
+## Start here
+
+<div class="bodu-cards">
+
+<div class="bodu-card">
+  <h3><a href="encryption-basics.html">Encryption basics</a></h3>
+  <p>The mental model: <code>BlockMode</code> vs .NET's <code>Mode</code>, how Key / IV / Tweak / Padding combine, how to generate random key material, and how to dispose of it safely.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="cipher-modes.html">Cipher block modes</a></h3>
+  <p>ECB, CBC, CFB, OFB, CTR — one worked round-trip per mode, with notes on when each is appropriate and when it is not.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="padding.html">Padding</a></h3>
+  <p>PKCS7, Zeros, and None — how each one pads, when it round-trips cleanly, and when it silently loses bytes.</p>
+</div>
+
+</div>
+
+## Symmetric ciphers
+
+Each of the five block ciphers ships with its own page containing a complete encrypt-and-decrypt walk-through using its native sizes:
+
+| Cipher | Block | Key | Extras | Guide |
+|---|---|---|---|---|
+| `Threefish256` | 256 bits (32 B) | 256 bits (32 B) | 128-bit tweak | [Using Threefish-256](threefish-256.md) |
+| `Threefish512` | 512 bits (64 B) | 512 bits (64 B) | 128-bit tweak | [Using Threefish-512](threefish-512.md) |
+| `Threefish1024` | 1024 bits (128 B) | 1024 bits (128 B) | 128-bit tweak | [Using Threefish-1024](threefish-1024.md) |
+| `Skipjack` | 64 bits (8 B) | 80 bits (10 B) | — | [Using Skipjack](skipjack.md) |
+| `Blowfish` | 64 bits (8 B) | 32–448 bits, 8-bit steps | — | [Using Blowfish](blowfish.md) |
+
+All five share the same high-level shape: a `SymmetricAlgorithm` (or `TweakableSymmetricAlgorithm`) that you configure with `BlockMode`, `Padding`, `Key`, `IV` (and `Tweak` for Threefish), then drive with `CreateEncryptor()` / `CreateDecryptor()` or the `Encrypt` / `Decrypt` extension methods.
+
+## Hashing
+
+[Using hashes and checksums](hashing.md) — concrete recipes for non-cryptographic checksums (Fletcher, Adler, FNV, CRC), keyed short-input hashes (SipHash), cryptographic digests (Tiger), and streaming integrity with `MerkleTreeHash` / `ParallelMerkleTreeHash`.
+
+## Related concepts
+
+- [Cipher modes diagram walkthrough](../../api/Bodu.Security.Cryptography.CipherBlockMode.html) — the pedagogical data-flow panels for each of the five classic modes.
+- [AEAD modes overview](../../api/Bodu.Security.Cryptography.GcmModeTransform.html) — how GCM, CCM, OCB, EAX, SIV, and GCM-SIV relate.
+- [Merkle tree construction](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) and the [parallel pipeline diagram](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
+
+## A note on AEAD
+
+This library ships a family of AEAD mode transforms — `GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `EaxModeTransform`, `SivModeTransform`, `GcmSivModeTransform` — implemented against the internal `IBlockCipher` engines. They are currently consumed by the library's own tests rather than directly by external callers.
+
+If you need authenticated encryption in an application today, use the BCL's <xref:System.Security.Cryptography.AesGcm?displayProperty=nameWithType> or <xref:System.Security.Cryptography.AesCcm?displayProperty=nameWithType>, which are hardware-accelerated and FIPS-validated on supported platforms.

--- a/docs/guides/cryptography/padding.md
+++ b/docs/guides/cryptography/padding.md
@@ -1,0 +1,114 @@
+---
+title: Padding
+---
+
+# Padding
+
+Block ciphers encrypt fixed-size blocks. When a plaintext is not a whole number of blocks long, the last block has to be *padded* — and the receiver has to know how to *unpad* it. This page covers the three padding schemes supported by the library and shows when each one is appropriate.
+
+The supported modes come from the standard <xref:System.Security.Cryptography.PaddingMode> enum. Set them via the algorithm's `Padding` property, or construct a strategy directly through <xref:Bodu.Security.Cryptography.PaddingFactory>.
+
+## PKCS7 — the safe default
+
+**Use for:** any block-oriented mode (CBC, ECB) where the plaintext is arbitrary binary or text.
+
+PKCS7 appends *N* bytes, each with the value *N*, where *N* is chosen to bring the plaintext to the next block boundary. When the plaintext is already block-aligned, an entire extra block of *block_size* bytes is appended, each carrying the value *block_size*. That sounds wasteful but it's what makes unpadding unambiguous: the last byte always tells you how many pad bytes to strip.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] plaintext  = new byte[100];      // not a multiple of 32
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+PKCS7 round-trips cleanly for any plaintext length, including zero.
+
+**Note on padding oracles.** PKCS7 unpadding validates the trailing bytes and rejects a ciphertext whose last block is not well-formed. Historically this has been the source of "padding oracle" attacks against CBC when an attacker can distinguish a padding failure from a MAC failure via timing or error messages. The library validates in constant time inside `Pkcs7Padding.Unpad`, but you should still pair CBC-with-PKCS7 encryption with a MAC over the ciphertext (encrypt-then-MAC) when the ciphertext travels across a trust boundary.
+
+## Zeros — for application-framed messages
+
+**Use for:** plaintexts that already carry their own length (a length prefix, a terminator, or a framed binary record) and are produced with a deterministic shape.
+
+Zero padding appends `0x00` bytes until the plaintext reaches a block boundary. It does nothing when the plaintext is already block-aligned. The problem with unpadding is that `0x00` is a perfectly valid plaintext byte — `Unpad` strips trailing zeros, and it cannot tell whether those zeros were padding or part of the real message.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.Zeros,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+// Plaintext has a length prefix, so trailing zeros are unambiguous.
+byte[] plaintext = BuildMessageWithLengthPrefix(body: new byte[97]);
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+
+// Recovered may end in extra 0x00 bytes; consult the length prefix to strip them.
+```
+
+Zero padding is appropriate when **the application layer already knows the real length**. If it doesn't, prefer PKCS7.
+
+## None — only for block-aligned or stream modes
+
+**Use for:** stream-shaped modes (CTR, CFB, OFB) that don't need padding, or when you have already padded the plaintext in your own code and want the cipher to leave it alone.
+
+```csharp
+// Stream-shaped mode: ciphertext length == plaintext length.
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] plaintext  = new byte[100];     // any length is fine
+byte[] ciphertext = alg.Encrypt(plaintext);    // 100 bytes out
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+`PaddingMode.None` combined with a block-oriented mode (CBC, ECB) and a plaintext that isn't a multiple of the block size will throw <xref:System.Security.Cryptography.CryptographicException> during encryption. Don't use the two together unless you know your plaintext is block-aligned.
+
+## Choosing — quick guide
+
+| If your plaintext is… | and your mode is… | Use | Ciphertext length |
+|---|---|---|---|
+| Arbitrary bytes | CBC, ECB | **PKCS7** | Plaintext + 1–block bytes |
+| Framed (length-prefixed / terminated) | CBC, ECB | **Zeros** or **PKCS7** | ≥ plaintext, to next block boundary |
+| Any length | CTR, CFB, OFB | **None** | Exactly plaintext length |
+| Already block-aligned | CBC, ECB | **None** (if sure) | Exactly plaintext length |
+
+## Using the strategy directly
+
+For advanced scenarios you can obtain an <xref:Bodu.Security.Cryptography.IPaddingStrategy> directly and apply it to a byte span:
+
+```csharp
+using Bodu.Security.Cryptography;
+using System.Security.Cryptography;
+
+IPaddingStrategy pkcs7 = PaddingFactory.Create(PaddingMode.PKCS7);
+
+byte[] padded   = pkcs7.Pad(plaintext, blockSize: 32);
+byte[] unpadded = pkcs7.Unpad(padded, blockSize: 32);
+```
+
+This is primarily useful if you're composing a custom encryption pipeline against <xref:Bodu.Security.Cryptography.IBlockCipherModeTransform>.
+
+## Where to go next
+
+- [Cipher block modes](cipher-modes.md) — which padding pairs with which mode.
+- [Encryption basics](encryption-basics.md) — the full Key/IV/Tweak/Padding lifecycle.

--- a/docs/guides/cryptography/skipjack.md
+++ b/docs/guides/cryptography/skipjack.md
@@ -1,0 +1,105 @@
+---
+title: Using Skipjack
+---
+
+# Using Skipjack
+
+<xref:Bodu.Security.Cryptography.Skipjack> is an NSA-designed block cipher declassified in 1998. It is included for **legacy interoperability and research** — do not use it to protect sensitive data in new applications.
+
+> [!IMPORTANT]
+> Skipjack has an 80-bit key and a 64-bit block. The short key is well below modern security margins, and the 64-bit block is vulnerable to birthday-bound attacks (SWEET32) when more than a few gigabytes are encrypted under the same key. For new work, use AES (via the BCL's <xref:System.Security.Cryptography.Aes?displayProperty=nameWithType>).
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 64 bits (8 bytes) | Fixed — cannot be configured. |
+| Key size | 80 bits (10 bytes) | Fixed. |
+| IV size | 64 bits (8 bytes) | Matches the block size. |
+| Tweak | — | Skipjack is not tweakable. |
+
+## Encrypt and decrypt — CBC + PKCS7
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = Encoding.UTF8.GetBytes("legacy payload");
+
+byte[] key, iv, ciphertext;
+using (var alg = new Skipjack { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 })
+{
+    alg.GenerateKey();           // 10 bytes
+    alg.GenerateIV();            // 8 bytes
+
+    key = alg.Key;
+    iv  = alg.IV;
+
+    ciphertext = alg.Encrypt(plaintext);
+}
+
+byte[] recovered;
+using (var alg = new Skipjack { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7,
+                                 Key = key, IV = iv })
+{
+    recovered = alg.Decrypt(ciphertext);
+}
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+## Encrypt and decrypt — CTR (stream mode)
+
+```csharp
+using var alg = new Skipjack
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();              // initial counter block — must be unique per message
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+Skipjack's 8-byte counter space is small. Encrypting more than ~2³² blocks (32 GB) under the same key in CTR mode is unsafe because the counter is close to wrapping. `CtrModeTransform` will throw if the counter actually reaches its initial value.
+
+## Loading a known key
+
+Skipjack's key is small enough (10 bytes) that you might keep it embedded in a configuration file or a key-wrapping envelope. Either way, set it explicitly:
+
+```csharp
+byte[] key = new byte[]
+{
+    0x00, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11,
+};
+
+using var alg = new Skipjack
+{
+    Key       = key,
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+};
+alg.GenerateIV();
+byte[] ciphertext = alg.Encrypt(plaintext);
+```
+
+## When to use Skipjack
+
+- **Interoperability** with systems that historically used Skipjack (e.g. legacy US government protocols).
+- **Educational exercises** and cipher-design studies.
+- **Regression fixtures** where you need a deterministic pinpoint cipher whose test vectors are well-known.
+
+For anything else, reach for AES or Threefish.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key/IV lifecycle.
+- [Cipher block modes](cipher-modes.md) — CFB, OFB, ECB also work with Skipjack.
+- [Padding](padding.md) — which padding scheme pairs with which mode.
+- [Using Blowfish](blowfish.md) — another 64-bit-block cipher with a variable key size.

--- a/docs/guides/cryptography/threefish-1024.md
+++ b/docs/guides/cryptography/threefish-1024.md
@@ -1,0 +1,83 @@
+---
+title: Using Threefish-1024
+---
+
+# Using Threefish-1024
+
+<xref:Bodu.Security.Cryptography.Threefish1024> is the largest variant in the Threefish family: **1024-bit (128-byte) blocks** with a **1024-bit (128-byte) key** and a **128-bit (16-byte) tweak**. Reach for Threefish-1024 when you want the widest plausible block size — for example in domains that demand very large key/block margins, or where you want to encrypt a chunk that's naturally 128 bytes wide without chaining overhead per inner field.
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 1024 bits (128 bytes) | Ciphertext is a multiple of 128 bytes (except in stream modes). |
+| Key size | 1024 bits (128 bytes) | Fixed. |
+| Tweak size | 128 bits (16 bytes) | Fixed across the Threefish family. |
+| IV size | 1024 bits (128 bytes) | Always matches the block size. |
+
+## Encrypt and decrypt — CBC + PKCS7
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = Encoding.UTF8.GetBytes("a substantial payload that benefits from a 128-byte block");
+
+byte[] key, iv, tweak, ciphertext;
+using (var alg = new Threefish1024 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 })
+{
+    alg.GenerateKey();
+    alg.GenerateIV();
+    alg.GenerateTweak();
+
+    key   = alg.Key;     // 128 bytes
+    iv    = alg.IV;      // 128 bytes
+    tweak = alg.Tweak;   // 16 bytes
+
+    ciphertext = alg.Encrypt(plaintext);
+}
+
+byte[] recovered;
+using (var alg = new Threefish1024 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7,
+                                      Key = key, IV = iv, Tweak = tweak })
+{
+    recovered = alg.Decrypt(ciphertext);
+}
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+## Encrypt and decrypt — CTR (stream mode)
+
+```csharp
+using var alg = new Threefish1024
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+## Trade-offs worth knowing
+
+- **Memory and throughput.** Threefish-1024 has the largest key schedule of the family (17 subkeys of 128 bytes each) and therefore the largest per-instance memory footprint. Throughput is roughly half of Threefish-512 on the same CPU.
+- **Padding waste.** A PKCS7 round-up to the next 128-byte boundary costs *more* than the 32-byte Threefish-256 round-up. If your plaintexts are short, Threefish-256 produces smaller ciphertexts.
+- **When to prefer it.** When your natural record size is already ≥ 128 bytes, when you want a single-block encryption of a large structured field, or when you want the widest defensive margin against future block-size attacks.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key/IV/Tweak lifecycle.
+- [Cipher block modes](cipher-modes.md) — CFB / OFB / ECB also work with `Threefish1024`.
+- [Padding](padding.md) — which padding scheme pairs with which mode.
+- Other variants: [Threefish-256](threefish-256.md), [Threefish-512](threefish-512.md).

--- a/docs/guides/cryptography/threefish-256.md
+++ b/docs/guides/cryptography/threefish-256.md
@@ -1,0 +1,155 @@
+---
+title: Using Threefish-256
+---
+
+# Using Threefish-256
+
+<xref:Bodu.Security.Cryptography.Threefish256> is the 256-bit variant of the Threefish tweakable block cipher family — the core primitive underneath the Skein hash function. It operates on **256-bit (32-byte) blocks** with a **256-bit (32-byte) key** and a **128-bit (16-byte) tweak**.
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 256 bits (32 bytes) | Ciphertext is a multiple of 32 bytes (except in stream modes). |
+| Key size | 256 bits (32 bytes) | Fixed — there is no shorter or longer key variant. |
+| Tweak size | 128 bits (16 bytes) | Fixed across the Threefish family. |
+| IV size | 256 bits (32 bytes) | Always matches the block size. |
+
+## Encrypt and decrypt — CBC + PKCS7
+
+The default configuration. Use this unless you have a specific reason to pick a different mode.
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = Encoding.UTF8.GetBytes("a message to protect");
+
+// Encrypt
+byte[] key, iv, tweak, ciphertext;
+using (var alg = new Threefish256 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 })
+{
+    alg.GenerateKey();
+    alg.GenerateIV();
+    alg.GenerateTweak();
+
+    key   = alg.Key;     // 32 bytes
+    iv    = alg.IV;      // 32 bytes
+    tweak = alg.Tweak;   // 16 bytes
+
+    ciphertext = alg.Encrypt(plaintext);
+}
+
+// Decrypt — supplying the same Key, IV and Tweak
+byte[] recovered;
+using (var alg = new Threefish256 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7,
+                                     Key = key, IV = iv, Tweak = tweak })
+{
+    recovered = alg.Decrypt(ciphertext);
+}
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+The IV and tweak are *not* secret — they travel with the ciphertext. The key is the secret; store it separately.
+
+## Encrypt and decrypt — CTR (stream mode, parallelisable)
+
+CTR gives you variable-length output, random-access seeking, and no padding:
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,    // CTR doesn't pad
+};
+alg.GenerateKey();
+alg.GenerateIV();     // initial counter block
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);   // same length as plaintext
+byte[] recovered  = alg.Decrypt(ciphertext);
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+**Do not reuse an `(IV, Key)` pair** across messages in CTR. <xref:Bodu.Security.Cryptography.CtrModeTransform> detects counter wrap-around and throws, but it cannot prevent you from using the same initial counter twice.
+
+## Using the tweak as a domain separator
+
+The tweak lets you derive many independent encryption "lanes" from the same key. Two messages encrypted with the same key but different tweaks produce completely unrelated ciphertext:
+
+```csharp
+byte[] key = new byte[32];
+RandomNumberGenerator.Fill(key);
+
+byte[] Encrypt(byte[] plaintext, byte[] iv, byte[] tweak)
+{
+    using var alg = new Threefish256 { Key = key, IV = iv, Tweak = tweak };
+    return alg.Encrypt(plaintext);
+}
+
+byte[] iv = new byte[32];
+RandomNumberGenerator.Fill(iv);
+
+// Same key, same IV, same plaintext — different tweaks → unrelated ciphertext.
+byte[] userTweak    = Encoding.UTF8.GetBytes("user-records\0\0\0\0");   // 16 bytes
+byte[] sessionTweak = Encoding.UTF8.GetBytes("session-keys\0\0\0\0");
+
+byte[] c1 = Encrypt(plaintext, iv, userTweak);
+byte[] c2 = Encrypt(plaintext, iv, sessionTweak);
+// c1 and c2 are unrelated.
+```
+
+A common pattern is to set the tweak to a record ID, a filesystem path, or a message counter, so that even if the same plaintext appears in two places, their ciphertexts are independent.
+
+## File encryption
+
+```csharp
+using var alg = new Threefish256 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 };
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+using (var src = File.OpenRead("report.bin"))
+using (var dst = File.Create("report.enc"))
+{
+    // Write IV + tweak as a header so the receiver can decrypt.
+    dst.Write(alg.IV);          // 32 bytes
+    dst.Write(alg.Tweak);       // 16 bytes
+    alg.Encrypt(src, dst, bufferSize: 8192);
+}
+
+// Store alg.Key separately in your secrets vault.
+```
+
+Decryption reverses the header:
+
+```csharp
+byte[] iv, tweak;
+using var src = File.OpenRead("report.enc");
+iv    = new byte[32]; src.ReadExactly(iv);
+tweak = new byte[16]; src.ReadExactly(tweak);
+
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+    Key       = LoadKeyFromVault(),
+    IV        = iv,
+    Tweak     = tweak,
+};
+using var dst = File.Create("report.recovered.bin");
+alg.Decrypt(src, dst, bufferSize: 8192);
+```
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key/IV/Tweak lifecycle.
+- [Cipher block modes](cipher-modes.md) — CFB / OFB / ECB also work with `Threefish256`.
+- [Padding](padding.md) — when to set `PaddingMode.None` vs `PKCS7`.
+- Other variants: [Threefish-512](threefish-512.md), [Threefish-1024](threefish-1024.md).

--- a/docs/guides/cryptography/threefish-512.md
+++ b/docs/guides/cryptography/threefish-512.md
@@ -1,0 +1,120 @@
+---
+title: Using Threefish-512
+---
+
+# Using Threefish-512
+
+<xref:Bodu.Security.Cryptography.Threefish512> is the 512-bit variant of the Threefish tweakable block cipher family. It operates on **512-bit (64-byte) blocks** with a **512-bit (64-byte) key** and a **128-bit (16-byte) tweak**. Of the three Threefish variants, this is the one used as the core of the standard Skein hash function.
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 512 bits (64 bytes) | Ciphertext is a multiple of 64 bytes (except in stream modes). |
+| Key size | 512 bits (64 bytes) | Fixed. |
+| Tweak size | 128 bits (16 bytes) | Fixed across the Threefish family. |
+| IV size | 512 bits (64 bytes) | Always matches the block size. |
+
+## Encrypt and decrypt — CBC + PKCS7
+
+```csharp
+using System.Diagnostics;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = Encoding.UTF8.GetBytes("a longer record payload for the 64-byte block cipher");
+
+byte[] key, iv, tweak, ciphertext;
+using (var alg = new Threefish512 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7 })
+{
+    alg.GenerateKey();
+    alg.GenerateIV();
+    alg.GenerateTweak();
+
+    key   = alg.Key;     // 64 bytes
+    iv    = alg.IV;      // 64 bytes
+    tweak = alg.Tweak;   // 16 bytes
+
+    ciphertext = alg.Encrypt(plaintext);
+}
+
+byte[] recovered;
+using (var alg = new Threefish512 { BlockMode = CipherBlockMode.CBC, Padding = PaddingMode.PKCS7,
+                                     Key = key, IV = iv, Tweak = tweak })
+{
+    recovered = alg.Decrypt(ciphertext);
+}
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+## Encrypt and decrypt — CTR (stream mode, parallelisable)
+
+```csharp
+using var alg = new Threefish512
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+
+Debug.Assert(plaintext.SequenceEqual(recovered));
+```
+
+With a 512-bit block the counter space is astronomical; wrap-around is a theoretical concern only. CTR's usual rule still stands: never reuse an `(IV, Key)` pair across messages.
+
+## Loading and reusing a known key
+
+If you've stored a key in a secrets manager, load it directly rather than calling `GenerateKey()`:
+
+```csharp
+byte[] key = LoadKeyFromVault(keyId: "threefish-512/main");
+Debug.Assert(key.Length == 64);
+
+using var alg = new Threefish512 { Key = key, BlockMode = CipherBlockMode.CTR, Padding = PaddingMode.None };
+alg.GenerateIV();           // fresh per message
+alg.GenerateTweak();        // or set a per-record tweak
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+```
+
+## Per-record tweak
+
+Threefish's tweak is particularly useful when encrypting many small records under the same key. Using the record's stable ID as a tweak gives each record an independent encryption stream without key rotation:
+
+```csharp
+byte[] RecordTweak(long recordId)
+{
+    byte[] tweak = new byte[16];
+    BinaryPrimitives.WriteInt64LittleEndian(tweak.AsSpan(0, 8), recordId);
+    return tweak;
+}
+
+byte[] EncryptRecord(byte[] key, byte[] iv, long recordId, byte[] plaintext)
+{
+    using var alg = new Threefish512
+    {
+        Key       = key,
+        IV        = iv,
+        Tweak     = RecordTweak(recordId),
+        BlockMode = CipherBlockMode.CBC,
+        Padding   = PaddingMode.PKCS7,
+    };
+    return alg.Encrypt(plaintext);
+}
+```
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key/IV/Tweak lifecycle.
+- [Cipher block modes](cipher-modes.md) — CFB / OFB / ECB also work with `Threefish512`.
+- [Padding](padding.md) — which padding scheme pairs with which mode.
+- Other variants: [Threefish-256](threefish-256.md), [Threefish-1024](threefish-1024.md).

--- a/docs/guides/cryptography/toc.yml
+++ b/docs/guides/cryptography/toc.yml
@@ -1,0 +1,23 @@
+# ./<Project Root Dir>/docs/guides/cryptography/toc.yml
+- name: Overview
+  href: index.md
+- name: Encryption basics
+  href: encryption-basics.md
+- name: Cipher block modes
+  href: cipher-modes.md
+- name: Padding
+  href: padding.md
+- name: Hashing and checksums
+  href: hashing.md
+- name: Symmetric algorithms
+  items:
+    - name: Threefish-256
+      href: threefish-256.md
+    - name: Threefish-512
+      href: threefish-512.md
+    - name: Threefish-1024
+      href: threefish-1024.md
+    - name: Skipjack
+      href: skipjack.md
+    - name: Blowfish
+      href: blowfish.md

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -1,0 +1,26 @@
+# ./<Project Root Dir>/docs/guides/toc.yml
+- name: Cryptography
+  href: cryptography/
+  items:
+    - name: Overview
+      href: cryptography/index.md
+    - name: Encryption basics
+      href: cryptography/encryption-basics.md
+    - name: Cipher block modes
+      href: cryptography/cipher-modes.md
+    - name: Padding
+      href: cryptography/padding.md
+    - name: Hashing and checksums
+      href: cryptography/hashing.md
+    - name: Symmetric algorithms
+      items:
+        - name: Threefish-256
+          href: cryptography/threefish-256.md
+        - name: Threefish-512
+          href: cryptography/threefish-512.md
+        - name: Threefish-1024
+          href: cryptography/threefish-1024.md
+        - name: Skipjack
+          href: cryptography/skipjack.md
+        - name: Blowfish
+          href: cryptography/blowfish.md

--- a/docs/toc.yml
+++ b/docs/toc.yml
@@ -1,5 +1,7 @@
 # ./<Project Root Dir>/docs/toc.yml
 - name: Docs
   href: docs/
+- name: Guides
+  href: guides/
 - name: API
   href: api/


### PR DESCRIPTION
## Summary

- Add a new top-level **Guides** section to the docs site, with ten recipe-style walk-throughs under `docs/guides/cryptography/` covering how to use `Bodu.Security.Cryptography` in real applications.
- Every symmetric algorithm (Threefish-256 / 512 / 1024, Skipjack, Blowfish) gets its own page with a complete encrypt-and-decrypt round-trip using its native sizes, plus Key / IV / Tweak lifecycle guidance.
- Concept pages cover the `BlockMode` vs .NET `Mode` distinction, each of the five classic block cipher modes (ECB / CBC / CFB / OFB / CTR) with worked examples, and each padding scheme (PKCS7 / Zeros / None) with round-trip caveats.
- A hashing cookbook shows six patterns: non-crypto checksum, keyed hash (SipHash), cryptographic digest (Tiger), constant-time verify, streaming file hash, and Merkle tree root.
- Added `<seealso>` entries linking each cipher, mode, padding, hash, and Merkle class to its guide page (or the relevant section within). Anchors target specific mode walk-throughs and hashing patterns for precision.

## Test plan

- [ ] GitHub Actions `docfx-build-publish` workflow builds cleanly — no broken links or XML-doc warnings on the newly added `<seealso>` entries.
- [ ] Published GitHub Pages site shows a new **Guides** top-level nav entry that expands into the cryptography sub-tree.
- [ ] `/api/Bodu.Security.Cryptography.Threefish256.html` (and each of the other four cipher pages) renders a See Also section linking to the matching guide.
- [ ] `/guides/cryptography/` loads and all internal links resolve (including `<xref:…>` cross-refs and the anchor-linked mode sub-sections).
- [ ] Local `dotnet build Bodu.sln` stays analyzer-clean — no new CS1591 / XML-doc warnings.

## Scope notes

The AEAD mode transforms (`GcmModeTransform` et al.) require an `IBlockCipher`, and the concrete engines that satisfy that interface are currently `internal`. Rather than document a path users cannot actually walk, the hub page calls this out explicitly and points callers needing authenticated encryption today at the BCL's `AesGcm` / `AesCcm`.

https://claude.ai/code/session_01TcQuZVRdUAxF7sPRvNJ98Y