### PR TITLE
test(io.hashing): harden exception and edge-case coverage for CRC and Fletcher

### DIFF
--- a/Bodu.IO/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.cs
+++ b/Bodu.IO/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.cs
@@ -1,0 +1,332 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockNonCryptographicHashAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Contains unit tests for <see cref="BlockNonCryptographicHashAlgorithm{T}" /> that exercise branches not
+/// reachable through the production <see cref="Fletcher{TSelf}" /> derivatives — specifically the
+/// <c>blockSize &lt;= 0</c> constructor guard, the <c>CopyResidualStateFrom(null)</c> guard, and both
+/// padded-finalisation code paths governed by <see cref="BlockNonCryptographicHashAlgorithm{T}" />'s
+/// <c>ShouldPadFinalBlock</c> and <c>AllowUnalignedFinalBlock</c> virtual members.
+/// </summary>
+[TestClass]
+public class BlockNonCryptographicHashAlgorithmTests
+{
+    /// <summary>
+    /// A test-only block hasher with block size 4 that records every full block passed to
+    /// <see cref="ProcessBlock(ReadOnlySpan{byte})" />. <c>ShouldPadFinalBlock</c> defaults to <see langword="false" />
+    /// so the final residual is passed through verbatim, matching the Fletcher production path.
+    /// </summary>
+    private sealed class RecordingBlockHasher
+        : BlockNonCryptographicHashAlgorithm<RecordingBlockHasher>
+    {
+        public readonly List<byte[]> Blocks = new();
+
+        public RecordingBlockHasher()
+            : base(hashLengthInBytes: 4, blockSize: 4)
+        {
+        }
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block)
+        {
+            Blocks.Add(block.ToArray());
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength)
+            => throw new InvalidOperationException("PadBlock should not be reached: ShouldPadFinalBlock is false.");
+
+        protected override byte[] ProcessFinalBlock() => new byte[4];
+
+        protected override bool ShouldPadFinalBlock() => false;
+
+        protected override RecordingBlockHasher Clone()
+        {
+            RecordingBlockHasher clone = new();
+            clone.Blocks.AddRange(Blocks);
+            clone.CopyResidualStateFrom(this);
+            return clone;
+        }
+
+        public void CopyFromExposed(BlockNonCryptographicHashAlgorithm<RecordingBlockHasher>? source)
+            => CopyResidualStateFrom(source!);
+    }
+
+    /// <summary>
+    /// A test-only block hasher that exercises the <c>ShouldPadFinalBlock = true</c> path. Padding is a simple
+    /// zero-fill out to the next block boundary plus a length-encoding block; <see cref="AllowUnalignedFinalBlock" />
+    /// defaults to <see langword="false" /> so <c>GetCurrentHashCore</c> slices the padded output into
+    /// block-sized chunks before forwarding to <c>ProcessBlock</c>.
+    /// </summary>
+    private sealed class PaddingBlockHasher
+        : BlockNonCryptographicHashAlgorithm<PaddingBlockHasher>
+    {
+        // Shared across the outer instance and any Clone() snapshots so block invocations performed during
+        // GetCurrentHashCore on the clone are observable through the outer instance's Blocks property.
+        public List<byte[]> Blocks = new();
+
+        public PaddingBlockHasher()
+            : base(hashLengthInBytes: 4, blockSize: 4)
+        {
+        }
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block)
+        {
+            Blocks.Add(block.ToArray());
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength)
+        {
+            // Return exactly two blocks of BlockSizeBytes — the residual (zero-padded) followed by a
+            // length-encoding block. Aligns with the ShouldPadFinalBlock=true, AllowUnalignedFinalBlock=false
+            // contract where GetCurrentHashCore slices the output into BlockSizeBytes chunks.
+            byte[] output = new byte[BlockSizeBytes * 2];
+            block.CopyTo(output);
+            output[BlockSizeBytes] = unchecked((byte)messageLength);
+            return output;
+        }
+
+        protected override byte[] ProcessFinalBlock() => new byte[4];
+
+        protected override PaddingBlockHasher Clone()
+        {
+            PaddingBlockHasher clone = new();
+            clone.Blocks = Blocks;
+            clone.CopyResidualStateFrom(this);
+            return clone;
+        }
+    }
+
+    /// <summary>
+    /// A padded hasher identical to <see cref="PaddingBlockHasher" /> except that it overrides
+    /// <c>AllowUnalignedFinalBlock</c> to <see langword="true" />, exercising the code path where
+    /// <c>GetCurrentHashCore</c> forwards the entire padded buffer to <c>ProcessBlock</c> in a single call
+    /// rather than slicing it into block-sized chunks.
+    /// </summary>
+    private sealed class UnalignedPaddingBlockHasher
+        : BlockNonCryptographicHashAlgorithm<UnalignedPaddingBlockHasher>
+    {
+        public readonly List<byte[]> Blocks = new();
+
+        public UnalignedPaddingBlockHasher()
+            : base(hashLengthInBytes: 4, blockSize: 4)
+        {
+        }
+
+        protected override bool AllowUnalignedFinalBlock => true;
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block)
+        {
+            Blocks.Add(block.ToArray());
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength)
+        {
+            byte[] output = new byte[BlockSizeBytes + 3];
+            block.CopyTo(output);
+            output[BlockSizeBytes] = unchecked((byte)messageLength);
+            return output;
+        }
+
+        protected override byte[] ProcessFinalBlock() => new byte[4];
+
+        protected override UnalignedPaddingBlockHasher Clone()
+        {
+            UnalignedPaddingBlockHasher clone = new();
+            clone.Blocks.AddRange(Blocks);
+            clone.CopyResidualStateFrom(this);
+            return clone;
+        }
+    }
+
+    private sealed class InvalidBlockSizeHasher
+        : BlockNonCryptographicHashAlgorithm<InvalidBlockSizeHasher>
+    {
+        public InvalidBlockSizeHasher()
+            : base(hashLengthInBytes: 4, blockSize: 0)
+        {
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) => Array.Empty<byte>();
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block) { }
+
+        protected override byte[] ProcessFinalBlock() => Array.Empty<byte>();
+
+        protected override InvalidBlockSizeHasher Clone() => this;
+    }
+
+    private sealed class NegativeBlockSizeHasher
+        : BlockNonCryptographicHashAlgorithm<NegativeBlockSizeHasher>
+    {
+        public NegativeBlockSizeHasher()
+            : base(hashLengthInBytes: 4, blockSize: -1)
+        {
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) => Array.Empty<byte>();
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block) { }
+
+        protected override byte[] ProcessFinalBlock() => Array.Empty<byte>();
+
+        protected override NegativeBlockSizeHasher Clone() => this;
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="BlockNonCryptographicHashAlgorithm{T}" /> constructor throws
+    /// <see cref="ArgumentOutOfRangeException" /> with <c>ParamName</c> equal to <c>blockSize</c> when the
+    /// supplied block size is zero.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenBlockSizeIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new InvalidBlockSizeHasher());
+        Assert.AreEqual("blockSize", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="BlockNonCryptographicHashAlgorithm{T}" /> constructor throws
+    /// <see cref="ArgumentOutOfRangeException" /> with <c>ParamName</c> equal to <c>blockSize</c> when the
+    /// supplied block size is negative.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenBlockSizeIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => new NegativeBlockSizeHasher());
+        Assert.AreEqual("blockSize", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockNonCryptographicHashAlgorithm{T}.CopyResidualStateFrom" /> throws
+    /// <see cref="ArgumentNullException" /> with <c>ParamName</c> equal to <c>source</c> when invoked with a
+    /// <see langword="null" /> source instance.
+    /// </summary>
+    [TestMethod]
+    public void CopyResidualStateFrom_WhenSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        RecordingBlockHasher hasher = new();
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() => hasher.CopyFromExposed(null));
+        Assert.AreEqual("source", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that when the residual buffer plus the incoming input exactly fill one block, the combined block
+    /// is emitted to <c>ProcessBlock</c> and the residual is cleared.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenResidualPlusInputExactlyFillsBlock_ShouldEmitOneAlignedBlock()
+    {
+        RecordingBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0x01, 0x02 });              // residual = 2 bytes
+        hasher.Append(new byte[] { 0x03, 0x04 });              // fills the block exactly
+
+        Assert.AreEqual(1, hasher.Blocks.Count);
+        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04 }, hasher.Blocks[0]);
+    }
+
+    /// <summary>
+    /// Verifies that when the combined residual plus incoming input is smaller than one block, no block is
+    /// emitted and the bytes are retained in the residual buffer.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenInputSmallerThanRemainingCapacity_ShouldAccumulateInResidualOnly()
+    {
+        RecordingBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0x01 });
+        hasher.Append(new byte[] { 0x02 });
+
+        Assert.AreEqual(0, hasher.Blocks.Count);
+    }
+
+    /// <summary>
+    /// Verifies that an input consisting of multiple full blocks (with no residual) is emitted as one
+    /// <c>ProcessBlock</c> invocation per block, in order.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenInputSpansMultipleFullBlocks_ShouldEmitEachBlockInOrder()
+    {
+        RecordingBlockHasher hasher = new();
+        byte[] input = new byte[]
+        {
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0x09, 0x0A, 0x0B, 0x0C,
+        };
+        hasher.Append(input);
+
+        Assert.AreEqual(3, hasher.Blocks.Count);
+        CollectionAssert.AreEqual(new byte[] { 0x01, 0x02, 0x03, 0x04 }, hasher.Blocks[0]);
+        CollectionAssert.AreEqual(new byte[] { 0x05, 0x06, 0x07, 0x08 }, hasher.Blocks[1]);
+        CollectionAssert.AreEqual(new byte[] { 0x09, 0x0A, 0x0B, 0x0C }, hasher.Blocks[2]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset" /> clears the residual
+    /// buffer accumulated by <c>ProcessBlocks</c> so that the next append cycle starts from an empty residual.
+    /// </summary>
+    [TestMethod]
+    public void Reset_AfterAppend_ShouldClearResidualBuffer()
+    {
+        RecordingBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0x01, 0x02, 0x03 });  // residual = 3 bytes
+        hasher.Reset();
+
+        // After Reset, a subsequent 4-byte append should produce exactly one aligned block consisting of the new
+        // bytes only (no carry-over from the discarded residual).
+        hasher.Append(new byte[] { 0xAA, 0xBB, 0xCC, 0xDD });
+
+        Assert.AreEqual(1, hasher.Blocks.Count);
+        CollectionAssert.AreEqual(new byte[] { 0xAA, 0xBB, 0xCC, 0xDD }, hasher.Blocks[0]);
+    }
+
+    /// <summary>
+    /// Verifies that when <c>ShouldPadFinalBlock</c> is <see langword="true" /> and
+    /// <c>AllowUnalignedFinalBlock</c> is <see langword="false" />, <c>GetCurrentHashCore</c> slices the padded
+    /// output into <see cref="BlockNonCryptographicHashAlgorithm{T}.BlockSizeBytes" />-sized chunks and invokes
+    /// <c>ProcessBlock</c> once per chunk.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentHash_WhenShouldPadAndAlignedFinalBlock_ShouldSlicePaddedOutputIntoBlocks()
+    {
+        PaddingBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0x11, 0x22 });  // residual = 2 bytes — no blocks emitted yet
+        Assert.AreEqual(0, hasher.Blocks.Count);
+
+        _ = hasher.GetCurrentHash();
+
+        // PadBlock returns two blocks of four bytes each; the padded payload must be sliced into exactly two
+        // ProcessBlock calls on the cloned instance. Blocks is shared with the clone so the outer instance
+        // witnesses the invocations.
+        Assert.AreEqual(2, hasher.Blocks.Count);
+        CollectionAssert.AreEqual(new byte[] { 0x11, 0x22, 0x00, 0x00 }, hasher.Blocks[0]);
+        Assert.AreEqual(4, hasher.Blocks[1].Length);
+    }
+
+    /// <summary>
+    /// Verifies that when <c>AllowUnalignedFinalBlock</c> is <see langword="true" />, <c>GetCurrentHashCore</c>
+    /// forwards the full padded buffer (whose length is not necessarily a multiple of
+    /// <see cref="BlockNonCryptographicHashAlgorithm{T}.BlockSizeBytes" />) to <c>ProcessBlock</c> in a single
+    /// call — the cloned instance must not throw despite the unaligned length.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentHash_WhenShouldPadAndUnalignedFinalBlockIsAllowed_ShouldForwardPaddedBufferWholesale()
+    {
+        UnalignedPaddingBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0x11, 0x22 });
+
+        // The padded buffer returned by PadBlock is 7 bytes, which is not a multiple of the 4-byte block size.
+        // With AllowUnalignedFinalBlock = true this must still succeed without throwing.
+        byte[] digest = hasher.GetCurrentHash();
+
+        Assert.IsNotNull(digest);
+        Assert.AreEqual(4, digest.Length);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcLookupTableBuilderTests.BuildLookupTable.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcLookupTableBuilderTests.BuildLookupTable.cs
@@ -98,6 +98,78 @@
             });
         }
 
+        /// <summary>
+        /// Verifies that invalid <paramref name="size" /> values surface via <see cref="ArgumentOutOfRangeException" />
+        /// whose <c>ParamName</c> matches the original parameter name, confirming the <see cref="ThrowHelper" />
+        /// contract rather than merely relying on the exception type.
+        /// </summary>
+        [TestMethod]
+        [DataRow(-1)]
+        [DataRow(0)]
+        [DataRow(65)]
+        public void BuildLookupTable_WhenSizeIsInvalid_ShouldReportSizeParamName(int size)
+        {
+            var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => CrcLookupTableBuilder.BuildLookupTable(size, 0x1UL, false));
+            Assert.AreEqual("size", ex.ParamName);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="CrcLookupTableBuilder.BuildLookupTable" /> produces the canonical first row
+        /// of the 8-bit <c>CRC-8/SMBUS</c> lookup table for polynomial <c>0x07</c> in non-reflected mode. The
+        /// verified entries are drawn from the published SMBus / CRC-8 reference table, ensuring the builder's
+        /// output is numerically correct rather than merely well-formed.
+        /// </summary>
+        [TestMethod]
+        public void BuildLookupTable_WhenStandardIsCRC8_SMBUS_ShouldMatchPublishedEntries()
+        {
+            ulong[] table = CrcLookupTableBuilder.BuildLookupTable(8, 0x07UL, reflectIn: false);
+
+            Assert.AreEqual(256, table.Length);
+            Assert.AreEqual(0x00UL, table[0x00]);
+            Assert.AreEqual(0x07UL, table[0x01]);
+            Assert.AreEqual(0x0EUL, table[0x02]);
+            Assert.AreEqual(0x09UL, table[0x03]);
+        }
+
+        /// <summary>
+        /// Verifies that the non-reflected and reflected variants of the same CRC-8 polynomial produce lookup
+        /// tables whose entry at index <c>1</c> is the bit-reversal of one another, confirming that the
+        /// <c>reflectIn</c> flag is the sole contributor to the difference.
+        /// </summary>
+        [TestMethod]
+        public void BuildLookupTable_WhenReflected_ShouldBeBitReversedAgainstNonReflected()
+        {
+            ulong[] nonReflected = CrcLookupTableBuilder.BuildLookupTable(8, 0x07UL, reflectIn: false);
+            ulong[] reflected = CrcLookupTableBuilder.BuildLookupTable(8, 0x07UL, reflectIn: true);
+
+            // Non-reflected table[1] is 0x07; reflected table[0x80] computes the CRC for the "reflected"
+            // single-bit input 0x01, which should match the bit-reverse of 0x07 = 0b00000111 → 0b11100000 = 0xE0.
+            Assert.AreEqual(0x07UL, nonReflected[0x01]);
+            Assert.AreEqual(0xE0UL, reflected[0x80]);
+        }
+
+        /// <summary>
+        /// Verifies that the reflected sub-8-bit branch of <see cref="CrcLookupTableBuilder.BuildLookupTable" />
+        /// (<c>size &lt; 8</c>, <c>reflectIn = true</c>) produces a 2-entry table and masks its entries to the
+        /// declared width.
+        /// </summary>
+        [TestMethod]
+        [DataRow(1)]
+        [DataRow(2)]
+        [DataRow(4)]
+        [DataRow(7)]
+        public void BuildLookupTable_WhenSizeIsLessThanEight_AndReflected_ShouldProduceTwoEntryMaskedTable(int size)
+        {
+            ulong[] table = CrcLookupTableBuilder.BuildLookupTable(size, 0x1UL, reflectIn: true);
+
+            Assert.AreEqual(2, table.Length);
+
+            ulong mask = ulong.MaxValue >> (64 - size);
+            foreach (ulong entry in table)
+                Assert.IsTrue((entry & ~mask) == 0, $"Entry {entry:X} exceeds size {size} bits.");
+        }
+
         [TestMethod]
         public void BuildLookupTable_WhenSizeIsOne_ShouldRespectBitMasking()
         {

--- a/Bodu.IO/test/IO.Hashing/CrcLookupTableCacheTests.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcLookupTableCacheTests.cs
@@ -236,6 +236,38 @@
         }
 
         /// <summary>
+        /// Verifies that invalid <paramref name="size" /> values surface an <see cref="ArgumentOutOfRangeException" />
+        /// whose <c>ParamName</c> is <c>size</c>, confirming the <see cref="ThrowHelper" /> contract propagates
+        /// through the cache lookup path.
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(-1)]
+        [DataRow(0)]
+        [DataRow(65)]
+        [DataRow(int.MaxValue)]
+        public void GetLookupTable_WhenSizeIsInvalid_ShouldReportSizeParamName(int size)
+        {
+            var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+                () => cache.GetLookupTable(size, 0x04C11DB7UL, reflectIn: false));
+            Assert.AreEqual("size", ex.ParamName);
+        }
+
+        /// <summary>
+        /// Verifies that <see cref="CrcLookupTableCache.GetLookupTable" /> succeeds at the inclusive boundary
+        /// values <see cref="CrcStandard.MinSize" /> (1-bit) and <see cref="CrcStandard.MaxSize" /> (64-bit).
+        /// </summary>
+        [DataTestMethod]
+        [DataRow(1, 2)]
+        [DataRow(64, 256)]
+        public void GetLookupTable_WhenSizeIsBoundaryValue_ShouldReturnExpectedTable(int size, int expectedLength)
+        {
+            ulong[] table = cache.GetLookupTable(size, 0x1UL, reflectIn: false);
+
+            Assert.IsNotNull(table);
+            Assert.AreEqual(expectedLength, table.Length);
+        }
+
+        /// <summary>
         /// Verifies that the cache returns a <see cref="ulong" /> array whose contents match the shared precomputed table.
         /// </summary>
         [TestMethod]

--- a/Bodu.IO/test/IO.Hashing/CrcStandardTests.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcStandardTests.cs
@@ -1,0 +1,227 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcStandardTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Contains unit tests for <see cref="CrcStandard" /> covering construction guards, equality semantics, and the
+/// <see cref="ISerializable" /> round-trip contract.
+/// </summary>
+[TestClass]
+public class CrcStandardTests
+{
+    private static CrcStandard CreateReference(
+        string name = "Test",
+        int size = 32,
+        ulong polynomial = 0x04C11DB7UL,
+        ulong initialValue = 0xFFFFFFFFUL,
+        bool reflectIn = true,
+        bool reflectOut = true,
+        ulong xOrOut = 0xFFFFFFFFUL)
+        => new(name, size, polynomial, initialValue, reflectIn, reflectOut, xOrOut);
+
+    /// <summary>
+    /// Verifies that passing <see langword="null" /> as the CRC name to the constructor throws
+    /// <see cref="ArgumentNullException" /> with <c>ParamName</c> equal to <c>name</c>.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenNameIsNull_ShouldThrowArgumentNullException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(
+            () => new CrcStandard(null!, 32, 0x04C11DB7UL, 0xFFFFFFFFUL, true, true, 0xFFFFFFFFUL));
+        Assert.AreEqual("name", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that passing an empty string as the CRC name to the constructor throws
+    /// <see cref="ArgumentException" /> with <c>ParamName</c> equal to <c>name</c>.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenNameIsEmpty_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(
+            () => new CrcStandard(string.Empty, 32, 0x04C11DB7UL, 0xFFFFFFFFUL, true, true, 0xFFFFFFFFUL));
+        Assert.AreEqual("name", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with a <paramref name="size" /> below
+    /// <see cref="CrcStandard.MinSize" /> throws <see cref="ArgumentOutOfRangeException" /> with <c>ParamName</c>
+    /// equal to <c>size</c>.
+    /// </summary>
+    /// <param name="size">The invalid width under test.</param>
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void Ctor_WhenSizeIsBelowMin_ShouldThrowArgumentOutOfRangeException(int size)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new CrcStandard("Test", size, 0x1UL, 0x0UL, false, false, 0x0UL));
+        Assert.AreEqual("size", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with a <paramref name="size" /> above
+    /// <see cref="CrcStandard.MaxSize" /> throws <see cref="ArgumentOutOfRangeException" /> with <c>ParamName</c>
+    /// equal to <c>size</c>.
+    /// </summary>
+    /// <param name="size">The invalid width under test.</param>
+    [DataTestMethod]
+    [DataRow(65)]
+    [DataRow(128)]
+    [DataRow(int.MaxValue)]
+    public void Ctor_WhenSizeIsAboveMax_ShouldThrowArgumentOutOfRangeException(int size)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new CrcStandard("Test", size, 0x1UL, 0x0UL, false, false, 0x0UL));
+        Assert.AreEqual("size", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that a successfully constructed <see cref="CrcStandard" /> returns the supplied parameter values
+    /// through every init-only property.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenParametersAreValid_ShouldRoundTripAllInitOnlyValues()
+    {
+        CrcStandard standard = new(
+            name: "Round-Trip",
+            size: 24,
+            polynomial: 0x864CFBUL,
+            initialValue: 0xB704CEUL,
+            reflectIn: false,
+            reflectOut: true,
+            xOrOut: 0xDEADBEEFUL);
+
+        Assert.AreEqual("Round-Trip", standard.Name);
+        Assert.AreEqual(24, standard.Size);
+        Assert.AreEqual(0x864CFBUL, standard.Polynomial);
+        Assert.AreEqual(0xB704CEUL, standard.InitialValue);
+        Assert.IsFalse(standard.ReflectIn);
+        Assert.IsTrue(standard.ReflectOut);
+        Assert.AreEqual(0xDEADBEEFUL, standard.XOrOut);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CrcStandard.Equals(CrcStandard?)" /> returns <see langword="false" /> when the
+    /// comparand is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenTypedOtherIsNull_ShouldReturnFalse()
+    {
+        CrcStandard a = CreateReference();
+        Assert.IsFalse(a.Equals((CrcStandard?)null));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CrcStandard.Equals(object?)" /> returns <see langword="false" /> when the
+    /// comparand is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenObjectOtherIsNull_ShouldReturnFalse()
+    {
+        CrcStandard a = CreateReference();
+        Assert.IsFalse(a.Equals((object?)null));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CrcStandard.Equals(object?)" /> returns <see langword="false" /> when the
+    /// comparand is not a <see cref="CrcStandard" />.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenObjIsDifferentType_ShouldReturnFalse()
+    {
+        CrcStandard a = CreateReference();
+        Assert.IsFalse(a.Equals("not a CrcStandard"));
+    }
+
+    /// <summary>
+    /// Verifies that two <see cref="CrcStandard" /> instances with identical parameters compare equal and
+    /// produce the same hash code.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenAllFieldsMatch_ShouldReturnTrueAndEqualHashCode()
+    {
+        CrcStandard a = CreateReference();
+        CrcStandard b = CreateReference();
+
+        Assert.IsTrue(a.Equals(b));
+        Assert.IsTrue(a.Equals((object)b));
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that changing any single field between two <see cref="CrcStandard" /> instances causes
+    /// <see cref="CrcStandard.Equals(CrcStandard?)" /> to return <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenAnySingleFieldDiffers_ShouldReturnFalse()
+    {
+        CrcStandard baseStandard = CreateReference();
+
+        Assert.IsFalse(baseStandard.Equals(CreateReference(name: "Other")));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(size: 16)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(polynomial: 0x1021UL)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(initialValue: 0UL)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(reflectIn: false)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(reflectOut: false)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(xOrOut: 0UL)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ISerializable.GetObjectData" /> populates the
+    /// <see cref="SerializationInfo" /> with the expected field set, and that a round-trip through the
+    /// private deserialisation constructor reproduces an equal instance.
+    /// </summary>
+    [TestMethod]
+    public void GetObjectData_WhenRoundTripped_ShouldProduceEqualInstance()
+    {
+        CrcStandard original = CreateReference(name: "Round-Trip", size: 24);
+
+        SerializationInfo info = new(typeof(CrcStandard), new FormatterConverter());
+        ((ISerializable)original).GetObjectData(info, new StreamingContext(StreamingContextStates.All));
+
+        Assert.AreEqual(original.Name, info.GetString(nameof(CrcStandard.Name)));
+        Assert.AreEqual(original.Size, info.GetInt32(nameof(CrcStandard.Size)));
+        Assert.AreEqual(original.Polynomial, info.GetUInt64(nameof(CrcStandard.Polynomial)));
+        Assert.AreEqual(original.InitialValue, info.GetUInt64(nameof(CrcStandard.InitialValue)));
+        Assert.AreEqual(original.ReflectIn, info.GetBoolean(nameof(CrcStandard.ReflectIn)));
+        Assert.AreEqual(original.ReflectOut, info.GetBoolean(nameof(CrcStandard.ReflectOut)));
+        Assert.AreEqual(original.XOrOut, info.GetUInt64(nameof(CrcStandard.XOrOut)));
+
+        // Replay the serialised payload through the private deserialisation constructor to prove the type can
+        // reconstruct itself from its own GetObjectData output.
+        System.Reflection.ConstructorInfo? deserCtor = typeof(CrcStandard).GetConstructor(
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance,
+            binder: null,
+            types: new[] { typeof(SerializationInfo), typeof(StreamingContext) },
+            modifiers: null);
+        Assert.IsNotNull(deserCtor, "Private deserialisation constructor must exist.");
+
+        CrcStandard restored = (CrcStandard)deserCtor!.Invoke(new object[] { info, new StreamingContext(StreamingContextStates.All) });
+        Assert.IsTrue(original.Equals(restored));
+        Assert.AreEqual(original.GetHashCode(), restored.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ISerializable.GetObjectData" /> throws <see cref="ArgumentNullException" /> with
+    /// <c>ParamName</c> equal to <c>info</c> when invoked with a <see langword="null" />
+    /// <see cref="SerializationInfo" />.
+    /// </summary>
+    [TestMethod]
+    public void GetObjectData_WhenInfoIsNull_ShouldThrowArgumentNullException()
+    {
+        CrcStandard standard = CreateReference();
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(
+            () => ((ISerializable)standard).GetObjectData(null!, new StreamingContext(StreamingContextStates.All)));
+        Assert.AreEqual("info", ex.ParamName);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcTests.ComputeHash.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.ComputeHash.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcTests.ComputeHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Bodu.IO.Hashing;
+
+public partial class CrcTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHash(System.ReadOnlySpan{byte})" /> on the reference input
+    /// <c>"123456789"</c> under CRC-32/ISO-HDLC produces the documented check value <c>0xCBF43926</c>, packed
+    /// little-endian.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsReferenceString_ForCRC32_ISOHDLC_ShouldMatchPublishedCheck()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] hash = crc.ComputeHash(RevEngCheckInput);
+
+        CollectionAssert.AreEqual(new byte[] { 0x26, 0x39, 0xF4, 0xCB }, hash);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Crc.ComputeHash(System.ReadOnlySpan{byte})" /> twice on different inputs
+    /// returns the digest of the second input — that is, the method resets internal state before hashing so that
+    /// residual accumulator state from the prior call cannot bleed into the new computation.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledTwice_ShouldResetBeforeHashing()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+
+        _ = crc.ComputeHash(Encoding.ASCII.GetBytes("first input, different length"));
+        byte[] second = crc.ComputeHash(RevEngCheckInput);
+
+        byte[] reference = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(reference, second);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHash(System.ReadOnlySpan{byte})" /> produces the same digest as the
+    /// streaming <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})" />
+    /// + <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()" /> pair across every
+    /// representative CRC variant.
+    /// </summary>
+    /// <param name="variant">The CRC variant under test.</param>
+    [TestMethod]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    public void ComputeHash_WhenComparedToStreamingHash_ShouldAgree(CrcTestVariant variant)
+    {
+        Crc oneShot = CreateAlgorithm(variant);
+        Crc streaming = CreateAlgorithm(variant);
+        streaming.Append(RevEngCheckInput);
+
+        byte[] oneShotHash = oneShot.ComputeHash(RevEngCheckInput);
+        byte[] streamingHash = streaming.GetCurrentHash();
+
+        CollectionAssert.AreEqual(streamingHash, oneShotHash);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHash(System.ReadOnlySpan{byte})" /> on an empty input produces the
+    /// empty-input digest declared by the specification for each representative CRC variant.
+    /// </summary>
+    /// <param name="variant">The CRC variant under test.</param>
+    [TestMethod]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    public void ComputeHash_WhenInputIsEmpty_ShouldMatchSpecificationEmptyDigest(CrcTestVariant variant)
+    {
+        NonCryptographicHashAlgorithmSpecification specification = GetSpecification(variant);
+        byte[] expected = System.Convert.FromHexString(specification.KnownAnswers.Empty!);
+
+        Crc crc = CreateAlgorithm(variant);
+        byte[] actual = crc.ComputeHash(System.Array.Empty<byte>());
+
+        CollectionAssert.AreEqual(expected, actual);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcTests.ComputeHashFrom.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.ComputeHashFrom.cs
@@ -1,0 +1,235 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcTests.ComputeHashFrom.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+public partial class CrcTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})" />
+    /// continues a prior hash by undoing finalisation and hashing additional data, yielding the same digest as
+    /// a single-shot hash over the combined input.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenResumedWithAdditionalInput_ShouldMatchSingleShotCombinedHash()
+    {
+        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+        byte[] rest = new byte[] { 0x35, 0x36, 0x37, 0x38, 0x39 };
+
+        byte[] firstHash = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(first);
+
+        Crc resumer = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] resumed = resumer.ComputeHashFrom(firstHash, rest);
+
+        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(combined, resumed);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> resumes from a prior digest
+    /// across a sliced window of <paramref name="newData" /> and matches the single-shot hash over the combined
+    /// <c>first + newData[offset..offset+length]</c> payload.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenOffsetLengthSlicesNewData_ShouldMatchFullCombinedHash()
+    {
+        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+        byte[] newData = new byte[] { 0xDE, 0xAD, 0x35, 0x36, 0x37, 0x38, 0x39, 0xBE, 0xEF };
+        int offset = 2;
+        int length = 5;
+
+        byte[] firstHash = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(first);
+
+        Crc resumer = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] resumed = resumer.ComputeHashFrom(firstHash, newData, offset, length);
+
+        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(combined, resumed);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[])" /> throws
+    /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>previousHash</c> when the
+    /// prior-digest argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenPreviousHashByteArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] newData = new byte[] { 0x01 };
+
+        var ex = Assert.ThrowsExactly<System.ArgumentNullException>(
+            () => crc.ComputeHashFrom(null!, newData));
+        Assert.AreEqual("previousHash", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[])" /> throws
+    /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>newData</c> when the
+    /// additional-data argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenNewDataByteArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] previousHash = new byte[crc.HashLengthInBytes];
+
+        var ex = Assert.ThrowsExactly<System.ArgumentNullException>(
+            () => crc.ComputeHashFrom(previousHash, null!));
+        Assert.AreEqual("newData", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> throws
+    /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>previousHash</c> when the
+    /// prior-digest argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenPreviousHashIsNull_ForOffsetOverload_ShouldThrowArgumentNullException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] newData = new byte[] { 0x01, 0x02, 0x03 };
+
+        var ex = Assert.ThrowsExactly<System.ArgumentNullException>(
+            () => crc.ComputeHashFrom(null!, newData, 0, newData.Length));
+        Assert.AreEqual("previousHash", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> throws
+    /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>newData</c> when the
+    /// additional-data argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenNewDataIsNull_ForOffsetOverload_ShouldThrowArgumentNullException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] previousHash = new byte[crc.HashLengthInBytes];
+
+        var ex = Assert.ThrowsExactly<System.ArgumentNullException>(
+            () => crc.ComputeHashFrom(previousHash, null!, 0, 0));
+        Assert.AreEqual("newData", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.TryComputeHashFrom" /> throws
+    /// <see cref="System.ArgumentException" /> with <c>ParamName</c> equal to <c>previousHash</c> when the
+    /// supplied prior digest is shorter than <see cref="Crc.HashLengthInBytes" />.
+    /// </summary>
+    [TestMethod]
+    public void TryComputeHashFrom_WhenPreviousHashLengthIsTooShort_ShouldThrowArgumentException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] previousHash = new byte[crc.HashLengthInBytes - 1];
+        byte[] newData = new byte[] { 0x01 };
+        byte[] destination = new byte[crc.HashLengthInBytes];
+
+        var ex = Assert.ThrowsExactly<System.ArgumentException>(
+            () => crc.TryComputeHashFrom(previousHash, newData, destination, out _));
+        Assert.AreEqual("previousHash", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.TryComputeHashFrom" /> throws
+    /// <see cref="System.ArgumentException" /> with <c>ParamName</c> equal to <c>previousHash</c> when the
+    /// supplied prior digest is longer than <see cref="Crc.HashLengthInBytes" />.
+    /// </summary>
+    [TestMethod]
+    public void TryComputeHashFrom_WhenPreviousHashLengthIsTooLong_ShouldThrowArgumentException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] previousHash = new byte[crc.HashLengthInBytes + 1];
+        byte[] newData = new byte[] { 0x01 };
+        byte[] destination = new byte[crc.HashLengthInBytes];
+
+        var ex = Assert.ThrowsExactly<System.ArgumentException>(
+            () => crc.TryComputeHashFrom(previousHash, newData, destination, out _));
+        Assert.AreEqual("previousHash", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.TryComputeHashFrom" /> returns <see langword="false" /> and writes zero bytes
+    /// when <paramref name="destination" /> is smaller than <see cref="Crc.HashLengthInBytes" />.
+    /// </summary>
+    [TestMethod]
+    public void TryComputeHashFrom_WhenDestinationIsTooSmall_ShouldReturnFalseAndWriteZeroBytes()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] previousHash = new byte[crc.HashLengthInBytes];
+        byte[] newData = new byte[] { 0x01, 0x02, 0x03 };
+        byte[] destination = new byte[crc.HashLengthInBytes - 1];
+
+        bool success = crc.TryComputeHashFrom(previousHash, newData, destination, out int written);
+
+        Assert.IsFalse(success);
+        Assert.AreEqual(0, written);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.TryComputeHashFrom" /> returns <see langword="true" /> and writes
+    /// <see cref="Crc.HashLengthInBytes" /> bytes into <paramref name="destination" /> when the destination has
+    /// exactly enough room.
+    /// </summary>
+    [TestMethod]
+    public void TryComputeHashFrom_WhenDestinationIsExactSize_ShouldReturnTrueAndWriteExpectedHash()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+        byte[] rest = new byte[] { 0x35, 0x36, 0x37, 0x38, 0x39 };
+        byte[] firstHash = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(first);
+        byte[] destination = new byte[crc.HashLengthInBytes];
+
+        bool success = crc.TryComputeHashFrom(firstHash, rest, destination, out int written);
+
+        Assert.IsTrue(success);
+        Assert.AreEqual(crc.HashLengthInBytes, written);
+
+        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(combined, destination);
+    }
+
+    /// <summary>
+    /// Verifies that resume semantics hold for a non-reflecting CRC (<c>CRC-16/XMODEM</c>), exercising the
+    /// <c>ReflectIn == ReflectOut == false</c> branch inside <see cref="Crc.TryComputeHashFrom" /> where bit
+    /// reversal is skipped.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenStandardIsNonReflecting_ShouldMatchSingleShotCombinedHash()
+    {
+        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+        byte[] rest = new byte[] { 0x35, 0x36, 0x37, 0x38, 0x39 };
+
+        byte[] firstHash = new Crc(CrcStandard.CRC16_XMODEM).ComputeHash(first);
+
+        Crc resumer = new(CrcStandard.CRC16_XMODEM);
+        byte[] resumed = resumer.ComputeHashFrom(firstHash, rest);
+
+        byte[] combined = new Crc(CrcStandard.CRC16_XMODEM).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(combined, resumed);
+    }
+
+    /// <summary>
+    /// Verifies that resume semantics hold for a CRC whose input reflection differs from its output reflection
+    /// (<c>CRC-12/UMTS</c>, <c>ReflectIn=false, ReflectOut=true</c>), exercising the <c>ReflectIn ^ ReflectOut</c>
+    /// branch in <see cref="Crc.TryComputeHashFrom" /> that applies bit reversal when undoing finalisation.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenReflectInDiffersFromReflectOut_ShouldMatchSingleShotCombinedHash()
+    {
+        CrcStandard asymmetric = CrcStandard.Get(CrcStandards.CRC12_UMTS);
+
+        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };
+        byte[] rest = new byte[] { 0x35, 0x36, 0x37, 0x38, 0x39 };
+
+        byte[] firstHash = new Crc(asymmetric).ComputeHash(first);
+
+        Crc resumer = new(asymmetric);
+        byte[] resumed = resumer.ComputeHashFrom(firstHash, rest);
+
+        byte[] combined = new Crc(asymmetric).ComputeHash(RevEngCheckInput);
+        CollectionAssert.AreEqual(combined, resumed);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcTests.Equals.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.Equals.cs
@@ -33,4 +33,28 @@ public partial class CrcTests
 
         Assert.IsFalse(a.Equals(b));
     }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.Equals(object?)" /> returns <see langword="false" /> when the comparand is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenObjIsNull_ShouldReturnFalse()
+    {
+        Crc a = new(CrcStandard.CRC32_ISOHDLC);
+
+        Assert.IsFalse(a.Equals(null));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.Equals(object?)" /> returns <see langword="false" /> when the comparand is
+    /// an object of an unrelated type.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenObjIsDifferentType_ShouldReturnFalse()
+    {
+        Crc a = new(CrcStandard.CRC32_ISOHDLC);
+
+        Assert.IsFalse(a.Equals("not a Crc"));
+    }
 }

--- a/Bodu.IO/test/IO.Hashing/CrcTests.GlobalCache.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.GlobalCache.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcTests.GlobalCache.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+public partial class CrcTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Crc.GlobalCache" /> is lazily initialised on first access and returns a usable,
+    /// non-null instance even when no explicit cache has been assigned.
+    /// </summary>
+    [TestMethod]
+    public void GlobalCache_WhenNotAssigned_ShouldReturnLazilyCreatedCache()
+    {
+        CrcLookupTableCache cache = Crc.GlobalCache;
+        Assert.IsNotNull(cache);
+
+        ulong[] table = cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+        Assert.IsNotNull(table);
+        Assert.AreEqual(256, table.Length);
+    }
+
+    /// <summary>
+    /// Verifies that assigning a non-null <see cref="CrcLookupTableCache" /> to <see cref="Crc.GlobalCache" />
+    /// replaces the active cache, and that restoring a fresh cache afterwards leaves no residual shared state.
+    /// </summary>
+    [TestMethod]
+    public void GlobalCache_WhenAssigned_ShouldReturnAssignedInstance()
+    {
+        CrcLookupTableCache original = Crc.GlobalCache;
+        try
+        {
+            CrcLookupTableCache replacement = new();
+            Crc.GlobalCache = replacement;
+
+            Assert.AreSame(replacement, Crc.GlobalCache);
+        }
+        finally
+        {
+            Crc.GlobalCache = original;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see langword="null" /> to <see cref="Crc.GlobalCache" /> throws
+    /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>value</c>, preserving the
+    /// previously configured cache.
+    /// </summary>
+    [TestMethod]
+    public void GlobalCache_WhenAssignedNull_ShouldThrowArgumentNullException()
+    {
+        var ex = Assert.ThrowsExactly<System.ArgumentNullException>(() => Crc.GlobalCache = null!);
+        Assert.AreEqual("value", ex.ParamName);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcTests.Properties.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.Properties.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcTests.Properties.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+public partial class CrcTests
+{
+    /// <summary>
+    /// Verifies that each publicly exposed property on <see cref="Crc" /> mirrors the configured
+    /// <see cref="CrcStandard" /> for every representative variant — the full parameter surface
+    /// (<see cref="Crc.CrcStandard" />, <see cref="Crc.Name" />, <see cref="Crc.Size" />,
+    /// <see cref="Crc.Polynomial" />, <see cref="Crc.InitialValue" />, <see cref="Crc.ReflectIn" />,
+    /// <see cref="Crc.ReflectOut" />, <see cref="Crc.XOrOut" />).
+    /// </summary>
+    /// <param name="variant">The CRC variant under test.</param>
+    /// <param name="expectedStandardPropertyName">
+    /// The name of the static property on <see cref="CrcStandard" /> that returns the expected standard instance;
+    /// used to retrieve the canonical <see cref="CrcStandard" /> for comparison.
+    /// </param>
+    [DataTestMethod]
+    [DataRow(CrcTestVariant.Crc8_SMBUS)]
+    [DataRow(CrcTestVariant.Crc16_ARC)]
+    [DataRow(CrcTestVariant.Crc32_IsoHdlc)]
+    [DataRow(CrcTestVariant.Crc64_Ecma182)]
+    public void Properties_WhenConstructedWithStandard_ShouldMirrorStandardValues(CrcTestVariant variant)
+    {
+        CrcStandard standard = variant switch
+        {
+            CrcTestVariant.Crc8_SMBUS => CrcStandard.CRC8_SMBUS,
+            CrcTestVariant.Crc16_ARC => CrcStandard.CRC16_ARC,
+            CrcTestVariant.Crc32_IsoHdlc => CrcStandard.CRC32_ISOHDLC,
+            CrcTestVariant.Crc64_Ecma182 => CrcStandard.CRC64_ECMA182,
+            _ => throw new System.ArgumentOutOfRangeException(nameof(variant), variant, null),
+        };
+
+        Crc crc = new(standard);
+
+        Assert.AreSame(standard, crc.CrcStandard);
+        Assert.AreEqual(standard.Name, crc.Name);
+        Assert.AreEqual(standard.Size, crc.Size);
+        Assert.AreEqual(standard.Polynomial, crc.Polynomial);
+        Assert.AreEqual(standard.InitialValue, crc.InitialValue);
+        Assert.AreEqual(standard.ReflectIn, crc.ReflectIn);
+        Assert.AreEqual(standard.ReflectOut, crc.ReflectOut);
+        Assert.AreEqual(standard.XOrOut, crc.XOrOut);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/CrcTests.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.cs
@@ -159,38 +159,4 @@ public partial class CrcTests
     }
 
 
-    ///// <summary>
-    ///// Verifies that <see cref="Crc.ComputeHash(ReadOnlySpan{byte})" /> on the reference input <c>"123456789"</c>
-    ///// under CRC-32/ISO-HDLC produces the documented check value <c>0xCBF43926</c>.
-    ///// </summary>
-    //[TestMethod]
-    //public void ComputeHash_WhenInputIs123456789_UnderCRC32_ISOHDLC_ShouldMatchPublishedCheck()
-    //{
-    //    Crc crc = new(CrcStandard.CRC32_ISOHDLC);
-    //    byte[] hash = crc.ComputeHash(CheckInput);
-
-    //    // CRC-32/ISO-HDLC stores little-endian; 0xCBF43926 → bytes [26, 39, F4, CB].
-    //    CollectionAssert.AreEqual(new byte[] { 0x26, 0x39, 0xF4, 0xCB }, hash);
-    //}
-
-    /// <summary>
-    /// Verifies that <see cref="Crc.ComputeHashFrom(ReadOnlySpan{byte}, ReadOnlySpan{byte})" /> continues a prior
-    /// hash by undoing finalisation and hashing additional data, yielding the same digest as a single-shot hash
-    /// over the combined input.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHashFrom_WhenResumedWithAdditionalInput_ShouldMatchSingleShotCombinedHash()
-    {
-        byte[] first = new byte[] { 0x31, 0x32, 0x33, 0x34 };  // "1234"
-        byte[] rest = new byte[] { 0x35, 0x36, 0x37, 0x38, 0x39 };  // "56789"
-
-        byte[] firstHash = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(first);
-
-        Crc resumer = new(CrcStandard.CRC32_ISOHDLC);
-        byte[] resumed = resumer.ComputeHashFrom(firstHash, rest);
-
-        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
-        CollectionAssert.AreEqual(combined, resumed);
-    }
-
 }

--- a/Bodu.IO/test/IO.Hashing/FletcherCtorGuardTests.cs
+++ b/Bodu.IO/test/IO.Hashing/FletcherCtorGuardTests.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FletcherCtorGuardTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Contains unit tests that exercise the hash-size validation in the protected <see cref="Fletcher{TSelf}" />
+/// constructor. The validation guard is not reachable through the concrete <see cref="Fletcher16" /> /
+/// <see cref="Fletcher32" /> / <see cref="Fletcher64" /> entry points (which each pass fixed, valid widths), so a
+/// test-only subclass is required to drive invalid inputs through the base constructor.
+/// </summary>
+[TestClass]
+public class FletcherCtorGuardTests
+{
+    /// <summary>
+    /// Test-only <see cref="Fletcher{TSelf}" /> subclass used solely to reach the protected constructor with
+    /// arbitrary hash sizes. The parameterless public constructor satisfies the CRTP <c>new()</c> constraint and
+    /// is never invoked directly by tests.
+    /// </summary>
+    private sealed class TestFletcher : Fletcher<TestFletcher>
+    {
+        public TestFletcher()
+            : base(16)
+        {
+        }
+
+        public TestFletcher(int hashSize)
+            : base(hashSize)
+        {
+        }
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="Fletcher{TSelf}" /> subclass with an unsupported hash size throws
+    /// <see cref="ArgumentException" /> whose <c>ParamName</c> is <c>hashSize</c> and whose message begins with
+    /// the literal <c>"Invalid hash size:"</c> prefix declared in the base constructor.
+    /// </summary>
+    /// <param name="hashSize">The invalid hash size under test.</param>
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(8)]
+    [DataRow(24)]
+    [DataRow(48)]
+    [DataRow(128)]
+    [DataRow(-1)]
+    public void Ctor_WhenHashSizeIsNotSupported_ShouldThrowArgumentException(int hashSize)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() => new TestFletcher(hashSize));
+        Assert.AreEqual("hashSize", ex.ParamName);
+        StringAssert.StartsWith(ex.Message, "Invalid hash size:");
+    }
+
+    /// <summary>
+    /// Verifies that each supported Fletcher hash size (16, 32, 64) is accepted by the base constructor without
+    /// exception and yields an instance with the matching <see cref="Fletcher{TSelf}.AlgorithmName" /> and
+    /// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.HashLengthInBytes" />.
+    /// </summary>
+    /// <param name="hashSize">The valid hash size under test.</param>
+    /// <param name="expectedBytes">The expected <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.HashLengthInBytes" />.</param>
+    [DataTestMethod]
+    [DataRow(16, 2)]
+    [DataRow(32, 4)]
+    [DataRow(64, 8)]
+    public void Ctor_WhenHashSizeIsSupported_ShouldProduceExpectedAlgorithmNameAndLength(int hashSize, int expectedBytes)
+    {
+        TestFletcher fletcher = new(hashSize);
+
+        Assert.AreEqual(expectedBytes, fletcher.HashLengthInBytes);
+        Assert.AreEqual($"Fletcher-{hashSize}", fletcher.AlgorithmName);
+    }
+}

--- a/Bodu.IO/test/IO.Hashing/FletcherTests.BlockBoundary.cs
+++ b/Bodu.IO/test/IO.Hashing/FletcherTests.BlockBoundary.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FletcherTests.BlockBoundary.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+public abstract partial class FletcherTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that appending inputs around the Fletcher block boundary (a spread of lengths covering residual-only,
+    /// exact-block, block-plus-one, and multi-block scenarios) produces identical digests whether the input is
+    /// submitted in a single call, in three roughly equal chunks, or one byte at a time — exercising the residual
+    /// buffer state machine inside <see cref="BlockNonCryptographicHashAlgorithm{T}.Append" />.
+    /// </summary>
+    /// <param name="length">The input length under test, in bytes.</param>
+    [DataTestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    [DataRow(4)]
+    [DataRow(5)]
+    [DataRow(7)]
+    [DataRow(8)]
+    [DataRow(9)]
+    [DataRow(15)]
+    [DataRow(16)]
+    [DataRow(17)]
+    [DataRow(63)]
+    [DataRow(64)]
+    [DataRow(65)]
+    public void Append_WhenInputStraddlesBlockBoundary_ShouldMatchAcrossSubmissionStyles(int length)
+    {
+        byte[] input = new byte[length];
+        for (int i = 0; i < length; i++)
+            input[i] = (byte)i;
+
+        TAlgorithm whole = CreateAlgorithm();
+        whole.Append(input);
+
+        TAlgorithm chunked = CreateAlgorithm();
+        int third = length / 3;
+        chunked.Append(input.AsSpan(0, third));
+        chunked.Append(input.AsSpan(third, third));
+        chunked.Append(input.AsSpan(third * 2, length - (third * 2)));
+
+        TAlgorithm perByte = CreateAlgorithm();
+        foreach (byte b in input)
+            perByte.Append(new[] { b });
+
+        byte[] wholeHash = whole.GetCurrentHash();
+        CollectionAssert.AreEqual(wholeHash, chunked.GetCurrentHash(),
+            $"Chunked append produced a different digest than single-shot for length {length}.");
+        CollectionAssert.AreEqual(wholeHash, perByte.GetCurrentHash(),
+            $"Byte-at-a-time append produced a different digest than single-shot for length {length}.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()" /> is
+    /// non-destructive: calling it mid-stream, appending additional data, and calling it again must yield the
+    /// same digest as the same sequence computed on a fresh instance without any intermediate observation.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentHash_WhenCalledMidStream_ShouldNotDisturbSubsequentHashing()
+    {
+        byte[] input = new byte[32];
+        for (int i = 0; i < input.Length; i++)
+            input[i] = (byte)(i ^ 0xAA);
+
+        TAlgorithm observed = CreateAlgorithm();
+        observed.Append(input.AsSpan(0, 16));
+        _ = observed.GetCurrentHash();
+        observed.Append(input.AsSpan(16));
+
+        TAlgorithm reference = CreateAlgorithm();
+        reference.Append(input);
+
+        CollectionAssert.AreEqual(reference.GetCurrentHash(), observed.GetCurrentHash());
+    }
+}


### PR DESCRIPTION
## Summary

Expands the `Bodu.IO` non-cryptographic hash test suite to drive 100% line coverage for `Crc`, `CrcStandard`, `CrcLookupTableBuilder`, `CrcLookupTableCache`, `Fletcher`, and `BlockNonCryptographicHashAlgorithm`, and to assert exception **type**, **ParamName**, and (where stable) the **message** for every argument-guarded entry point.

The existing RevEng catalogue test already exercises `Crc.ComputeHash` across 120+ standards; this PR fills in the gaps the catalogue can't reach:

- **Crc** — `ComputeHash` variant/empty-input paths, full `ComputeHashFrom` overload matrix with ParamName assertions on null guards, `TryComputeHashFrom` destination-too-small + wrong-length-`previousHash` branches, `ReflectIn != ReflectOut` resume path via CRC-12/UMTS, `GlobalCache` getter/setter/null guard, property-mirroring, `Equals(null)` / `Equals(other-type)`.
- **CrcStandard** — ctor guards (null/empty name, size out-of-range) with ParamName, per-field inequality matrix, `GetHashCode` contract, `ISerializable` round-trip through the private deserialisation constructor.
- **CrcLookupTableBuilder / CrcLookupTableCache** — ParamName assertion on the `size` guard, CRC-8/SMBUS published-entry verification, sub-8-bit reflected path, inclusive boundary sizes (1, 64).
- **Fletcher** — block-boundary cross-submission tests at `{0, 1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 63, 64, 65}` bytes, each cross-checked across single-shot / chunked / byte-at-a-time submission; non-destructive mid-stream `GetCurrentHash`; protected `Fletcher(int hashSize)` guard driven through a test-only subclass with `ParamName == "hashSize"` and the literal `"Invalid hash size:"` message prefix.
- **BlockNonCryptographicHashAlgorithm&lt;T&gt;** — direct coverage for the `blockSize <= 0` and `CopyResidualStateFrom(null)` guards, residual-plus-input state transitions (exact-fill, under-fill, multi-block), `Reset` clearing residual, and both `ShouldPadFinalBlock` + `AllowUnalignedFinalBlock` finalisation branches — paths previously unreachable through production `Fletcher` derivatives.

Intentional omission: `Sequential0To255` KATs for Fletcher-16/32/64 are not populated here — computing reference digests safely requires running the algorithm against a trusted implementation, and the block-boundary cross-submission tests already exercise the long-input path via structural cross-checks.

## Test plan

- [ ] `dotnet build Bodu.sln` passes (StyleCop / Roslynator / NetAnalyzers clean)
- [ ] `dotnet test Bodu.IO/test/Bodu.IO.Test.csproj --settings test.runsettings` passes
- [ ] Coverage collection:
  ```bash
  dotnet test Bodu.IO/test/Bodu.IO.Test.csproj --settings test.runsettings \
    --collect:"XPlat Code Coverage" --results-directory ./coverage-after
  reportgenerator -reports:coverage-after/**/coverage.cobertura.xml \
    -targetdir:./coverage-after/report -assemblyfilters:+Bodu.IO
  ```
- [ ] Verify `coverage-after/report/index.html` shows 100% line coverage for `Crc.cs`, `CrcStandard.cs`, `CrcLookupTableBuilder.cs`, `CrcLookupTableCache.cs`, `Fletcher.cs`, `Fletcher.{16,32,64}.cs`, and `BlockNonCryptographicHashAlgorithm.cs` (document any waiver for the private `CrcStandard(SerializationInfo, StreamingContext)` ctor if infeasible)
- [ ] Regression net: the 120+ RevEng catalogue tests in `CrcTests.Catalog.cs` remain green