### PR TITLE
feat(crypto): public AesBlockCipher and AEAD extensions, with usage guide

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AeadBlockCipherModeTransformExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography.Extensions
+{
+    /// <summary>
+    /// Provides one-shot convenience wrappers around <see cref="IAeadBlockCipherModeTransform" />
+    /// that handle associated-data processing, output buffer sizing, and the ciphertext + tag layout
+    /// in a single call.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The raw <see cref="IAeadBlockCipherModeTransform" /> contract requires callers to call
+    /// <see cref="IAeadBlockCipherModeTransform.ProcessAssociatedData" /> before <see cref="IAeadBlockCipherModeTransform.Encrypt" />
+    /// or <see cref="IAeadBlockCipherModeTransform.Decrypt" />, size the output buffer to
+    /// <c>plaintext.Length + TagSize</c> (or <c>ciphertextWithTag.Length - TagSize</c>), and
+    /// interpret the return value. These extension methods collapse all of that into a single call
+    /// that returns a correctly sized <see cref="byte" /> array.
+    /// </para>
+    /// <para>
+    /// AEAD transforms are stateful and single-use. Construct a new transform per message and pass
+    /// it to exactly one of these extension methods.
+    /// </para>
+    /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html">Using AEAD modes (guide with full encrypt / decrypt examples)</seealso>
+    public static class AeadBlockCipherModeTransformExtensions
+    {
+        /// <summary>
+        /// Encrypts <paramref name="plaintext" /> and returns a new byte array containing the
+        /// ciphertext concatenated with the authentication tag.
+        /// </summary>
+        /// <param name="transform">The AEAD transform. Must not be <see langword="null" />.</param>
+        /// <param name="plaintext">The data to encrypt.</param>
+        /// <param name="associatedData">
+        /// The data to authenticate but not encrypt. May be empty when no associated data is required.
+        /// </param>
+        /// <returns>
+        /// A newly allocated byte array of length <c>plaintext.Length + transform.TagSize</c>, containing
+        /// the ciphertext followed by the <see cref="IAeadBlockCipherModeTransform.TagSize" />-byte tag.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
+        /// <exception cref="InvalidOperationException">
+        /// The transform has already had its associated data processed or its plaintext / ciphertext consumed.
+        /// </exception>
+        public static byte[] Encrypt(
+            this IAeadBlockCipherModeTransform transform,
+            ReadOnlySpan<byte> plaintext,
+            ReadOnlySpan<byte> associatedData)
+        {
+            if (transform is null) throw new ArgumentNullException(nameof(transform));
+
+            transform.ProcessAssociatedData(associatedData);
+
+            byte[] output = new byte[plaintext.Length + transform.TagSize];
+            int written = transform.Encrypt(plaintext, output);
+
+            if (written != output.Length)
+                Array.Resize(ref output, written);
+
+            return output;
+        }
+
+        /// <summary>
+        /// Encrypts <paramref name="plaintext" /> with an empty associated-data stream and returns a new
+        /// byte array containing the ciphertext concatenated with the authentication tag.
+        /// </summary>
+        /// <param name="transform">The AEAD transform. Must not be <see langword="null" />.</param>
+        /// <param name="plaintext">The data to encrypt.</param>
+        /// <returns>
+        /// A newly allocated byte array of length <c>plaintext.Length + transform.TagSize</c>.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
+        public static byte[] Encrypt(
+            this IAeadBlockCipherModeTransform transform,
+            ReadOnlySpan<byte> plaintext)
+            => Encrypt(transform, plaintext, ReadOnlySpan<byte>.Empty);
+
+        /// <summary>
+        /// Verifies <paramref name="ciphertextWithTag" /> against <paramref name="associatedData" />, decrypts
+        /// the ciphertext, and returns the recovered plaintext.
+        /// </summary>
+        /// <param name="transform">The AEAD transform. Must not be <see langword="null" />.</param>
+        /// <param name="ciphertextWithTag">
+        /// The ciphertext followed immediately by the <see cref="IAeadBlockCipherModeTransform.TagSize" />-byte tag.
+        /// Must be at least <c>transform.TagSize</c> bytes long.
+        /// </param>
+        /// <param name="associatedData">
+        /// The data authenticated alongside the ciphertext. Must match what was supplied at encryption time.
+        /// </param>
+        /// <returns>
+        /// A newly allocated byte array of length <c>ciphertextWithTag.Length - transform.TagSize</c> containing
+        /// the recovered plaintext.
+        /// </returns>
+        /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="ciphertextWithTag" /> is shorter than <c>transform.TagSize</c> bytes.
+        /// </exception>
+        /// <exception cref="CryptographicException">
+        /// The authentication tag did not verify. The returned buffer is not written in this case.
+        /// </exception>
+        public static byte[] Decrypt(
+            this IAeadBlockCipherModeTransform transform,
+            ReadOnlySpan<byte> ciphertextWithTag,
+            ReadOnlySpan<byte> associatedData)
+        {
+            if (transform is null) throw new ArgumentNullException(nameof(transform));
+
+            if (ciphertextWithTag.Length < transform.TagSize)
+                throw new ArgumentException(
+                    $"Input must be at least {transform.TagSize} bytes (the tag size).",
+                    nameof(ciphertextWithTag));
+
+            transform.ProcessAssociatedData(associatedData);
+
+            byte[] plaintext = new byte[ciphertextWithTag.Length - transform.TagSize];
+            int written = transform.Decrypt(ciphertextWithTag, plaintext);
+
+            if (written != plaintext.Length)
+                Array.Resize(ref plaintext, written);
+
+            return plaintext;
+        }
+
+        /// <summary>
+        /// Verifies <paramref name="ciphertextWithTag" /> with an empty associated-data stream, decrypts it,
+        /// and returns the recovered plaintext.
+        /// </summary>
+        /// <param name="transform">The AEAD transform. Must not be <see langword="null" />.</param>
+        /// <param name="ciphertextWithTag">
+        /// The ciphertext followed immediately by the <see cref="IAeadBlockCipherModeTransform.TagSize" />-byte tag.
+        /// </param>
+        /// <returns>A newly allocated byte array containing the recovered plaintext.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
+        /// <exception cref="CryptographicException">The authentication tag did not verify.</exception>
+        public static byte[] Decrypt(
+            this IAeadBlockCipherModeTransform transform,
+            ReadOnlySpan<byte> ciphertextWithTag)
+            => Decrypt(transform, ciphertextWithTag, ReadOnlySpan<byte>.Empty);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AesBlockCipher.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography
+{
+    /// <summary>
+    /// Exposes the BCL <see cref="Aes" /> algorithm as an <see cref="IBlockCipher" />, providing the
+    /// single-block primitive that the authenticated-mode transforms (<see cref="GcmModeTransform" />,
+    /// <see cref="CcmModeTransform" />, <see cref="OcbModeTransform" />, <see cref="SivModeTransform" />,
+    /// <see cref="GcmSivModeTransform" />) require.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The adapter encrypts and decrypts exactly one 16-byte block per call, in ECB mode with no padding,
+    /// delegating to the BCL's hardware-accelerated <see cref="Aes" /> implementation. All key scheduling is
+    /// performed by the BCL on construction.
+    /// </para>
+    /// <para>
+    /// <see cref="AesBlockCipher" /> is not intended for direct encryption of user data. Wrap it in one of
+    /// the authenticated mode transforms listed above — the mode transform is responsible for chaining,
+    /// IV / nonce handling, associated-data authentication, and tag generation or verification.
+    /// </para>
+    /// <para>
+    /// Instances hold sensitive key material and must be disposed after use. Disposal releases the
+    /// underlying <see cref="Aes" /> instance and zeros its expanded key schedule.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    /// // Encrypt a single 16-byte block (typically used indirectly via an AEAD mode transform).
+    /// byte[] key = RandomNumberGenerator.GetBytes(16);
+    /// using var cipher = new AesBlockCipher(key);
+    ///
+    /// Span&lt;byte&gt; block = stackalloc byte[16];
+    /// Span&lt;byte&gt; output = stackalloc byte[16];
+    /// cipher.Encrypt(block, output);
+    /// </code>
+    /// </example>
+    /// <seealso href="../guides/cryptography/aead-modes.html">Using AEAD modes (guide with full encrypt / decrypt examples)</seealso>
+    public sealed class AesBlockCipher
+        : IBlockCipher
+    {
+        private readonly Aes aes;
+        private bool disposed;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="AesBlockCipher" /> class with the specified AES key.
+        /// </summary>
+        /// <param name="key">
+        /// The AES key. Valid lengths are 16, 24, or 32 bytes (AES-128, AES-192, or AES-256). A defensive copy
+        /// is taken — the caller may zero the original array immediately after construction.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="key" /> is <see langword="null" />.</exception>
+        /// <exception cref="CryptographicException"><paramref name="key" /> length is not 16, 24, or 32 bytes.</exception>
+        public AesBlockCipher(byte[] key)
+        {
+            if (key is null) throw new ArgumentNullException(nameof(key));
+
+            this.aes = Aes.Create();
+            this.aes.Key = key; // BCL validates length and throws CryptographicException on mismatch.
+        }
+
+        /// <inheritdoc />
+        /// <value>Always 16 (128 bits), the fixed AES block size.</value>
+        public int BlockSize => this.aes.BlockSize / 8;
+
+        /// <inheritdoc />
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="input" /> or <paramref name="output" /> is not exactly <see cref="BlockSize" /> bytes.
+        /// </exception>
+        public void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+            this.aes.EncryptEcb(input, output, PaddingMode.None);
+        }
+
+        /// <inheritdoc />
+        /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+        /// <exception cref="ArgumentException">
+        /// <paramref name="input" /> or <paramref name="output" /> is not exactly <see cref="BlockSize" /> bytes.
+        /// </exception>
+        public void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
+        {
+            ObjectDisposedException.ThrowIf(this.disposed, this);
+            this.aes.DecryptEcb(input, output, PaddingMode.None);
+        }
+
+        /// <summary>
+        /// Releases the underlying <see cref="Aes" /> instance, zeroing its expanded key schedule.
+        /// Subsequent calls to <see cref="Encrypt" /> or <see cref="Decrypt" /> throw
+        /// <see cref="ObjectDisposedException" />.
+        /// </summary>
+        public void Dispose()
+        {
+            if (!this.disposed)
+            {
+                this.aes.Dispose();
+                this.disposed = true;
+            }
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -38,6 +38,9 @@ namespace Bodu.Security.Cryptography
     /// AAD length is encoded as a 2-byte big-endian prefix (supports up to 65 279 bytes).
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html#ccm--a-two-pass-alternative">CCM walk-through in the AEAD-modes guide</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public sealed class CcmModeTransform : IAeadBlockCipherModeTransform
     {
         private const int NonceLengthBytes = 12;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
@@ -42,6 +42,9 @@ namespace Bodu.Security.Cryptography
     /// counter J0; for standard GCM with 96-bit nonces, the caller should pad to blockSize.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html#gcm--the-workhorse">GCM walk-through in the AEAD-modes guide</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public sealed class GcmModeTransform : IAeadBlockCipherModeTransform
     {
         private const int DefaultTagSize = 16;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -45,6 +45,9 @@ namespace Bodu.Security.Cryptography
     /// <see cref="IAeadBlockCipherModeTransform" /> convention.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html#gcm-siv--the-modern-replacement-for-gcm">GCM-SIV walk-through in the AEAD-modes guide</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public sealed class GcmSivModeTransform : IAeadBlockCipherModeTransform
     {
         private const int TagLengthBytes = 16;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs.cs
@@ -37,6 +37,9 @@ namespace Bodu.Security.Cryptography
     /// message.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html">Using AEAD modes (guide with GCM, CCM, OCB3, SIV, and GCM-SIV examples)</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public interface IAeadBlockCipherModeTransform
     {
         /// <summary>Gets the size of the authentication tag produced by this mode, in bytes.</summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -44,6 +44,9 @@ namespace Bodu.Security.Cryptography
     /// The L array uses GF(2^128) doubling with polynomial x^128 + x^7 + x^2 + x + 1 (big-endian).
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html#ocb3--single-pass-rfc-7253">OCB3 walk-through in the AEAD-modes guide</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public sealed class OcbModeTransform
         : IAeadBlockCipherModeTransform
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -47,6 +47,9 @@ namespace Bodu.Security.Cryptography
     /// <see cref="IAeadBlockCipherModeTransform" /> convention.
     /// </para>
     /// </remarks>
+    /// <seealso href="../guides/cryptography/aead-modes.html#siv--misuse-resistant">SIV walk-through in the AEAD-modes guide</seealso>
+    /// <seealso cref="AesBlockCipher" />
+    /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />
     public sealed class SivModeTransform : IAeadBlockCipherModeTransform
     {
         private const int TagLengthBytes = 16;

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -1,0 +1,248 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AeadBlockCipherModeTransformExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Security.Cryptography.Extensions
+{
+    /// <summary>
+    /// Verifies the one-shot <see cref="AeadBlockCipherModeTransformExtensions" /> wrappers round-trip
+    /// correctly against each of the five public AEAD mode transforms when composed with
+    /// <see cref="AesBlockCipher" /> as the underlying primitive.
+    /// </summary>
+    [TestClass]
+    public sealed class AeadBlockCipherModeTransformExtensionsTests
+    {
+        private static readonly byte[] Plaintext = System.Text.Encoding.UTF8.GetBytes(
+            "The quick brown fox jumps over the lazy dog.");
+
+        private static readonly byte[] AssociatedData = System.Text.Encoding.UTF8.GetBytes("context");
+
+        // Predictable keys and nonces keep the tests deterministic under failure triage.
+        private static byte[] NewKey() => new byte[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+        private static byte[] NewIv()  => new byte[16] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
+                                                         0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19 };
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM + AES recovers the original
+        /// plaintext when associated data is supplied on both sides.
+        /// </summary>
+        [TestMethod]
+        public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData);
+
+            byte[] recovered;
+            using (var cipher = new AesBlockCipher(key))
+                recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM + AES recovers the original
+        /// plaintext when the overload without associated data is used.
+        /// </summary>
+        [TestMethod]
+        public void Gcm_RoundTrip_NoAssociatedData_ShouldRecoverPlaintext()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext);
+
+            byte[] recovered;
+            using (var cipher = new AesBlockCipher(key))
+                recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using CCM + AES recovers the original
+        /// plaintext with associated data.
+        /// </summary>
+        [TestMethod]
+        public void Ccm_RoundTrip_ShouldRecoverPlaintext()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new CcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData);
+
+            byte[] recovered;
+            using (var cipher = new AesBlockCipher(key))
+                recovered = new CcmModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using OCB + AES recovers the original
+        /// plaintext with associated data.
+        /// </summary>
+        [TestMethod]
+        public void Ocb_RoundTrip_ShouldRecoverPlaintext()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new OcbModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData);
+
+            byte[] recovered;
+            using (var cipher = new AesBlockCipher(key))
+                recovered = new OcbModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using SIV + AES recovers the original
+        /// plaintext with associated data. SIV uses two independent AES keys.
+        /// </summary>
+        [TestMethod]
+        public void Siv_RoundTrip_ShouldRecoverPlaintext()
+        {
+            byte[] s2vKey = NewKey();
+            byte[] ctrKey = new byte[16];
+            RandomNumberGenerator.Fill(ctrKey);
+            byte[] iv = NewIv();
+
+            byte[] cipherWithTag;
+            using (var s2v = new AesBlockCipher(s2vKey))
+            using (var ctr = new AesBlockCipher(ctrKey))
+                cipherWithTag = new SivModeTransform(s2v, ctr, iv).Encrypt(Plaintext, AssociatedData);
+
+            byte[] recovered;
+            using (var s2v = new AesBlockCipher(s2vKey))
+            using (var ctr = new AesBlockCipher(ctrKey))
+                recovered = new SivModeTransform(s2v, ctr, iv).Decrypt(cipherWithTag, AssociatedData);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM-SIV + AES recovers the original
+        /// plaintext. GCM-SIV requires a master cipher plus a factory for the per-message cipher.
+        /// </summary>
+        [TestMethod]
+        public void GcmSiv_RoundTrip_ShouldRecoverPlaintext()
+        {
+            byte[] masterKey = NewKey();
+            byte[] iv = NewIv();
+
+            byte[] cipherWithTag;
+            using (var master = new AesBlockCipher(masterKey))
+                cipherWithTag = new GcmSivModeTransform(master, static k => new AesBlockCipher(k), iv)
+                    .Encrypt(Plaintext, AssociatedData);
+
+            byte[] recovered;
+            using (var master = new AesBlockCipher(masterKey))
+                recovered = new GcmSivModeTransform(master, static k => new AesBlockCipher(k), iv)
+                    .Decrypt(cipherWithTag, AssociatedData);
+
+            CollectionAssert.AreEqual(Plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that a single flipped bit in the authentication tag causes the
+        /// <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+        /// overload to throw <see cref="CryptographicException" />.
+        /// </summary>
+        [TestMethod]
+        public void Decrypt_WhenTagIsTampered_ShouldThrowCryptographicException()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData);
+
+            // Flip the last bit of the tag.
+            cipherWithTag[^1] ^= 0x01;
+
+            using var cipher2 = new AesBlockCipher(key);
+            var aead = new GcmModeTransform(cipher2, iv);
+            Assert.ThrowsException<CryptographicException>(() =>
+                aead.Decrypt(cipherWithTag, AssociatedData));
+        }
+
+        /// <summary>
+        /// Verifies that decryption fails with <see cref="CryptographicException" /> when the associated
+        /// data supplied at decrypt time does not match the data supplied at encrypt time.
+        /// </summary>
+        [TestMethod]
+        public void Decrypt_WhenAssociatedDataDiffers_ShouldThrowCryptographicException()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+
+            byte[] cipherWithTag;
+            using (var cipher = new AesBlockCipher(key))
+                cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData);
+
+            byte[] otherAad = System.Text.Encoding.UTF8.GetBytes("different-context");
+
+            using var cipher2 = new AesBlockCipher(key);
+            var aead = new GcmModeTransform(cipher2, iv);
+            Assert.ThrowsException<CryptographicException>(() =>
+                aead.Decrypt(cipherWithTag, otherAad));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Encrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+        /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
+        /// </summary>
+        [TestMethod]
+        public void Encrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                AeadBlockCipherModeTransformExtensions.Encrypt(null!, Plaintext, AssociatedData));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+        /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
+        /// </summary>
+        [TestMethod]
+        public void Decrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                AeadBlockCipherModeTransformExtensions.Decrypt(null!, new byte[32], AssociatedData));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+        /// throws <see cref="ArgumentException" /> when the ciphertext+tag input is shorter than the tag size.
+        /// </summary>
+        [TestMethod]
+        public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
+        {
+            byte[] key = NewKey();
+            byte[] iv  = NewIv();
+            using var cipher = new AesBlockCipher(key);
+            var aead = new GcmModeTransform(cipher, iv);
+
+            byte[] tooShort = new byte[aead.TagSize - 1];
+            Assert.ThrowsException<ArgumentException>(() =>
+                aead.Decrypt(tooShort, AssociatedData));
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AesBlockCipherTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AesBlockCipherTests.cs
@@ -1,0 +1,154 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AesBlockCipherTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Security.Cryptography;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Security.Cryptography
+{
+    /// <summary>
+    /// Verifies the public <see cref="AesBlockCipher" /> adapter: key-size validation, single-block
+    /// encrypt / decrypt round-trip against the BCL's <see cref="Aes" />, and disposal semantics.
+    /// </summary>
+    [TestClass]
+    public sealed class AesBlockCipherTests
+    {
+        /// <summary>
+        /// Verifies that constructing with a <see langword="null" /> key throws
+        /// <see cref="ArgumentNullException" />.
+        /// </summary>
+        [TestMethod]
+        public void Ctor_WhenKeyIsNull_ShouldThrowArgumentNullException()
+        {
+            Assert.ThrowsException<ArgumentNullException>(() => new AesBlockCipher(null!));
+        }
+
+        /// <summary>
+        /// Verifies that construction fails with <see cref="CryptographicException" /> when the supplied
+        /// key length is not one of the three AES variants (128 / 192 / 256 bits).
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(0)]
+        [DataRow(8)]
+        [DataRow(15)]
+        [DataRow(17)]
+        [DataRow(31)]
+        [DataRow(33)]
+        public void Ctor_WhenKeyLengthIsInvalid_ShouldThrowCryptographicException(int keyLength)
+        {
+            byte[] key = new byte[keyLength];
+            Assert.ThrowsException<CryptographicException>(() => new AesBlockCipher(key));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AesBlockCipher.BlockSize" /> reports the fixed AES block size of
+        /// 16 bytes regardless of key length.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(16)]
+        [DataRow(24)]
+        [DataRow(32)]
+        public void BlockSize_ForAnyValidKeyLength_ShouldBe16(int keyLength)
+        {
+            using var cipher = new AesBlockCipher(new byte[keyLength]);
+            Assert.AreEqual(16, cipher.BlockSize);
+        }
+
+        /// <summary>
+        /// Verifies that a single block encrypted by <see cref="AesBlockCipher" /> is recovered
+        /// byte-for-byte by a subsequent <see cref="AesBlockCipher.Decrypt" /> call using the same key.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(16)]
+        [DataRow(24)]
+        [DataRow(32)]
+        public void EncryptThenDecrypt_ShouldRecoverOriginalPlaintextBlock(int keyLength)
+        {
+            byte[] key = new byte[keyLength];
+            RandomNumberGenerator.Fill(key);
+
+            byte[] plaintext = new byte[16];
+            RandomNumberGenerator.Fill(plaintext);
+
+            byte[] ciphertext = new byte[16];
+            byte[] recovered  = new byte[16];
+
+            using (var cipher = new AesBlockCipher(key))
+                cipher.Encrypt(plaintext, ciphertext);
+
+            using (var cipher = new AesBlockCipher(key))
+                cipher.Decrypt(ciphertext, recovered);
+
+            CollectionAssert.AreEqual(plaintext, recovered);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AesBlockCipher" /> produces byte-for-byte identical output to the
+        /// BCL's <see cref="Aes.EncryptEcb(ReadOnlySpan{byte}, Span{byte}, PaddingMode)" /> — confirming
+        /// the adapter applies no additional transformation.
+        /// </summary>
+        [TestMethod]
+        public void Encrypt_ForSingleBlock_ShouldMatchBclEncryptEcb()
+        {
+            byte[] key = RandomNumberGenerator.GetBytes(16);
+            byte[] plaintext = RandomNumberGenerator.GetBytes(16);
+
+            byte[] ourCiphertext = new byte[16];
+            using (var cipher = new AesBlockCipher(key))
+                cipher.Encrypt(plaintext, ourCiphertext);
+
+            byte[] bclCiphertext = new byte[16];
+            using (Aes aes = Aes.Create())
+            {
+                aes.Key = key;
+                aes.EncryptEcb(plaintext, bclCiphertext, PaddingMode.None);
+            }
+
+            CollectionAssert.AreEqual(bclCiphertext, ourCiphertext);
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="AesBlockCipher.Encrypt" /> after <see cref="AesBlockCipher.Dispose" />
+        /// throws <see cref="ObjectDisposedException" />.
+        /// </summary>
+        [TestMethod]
+        public void Encrypt_AfterDispose_ShouldThrowObjectDisposedException()
+        {
+            var cipher = new AesBlockCipher(new byte[16]);
+            cipher.Dispose();
+
+            byte[] input = new byte[16], output = new byte[16];
+            Assert.ThrowsException<ObjectDisposedException>(() => cipher.Encrypt(input, output));
+        }
+
+        /// <summary>
+        /// Verifies that calling <see cref="AesBlockCipher.Decrypt" /> after <see cref="AesBlockCipher.Dispose" />
+        /// throws <see cref="ObjectDisposedException" />.
+        /// </summary>
+        [TestMethod]
+        public void Decrypt_AfterDispose_ShouldThrowObjectDisposedException()
+        {
+            var cipher = new AesBlockCipher(new byte[16]);
+            cipher.Dispose();
+
+            byte[] input = new byte[16], output = new byte[16];
+            Assert.ThrowsException<ObjectDisposedException>(() => cipher.Decrypt(input, output));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="AesBlockCipher.Dispose" /> is idempotent — calling it twice does not
+        /// throw.
+        /// </summary>
+        [TestMethod]
+        public void Dispose_WhenCalledTwice_ShouldNotThrow()
+        {
+            var cipher = new AesBlockCipher(new byte[16]);
+            cipher.Dispose();
+            cipher.Dispose();
+        }
+    }
+}

--- a/docs/guides/cryptography/aead-modes.md
+++ b/docs/guides/cryptography/aead-modes.md
@@ -1,0 +1,213 @@
+---
+title: Using AEAD modes
+---
+
+# Using AEAD modes
+
+**Authenticated encryption with associated data (AEAD)** combines confidentiality with integrity: the ciphertext carries a tag that detects any tampering with the ciphertext *or* with the associated metadata (headers, protocol fields, etc.) that travels alongside it.
+
+`Bodu.Security.Cryptography` ships five AEAD mode transforms, each implementing <xref:Bodu.Security.Cryptography.IAeadBlockCipherModeTransform>. All of them target a 16-byte (128-bit) block cipher — in practice, AES.
+
+| Mode | Class | Standard | Notes |
+|---|---|---|---|
+| **GCM** | <xref:Bodu.Security.Cryptography.GcmModeTransform> | NIST SP 800-38D | Single-pass; fastest with CLMUL hardware. IV reuse is catastrophic. |
+| **CCM** | <xref:Bodu.Security.Cryptography.CcmModeTransform> | NIST SP 800-38C | Two-pass (CTR + CBC-MAC). Fixed 12-byte nonce and 16-byte tag in this implementation. |
+| **OCB3** | <xref:Bodu.Security.Cryptography.OcbModeTransform> | RFC 7253 | Single-pass with offsets; configurable tag length (8 / 12 / 16 bytes). |
+| **SIV** | <xref:Bodu.Security.Cryptography.SivModeTransform> | RFC 5297 | Misuse-resistant — same message encrypts to the same ciphertext, but confidentiality is preserved. Needs two independent AES keys. |
+| **GCM-SIV** | <xref:Bodu.Security.Cryptography.GcmSivModeTransform> | RFC 8452 | Misuse-resistant successor to GCM; POLYVAL-based. |
+
+## Prerequisites — an AES `IBlockCipher`
+
+Every mode transform in this family takes an <xref:Bodu.Security.Cryptography.IBlockCipher> as its primitive. The library ships one public implementation, <xref:Bodu.Security.Cryptography.AesBlockCipher>, which wraps the BCL's hardware-accelerated `Aes`.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+byte[] key = RandomNumberGenerator.GetBytes(16);  // AES-128; 24 or 32 also valid
+using var cipher = new AesBlockCipher(key);
+```
+
+`AesBlockCipher` implements `IBlockCipher`, exposes a 16-byte block size, and forwards single-block encrypt / decrypt calls to `Aes.EncryptEcb` / `Aes.DecryptEcb`. It is the glue that makes every mode transform below usable.
+
+## Prerequisites — the extension methods
+
+Calling an `IAeadBlockCipherModeTransform` directly requires four steps:
+
+1. Call `ProcessAssociatedData(aad)` (even if the AAD is empty).
+2. Size the output buffer to `plaintext.Length + TagSize`.
+3. Call `Encrypt(plaintext, output)` and inspect the returned byte count.
+4. For decrypt, size the output to `ciphertextWithTag.Length - TagSize` and call `Decrypt`.
+
+The `Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions` class collapses all of that into a single call that returns a correctly sized `byte[]`:
+
+```csharp
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] cipherWithTag = aead.Encrypt(plaintext, associatedData);
+byte[] recovered     = aead.Decrypt(cipherWithTag, associatedData);
+```
+
+The examples below all use those extension methods.
+
+## GCM — the workhorse
+
+GCM is the default choice for almost any authenticated-encryption workload. It's single-pass, hardware-accelerated, and part of TLS 1.3.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("secret payload");
+byte[] aad       = System.Text.Encoding.UTF8.GetBytes("correlation-id:42");
+
+byte[] key = RandomNumberGenerator.GetBytes(32);          // AES-256
+byte[] iv  = new byte[16];                                 // J0 in GCM
+RandomNumberGenerator.Fill(iv.AsSpan(0, 12));              // 12-byte nonce
+iv[15] = 0x01;                                             // GCM counter-start convention
+
+// Encrypt — produces ciphertext || 16-byte tag
+byte[] cipherWithTag;
+using (var cipher = new AesBlockCipher(key))
+    cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(plaintext, aad);
+
+// Decrypt — throws CryptographicException if the ciphertext or AAD has been tampered with
+byte[] recovered;
+using (var cipher = new AesBlockCipher(key))
+    recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag, aad);
+```
+
+> [!WARNING]
+> **Never reuse a `(key, nonce)` pair.** Doing so in GCM is catastrophic — the XOR of two ciphertexts recovers the XOR of the plaintexts, *and* an attacker can recover the hash key H and forge arbitrary messages. If you cannot guarantee nonce uniqueness, use SIV or GCM-SIV instead.
+
+### On the 16-byte IV
+
+This implementation takes the initial counter block J0 directly as its 16-byte IV, following NIST SP 800-38D. For the standard 96-bit-nonce mode, build J0 as `nonce || 0x00000001` (12 bytes of nonce followed by a 4-byte big-endian 1). The snippet above does this explicitly.
+
+## CCM — a two-pass alternative
+
+CCM is the standard AEAD in constrained and legacy environments (Bluetooth LE, older IPsec profiles, IEEE 802.11i). It pairs CTR encryption with CBC-MAC over the formatted message. The library's implementation fixes the deployment profile most commonly used: 12-byte nonce, 16-byte tag, up to 2²⁴−1 byte messages.
+
+```csharp
+byte[] key = RandomNumberGenerator.GetBytes(16);
+byte[] iv  = new byte[16];
+RandomNumberGenerator.Fill(iv.AsSpan(0, 12));  // first 12 bytes are the CCM nonce
+
+byte[] cipherWithTag;
+using (var cipher = new AesBlockCipher(key))
+    cipherWithTag = new CcmModeTransform(cipher, iv).Encrypt(plaintext, aad);
+
+byte[] recovered;
+using (var cipher = new AesBlockCipher(key))
+    recovered = new CcmModeTransform(cipher, iv).Decrypt(cipherWithTag, aad);
+```
+
+Only the first 12 bytes of the IV are consumed as the nonce; the remaining bytes are ignored.
+
+## OCB3 — single-pass, RFC 7253
+
+OCB3 achieves single-pass AEAD through an offset trick: the same per-block offset drives both the cipher and the MAC accumulator. It's typically the fastest software AEAD on CPUs without AES-GCM hardware, and the tag length is configurable.
+
+```csharp
+byte[] key = RandomNumberGenerator.GetBytes(16);
+byte[] iv  = new byte[16];
+RandomNumberGenerator.Fill(iv.AsSpan(0, 12));  // first 12 bytes are the OCB3 nonce
+
+byte[] cipherWithTag;
+using (var cipher = new AesBlockCipher(key))
+    // Default tag length of 16 bytes; pass `tagLen: 12` or 8 for the smaller RFC 7253 variants.
+    cipherWithTag = new OcbModeTransform(cipher, iv).Encrypt(plaintext, aad);
+
+byte[] recovered;
+using (var cipher = new AesBlockCipher(key))
+    recovered = new OcbModeTransform(cipher, iv).Decrypt(cipherWithTag, aad);
+```
+
+## SIV — misuse-resistant
+
+SIV (RFC 5297) derives its IV from the message itself, so encrypting the same plaintext twice with the same key produces the same ciphertext — but confidentiality is preserved beyond confirming equality, and the scheme does not fail catastrophically on accidental nonce reuse. Use SIV when you cannot guarantee a unique nonce per message (for example, for deterministic key wrapping or for messages replayed across retries).
+
+SIV uses two independent AES keys — one for the S2V / CMAC authentication pass (`K₁`), one for the CTR encryption pass (`K₂`):
+
+```csharp
+byte[] s2vKey = RandomNumberGenerator.GetBytes(16);  // K₁
+byte[] ctrKey = RandomNumberGenerator.GetBytes(16);  // K₂
+byte[] iv     = new byte[16];                        // accepted for interface compatibility
+
+byte[] cipherWithTag;
+using (var s2v = new AesBlockCipher(s2vKey))
+using (var ctr = new AesBlockCipher(ctrKey))
+    cipherWithTag = new SivModeTransform(s2v, ctr, iv).Encrypt(plaintext, aad);
+
+byte[] recovered;
+using (var s2v = new AesBlockCipher(s2vKey))
+using (var ctr = new AesBlockCipher(ctrKey))
+    recovered = new SivModeTransform(s2v, ctr, iv).Decrypt(cipherWithTag, aad);
+```
+
+The `iv` argument is kept for interface compatibility but is not used — SIV derives its synthetic IV from the AAD and plaintext.
+
+## GCM-SIV — the modern replacement for GCM
+
+GCM-SIV (RFC 8452) is a misuse-resistant AEAD with GCM-like performance. It's the preferred choice when you want GCM's speed *and* need to tolerate accidental nonce reuse. The construction uses AES internally, but with a key-derivation step — so the constructor takes a master cipher **and** a factory that produces a new cipher for the derived per-message key.
+
+```csharp
+byte[] masterKey = RandomNumberGenerator.GetBytes(16);
+byte[] iv        = new byte[16];
+RandomNumberGenerator.Fill(iv.AsSpan(0, 12));  // first 12 bytes are the nonce
+
+byte[] cipherWithTag;
+using (var master = new AesBlockCipher(masterKey))
+    cipherWithTag = new GcmSivModeTransform(
+        master,
+        static k => new AesBlockCipher(k),  // factory for the derived per-message cipher
+        iv).Encrypt(plaintext, aad);
+
+byte[] recovered;
+using (var master = new AesBlockCipher(masterKey))
+    recovered = new GcmSivModeTransform(
+        master,
+        static k => new AesBlockCipher(k),
+        iv).Decrypt(cipherWithTag, aad);
+```
+
+The factory expression `static k => new AesBlockCipher(k)` is the canonical form — the `static` modifier avoids a closure allocation.
+
+## One-transform, one-message
+
+Every AEAD transform in this library is **stateful and single-use**. Construct a new transform for every message — do not attempt to call `Encrypt` twice on the same instance. The extension methods enforce this by invoking `ProcessAssociatedData` internally, which most implementations allow only once.
+
+The pattern throughout these examples —
+
+```csharp
+using (var cipher = new AesBlockCipher(key))
+    cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(plaintext, aad);
+```
+
+— constructs a fresh `AesBlockCipher` and a fresh `GcmModeTransform` inside the `using`, runs one encryption, and lets them both fall out of scope.
+
+## Tamper detection
+
+Decrypt throws <xref:System.Security.Cryptography.CryptographicException> if **any** part of the ciphertext, the tag, or the AAD has been modified since encryption. The extension methods do not catch it — callers must decide whether to log, retry, or reject:
+
+```csharp
+try
+{
+    byte[] plaintext = aead.Decrypt(cipherWithTag, aad);
+    // …proceed with the plaintext
+}
+catch (CryptographicException)
+{
+    // Tag did not verify — reject the message entirely.
+    // Do not act on any partial plaintext (the extension method does not leak any).
+}
+```
+
+On the wire, a failed tag check is indistinguishable from an attack; treat every failure as adversarial.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key / IV / Tweak / Padding lifecycle for the non-AEAD ciphers.
+- [Cipher block modes](cipher-modes.md) — the five classic non-authenticated modes (ECB / CBC / CFB / OFB / CTR).
+- API reference: [<xref:Bodu.Security.Cryptography.AesBlockCipher>] · [<xref:Bodu.Security.Cryptography.IAeadBlockCipherModeTransform>] · [<xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions>].

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -23,6 +23,11 @@ If you're looking for the generated API reference, see the [Bodu.Security.Crypto
 </div>
 
 <div class="bodu-card">
+  <h3><a href="aead-modes.html">AEAD modes</a></h3>
+  <p>GCM, CCM, OCB3, SIV, GCM-SIV — authenticated encryption with AES, using <code>AesBlockCipher</code> plus the one-shot extension methods.</p>
+</div>
+
+<div class="bodu-card">
   <h3><a href="padding.html">Padding</a></h3>
   <p>PKCS7, Zeros, and None — how each one pads, when it round-trips cleanly, and when it silently loses bytes.</p>
 </div>
@@ -53,8 +58,6 @@ All five share the same high-level shape: a `SymmetricAlgorithm` (or `TweakableS
 - [AEAD modes overview](../../api/Bodu.Security.Cryptography.GcmModeTransform.html) — how GCM, CCM, OCB, EAX, SIV, and GCM-SIV relate.
 - [Merkle tree construction](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) and the [parallel pipeline diagram](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
 
-## A note on AEAD
+## Authenticated encryption
 
-This library ships a family of AEAD mode transforms — `GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `EaxModeTransform`, `SivModeTransform`, `GcmSivModeTransform` — implemented against the internal `IBlockCipher` engines. They are currently consumed by the library's own tests rather than directly by external callers.
-
-If you need authenticated encryption in an application today, use the BCL's <xref:System.Security.Cryptography.AesGcm?displayProperty=nameWithType> or <xref:System.Security.Cryptography.AesCcm?displayProperty=nameWithType>, which are hardware-accelerated and FIPS-validated on supported platforms.
+For authenticated-encryption-with-associated-data (AEAD), pair the public <xref:Bodu.Security.Cryptography.AesBlockCipher> with one of the mode transforms — `GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `SivModeTransform`, or `GcmSivModeTransform` — and call through the one-shot <xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions> helpers. The [AEAD modes guide](aead-modes.md) walks through each mode end-to-end.

--- a/docs/guides/cryptography/toc.yml
+++ b/docs/guides/cryptography/toc.yml
@@ -5,6 +5,8 @@
   href: encryption-basics.md
 - name: Cipher block modes
   href: cipher-modes.md
+- name: AEAD modes
+  href: aead-modes.md
 - name: Padding
   href: padding.md
 - name: Hashing and checksums

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -8,6 +8,8 @@
       href: cryptography/encryption-basics.md
     - name: Cipher block modes
       href: cryptography/cipher-modes.md
+    - name: AEAD modes
+      href: cryptography/aead-modes.md
     - name: Padding
       href: cryptography/padding.md
     - name: Hashing and checksums


### PR DESCRIPTION
## Summary

Make the AEAD mode transforms (GCM / CCM / OCB3 / SIV / GCM-SIV) reachable from external callers and document them end-to-end.

**New public API** (`Bodu.Security.Cryptography`):

- **`AesBlockCipher : IBlockCipher`** — wraps `System.Security.Cryptography.Aes` as a 16-byte single-block primitive in ECB + no-padding mode. Supports AES-128 / 192 / 256. Intended to be composed with an AEAD mode transform, not used directly.
- **`AeadBlockCipherModeTransformExtensions`** (in `Bodu.Security.Cryptography.Extensions`) — one-shot wrappers on `IAeadBlockCipherModeTransform`:
  - `Encrypt(plaintext, aad) → byte[]`
  - `Encrypt(plaintext) → byte[]`
  - `Decrypt(ctWithTag, aad) → byte[]`
  - `Decrypt(ctWithTag) → byte[]`

  Each call runs `ProcessAssociatedData`, sizes the output buffer, and returns a correctly sized `byte[]`. `Decrypt` propagates `CryptographicException` on tag failure.

**Tests:**
- `AesBlockCipherTests` — 8 tests covering null / invalid-length keys, block size, round-trip at every AES key length, BCL parity, and disposal.
- `AeadBlockCipherModeTransformExtensionsTests` — 11 tests covering round-trip with each of the five AEAD modes, with and without AAD; tamper detection (flipped tag bit, mismatched AAD); argument validation.

**Documentation:**
- New `docs/guides/cryptography/aead-modes.md` with a mode-comparison table, `AesBlockCipher` prerequisite, one-shot extension pattern, and a complete encrypt-and-decrypt walk-through for each of the five AEAD modes.
- Hub page now features a fourth card pointing at the AEAD guide; dropped the "AEAD not reachable" disclaimer added in PR #24.
- `docs/guides/toc.yml` and `docs/guides/cryptography/toc.yml` list the new page.
- Added `<seealso>` links on all five AEAD mode classes plus `IAeadBlockCipherModeTransform` — each points at the relevant guide section and at `AesBlockCipher` / the extensions.

## Test plan

- [ ] GitHub Actions build passes; the new tests run cleanly against the library.
- [ ] `dotnet build Bodu.sln` is analyzer-clean (no new CS1591 / XML-doc warnings from the new public types).
- [ ] DocFX build publishes the new `guides/cryptography/aead-modes.html` page and surfaces it in the `Guides` nav.
- [ ] API pages for `GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `SivModeTransform`, `GcmSivModeTransform`, and `IAeadBlockCipherModeTransform` show a See Also section linking to the guide.
- [ ] `/api/Bodu.Security.Cryptography.AesBlockCipher.html` and `/api/Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions.html` render.

https://claude.ai/code/session_01TcQuZVRdUAxF7sPRvNJ98Y