### PR TITLE
test: fix three failing tests across Core and Security.Cryptography

### DIFF
--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
@@ -371,7 +371,7 @@ public partial class ConcurrentCircularBufferTests
                     }
 
                     var count = buffer.Count;
-                    if (count < 0 || count > 1)
+                    if (count < 0 || count > MinCapacity)
                         Interlocked.Increment(ref countViolations);
                 }
             }));
@@ -388,7 +388,7 @@ public partial class ConcurrentCircularBufferTests
             $"Faults={faults}, CountViolations={countViolations}");
 
         Assert.IsTrue(completed, $"Tasks did not complete within {deadlockTimeoutMs} ms — possible deadlock or livelock.");
-        Assert.AreEqual(0, faults, "No exceptions expected from TryEnqueue or TryDequeue under capacity-1 churn.");
+        Assert.AreEqual(0, faults, "No exceptions expected from TryEnqueue or TryDequeue under capacity-churn.");
         Assert.AreEqual(0, countViolations, $"Count must remain within [0, {MinCapacity}] at all times.");
         Assert.AreEqual(MinCapacity, buffer.Capacity, $"Capacity must remain {MinCapacity} throughout.");
     }

--- a/Bodu.Core/test/Extensions/NumericExtensionsTests.ReverseBits.cs
+++ b/Bodu.Core/test/Extensions/NumericExtensionsTests.ReverseBits.cs
@@ -456,7 +456,7 @@ public partial class NumericExtensionsTests
     [DataRow((ushort)0x1234, 8, (ushort)0x002C)] // low byte 0x34 → 0x2C
     [DataRow((ushort)0xFF34, 8, (ushort)0x002C)] // high byte ignored
     [DataRow((ushort)0x00AB, 12, (ushort)0x0D50)] // low 12 bits
-    [DataRow((ushort)0xFFAB, 12, (ushort)0x0D50)] // high nibble ignored
+    [DataRow((ushort)0xF0AB, 12, (ushort)0x0D50)] // high nibble ignored
     public void ReverseBits_WhenBitLengthIsPartial_ForUShort_ShouldReturnLowBitsReversed(ushort value, int bitLength, ushort expected) =>
         Assert.AreEqual(expected, value.ReverseBits(bitLength));
 
@@ -593,7 +593,7 @@ public partial class NumericExtensionsTests
     [TestMethod]
     [DataRow(0xFFFFFFFFFFFFFF12ul, 8, 0x48ul)]          // low byte 0x12 → 0x48, high bits ignored
     [DataRow(0x0000000000000012ul, 8, 0x48ul)]          // same low byte, zero high bits
-    [DataRow(0xABCDEF0123456789ul, 32, 0x91E6A2C8ul)]  // low 32 bits 0x23456789 → 0x91E6A2C8
+    [DataRow(0xABCDEF0123456789ul, 32, 0x91E6A2C4ul)]   // low 32 bits 0x23456789 → 0x91E6A2C4
     [DataRow(0x00000000FFFFFFFFul, 40, 0xFFFFFFFF00ul)] // low 40 bits: 32 set bits shift to the top of the window
     public void ReverseBits_WhenBitLengthIsPartial_ForULong_ShouldReturnLowBitsReversed(ulong value, int bitLength, ulong expected) =>
         Assert.AreEqual(expected, value.ReverseBits(bitLength));

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -181,7 +181,7 @@ namespace Bodu.Security.Cryptography.Extensions
             var aead = new GcmModeTransform(cipher2, iv);
             Assert.ThrowsExactly<CryptographicException>(() =>
             {
-                aead.Decrypt(cipherWithTag, AssociatedData);
+                aead.Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
             });
         }
 
@@ -205,7 +205,7 @@ namespace Bodu.Security.Cryptography.Extensions
             var aead = new GcmModeTransform(cipher2, iv);
             Assert.ThrowsExactly<CryptographicException>(() =>
             {
-                aead.Decrypt(cipherWithTag, otherAad);
+                aead.Decrypt(cipherWithTag, otherAad.AsSpan().AsReadOnly());
             });
         }
 


### PR DESCRIPTION
## Summary

Single-commit branch (`5b3a5e6`) fixing three flaky tests:

- `ConcurrentCircularBufferTests._Stress.cs` — MinCapacity alignment
- `NumericExtensionsTests.ReverseBits.cs` — ReverseBits partial-bit test data
- `AeadBlockCipherModeTransformExtensionsTests.cs` — AEAD Decrypt disambiguation

## State vs master

This PR appears to be **fully superseded by master's #38** (`4feb06c test: fix failing tests in Core and Security.Cryptography`). Running `git diff origin/master origin/claude/fix-failing-tests-XWJEb` on all three touched files shows **0 lines of difference** — the branch's final content is content-identical to master.

The PR will likely show an empty diff and can be closed without merging. Opening it per request so the status is visible in the PR list.

## Test plan

- [ ] Confirm PR diff is empty (branch content already in master)
- [ ] Close as superseded if confirmed