### PR TITLE
feat(crypto): promote block-cipher engines to public + composing guide

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlowfishBlockCipher.cs
@@ -24,11 +24,15 @@ namespace Bodu.Security.Cryptography
     /// material and expanded S-box state are zeroed securely on disposal.
     /// </para>
     /// <para>
-    /// This class is intended for internal use only. Callers should use <see cref="Blowfish" /> with a
-    /// <see cref="System.Security.Cryptography.CryptoStream" /> rather than invoking this class directly.
+    /// Most callers should prefer the higher-level <see cref="Blowfish" /> class, which exposes the standard
+    /// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract. Use <see cref="BlowfishBlockCipher" /> directly only
+    /// when composing the raw block primitive with an <see cref="IBlockCipherModeTransform" /> (for example via
+    /// <see cref="BlockCipherModeFactory" />) or with an <see cref="IPaddingStrategy" />.
     /// </para>
     /// </remarks>
-    internal sealed class BlowfishBlockCipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    /// <seealso cref="Blowfish" />
+    public sealed class BlowfishBlockCipher
         : IBlockCipher
     {
         private const int BlockSizeInBytes = 8;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
@@ -39,8 +39,16 @@ namespace Bodu.Security.Cryptography
     /// This implementation is constant-time in its control flow, but the S-box lookup table remains data-dependent. As such, this
     /// implementation is <b>not</b> hardened against timing or cache-based side-channel attacks.
     /// </para>
+    /// <para>
+    /// Most callers should prefer the higher-level <see cref="Skipjack" /> class, which exposes the standard
+    /// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract. Use <see cref="SkipjackBlockCipher" /> directly only
+    /// when composing the raw block primitive with an <see cref="IBlockCipherModeTransform" /> (for example via
+    /// <see cref="BlockCipherModeFactory" />) or with an <see cref="IPaddingStrategy" />.
+    /// </para>
     /// </remarks>
-    internal sealed class SkipjackBlockCipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    /// <seealso cref="Skipjack" />
+    public sealed class SkipjackBlockCipher
         : IBlockCipher
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
@@ -15,10 +15,20 @@
     /// 128-bit tweak.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Threefish is a tweakable block cipher optimised for 64-bit platforms and forms the core primitive of the Skein hash function.
     /// The <c>Threefish-1024</c> variant operates on sixteen 64-bit words over 80 rounds using modular addition, bitwise rotation, and XOR.
+    /// </para>
+    /// <para>
+    /// Most callers should prefer the higher-level <see cref="Threefish1024" /> class, which exposes the standard
+    /// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract. Use <see cref="Threefish1024Cipher" /> directly only
+    /// when composing the raw block primitive with an <see cref="IBlockCipherModeTransform" /> (for example via
+    /// <see cref="BlockCipherModeFactory" />) or with an <see cref="IPaddingStrategy" />.
+    /// </para>
     /// </remarks>
-    internal sealed class Threefish1024Cipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    /// <seealso cref="Threefish1024" />
+    public sealed class Threefish1024Cipher
         : ThreefishBlockCipher
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
@@ -15,10 +15,20 @@
     /// tweak.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Threefish is a tweakable block cipher optimised for 64-bit platforms and forms the core primitive of the Skein hash function.
     /// The <c>Threefish-256</c> variant operates on four 64-bit words over 72 rounds using modular addition, bitwise rotation, and XOR.
+    /// </para>
+    /// <para>
+    /// Most callers should prefer the higher-level <see cref="Threefish256" /> class, which exposes the standard
+    /// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract. Use <see cref="Threefish256Cipher" /> directly only
+    /// when composing the raw block primitive with an <see cref="IBlockCipherModeTransform" /> (for example via
+    /// <see cref="BlockCipherModeFactory" />) or with an <see cref="IPaddingStrategy" />.
+    /// </para>
     /// </remarks>
-    internal sealed class Threefish256Cipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    /// <seealso cref="Threefish256" />
+    public sealed class Threefish256Cipher
         : ThreefishBlockCipher
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
@@ -15,10 +15,20 @@
     /// tweak.
     /// </summary>
     /// <remarks>
+    /// <para>
     /// Threefish is a tweakable block cipher optimised for 64-bit platforms and forms the core primitive of the Skein hash function.
     /// The <c>Threefish-512</c> variant operates on eight 64-bit words over 72 rounds using modular addition, bitwise rotation, and XOR.
+    /// </para>
+    /// <para>
+    /// Most callers should prefer the higher-level <see cref="Threefish512" /> class, which exposes the standard
+    /// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract. Use <see cref="Threefish512Cipher" /> directly only
+    /// when composing the raw block primitive with an <see cref="IBlockCipherModeTransform" /> (for example via
+    /// <see cref="BlockCipherModeFactory" />) or with an <see cref="IPaddingStrategy" />.
+    /// </para>
     /// </remarks>
-    internal sealed class Threefish512Cipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    /// <seealso cref="Threefish512" />
+    public sealed class Threefish512Cipher
         : ThreefishBlockCipher
     {
         /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.cs
@@ -16,10 +16,21 @@
     /// <c>Threefish-1024</c> variants.
     /// </summary>
     /// <remarks>
-    /// Derived classes supply the block size, word count, rotation schedule, and round count for a specific Threefish variant, along
-    /// with their own <see cref="Encrypt" /> and <see cref="Decrypt" /> implementations.
+    /// <para>
+    /// Derived classes — <see cref="Threefish256Cipher" />, <see cref="Threefish512Cipher" />, and
+    /// <see cref="Threefish1024Cipher" /> — supply the block size, word count, rotation schedule, and round count for a
+    /// specific Threefish variant, along with their own <see cref="Encrypt" /> and <see cref="Decrypt" /> implementations.
+    /// </para>
+    /// <para>
+    /// External callers cannot derive new variants: the constructor and protected members are scoped <c>private protected</c>,
+    /// limiting derivation to the three variants that ship with this library. Use <see cref="Threefish256Cipher" />,
+    /// <see cref="Threefish512Cipher" />, or <see cref="Threefish1024Cipher" /> for the raw block primitive, or one of the
+    /// higher-level <see cref="Threefish256" />, <see cref="Threefish512" />, or <see cref="Threefish1024" /> wrappers for
+    /// the standard <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> contract.
+    /// </para>
     /// </remarks>
-    internal abstract partial class ThreefishBlockCipher
+    /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs. SymmetricAlgorithm</seealso>
+    public abstract partial class ThreefishBlockCipher
         : IBlockCipher
     {
         /// <summary>
@@ -27,19 +38,19 @@
         /// subkey injection.
         /// </summary>
         // KeySchedule: [K0, K1, K2, K3, K4=parity, K0, K1, K2, K3]
-        protected readonly ulong[] KeySchedule;
+        private protected readonly ulong[] KeySchedule;
 
         /// <summary>
         /// The expanded tweak schedule, containing the two tweak words, their XOR, and the repeated tweak words used during subkey
         /// injection.
         /// </summary>
         // TweakSchedule: [T0, T1, T2=T0^T1, T0, T1]
-        protected readonly ulong[] TweakSchedule;
+        private protected readonly ulong[] TweakSchedule;
 
         /// <summary>
         /// Indicates whether the instance has been disposed.
         /// </summary>
-        protected bool disposed = false;
+        private protected bool disposed = false;
 
         private const ulong KeyParityValue = 0x1BD11BDAA9FC1A22;
 
@@ -53,7 +64,7 @@
         /// <exception cref="ArgumentException">
         /// <paramref name="key" /> or <paramref name="tweak" /> has an invalid length.
         /// </exception>
-        protected ThreefishBlockCipher(ReadOnlySpan<byte> key, ReadOnlySpan<byte> tweak)
+        private protected ThreefishBlockCipher(ReadOnlySpan<byte> key, ReadOnlySpan<byte> tweak)
         {
             ThrowHelper.ThrowIfSpanLengthIsNotEqualTo(key, this.BlockSize);
             ThrowHelper.ThrowIfSpanLengthIsNotEqualTo(tweak, 16);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PrimitiveCompositionEquivalenceTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PrimitiveCompositionEquivalenceTests.cs
@@ -1,0 +1,229 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="PrimitiveCompositionEquivalenceTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Linq;
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Security.Cryptography
+{
+    /// <summary>
+    /// Smoke-tests for the public block-cipher engines (<see cref="SkipjackBlockCipher" />,
+    /// <see cref="BlowfishBlockCipher" />, and the three Threefish variants), and verifies that the
+    /// direct <see cref="IBlockCipher" /> + <see cref="BlockCipherModeFactory" /> + <see cref="PaddingFactory" />
+    /// composition produces the same ciphertext as the equivalent <see cref="System.Security.Cryptography.SymmetricAlgorithm" />
+    /// wrapper. This is the equivalence claimed by the
+    /// <a href="../../docs/guides/cryptography/composing-primitives.md">composing-primitives guide</a>.
+    /// </summary>
+    [TestClass]
+    public sealed class PrimitiveCompositionEquivalenceTests
+    {
+        private static readonly byte[] Plaintext = System.Text.Encoding.UTF8.GetBytes(
+            "The quick brown fox jumps over the lazy dog twice over.");
+
+        /// <summary>
+        /// Verifies that <see cref="SkipjackBlockCipher" /> composed manually with CBC + PKCS7 produces the
+        /// same ciphertext as the equivalent <see cref="Skipjack" /> wrapper configured the same way.
+        /// </summary>
+        [TestMethod]
+        public void Skipjack_DirectAndWrapper_ShouldProduceIdenticalCiphertext()
+        {
+            byte[] key = RandomNumberGenerator.GetBytes(10);
+            byte[] iv  = RandomNumberGenerator.GetBytes(8);
+
+            byte[] direct = EncryptDirect_Skipjack(key, iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+            byte[] viaAlg = EncryptViaWrapper_Skipjack(key, iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+
+            CollectionAssert.AreEqual(viaAlg, direct);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="BlowfishBlockCipher" /> composed manually with CBC + PKCS7 produces the
+        /// same ciphertext as the equivalent <see cref="Blowfish" /> wrapper.
+        /// </summary>
+        [TestMethod]
+        public void Blowfish_DirectAndWrapper_ShouldProduceIdenticalCiphertext()
+        {
+            byte[] key = RandomNumberGenerator.GetBytes(16);  // 128-bit Blowfish key (default)
+            byte[] iv  = RandomNumberGenerator.GetBytes(8);
+
+            byte[] direct = EncryptDirect_Blowfish(key, iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+            byte[] viaAlg = EncryptViaWrapper_Blowfish(key, iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+
+            CollectionAssert.AreEqual(viaAlg, direct);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Threefish256Cipher" /> composed manually with CTR (no padding) produces
+        /// the same ciphertext as the equivalent <see cref="Threefish256" /> wrapper.
+        /// </summary>
+        [TestMethod]
+        public void Threefish256_DirectAndWrapper_ShouldProduceIdenticalCiphertext()
+        {
+            byte[] key   = RandomNumberGenerator.GetBytes(32);
+            byte[] iv    = RandomNumberGenerator.GetBytes(32);
+            byte[] tweak = RandomNumberGenerator.GetBytes(16);
+
+            byte[] direct = EncryptDirect_Threefish(
+                () => new Threefish256Cipher(key, tweak),
+                iv, CipherBlockMode.CTR, PaddingMode.None, Plaintext);
+
+            byte[] viaAlg;
+            using (var alg = new Threefish256
+            {
+                BlockMode = CipherBlockMode.CTR,
+                Padding   = PaddingMode.None,
+                Key       = key,
+                IV        = iv,
+                Tweak     = tweak,
+            })
+            {
+                viaAlg = alg.Encrypt(Plaintext);
+            }
+
+            CollectionAssert.AreEqual(viaAlg, direct);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Threefish512Cipher" /> composed manually with CBC + PKCS7 produces the
+        /// same ciphertext as the equivalent <see cref="Threefish512" /> wrapper.
+        /// </summary>
+        [TestMethod]
+        public void Threefish512_DirectAndWrapper_ShouldProduceIdenticalCiphertext()
+        {
+            byte[] key   = RandomNumberGenerator.GetBytes(64);
+            byte[] iv    = RandomNumberGenerator.GetBytes(64);
+            byte[] tweak = RandomNumberGenerator.GetBytes(16);
+
+            byte[] direct = EncryptDirect_Threefish(
+                () => new Threefish512Cipher(key, tweak),
+                iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+
+            byte[] viaAlg;
+            using (var alg = new Threefish512
+            {
+                BlockMode = CipherBlockMode.CBC,
+                Padding   = PaddingMode.PKCS7,
+                Key       = key,
+                IV        = iv,
+                Tweak     = tweak,
+            })
+            {
+                viaAlg = alg.Encrypt(Plaintext);
+            }
+
+            CollectionAssert.AreEqual(viaAlg, direct);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Threefish1024Cipher" /> composed manually with CBC + PKCS7 produces the
+        /// same ciphertext as the equivalent <see cref="Threefish1024" /> wrapper.
+        /// </summary>
+        [TestMethod]
+        public void Threefish1024_DirectAndWrapper_ShouldProduceIdenticalCiphertext()
+        {
+            byte[] key   = RandomNumberGenerator.GetBytes(128);
+            byte[] iv    = RandomNumberGenerator.GetBytes(128);
+            byte[] tweak = RandomNumberGenerator.GetBytes(16);
+
+            byte[] direct = EncryptDirect_Threefish(
+                () => new Threefish1024Cipher(key, tweak),
+                iv, CipherBlockMode.CBC, PaddingMode.PKCS7, Plaintext);
+
+            byte[] viaAlg;
+            using (var alg = new Threefish1024
+            {
+                BlockMode = CipherBlockMode.CBC,
+                Padding   = PaddingMode.PKCS7,
+                Key       = key,
+                IV        = iv,
+                Tweak     = tweak,
+            })
+            {
+                viaAlg = alg.Encrypt(Plaintext);
+            }
+
+            CollectionAssert.AreEqual(viaAlg, direct);
+        }
+
+        /// <summary>
+        /// Verifies that the now-public <see cref="ThreefishBlockCipher" /> base type cannot be derived from
+        /// outside the assembly: its constructor is <c>private protected</c>, so external derivation produces
+        /// a compile-time error. Inside the assembly, the three shipped variants successfully derive — proven
+        /// by the round-trip tests above.
+        /// </summary>
+        [TestMethod]
+        public void ThreefishBlockCipher_BaseConstructor_IsNotExternallyDerivable()
+        {
+            // Asserting the type is sealed-from-the-outside is a compile-time check rather than a runtime one.
+            // We can at least verify that the three shipped variants exist and round-trip — proving that
+            // intra-assembly derivation still works after the visibility narrowing.
+            byte[] key = new byte[32], iv = new byte[32], tweak = new byte[16];
+            using var cipher = new Threefish256Cipher(key, tweak);
+            byte[] block  = new byte[32];
+            byte[] output = new byte[32];
+            cipher.Encrypt(block, output);
+            Assert.AreEqual(32, cipher.BlockSize);
+        }
+
+        // ── Helpers ────────────────────────────────────────────────────────────────────────────────
+
+        private static byte[] EncryptDirect_Skipjack(byte[] key, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            using IBlockCipher cipher = new SkipjackBlockCipher(key);
+            return EncryptDirect(cipher, iv, mode, padding, plaintext);
+        }
+
+        private static byte[] EncryptDirect_Blowfish(byte[] key, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            using IBlockCipher cipher = new BlowfishBlockCipher(key);
+            return EncryptDirect(cipher, iv, mode, padding, plaintext);
+        }
+
+        private static byte[] EncryptDirect_Threefish(Func<IBlockCipher> factory, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            using IBlockCipher cipher = factory();
+            return EncryptDirect(cipher, iv, mode, padding, plaintext);
+        }
+
+        private static byte[] EncryptDirect(IBlockCipher cipher, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            IBlockCipherModeTransform modeTransform = BlockCipherModeFactory.Create(mode, cipher, iv);
+            IPaddingStrategy paddingStrategy = PaddingFactory.Create(padding);
+
+            byte[] padded = paddingStrategy.Pad(plaintext, cipher.BlockSize);
+            byte[] ciphertext = new byte[padded.Length];
+            modeTransform.Transform(padded, ciphertext, encrypt: true);
+            return ciphertext;
+        }
+
+        private static byte[] EncryptViaWrapper_Skipjack(byte[] key, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            using var alg = new Skipjack
+            {
+                BlockMode = mode,
+                Padding   = padding,
+                Key       = key,
+                IV        = iv,
+            };
+            return alg.Encrypt(plaintext);
+        }
+
+        private static byte[] EncryptViaWrapper_Blowfish(byte[] key, byte[] iv, CipherBlockMode mode, PaddingMode padding, byte[] plaintext)
+        {
+            using var alg = new Blowfish
+            {
+                BlockMode = mode,
+                Padding   = padding,
+                Key       = key,
+                IV        = iv,
+            };
+            return alg.Encrypt(plaintext);
+        }
+    }
+}

--- a/docs/guides/cryptography/aead-modes.md
+++ b/docs/guides/cryptography/aead-modes.md
@@ -18,7 +18,7 @@ title: Using AEAD modes
 
 ## Prerequisites — an AES `IBlockCipher`
 
-Every mode transform in this family takes an <xref:Bodu.Security.Cryptography.IBlockCipher> as its primitive. The library ships one public implementation, <xref:Bodu.Security.Cryptography.AesBlockCipher>, which wraps the BCL's hardware-accelerated `Aes`.
+Every mode transform in this family takes an <xref:Bodu.Security.Cryptography.IBlockCipher> as its primitive **and assumes a 16-byte (128-bit) block size**. That assumption is baked into the counter formats, the GHASH/POLYVAL field, and the offset schedules — so the library's other primitives (Skipjack and Blowfish at 8 bytes, Threefish-256/512/1024 at 32/64/128 bytes) are not eligible. <xref:Bodu.Security.Cryptography.AesBlockCipher>, which wraps the BCL's hardware-accelerated `Aes`, is the only primitive that fits.
 
 ```csharp
 using System.Security.Cryptography;
@@ -29,6 +29,8 @@ using var cipher = new AesBlockCipher(key);
 ```
 
 `AesBlockCipher` implements `IBlockCipher`, exposes a 16-byte block size, and forwards single-block encrypt / decrypt calls to `Aes.EncryptEcb` / `Aes.DecryptEcb`. It is the glue that makes every mode transform below usable.
+
+If you need authenticated encryption with one of the *non-128-bit* ciphers (Skipjack, Blowfish, or Threefish), see the [composing primitives guide](composing-primitives.md) — you can still use the classic mode transforms (CBC, CTR, etc.) directly with their primitives, and layer your own MAC (HMAC, Poly1305) over the resulting ciphertext for an encrypt-then-MAC construction.
 
 ## Prerequisites — the extension methods
 

--- a/docs/guides/cryptography/composing-primitives.md
+++ b/docs/guides/cryptography/composing-primitives.md
@@ -1,0 +1,174 @@
+---
+title: Composing primitives — direct use vs. SymmetricAlgorithm
+---
+
+# Composing primitives — direct use vs. `SymmetricAlgorithm`
+
+`Bodu.Security.Cryptography` exposes its block ciphers at **two levels**:
+
+1. The **raw block primitive** — `SkipjackBlockCipher`, `BlowfishBlockCipher`, `Threefish256Cipher`, `Threefish512Cipher`, `Threefish1024Cipher`, `AesBlockCipher`. Each implements <xref:Bodu.Security.Cryptography.IBlockCipher>: encrypt and decrypt one fixed-size block. Compose with <xref:Bodu.Security.Cryptography.BlockCipherModeFactory> and <xref:Bodu.Security.Cryptography.PaddingFactory> when you need the full mode + padding pipeline visible at the call site.
+2. The **`SymmetricAlgorithm`** wrappers — <xref:Bodu.Security.Cryptography.Skipjack>, <xref:Bodu.Security.Cryptography.Blowfish>, <xref:Bodu.Security.Cryptography.Threefish256>, <xref:Bodu.Security.Cryptography.Threefish512>, <xref:Bodu.Security.Cryptography.Threefish1024>. These derive from <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType> and integrate with `CryptoStream`, `ICryptoTransform`, and the `Encrypt` / `Decrypt` extension methods.
+
+Both levels produce **byte-for-byte identical ciphertext** for the same Key, IV, (Tweak), Mode, and Padding. Pick the level that matches your use case:
+
+| Use the primitive when… | Use the SymmetricAlgorithm when… |
+|---|---|
+| You want each step (encrypt block, accumulate MAC, manage IV, pad) explicit at the call site. | You want a one-liner for `byte[] cipher = alg.Encrypt(plaintext)`. |
+| You're composing custom AEAD, custom padding, or a streaming protocol. | You're integrating with `CryptoStream`, `RSACryptoServiceProvider`-style ceremony, or .NET ecosystem code. |
+| You need to share an `IBlockCipher` between an AEAD transform and a classic mode transform. | You're following the common .NET pattern most readers already know. |
+
+## A note on AEAD modes
+
+The five AEAD mode transforms (`GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `SivModeTransform`, `GcmSivModeTransform`) are designed for **128-bit-block ciphers** — their counter formats, GHASH/POLYVAL field, and offset schedules all assume 16-byte blocks. Skipjack and Blowfish have 8-byte blocks; the Threefish family starts at 32 bytes. Only <xref:Bodu.Security.Cryptography.AesBlockCipher> fits, which is why the [AEAD modes guide](aead-modes.md) is exclusively AES-based. The classic modes shown here (CBC / CTR / CFB / OFB / ECB) work with any block size and so cover the rest of the cipher family.
+
+## Pattern 1 — direct primitive composition
+
+Encrypt a message under Skipjack with CBC + PKCS7, manually composing the cipher, mode transform, and padding strategy:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+byte[] key = new byte[10];   RandomNumberGenerator.Fill(key);
+byte[] iv  = new byte[8];    RandomNumberGenerator.Fill(iv);
+
+byte[] plaintext = System.Text.Encoding.UTF8.GetBytes("legacy payload");
+
+// 1. Build the primitive.
+using IBlockCipher cipher = new SkipjackBlockCipher(key);
+
+// 2. Wrap with a mode transform.
+IBlockCipherModeTransform mode = BlockCipherModeFactory.Create(CipherBlockMode.CBC, cipher, iv);
+
+// 3. Choose a padding strategy.
+IPaddingStrategy padding = PaddingFactory.Create(PaddingMode.PKCS7);
+
+// 4. Pad, transform, and emit.
+byte[] padded = padding.Pad(plaintext, cipher.BlockSize);
+byte[] ciphertext = new byte[padded.Length];
+mode.Transform(padded, ciphertext, encrypt: true);
+```
+
+Decrypt is the same flow reversed:
+
+```csharp
+using IBlockCipher cipher = new SkipjackBlockCipher(key);
+IBlockCipherModeTransform mode = BlockCipherModeFactory.Create(CipherBlockMode.CBC, cipher, iv);
+IPaddingStrategy padding = PaddingFactory.Create(PaddingMode.PKCS7);
+
+byte[] decrypted = new byte[ciphertext.Length];
+mode.Transform(ciphertext, decrypted, encrypt: false);
+byte[] recovered = padding.Unpad(decrypted, cipher.BlockSize);
+```
+
+The same shape works for **every** primitive — swap `SkipjackBlockCipher` for `BlowfishBlockCipher`, or for one of the Threefish variants (which take a key *and* a 16-byte tweak):
+
+```csharp
+byte[] key   = new byte[32];  RandomNumberGenerator.Fill(key);
+byte[] iv    = new byte[32];  RandomNumberGenerator.Fill(iv);
+byte[] tweak = new byte[16];  RandomNumberGenerator.Fill(tweak);
+
+using IBlockCipher cipher = new Threefish256Cipher(key, tweak);
+IBlockCipherModeTransform mode = BlockCipherModeFactory.Create(CipherBlockMode.CTR, cipher, iv);
+
+// CTR is a stream mode — no padding.
+byte[] ciphertext = new byte[plaintext.Length];
+mode.Transform(plaintext, ciphertext, encrypt: true);
+```
+
+## Pattern 2 — `SymmetricAlgorithm` wrapper
+
+The same Skipjack-CBC-PKCS7 encryption written through the high-level wrapper:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+using var alg = new Skipjack
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+    Key       = key,    // same 10 bytes
+    IV        = iv,     // same 8 bytes
+};
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+Internally, `Skipjack.CreateEncryptor` builds the same `SkipjackBlockCipher` + `CbcModeTransform` + `Pkcs7Padding` you composed by hand in Pattern 1. **The ciphertext is byte-for-byte identical.** That's the contract worth remembering: the two patterns are equivalent — the wrapper exists for convenience, not for behaviour.
+
+The Threefish wrappers carry the same equivalence, with `Tweak` flowing into the constructor of `Threefish*Cipher`:
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CTR,
+    Padding   = PaddingMode.None,
+    Key       = key,    // 32 bytes
+    IV        = iv,     // 32 bytes
+    Tweak     = tweak,  // 16 bytes
+};
+
+byte[] ciphertext = alg.Encrypt(plaintext);
+```
+
+## Verifying the equivalence
+
+Inside a single test you can prove the two patterns produce the same ciphertext byte-for-byte:
+
+```csharp
+byte[] key       = RandomNumberGenerator.GetBytes(10);
+byte[] iv        = RandomNumberGenerator.GetBytes(8);
+byte[] plaintext = RandomNumberGenerator.GetBytes(64);
+
+// Direct path.
+byte[] direct;
+using (IBlockCipher cipher = new SkipjackBlockCipher(key))
+{
+    var mode = BlockCipherModeFactory.Create(CipherBlockMode.CBC, cipher, iv);
+    var pad  = PaddingFactory.Create(PaddingMode.PKCS7);
+
+    byte[] padded = pad.Pad(plaintext, cipher.BlockSize);
+    direct = new byte[padded.Length];
+    mode.Transform(padded, direct, encrypt: true);
+}
+
+// SymmetricAlgorithm path.
+byte[] viaAlg;
+using (var alg = new Skipjack
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.PKCS7,
+    Key       = key,
+    IV        = iv,
+})
+{
+    viaAlg = alg.Encrypt(plaintext);
+}
+
+Debug.Assert(direct.SequenceEqual(viaAlg));
+```
+
+## When to favour each pattern
+
+**Reach for the direct primitive when:**
+
+- You're building a *custom* construction — your own AEAD, a MAC over framing fields, an authenticated channel — and you need explicit access to the block primitive at every step.
+- You're composing across modes — for example, encrypting a header with CBC and a body with CTR under the same key — and want a single `IBlockCipher` instance shared by both transforms.
+- You need to pass a Bodu cipher into a third-party API that expects an `IBlockCipher`.
+
+**Reach for the `SymmetricAlgorithm` wrapper when:**
+
+- You're emitting a single message and want the one-liner.
+- You're plugging into `System.Security.Cryptography.CryptoStream`, ASP.NET DataProtection, or any other API that accepts a `SymmetricAlgorithm`.
+- You're following the convention readers already know — `Encrypt` / `Decrypt` extension methods, `CreateEncryptor` / `CreateDecryptor` for stream-style use.
+
+## Where to go next
+
+- [Encryption basics](encryption-basics.md) — the Key / IV / Tweak / Padding lifecycle for the `SymmetricAlgorithm` wrappers.
+- [Cipher block modes](cipher-modes.md) — what each of the five classic modes does, and worked examples through the wrapper API.
+- [AEAD modes](aead-modes.md) — for authenticated encryption (AES-only, via `AesBlockCipher`).
+- [Padding](padding.md) — PKCS7 / Zeros / None and when each is safe.
+- API reference: [<xref:Bodu.Security.Cryptography.IBlockCipher>] · [<xref:Bodu.Security.Cryptography.BlockCipherModeFactory>] · [<xref:Bodu.Security.Cryptography.PaddingFactory>] · [<xref:Bodu.Security.Cryptography.IBlockCipherModeTransform>].

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -32,6 +32,11 @@ If you're looking for the generated API reference, see the [Bodu.Security.Crypto
   <p>PKCS7, Zeros, and None — how each one pads, when it round-trips cleanly, and when it silently loses bytes.</p>
 </div>
 
+<div class="bodu-card">
+  <h3><a href="composing-primitives.html">Composing primitives</a></h3>
+  <p>The two patterns side by side — manual <code>IBlockCipher</code> + <code>BlockCipherModeFactory</code> + <code>PaddingFactory</code>, and the equivalent through the <code>SymmetricAlgorithm</code> wrappers.</p>
+</div>
+
 </div>
 
 ## Symmetric ciphers

--- a/docs/guides/cryptography/toc.yml
+++ b/docs/guides/cryptography/toc.yml
@@ -7,6 +7,8 @@
   href: cipher-modes.md
 - name: AEAD modes
   href: aead-modes.md
+- name: Composing primitives
+  href: composing-primitives.md
 - name: Padding
   href: padding.md
 - name: Hashing and checksums

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -10,6 +10,8 @@
       href: cryptography/cipher-modes.md
     - name: AEAD modes
       href: cryptography/aead-modes.md
+    - name: Composing primitives
+      href: cryptography/composing-primitives.md
     - name: Padding
       href: cryptography/padding.md
     - name: Hashing and checksums


### PR DESCRIPTION
## Summary

Expose the raw block-cipher primitives so external callers can compose them with `BlockCipherModeFactory` + `PaddingFactory` directly — alongside the existing `SymmetricAlgorithm` wrappers. Both paths produce **byte-for-byte identical ciphertext**; the user picks the layer that fits their use case.

**Promoted to public** (previously `internal`):

| Type | Block | Key | Notes |
|---|---|---|---|
| `SkipjackBlockCipher` | 8 B | 10 B | `IBlockCipher` |
| `BlowfishBlockCipher` | 8 B | 4 – 56 B | `IBlockCipher` |
| `Threefish256Cipher` | 32 B | 32 B | `IBlockCipher`, 16-B tweak |
| `Threefish512Cipher` | 64 B | 64 B | `IBlockCipher`, 16-B tweak |
| `Threefish1024Cipher` | 128 B | 128 B | `IBlockCipher`, 16-B tweak |
| `ThreefishBlockCipher` | abstract | — | Constructor + protected fields/helpers narrowed to `private protected` so external derivation is blocked while the in-assembly variants continue to compile |

Each newly-public engine now carries a "use the `SymmetricAlgorithm` wrapper unless you need the primitive" pointer in its `<remarks>`, plus `<seealso>` links to the matching wrapper class and to the new composing-primitives guide.

**Documentation:**

- New `docs/guides/cryptography/composing-primitives.md` walks through both patterns side by side: direct primitive composition (cipher + mode + padding) and the equivalent `SymmetricAlgorithm` wrapper. The byte-for-byte equivalence guarantee is called out explicitly.
- `aead-modes.md` now explicitly notes the 128-bit-block constraint that makes AES the only option for AEAD, and links to the composing-primitives guide for the non-AES ciphers.
- Hub page (`index.md`) gains a "Composing primitives" card; both TOCs list the new page.

**Tests:**

`PrimitiveCompositionEquivalenceTests` proves the equivalence — for each of the five newly-public engines, the manual `BlockCipherModeFactory` + `PaddingFactory` composition produces ciphertext identical to the equivalent `SymmetricAlgorithm` wrapper. Five round-trip tests plus one intra-assembly derivation sanity check.

## Test plan

- [ ] `dotnet build Bodu.sln` is analyzer-clean — no new CS1591 / XML-doc warnings on the newly-exposed public types.
- [ ] `dotnet test` runs cleanly, including the new `PrimitiveCompositionEquivalenceTests`.
- [ ] DocFX build publishes `/guides/cryptography/composing-primitives.html` and surfaces it under the Guides nav.
- [ ] API pages for the five newly-public engines render with their new `<remarks>` text and See-Also links.
- [ ] No regressions in the existing `SkipjackBlockCipherTests`, `BlowfishBlockCipherTests`, or Threefish-cipher tests (they continue to compile against the now-public types).

https://claude.ai/code/session_01TcQuZVRdUAxF7sPRvNJ98Y