### PR TITLE
refactor(core): make FiscalWeekQuarterProvider a recurring calendar rule

### DIFF
--- a/Bodu.Core/src/Extensions/FiscalWeekQuarterProvider.cs
+++ b/Bodu.Core/src/Extensions/FiscalWeekQuarterProvider.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProvider.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,9 +14,9 @@ namespace Bodu.Extensions;
 /// </summary>
 /// <remarks>
 /// <para>
-/// This provider implements a fiscal calendar in which each quarter consists of exactly 13 weeks, divided
-/// into three fiscal periods according to the <see cref="FiscalWeekPattern"/> supplied at construction.
-/// Quarters are defined as contiguous 13-week blocks measured from the configured fiscal year start:
+/// This provider describes a recurring fiscal calendar rule. Each quarter consists of exactly 13 weeks,
+/// divided into three fiscal periods according to the <see cref="FiscalWeekPattern"/> supplied at
+/// construction. Quarters are defined as contiguous 13-week blocks measured from the fiscal year start:
 /// </para>
 /// <list type="bullet">
 /// <item>
@@ -42,29 +42,29 @@ namespace Bodu.Extensions;
 /// exposed via the <see cref="Pattern"/> property for consumers that require intra-quarter period logic.
 /// </para>
 /// <para>
-/// The fiscal year may contain a 53rd week when the span between the computed fiscal year start and the
+/// A fiscal year may contain a 53rd week when the span between the computed fiscal year start and the
 /// equivalent start in the following year exceeds 364 days. In a 53-week year, the extra week is always
 /// appended to Q4.
 /// </para>
 /// <para>
 /// The fiscal week start day is governed by the <see cref="DayOfWeek"/> supplied to the constructor.
-/// The anchor date is automatically aligned to the nearest occurrence of that day on or before the
-/// computed start of the fiscal year.
+/// Year-specific values — the fiscal year start date, whether a given year contains 53 weeks, and
+/// quarter boundaries — are computed on demand from either an explicit <c>fiscalYear</c> argument or
+/// from the input date itself.
 /// </para>
 /// </remarks>
 public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
 {
+    private readonly int _anchorMonth;
+    private readonly DayOfWeek _anchorDayOfWeek;
     private readonly DayOfWeek _firstDayOfWeek;
-    private readonly long _fiscalYearStartTicks;
-    private readonly bool _is53WeekFiscalYear;
+    private readonly bool _useNearestDayOfWeek;
     private readonly FiscalWeekPattern _pattern;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FiscalWeekQuarterProvider"/> class using the
-    /// specified fiscal year anchor parameters and aligning the fiscal year start to the configured
-    /// fiscal week start day.
+    /// specified anchor month and alignment options.
     /// </summary>
-    /// <param name="year">The calendar year of the fiscal year anchor month.</param>
     /// <param name="month">The calendar month (1–12) of the fiscal year anchor.</param>
     /// <param name="dayOfWeek">
     /// The day of the week on which each fiscal week begins. Common values are
@@ -72,17 +72,16 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// Defaults to <see cref="DayOfWeek.Saturday"/>.
     /// </param>
     /// <param name="isFiscalYearEnd">
-    /// When <see langword="true"/>, the <paramref name="year"/> and <paramref name="month"/> identify
-    /// the fiscal year's closing month, and the actual fiscal start date is derived from the month that
-    /// follows. When <see langword="false"/>, they identify the fiscal year's opening month directly.
-    /// Defaults to <see langword="true"/>.
+    /// When <see langword="true"/>, <paramref name="month"/> identifies the fiscal year's closing
+    /// month, and the actual fiscal start month is the one that follows. When <see langword="false"/>,
+    /// <paramref name="month"/> identifies the fiscal year's opening month directly. Defaults to
+    /// <see langword="true"/>.
     /// </param>
     /// <param name="useNearestDayOfWeek">
     /// <see langword="true"/> to align the fiscal year start to the occurrence of
     /// <paramref name="dayOfWeek"/> nearest to the computed anchor date;
     /// <see langword="false"/> to align it to the occurrence of <paramref name="dayOfWeek"/>
-    /// on or before the computed anchor date.
-    /// Defaults to <see langword="true"/>.
+    /// on or before the computed anchor date. Defaults to <see langword="true"/>.
     /// </param>
     /// <param name="pattern">
     /// The week distribution pattern applied to the three fiscal periods within each quarter.
@@ -90,16 +89,15 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// </param>
     /// <remarks>
     /// <para>
-    /// The fiscal year start date is derived from the computed fiscal anchor and then aligned to the
-    /// configured fiscal week start day using one of two strategies:
+    /// The fiscal year start for a given <c>fiscalYear</c> is derived from the first day of the anchor
+    /// month in that year, then aligned to the configured fiscal week start day using one of two
+    /// strategies:
     /// </para>
     /// <list type="bullet">
     /// <item>
     /// <description>
     /// When <paramref name="useNearestDayOfWeek"/> is <see langword="true"/>, the start date is aligned
-    /// to the occurrence of <paramref name="dayOfWeek"/> nearest to the computed anchor date. This
-    /// aligned date may fall up to three days before or after the anchor, depending on which occurrence
-    /// is closer.
+    /// to the occurrence of <paramref name="dayOfWeek"/> nearest to the computed anchor date.
     /// </description>
     /// </item>
     /// <item>
@@ -116,47 +114,27 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="dayOfWeek"/> is not a defined <see cref="DayOfWeek"/> value,
+    /// Thrown when <paramref name="month"/> is not in the range 1–12,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined <see cref="DayOfWeek"/> value,
     /// -or- <paramref name="pattern"/> is not a defined <see cref="FiscalWeekPattern"/> value.
     /// </exception>
     public FiscalWeekQuarterProvider(
-        int year,
         int month,
         DayOfWeek dayOfWeek = DayOfWeek.Saturday,
         bool isFiscalYearEnd = true,
         bool useNearestDayOfWeek = true,
         FiscalWeekPattern pattern = FiscalWeekPattern.Weeks445)
     {
+        ThrowHelper.ThrowIfOutOfRange(month, 1, 12);
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
         ThrowHelper.ThrowIfEnumValueIsUndefined(pattern);
 
         _pattern = pattern;
-
-        // When isFiscalYearEnd is true, the fiscal year begins in the month following the anchor month.
-        // The first day of each fiscal week is therefore one day after the anchor day-of-week.
-        int startMonth = month + (isFiscalYearEnd ? 1 : 0);
+        _anchorMonth = month + (isFiscalYearEnd ? 1 : 0);
+        _anchorDayOfWeek = dayOfWeek;
         _firstDayOfWeek = isFiscalYearEnd ? (DayOfWeek)(((int)dayOfWeek + 1) % 7) : dayOfWeek;
-
-        _fiscalYearStartTicks = useNearestDayOfWeek
-            ? AlignToNearestDayOfWeek(
-                DateTimeExtensions.GetDateTicks(year, startMonth, 1),
-                dayOfWeek)
-            : AlignToOnOrBeforeDayOfWeek(
-                DateTimeExtensions.GetDateTicks(year, startMonth, 1),
-                dayOfWeek);
-
-        _is53WeekFiscalYear = ComputeIs53WeekYear(_fiscalYearStartTicks, year, startMonth, _firstDayOfWeek, useNearestDayOfWeek);
+        _useNearestDayOfWeek = useNearestDayOfWeek;
     }
-
-    /// <summary>
-    /// Gets a value indicating whether the configured fiscal year contains 53 weeks rather than the
-    /// standard 52.
-    /// </summary>
-    /// <value>
-    /// <see langword="true"/> if the fiscal year spans 371 days (53 complete weeks);
-    /// <see langword="false"/> if it spans 364 days (52 complete weeks).
-    /// </value>
-    public bool Is53WeekFiscalYear => _is53WeekFiscalYear;
 
     /// <summary>
     /// Gets the week distribution pattern applied to the three fiscal periods within each quarter.
@@ -167,90 +145,122 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// </value>
     public FiscalWeekPattern Pattern => _pattern;
 
-    /// <summary>
-    /// Gets the total number of weeks in the fiscal year.
-    /// </summary>
-    /// <value>53 in a 53-week fiscal year; otherwise, 52.</value>
-    public int WeeksInFiscalYear => _is53WeekFiscalYear ? 53 : 52;
+    /// <inheritdoc />
+    public bool Is53WeekFiscalYear(int fiscalYear) =>
+        ComputeIs53WeekYear(
+            GetFiscalYearStartTicks(fiscalYear),
+            fiscalYear,
+            _anchorMonth,
+            _firstDayOfWeek,
+            _useNearestDayOfWeek);
+
+    /// <inheritdoc />
+    public int GetWeeksInFiscalYear(int fiscalYear) =>
+        Is53WeekFiscalYear(fiscalYear) ? 53 : 52;
 
     /// <inheritdoc />
     public int GetQuarter(DateTime dateTime)
     {
-        ValidateDateInFiscalYear(dateTime);
-
-        int weeksFromStart = (int)((dateTime.Ticks - _fiscalYearStartTicks) / DateTimeExtensions.TicksPerWeek);
-        int quarter = (weeksFromStart / 13) + 1;
+        int fiscalYear = GetFiscalYearFor(dateTime);
+        long fiscalYearStartTicks = GetFiscalYearStartTicks(fiscalYear);
+        int weeksFromStart = (int)((dateTime.Ticks - fiscalYearStartTicks) / DateTimeExtensions.TicksPerWeek);
 
         // In a 53-week year the final week computes as quarter 5; clamp it back to Q4.
-        if (quarter > 4)
-            quarter = 4;
-
-        return quarter;
+        return Math.Min((weeksFromStart / 13) + 1, 4);
     }
 
     /// <inheritdoc />
-    public int GetQuarter(DateOnly dateOnly) => GetQuarter(dateOnly.ToDateTime(TimeOnly.MinValue));
+    public int GetQuarter(DateOnly dateOnly) =>
+        GetQuarter(dateOnly.ToDateTime(TimeOnly.MinValue));
 
     /// <inheritdoc />
-    public DateTime GetQuarterEnd(DateTime dateTime) => GetQuarterEnd(GetQuarter(dateTime));
+    public DateTime GetQuarterEnd(DateTime dateTime) =>
+        GetQuarterEnd(GetQuarter(dateTime), GetFiscalYearFor(dateTime));
 
     /// <inheritdoc />
-    public DateTime GetQuarterEnd(int quarter)
+    [Obsolete("Use GetQuarterEnd(int quarter, int fiscalYear).")]
+    public DateTime GetQuarterEnd(int quarter) =>
+        throw new NotSupportedException(
+            "A fiscal year must be provided. Use GetQuarterEnd(int quarter, int fiscalYear).");
+
+    /// <inheritdoc />
+    public DateTime GetQuarterEnd(int quarter, int fiscalYear)
     {
-        DateTime start = GetQuarterStart(quarter);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+
+        DateTime start = GetQuarterStart(quarter, fiscalYear);
 
         // Q4 absorbs the additional week in a 53-week fiscal year; all other quarters are exactly 13 weeks.
-        int weeks = (quarter == 4 && _is53WeekFiscalYear) ? 14 : 13;
+        int weeks = (quarter == 4 && Is53WeekFiscalYear(fiscalYear)) ? 14 : 13;
         long endTicks = start.Ticks + ((long)weeks * DateTimeExtensions.TicksPerWeek) - DateTimeExtensions.TicksPerDay;
 
         return new DateTime(DateTimeExtensions.GetDateAsTicks(endTicks), DateTimeKind.Unspecified);
     }
 
     /// <inheritdoc />
-    public DateOnly GetQuarterEndDate(DateOnly dateOnly) => GetQuarterEnd(dateOnly.ToDateTime(TimeOnly.MinValue)).ToDateOnly();
+    public DateOnly GetQuarterEndDate(DateOnly dateOnly) =>
+        GetQuarterEnd(dateOnly.ToDateTime(TimeOnly.MinValue)).ToDateOnly();
 
     /// <inheritdoc />
-    public DateOnly GetQuarterEndDate(int quarter) => GetQuarterEnd(quarter).ToDateOnly();
+    [Obsolete("Use GetQuarterEndDate(int quarter, int fiscalYear).")]
+    public DateOnly GetQuarterEndDate(int quarter) =>
+        throw new NotSupportedException(
+            "A fiscal year must be provided. Use GetQuarterEndDate(int quarter, int fiscalYear).");
 
     /// <inheritdoc />
-    public DateTime GetQuarterStart(DateTime dateTime)
-    {
-        ValidateDateInFiscalYear(dateTime);
-        return GetQuarterStart(GetQuarter(dateTime));
-    }
+    public DateOnly GetQuarterEndDate(int quarter, int fiscalYear) =>
+        GetQuarterEnd(quarter, fiscalYear).ToDateOnly();
 
     /// <inheritdoc />
-    public DateTime GetQuarterStart(int quarter)
+    public DateTime GetQuarterStart(DateTime dateTime) =>
+        GetQuarterStart(GetQuarter(dateTime), GetFiscalYearFor(dateTime));
+
+    /// <inheritdoc />
+    [Obsolete("Use GetQuarterStart(int quarter, int fiscalYear).")]
+    public DateTime GetQuarterStart(int quarter) =>
+        throw new NotSupportedException(
+            "A fiscal year must be provided. Use GetQuarterStart(int quarter, int fiscalYear).");
+
+    /// <inheritdoc />
+    public DateTime GetQuarterStart(int quarter, int fiscalYear)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
 
         long offsetTicks = (long)(quarter - 1) * 13L * DateTimeExtensions.TicksPerWeek;
-        long startTicks = _fiscalYearStartTicks + offsetTicks;
+        long startTicks = GetFiscalYearStartTicks(fiscalYear) + offsetTicks;
 
         return new DateTime(DateTimeExtensions.GetDateAsTicks(startTicks), DateTimeKind.Unspecified);
     }
 
     /// <inheritdoc />
-    public DateOnly GetQuarterStartDate(DateOnly dateOnly) => GetQuarterStart(dateOnly.ToDateTime(TimeOnly.MinValue)).ToDateOnly();
+    public DateOnly GetQuarterStartDate(DateOnly dateOnly) =>
+        GetQuarterStart(dateOnly.ToDateTime(TimeOnly.MinValue)).ToDateOnly();
 
     /// <inheritdoc />
-    public DateOnly GetQuarterStartDate(int quarter) => GetQuarterStart(quarter).ToDateOnly();
+    [Obsolete("Use GetQuarterStartDate(int quarter, int fiscalYear).")]
+    public DateOnly GetQuarterStartDate(int quarter) =>
+        throw new NotSupportedException(
+            "A fiscal year must be provided. Use GetQuarterStartDate(int quarter, int fiscalYear).");
+
+    /// <inheritdoc />
+    public DateOnly GetQuarterStartDate(int quarter, int fiscalYear) =>
+        GetQuarterStart(quarter, fiscalYear).ToDateOnly();
 
     /// <summary>
-    /// Returns the tick value of the nearest occurrence of <paramref name="weekStart"/> on or before the
-    /// date represented by <paramref name="ticks"/>.
+    /// Returns the tick value of the occurrence of <paramref name="weekStart"/> nearest to the date
+    /// represented by <paramref name="ticks"/>.
     /// </summary>
     /// <param name="ticks">The tick value of the reference date.</param>
     /// <param name="weekStart">The target <see cref="DayOfWeek"/> to align to.</param>
     /// <returns>
-    /// The tick value of the most recent <paramref name="weekStart"/> day on or before the input date.
+    /// The tick value of the nearest <paramref name="weekStart"/> day.
     /// </returns>
     private static long AlignToNearestDayOfWeek(long ticks, DayOfWeek weekStart) =>
         DateTimeExtensions.GetTicksForNearestDayOfWeek(ticks, weekStart);
 
     /// <summary>
-    /// Returns the tick value of the nearest occurrence of <paramref name="weekStart"/> on or before the
-    /// date represented by <paramref name="ticks"/>.
+    /// Returns the tick value of the occurrence of <paramref name="weekStart"/> on or before the date
+    /// represented by <paramref name="ticks"/>.
     /// </summary>
     /// <param name="ticks">The tick value of the reference date.</param>
     /// <param name="weekStart">The target <see cref="DayOfWeek"/> to align to.</param>
@@ -264,7 +274,7 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// Determines whether the fiscal year that begins at <paramref name="fiscalYearStartTicks"/> spans
     /// more than 52 weeks (i.e., contains a 53rd week).
     /// </summary>
-    /// <param name="fiscalYearStartTicks">The tick value of the first day of the current fiscal year.</param>
+    /// <param name="fiscalYearStartTicks">The tick value of the first day of the fiscal year.</param>
     /// <param name="year">The calendar year of the fiscal anchor month.</param>
     /// <param name="startMonth">
     /// The calendar month in which the fiscal year begins (already adjusted for <c>isFiscalYearEnd</c>).
@@ -273,11 +283,9 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     /// The fiscal week start day, used to align the equivalent anchor in the following year.
     /// </param>
     /// <param name="useNearestDayOfWeek">
-    /// <see langword="true"/> to align the fiscal year start to the occurrence of
-    /// <paramref name="firstDayOfWeek"/> nearest to the computed anchor date;
-    /// <see langword="false"/> to align it to the occurrence of <paramref name="firstDayOfWeek"/>
-    /// on or before the computed anchor date.
-    /// Defaults to <see langword="true"/>.
+    /// <see langword="true"/> to align to the occurrence of <paramref name="firstDayOfWeek"/> nearest
+    /// the computed anchor; <see langword="false"/> to align to the occurrence on or before the
+    /// computed anchor.
     /// </param>
     /// <returns>
     /// <see langword="true"/> if the fiscal year spans more than 364 days; otherwise,
@@ -305,32 +313,54 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
     }
 
     /// <summary>
-    /// Validates that <paramref name="dateTime"/> falls within the bounds of the fiscal year configured
-    /// for this provider instance.
+    /// Computes the tick value of the first day of the specified fiscal year using the provider's
+    /// recurring calendar rule.
     /// </summary>
-    /// <param name="dateTime">The date and time to validate.</param>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="dateTime"/> does not fall within the fiscal year defined by this
-    /// provider.
-    /// </exception>
-    private void ValidateDateInFiscalYear(DateTime dateTime)
+    /// <param name="fiscalYear">The fiscal year whose start date is being requested.</param>
+    /// <returns>The tick value of the first day of the fiscal year, aligned to the configured week start.</returns>
+    private long GetFiscalYearStartTicks(int fiscalYear)
     {
-        // Align the input date back to the start of its fiscal week. A date belongs to a fiscal year
-        // if the week in which it falls begins within [fiscalYearStart, fiscalYearStart + yearLength).
+        long anchorTicks = DateTimeExtensions.GetDateTicks(fiscalYear, _anchorMonth, 1);
+        return _useNearestDayOfWeek
+            ? AlignToNearestDayOfWeek(anchorTicks, _anchorDayOfWeek)
+            : AlignToOnOrBeforeDayOfWeek(anchorTicks, _anchorDayOfWeek);
+    }
+
+    /// <summary>
+    /// Resolves the fiscal year that contains <paramref name="dateTime"/> under the provider's
+    /// recurring calendar rule.
+    /// </summary>
+    /// <param name="dateTime">The date to map to a fiscal year.</param>
+    /// <returns>The fiscal year whose 52- or 53-week span contains the fiscal week of the input date.</returns>
+    /// <remarks>
+    /// A fiscal year can straddle at most two calendar years, so the search inspects the three
+    /// candidates <c>dateTime.Year - 1</c>, <c>dateTime.Year</c>, and <c>dateTime.Year + 1</c>. The
+    /// input date's fiscal week start (aligned backwards to the configured first day of the week)
+    /// must fall within <c>[fiscalYearStart, fiscalYearStart + length)</c>, where <c>length</c> is
+    /// 371 days in a 53-week year and 364 days otherwise.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when no candidate fiscal year contains <paramref name="dateTime"/>.
+    /// </exception>
+    private int GetFiscalYearFor(DateTime dateTime)
+    {
         long weekStartTicks = dateTime.Ticks
             - DateTimeExtensions.GetTicksSincePreviousOrSameDayOfWeek(dateTime.Ticks, _firstDayOfWeek);
 
-        long deltaDays = (weekStartTicks - _fiscalYearStartTicks) / DateTimeExtensions.TicksPerDay;
-        int fiscalYearLengthDays = _is53WeekFiscalYear ? 371 : 364;
-
-        if (deltaDays < 0 || deltaDays >= fiscalYearLengthDays)
+        int calendarYear = dateTime.Year;
+        for (int candidate = calendarYear - 1; candidate <= calendarYear + 1; candidate++)
         {
-            throw new ArgumentOutOfRangeException(
-                nameof(dateTime),
-                string.Format(
-                    ResourceStrings.Arg_OutOfRange_DateOutsideFiscalYear,
-                    dateTime,
-                    new DateTime(_fiscalYearStartTicks, DateTimeKind.Unspecified)));
+            long start = GetFiscalYearStartTicks(candidate);
+            bool is53 = ComputeIs53WeekYear(start, candidate, _anchorMonth, _firstDayOfWeek, _useNearestDayOfWeek);
+            int lengthDays = is53 ? 371 : 364;
+
+            long deltaDays = (weekStartTicks - start) / DateTimeExtensions.TicksPerDay;
+            if (deltaDays >= 0 && deltaDays < lengthDays)
+                return candidate;
         }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(dateTime),
+            $"Unable to determine the fiscal year for date '{dateTime:yyyy-MM-dd}'.");
     }
 }

--- a/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
+++ b/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="IQuarterDefinitionProvider.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,12 +12,15 @@ namespace Bodu.Extensions;
 /// Defines a provider interface for custom quarter calculation logic based on <see cref="DateTime"/> or <see cref="DateOnly"/> values.
 /// </summary>
 /// <remarks>
-/// Implement this interface to support custom fiscal or logical quarter systems in methods that accept a
-/// <see cref="CalendarQuarterDefinition.Custom"/> value. This interface is used by a wide range of APIs that require quarter-related
-/// computations for both <see cref="DateTime"/> and <see cref="DateOnly"/> inputs.
 /// <para>
-/// Example use cases include 4–4–5 calendars, academic terms, retail fiscal calendars, or historical reporting quarters that do not
-/// align with calendar or standard financial quarters.
+/// Implementations describe a recurring quarter rule — a fiscal or logical calendar definition that is
+/// independent of any single year. Year-specific values, such as quarter start and end dates or whether a
+/// fiscal year contains a 53rd week, are derived on demand from the <see cref="DateTime"/> or
+/// <see cref="DateOnly"/> input, or from an explicit <c>fiscalYear</c> argument.
+/// </para>
+/// <para>
+/// Example use cases include 4–4–5 calendars, academic terms, retail fiscal calendars, or historical reporting
+/// quarters that do not align with calendar or standard financial quarters.
 /// </para>
 /// <para>Methods that support this interface include:</para>
 /// <list type="bullet">
@@ -32,11 +35,6 @@ namespace Bodu.Extensions;
 /// <item><see cref="DateOnlyExtensions.IsFirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/></item>
 /// <item><see cref="DateOnlyExtensions.IsLastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/></item>
 /// </list>
-/// <para>
-/// Implementers must define logic for determining both the quarter number and the corresponding start and end dates for a given date or
-/// quarter index. Overloads support both <see cref="DateTime"/> and <see cref="DateOnly"/> inputs to allow compatibility with
-/// time-specific or date-only calculations.
-/// </para>
 /// </remarks>
 public interface IQuarterDefinitionProvider
 {
@@ -46,7 +44,7 @@ public interface IQuarterDefinitionProvider
     /// <param name="dateTime">The input <see cref="DateTime"/> for which to determine the quarter.</param>
     /// <returns>An integer in the range 1 to 4 representing the quarter that includes <paramref name="dateTime"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateTime"/> does not fall within a valid or recognized quarter definition.
+    /// Thrown when <paramref name="dateTime"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     int GetQuarter(DateTime dateTime);
 
@@ -56,7 +54,7 @@ public interface IQuarterDefinitionProvider
     /// <param name="dateOnly">The input <see cref="DateOnly"/> for which to determine the quarter.</param>
     /// <returns>An integer in the range 1 to 4 representing the quarter that includes <paramref name="dateOnly"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateOnly"/> does not fall within a valid or recognized quarter definition.
+    /// Thrown when <paramref name="dateOnly"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     int GetQuarter(DateOnly dateOnly);
 
@@ -69,20 +67,27 @@ public interface IQuarterDefinitionProvider
     /// The result preserves the original <see cref="DateTime.Kind"/>.
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateTime"/> does not fall within a valid or recognized quarter.
+    /// Thrown when <paramref name="dateTime"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     DateTime GetQuarterEnd(DateTime dateTime);
 
     /// <summary>
-    /// Returns the last day of the specified quarter number (1–4) within the configured fiscal year.
+    /// Returns the last day of the specified quarter number (1–4).
     /// </summary>
     /// <param name="quarter">The quarter number (1–4).</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> set to midnight (00:00:00) on the last day of the specified quarter. The result preserves the intended
-    /// <see cref="DateTime.Kind"/> and contextual interpretation.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="quarter"/> value is not between 1 and 4.</exception>
+    /// <returns>A <see cref="DateTime"/> set to midnight (00:00:00) on the last day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    [Obsolete("Use the overload that accepts a fiscalYear parameter.")]
     DateTime GetQuarterEnd(int quarter);
+
+    /// <summary>
+    /// Returns the last day of the specified quarter number (1–4) within the given fiscal year.
+    /// </summary>
+    /// <param name="quarter">The quarter number (1–4).</param>
+    /// <param name="fiscalYear">The fiscal year whose quarter boundary is being requested.</param>
+    /// <returns>A <see cref="DateTime"/> set to midnight (00:00:00) on the last day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    DateTime GetQuarterEnd(int quarter, int fiscalYear);
 
     /// <summary>
     /// Returns the last day of the quarter that contains the specified <see cref="DateOnly"/>.
@@ -90,17 +95,27 @@ public interface IQuarterDefinitionProvider
     /// <param name="dateOnly">The input <see cref="DateOnly"/> for which to determine the end of the quarter.</param>
     /// <returns>A <see cref="DateOnly"/> representing the final day of the quarter that includes <paramref name="dateOnly"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateOnly"/> does not fall within a valid or recognized quarter.
+    /// Thrown when <paramref name="dateOnly"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     DateOnly GetQuarterEndDate(DateOnly dateOnly);
 
     /// <summary>
-    /// Returns the last day of the specified quarter number (1–4) within the configured fiscal year.
+    /// Returns the last day of the specified quarter number (1–4).
     /// </summary>
     /// <param name="quarter">The quarter number (1–4).</param>
     /// <returns>A <see cref="DateOnly"/> representing the final day of the specified quarter.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="quarter"/> value is not between 1 and 4.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    [Obsolete("Use the overload that accepts a fiscalYear parameter.")]
     DateOnly GetQuarterEndDate(int quarter);
+
+    /// <summary>
+    /// Returns the last day of the specified quarter number (1–4) within the given fiscal year.
+    /// </summary>
+    /// <param name="quarter">The quarter number (1–4).</param>
+    /// <param name="fiscalYear">The fiscal year whose quarter boundary is being requested.</param>
+    /// <returns>A <see cref="DateOnly"/> representing the final day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    DateOnly GetQuarterEndDate(int quarter, int fiscalYear);
 
     /// <summary>
     /// Returns the first day of the quarter that contains the specified <see cref="DateTime"/>.
@@ -111,20 +126,27 @@ public interface IQuarterDefinitionProvider
     /// The result preserves the original <see cref="DateTime.Kind"/>.
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateTime"/> does not fall within a valid or recognized quarter.
+    /// Thrown when <paramref name="dateTime"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     DateTime GetQuarterStart(DateTime dateTime);
 
     /// <summary>
-    /// Returns the first day of the specified quarter number (1–4) within the configured fiscal year.
+    /// Returns the first day of the specified quarter number (1–4).
     /// </summary>
     /// <param name="quarter">The quarter number (1–4).</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> set to midnight (00:00:00) on the first day of the specified quarter. The result preserves the
-    /// intended <see cref="DateTime.Kind"/> and contextual interpretation.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="quarter"/> value is not between 1 and 4.</exception>
+    /// <returns>A <see cref="DateTime"/> set to midnight (00:00:00) on the first day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    [Obsolete("Use the overload that accepts a fiscalYear parameter.")]
     DateTime GetQuarterStart(int quarter);
+
+    /// <summary>
+    /// Returns the first day of the specified quarter number (1–4) within the given fiscal year.
+    /// </summary>
+    /// <param name="quarter">The quarter number (1–4).</param>
+    /// <param name="fiscalYear">The fiscal year whose quarter boundary is being requested.</param>
+    /// <returns>A <see cref="DateTime"/> set to midnight (00:00:00) on the first day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    DateTime GetQuarterStart(int quarter, int fiscalYear);
 
     /// <summary>
     /// Returns the first day of the quarter that contains the specified <see cref="DateOnly"/>.
@@ -132,15 +154,42 @@ public interface IQuarterDefinitionProvider
     /// <param name="dateOnly">The input <see cref="DateOnly"/> for which to determine the start of the quarter.</param>
     /// <returns>A <see cref="DateOnly"/> representing the first day of the quarter that includes <paramref name="dateOnly"/>.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when the <paramref name="dateOnly"/> does not fall within a valid or recognized quarter.
+    /// Thrown when <paramref name="dateOnly"/> cannot be mapped to a recognised fiscal year.
     /// </exception>
     DateOnly GetQuarterStartDate(DateOnly dateOnly);
 
     /// <summary>
-    /// Returns the first day of the specified quarter number (1–4) within the configured fiscal year.
+    /// Returns the first day of the specified quarter number (1–4).
     /// </summary>
     /// <param name="quarter">The quarter number (1–4).</param>
     /// <returns>A <see cref="DateOnly"/> representing the first day of the specified quarter.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when the <paramref name="quarter"/> value is not between 1 and 4.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    [Obsolete("Use the overload that accepts a fiscalYear parameter.")]
     DateOnly GetQuarterStartDate(int quarter);
+
+    /// <summary>
+    /// Returns the first day of the specified quarter number (1–4) within the given fiscal year.
+    /// </summary>
+    /// <param name="quarter">The quarter number (1–4).</param>
+    /// <param name="fiscalYear">The fiscal year whose quarter boundary is being requested.</param>
+    /// <returns>A <see cref="DateOnly"/> representing the first day of the specified quarter.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter"/> is not between 1 and 4.</exception>
+    DateOnly GetQuarterStartDate(int quarter, int fiscalYear);
+
+    /// <summary>
+    /// Returns a value indicating whether the specified fiscal year contains 53 weeks rather than the standard 52.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year to test.</param>
+    /// <returns>
+    /// <see langword="true"/> if the fiscal year spans 371 days (53 complete weeks);
+    /// <see langword="false"/> if it spans 364 days (52 complete weeks).
+    /// </returns>
+    bool Is53WeekFiscalYear(int fiscalYear);
+
+    /// <summary>
+    /// Returns the total number of weeks in the specified fiscal year.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year to query.</param>
+    /// <returns>53 in a 53-week fiscal year; otherwise, 52.</returns>
+    int GetWeeksInFiscalYear(int fiscalYear);
 }

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.cs
@@ -216,6 +216,36 @@ namespace Bodu.Extensions
             {
                 throw new ArgumentOutOfRangeException(nameof(quarter), "This provider intentionally returns invalid quarter mappings.");
             }
+
+            public DateTime GetQuarterStart(int quarter, int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quarter), "This provider intentionally returns invalid quarter mappings.");
+            }
+
+            public DateTime GetQuarterEnd(int quarter, int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quarter), "This provider intentionally returns invalid quarter mappings.");
+            }
+
+            public DateOnly GetQuarterStartDate(int quarter, int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quarter), "This provider intentionally returns invalid quarter mappings.");
+            }
+
+            public DateOnly GetQuarterEndDate(int quarter, int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(quarter), "This provider intentionally returns invalid quarter mappings.");
+            }
+
+            public bool Is53WeekFiscalYear(int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fiscalYear), "This provider intentionally returns invalid quarter mappings.");
+            }
+
+            public int GetWeeksInFiscalYear(int fiscalYear)
+            {
+                throw new ArgumentOutOfRangeException(nameof(fiscalYear), "This provider intentionally returns invalid quarter mappings.");
+            }
         }
 
         public sealed class ValidQuarterProvider : IQuarterDefinitionProvider
@@ -365,6 +395,20 @@ namespace Bodu.Extensions
             public DateOnly GetQuarterStartDate(DateOnly dateOnly) => GetQuarterStart(dateOnly.ToDateTime(TimeOnly.MinValue)).ToDateOnly();
 
             public DateOnly GetQuarterStartDate(int quarter) => GetQuarterStartDate(GetQuarterStart(quarter).ToDateOnly());
+
+#pragma warning disable CS0618 // intentional: delegate the fiscal-year overloads to the existing fixed-year implementations
+            public DateTime GetQuarterStart(int quarter, int fiscalYear) => GetQuarterStart(quarter);
+
+            public DateTime GetQuarterEnd(int quarter, int fiscalYear) => GetQuarterEnd(quarter);
+
+            public DateOnly GetQuarterStartDate(int quarter, int fiscalYear) => GetQuarterStartDate(quarter);
+
+            public DateOnly GetQuarterEndDate(int quarter, int fiscalYear) => GetQuarterEndDate(quarter);
+#pragma warning restore CS0618
+
+            public bool Is53WeekFiscalYear(int fiscalYear) => false;
+
+            public int GetWeeksInFiscalYear(int fiscalYear) => 52;
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.Ctors.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.Ctors.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_Constructor.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,13 +13,39 @@ namespace Bodu.Extensions
     {
         /// <summary>
         /// Verifies that the constructor throws <see cref="ArgumentOutOfRangeException" /> when
+        /// <c>month</c> is below the valid range (1–12).
+        /// </summary>
+        [TestMethod]
+        [DataRow(0)]
+        [DataRow(-1)]
+        public void Constructor_WhenMonthIsBelowValidRange_ShouldThrowException(int month)
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+                new FiscalWeekQuarterProvider(month));
+        }
+
+        /// <summary>
+        /// Verifies that the constructor throws <see cref="ArgumentOutOfRangeException" /> when
+        /// <c>month</c> is above the valid range (1–12).
+        /// </summary>
+        [TestMethod]
+        [DataRow(13)]
+        [DataRow(100)]
+        public void Constructor_WhenMonthIsAboveValidRange_ShouldThrowException(int month)
+        {
+            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+                new FiscalWeekQuarterProvider(month));
+        }
+
+        /// <summary>
+        /// Verifies that the constructor throws <see cref="ArgumentOutOfRangeException" /> when
         /// <c>dayOfWeek</c> is not a defined <see cref="DayOfWeek" /> value.
         /// </summary>
         [TestMethod]
         public void Constructor_WhenDayOfWeekIsUndefined_ShouldThrowException()
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                new FiscalWeekQuarterProvider(2023, 1, (DayOfWeek)99));
+                new FiscalWeekQuarterProvider(1, (DayOfWeek)99));
         }
 
         /// <summary>
@@ -30,7 +56,7 @@ namespace Bodu.Extensions
         public void Constructor_WhenPatternIsUndefined_ShouldThrowException()
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: (FiscalWeekPattern)99));
+                new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: (FiscalWeekPattern)99));
         }
 
         /// <summary>
@@ -43,7 +69,7 @@ namespace Bodu.Extensions
         [DataRow(FiscalWeekPattern.Weeks445)]
         public void Pattern_WhenConstructed_ShouldReturnSuppliedPattern(FiscalWeekPattern pattern)
         {
-            var provider = new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: pattern);
+            var provider = new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: pattern);
             Assert.AreEqual(pattern, provider.Pattern);
         }
 
@@ -54,24 +80,24 @@ namespace Bodu.Extensions
         [TestMethod]
         public void Pattern_WhenConstructedWithDefaultPattern_ShouldReturnWeeks445()
         {
-            var provider = new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false);
+            var provider = new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false);
             Assert.AreEqual(FiscalWeekPattern.Weeks445, provider.Pattern);
         }
 
         /// <summary>
         /// Verifies that two providers constructed with the same parameters but different
-        /// <see cref="FiscalWeekPattern" /> values report the same <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear" />
-        /// result, confirming that the pattern does not affect quarter boundary arithmetic.
+        /// <see cref="FiscalWeekPattern" /> values produce identical quarter boundaries and 53-week
+        /// detection results, confirming that the pattern does not affect quarter boundary arithmetic.
         /// </summary>
         [TestMethod]
         public void Constructor_WhenPatternDiffers_ShouldNotAffectQuarterBoundaries()
         {
-            var p544 = new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks544);
-            var p445 = new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
+            var p544 = new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks544);
+            var p445 = new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
 
-            Assert.AreEqual(p544.GetQuarterStart(1), p445.GetQuarterStart(1));
-            Assert.AreEqual(p544.GetQuarterEnd(4), p445.GetQuarterEnd(4));
-            Assert.AreEqual(p544.Is53WeekFiscalYear, p445.Is53WeekFiscalYear);
+            Assert.AreEqual(p544.GetQuarterStart(1, 2023), p445.GetQuarterStart(1, 2023));
+            Assert.AreEqual(p544.GetQuarterEnd(4, 2023), p445.GetQuarterEnd(4, 2023));
+            Assert.AreEqual(p544.Is53WeekFiscalYear(2023), p445.Is53WeekFiscalYear(2023));
         }
 
         /// <summary>
@@ -82,7 +108,7 @@ namespace Bodu.Extensions
         public void Constructor_WhenIsFiscalYearEndIsTrue_ShouldInitialiseWithoutThrowing()
         {
             // Fiscal year ends in January; provider derives the start from the following month.
-            var provider = new FiscalWeekQuarterProvider(2022, 1, DayOfWeek.Saturday, isFiscalYearEnd: true);
+            var provider = new FiscalWeekQuarterProvider(1, DayOfWeek.Saturday, isFiscalYearEnd: true);
             Assert.IsNotNull(provider);
         }
     }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarter.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarter.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_GetQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -33,7 +33,7 @@ namespace Bodu.Extensions
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> returns 4 for a
         /// date in the 53rd week of a 53-week fiscal year. 28 December 2020 is the first day of fiscal
-        /// week 53 in <see cref="Sunday53" /> (364 days from the FY start) and is always valid.
+        /// week 53 in <see cref="Sunday53" /> (364 days from the FY start).
         /// </summary>
         [TestMethod]
         public void GetQuarter_WhenDateIsInThe53rdWeek_ShouldReturnQuarter4()
@@ -43,66 +43,84 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> resolves a date
+        /// that falls before the anchor fiscal year into the preceding fiscal year and returns its
+        /// quarter number from that year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateTimeIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarter_WhenDateTimeIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            // Dec 31, 2022 is one week before the Sunday52 fiscal year that starts Jan 1, 2023.
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarter(new DateTime(2022, 12, 31)));
+            // Dec 31, 2022 = Saturday. Under Sunday52 the week starts Dec 25, 2022, which sits in FY 2022
+            // (starting Jan 2, 2022). FY 2022 is a 52-week year, so this date is in its Q4.
+            Assert.AreEqual(4, Sunday52.GetQuarter(new DateTime(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> resolves a date
+        /// that falls after the anchor fiscal year into the following fiscal year and returns its
+        /// quarter number from that year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateTimeIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarter_WhenDateTimeIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            // Dec 31, 2023 is the first day of the next fiscal year for Sunday52 (which starts on that Sunday).
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarter(new DateTime(2023, 12, 31)));
+            // Dec 31, 2023 = Sunday; this is the first day of FY 2024 under Sunday52 (nearest Sunday to Jan 1, 2024).
+            Assert.AreEqual(1, Sunday52.GetQuarter(new DateTime(2023, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date is the first day of the fiscal year
-        /// that follows the 53-week <see cref="Sunday53" /> provider.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> maps the first day
+        /// of the next fiscal year following a 53-week year into Q1 of that next fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateTimeIsFirstDayOfNextFiscalYearIn53WeekYear_ShouldThrowException()
+        public void GetQuarter_WhenDateTimeIsFirstDayOfNextFiscalYearAfter53WeekYear_ShouldReturnQuarter1()
         {
-            // Jan 3, 2021 is the next fiscal year start for Sunday53 (nearest Sunday to Jan 1, 2021).
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday53.GetQuarter(new DateTime(2021, 1, 3)));
+            // Jan 3, 2021 = Sunday — the first day of FY 2021 under Sunday53.
+            Assert.AreEqual(1, Sunday53.GetQuarter(new DateTime(2021, 1, 3)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start in
-        /// a provider whose fiscal year begins in a prior calendar year.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> resolves a date
+        /// before the anchor fiscal year in a provider whose fiscal year begins in the prior calendar
+        /// year into the correct preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateTimeIsBeforeFiscalYearStartAcrossCalendarYear_ShouldThrowException()
+        public void GetQuarter_WhenDateTimeIsBeforeAnchorFiscalYearAcrossCalendarYear_ShouldResolveToPriorFiscalYear()
         {
-            // Dec 28, 2019 is one week before the Sunday53 fiscal year that starts Dec 29, 2019.
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday53.GetQuarter(new DateTime(2019, 12, 28)));
+            // Dec 28, 2019 = Saturday. FY 2020 under Sunday53 begins Dec 29, 2019, so Dec 28, 2019 sits
+            // in FY 2019 (begins Dec 30, 2018, 52 weeks) at its Q4.
+            Assert.AreEqual(4, Sunday53.GetQuarter(new DateTime(2019, 12, 28)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end in
-        /// the <see cref="Saturday52" /> provider, whose fiscal year ends in March of the following year.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> maps the first day
+        /// of the next fiscal year in the <see cref="Saturday52" /> provider (whose fiscal year ends in
+        /// March) into Q1 of that fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateTimeIsAfterFiscalYearEndAcrossCalendarYear_ShouldThrowException()
+        public void GetQuarter_WhenDateTimeIsAfterAnchorFiscalYearAcrossCalendarYear_ShouldResolveToNextFiscalYear()
         {
-            // Mar 30, 2024 is the first day of the fiscal year following Saturday52.
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Saturday52.GetQuarter(new DateTime(2024, 3, 30)));
+            // Mar 30, 2024 = Saturday — the first day of FY 2024 under Saturday52.
+            Assert.AreEqual(1, Saturday52.GetQuarter(new DateTime(2024, 3, 30)));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> resolves a date in
+        /// the calendar year preceding the anchor month of a fiscal-year-end provider into the correct
+        /// fiscal year.
+        /// </summary>
+        [TestMethod]
+        public void GetQuarter_WhenDateTimeIsInPriorCalendarYearOfFiscalYearEndProvider_ShouldResolveToPriorFiscalYear()
+        {
+            // Provider: fiscal year ends in January; so FY 2024 begins Feb 2024 and FY 2023 ends Jan 2024.
+            // Jan 15, 2024 must resolve to FY 2023.
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true,
+                useNearestDayOfWeek: true);
+
+            int expectedQuarter = provider.GetQuarter(new DateTime(2024, 1, 15));
+            Assert.AreEqual(4, expectedQuarter);
         }
 
         // -----------------------------------------------------------------------
@@ -125,29 +143,23 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateOnly)" /> resolves a date
+        /// before the anchor fiscal year into the preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateOnlyIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarter_WhenDateOnlyIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-            {
-                Sunday52.GetQuarter(new DateOnly(2022, 12, 31));
-            });
+            Assert.AreEqual(4, Sunday52.GetQuarter(new DateOnly(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarter(DateOnly)" /> resolves a date
+        /// after the anchor fiscal year into the following fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarter_WhenDateOnlyIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarter_WhenDateOnlyIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-            {
-                Sunday52.GetQuarter(new DateOnly(2023, 12, 31));
-            });
+            Assert.AreEqual(1, Sunday52.GetQuarter(new DateOnly(2023, 12, 31)));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterEnd.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterEnd.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_GetQuarterEnd.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,32 +12,33 @@ namespace Bodu.Extensions
     public partial class FiscalWeekQuarterProviderTests
     {
         // -----------------------------------------------------------------------
-        // GetQuarterEnd(int)
+        // GetQuarterEnd(int, int)
         // -----------------------------------------------------------------------
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> returns the correct
-        /// quarter end date for each quarter across all four providers.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> returns the
+        /// correct quarter end date for each quarter of each fiscal year across all four providers.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
-        public void GetQuarterEnd_WhenCalledWithQuarterNumber_ShouldReturnExpectedEndDate(
+        public void GetQuarterEnd_WhenCalledWithQuarterAndFiscalYear_ShouldReturnExpectedEndDate(
             FiscalWeekQuarterProvider provider,
             int quarter,
+            int fiscalYear,
             DateTime _,
             DateTime expectedEnd)
         {
-            Assert.AreEqual(expectedEnd, provider.GetQuarterEnd(quarter));
+            Assert.AreEqual(expectedEnd, provider.GetQuarterEnd(quarter, fiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> returns a
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> returns a
         /// <see cref="DateTime" /> with <see cref="DateTimeKind.Unspecified" />.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEnd_WhenCalledWithQuarterNumber_ShouldReturnUnspecifiedKind()
+        public void GetQuarterEnd_WhenCalledWithQuarterAndFiscalYear_ShouldReturnUnspecifiedKind()
         {
-            Assert.AreEqual(DateTimeKind.Unspecified, Sunday52.GetQuarterEnd(1).Kind);
+            Assert.AreEqual(DateTimeKind.Unspecified, Sunday52.GetQuarterEnd(1, Sunday52FiscalYear).Kind);
         }
 
         /// <summary>
@@ -46,8 +47,8 @@ namespace Bodu.Extensions
         [TestMethod]
         public void GetQuarterEnd_WhenFiscalYearIs52Weeks_Q4ShouldSpan13Weeks()
         {
-            var start = Sunday52.GetQuarterStart(4);
-            var end = Sunday52.GetQuarterEnd(4);
+            var start = Sunday52.GetQuarterStart(4, Sunday52FiscalYear);
+            var end = Sunday52.GetQuarterEnd(4, Sunday52FiscalYear);
             Assert.AreEqual(91, (end - start).Days + 1, "Q4 must span 91 days (13 weeks) in a 52-week year.");
         }
 
@@ -57,8 +58,8 @@ namespace Bodu.Extensions
         [TestMethod]
         public void GetQuarterEnd_WhenFiscalYearIs53Weeks_Q4ShouldSpan14Weeks()
         {
-            var start = Sunday53.GetQuarterStart(4);
-            var end = Sunday53.GetQuarterEnd(4);
+            var start = Sunday53.GetQuarterStart(4, Sunday53FiscalYear);
+            var end = Sunday53.GetQuarterEnd(4, Sunday53FiscalYear);
             Assert.AreEqual(98, (end - start).Days + 1, "Q4 must span 98 days (14 weeks) in a 53-week year.");
         }
 
@@ -72,8 +73,8 @@ namespace Bodu.Extensions
         [DataRow(3)]
         public void GetQuarterEnd_WhenFiscalYearIs53WeeksAndQuarterIs1To3_ShouldSpan13Weeks(int quarter)
         {
-            var start = Sunday53.GetQuarterStart(quarter);
-            var end = Sunday53.GetQuarterEnd(quarter);
+            var start = Sunday53.GetQuarterStart(quarter, Sunday53FiscalYear);
+            var end = Sunday53.GetQuarterEnd(quarter, Sunday53FiscalYear);
             Assert.AreEqual(91, (end - start).Days + 1, $"Q{quarter} must span 91 days in a 53-week year.");
         }
 
@@ -84,12 +85,20 @@ namespace Bodu.Extensions
         [TestMethod]
         public void GetQuarterEnd_WhenConsecutiveQuarters_EndShouldBeOneDayBeforeNextStart()
         {
-            foreach (var provider in new[] { Sunday52, Monday52Leap, Sunday53, Saturday52 })
+            var fixtures = new (FiscalWeekQuarterProvider Provider, int FiscalYear)[]
+            {
+                (Sunday52, Sunday52FiscalYear),
+                (Monday52Leap, Monday52LeapFiscalYear),
+                (Sunday53, Sunday53FiscalYear),
+                (Saturday52, Saturday52FiscalYear),
+            };
+
+            foreach (var (provider, fiscalYear) in fixtures)
             {
                 for (int q = 1; q <= 3; q++)
                 {
-                    var end = provider.GetQuarterEnd(q);
-                    var nextStart = provider.GetQuarterStart(q + 1);
+                    var end = provider.GetQuarterEnd(q, fiscalYear);
+                    var nextStart = provider.GetQuarterStart(q + 1, fiscalYear);
                     Assert.AreEqual(1, (nextStart - end).Days,
                         $"Q{q} end must be one day before Q{q + 1} start.");
                 }
@@ -97,7 +106,7 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is less than 1.
         /// </summary>
         [TestMethod]
@@ -106,11 +115,11 @@ namespace Bodu.Extensions
         public void GetQuarterEnd_WhenQuarterIsBelowValidRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEnd(quarter));
+                Sunday52.GetQuarterEnd(quarter, Sunday52FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is greater than 4.
         /// </summary>
         [TestMethod]
@@ -119,8 +128,25 @@ namespace Bodu.Extensions
         public void GetQuarterEnd_WhenQuarterIsAboveValidRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEnd(quarter));
+                Sunday52.GetQuarterEnd(quarter, Sunday52FiscalYear));
         }
+
+        // -----------------------------------------------------------------------
+        // GetQuarterEnd(int) — obsolete single-arg overload
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Verifies that the obsolete single-argument
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> overload throws
+        /// <see cref="NotSupportedException" />.
+        /// </summary>
+        [TestMethod]
+#pragma warning disable CS0618 // intentional: we verify the obsolete overload still throws
+        public void GetQuarterEnd_ObsoleteSingleArgOverload_ShouldThrowNotSupportedException()
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => Sunday52.GetQuarterEnd(1));
+        }
+#pragma warning restore CS0618
 
         // -----------------------------------------------------------------------
         // GetQuarterEnd(DateTime)
@@ -135,6 +161,7 @@ namespace Bodu.Extensions
         public void GetQuarterEnd_WhenDateTimeIsFirstDayOfQuarter_ShouldReturnEndOfThatQuarter(
             FiscalWeekQuarterProvider provider,
             int _,
+            int __,
             DateTime expectedStart,
             DateTime expectedEnd)
         {
@@ -143,27 +170,24 @@ namespace Bodu.Extensions
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> returns the
-        /// same end date when the input is the last day of that quarter, for Q1 through Q3.
-        /// Q4 last-day entries are skipped because those dates fall in the validation dead zone
-        /// (see class-level remarks).
+        /// same end date when the input is the last day of that quarter, across every quarter and every
+        /// fixture provider.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
         public void GetQuarterEnd_WhenDateTimeIsLastDayOfQuarter_ShouldReturnThatDate(
             FiscalWeekQuarterProvider provider,
-            int quarter,
-            DateTime __,
+            int _,
+            int __,
+            DateTime ___,
             DateTime expectedEnd)
         {
-            if (quarter == 4) return; // Q4 last day is in the validation dead zone; see class remarks.
-
             Assert.AreEqual(expectedEnd, provider.GetQuarterEnd(expectedEnd));
         }
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> returns the
         /// Q4 end date (2 January 2021) for a date in the 53rd week of <see cref="Sunday53" />.
-        /// 28 December 2020 is used — the first day of week 53, always valid.
         /// </summary>
         [TestMethod]
         public void GetQuarterEnd_WhenDateTimeIsInThe53rdWeek_ShouldReturnQ4EndDate()
@@ -182,37 +206,36 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> resolves a date
+        /// before the anchor fiscal year into the preceding fiscal year and returns that year's Q4 end.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEnd_WhenDateTimeIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarterEnd_WhenDateTimeIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEnd(new DateTime(2022, 12, 31)));
+            // Dec 31, 2022 resolves into FY 2022 (Jan 2, 2022 – Dec 31, 2022); Q4 ends Dec 31, 2022.
+            Assert.AreEqual(new DateTime(2022, 12, 31), Sunday52.GetQuarterEnd(new DateTime(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> resolves a date
+        /// after the anchor fiscal year into the following fiscal year and returns that year's Q1 end.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEnd_WhenDateTimeIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarterEnd_WhenDateTimeIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEnd(new DateTime(2023, 12, 31)));
+            // Dec 31, 2023 = the first day of FY 2024 under Sunday52; Q1 of FY 2024 ends Mar 30, 2024.
+            Assert.AreEqual(new DateTime(2024, 3, 30), Sunday52.GetQuarterEnd(new DateTime(2023, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> for the first day of the next fiscal year in a
-        /// 53-week provider, confirming the 371-day upper boundary is enforced.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(DateTime)" /> maps the first
+        /// day of the next fiscal year following a 53-week year into Q1 end of that next year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEnd_WhenDateTimeIsFirstDayOfNextFiscalYearIn53WeekYear_ShouldThrowException()
+        public void GetQuarterEnd_WhenDateTimeIsFirstDayOfNextFiscalYearAfter53WeekYear_ShouldReturnQ1EndOfNextYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday53.GetQuarterEnd(new DateTime(2021, 1, 3)));
+            // Jan 3, 2021 = Sunday — first day of FY 2021 under Sunday53; Q1 ends Apr 3, 2021.
+            Assert.AreEqual(new DateTime(2021, 4, 3), Sunday53.GetQuarterEnd(new DateTime(2021, 1, 3)));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterEndDate.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterEndDate.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_GetQuarterEndDate.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,39 +12,40 @@ namespace Bodu.Extensions
     public partial class FiscalWeekQuarterProviderTests
     {
         // -----------------------------------------------------------------------
-        // GetQuarterEndDate(int)
+        // GetQuarterEndDate(int, int)
         // -----------------------------------------------------------------------
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int)" /> returns a result
-        /// equal to <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> converted to
-        /// <see cref="DateOnly" />, for all quarters and all providers.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int, int)" /> returns a
+        /// result equal to <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> converted to
+        /// <see cref="DateOnly" />, for all quarters, fiscal years, and providers.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
-        public void GetQuarterEndDate_WhenCalledWithQuarterNumber_ShouldMatchGetQuarterEndConvertedToDateOnly(
+        public void GetQuarterEndDate_WhenCalledWithQuarterAndFiscalYear_ShouldMatchGetQuarterEndConvertedToDateOnly(
             FiscalWeekQuarterProvider provider,
             int quarter,
+            int fiscalYear,
             DateTime _,
             DateTime __)
         {
             Assert.AreEqual(
-                DateOnly.FromDateTime(provider.GetQuarterEnd(quarter)),
-                provider.GetQuarterEndDate(quarter));
+                DateOnly.FromDateTime(provider.GetQuarterEnd(quarter, fiscalYear)),
+                provider.GetQuarterEndDate(quarter, fiscalYear));
         }
 
         /// <summary>
-        /// Verifies that the Q4 end date for <see cref="Sunday53" /> is 2 January 2021, confirming the
-        /// 53rd week end is correctly represented as a <see cref="DateOnly" />.
+        /// Verifies that the Q4 end date for <see cref="Sunday53" /> in fiscal year 2020 is 2 January 2021,
+        /// confirming the 53rd week end is correctly represented as a <see cref="DateOnly" />.
         /// </summary>
         [TestMethod]
         public void GetQuarterEndDate_WhenFiscalYearIs53Weeks_Q4ShouldEndOnCorrectDate()
         {
-            Assert.AreEqual(new DateOnly(2021, 1, 2), Sunday53.GetQuarterEndDate(4));
+            Assert.AreEqual(new DateOnly(2021, 1, 2), Sunday53.GetQuarterEndDate(4, Sunday53FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is outside the valid range.
         /// </summary>
         [TestMethod]
@@ -53,8 +54,25 @@ namespace Bodu.Extensions
         public void GetQuarterEndDate_WhenQuarterIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEndDate(quarter));
+                Sunday52.GetQuarterEndDate(quarter, Sunday52FiscalYear));
         }
+
+        // -----------------------------------------------------------------------
+        // GetQuarterEndDate(int) — obsolete single-arg overload
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Verifies that the obsolete single-argument
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int)" /> overload throws
+        /// <see cref="NotSupportedException" />.
+        /// </summary>
+        [TestMethod]
+#pragma warning disable CS0618 // intentional: we verify the obsolete overload still throws
+        public void GetQuarterEndDate_ObsoleteSingleArgOverload_ShouldThrowNotSupportedException()
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => Sunday52.GetQuarterEndDate(1));
+        }
+#pragma warning restore CS0618
 
         // -----------------------------------------------------------------------
         // GetQuarterEndDate(DateOnly)
@@ -62,14 +80,14 @@ namespace Bodu.Extensions
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> returns the
-        /// correct quarter end date when the input is the first day of each quarter, for all four providers.
-        /// First days are always the fiscal week start day and are always valid.
+        /// correct quarter end date when the input is the first day of each quarter.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
         public void GetQuarterEndDate_WhenCalledWithFirstDayOfQuarter_ShouldReturnExpectedEndDate(
             FiscalWeekQuarterProvider provider,
-            int quarter,
+            int _,
+            int __,
             DateTime expectedStart,
             DateTime expectedEnd)
         {
@@ -80,19 +98,20 @@ namespace Bodu.Extensions
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> and
-        /// <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int)" /> return the same result when
-        /// supplied with the first day of each quarter.
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(int, int)" /> return the same result
+        /// when supplied with the first day of each quarter.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
         public void GetQuarterEndDate_WhenCalledWithFirstDayOfQuarter_ShouldMatchIntOverload(
             FiscalWeekQuarterProvider provider,
             int quarter,
+            int fiscalYear,
             DateTime expectedStart,
             DateTime _)
         {
             Assert.AreEqual(
-                provider.GetQuarterEndDate(quarter),
+                provider.GetQuarterEndDate(quarter, fiscalYear),
                 provider.GetQuarterEndDate(DateOnly.FromDateTime(expectedStart)));
         }
 
@@ -109,7 +128,7 @@ namespace Bodu.Extensions
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> returns the
         /// Q4 end date (2 January 2021) for a date in the 53rd week of the <see cref="Sunday53" />
-        /// provider. 28 December 2020 (first day of week 53) is used as the input.
+        /// provider.
         /// </summary>
         [TestMethod]
         public void GetQuarterEndDate_WhenDateOnlyIsInThe53rdWeek_ShouldReturnQ4EndDate()
@@ -129,49 +148,48 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> resolves a
+        /// date before the anchor fiscal year into the preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEndDate_WhenDateOnlyIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarterEndDate_WhenDateOnlyIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEndDate(new DateOnly(2022, 12, 31)));
+            // Dec 31, 2022 → FY 2022 Q4 end = Dec 31, 2022.
+            Assert.AreEqual(new DateOnly(2022, 12, 31), Sunday52.GetQuarterEndDate(new DateOnly(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> resolves a
+        /// date after the anchor fiscal year into the following fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEndDate_WhenDateOnlyIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarterEndDate_WhenDateOnlyIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterEndDate(new DateOnly(2023, 12, 31)));
+            // Dec 31, 2023 → FY 2024 Q1 end = Mar 30, 2024.
+            Assert.AreEqual(new DateOnly(2024, 3, 30), Sunday52.GetQuarterEndDate(new DateOnly(2023, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the
-        /// <see cref="Sunday53" /> fiscal year, which begins in December of the prior calendar year.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> resolves a
+        /// date prior to the 53-week fiscal year (<see cref="Sunday53" />) into the preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEndDate_WhenDateOnlyIsBeforeFiscalYearStartAcrossCalendarYear_ShouldThrowException()
+        public void GetQuarterEndDate_WhenDateOnlyIsBeforeAnchorFiscalYearAcrossCalendarYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday53.GetQuarterEndDate(new DateOnly(2019, 12, 28)));
+            // Dec 28, 2019 resolves into FY 2019 (starts Dec 30, 2018, 52 weeks); Q4 end = Dec 28, 2019.
+            Assert.AreEqual(new DateOnly(2019, 12, 28), Sunday53.GetQuarterEndDate(new DateOnly(2019, 12, 28)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> for the first day of the next fiscal year following
-        /// the 53-week <see cref="Sunday53" /> provider.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterEndDate(DateOnly)" /> maps the
+        /// first day of the next fiscal year following the 53-week <see cref="Sunday53" /> provider into
+        /// Q1 end of that next year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterEndDate_WhenDateOnlyIsFirstDayOfNextFiscalYearIn53WeekYear_ShouldThrowException()
+        public void GetQuarterEndDate_WhenDateOnlyIsFirstDayOfNextFiscalYearAfter53WeekYear_ShouldReturnQ1EndOfNextYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday53.GetQuarterEndDate(new DateOnly(2021, 1, 3)));
+            // Jan 3, 2021 = first day of FY 2021 under Sunday53; Q1 ends Apr 3, 2021.
+            Assert.AreEqual(new DateOnly(2021, 4, 3), Sunday53.GetQuarterEndDate(new DateOnly(2021, 1, 3)));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterStart.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterStart.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_GetQuarterStart.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,32 +12,33 @@ namespace Bodu.Extensions
     public partial class FiscalWeekQuarterProviderTests
     {
         // -----------------------------------------------------------------------
-        // GetQuarterStart(int)
+        // GetQuarterStart(int, int)
         // -----------------------------------------------------------------------
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" /> returns the correct
-        /// quarter start date for each quarter across all four providers.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> returns the
+        /// correct quarter start date for each quarter of each fiscal year across all four providers.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
-        public void GetQuarterStart_WhenCalledWithQuarterNumber_ShouldReturnExpectedStartDate(
+        public void GetQuarterStart_WhenCalledWithQuarterAndFiscalYear_ShouldReturnExpectedStartDate(
             FiscalWeekQuarterProvider provider,
             int quarter,
+            int fiscalYear,
             DateTime expectedStart,
             DateTime _)
         {
-            Assert.AreEqual(expectedStart, provider.GetQuarterStart(quarter));
+            Assert.AreEqual(expectedStart, provider.GetQuarterStart(quarter, fiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" /> returns a
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> returns a
         /// <see cref="DateTime" /> with <see cref="DateTimeKind.Unspecified" />.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStart_WhenCalledWithQuarterNumber_ShouldReturnUnspecifiedKind()
+        public void GetQuarterStart_WhenCalledWithQuarterAndFiscalYear_ShouldReturnUnspecifiedKind()
         {
-            Assert.AreEqual(DateTimeKind.Unspecified, Sunday52.GetQuarterStart(1).Kind);
+            Assert.AreEqual(DateTimeKind.Unspecified, Sunday52.GetQuarterStart(1, Sunday52FiscalYear).Kind);
         }
 
         /// <summary>
@@ -49,14 +50,14 @@ namespace Bodu.Extensions
         {
             for (int q = 1; q <= 3; q++)
             {
-                var current = Sunday52.GetQuarterStart(q);
-                var next = Sunday52.GetQuarterStart(q + 1);
+                var current = Sunday52.GetQuarterStart(q, Sunday52FiscalYear);
+                var next = Sunday52.GetQuarterStart(q + 1, Sunday52FiscalYear);
                 Assert.AreEqual(91, (next - current).Days, $"Gap between Q{q} and Q{q + 1} starts.");
             }
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is less than 1.
         /// </summary>
         [TestMethod]
@@ -65,11 +66,11 @@ namespace Bodu.Extensions
         public void GetQuarterStart_WhenQuarterIsBelowValidRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStart(quarter));
+                Sunday52.GetQuarterStart(quarter, Sunday52FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is greater than 4.
         /// </summary>
         [TestMethod]
@@ -78,8 +79,26 @@ namespace Bodu.Extensions
         public void GetQuarterStart_WhenQuarterIsAboveValidRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStart(quarter));
+                Sunday52.GetQuarterStart(quarter, Sunday52FiscalYear));
         }
+
+        // -----------------------------------------------------------------------
+        // GetQuarterStart(int) — obsolete single-arg overload
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Verifies that the obsolete single-argument
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" /> overload throws
+        /// <see cref="NotSupportedException" />, because the provider no longer tracks a single fiscal
+        /// year.
+        /// </summary>
+        [TestMethod]
+#pragma warning disable CS0618 // intentional: we verify the obsolete overload still throws
+        public void GetQuarterStart_ObsoleteSingleArgOverload_ShouldThrowNotSupportedException()
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => Sunday52.GetQuarterStart(1));
+        }
+#pragma warning restore CS0618
 
         // -----------------------------------------------------------------------
         // GetQuarterStart(DateTime)
@@ -94,28 +113,27 @@ namespace Bodu.Extensions
         public void GetQuarterStart_WhenDateTimeIsFirstDayOfQuarter_ShouldReturnThatDate(
             FiscalWeekQuarterProvider provider,
             int _,
+            int __,
             DateTime expectedStart,
-            DateTime __)
+            DateTime ___)
         {
             Assert.AreEqual(expectedStart, provider.GetQuarterStart(expectedStart));
         }
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> returns the
-        /// correct quarter start date when the input is the last day of that quarter, for Q1 through Q3.
-        /// Q4 last-day entries are skipped because those dates fall in the fiscal week validation dead zone
-        /// and throw <see cref="ArgumentOutOfRangeException" /> (see class-level remarks).
+        /// correct quarter start date when the input is the last day of that quarter, across every
+        /// quarter and every fixture provider.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
         public void GetQuarterStart_WhenDateTimeIsLastDayOfQuarter_ShouldReturnStartOfThatQuarter(
             FiscalWeekQuarterProvider provider,
-            int quarter,
+            int _,
+            int __,
             DateTime expectedStart,
             DateTime expectedEnd)
         {
-            if (quarter == 4) return; // Q4 last day is in the validation dead zone; see class remarks.
-
             Assert.AreEqual(expectedStart, provider.GetQuarterStart(expectedEnd));
         }
 
@@ -133,7 +151,7 @@ namespace Bodu.Extensions
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> returns the
         /// Q4 start date for a date in the 53rd week of the <see cref="Sunday53" /> fiscal year.
-        /// 28 December 2020 is the first day of week 53 (Sunday, always valid).
+        /// 28 December 2020 is the first day of week 53.
         /// </summary>
         [TestMethod]
         public void GetQuarterStart_WhenDateTimeIsInThe53rdWeek_ShouldReturnQ4StartDate()
@@ -142,37 +160,40 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> resolves a
+        /// date prior to the anchor fiscal year into the preceding fiscal year and returns that year's
+        /// Q4 start date.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStart_WhenDateTimeIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarterStart_WhenDateTimeIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStart(new DateTime(2022, 12, 31)));
+            // Dec 31, 2022 resolves into FY 2022 (starts Jan 2, 2022) at its Q4 boundary.
+            // FY 2022 Q4 starts Jan 2 + 273 days = Oct 2, 2022.
+            Assert.AreEqual(new DateTime(2022, 10, 2), Sunday52.GetQuarterStart(new DateTime(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> resolves a
+        /// date after the anchor fiscal year into the following fiscal year and returns that year's
+        /// Q1 start date.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStart_WhenDateTimeIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarterStart_WhenDateTimeIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStart(new DateTime(2023, 12, 31)));
+            // Dec 31, 2023 = the first day of FY 2024 under Sunday52 (nearest Sunday to Jan 1, 2024).
+            Assert.AreEqual(new DateTime(2023, 12, 31), Sunday52.GetQuarterStart(new DateTime(2023, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the April start of
-        /// the <see cref="Saturday52" /> provider.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStart(DateTime)" /> resolves a
+        /// date prior to the April-anchored fiscal year into the preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStart_WhenDateTimeIsBeforeAprilStartFiscalYear_ShouldThrowException()
+        public void GetQuarterStart_WhenDateTimeIsBeforeAprilAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Saturday52.GetQuarterStart(new DateTime(2023, 3, 31)));
+            // Mar 31, 2023 = Friday. FY 2022 under Saturday52 starts Apr 2, 2022, 52 weeks; Q4 starts
+            // Apr 2 + 273 days = Dec 31, 2022.
+            Assert.AreEqual(new DateTime(2022, 12, 31), Saturday52.GetQuarterStart(new DateTime(2023, 3, 31)));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterStartDate.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.GetQuarterStartDate.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_GetQuarterStartDate.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,29 +12,31 @@ namespace Bodu.Extensions
     public partial class FiscalWeekQuarterProviderTests
     {
         // -----------------------------------------------------------------------
-        // GetQuarterStartDate(int)
+        // GetQuarterStartDate(int, int)
         // -----------------------------------------------------------------------
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(int)" /> returns a
-        /// <see cref="DateOnly" /> consistent with <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" />
-        /// for each quarter across all four providers.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(int, int)" /> returns a
+        /// <see cref="DateOnly" /> consistent with
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> for each quarter of each
+        /// fiscal year across all four providers.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
-        public void GetQuarterStartDate_WhenCalledWithQuarterNumber_ShouldMatchGetQuarterStartConvertedToDateOnly(
+        public void GetQuarterStartDate_WhenCalledWithQuarterAndFiscalYear_ShouldMatchGetQuarterStartConvertedToDateOnly(
             FiscalWeekQuarterProvider provider,
             int quarter,
+            int fiscalYear,
             DateTime _,
             DateTime __)
         {
             Assert.AreEqual(
-                DateOnly.FromDateTime(provider.GetQuarterStart(quarter)),
-                provider.GetQuarterStartDate(quarter));
+                DateOnly.FromDateTime(provider.GetQuarterStart(quarter, fiscalYear)),
+                provider.GetQuarterStartDate(quarter, fiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(int)" /> throws
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(int, int)" /> throws
         /// <see cref="ArgumentOutOfRangeException" /> when <c>quarter</c> is outside the valid range.
         /// </summary>
         [TestMethod]
@@ -43,8 +45,25 @@ namespace Bodu.Extensions
         public void GetQuarterStartDate_WhenQuarterIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int quarter)
         {
             Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStartDate(quarter));
+                Sunday52.GetQuarterStartDate(quarter, Sunday52FiscalYear));
         }
+
+        // -----------------------------------------------------------------------
+        // GetQuarterStartDate(int) — obsolete single-arg overload
+        // -----------------------------------------------------------------------
+
+        /// <summary>
+        /// Verifies that the obsolete single-argument
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(int)" /> overload throws
+        /// <see cref="NotSupportedException" />.
+        /// </summary>
+        [TestMethod]
+#pragma warning disable CS0618 // intentional: we verify the obsolete overload still throws
+        public void GetQuarterStartDate_ObsoleteSingleArgOverload_ShouldThrowNotSupportedException()
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() => Sunday52.GetQuarterStartDate(1));
+        }
+#pragma warning restore CS0618
 
         // -----------------------------------------------------------------------
         // GetQuarterStartDate(DateOnly)
@@ -52,20 +71,18 @@ namespace Bodu.Extensions
 
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> returns
-        /// the correct quarter start when the input is the last day of each quarter, for Q1 through Q3.
-        /// Q4 last-day inputs are skipped because those dates fall in the validation dead zone
-        /// (see class-level remarks).
+        /// the correct quarter start when the input is the last day of that quarter, across every quarter
+        /// and every fixture provider.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(GetQuarterBoundaryTestData), DynamicDataSourceType.Method)]
         public void GetQuarterStartDate_WhenCalledWithLastDayOfQuarter_ShouldReturnExpectedStartDate(
             FiscalWeekQuarterProvider provider,
-            int quarter,
+            int _,
+            int __,
             DateTime expectedStart,
             DateTime expectedEnd)
         {
-            if (quarter == 4) return; // Q4 last day is in the validation dead zone; see class remarks.
-
             Assert.AreEqual(
                 DateOnly.FromDateTime(expectedStart),
                 provider.GetQuarterStartDate(DateOnly.FromDateTime(expectedEnd)));
@@ -87,7 +104,7 @@ namespace Bodu.Extensions
         /// <summary>
         /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> returns
         /// the Q4 start when the input is 28 December 2020, the first day of fiscal week 53 in the
-        /// <see cref="Sunday53" /> provider (a Sunday, always valid).
+        /// <see cref="Sunday53" /> provider.
         /// </summary>
         [TestMethod]
         public void GetQuarterStartDate_WhenDateOnlyIsInThe53rdWeek_ShouldReturnQ4StartDate()
@@ -98,25 +115,25 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls before the fiscal year start.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> resolves
+        /// a date before the anchor fiscal year into the preceding fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStartDate_WhenDateOnlyIsBeforeFiscalYearStart_ShouldThrowException()
+        public void GetQuarterStartDate_WhenDateOnlyIsBeforeAnchorFiscalYear_ShouldResolveToPriorFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStartDate(new DateOnly(2022, 12, 31)));
+            // Dec 31, 2022 → FY 2022 Q4 start = Oct 2, 2022.
+            Assert.AreEqual(new DateOnly(2022, 10, 2), Sunday52.GetQuarterStartDate(new DateOnly(2022, 12, 31)));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> throws
-        /// <see cref="ArgumentOutOfRangeException" /> when the date falls after the fiscal year end.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetQuarterStartDate(DateOnly)" /> resolves
+        /// a date after the anchor fiscal year into the following fiscal year.
         /// </summary>
         [TestMethod]
-        public void GetQuarterStartDate_WhenDateOnlyIsAfterFiscalYearEnd_ShouldThrowException()
+        public void GetQuarterStartDate_WhenDateOnlyIsAfterAnchorFiscalYear_ShouldResolveToNextFiscalYear()
         {
-            Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-                Sunday52.GetQuarterStartDate(new DateOnly(2023, 12, 31)));
+            // Dec 31, 2023 → FY 2024 Q1 start = Dec 31, 2023.
+            Assert.AreEqual(new DateOnly(2023, 12, 31), Sunday52.GetQuarterStartDate(new DateOnly(2023, 12, 31)));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.Is53WeekFiscalYear.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.Is53WeekFiscalYear.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------- //
+// --------------------------------------------------------------------------------------------------------------- //
 // <copyright file="FiscalWeekQuarterProviderTests_Is53WeekFiscalYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -125,8 +125,8 @@ namespace Bodu.Extensions
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear" /> returns the correct value
-        /// across a range of 52-week and 53-week fiscal year configurations.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" /> returns the
+        /// correct value across a range of 52-week and 53-week fiscal year configurations.
         /// </summary>
         [TestMethod]
         [DynamicData(nameof(Get53WeekYearTestData), DynamicDataSourceType.Method)]
@@ -138,62 +138,62 @@ namespace Bodu.Extensions
             bool useNearestDayOfWeek,
             bool expected)
         {
-            var provider = new FiscalWeekQuarterProvider(year, month, dayOfWeek, isFiscalYearEnd, useNearestDayOfWeek);
-            Assert.AreEqual(expected, provider.Is53WeekFiscalYear);
+            var provider = new FiscalWeekQuarterProvider(month, dayOfWeek, isFiscalYearEnd, useNearestDayOfWeek);
+            Assert.AreEqual(expected, provider.Is53WeekFiscalYear(year));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear" /> returns
-        /// <see langword="false" /> for the shared <see cref="Sunday52" /> provider.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" /> returns
+        /// <see langword="false" /> for the shared <see cref="Sunday52" /> provider in fiscal year 2023.
         /// </summary>
         [TestMethod]
         public void Is53WeekFiscalYear_WhenFiscalYearIs52Weeks_ShouldReturnFalse()
         {
-            Assert.IsFalse(Sunday52.Is53WeekFiscalYear);
+            Assert.IsFalse(Sunday52.Is53WeekFiscalYear(Sunday52FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear" /> returns
-        /// <see langword="true" /> for the shared <see cref="Sunday53" /> provider.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" /> returns
+        /// <see langword="true" /> for the shared <see cref="Sunday53" /> provider in fiscal year 2020.
         /// </summary>
         [TestMethod]
         public void Is53WeekFiscalYear_WhenFiscalYearIs53Weeks_ShouldReturnTrue()
         {
-            Assert.IsTrue(Sunday53.Is53WeekFiscalYear);
+            Assert.IsTrue(Sunday53.Is53WeekFiscalYear(Sunday53FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.WeeksInFiscalYear" /> returns 52 for a
-        /// standard 52-week fiscal year.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetWeeksInFiscalYear(int)" /> returns 52
+        /// for a standard 52-week fiscal year.
         /// </summary>
         [TestMethod]
-        public void WeeksInFiscalYear_When52WeekYear_ShouldReturn52()
+        public void GetWeeksInFiscalYear_When52WeekYear_ShouldReturn52()
         {
-            Assert.AreEqual(52, Sunday52.WeeksInFiscalYear);
+            Assert.AreEqual(52, Sunday52.GetWeeksInFiscalYear(Sunday52FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.WeeksInFiscalYear" /> returns 53 for a
-        /// 53-week fiscal year.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetWeeksInFiscalYear(int)" /> returns 53
+        /// for a 53-week fiscal year.
         /// </summary>
         [TestMethod]
-        public void WeeksInFiscalYear_When53WeekYear_ShouldReturn53()
+        public void GetWeeksInFiscalYear_When53WeekYear_ShouldReturn53()
         {
-            Assert.AreEqual(53, Sunday53.WeeksInFiscalYear);
+            Assert.AreEqual(53, Sunday53.GetWeeksInFiscalYear(Sunday53FiscalYear));
         }
 
         /// <summary>
-        /// Verifies that <see cref="FiscalWeekQuarterProvider.WeeksInFiscalYear" /> and
-        /// <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear" /> are consistent with each other for
-        /// both 52-week and 53-week providers.
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetWeeksInFiscalYear(int)" /> and
+        /// <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" /> agree for every shared
+        /// fixture provider.
         /// </summary>
         [TestMethod]
-        public void WeeksInFiscalYear_ShouldBeConsistentWithIs53WeekFiscalYear()
+        public void GetWeeksInFiscalYear_ShouldBeConsistentWithIs53WeekFiscalYear()
         {
-            Assert.AreEqual(Sunday52.Is53WeekFiscalYear ? 53 : 52, Sunday52.WeeksInFiscalYear);
-            Assert.AreEqual(Monday52Leap.Is53WeekFiscalYear ? 53 : 52, Monday52Leap.WeeksInFiscalYear);
-            Assert.AreEqual(Sunday53.Is53WeekFiscalYear ? 53 : 52, Sunday53.WeeksInFiscalYear);
-            Assert.AreEqual(Saturday52.Is53WeekFiscalYear ? 53 : 52, Saturday52.WeeksInFiscalYear);
+            Assert.AreEqual(Sunday52.Is53WeekFiscalYear(Sunday52FiscalYear) ? 53 : 52, Sunday52.GetWeeksInFiscalYear(Sunday52FiscalYear));
+            Assert.AreEqual(Monday52Leap.Is53WeekFiscalYear(Monday52LeapFiscalYear) ? 53 : 52, Monday52Leap.GetWeeksInFiscalYear(Monday52LeapFiscalYear));
+            Assert.AreEqual(Sunday53.Is53WeekFiscalYear(Sunday53FiscalYear) ? 53 : 52, Sunday53.GetWeeksInFiscalYear(Sunday53FiscalYear));
+            Assert.AreEqual(Saturday52.Is53WeekFiscalYear(Saturday52FiscalYear) ? 53 : 52, Saturday52.GetWeeksInFiscalYear(Saturday52FiscalYear));
         }
     }
 }

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.MultiYear.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.MultiYear.cs
@@ -1,0 +1,191 @@
+// --------------------------------------------------------------------------------------------------------------- //
+// <copyright file="FiscalWeekQuarterProviderTests.MultiYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions
+{
+    public partial class FiscalWeekQuarterProviderTests
+    {
+        /// <summary>
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" /> returns the
+        /// expected result for multiple fiscal years under a single provider instance, confirming that
+        /// the provider is stateless with respect to any single year and computes values on demand.
+        /// </summary>
+        /// <remarks>
+        /// Under a Saturday-aligned, nearest-day, fiscal-year-end-January rule, the 53-week fiscal years
+        /// between 2000 and 2030 are 2000, 2005, 2011, 2016, 2022, and 2028 — each has a span of 371 days
+        /// between the nearest-Saturday alignments of consecutive 1 February anchors.
+        /// </remarks>
+        [TestMethod]
+        [DataRow(2016, true)]
+        [DataRow(2022, true)]
+        [DataRow(2028, true)]
+        [DataRow(2020, false)]
+        [DataRow(2024, false)]
+        [DataRow(2025, false)]
+        public void Is53WeekFiscalYear_WhenInvokedForMultipleYearsUnderSameRule_ShouldReturnExpected(int fiscalYear, bool expected)
+        {
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true);
+
+            Assert.AreEqual(expected, provider.Is53WeekFiscalYear(fiscalYear));
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="FiscalWeekQuarterProvider.GetWeeksInFiscalYear(int)" /> returns
+        /// either 52 or 53 consistent with <see cref="FiscalWeekQuarterProvider.Is53WeekFiscalYear(int)" />
+        /// across a range of fiscal years.
+        /// </summary>
+        [TestMethod]
+        public void GetWeeksInFiscalYear_AcrossMultipleYears_ShouldBeConsistentWithIs53WeekFiscalYear()
+        {
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true);
+
+            for (int year = 2000; year <= 2040; year++)
+            {
+                int expected = provider.Is53WeekFiscalYear(year) ? 53 : 52;
+                Assert.AreEqual(expected, provider.GetWeeksInFiscalYear(year),
+                    $"GetWeeksInFiscalYear({year}) must agree with Is53WeekFiscalYear({year}).");
+            }
+        }
+
+        /// <summary>
+        /// Verifies the cross-year boundary invariant holds for every fiscal year in 2000–2040: the start
+        /// of Q1 in year <c>y</c> must equal the day after the end of Q4 in year <c>y - 1</c>, and each
+        /// consecutive quarter within a year must also be contiguous. The total number of days across all
+        /// four quarters must equal <c>GetWeeksInFiscalYear(y) × 7</c>. Verified under both alignment
+        /// strategies.
+        /// </summary>
+        [TestMethod]
+        [DataRow(true)]
+        [DataRow(false)]
+        public void GetQuarterBoundaries_AcrossFiscalYears2000To2040_ShouldBeContiguous(bool useNearestDayOfWeek)
+        {
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true,
+                useNearestDayOfWeek: useNearestDayOfWeek);
+
+            for (int year = 2001; year <= 2040; year++)
+            {
+                DateTime q4PrevEnd = provider.GetQuarterEnd(4, year - 1);
+                DateTime q1Start = provider.GetQuarterStart(1, year);
+                Assert.AreEqual(q4PrevEnd.AddDays(1), q1Start,
+                    $"Q1 of FY {year} must begin the day after Q4 of FY {year - 1}.");
+
+                for (int q = 1; q <= 3; q++)
+                {
+                    DateTime end = provider.GetQuarterEnd(q, year);
+                    DateTime nextStart = provider.GetQuarterStart(q + 1, year);
+                    Assert.AreEqual(end.AddDays(1), nextStart,
+                        $"FY {year} Q{q} end must be the day before Q{q + 1} start.");
+                }
+
+                int totalDays = 0;
+                for (int q = 1; q <= 4; q++)
+                {
+                    DateTime start = provider.GetQuarterStart(q, year);
+                    DateTime end = provider.GetQuarterEnd(q, year);
+                    totalDays += (int)(end - start).TotalDays + 1;
+                }
+
+                int expectedDays = provider.GetWeeksInFiscalYear(year) * 7;
+                Assert.AreEqual(expectedDays, totalDays,
+                    $"FY {year} must contain exactly {expectedDays} days across all four quarters.");
+            }
+        }
+
+        /// <summary>
+        /// Verifies that in a 53-week fiscal year Q4 spans exactly 98 days (14 weeks) while Q1–Q3 each
+        /// span exactly 91 days (13 weeks), confirming the extra week is confined to Q4.
+        /// </summary>
+        [TestMethod]
+        public void GetQuarterStartEnd_In53WeekYear_ShouldConfineExtraWeekToQ4()
+        {
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true);
+
+            int fiscalYear = FindFirst53WeekYear(provider, 2000, 2040);
+
+            for (int q = 1; q <= 3; q++)
+            {
+                DateTime start = provider.GetQuarterStart(q, fiscalYear);
+                DateTime end = provider.GetQuarterEnd(q, fiscalYear);
+                int days = (int)(end - start).TotalDays + 1;
+                Assert.AreEqual(91, days, $"Q{q} of FY {fiscalYear} must span 91 days.");
+            }
+
+            DateTime q4Start = provider.GetQuarterStart(4, fiscalYear);
+            DateTime q4End = provider.GetQuarterEnd(4, fiscalYear);
+            int q4Days = (int)(q4End - q4Start).TotalDays + 1;
+            Assert.AreEqual(98, q4Days, $"Q4 of FY {fiscalYear} must span 98 days (14 weeks).");
+        }
+
+        /// <summary>
+        /// Verifies that the last day of Q4 in fiscal year <c>y</c> maps back to quarter 4, and that the
+        /// first day of Q1 in fiscal year <c>y + 1</c> maps to quarter 1, exercising the
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarter(DateTime)" /> boundary handoff. Uses a
+        /// provider configured with <c>isFiscalYearEnd: false</c> so the fiscal year start day and the
+        /// first day of each fiscal week are identical, avoiding the 1-day offset that arises under
+        /// <c>isFiscalYearEnd: true</c>.
+        /// </summary>
+        [TestMethod]
+        public void GetQuarter_AtFiscalYearBoundary_ShouldHandoffCorrectly()
+        {
+            DateTime q4End = Sunday52.GetQuarterEnd(4, Sunday52FiscalYear);
+            Assert.AreEqual(4, Sunday52.GetQuarter(q4End));
+
+            DateTime q1NextStart = Sunday52.GetQuarterStart(1, Sunday52FiscalYear + 1);
+            Assert.AreEqual(1, Sunday52.GetQuarter(q1NextStart));
+        }
+
+        /// <summary>
+        /// Verifies that the <see cref="DateOnly" /> overloads of every quarter-computation method return
+        /// results identical to their <see cref="DateTime" /> counterparts for the same input date.
+        /// </summary>
+        [TestMethod]
+        public void DateOnlyOverloads_ShouldProduceSameResultsAsDateTimeOverloads()
+        {
+            var provider = new FiscalWeekQuarterProvider(
+                month: 1,
+                dayOfWeek: DayOfWeek.Saturday,
+                isFiscalYearEnd: true);
+
+            DateTime dateTime = new DateTime(2024, 6, 15);
+            DateOnly dateOnly = DateOnly.FromDateTime(dateTime);
+
+            Assert.AreEqual(provider.GetQuarter(dateTime), provider.GetQuarter(dateOnly));
+            Assert.AreEqual(
+                DateOnly.FromDateTime(provider.GetQuarterStart(dateTime)),
+                provider.GetQuarterStartDate(dateOnly));
+            Assert.AreEqual(
+                DateOnly.FromDateTime(provider.GetQuarterEnd(dateTime)),
+                provider.GetQuarterEndDate(dateOnly));
+        }
+
+        private static int FindFirst53WeekYear(FiscalWeekQuarterProvider provider, int fromYear, int toYear)
+        {
+            for (int year = fromYear; year <= toYear; year++)
+            {
+                if (provider.Is53WeekFiscalYear(year))
+                    return year;
+            }
+
+            throw new InvalidOperationException(
+                $"No 53-week fiscal year found in the range {fromYear}–{toYear}.");
+        }
+    }
+}

--- a/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.cs
+++ b/Bodu.Core/test/Extensions/FiscalWeekQuarterProviderTests.cs
@@ -15,9 +15,11 @@ namespace Bodu.Extensions
     /// </summary>
     /// <remarks>
     /// <para>
-    /// All providers used as shared fixtures use <c>isFiscalYearEnd: false</c> combined with an anchor month
-    /// whose first day is exactly the desired <see cref="DayOfWeek" />, eliminating alignment ambiguity and
-    /// making expected quarter boundaries straightforwardly verifiable from first principles.
+    /// <see cref="FiscalWeekQuarterProvider" /> describes a recurring fiscal calendar rule; year-specific
+    /// values (fiscal year start, 53-week detection, quarter boundaries) are computed on demand from
+    /// either an explicit <c>fiscalYear</c> argument or from the input date via an internal cross-year
+    /// search. Dates near a fiscal year boundary therefore resolve to the correct neighbouring fiscal
+    /// year rather than throwing.
     /// </para>
     /// <para>
     /// Four providers are defined to give broad scenario coverage:
@@ -26,95 +28,76 @@ namespace Bodu.Extensions
     /// <item>
     /// <term><see cref="Sunday52" /></term>
     /// <description>
-    /// 52-week Sunday-start fiscal year beginning 1 January 2023 (a Sunday).
+    /// 52-week Sunday-start rule; when applied to fiscal year 2023 the year begins 1 January 2023 (a Sunday).
     /// </description>
     /// </item>
     /// <item>
     /// <term><see cref="Monday52Leap" /></term>
     /// <description>
-    /// 52-week Monday-start fiscal year beginning 1 January 2024 (a Monday). 2024 is a leap year.
+    /// 52-week Monday-start rule; fiscal year 2024 begins 1 January 2024 (a Monday). 2024 is a leap year.
     /// </description>
     /// </item>
     /// <item>
     /// <term><see cref="Sunday53" /></term>
     /// <description>
-    /// 53-week Sunday-start fiscal year beginning 29 December 2019. Q4 contains 14 weeks and
-    /// ends 2 January 2021.
+    /// 53-week Sunday-start rule; fiscal year 2020 begins 29 December 2019 and ends 2 January 2021
+    /// (Q4 spans 14 weeks).
     /// </description>
     /// </item>
     /// <item>
     /// <term><see cref="Saturday52" /></term>
     /// <description>
-    /// 52-week Saturday-start fiscal year beginning 1 April 2023, straddling the calendar year.
+    /// 52-week Saturday-start rule; fiscal year 2023 begins 1 April 2023 and ends 29 March 2024, straddling
+    /// the calendar year.
     /// </description>
     /// </item>
     /// </list>
-    /// <para>
-    /// <strong>Known validation constraint:</strong>
-    /// <see cref="FiscalWeekQuarterProvider" /> aligns each input date <em>forward</em> to the next
-    /// <c>_firstDayOfWeek</c> occurrence to determine its fiscal week. Dates in the last 1–6 days of
-    /// the final fiscal week — those that are not the fiscal week start day itself — resolve to a
-    /// <c>weekStartTicks</c> value that falls in the next fiscal year and therefore throw
-    /// <see cref="ArgumentOutOfRangeException" />. Affected dates per provider:
-    /// </para>
-    /// <list type="bullet">
-    /// <item><description><see cref="Sunday52" />: 28–30 December 2023 (Thu–Sat)</description></item>
-    /// <item><description><see cref="Monday52Leap" />: 27–29 December 2024 (Fri–Sun)</description></item>
-    /// <item><description><see cref="Sunday53" />: 31 December 2020–2 January 2021 (Thu–Sat)</description></item>
-    /// <item><description><see cref="Saturday52" />: 27–29 March 2024 (Wed–Fri)</description></item>
-    /// </list>
-    /// <para>
-    /// Test data and test methods avoid these dates. Quarter boundary tests that operate on the last day of
-    /// a quarter use only Q1–Q3, and Q4 coverage uses the <em>first</em> day of the final fiscal week.
-    /// </para>
     /// </remarks>
     [TestClass]
     public partial class FiscalWeekQuarterProviderTests
     {
-        // Jan 1, 2023 = Sunday — alignment is exact; no ambiguity.
-        // FY: 2023-01-01 – 2023-12-30 | 52 weeks | Weeks544
+        // FY 2023 — Jan 1, 2023 = Sunday — alignment is exact; no ambiguity.
+        // FY 2023: 2023-01-01 – 2023-12-30 | 52 weeks | Weeks544
         // Q1: 2023-01-01 – 2023-04-01  Q2: 2023-04-02 – 2023-07-01
         // Q3: 2023-07-02 – 2023-09-30  Q4: 2023-10-01 – 2023-12-30
-        private static readonly FiscalWeekQuarterProvider Sunday52 =
-            new FiscalWeekQuarterProvider(2023, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks544);
+        private const int Sunday52FiscalYear = 2023;
 
-        // Jan 1, 2024 = Monday — alignment is exact; no ambiguity.
-        // 2024 is a leap year (contains Feb 29). FY: 2024-01-01 – 2024-12-29 | 52 weeks | Weeks445
+        private static readonly FiscalWeekQuarterProvider Sunday52 =
+            new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks544);
+
+        // FY 2024 — Jan 1, 2024 = Monday — alignment is exact; no ambiguity.
+        // 2024 is a leap year (contains Feb 29). FY 2024: 2024-01-01 – 2024-12-29 | 52 weeks | Weeks445
         // Q1: 2024-01-01 – 2024-03-31  Q2: 2024-04-01 – 2024-06-30
         // Q3: 2024-07-01 – 2024-09-29  Q4: 2024-09-30 – 2024-12-29
-        private static readonly FiscalWeekQuarterProvider Monday52Leap =
-            new FiscalWeekQuarterProvider(2024, 1, DayOfWeek.Monday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
+        private const int Monday52LeapFiscalYear = 2024;
 
-        // Jan 1, 2020 = Wednesday — nearest Sunday is Dec 29, 2019 (3 days earlier).
-        // 2020 is a leap year. FY: 2019-12-29 – 2021-01-02 | 53 weeks | Weeks445
+        private static readonly FiscalWeekQuarterProvider Monday52Leap =
+            new FiscalWeekQuarterProvider(1, DayOfWeek.Monday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
+
+        // FY 2020 — Jan 1, 2020 = Wednesday — nearest Sunday is Dec 29, 2019 (3 days earlier).
+        // 2020 is a leap year. FY 2020: 2019-12-29 – 2021-01-02 | 53 weeks | Weeks445
         // Q1: 2019-12-29 – 2020-03-28  Q2: 2020-03-29 – 2020-06-27
         // Q3: 2020-06-28 – 2020-09-26  Q4: 2020-09-27 – 2021-01-02  (14 weeks)
-        private static readonly FiscalWeekQuarterProvider Sunday53 =
-            new FiscalWeekQuarterProvider(2020, 1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
+        private const int Sunday53FiscalYear = 2020;
 
-        // Apr 1, 2023 = Saturday — alignment is exact; no ambiguity.
-        // Straddles calendar year; Q4 falls in a leap year (2024). FY: 2023-04-01 – 2024-03-29 | 52 weeks | Weeks454
+        private static readonly FiscalWeekQuarterProvider Sunday53 =
+            new FiscalWeekQuarterProvider(1, DayOfWeek.Sunday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks445);
+
+        // FY 2023 — Apr 1, 2023 = Saturday — alignment is exact; no ambiguity.
+        // Straddles calendar year; Q4 falls in a leap year (2024). FY 2023: 2023-04-01 – 2024-03-29 | 52 weeks | Weeks454
         // Q1: 2023-04-01 – 2023-06-30  Q2: 2023-07-01 – 2023-09-29
         // Q3: 2023-09-30 – 2023-12-29  Q4: 2023-12-30 – 2024-03-29
+        private const int Saturday52FiscalYear = 2023;
+
         private static readonly FiscalWeekQuarterProvider Saturday52 =
-            new FiscalWeekQuarterProvider(2023, 4, DayOfWeek.Saturday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks454);
+            new FiscalWeekQuarterProvider(4, DayOfWeek.Saturday, isFiscalYearEnd: false, pattern: FiscalWeekPattern.Weeks454);
 
         /// <summary>
         /// Provides quarter number test cases: (provider, date, expectedQuarter).
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// Includes mid-quarter dates, the first day of each quarter, and — for Q1 through Q3 —
-        /// the last day of each quarter. Leap day (29 February) is explicitly covered.
-        /// </para>
-        /// <para>
-        /// Q4 last-day entries are intentionally omitted. Dates in the last 1–6 days of the final
-        /// fiscal week (those that are not the fiscal week start day itself) produce a
-        /// <c>weekStartTicks</c> value that falls in the following fiscal year and therefore throw
-        /// <see cref="ArgumentOutOfRangeException" />. Q4 coverage instead uses the first day of
-        /// the final fiscal week, which is always valid (it is the <c>_firstDayOfWeek</c> itself,
-        /// giving a forward offset of zero).
-        /// </para>
+        /// Includes mid-quarter dates, the first day of each quarter, and the last day of each
+        /// quarter (including Q4). Leap day (29 February) is explicitly covered.
         /// </remarks>
         public static IEnumerable<object[]> GetQuarterNumberTestData()
         {
@@ -131,6 +114,7 @@ namespace Bodu.Extensions
             yield return new object[] { Sunday52, new DateTime(2023, 11, 15), 4 }; // mid-Q4
             yield return new object[] { Sunday52, new DateTime(2023, 10, 1), 4 }; // Q4 first day (Sunday)
             yield return new object[] { Sunday52, new DateTime(2023, 12, 24), 4 }; // first day of final fiscal week (Sun)
+            yield return new object[] { Sunday52, new DateTime(2023, 12, 30), 4 }; // Q4 last day (Saturday)
 
             // Monday52Leap — Q1 last day is Sunday (always valid); Q4 uses final week start (Mon 23 Dec)
             yield return new object[] { Monday52Leap, new DateTime(2024, 2, 29), 1 }; // leap day in Q1
@@ -145,6 +129,7 @@ namespace Bodu.Extensions
             yield return new object[] { Monday52Leap, new DateTime(2024, 11, 5), 4 }; // mid-Q4
             yield return new object[] { Monday52Leap, new DateTime(2024, 9, 30), 4 }; // Q4 first day (Monday)
             yield return new object[] { Monday52Leap, new DateTime(2024, 12, 23), 4 }; // first day of final fiscal week (Mon)
+            yield return new object[] { Monday52Leap, new DateTime(2024, 12, 29), 4 }; // Q4 last day (Sunday)
 
             // Sunday53 — FY spans two calendar years; Dec 27, 2020 is the first day of week 53 (Sunday)
             yield return new object[] { Sunday53, new DateTime(2019, 12, 29), 1 }; // FY first day (prior calendar year)
@@ -159,6 +144,7 @@ namespace Bodu.Extensions
             yield return new object[] { Sunday53, new DateTime(2020, 9, 27), 4 }; // Q4 first day (Sunday)
             yield return new object[] { Sunday53, new DateTime(2020, 12, 25), 4 }; // mid-Q4
             yield return new object[] { Sunday53, new DateTime(2020, 12, 27), 4 }; // first day of fiscal week 53 (Sunday)
+            yield return new object[] { Sunday53, new DateTime(2021, 1, 2), 4 }; // Q4 last day (Saturday) — 53rd week end
 
             // Saturday52 — Q4 first day is Dec 30 (Saturday); final week start is Mar 23, 2024 (Saturday)
             yield return new object[] { Saturday52, new DateTime(2023, 5, 15), 1 }; // mid-Q1
@@ -173,49 +159,44 @@ namespace Bodu.Extensions
             yield return new object[] { Saturday52, new DateTime(2023, 12, 30), 4 }; // Q4 first day (Saturday)
             yield return new object[] { Saturday52, new DateTime(2024, 1, 15), 4 }; // mid-Q4
             yield return new object[] { Saturday52, new DateTime(2024, 3, 23), 4 }; // first day of final fiscal week (Sat)
+            yield return new object[] { Saturday52, new DateTime(2024, 3, 29), 4 }; // Q4 last day (Friday)
         }
 
         /// <summary>
-        /// Provides quarter boundary test cases: (provider, quarter, expectedStart, expectedEnd).
+        /// Provides quarter boundary test cases: (provider, quarter, fiscalYear, expectedStart, expectedEnd).
         /// </summary>
         /// <remarks>
-        /// <para>
-        /// Each row covers one quarter of one provider. The <c>expectedStart</c> and <c>expectedEnd</c>
-        /// values are the dates returned by <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int)" />
-        /// and <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int)" /> respectively — both purely
+        /// Each row covers one quarter of one provider within a specific fiscal year. The
+        /// <c>expectedStart</c> and <c>expectedEnd</c> values are the dates returned by
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterStart(int, int)" /> and
+        /// <see cref="FiscalWeekQuarterProvider.GetQuarterEnd(int, int)" /> respectively — both purely
         /// arithmetic and both <see cref="DateTimeKind.Unspecified" />.
-        /// </para>
-        /// <para>
-        /// Tests that pass <c>expectedEnd</c> to a <see cref="DateTime" />- or
-        /// <see cref="DateOnly" />-accepting overload must guard against Q4 rows, because the last
-        /// day of Q4 falls in the validation dead zone described in the class remarks.
-        /// </para>
         /// </remarks>
         public static IEnumerable<object[]> GetQuarterBoundaryTestData()
         {
-            // Sunday52 (2023-01-01 – 2023-12-30)
-            yield return new object[] { Sunday52, 1, new DateTime(2023, 1, 1), new DateTime(2023, 4, 1) };
-            yield return new object[] { Sunday52, 2, new DateTime(2023, 4, 2), new DateTime(2023, 7, 1) };
-            yield return new object[] { Sunday52, 3, new DateTime(2023, 7, 2), new DateTime(2023, 9, 30) };
-            yield return new object[] { Sunday52, 4, new DateTime(2023, 10, 1), new DateTime(2023, 12, 30) };
+            // Sunday52, FY 2023 (2023-01-01 – 2023-12-30)
+            yield return new object[] { Sunday52, 1, Sunday52FiscalYear, new DateTime(2023, 1, 1), new DateTime(2023, 4, 1) };
+            yield return new object[] { Sunday52, 2, Sunday52FiscalYear, new DateTime(2023, 4, 2), new DateTime(2023, 7, 1) };
+            yield return new object[] { Sunday52, 3, Sunday52FiscalYear, new DateTime(2023, 7, 2), new DateTime(2023, 9, 30) };
+            yield return new object[] { Sunday52, 4, Sunday52FiscalYear, new DateTime(2023, 10, 1), new DateTime(2023, 12, 30) };
 
-            // Monday52Leap (2024-01-01 – 2024-12-29) — leap year
-            yield return new object[] { Monday52Leap, 1, new DateTime(2024, 1, 1), new DateTime(2024, 3, 31) };
-            yield return new object[] { Monday52Leap, 2, new DateTime(2024, 4, 1), new DateTime(2024, 6, 30) };
-            yield return new object[] { Monday52Leap, 3, new DateTime(2024, 7, 1), new DateTime(2024, 9, 29) };
-            yield return new object[] { Monday52Leap, 4, new DateTime(2024, 9, 30), new DateTime(2024, 12, 29) };
+            // Monday52Leap, FY 2024 (2024-01-01 – 2024-12-29) — leap year
+            yield return new object[] { Monday52Leap, 1, Monday52LeapFiscalYear, new DateTime(2024, 1, 1), new DateTime(2024, 3, 31) };
+            yield return new object[] { Monday52Leap, 2, Monday52LeapFiscalYear, new DateTime(2024, 4, 1), new DateTime(2024, 6, 30) };
+            yield return new object[] { Monday52Leap, 3, Monday52LeapFiscalYear, new DateTime(2024, 7, 1), new DateTime(2024, 9, 29) };
+            yield return new object[] { Monday52Leap, 4, Monday52LeapFiscalYear, new DateTime(2024, 9, 30), new DateTime(2024, 12, 29) };
 
-            // Sunday53 (2019-12-29 – 2021-01-02) — 53-week year; Q4 spans 14 weeks
-            yield return new object[] { Sunday53, 1, new DateTime(2019, 12, 29), new DateTime(2020, 3, 28) };
-            yield return new object[] { Sunday53, 2, new DateTime(2020, 3, 29), new DateTime(2020, 6, 27) };
-            yield return new object[] { Sunday53, 3, new DateTime(2020, 6, 28), new DateTime(2020, 9, 26) };
-            yield return new object[] { Sunday53, 4, new DateTime(2020, 9, 27), new DateTime(2021, 1, 2) };
+            // Sunday53, FY 2020 (2019-12-29 – 2021-01-02) — 53-week year; Q4 spans 14 weeks
+            yield return new object[] { Sunday53, 1, Sunday53FiscalYear, new DateTime(2019, 12, 29), new DateTime(2020, 3, 28) };
+            yield return new object[] { Sunday53, 2, Sunday53FiscalYear, new DateTime(2020, 3, 29), new DateTime(2020, 6, 27) };
+            yield return new object[] { Sunday53, 3, Sunday53FiscalYear, new DateTime(2020, 6, 28), new DateTime(2020, 9, 26) };
+            yield return new object[] { Sunday53, 4, Sunday53FiscalYear, new DateTime(2020, 9, 27), new DateTime(2021, 1, 2) };
 
-            // Saturday52 (2023-04-01 – 2024-03-29) — straddles calendar year; Q4 within leap year
-            yield return new object[] { Saturday52, 1, new DateTime(2023, 4, 1), new DateTime(2023, 6, 30) };
-            yield return new object[] { Saturday52, 2, new DateTime(2023, 7, 1), new DateTime(2023, 9, 29) };
-            yield return new object[] { Saturday52, 3, new DateTime(2023, 9, 30), new DateTime(2023, 12, 29) };
-            yield return new object[] { Saturday52, 4, new DateTime(2023, 12, 30), new DateTime(2024, 3, 29) };
+            // Saturday52, FY 2023 (2023-04-01 – 2024-03-29) — straddles calendar year; Q4 within leap year
+            yield return new object[] { Saturday52, 1, Saturday52FiscalYear, new DateTime(2023, 4, 1), new DateTime(2023, 6, 30) };
+            yield return new object[] { Saturday52, 2, Saturday52FiscalYear, new DateTime(2023, 7, 1), new DateTime(2023, 9, 29) };
+            yield return new object[] { Saturday52, 3, Saturday52FiscalYear, new DateTime(2023, 9, 30), new DateTime(2023, 12, 29) };
+            yield return new object[] { Saturday52, 4, Saturday52FiscalYear, new DateTime(2023, 12, 30), new DateTime(2024, 3, 29) };
         }
     }
 }


### PR DESCRIPTION
Drop the single-year instance model that forced callers to construct a new
provider per fiscal year and produced a validation "dead zone" around each
year's boundary week. The provider now encodes the recurring rule only
(anchor month, week-start day, alignment strategy, pattern), and every
year-specific value — fiscal year start, 53-week detection, quarter
boundaries — is derived on demand from either an explicit fiscalYear
argument or an internal GetFiscalYearFor that maps a date to the fiscal
year containing its fiscal week.

Interface changes:
- IQuarterDefinitionProvider gains (quarter, fiscalYear) overloads for every
  Get*Start/End method plus Is53WeekFiscalYear(int) and
  GetWeeksInFiscalYear(int).
- The existing single-arg Get*Start/End overloads are kept for binary
  compatibility, decorated [Obsolete]; the concrete FiscalWeekQuarterProvider
  implementations throw NotSupportedException since no single year is tracked.

Behaviour changes:
- Dates previously caught by ValidateDateInFiscalYear's dead zone now resolve
  into the neighbouring fiscal year (the fiscal week that straddles the
  boundary is assigned to the year containing its week start).
- Tests that asserted ArgumentOutOfRangeException for those dates are
  rewritten to assert the new cross-year resolution behaviour.

Test coverage:
- Existing partials threaded with a fiscalYear column in the boundary test
  data generator and updated per-fixture year constants.
- New MultiYear partial adds: multi-year Is53WeekFiscalYear coverage, the
  GetWeeksInFiscalYear/Is53WeekFiscalYear consistency check, and the 2001–2040
  cross-year contiguity invariant (Q4 end + 1 == next Q1 start for every year
  and quarter-by-quarter within each year, under both alignment strategies).
- Obsolete-overload stubs covered with NotSupportedException assertions.
- Mock ValidQuarterProvider / InValidQuarterProvider extended with the new
  interface members so the rest of the test project continues to compile.

https://claude.ai/code/session_019wDrLC6pE1jN5gUTWfALCV