### PR TITLE
feat(crypto): add ANSI X.923, ISO 10126, and ISO/IEC 7816-4 padding s…

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ansix923Padding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    using System;
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Implements the ANSI X.923 padding scheme, which appends <c>N - 1</c> bytes of value
+    /// <c>0x00</c> followed by a trailing byte holding the padding length <c>N</c>.
+    /// </summary>
+    /// <remarks>
+    /// A full block of padding is always added when the input is already block-aligned so
+    /// that <see cref="Unpad" /> can unambiguously recover the original length. Valid values
+    /// of <c>N</c> lie in the range <c>1..blockSize</c>. <see cref="Unpad" /> validates in
+    /// constant time to resist padding-oracle side channels.
+    /// </remarks>
+    public sealed class Ansix923Padding : IPaddingStrategy
+    {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => true;
+
+        /// <summary>
+        /// Applies ANSI X.923 padding to the input data, ensuring the total output is a
+        /// multiple of the block size.
+        /// </summary>
+        /// <param name="input">The data to pad.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The padded data as a byte array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="blockSize" /> is less than or equal to zero.</exception>
+        public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            if (blockSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be greater than zero.");
+
+            int paddingLength = blockSize - (input.Length % blockSize);
+            if (paddingLength == 0)
+                paddingLength = blockSize;
+
+            byte[] result = new byte[input.Length + paddingLength];
+            input.CopyTo(result);
+
+            // Remaining pad bytes are already 0x00 from array allocation; only the trailing
+            // length byte needs to be written.
+            result[result.Length - 1] = (byte)paddingLength;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Validates and removes ANSI X.923 padding from the specified input data.
+        /// </summary>
+        /// <param name="input">The padded data.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The unpadded data as a byte array.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="input" /> is empty or not aligned to the block size.</exception>
+        /// <exception cref="CryptographicException">Thrown if the padding is invalid or malformed.</exception>
+        public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            // Constant-time verification to mitigate CBC padding-oracle attacks.
+            if (input.Length == 0 || input.Length % blockSize != 0)
+                throw new ArgumentException("Input is not a valid ANSI X.923 padded block sequence.", nameof(input));
+
+            int length = input.Length;
+            int padLen = input[length - 1];
+
+            int geOne = ((-padLen) >> 31) & 1;                  // 1 iff padLen >= 1
+            int leBlock = ((padLen - blockSize - 1) >> 31) & 1; // 1 iff padLen <= blockSize
+            int valid = geOne & leBlock;
+
+            // effective = valid == 1 ? padLen : blockSize (branchless)
+            int effective = (valid * padLen) + ((1 - valid) * blockSize);
+
+            // Walk the last blockSize bytes unconditionally. Every byte in the padding
+            // region, other than the final length byte, must be 0x00.
+            int start = length - blockSize;
+            int lastIndex = length - 1;
+            for (int i = start; i < length; i++)
+            {
+                int diff = i - (length - effective);
+                int shouldBePadByte = ((~diff) >> 31) & 1; // 1 iff i >= length - effective
+
+                // isLastByte = (i == length - 1) ? 1 : 0 (branchless)
+                int xorLast = i ^ lastIndex;
+                int isLastByte = (((xorLast - 1) & ~xorLast) >> 31) & 1;
+
+                // Expected value in padding region: 0x00 for interior bytes, padLen for the last byte.
+                int expected = isLastByte * padLen;
+                int xorExpected = input[i] ^ expected;
+                int matches = (((xorExpected - 1) & ~xorExpected) >> 31) & 1;
+
+                int constraint = (1 - shouldBePadByte) | matches;
+                valid &= constraint;
+            }
+
+            if (valid == 0)
+                throw new CryptographicException("Invalid ANSI X.923 padding.");
+
+            return input.Slice(0, length - padLen).ToArray();
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -62,6 +62,32 @@ namespace Bodu.Security.Cryptography
             this.padding = PaddingFactory.Create(paddingMode);
         }
 
+        /// <summary>
+        /// Initialises a new instance of the <see cref="BlockCipherTransform" /> class using
+        /// the specified cipher engine, mode, extended padding scheme, initialisation vector,
+        /// and transform direction.
+        /// </summary>
+        /// <param name="cipher">
+        /// The configured <see cref="IBlockCipher" /> engine to use. Must not be <see langword="null" />.
+        /// </param>
+        /// <param name="cipherMode">The block cipher mode of operation (for example, <see cref="CipherBlockMode.CBC" />).</param>
+        /// <param name="paddingMode">
+        /// The extended padding scheme to apply to the final block. Accepts values beyond the
+        /// framework <see cref="PaddingMode" /> enum, including <see cref="BoduPaddingMode.ISO7816_4" />.
+        /// </param>
+        /// <param name="iv">The initialisation vector for the cipher mode. Must match the cipher block size.</param>
+        /// <param name="encrypt">
+        /// <see langword="true" /> to configure for encryption; <see langword="false" /> for decryption.
+        /// </param>
+        /// <exception cref="ArgumentNullException"><paramref name="cipher" /> is <see langword="null" />.</exception>
+        protected BlockCipherTransform(IBlockCipher cipher, CipherBlockMode cipherMode, BoduPaddingMode paddingMode, byte[] iv, bool encrypt)
+        {
+            this.cipher = cipher ?? throw new ArgumentNullException(nameof(cipher));
+            this.encrypt = encrypt;
+            this.mode = BlockCipherModeFactory.Create(cipherMode, cipher, iv);
+            this.padding = PaddingFactory.Create(paddingMode);
+        }
+
         /// <inheritdoc />
         public bool CanReuseTransform => false;
 
@@ -123,7 +149,7 @@ namespace Bodu.Security.Cryptography
             }
             else
             {
-                bool stripPadding = this.padding is Pkcs7Padding;
+                bool stripPadding = this.padding.StripsPaddingOnUnpad;
 
                 if (stripPadding && input.Length <= this.cipher.BlockSize)
                 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BoduPaddingMode.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BoduPaddingMode.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduPaddingMode.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Specifies a padding scheme for block-cipher operations. Mirrors the values of the
+    /// framework <see cref="PaddingMode" /> enum and adds schemes that are not part of the
+    /// framework surface.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Numeric values <c>0</c> through <c>4</c> are deliberately aligned with
+    /// <see cref="PaddingMode" /> so that a <see cref="BoduPaddingMode" /> value may be
+    /// converted to the framework enum by cast for the five values the framework defines.
+    /// The <see cref="ISO7816_4" /> value has no framework counterpart.
+    /// </para>
+    /// <para>
+    /// Pass a <see cref="BoduPaddingMode" /> to
+    /// <see cref="PaddingFactory.Create(BoduPaddingMode)" /> to obtain the matching
+    /// <see cref="IPaddingStrategy" /> implementation.
+    /// </para>
+    /// </remarks>
+    public enum BoduPaddingMode
+    {
+        /// <summary>
+        /// No padding is applied. The input must already be a multiple of the block size.
+        /// Equivalent to <see cref="PaddingMode.None" />.
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// PKCS#7 padding (RFC 5652). Each pad byte holds the padding length.
+        /// Equivalent to <see cref="PaddingMode.PKCS7" />.
+        /// </summary>
+        PKCS7 = 1,
+
+        /// <summary>
+        /// Zero padding. Appends <c>0x00</c> bytes until the input aligns with the block
+        /// size. Not self-describing. Equivalent to <see cref="PaddingMode.Zeros" />.
+        /// </summary>
+        Zeros = 2,
+
+        /// <summary>
+        /// ANSI X.923 padding. Pad bytes are <c>0x00</c> except the final byte, which
+        /// holds the padding length. Equivalent to <see cref="PaddingMode.ANSIX923" />.
+        /// </summary>
+        ANSIX923 = 3,
+
+        /// <summary>
+        /// ISO 10126 padding. Pad bytes are random except the final byte, which holds the
+        /// padding length. Equivalent to <see cref="PaddingMode.ISO10126" />.
+        /// </summary>
+        ISO10126 = 4,
+
+        /// <summary>
+        /// ISO/IEC 7816-4 padding (also known as "one-and-zeros" or bit padding). The first
+        /// pad byte is <c>0x80</c> and remaining pad bytes are <c>0x00</c>. A full block of
+        /// padding is appended when the input is already block-aligned so that unpadding is
+        /// unambiguous.
+        /// </summary>
+        /// <remarks>
+        /// This value has no counterpart in the framework <see cref="PaddingMode" /> enum.
+        /// It is widely used in smart-card standards, SHA-3/Keccak and CMAC.
+        /// </remarks>
+        ISO7816_4 = 5,
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.Padding.cs
@@ -241,6 +241,184 @@ namespace Bodu.Security.Cryptography
         }
 
         /// <summary>
+        /// Removes padding from a block using the extended <see cref="BoduPaddingMode" />
+        /// selector and returns the depadded data as a newly allocated array.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> that was applied to <paramref name="block" />.</param>
+        /// <param name="blockSizeBytes">The block size, in bytes, used when the input was padded.</param>
+        /// <param name="block">The input buffer containing the padded block or blocks.</param>
+        /// <param name="offset">The zero-based offset in <paramref name="block" /> at which the padded data begins.</param>
+        /// <param name="count">The number of bytes to read from <paramref name="block" /> starting at <paramref name="offset" />.</param>
+        /// <returns>A newly allocated <see cref="byte" /> array containing the input data with padding removed.</returns>
+        /// <exception cref="CryptographicException">
+        /// The padding is invalid, the specified range is not a positive multiple of <paramref name="blockSizeBytes" />,
+        /// or the padding mode is unsupported.
+        /// </exception>
+        public static byte[] DepadBlock(BoduPaddingMode padding, int blockSizeBytes, byte[] block, int offset, int count)
+        {
+            if (padding == BoduPaddingMode.ISO7816_4)
+            {
+                ThrowHelper.ThrowIfLessThanOrEqual(blockSizeBytes, 0);
+                var strategy = new Iso7816_4Padding();
+                return strategy.Unpad(new ReadOnlySpan<byte>(block, offset, count), blockSizeBytes);
+            }
+
+            return DepadBlock((PaddingMode)padding, blockSizeBytes, block, offset, count);
+        }
+
+        /// <summary>
+        /// Removes padding from a block using the extended <see cref="BoduPaddingMode" />
+        /// selector and writes the depadded data into the specified destination span.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> applied to <paramref name="source" />.</param>
+        /// <param name="blockSizeBytes">The block size, in bytes, used when the input was padded.</param>
+        /// <param name="source">The padded input data. Its length must be a positive multiple of <paramref name="blockSizeBytes" />.</param>
+        /// <param name="destination">The destination span that receives the depadded data.</param>
+        /// <returns>The number of bytes written to <paramref name="destination" /> after padding has been removed.</returns>
+        /// <exception cref="CryptographicException">
+        /// The padding is invalid, <paramref name="source" /> is not a positive multiple of <paramref name="blockSizeBytes" />,
+        /// or the padding mode is unsupported.
+        /// </exception>
+        public static int DepadBlock(
+            BoduPaddingMode padding,
+            int blockSizeBytes,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination)
+        {
+            if (padding == BoduPaddingMode.ISO7816_4)
+            {
+                ThrowHelper.ThrowIfLessThanOrEqual(blockSizeBytes, 0);
+                ThrowHelper.ThrowIfSpanLengthNotPositiveMultipleOf(source, blockSizeBytes);
+
+                var strategy = new Iso7816_4Padding();
+                byte[] unpadded = strategy.Unpad(source, blockSizeBytes);
+                ThrowHelper.ThrowIfSpanLengthIsInsufficient(destination, 0, unpadded.Length);
+                unpadded.AsSpan().CopyTo(destination);
+                return unpadded.Length;
+            }
+
+            return DepadBlock((PaddingMode)padding, blockSizeBytes, source, destination);
+        }
+
+        /// <summary>
+        /// Applies the specified <see cref="BoduPaddingMode" /> to a block and returns the
+        /// padded data as a newly allocated array.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> to apply.</param>
+        /// <param name="blockSizeBytes">The block size in bytes used to align the output.</param>
+        /// <param name="block">The input buffer containing the data to pad.</param>
+        /// <param name="offset">The zero-based offset in <paramref name="block" /> at which to begin reading.</param>
+        /// <param name="count">The number of bytes to read from <paramref name="block" /> starting at <paramref name="offset" />.</param>
+        /// <returns>A newly allocated <see cref="byte" /> array containing the input data with padding applied.</returns>
+        /// <exception cref="CryptographicException">
+        /// The padding mode is invalid, or <paramref name="padding" /> is <see cref="BoduPaddingMode.None" /> and the
+        /// input length is not block-aligned.
+        /// </exception>
+        public static byte[] PadBlock(BoduPaddingMode padding, int blockSizeBytes, byte[] block, int offset, int count)
+        {
+            if (padding == BoduPaddingMode.ISO7816_4)
+            {
+                ThrowHelper.ThrowIfLessThan(blockSizeBytes, 1);
+                var strategy = new Iso7816_4Padding();
+                return strategy.Pad(new ReadOnlySpan<byte>(block, offset, count), blockSizeBytes);
+            }
+
+            return PadBlock((PaddingMode)padding, blockSizeBytes, block, offset, count);
+        }
+
+        /// <summary>
+        /// Applies the specified <see cref="BoduPaddingMode" /> to a block and writes the
+        /// padded result into the destination span.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> to apply.</param>
+        /// <param name="blockSizeBytes">The block size in bytes used to align the output.</param>
+        /// <param name="source">The input data to pad.</param>
+        /// <param name="destination">The destination span that receives the padded result.</param>
+        /// <returns>The total number of bytes written to <paramref name="destination" />.</returns>
+        /// <exception cref="ArgumentException"><paramref name="destination" /> is too small to hold the padded result.</exception>
+        /// <exception cref="CryptographicException">
+        /// The padding mode is invalid, or <paramref name="padding" /> is <see cref="BoduPaddingMode.None" /> and the
+        /// input length is not a multiple of <paramref name="blockSizeBytes" />.
+        /// </exception>
+        public static int PadBlock(
+            BoduPaddingMode padding,
+            int blockSizeBytes,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination)
+        {
+            if (padding == BoduPaddingMode.ISO7816_4)
+            {
+                ThrowHelper.ThrowIfLessThan(blockSizeBytes, 1);
+
+                var strategy = new Iso7816_4Padding();
+                byte[] padded = strategy.Pad(source, blockSizeBytes);
+                ThrowHelper.ThrowIfSpanLengthIsInsufficient(destination, 0, padded.Length);
+                padded.AsSpan().CopyTo(destination);
+                return padded.Length;
+            }
+
+            return PadBlock((PaddingMode)padding, blockSizeBytes, source, destination);
+        }
+
+        /// <summary>
+        /// Attempts to remove padding from the specified input buffer using the given
+        /// <see cref="BoduPaddingMode" />.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> to validate and remove.</param>
+        /// <param name="blockSizeBytes">The block size in bytes used when the input was padded.</param>
+        /// <param name="source">The padded input buffer.</param>
+        /// <param name="destination">The destination span that receives the depadded data.</param>
+        /// <param name="bytesWritten">When this method returns, contains the number of bytes written to <paramref name="destination" />.</param>
+        /// <returns><see langword="true" /> if depadding was successful; otherwise, <see langword="false" />.</returns>
+        public static bool TryDepadBlock(
+            BoduPaddingMode padding,
+            int blockSizeBytes,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            try
+            {
+                bytesWritten = DepadBlock(padding, blockSizeBytes, source, destination);
+                return true;
+            }
+            catch
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Attempts to apply padding to the specified input buffer using the given
+        /// <see cref="BoduPaddingMode" />.
+        /// </summary>
+        /// <param name="padding">The <see cref="BoduPaddingMode" /> to apply.</param>
+        /// <param name="blockSizeBytes">The block size in bytes used to align the output.</param>
+        /// <param name="source">The input buffer to pad.</param>
+        /// <param name="destination">The destination span that receives the padded data.</param>
+        /// <param name="bytesWritten">When this method returns, contains the number of bytes written to <paramref name="destination" />.</param>
+        /// <returns><see langword="true" /> if padding was successfully applied; otherwise, <see langword="false" />.</returns>
+        public static bool TryPadBlock(
+            BoduPaddingMode padding,
+            int blockSizeBytes,
+            ReadOnlySpan<byte> source,
+            Span<byte> destination,
+            out int bytesWritten)
+        {
+            try
+            {
+                bytesWritten = PadBlock(padding, blockSizeBytes, source, destination);
+                return true;
+            }
+            catch
+            {
+                bytesWritten = 0;
+                return false;
+            }
+        }
+
+        /// <summary>
         /// Checks whether a span consists entirely of a single repeated byte value.
         /// </summary>
         /// <param name="span">The span to validate.</param>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IPaddingStrategy.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IPaddingStrategy.cs
@@ -18,6 +18,19 @@
     public interface IPaddingStrategy
     {
         /// <summary>
+        /// Gets a value indicating whether <see cref="Unpad" /> inspects the final block
+        /// and may return fewer bytes than it received. Self-describing schemes such as
+        /// PKCS#7, ANSI X.923, ISO 10126 and ISO/IEC 7816-4 return <see langword="true" />;
+        /// pass-through schemes such as zero padding and no padding return <see langword="false" />.
+        /// </summary>
+        /// <remarks>
+        /// Streaming block-cipher transforms use this flag to decide whether the final
+        /// ciphertext block must be deferred during decryption so that padding validation
+        /// and removal can happen at the stream boundary.
+        /// </remarks>
+        bool StripsPaddingOnUnpad { get; }
+
+        /// <summary>
         /// Applies padding to the input data to align it with the specified block size.
         /// </summary>
         /// <param name="input">The input data to be padded.</param>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso10126Padding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    using System;
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Implements the ISO 10126 padding scheme, which appends <c>N - 1</c> cryptographically
+    /// random bytes followed by a trailing byte holding the padding length <c>N</c>.
+    /// </summary>
+    /// <remarks>
+    /// A full block of padding is always added when the input is already block-aligned so
+    /// that <see cref="Unpad" /> can unambiguously recover the original length. The interior
+    /// pad bytes are not reconstructable on decryption, so only the trailing length byte is
+    /// validated. ISO 10126 was withdrawn by ISO in 2007; it is supported for interoperability
+    /// with existing ciphertexts.
+    /// </remarks>
+    public sealed class Iso10126Padding : IPaddingStrategy
+    {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => true;
+
+        /// <summary>
+        /// Applies ISO 10126 padding to the input data, ensuring the total output is a
+        /// multiple of the block size.
+        /// </summary>
+        /// <param name="input">The data to pad.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The padded data as a byte array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="blockSize" /> is less than or equal to zero.</exception>
+        public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            if (blockSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be greater than zero.");
+
+            int paddingLength = blockSize - (input.Length % blockSize);
+            if (paddingLength == 0)
+                paddingLength = blockSize;
+
+            byte[] result = new byte[input.Length + paddingLength];
+            input.CopyTo(result);
+
+            // Fill the interior pad region with random bytes, then overwrite the final byte
+            // with the pad length. paddingLength - 1 can be zero (when paddingLength == 1),
+            // in which case the interior region is empty and only the length byte is written.
+            int interiorLength = paddingLength - 1;
+            if (interiorLength > 0)
+            {
+                Span<byte> interior = result.AsSpan(input.Length, interiorLength);
+                RandomNumberGenerator.Fill(interior);
+            }
+
+            result[result.Length - 1] = (byte)paddingLength;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Validates and removes ISO 10126 padding from the specified input data.
+        /// </summary>
+        /// <param name="input">The padded data.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The unpadded data as a byte array.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="input" /> is empty or not aligned to the block size.</exception>
+        /// <exception cref="CryptographicException">Thrown if the trailing length byte is out of range.</exception>
+        public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            if (input.Length == 0 || input.Length % blockSize != 0)
+                throw new ArgumentException("Input is not a valid ISO 10126 padded block sequence.", nameof(input));
+
+            int length = input.Length;
+            int padLen = input[length - 1];
+
+            // Only the trailing length byte can be validated; interior pad bytes are random.
+            if (padLen < 1 || padLen > blockSize)
+                throw new CryptographicException("Invalid ISO 10126 padding.");
+
+            return input.Slice(0, length - padLen).ToArray();
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7816_4Padding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    using System;
+    using System.Security.Cryptography;
+
+    /// <summary>
+    /// Implements the ISO/IEC 7816-4 padding scheme (also known as "one-and-zeros" or bit
+    /// padding). The first pad byte is <c>0x80</c> and remaining pad bytes are <c>0x00</c>.
+    /// </summary>
+    /// <remarks>
+    /// A full block of padding is always added when the input is already block-aligned so
+    /// that <see cref="Unpad" /> can unambiguously recover the original length by locating
+    /// the terminator. The scheme is widely used in smart-card protocols, SHA-3/Keccak and
+    /// CMAC. <see cref="Unpad" /> validates in constant time over the final block to resist
+    /// padding-oracle side channels.
+    /// </remarks>
+    public sealed class Iso7816_4Padding : IPaddingStrategy
+    {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => true;
+
+        /// <summary>
+        /// Applies ISO/IEC 7816-4 padding to the input data, ensuring the total output is a
+        /// multiple of the block size.
+        /// </summary>
+        /// <param name="input">The data to pad.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The padded data as a byte array.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="blockSize" /> is less than or equal to zero.</exception>
+        public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            if (blockSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(blockSize), "Block size must be greater than zero.");
+
+            int paddingLength = blockSize - (input.Length % blockSize);
+            if (paddingLength == 0)
+                paddingLength = blockSize;
+
+            byte[] result = new byte[input.Length + paddingLength];
+            input.CopyTo(result);
+
+            // First pad byte is 0x80; remaining pad bytes are 0x00 (already from allocation).
+            result[input.Length] = 0x80;
+
+            return result;
+        }
+
+        /// <summary>
+        /// Validates and removes ISO/IEC 7816-4 padding from the specified input data.
+        /// </summary>
+        /// <param name="input">The padded data.</param>
+        /// <param name="blockSize">The block size in bytes.</param>
+        /// <returns>The unpadded data as a byte array.</returns>
+        /// <exception cref="ArgumentException">Thrown if <paramref name="input" /> is empty or not aligned to the block size.</exception>
+        /// <exception cref="CryptographicException">Thrown if the padding terminator is missing or malformed.</exception>
+        public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
+        {
+            if (input.Length == 0 || input.Length % blockSize != 0)
+                throw new ArgumentException("Input is not a valid ISO/IEC 7816-4 padded block sequence.", nameof(input));
+
+            int length = input.Length;
+            int start = length - blockSize;
+
+            // Constant-time terminator scan over the final block. Walk every byte; for each
+            // position compute two masks:
+            //  - terminatorHere: 1 iff the byte equals 0x80 and no terminator has been seen yet.
+            //  - validTail:      1 iff the byte equals 0x00 (expected after the terminator).
+            // Accumulate the terminator index and verify the tail beyond it is all zeros.
+            int terminatorSeen = 0;
+            int terminatorIndex = -1;
+            int valid = 1;
+
+            for (int i = length - 1; i >= start; i--)
+            {
+                byte b = input[i];
+
+                // is80 = (b == 0x80) ? 1 : 0 (branchless)
+                int xor80 = b ^ 0x80;
+                int is80 = (((xor80 - 1) & ~xor80) >> 31) & 1;
+
+                // is00 = (b == 0x00) ? 1 : 0 (branchless)
+                int is00 = (((b - 1) & ~b) >> 31) & 1;
+
+                // First 0x80 found while walking backwards marks the terminator.
+                int firstTerminatorHere = is80 & (1 - terminatorSeen);
+
+                // Record the terminator index (branchless).
+                terminatorIndex = (firstTerminatorHere * i) + ((1 - firstTerminatorHere) * terminatorIndex);
+                terminatorSeen |= firstTerminatorHere;
+
+                // Before the terminator is found, every byte must be 0x00. After the terminator
+                // is found (including the terminator byte itself), no further constraint applies
+                // to that iteration — the bytes further left belong to the plaintext.
+                int constraint = terminatorSeen | is00;
+                valid &= constraint;
+            }
+
+            if (terminatorSeen == 0 || valid == 0)
+                throw new CryptographicException("Invalid ISO/IEC 7816-4 padding.");
+
+            return input.Slice(0, terminatorIndex).ToArray();
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -13,6 +13,9 @@
     /// </remarks>
     public sealed class NoPadding : IPaddingStrategy
     {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => false;
+
         /// <summary>
         /// Returns a copy of <paramref name="input" /> after verifying that its length is a multiple of <paramref name="blockSize" />.
         /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
@@ -1,4 +1,4 @@
-﻿namespace Bodu.Security.Cryptography
+namespace Bodu.Security.Cryptography
 {
     using System;
     using System.Collections.Generic;
@@ -8,16 +8,19 @@
     using System.Threading.Tasks;
 
     /// <summary>
-    /// Creates <see cref="IPaddingStrategy" /> instances for the standard <see cref="PaddingMode" /> values.
+    /// Creates <see cref="IPaddingStrategy" /> instances for the framework
+    /// <see cref="PaddingMode" /> values and for the extended <see cref="BoduPaddingMode" /> values.
     /// </summary>
-    /// <seealso href="../guides/cryptography/padding.html">Padding guide — PKCS7, Zeros, and None with worked examples</seealso>
+    /// <seealso href="../guides/cryptography/padding.html">Padding guide — PKCS7, Zeros, None, ANSI X.923, ISO 10126 and ISO/IEC 7816-4 with worked examples</seealso>
     public static class PaddingFactory
     {
         /// <summary>
-        /// Creates a new <see cref="IPaddingStrategy" /> for the specified padding mode.
+        /// Creates a new <see cref="IPaddingStrategy" /> for the specified framework padding mode.
         /// </summary>
-        /// <param name="mode">The padding scheme to apply. Supported values are <see cref="PaddingMode.PKCS7" />,
-        /// <see cref="PaddingMode.Zeros" />, and <see cref="PaddingMode.None" />.</param>
+        /// <param name="mode">The padding scheme to apply. Supported values are
+        /// <see cref="PaddingMode.PKCS7" />, <see cref="PaddingMode.Zeros" />,
+        /// <see cref="PaddingMode.None" />, <see cref="PaddingMode.ANSIX923" /> and
+        /// <see cref="PaddingMode.ISO10126" />.</param>
         /// <returns>An <see cref="IPaddingStrategy" /> that implements the requested <paramref name="mode" />.</returns>
         /// <exception cref="CryptographicException">Thrown if <paramref name="mode" /> is not a supported padding scheme.</exception>
         public static IPaddingStrategy Create(PaddingMode mode) => mode switch
@@ -25,6 +28,26 @@
             PaddingMode.PKCS7 => new Pkcs7Padding(),
             PaddingMode.Zeros => new ZeroPadding(),
             PaddingMode.None => new NoPadding(),
+            PaddingMode.ANSIX923 => new Ansix923Padding(),
+            PaddingMode.ISO10126 => new Iso10126Padding(),
+            _ => throw new CryptographicException($"Unsupported padding mode: {mode}")
+        };
+
+        /// <summary>
+        /// Creates a new <see cref="IPaddingStrategy" /> for the specified extended padding mode.
+        /// </summary>
+        /// <param name="mode">The padding scheme to apply. In addition to the five framework-enum values
+        /// this overload supports <see cref="BoduPaddingMode.ISO7816_4" />.</param>
+        /// <returns>An <see cref="IPaddingStrategy" /> that implements the requested <paramref name="mode" />.</returns>
+        /// <exception cref="CryptographicException">Thrown if <paramref name="mode" /> is not a supported padding scheme.</exception>
+        public static IPaddingStrategy Create(BoduPaddingMode mode) => mode switch
+        {
+            BoduPaddingMode.PKCS7 => new Pkcs7Padding(),
+            BoduPaddingMode.Zeros => new ZeroPadding(),
+            BoduPaddingMode.None => new NoPadding(),
+            BoduPaddingMode.ANSIX923 => new Ansix923Padding(),
+            BoduPaddingMode.ISO10126 => new Iso10126Padding(),
+            BoduPaddingMode.ISO7816_4 => new Iso7816_4Padding(),
             _ => throw new CryptographicException($"Unsupported padding mode: {mode}")
         };
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -13,6 +13,9 @@
     /// </remarks>
     public sealed class Pkcs7Padding : IPaddingStrategy
     {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => true;
+
         /// <summary>
         /// Applies PKCS#7 padding to the input data, ensuring the total output is a multiple of the block size.
         /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
@@ -12,6 +12,9 @@
     /// </remarks>
     public sealed class ZeroPadding : IPaddingStrategy
     {
+        /// <inheritdoc />
+        public bool StripsPaddingOnUnpad => false;
+
         /// <summary>
         /// Pads the input with zero bytes to align its length to a multiple of the block size.
         /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Ansix923PaddingTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Ansix923PaddingTests.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ansix923PaddingTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    [TestClass]
+    public sealed partial class Ansix923PaddingTests
+        : PaddingStrategyTests<Ansix923Padding>
+    {
+        protected override int BlockSize => 16;
+
+        protected override bool ValidatesPaddingOnUnpad => true;
+
+        protected override byte[] CreatePlaintextWithResidual(int residualBytes)
+        {
+            byte[] buf = new byte[residualBytes];
+            for (int i = 0; i < buf.Length; i++)
+                buf[i] = (byte)(0x30 + i);
+            return buf;
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Ansix923Padding.Pad" /> writes <c>0x00</c> for every
+        /// interior pad byte and the pad length in the trailing byte.
+        /// </summary>
+        [TestMethod]
+        public void Pad_WhenInputHasResidual_ShouldWriteZeroInteriorAndTrailingLength()
+        {
+            var padding = this.CreatePadding();
+            byte[] plaintext = this.CreatePlaintextWithResidual(this.BlockSize - 5);
+
+            byte[] padded = padding.Pad(plaintext, this.BlockSize);
+
+            Assert.AreEqual(this.BlockSize, padded.Length);
+            Assert.AreEqual((byte)5, padded[padded.Length - 1]);
+
+            for (int i = plaintext.Length; i < padded.Length - 1; i++)
+                Assert.AreEqual((byte)0x00, padded[i], $"Interior pad byte at index {i} must be 0x00.");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Iso10126PaddingTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Iso10126PaddingTests.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso10126PaddingTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography
+{
+    [TestClass]
+    public sealed partial class Iso10126PaddingTests
+        : PaddingStrategyTests<Iso10126Padding>
+    {
+        protected override int BlockSize => 16;
+
+        protected override bool ValidatesPaddingOnUnpad => true;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// ISO 10126 pad bytes are random and cannot be validated on decryption, so the
+        /// generic tamper test for interior bytes does not apply to this scheme.
+        /// </remarks>
+        protected override bool ValidatesInteriorPaddingOnUnpad => false;
+
+        protected override byte[] CreatePlaintextWithResidual(int residualBytes)
+        {
+            byte[] buf = new byte[residualBytes];
+            for (int i = 0; i < buf.Length; i++)
+                buf[i] = (byte)(0x30 + i);
+            return buf;
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso10126Padding.Pad" /> writes the pad length in the
+        /// trailing byte of the padded output.
+        /// </summary>
+        [TestMethod]
+        public void Pad_WhenInputHasResidual_ShouldWritePadLengthInTrailingByte()
+        {
+            var padding = this.CreatePadding();
+            byte[] plaintext = this.CreatePlaintextWithResidual(this.BlockSize - 5);
+
+            byte[] padded = padding.Pad(plaintext, this.BlockSize);
+
+            Assert.AreEqual(this.BlockSize, padded.Length);
+            Assert.AreEqual((byte)5, padded[padded.Length - 1]);
+        }
+
+        /// <summary>
+        /// Verifies that two successive calls to <see cref="Iso10126Padding.Pad" /> on the
+        /// same plaintext produce different interior pad bytes (the scheme fills with
+        /// cryptographically random data).
+        /// </summary>
+        [TestMethod]
+        public void Pad_WhenCalledRepeatedly_ShouldProduceDifferentInteriorBytes()
+        {
+            // Residual leaves 10 pad bytes (9 random interior + 1 length) — enough room that
+            // a repeat collision across two draws is astronomically unlikely.
+            var padding = this.CreatePadding();
+            byte[] plaintext = this.CreatePlaintextWithResidual(this.BlockSize - 10);
+
+            byte[] first = padding.Pad(plaintext, this.BlockSize);
+            byte[] second = padding.Pad(plaintext, this.BlockSize);
+
+            bool interiorDiffers = false;
+            for (int i = plaintext.Length; i < first.Length - 1; i++)
+            {
+                if (first[i] != second[i])
+                {
+                    interiorDiffers = true;
+                    break;
+                }
+            }
+
+            Assert.IsTrue(interiorDiffers, "Two successive ISO 10126 pads on the same plaintext must produce different interior bytes.");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Iso7816_4PaddingTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Iso7816_4PaddingTests.cs
@@ -1,0 +1,125 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7816_4PaddingTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography
+{
+    [TestClass]
+    public sealed partial class Iso7816_4PaddingTests
+        : PaddingStrategyTests<Iso7816_4Padding>
+    {
+        protected override int BlockSize => 16;
+
+        protected override bool ValidatesPaddingOnUnpad => true;
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// ISO/IEC 7816-4 uses a terminator pattern (<c>0x80</c> followed by <c>0x00</c>)
+        /// rather than a trailing length byte, so tests built around a length-byte layout
+        /// do not apply to this scheme.
+        /// </remarks>
+        protected override bool HasLengthByte => false;
+
+        protected override byte[] CreatePlaintextWithResidual(int residualBytes)
+        {
+            byte[] buf = new byte[residualBytes];
+            for (int i = 0; i < buf.Length; i++)
+                buf[i] = (byte)(0x30 + i);
+            return buf;
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso7816_4Padding.Pad" /> writes <c>0x80</c> as the first
+        /// pad byte and <c>0x00</c> for every subsequent pad byte.
+        /// </summary>
+        [TestMethod]
+        public void Pad_WhenInputHasResidual_ShouldWriteTerminatorFollowedByZeroBytes()
+        {
+            var padding = this.CreatePadding();
+            byte[] plaintext = this.CreatePlaintextWithResidual(this.BlockSize - 5);
+
+            byte[] padded = padding.Pad(plaintext, this.BlockSize);
+
+            Assert.AreEqual(this.BlockSize, padded.Length);
+            Assert.AreEqual((byte)0x80, padded[plaintext.Length], "First pad byte must be 0x80.");
+
+            for (int i = plaintext.Length + 1; i < padded.Length; i++)
+                Assert.AreEqual((byte)0x00, padded[i], $"Pad byte after the terminator at index {i} must be 0x00.");
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso7816_4Padding.Pad" /> appends a full block of padding
+        /// (<c>0x80</c> followed by <see cref="BlockSize" /> - 1 zero bytes) when the input
+        /// is already block-aligned.
+        /// </summary>
+        [TestMethod]
+        public void Pad_WhenInputIsBlockAligned_ShouldAppendFullBlockOfPadding()
+        {
+            var padding = this.CreatePadding();
+            byte[] plaintext = this.CreatePlaintextWithResidual(0);
+
+            byte[] padded = padding.Pad(plaintext, this.BlockSize);
+
+            Assert.AreEqual(plaintext.Length + this.BlockSize, padded.Length);
+            Assert.AreEqual((byte)0x80, padded[plaintext.Length], "Terminator must sit at the start of the appended block.");
+
+            for (int i = plaintext.Length + 1; i < padded.Length; i++)
+                Assert.AreEqual((byte)0x00, padded[i]);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso7816_4Padding.Unpad" /> preserves a plaintext byte of
+        /// <c>0x80</c> that sits immediately before the terminator, which is the rightmost
+        /// <c>0x80</c> in the final block.
+        /// </summary>
+        [TestMethod]
+        public void Unpad_WhenPlaintextEndsWithTerminatorValue_ShouldReturnOriginal()
+        {
+            var padding = this.CreatePadding();
+
+            byte[] plaintext = new byte[this.BlockSize - 3];
+            for (int i = 0; i < plaintext.Length - 1; i++)
+                plaintext[i] = (byte)(0x30 + i);
+            plaintext[plaintext.Length - 1] = 0x80;
+
+            byte[] padded = padding.Pad(plaintext, this.BlockSize);
+            byte[] unpadded = padding.Unpad(padded, this.BlockSize);
+
+            CollectionAssert.AreEqual(plaintext, unpadded);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso7816_4Padding.Unpad" /> rejects a final block that
+        /// contains no terminator byte.
+        /// </summary>
+        [TestMethod]
+        public void Unpad_WhenFinalBlockHasNoTerminator_ShouldThrowCryptographicException()
+        {
+            var padding = this.CreatePadding();
+            byte[] input = new byte[this.BlockSize];
+
+            Assert.ThrowsExactly<CryptographicException>(() => padding.Unpad(input, this.BlockSize));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="Iso7816_4Padding.Unpad" /> rejects a block where bytes
+        /// after the terminator are non-zero.
+        /// </summary>
+        [TestMethod]
+        public void Unpad_WhenBytesAfterTerminatorAreNonZero_ShouldThrowCryptographicException()
+        {
+            var padding = this.CreatePadding();
+
+            byte[] input = new byte[this.BlockSize];
+            input[this.BlockSize - 3] = 0x80;
+            input[this.BlockSize - 2] = 0x00;
+            input[this.BlockSize - 1] = 0xFF;
+
+            Assert.ThrowsExactly<CryptographicException>(() => padding.Unpad(input, this.BlockSize));
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingFactoryTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingFactoryTests.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="PaddingFactoryTests.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,7 +12,7 @@ namespace Bodu.Security.Cryptography
     public class PaddingFactoryTests
     {
         /// <summary>
-        /// Verifies that <see cref="PaddingFactory.Create" /> rejects an undefined
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> rejects an undefined
         /// <see cref="PaddingMode" /> value with a clean exception message.
         /// </summary>
         [TestMethod]
@@ -20,6 +20,83 @@ namespace Bodu.Security.Cryptography
         {
             var ex = Assert.ThrowsExactly<CryptographicException>(() => PaddingFactory.Create((PaddingMode)999));
             Assert.IsFalse(ex.Message.Contains("this."), "Exception message must not contain 'this.' artifact.");
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(BoduPaddingMode)" /> rejects an
+        /// undefined <see cref="BoduPaddingMode" /> value with a clean exception message.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenBoduPaddingModeIsInvalid_ShouldThrowWithCleanMessage()
+        {
+            var ex = Assert.ThrowsExactly<CryptographicException>(() => PaddingFactory.Create((BoduPaddingMode)999));
+            Assert.IsFalse(ex.Message.Contains("this."), "Exception message must not contain 'this.' artifact.");
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> returns a
+        /// <see cref="Pkcs7Padding" /> for <see cref="PaddingMode.PKCS7" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenPaddingModeIsPkcs7_ShouldReturnPkcs7Padding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(PaddingMode.PKCS7);
+            Assert.IsInstanceOfType<Pkcs7Padding>(strategy);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> returns a
+        /// <see cref="ZeroPadding" /> for <see cref="PaddingMode.Zeros" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenPaddingModeIsZeros_ShouldReturnZeroPadding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(PaddingMode.Zeros);
+            Assert.IsInstanceOfType<ZeroPadding>(strategy);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> returns a
+        /// <see cref="NoPadding" /> for <see cref="PaddingMode.None" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenPaddingModeIsNone_ShouldReturnNoPadding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(PaddingMode.None);
+            Assert.IsInstanceOfType<NoPadding>(strategy);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> returns an
+        /// <see cref="Ansix923Padding" /> for <see cref="PaddingMode.ANSIX923" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenPaddingModeIsAnsix923_ShouldReturnAnsix923Padding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(PaddingMode.ANSIX923);
+            Assert.IsInstanceOfType<Ansix923Padding>(strategy);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(PaddingMode)" /> returns an
+        /// <see cref="Iso10126Padding" /> for <see cref="PaddingMode.ISO10126" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenPaddingModeIsIso10126_ShouldReturnIso10126Padding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(PaddingMode.ISO10126);
+            Assert.IsInstanceOfType<Iso10126Padding>(strategy);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="PaddingFactory.Create(BoduPaddingMode)" /> returns an
+        /// <see cref="Iso7816_4Padding" /> for <see cref="BoduPaddingMode.ISO7816_4" />.
+        /// </summary>
+        [TestMethod]
+        public void Create_WhenBoduPaddingModeIsIso7816_4_ShouldReturnIso7816_4Padding()
+        {
+            IPaddingStrategy strategy = PaddingFactory.Create(BoduPaddingMode.ISO7816_4);
+            Assert.IsInstanceOfType<Iso7816_4Padding>(strategy);
         }
     }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.Unpad.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.Unpad.cs
@@ -18,9 +18,9 @@ namespace Bodu.Security.Cryptography
         [TestMethod]
         public void Unpad_WhenPaddingIsCorrupted_ShouldThrowCryptographicExceptionWithCleanMessage()
         {
-            if (!this.ValidatesPaddingOnUnpad)
+            if (!this.ValidatesPaddingOnUnpad || !this.ValidatesInteriorPaddingOnUnpad || !this.HasLengthByte)
             {
-                Assert.Inconclusive($"{typeof(TPadding).Name} does not validate padding on Unpad.");
+                Assert.Inconclusive($"{typeof(TPadding).Name} does not validate interior padding bytes via a length-byte layout.");
                 return;
             }
 

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.cs
@@ -44,6 +44,21 @@ namespace Bodu.Security.Cryptography
         protected virtual bool SupportsUnalignedInput => true;
 
         /// <summary>
+        /// Gets a value indicating whether <c>Unpad</c> validates the contents of the interior
+        /// pad bytes (not just the trailing length byte or terminator). PKCS#7, ANSI X.923 and
+        /// ISO/IEC 7816-4 all validate interior bytes; ISO 10126 does not because its interior
+        /// bytes are random and cannot be reconstructed during decryption.
+        /// </summary>
+        protected virtual bool ValidatesInteriorPaddingOnUnpad => true;
+
+        /// <summary>
+        /// Gets a value indicating whether the padding scheme encodes its pad length in the
+        /// final byte of the padded block. PKCS#7, ANSI X.923 and ISO 10126 do; ISO/IEC 7816-4
+        /// uses a terminator pattern instead and returns <see langword="false" />.
+        /// </summary>
+        protected virtual bool HasLengthByte => true;
+
+        /// <summary>
         /// Gets a sample plaintext that is shorter than <see cref="BlockSize" /> by the
         /// specified <paramref name="residualBytes" /> count. Used by the single-byte padding
         /// and round-trip tests.

--- a/docs/guides/cryptography/padding.md
+++ b/docs/guides/cryptography/padding.md
@@ -4,9 +4,9 @@ title: Padding
 
 # Padding
 
-Block ciphers encrypt fixed-size blocks. When a plaintext is not a whole number of blocks long, the last block has to be *padded* — and the receiver has to know how to *unpad* it. This page covers the three padding schemes supported by the library and shows when each one is appropriate.
+Block ciphers encrypt fixed-size blocks. When a plaintext is not a whole number of blocks long, the last block has to be *padded* — and the receiver has to know how to *unpad* it. This page covers the padding schemes supported by the library and shows when each one is appropriate.
 
-The supported modes come from the standard <xref:System.Security.Cryptography.PaddingMode> enum. Set them via the algorithm's `Padding` property, or construct a strategy directly through <xref:Bodu.Security.Cryptography.PaddingFactory>.
+The five framework modes come from the standard <xref:System.Security.Cryptography.PaddingMode> enum. Set them via the algorithm's `Padding` property, or construct a strategy directly through <xref:Bodu.Security.Cryptography.PaddingFactory>. An extended <xref:Bodu.Security.Cryptography.BoduPaddingMode> enum mirrors those values and adds ISO/IEC 7816-4 bit padding for scenarios where the framework enum is not expressive enough.
 
 ## PKCS7 — the safe default
 
@@ -61,6 +61,56 @@ byte[] recovered  = alg.Decrypt(ciphertext);
 
 Zero padding is appropriate when **the application layer already knows the real length**. If it doesn't, prefer PKCS7.
 
+## ANSI X.923 — length byte, zero-filled interior
+
+**Use for:** interoperability with legacy systems or specifications that mandate ANSI X.923.
+
+ANSI X.923 appends `N - 1` bytes of value `0x00` followed by a trailing byte holding the padding length `N`. When the plaintext is already block-aligned, a full extra block of padding is appended so unpadding remains unambiguous. `Unpad` validates in constant time that all interior pad bytes are `0x00` and that the trailing length byte is in range.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.ANSIX923,
+};
+alg.GenerateKey();
+alg.GenerateIV();
+alg.GenerateTweak();
+
+byte[] plaintext  = new byte[100];
+byte[] ciphertext = alg.Encrypt(plaintext);
+byte[] recovered  = alg.Decrypt(ciphertext);
+```
+
+The same padding-oracle caution as PKCS7 applies: pair with a MAC when the ciphertext crosses a trust boundary.
+
+## ISO 10126 — length byte, random interior
+
+**Use for:** interoperability with existing ISO 10126 ciphertexts. The scheme was withdrawn by ISO in 2007 and is not recommended for new designs — prefer PKCS7.
+
+ISO 10126 is shaped like ANSI X.923 except the interior pad bytes are cryptographically random instead of `0x00`. Because the random bytes cannot be reconstructed during decryption, `Unpad` only validates the trailing length byte.
+
+```csharp
+using var alg = new Threefish256
+{
+    BlockMode = CipherBlockMode.CBC,
+    Padding   = PaddingMode.ISO10126,
+};
+```
+
+## ISO/IEC 7816-4 — bit padding (one-and-zeros)
+
+**Use for:** smart-card protocols and crypto constructions that require the 7816-4 shape (for example CMAC, SHA-3/Keccak). Access this mode through the extended <xref:Bodu.Security.Cryptography.BoduPaddingMode> enum, which is not part of the framework `PaddingMode` surface.
+
+ISO/IEC 7816-4 appends a single `0x80` byte followed by `0x00` bytes out to the next block boundary. When the plaintext is already block-aligned, a full extra block of padding is appended. `Unpad` scans the final block in constant time for the rightmost `0x80`: everything after it must be `0x00`, and the byte itself marks the end of the plaintext.
+
+```csharp
+IPaddingStrategy bitPadding = PaddingFactory.Create(BoduPaddingMode.ISO7816_4);
+
+byte[] padded   = bitPadding.Pad(plaintext, blockSize: 32);
+byte[] unpadded = bitPadding.Unpad(padded, blockSize: 32);
+```
+
 ## None — only for block-aligned or stream modes
 
 **Use for:** stream-shaped modes (CTR, CFB, OFB) that don't need padding, or when you have already padded the plaintext in your own code and want the cipher to leave it alone.
@@ -91,6 +141,9 @@ byte[] recovered  = alg.Decrypt(ciphertext);
 | Framed (length-prefixed / terminated) | CBC, ECB | **Zeros** or **PKCS7** | ≥ plaintext, to next block boundary |
 | Any length | CTR, CFB, OFB | **None** | Exactly plaintext length |
 | Already block-aligned | CBC, ECB | **None** (if sure) | Exactly plaintext length |
+| Interop with ANSI X.923 spec | CBC, ECB | **ANSIX923** | Plaintext + 1–block bytes |
+| Interop with legacy ISO 10126 ciphertext | CBC, ECB | **ISO10126** | Plaintext + 1–block bytes |
+| Smart-card / CMAC / bit-oriented protocols | CBC, ECB | **ISO7816_4** (via `BoduPaddingMode`) | Plaintext + 1–block bytes |
 
 ## Using the strategy directly
 


### PR DESCRIPTION
…trategies

Close the gap where System.PaddingMode.ANSIX923 and .ISO10126 were only reachable via the legacy CryptoHelpers static API by adding full IPaddingStrategy implementations and wiring them through PaddingFactory, so they are now selectable at the block-cipher level. Introduce a new BoduPaddingMode enum that mirrors the framework values and adds ISO/IEC 7816-4 bit padding (0x80 + 0x00 terminator, widely used in smart-card, CMAC, and SHA-3 scenarios) which the closed framework enum cannot express. Generalise BlockCipherTransform's "defer last block" heuristic from a PKCS7 type check to an IPaddingStrategy.StripsPaddingOnUnpad property so every validating scheme works correctly through the streaming transform. Includes constant-time unpad validators, tests, and docs.

https://claude.ai/code/session_01NzrRsdbvkEe6eDG7KGjFad