### PR TITLE
test(io.hashing): swap stringly-typed KATs for typed NonCryptographicHashKnownAnswers

### DIFF
--- a/Bodu.IO/test/IO.Hashing/CrcTests.cs
+++ b/Bodu.IO/test/IO.Hashing/CrcTests.cs
@@ -5,7 +5,6 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections.Generic;
 using System.Text;
 
 namespace Bodu.IO.Hashing;
@@ -38,7 +37,7 @@ public enum CrcTestVariant
 public partial class CrcTests
     : NonCryptographicHashAlgorithmTests<CrcTests, Crc, CrcTestVariant>
 {
-    private static readonly byte[] CheckInput = Encoding.ASCII.GetBytes("123456789");
+    private static readonly byte[] RevEngCheckInput = Encoding.ASCII.GetBytes("123456789");
 
     /// <inheritdoc />
     protected override CrcTestVariant DefaultVariant => CrcTestVariant.Crc32_IsoHdlc;
@@ -47,63 +46,93 @@ public partial class CrcTests
     protected override Crc CreateAlgorithm(CrcTestVariant variant) => new(StandardFor(variant));
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Each variant seeds <see cref="NonCryptographicHashKnownAnswers.Empty" /> with the algorithm's empty-input
+    /// digest and contributes the RevEng catalogue <c>"123456789"</c> check vector via
+    /// <see cref="NonCryptographicHashKnownAnswers.Additional" />. Broader shared-input coverage for CRC is
+    /// deferred to <c>CrcTests.Catalog.cs</c>, which exercises every catalogued CRC standard in one pass.
+    /// </remarks>
     protected override NonCryptographicHashAlgorithmSpecification GetSpecification(CrcTestVariant variant) => variant switch
     {
         CrcTestVariant.Crc8_SMBUS => new()
         {
             HashLengthInBytes = 1,
             IsResumable = true,
+            KnownAnswers = new()
+            {
+                Empty = "00",
+                Additional =
+                [
+                    new()
+                    {
+                        Name = "RevEng/123456789",
+                        Input = RevEngCheckInput,
+                        ExpectedHex = "F4",
+                    },
+                ],
+            },
         },
         CrcTestVariant.Crc16_ARC => new()
         {
             HashLengthInBytes = 2,
             IsResumable = true,
+            KnownAnswers = new()
+            {
+                Empty = "0000",
+                Additional =
+                [
+                    new()
+                    {
+                        Name = "RevEng/123456789",
+                        Input = RevEngCheckInput,
+                        ExpectedHex = "3DBB",
+                    },
+                ],
+            },
         },
         CrcTestVariant.Crc32_IsoHdlc => new()
         {
             HashLengthInBytes = 4,
             IsResumable = true,
+            KnownAnswers = new()
+            {
+                Empty = "00000000",
+                Additional =
+                [
+                    new()
+                    {
+                        Name = "RevEng/123456789",
+                        Input = RevEngCheckInput,
+                        ExpectedHex = "2639F4CB",
+                    },
+                ],
+            },
         },
         CrcTestVariant.Crc64_Ecma182 => new()
         {
             HashLengthInBytes = 8,
             IsResumable = true,
+            KnownAnswers = new()
+            {
+                Empty = "0000000000000000",
+                Additional =
+                [
+                    new()
+                    {
+                        Name = "RevEng/123456789",
+                        Input = RevEngCheckInput,
+                        ExpectedHex = "4773490B5FDF406C",
+                    },
+                ],
+            },
         },
         _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, null),
     };
 
     /// <inheritdoc />
     /// <remarks>
-    /// Only the <c>Empty</c> named input and the canonical RevEng check value (computed against
-    /// <c>"123456789"</c>, not a <see cref="SharedInputs" /> entry) are seeded here. The full catalogue check is
-    /// carried out in <c>CrcTests.Catalog.cs</c>, so variant-agnostic known answers for other shared inputs are
-    /// deliberately omitted to keep the parameterised test matrix tractable.
-    /// </remarks>
-    protected override IReadOnlyDictionary<string, string> GetExpectedHashesForNamedInputs(CrcTestVariant variant) => variant switch
-    {
-        CrcTestVariant.Crc8_SMBUS => new Dictionary<string, string>
-        {
-            ["Empty"] = "00",
-        },
-        CrcTestVariant.Crc16_ARC => new Dictionary<string, string>
-        {
-            ["Empty"] = "0000",
-        },
-        CrcTestVariant.Crc32_IsoHdlc => new Dictionary<string, string>
-        {
-            ["Empty"] = "00000000",
-        },
-        CrcTestVariant.Crc64_Ecma182 => new Dictionary<string, string>
-        {
-            ["Empty"] = "0000000000000000",
-        },
-        _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, null),
-    };
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// The common incremental test is skipped for CRC; the catalogue partial provides exhaustive coverage of the
-    /// canonical check vectors against all 100+ RevEng standards instead.
+    /// The common incremental test is skipped for CRC; the catalogue partial provides exhaustive coverage of
+    /// the canonical check vectors against all 100+ RevEng standards instead.
     /// </remarks>
     protected override IEnumerable<string> GetIncrementalHashValue(CrcTestVariant variant) => Array.Empty<string>();
 
@@ -150,23 +179,9 @@ public partial class CrcTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Crc.ComputeHash(ReadOnlySpan{byte})" /> on the reference input <c>"123456789"</c>
-    /// under CRC-32/ISO-HDLC produces the documented check value <c>0xCBF43926</c>.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIs123456789_UnderCRC32_ISOHDLC_ShouldMatchPublishedCheck()
-    {
-        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
-        byte[] hash = crc.ComputeHash(CheckInput);
-
-        // CRC-32/ISO-HDLC stores little-endian; 0xCBF43926 → bytes [26, 39, F4, CB].
-        CollectionAssert.AreEqual(new byte[] { 0x26, 0x39, 0xF4, 0xCB }, hash);
-    }
-
-    /// <summary>
-    /// Verifies that <see cref="Crc.ComputeHashFrom(ReadOnlySpan{byte}, ReadOnlySpan{byte})" /> continues a prior
-    /// hash by undoing finalisation and hashing additional data, yielding the same digest as a single-shot hash
-    /// over the combined input.
+    /// Verifies that <see cref="Crc.ComputeHashFrom(ReadOnlySpan{byte}, ReadOnlySpan{byte})" /> continues a
+    /// prior hash by undoing finalisation and hashing additional data, yielding the same digest as a
+    /// single-shot hash over the combined input.
     /// </summary>
     [TestMethod]
     public void ComputeHashFrom_WhenResumedWithAdditionalInput_ShouldMatchSingleShotCombinedHash()
@@ -179,13 +194,13 @@ public partial class CrcTests
         Crc resumer = new(CrcStandard.CRC32_ISOHDLC);
         byte[] resumed = resumer.ComputeHashFrom(firstHash, rest);
 
-        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(CheckInput);
+        byte[] combined = new Crc(CrcStandard.CRC32_ISOHDLC).ComputeHash(RevEngCheckInput);
         CollectionAssert.AreEqual(combined, resumed);
     }
 
     /// <summary>
-    /// Verifies that two <see cref="Crc" /> instances configured with identical <see cref="CrcStandard" /> values
-    /// report equal via <see cref="Crc.Equals(object?)" /> and produce matching hash codes.
+    /// Verifies that two <see cref="Crc" /> instances configured with identical <see cref="CrcStandard" />
+    /// values report equal via <see cref="Crc.Equals(object?)" /> and produce matching hash codes.
     /// </summary>
     [TestMethod]
     public void Equals_WhenStandardsMatch_ShouldReturnTrueAndEqualHashCode()
@@ -198,8 +213,8 @@ public partial class CrcTests
     }
 
     /// <summary>
-    /// Verifies that two <see cref="Crc" /> instances configured with different <see cref="CrcStandard" /> values
-    /// report unequal via <see cref="Crc.Equals(object?)" />.
+    /// Verifies that two <see cref="Crc" /> instances configured with different <see cref="CrcStandard" />
+    /// values report unequal via <see cref="Crc.Equals(object?)" />.
     /// </summary>
     [TestMethod]
     public void Equals_WhenStandardsDiffer_ShouldReturnFalse()

--- a/Bodu.IO/test/IO.Hashing/Fletcher16Tests.cs
+++ b/Bodu.IO/test/IO.Hashing/Fletcher16Tests.cs
@@ -20,16 +20,13 @@ public sealed partial class Fletcher16Tests
             HashLengthInBytes = 2,
             AlgorithmName = "Fletcher-16",
             BlockSizeBytes = 1,
-        };
-
-    /// <inheritdoc />
-    protected override IReadOnlyDictionary<string, string> GetExpectedHashesForNamedInputs(SingleTestVariant variant) =>
-        new Dictionary<string, string>
-        {
-            ["Empty"] = "0000",
-            ["ABC"] = "8BC6",
-            ["QuickBrownFox"] = "FEE8",
-            ["Zeros_16"] = "0000",
+            KnownAnswers = new()
+            {
+                Empty = "0000",
+                Abc = "8BC6",
+                QuickBrownFox = "FEE8",
+                Zeros16 = "0000",
+            },
         };
 
     /// <inheritdoc />

--- a/Bodu.IO/test/IO.Hashing/Fletcher32Tests.cs
+++ b/Bodu.IO/test/IO.Hashing/Fletcher32Tests.cs
@@ -20,16 +20,13 @@ public sealed partial class Fletcher32Tests
             HashLengthInBytes = 4,
             AlgorithmName = "Fletcher-32",
             BlockSizeBytes = 2,
-        };
-
-    /// <inheritdoc />
-    protected override IReadOnlyDictionary<string, string> GetExpectedHashesForNamedInputs(SingleTestVariant variant) =>
-        new Dictionary<string, string>
-        {
-            ["Empty"] = "00000000",
-            ["ABC"] = "84C54284",
-            ["QuickBrownFox"] = "53CD5B8D",
-            ["Zeros_16"] = "00000000",
+            KnownAnswers = new()
+            {
+                Empty = "00000000",
+                Abc = "84C54284",
+                QuickBrownFox = "53CD5B8D",
+                Zeros16 = "00000000",
+            },
         };
 
     /// <inheritdoc />

--- a/Bodu.IO/test/IO.Hashing/Fletcher64Tests.cs
+++ b/Bodu.IO/test/IO.Hashing/Fletcher64Tests.cs
@@ -20,16 +20,13 @@ public sealed partial class Fletcher64Tests
             HashLengthInBytes = 8,
             AlgorithmName = "Fletcher-64",
             BlockSizeBytes = 4,
-        };
-
-    /// <inheritdoc />
-    protected override IReadOnlyDictionary<string, string> GetExpectedHashesForNamedInputs(SingleTestVariant variant) =>
-        new Dictionary<string, string>
-        {
-            ["Empty"] = "0000000000000000",
-            ["ABC"] = "0043424100434241",
-            ["QuickBrownFox"] = "7CA0BCD01F153C78",
-            ["Zeros_16"] = "0000000000000000",
+            KnownAnswers = new()
+            {
+                Empty = "0000000000000000",
+                Abc = "0043424100434241",
+                QuickBrownFox = "7CA0BCD01F153C78",
+                Zeros16 = "0000000000000000",
+            },
         };
 
     /// <inheritdoc />

--- a/Bodu.IO/test/IO.Hashing/FletcherTests.cs
+++ b/Bodu.IO/test/IO.Hashing/FletcherTests.cs
@@ -18,8 +18,8 @@ namespace Bodu.IO.Hashing;
 /// The shared behaviour captured here — empty input producing an all-zero checksum, the <c>Fletcher-</c> name
 /// prefix, and sixteen-zero input stability — holds for every derived Fletcher variant. Size-specific known
 /// answers are supplied by the concrete test classes through
-/// <see cref="NonCryptographicHashAlgorithmTests{TTest, TAlgorithm, TVariant}.GetExpectedHashesForNamedInputs(TVariant)" />
-/// and <see cref="NonCryptographicHashAlgorithmTests{TTest, TAlgorithm, TVariant}.GetIncrementalHashValue(TVariant)" />.
+/// <see cref="NonCryptographicHashAlgorithmSpecification.KnownAnswers" /> and
+/// <see cref="NonCryptographicHashAlgorithmTests{TTest, TAlgorithm, TVariant}.GetIncrementalHashValue(TVariant)" />.
 /// </remarks>
 public abstract partial class FletcherTests<TTest, TAlgorithm>
     : NonCryptographicHashAlgorithmTests<TTest, TAlgorithm, SingleTestVariant>

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmSpecification.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmSpecification.cs
@@ -78,4 +78,14 @@ public record NonCryptographicHashAlgorithmSpecification
     /// Defaults to <see langword="false" />.
     /// </value>
     public bool IsResumable { get; init; } = false;
+
+    /// <summary>
+    /// Gets the known-answer test vectors associated with this variant.
+    /// </summary>
+    /// <value>
+    /// A <see cref="NonCryptographicHashKnownAnswers" /> record carrying the expected digests for the shared
+    /// inputs and any algorithm-specific extension vectors. Defaults to an empty record, in which case the
+    /// harness emits no named-input assertions for this variant.
+    /// </value>
+    public NonCryptographicHashKnownAnswers KnownAnswers { get; init; } = new();
 }

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
@@ -37,7 +37,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
     public void Append_WhenCalledInChunks_ShouldMatchSingleAppend(TVariant variant)
     {
-        byte[] data = SharedInputs["Sequential_0_255"];
+        byte[] data = NonCryptographicHashSharedInputs.Sequential0To255;
 
         NonCryptographicHashAlgorithm whole = CreateAlgorithm(variant);
         whole.Append(data);
@@ -60,7 +60,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
     public void Append_WhenCalledOneByteAtATime_ShouldMatchSingleAppend(TVariant variant)
     {
-        byte[] data = SharedInputs["QuickBrownFox"];
+        byte[] data = NonCryptographicHashSharedInputs.QuickBrownFox;
 
         NonCryptographicHashAlgorithm whole = CreateAlgorithm(variant);
         whole.Append(data);

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.AppendAsync.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.AppendAsync.cs
@@ -21,7 +21,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
     public async Task AppendAsync_WhenHashingStream_ShouldMatchSynchronousAppend(TVariant variant)
     {
-        byte[] data = SharedInputs["Sequential_0_255"];
+        byte[] data = NonCryptographicHashSharedInputs.Sequential0To255;
 
         NonCryptographicHashAlgorithm streaming = CreateAlgorithm(variant);
         using (MemoryStream source = new(data))

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetCurrentHash.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetCurrentHash.cs
@@ -60,7 +60,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetCurrentHash_WhenCalledRepeatedly_ShouldReturnSameDigest(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] first = algorithm.GetCurrentHash();
         byte[] second = algorithm.GetCurrentHash();
@@ -80,7 +80,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetCurrentHash_WhenWritingToSpan_ShouldMatchArrayOverload(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["QuickBrownFox"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.QuickBrownFox);
 
         byte[] expected = algorithm.GetCurrentHash();
 

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashAndReset.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashAndReset.cs
@@ -20,11 +20,11 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetHashAndReset_AfterAppend_ShouldReturnFinalDigest(TVariant variant)
     {
         NonCryptographicHashAlgorithm snapshot = CreateAlgorithm(variant);
-        snapshot.Append(SharedInputs["ABC"]);
+        snapshot.Append(NonCryptographicHashSharedInputs.Abc);
         byte[] expected = snapshot.GetCurrentHash();
 
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] actual = algorithm.GetHashAndReset();
 
@@ -41,7 +41,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetHashAndReset_AfterAppend_ShouldResetInstance(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["QuickBrownFox"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.QuickBrownFox);
         _ = algorithm.GetHashAndReset();
 
         NonCryptographicHashAlgorithm baseline = CreateAlgorithm(variant);
@@ -59,7 +59,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetHashAndReset_WhenWritingToSpan_ShouldReturnHashAndResetInstance(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["Sequential_0_255"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Sequential0To255);
 
         byte[] destination = new byte[algorithm.HashLengthInBytes];
         int written = algorithm.GetHashAndReset(destination);

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashCode.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashCode.cs
@@ -37,7 +37,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void GetHashCode_WhenInvoked_ShouldNotMutateAccumulatorState(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] before = algorithm.GetCurrentHash();
         _ = algorithm.GetHashCode();

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Reset.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Reset.cs
@@ -20,7 +20,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void Reset_AfterAppend_ShouldRestoreInitialState(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["QuickBrownFox"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.QuickBrownFox);
         algorithm.Reset();
 
         NonCryptographicHashAlgorithm baseline = CreateAlgorithm(variant);
@@ -55,12 +55,12 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void Reset_BetweenAppends_ShouldDiscardAccumulatedInput(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["Sequential_0_255"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Sequential0To255);
         algorithm.Reset();
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         NonCryptographicHashAlgorithm direct = CreateAlgorithm(variant);
-        direct.Append(SharedInputs["ABC"]);
+        direct.Append(NonCryptographicHashSharedInputs.Abc);
 
         CollectionAssert.AreEqual(direct.GetCurrentHash(), algorithm.GetCurrentHash());
     }

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetCurrentHash.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetCurrentHash.cs
@@ -21,7 +21,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetCurrentHash_WhenDestinationIsExactSize_ShouldReturnTrueAndWriteHash(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] expected = algorithm.GetCurrentHash();
         byte[] destination = new byte[algorithm.HashLengthInBytes];
@@ -43,7 +43,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetCurrentHash_WhenDestinationIsTooSmall_ShouldReturnFalse(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] destination = new byte[algorithm.HashLengthInBytes - 1];
         if (destination.Length == 0)
@@ -68,7 +68,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetCurrentHash_WhenSuccessful_ShouldNotMutateAccumulatorState(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["QuickBrownFox"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.QuickBrownFox);
 
         byte[] first = new byte[algorithm.HashLengthInBytes];
         Assert.IsTrue(algorithm.TryGetCurrentHash(first, out _));

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetHashAndReset.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetHashAndReset.cs
@@ -20,11 +20,11 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetHashAndReset_WhenDestinationIsExactSize_ShouldReturnTrueAndWriteHash(TVariant variant)
     {
         NonCryptographicHashAlgorithm snapshot = CreateAlgorithm(variant);
-        snapshot.Append(SharedInputs["ABC"]);
+        snapshot.Append(NonCryptographicHashSharedInputs.Abc);
         byte[] expected = snapshot.GetCurrentHash();
 
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
 
         byte[] destination = new byte[algorithm.HashLengthInBytes];
         bool succeeded = algorithm.TryGetHashAndReset(destination, out int written);
@@ -44,7 +44,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetHashAndReset_WhenDestinationIsTooSmall_ShouldReturnFalseAndPreserveState(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["ABC"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Abc);
         byte[] before = algorithm.GetCurrentHash();
 
         byte[] destination = new byte[algorithm.HashLengthInBytes - 1];
@@ -72,7 +72,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     public void TryGetHashAndReset_WhenSuccessful_ShouldResetInstance(TVariant variant)
     {
         NonCryptographicHashAlgorithm algorithm = CreateAlgorithm(variant);
-        algorithm.Append(SharedInputs["Sequential_0_255"]);
+        algorithm.Append(NonCryptographicHashSharedInputs.Sequential0To255);
 
         byte[] destination = new byte[algorithm.HashLengthInBytes];
         Assert.IsTrue(algorithm.TryGetHashAndReset(destination, out _));

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashAlgorithmTests.cs
@@ -5,7 +5,6 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.IO.Hashing;
-using System.Text;
 
 namespace Bodu.IO.Hashing;
 
@@ -31,8 +30,8 @@ public enum SingleTestVariant
 /// <typeparam name="TVariant">The enumeration type used to represent algorithm configuration variants.</typeparam>
 /// <remarks>
 /// This class supplies a standardised infrastructure for testing non-cryptographic hash algorithms across one or
-/// more configurations — shared input vectors, variant differentiation, incremental-append parity, reset
-/// semantics, and named known-answer evaluation.
+/// more configurations — variant differentiation, incremental-append parity, reset semantics, and data-driven
+/// known-answer evaluation via the typed <see cref="NonCryptographicHashKnownAnswers" /> record.
 /// </remarks>
 public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorithm, TVariant>
     where TTest : NonCryptographicHashAlgorithmTests<TTest, TAlgorithm, TVariant>, new()
@@ -40,55 +39,45 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     where TVariant : struct, Enum
 {
     /// <summary>
-    /// Defines shared named input vectors used across all non-cryptographic hash algorithm test cases.
-    /// </summary>
-    /// <remarks>
-    /// Each entry maps a semantic name (for example, <c>Empty</c>, <c>ABC</c>, <c>Zeros_16</c>) to a
-    /// representative input payload. These inputs are paired with expected output values supplied by
-    /// <see cref="GetExpectedHashesForNamedInputs(TVariant)" /> to drive known-answer assertions.
-    /// </remarks>
-    protected static readonly IReadOnlyDictionary<string, byte[]> SharedInputs = new Dictionary<string, byte[]>
-    {
-        ["Empty"] = Array.Empty<byte>(),
-        ["ABC"] = Encoding.ASCII.GetBytes("ABC"),
-        ["QuickBrownFox"] = Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog"),
-        ["Zeros_16"] = new byte[16],
-        ["Sequential_0_255"] = Enumerable.Range(0, 255).Select(i => (byte)i).ToArray(),
-    };
-
-    /// <summary>
     /// Returns the <see cref="NonCryptographicHashAlgorithmSpecification" /> describing the expected properties
-    /// of <typeparamref name="TAlgorithm" /> when constructed for the given <paramref name="variant" />.
+    /// of <typeparamref name="TAlgorithm" /> — including its known-answer test vectors — when constructed for
+    /// the given <paramref name="variant" />.
     /// </summary>
     /// <param name="variant">The variant under test.</param>
-    /// <returns>A specification describing expected output width, block size, and distribution parameters.</returns>
+    /// <returns>A specification describing expected output width, block size, distribution parameters, and KATs.</returns>
     protected abstract NonCryptographicHashAlgorithmSpecification GetSpecification(TVariant variant);
 
     /// <summary>
     /// Gets the default variant to use in non-parameterised test scenarios.
     /// </summary>
     /// <remarks>
-    /// The default variant represents the canonical or most common configuration of the algorithm under test. It
-    /// is used for tests that do not require variant-specific logic.
+    /// The default variant represents the canonical or most common configuration of the algorithm under test.
+    /// It is used for tests that do not require variant-specific logic.
     /// </remarks>
     protected virtual TVariant DefaultVariant => GetNonCryptographicHashAlgorithmVariants().First();
 
     /// <summary>
     /// Gets the expected hash result for an empty input using <see cref="DefaultVariant" />.
     /// </summary>
-    /// <exception cref="KeyNotFoundException">
-    /// Thrown if no expected hash is defined for the <c>Empty</c> named input under the default variant.
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the default variant's <see cref="NonCryptographicHashKnownAnswers.Empty" /> slot is unset.
     /// </exception>
     /// <remarks>
-    /// Expected results are sourced from <see cref="GetExpectedHashesForNamedInputs(TVariant)" />. Override in a
-    /// derived class to supply an alternative computation when no <c>Empty</c> entry is provided.
+    /// Override in a derived class to supply an alternative computation when the algorithm does not declare a
+    /// published empty-input KAT.
     /// </remarks>
-    protected virtual byte[] ExpectedEmptyInputHash =>
-        Convert.FromHexString(
-            GetExpectedHashesForNamedInputs(DefaultVariant).TryGetValue("Empty", out var hex)
-                ? hex
-                : throw new KeyNotFoundException(
-                    $"Expected hash for \"Empty\" input is not defined for variant '{DefaultVariant}'."));
+    protected virtual byte[] ExpectedEmptyInputHash
+    {
+        get
+        {
+            var knownAnswers = GetSpecification(DefaultVariant).KnownAnswers;
+            if (knownAnswers.Empty is { } hex)
+                return Convert.FromHexString(hex);
+
+            throw new InvalidOperationException(
+                $"Expected hash for the empty input is not defined for variant '{DefaultVariant}'.");
+        }
+    }
 
     /// <summary>
     /// Returns test case parameters for each defined algorithm variant.
@@ -130,9 +119,8 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="variant">The variant under test.</param>
     /// <returns>
     /// A sequence of expected hex-encoded hash values. The entry at index <c>i</c> is the hash of the first
-    /// <c>i</c> bytes of the incremental sequence (so index 0 is the empty-input hash). Derived classes may
-    /// supply as many or as few entries as they wish; an empty sequence causes the incremental test to be
-    /// marked inconclusive.
+    /// <c>i</c> bytes of the incremental sequence (so index 0 is the empty-input hash). An empty sequence
+    /// causes the incremental test to be marked inconclusive.
     /// </returns>
     /// <remarks>
     /// The incremental test iterates once per entry, appending one further byte at each step and comparing the
@@ -142,40 +130,40 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     protected abstract IEnumerable<string> GetIncrementalHashValue(TVariant variant);
 
     /// <summary>
-    /// Returns a dictionary of expected hash outputs for well-known named inputs such as <c>Empty</c>,
-    /// <c>ABC</c>, or <c>Zeros_16</c>.
-    /// </summary>
-    /// <param name="variant">The variant to retrieve expected results for.</param>
-    /// <returns>
-    /// A dictionary mapping input names (from <see cref="SharedInputs" />) to their expected hex-encoded hash
-    /// strings. Sparse dictionaries are permitted — inputs with no matching entry are skipped by
-    /// <see cref="GetTestVectors" /> rather than failing.
-    /// </returns>
-    protected abstract IReadOnlyDictionary<string, string> GetExpectedHashesForNamedInputs(TVariant variant);
-
-    /// <summary>
-    /// Combines shared input vectors with expected output values to generate test vectors for a specific variant.
+    /// Yields the known-answer vectors declared by the specification for the given <paramref name="variant" />:
+    /// each populated typed slot on <see cref="NonCryptographicHashKnownAnswers" /> paired with its
+    /// corresponding shared input, followed by every algorithm-specific entry in
+    /// <see cref="NonCryptographicHashKnownAnswers.Additional" />.
     /// </summary>
     /// <param name="variant">The variant to generate test vectors for.</param>
-    /// <returns>
-    /// A sequence of <see cref="KnownAnswerTest" /> instances representing named test inputs and their expected
-    /// hash results. Inputs without a matching expected entry in
-    /// <see cref="GetExpectedHashesForNamedInputs(TVariant)" /> are omitted.
-    /// </returns>
+    /// <returns>A sequence of <see cref="KnownAnswerTest" /> records driving named-input assertions.</returns>
     protected virtual IEnumerable<KnownAnswerTest> GetTestVectors(TVariant variant)
     {
-        var expected = GetExpectedHashesForNamedInputs(variant);
-        foreach (var (name, input) in SharedInputs)
+        var knownAnswers = GetSpecification(variant).KnownAnswers;
+
+        if (knownAnswers.Empty is { } empty)
+            yield return CreateVector(nameof(knownAnswers.Empty), NonCryptographicHashSharedInputs.Empty, empty);
+
+        if (knownAnswers.Abc is { } abc)
+            yield return CreateVector(nameof(knownAnswers.Abc), NonCryptographicHashSharedInputs.Abc, abc);
+
+        if (knownAnswers.QuickBrownFox is { } qbf)
+            yield return CreateVector(nameof(knownAnswers.QuickBrownFox), NonCryptographicHashSharedInputs.QuickBrownFox, qbf);
+
+        if (knownAnswers.Zeros16 is { } zeros)
+            yield return CreateVector(nameof(knownAnswers.Zeros16), NonCryptographicHashSharedInputs.Zeros16, zeros);
+
+        if (knownAnswers.Sequential0To255 is { } sequential)
+            yield return CreateVector(nameof(knownAnswers.Sequential0To255), NonCryptographicHashSharedInputs.Sequential0To255, sequential);
+
+        foreach (var extra in knownAnswers.Additional)
         {
-            if (expected.TryGetValue(name, out var hex))
+            yield return new KnownAnswerTest
             {
-                yield return new KnownAnswerTest
-                {
-                    Name = name,
-                    Input = input,
-                    ExpectedOutput = Convert.FromHexString(hex),
-                };
-            }
+                Name = extra.Name,
+                Input = extra.Input,
+                ExpectedOutput = Convert.FromHexString(extra.ExpectedHex),
+            };
         }
     }
 
@@ -195,4 +183,12 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
             }
         }
     }
+
+    private static KnownAnswerTest CreateVector(string name, byte[] input, string expectedHex) =>
+        new()
+        {
+            Name = name,
+            Input = input,
+            ExpectedOutput = Convert.FromHexString(expectedHex),
+        };
 }

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashKnownAnswer.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashKnownAnswer.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashKnownAnswer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Represents a single algorithm-specific known-answer test vector — an arbitrary named input payload paired
+/// with the expected hex-encoded digest produced by the algorithm under test.
+/// </summary>
+/// <remarks>
+/// Instances populate the
+/// <see cref="NonCryptographicHashKnownAnswers.Additional" /> collection and let concrete test classes contribute
+/// algorithm-specific vectors (for example, the RevEng catalogue <c>"123456789"</c> CRC check value) without
+/// bespoke <c>[DataRow]</c> plumbing. Common shared inputs — empty, <c>"ABC"</c>, the quick-brown-fox sentence,
+/// sixteen zero bytes, and the 0x00..0xFE sequence — are already covered by the typed slots on
+/// <see cref="NonCryptographicHashKnownAnswers" /> and should not be duplicated here.
+/// </remarks>
+public sealed record NonCryptographicHashKnownAnswer
+{
+    /// <summary>Gets the semantic name of this test vector used in diagnostic messages.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the raw input bytes to append to the algorithm.</summary>
+    public required byte[] Input { get; init; }
+
+    /// <summary>Gets the hex-encoded expected digest produced by hashing <see cref="Input" />.</summary>
+    public required string ExpectedHex { get; init; }
+}

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashKnownAnswers.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashKnownAnswers.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashKnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Declares the expected digests produced by an algorithm variant when hashing the common shared inputs, plus
+/// any algorithm-specific extension vectors.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each typed slot (<see cref="Empty" />, <see cref="Abc" />, <see cref="QuickBrownFox" />, <see cref="Zeros16" />,
+/// <see cref="Sequential0To255" />) carries the hex-encoded expected digest for the corresponding named input
+/// declared in <see cref="NonCryptographicHashSharedInputs" />. A <see langword="null" /> slot signals that no
+/// published value is available for the algorithm under test and the harness skips that particular vector.
+/// </para>
+/// <para>
+/// Vectors that fall outside the shared-input set — for example, the RevEng catalogue
+/// <c>"123456789"</c> CRC check — live on the <see cref="Additional" /> list and are driven by the same
+/// data-driven test harness, avoiding bespoke <c>[DataRow]</c> definitions.
+/// </para>
+/// </remarks>
+public sealed record NonCryptographicHashKnownAnswers
+{
+    /// <summary>Gets the expected hex digest for an empty input, or <see langword="null" /> when unspecified.</summary>
+    public string? Empty { get; init; }
+
+    /// <summary>Gets the expected hex digest for the ASCII input <c>"ABC"</c>, or <see langword="null" /> when unspecified.</summary>
+    public string? Abc { get; init; }
+
+    /// <summary>
+    /// Gets the expected hex digest for the ASCII input
+    /// <c>"The quick brown fox jumps over the lazy dog"</c>, or <see langword="null" /> when unspecified.
+    /// </summary>
+    public string? QuickBrownFox { get; init; }
+
+    /// <summary>Gets the expected hex digest for sixteen zero bytes, or <see langword="null" /> when unspecified.</summary>
+    public string? Zeros16 { get; init; }
+
+    /// <summary>
+    /// Gets the expected hex digest for the 255-byte sequence <c>0x00, 0x01, …, 0xFE</c>, or
+    /// <see langword="null" /> when unspecified.
+    /// </summary>
+    public string? Sequential0To255 { get; init; }
+
+    /// <summary>
+    /// Gets algorithm-specific known-answer vectors that fall outside the shared-input set.
+    /// </summary>
+    /// <value>A list of named vectors. Defaults to an empty list.</value>
+    public IReadOnlyList<NonCryptographicHashKnownAnswer> Additional { get; init; } =
+        Array.Empty<NonCryptographicHashKnownAnswer>();
+}

--- a/Bodu.IO/test/IO.Hashing/NonCryptographicHashSharedInputs.cs
+++ b/Bodu.IO/test/IO.Hashing/NonCryptographicHashSharedInputs.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashSharedInputs.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Provides the canonical byte payloads that back the typed slots on
+/// <see cref="NonCryptographicHashKnownAnswers" />.
+/// </summary>
+/// <remarks>
+/// Arrays are allocated once and shared across all test runs. Test code must treat them as immutable even
+/// though <see cref="byte" /> arrays are mutable by the CLR — mutating a shared input would corrupt every other
+/// variant relying on the same payload.
+/// </remarks>
+internal static class NonCryptographicHashSharedInputs
+{
+    /// <summary>The empty input (zero bytes).</summary>
+    public static readonly byte[] Empty = Array.Empty<byte>();
+
+    /// <summary>The three ASCII bytes of the string <c>"ABC"</c>.</summary>
+    public static readonly byte[] Abc = Encoding.ASCII.GetBytes("ABC");
+
+    /// <summary>The 43 ASCII bytes of the pangram <c>"The quick brown fox jumps over the lazy dog"</c>.</summary>
+    public static readonly byte[] QuickBrownFox =
+        Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog");
+
+    /// <summary>Sixteen zero bytes.</summary>
+    public static readonly byte[] Zeros16 = new byte[16];
+
+    /// <summary>The 255-byte sequence <c>0x00, 0x01, …, 0xFE</c>.</summary>
+    public static readonly byte[] Sequential0To255 =
+        Enumerable.Range(0, 255).Select(i => (byte)i).ToArray();
+}


### PR DESCRIPTION
## Summary

Single commit (`199978b test(io.hashing): swap stringly-typed KATs for typed NonCryptographicHashKnownAnswers`) that introduces a typed-record-based KAT representation for the non-cryptographic hash harness in `Bodu.IO.Hashing`.

## State vs master

The same work already landed on master via `ad21997` (identical commit subject). Direct-tree diff vs master is **865 insertions / 2,592 deletions across 39 files** — merging this branch would *delete* ~2,592 lines of master's subsequent harness and test-coverage improvements (the KAT infrastructure evolved substantially after this branch was cut; much of the incremental coverage hardening from PR #41 rides on top of that evolution).

Merging as-is would regress master.

## Test plan

- [ ] Review whether any of the branch's additions are genuinely novel vs master's `ad21997` + subsequent harness work
- [ ] Otherwise close as superseded