### PR TITLE
test(core): stabilise flaky ConcurrentCircularBuffer AllowOverwrite tests

### DIFF
--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.AllowOverwrite.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.AllowOverwrite.cs
@@ -131,6 +131,12 @@ public partial class ConcurrentCircularBufferTests
         // At minimum, the read path must not have thrown; reaching this line confirms stability.
     }
 
+    /// <summary>
+    /// Verifies that a write to <see cref="ConcurrentCircularBuffer{T}.AllowOverwrite" /> is observed by a
+    /// concurrently running enqueuer, such that at least one enqueue against a full buffer throws
+    /// <see cref="InvalidOperationException" /> while overwriting is disabled, and ongoing toggling between
+    /// <see langword="true" /> and <see langword="false" /> continues without corrupting the buffer.
+    /// </summary>
     [TestMethod]
     public void AllowOverwrite_WhenToggledDuringEnqueue_ShouldAffectBehaviorImmediately()
     {
@@ -141,9 +147,17 @@ public partial class ConcurrentCircularBufferTests
 
         var exceptions = new ConcurrentBag<Exception>();
 
+        // Handshake: the toggler establishes AllowOverwrite = false before the writer's first
+        // Enqueue, guaranteeing at least one observation of the disabled state against a full
+        // buffer. Concurrent toggling then proceeds for the remainder of both loops so the test
+        // still exercises inter-thread visibility under contention.
+        using var togglerPrimed = new ManualResetEventSlim(initialState: false);
+
         var writer = Task.Run(() =>
         {
-            for (int i = 0; i < 200; i++) // more iterations
+            togglerPrimed.Wait();
+
+            for (int i = 0; i < 200; i++)
             {
                 try
                 {
@@ -154,17 +168,22 @@ public partial class ConcurrentCircularBufferTests
                     exceptions.Add(ex);
                 }
 
-                // Introduce random delay to vary interleaving
+                // Introduce variable delay to broaden interleaving with the toggler.
                 Thread.SpinWait(1000 + (i % 5) * 100);
             }
         });
 
         var toggler = Task.Run(() =>
         {
-            for (int i = 0; i < 200; i++)
+            buffer.AllowOverwrite = false;
+            togglerPrimed.Set();
+
+            // Continue alternating starting from i = 1 so the next write is true, preserving
+            // the original true/false cadence after the primed false state.
+            for (int i = 1; i < 200; i++)
             {
                 buffer.AllowOverwrite = (i % 2 == 0);
-                Thread.SpinWait(2000); // longer delay to keep setting stable
+                Thread.SpinWait(2000);
             }
         });
 

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.AllowOverwrite.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.AllowOverwrite.cs
@@ -193,6 +193,12 @@ public partial class ConcurrentCircularBufferTests
         Assert.IsTrue(exceptions.All(e => e is InvalidOperationException));
     }
 
+    /// <summary>
+    /// Verifies that under sustained concurrent load with <see cref="ConcurrentCircularBuffer{T}.AllowOverwrite" />
+    /// toggling between <see langword="true" /> and <see langword="false" />, the enqueuer observes at least one
+    /// success (while overwriting is enabled) and at least one <see cref="InvalidOperationException" /> (while
+    /// overwriting is disabled), and no unexpected exception type escapes.
+    /// </summary>
     [TestMethod]
     public void AllowOverwrite_WhenToggledUnderLoad_ShouldProduceMixedEnqueueResultsWithoutCrashing()
     {
@@ -204,8 +210,16 @@ public partial class ConcurrentCircularBufferTests
         var exceptions = new ConcurrentBag<Exception>();
         int successes = 0;
 
+        // Handshake: the toggler establishes AllowOverwrite = false before the writer's first
+        // Enqueue, guaranteeing at least one deterministic InvalidOperationException against
+        // the full buffer. The subsequent toggle loop still exercises both true and false
+        // states concurrently, so the "some successes" assertion remains meaningful.
+        using var togglerPrimed = new ManualResetEventSlim(initialState: false);
+
         var writer = Task.Run(() =>
         {
+            togglerPrimed.Wait();
+
             for (int i = 0; i < 2000; i++)
             {
                 try
@@ -224,7 +238,12 @@ public partial class ConcurrentCircularBufferTests
 
         var toggler = Task.Run(() =>
         {
-            for (int i = 0; i < 2000; i++)
+            buffer.AllowOverwrite = false;
+            togglerPrimed.Set();
+
+            // Continue alternating starting from i = 1 so the next write is true, preserving
+            // the original true/false cadence after the primed false state.
+            for (int i = 1; i < 2000; i++)
             {
                 buffer.AllowOverwrite = (i % 2 == 0);
                 Thread.SpinWait(400);

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enqueue.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enqueue.cs
@@ -19,6 +19,11 @@ public partial class ConcurrentCircularBufferTests
         AssertBufferContainsExactlyValues(buffer, 10, 11);
     }
 
+    /// <summary>
+    /// Verifies that when <see cref="ConcurrentCircularBuffer{T}.AllowOverwrite" /> is toggled concurrently with
+    /// enqueueing into a full buffer, at least one enqueue throws <see cref="InvalidOperationException" /> while
+    /// overwriting is disabled, and the buffer never exceeds its configured capacity.
+    /// </summary>
     [TestMethod]
     public void Enqueue_WhenAllowOverwriteToggledDuringEnqueue_ShouldAlternateBetweenThrowsAndEvictions()
     {
@@ -28,8 +33,15 @@ public partial class ConcurrentCircularBufferTests
 
         var exceptions = new ConcurrentBag<Exception>();
 
+        // Handshake: the toggler confirms AllowOverwrite = false before the writer's first
+        // Enqueue, guaranteeing at least one deterministic InvalidOperationException against
+        // the full buffer. Concurrent toggling then proceeds for the remainder of both loops.
+        using var togglerPrimed = new ManualResetEventSlim(initialState: false);
+
         var writer = Task.Run(() =>
         {
+            togglerPrimed.Wait();
+
             for (int i = 0; i < 200; i++)
             {
                 try { buffer.Enqueue(new TestItem(100 + i)); }
@@ -40,16 +52,21 @@ public partial class ConcurrentCircularBufferTests
 
         var toggler = Task.Run(() =>
         {
-            for (int i = 0; i < 200; i++)
+            buffer.AllowOverwrite = false;
+            togglerPrimed.Set();
+
+            // Continue flipping starting from i = 1 so the next write remains false,
+            // preserving the original "true on i % 3 == 0" cadence after the primed state.
+            for (int i = 1; i < 200; i++)
             {
-                buffer.AllowOverwrite = (i % 3 == 0); // flip sometimes
+                buffer.AllowOverwrite = (i % 3 == 0);
                 Thread.SpinWait(50);
             }
         });
 
         Task.WaitAll(writer, toggler);
 
-        // We expect a mix: some throws (when flag false and full), some evictions (when flag true)
+        // We expect a mix: some throws (when flag false and full), some evictions (when flag true).
         Assert.IsTrue(exceptions.Count > 0, "Expected some InvalidOperationExceptions while overwrite was disabled.");
         Assert.IsTrue(buffer.Count <= buffer.Capacity);
     }


### PR DESCRIPTION
## Summary

Three `ConcurrentCircularBuffer` tests shared the same race-based structure: a
writer task and a toggler task coordinated only by `Thread.SpinWait`, with the
writer expected to observe `AllowOverwrite == false` against a full buffer at
least once. On unlucky scheduling the writer could complete every iteration
without ever seeing `false`, and the `exceptions.Count > 0` assertion would
fire (the original flake — roughly 1 run in 50).

The production `ConcurrentCircularBuffer` is not at fault: `AllowOverwrite`
uses `Volatile.Read` / `Volatile.Write`, and `InternalEnqueue` correctly
consults the flag once per full-buffer attempt — snapshot semantics are
intentional for the lock-free design.

Applied a `ManualResetEventSlim` handshake to all three tests:

- The toggler deterministically sets `AllowOverwrite = false` and signals
  before the writer's first `Enqueue`, guaranteeing at least one
  `InvalidOperationException` against the full buffer.
- Toggle loops resume from `i = 1` so the original modular cadence
  (`i % 2 == 0`, `i % 3 == 0`) is preserved for the remainder of the run.
- Both tasks still race concurrently for the remaining iterations, keeping
  the "toggled during enqueue" intent intact.

Tests affected:

- `ConcurrentCircularBufferTests.AllowOverwrite.cs` —
  `AllowOverwrite_WhenToggledDuringEnqueue_ShouldAffectBehaviorImmediately`
- `ConcurrentCircularBufferTests.AllowOverwrite.cs` —
  `AllowOverwrite_WhenToggledUnderLoad_ShouldProduceMixedEnqueueResultsWithoutCrashing`
- `ConcurrentCircularBufferTests.Enqueue.cs` —
  `Enqueue_WhenAllowOverwriteToggledDuringEnqueue_ShouldAlternateBetweenThrowsAndEvictions`

Test-only change; no production code is affected.

## Test plan

- [x] Run each of the three tests in isolation and confirm pass
- [x] Loop each test 100× and confirm 100/100 green (flake gone)
- [ ] Full `ConcurrentCircularBufferTests` suite still passes
- [ ] Full solution build is clean (no new analyzer warnings, no CS1591)