### PR TITLE
test: fix failing tests in Core and Security.Cryptography

### DIFF
--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
@@ -371,7 +371,7 @@ public partial class ConcurrentCircularBufferTests
                     }
 
                     var count = buffer.Count;
-                    if (count < 0 || count > 1)
+                    if (count < 0 || count > MinCapacity)
                         Interlocked.Increment(ref countViolations);
                 }
             }));
@@ -388,7 +388,7 @@ public partial class ConcurrentCircularBufferTests
             $"Faults={faults}, CountViolations={countViolations}");
 
         Assert.IsTrue(completed, $"Tasks did not complete within {deadlockTimeoutMs} ms — possible deadlock or livelock.");
-        Assert.AreEqual(0, faults, "No exceptions expected from TryEnqueue or TryDequeue under capacity-1 churn.");
+        Assert.AreEqual(0, faults, "No exceptions expected from TryEnqueue or TryDequeue under capacity-churn.");
         Assert.AreEqual(0, countViolations, $"Count must remain within [0, {MinCapacity}] at all times.");
         Assert.AreEqual(MinCapacity, buffer.Capacity, $"Capacity must remain {MinCapacity} throughout.");
     }

--- a/Bodu.Core/test/Extensions/NumericExtensionsTests.ReverseBits.cs
+++ b/Bodu.Core/test/Extensions/NumericExtensionsTests.ReverseBits.cs
@@ -456,7 +456,7 @@ public partial class NumericExtensionsTests
     [DataRow((ushort)0x1234, 8, (ushort)0x002C)] // low byte 0x34 → 0x2C
     [DataRow((ushort)0xFF34, 8, (ushort)0x002C)] // high byte ignored
     [DataRow((ushort)0x00AB, 12, (ushort)0x0D50)] // low 12 bits
-    [DataRow((ushort)0xFFAB, 12, (ushort)0x0D50)] // high nibble ignored
+    [DataRow((ushort)0xF0AB, 12, (ushort)0x0D50)] // high nibble ignored
     public void ReverseBits_WhenBitLengthIsPartial_ForUShort_ShouldReturnLowBitsReversed(ushort value, int bitLength, ushort expected) =>
         Assert.AreEqual(expected, value.ReverseBits(bitLength));
 
@@ -593,7 +593,7 @@ public partial class NumericExtensionsTests
     [TestMethod]
     [DataRow(0xFFFFFFFFFFFFFF12ul, 8, 0x48ul)]          // low byte 0x12 → 0x48, high bits ignored
     [DataRow(0x0000000000000012ul, 8, 0x48ul)]          // same low byte, zero high bits
-    [DataRow(0xABCDEF0123456789ul, 32, 0x91E6A2C8ul)]  // low 32 bits 0x23456789 → 0x91E6A2C8
+    [DataRow(0xABCDEF0123456789ul, 32, 0x91E6A2C4ul)]   // low 32 bits 0x23456789 → 0x91E6A2C4
     [DataRow(0x00000000FFFFFFFFul, 40, 0xFFFFFFFF00ul)] // low 40 bits: 32 set bits shift to the top of the window
     public void ReverseBits_WhenBitLengthIsPartial_ForULong_ShouldReturnLowBitsReversed(ulong value, int bitLength, ulong expected) =>
         Assert.AreEqual(expected, value.ReverseBits(bitLength));

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -181,7 +181,7 @@ namespace Bodu.Security.Cryptography.Extensions
             var aead = new GcmModeTransform(cipher2, iv);
             Assert.ThrowsExactly<CryptographicException>(() =>
             {
-                aead.Decrypt(cipherWithTag, AssociatedData);
+                aead.Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
             });
         }
 
@@ -205,7 +205,7 @@ namespace Bodu.Security.Cryptography.Extensions
             var aead = new GcmModeTransform(cipher2, iv);
             Assert.ThrowsExactly<CryptographicException>(() =>
             {
-                aead.Decrypt(cipherWithTag, otherAad);
+                aead.Decrypt(cipherWithTag, otherAad.AsSpan().AsReadOnly());
             });
         }
 


### PR DESCRIPTION
## Summary

Fixes three failing tests across `Bodu.Core` and `Bodu.Security.Cryptography`. All 26,252 tests now pass:

- **Bodu.Core**: 20,290 passed
- **Bodu.IO**: 354 passed (already passing)
- **Bodu.Security.Cryptography**: 5,608 passed

## Changes

### `Bodu.Core` — `NumericExtensionsTests.ReverseBits`

Two `DataRow` expected values were mathematically wrong:

- `ReverseBits(0xFFAB, 12)` produces `0xD5F` (not `0xD50`), because the low 12 bits of `0xFFAB` are `0xFAB`, not `0x0AB`. Changed the input to `0xF0AB` so the "high nibble ignored" comment is accurate (low 12 bits = `0x0AB`, reversed = `0xD50`).
- `ReverseBits(0xABCDEF0123456789, 32)` produces `0x91E6A2C4` (not `0x91E6A2C8`). Low 32 bits `0x23456789` reversed bit-by-bit is `0x91E6A2C4`. Corrected the expected value and comment.

### `Bodu.Core` — `ConcurrentCircularBufferTests._Stress`

`StressTest_WhenCapacityIsMin_ShouldRemainStableUnderMaxContention` creates a buffer with capacity `MinCapacity` (=2), but the reader-side violation check used a hardcoded `count > 1`, flagging valid state as a violation. Changed to `count > MinCapacity` to match the writer branch and the final assertion.

### `Bodu.Security.Cryptography` — `AeadBlockCipherModeTransformExtensionsTests`

Two tests (`Decrypt_WhenTagIsTampered_...`, `Decrypt_WhenAssociatedDataDiffers_...`) expected `CryptographicException` but received `ArgumentException`. Root cause: `aead.Decrypt(cipherWithTag, AssociatedData)` passing a `byte[]` for the second argument resolves to the instance method `GcmModeTransform.Decrypt(ReadOnlySpan<byte>, Span<byte>)` — i.e. the `byte[]` was being treated as the *output buffer*, which was too small and threw `ArgumentException`.

Added `.AsSpan().AsReadOnly()` on the associated-data argument to force overload resolution to the intended `AeadBlockCipherModeTransformExtensions.Decrypt(..., ReadOnlySpan<byte>, ReadOnlySpan<byte>)` extension method — matching the existing convention used by the passing round-trip tests in the same class.

## Test plan

- [x] `dotnet test Bodu.Core/test/Bodu.Core.Test.csproj` — 20,290 pass
- [x] `dotnet test Bodu.IO/test/Bodu.IO.Test.csproj` — 354 pass
- [x] `dotnet test Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj` — 5,608 pass
- [ ] CI build-and-test workflow green on PR

https://claude.ai/code/session_01LPgGFnX6NvomAvcCW6bDui