### PR TITLE
feat(calendar): add Australian notable date catalogue with state/territory scoping

### DIFF
--- a/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
+++ b/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
@@ -44,6 +44,7 @@
     <None Remove="Globalization.Calendar\NotableDates.xsd" />
     <None Remove="Globalization.Calendar\Resources\Common.xml" />
     <None Remove="Globalization.Calendar\Resources\Christian.xml" />
+    <None Remove="Globalization.Calendar\Resources\AU.xml" />
     <None Remove="Globalization.Calendar\Resources\US.xml" />
     <None Remove="Globalization.Calendar\Resources\GB.xml" />
     <None Remove="Globalization.Calendar\Resources\FR.xml" />
@@ -62,6 +63,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="Globalization.Calendar\Resources\Common.xml" />
     <EmbeddedResource Include="Globalization.Calendar\Resources\Christian.xml" />
+    <EmbeddedResource Include="Globalization.Calendar\Resources\AU.xml" />
     <EmbeddedResource Include="Globalization.Calendar\Resources\US.xml" />
     <EmbeddedResource Include="Globalization.Calendar\Resources\GB.xml" />
     <EmbeddedResource Include="Globalization.Calendar\Resources\FR.xml" />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/AU.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/AU.xml
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Australian public holidays and widely observed cultural dates.
+
+  Cherry-picks each inherited rule explicitly. Locally declared rules
+  override their inherited namesake. New rules added to Common.xml or
+  Christian.xml do not appear here unless added to the <UseFrom> lists
+  below.
+
+  Australia has a strong country-vs-state split: Australia Day, Anzac
+  Day, the Easter family and Christmas/Boxing Day are observed nation
+  wide (territory="AU"); Labour Day, the King's Birthday and several
+  capital-city days vary substantially across the eight states and
+  territories (territory="AU-NSW", "AU-VIC", "AU-QLD", "AU-SA",
+  "AU-WA", "AU-TAS", "AU-NT", "AU-ACT").
+
+  Every emitted NotableDate carries its originating TerritoryCode, so
+  callers may delineate national from subdivision-scoped entries when
+  producing lists, e.g.
+
+    var all      = service.GetNotableDates(2026, "AU");
+    var national = all.Where(n => n.TerritoryCode == "AU");
+    var perState = all.Where(n => n.TerritoryCode is { Length: > 3 } c
+                                  && c.StartsWith("AU-"))
+                      .GroupBy(n => n.TerritoryCode!);
+
+    // Or scope the query to a single subdivision; national rules and
+    // subdivision-only rules are returned together, each retaining its
+    // own TerritoryCode for downstream grouping or labelling:
+    var victoria = service.GetNotableDates(2026, "AU-VIC");
+-->
+<NotableDates xmlns="urn:bodu:globalization:calendar"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <UseFrom resource="Bodu.Globalization.Calendar.Resources.Common.xml">
+    <Use name="Valentine's Day" territory="AU" />
+    <Use name="April Fool's Day" territory="AU" />
+    <Use name="Halloween" territory="AU" />
+    <Use name="Remembrance Day" territory="AU" />
+  </UseFrom>
+
+  <UseFrom resource="Bodu.Globalization.Calendar.Resources.Christian.xml">
+    <Use name="Easter Sunday" territory="AU" />
+    <Use name="Good Friday" territory="AU" nonWorking="true" />
+    <Use name="Easter Saturday" territory="AU" nonWorking="true" />
+    <Use name="Easter Monday" territory="AU" nonWorking="true" />
+    <Use name="Christmas Eve" territory="AU" />
+    <Use name="Christmas Day" territory="AU" nonWorking="true" />
+  </UseFrom>
+
+  <!-- ============================================================ -->
+  <!-- National (territory="AU")                                    -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="New Year's Day">
+    <Rule category="Holiday" territory="AU" nonWorking="true">
+      <Fixed month="January" day="1" />
+      <Tag>NationalHoliday</Tag>
+      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Australia Day">
+    <Rule category="Holiday" territory="AU" nonWorking="true"
+          comment="Public holiday since 1994; substitute Monday observed when 26 January falls on a weekend.">
+      <Fixed month="January" day="26" />
+      <Tag>NationalHoliday</Tag>
+      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Anzac Day">
+    <Rule category="Remembrance" territory="AU" nonWorking="true"
+          comment="Observed on 25 April. Per-state rules govern any substitute day when the date falls on a weekend; the date itself is not shifted.">
+      <Fixed month="April" day="25" />
+      <Tag>NationalHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Boxing Day">
+    <Rule category="Holiday" territory="AU" nonWorking="true">
+      <Fixed month="December" day="26" />
+      <Tag>NationalHoliday</Tag>
+      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- New South Wales (territory="AU-NSW")                         -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="King's Birthday (NSW)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-NSW" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Bank Holiday (NSW)">
+    <Rule name="Bank Holiday" category="Observance" territory="AU-NSW"
+          comment="Observed by banks and the financial sector only; not a general public holiday.">
+      <DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>BankHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Labour Day (NSW)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-NSW" nonWorking="true">
+      <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Victoria (territory="AU-VIC")                                -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Labour Day (VIC)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-VIC" nonWorking="true">
+      <DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (VIC)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-VIC" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="AFL Grand Final Friday">
+    <Rule category="Holiday" territory="AU-VIC" firstYear="2015" nonWorking="true"
+          comment="Proclaimed annually by the Victorian Governor; the date varies with the AFL season. Approximated here as the last Friday of September.">
+      <DayOfWeekInMonth month="September" dayOfWeek="Friday" weekOrdinal="Last" />
+      <Tag>StateHoliday</Tag>
+      <Tag>Approximate</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Melbourne Cup Day">
+    <Rule category="Holiday" territory="AU-VIC" nonWorking="true"
+          comment="Statutorily defined as the Tuesday in the week in which the first Tuesday in November occurs — equivalent to the first Tuesday of November.">
+      <DayOfWeekInMonth month="November" dayOfWeek="Tuesday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Queensland (territory="AU-QLD")                              -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Labour Day (QLD)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-QLD" nonWorking="true">
+      <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (QLD)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-QLD" firstYear="2016" nonWorking="true"
+          comment="Moved to October from 2016 onwards; prior years observed in June.">
+      <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Royal Queensland Show (Brisbane)">
+    <Rule name="Royal Queensland Show" category="Cultural" territory="AU-QLD" nonWorking="true"
+          comment="Brisbane metropolitan area only — not observed state-wide.">
+      <DayOfWeekInMonth month="August" dayOfWeek="Wednesday" weekOrdinal="Second" />
+      <Tag>RegionalHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- South Australia (territory="AU-SA")                          -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Adelaide Cup Day">
+    <Rule category="Holiday" territory="AU-SA" nonWorking="true">
+      <DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (SA)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-SA" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Labour Day (SA)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-SA" nonWorking="true">
+      <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Proclamation Day">
+    <Rule category="Holiday" territory="AU-SA" nonWorking="true"
+          comment="Observed on 26 December in lieu of Boxing Day in South Australia.">
+      <Fixed month="December" day="26" />
+      <Tag>StateHoliday</Tag>
+      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Western Australia (territory="AU-WA")                        -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Labour Day (WA)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-WA" nonWorking="true">
+      <DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Western Australia Day">
+    <Rule category="Holiday" territory="AU-WA" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (WA)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-WA" nonWorking="true"
+          comment="Proclaimed annually by the Governor of Western Australia; typically the last Monday of September or the first Monday of October. Approximated here as the last Monday of September.">
+      <DayOfWeekInMonth month="September" dayOfWeek="Monday" weekOrdinal="Last" />
+      <Tag>StateHoliday</Tag>
+      <Tag>Approximate</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Tasmania (territory="AU-TAS")                                -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Eight Hours Day">
+    <Rule category="Holiday" territory="AU-TAS" nonWorking="true">
+      <DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (TAS)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-TAS" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>StateHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Recreation Day">
+    <Rule category="Holiday" territory="AU-TAS" nonWorking="true"
+          comment="Observed in the northern half of Tasmania only, in lieu of Royal Hobart Show Day in the south.">
+      <DayOfWeekInMonth month="November" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>RegionalHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Northern Territory (territory="AU-NT")                       -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="May Day">
+    <Rule category="Holiday" territory="AU-NT" nonWorking="true">
+      <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (NT)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-NT" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Picnic Day">
+    <Rule category="Holiday" territory="AU-NT" nonWorking="true">
+      <DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <!-- ============================================================ -->
+  <!-- Australian Capital Territory (territory="AU-ACT")            -->
+  <!-- ============================================================ -->
+
+  <NotableDate name="Canberra Day">
+    <Rule category="Holiday" territory="AU-ACT" nonWorking="true">
+      <DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Reconciliation Day">
+    <Rule category="Holiday" territory="AU-ACT" firstYear="2018" nonWorking="true"
+          comment="Introduced in 2018. Statutorily defined as the first Monday on or after 27 May; approximated here as the last Monday of May.">
+      <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="Last" />
+      <Tag>TerritoryHoliday</Tag>
+      <Tag>Approximate</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="King's Birthday (ACT)">
+    <Rule name="King's Birthday" category="Holiday" territory="AU-ACT" nonWorking="true">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+  <NotableDate name="Labour Day (ACT)">
+    <Rule name="Labour Day" category="Holiday" territory="AU-ACT" nonWorking="true">
+      <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>TerritoryHoliday</Tag>
+    </Rule>
+  </NotableDate>
+
+</NotableDates>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustralianNotableDatesTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustralianNotableDatesTests.cs
@@ -1,0 +1,233 @@
+using Bodu.Extensions;
+using System.Linq;
+
+namespace Bodu.Globalization.Calendar
+{
+	/// <summary>
+	/// Verifies the end-to-end behaviour of the embedded <c>AU.xml</c> rule catalogue across the <see cref="NotableDateService" />,
+	/// including national-vs-subdivision scoping, weekend substitute handling, the <c>firstYear</c> bound on Reconciliation Day, and
+	/// caller-side delineation of country and state/territory entries via <see cref="NotableDate.TerritoryCode" />.
+	/// </summary>
+	[TestClass]
+	public sealed class AustralianNotableDatesTests
+	{
+		private const string AuResource = "Bodu.Globalization.Calendar.Resources.AU.xml";
+
+		private static readonly string[] ExpectedTerritories =
+		{
+			"AU",
+			"AU-ACT",
+			"AU-NSW",
+			"AU-NT",
+			"AU-QLD",
+			"AU-SA",
+			"AU-TAS",
+			"AU-VIC",
+			"AU-WA",
+		};
+
+		private static NotableDateService BuildAuService() =>
+			new(
+				new[] { (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(AuResource) },
+				CalendarWeekendDefinition.SaturdaySunday);
+
+		/// <summary>
+		/// Verifies that querying the country scope returns the four national fixed-date holidays at their unadjusted positions for
+		/// year 2026, when none of them collide with a weekend.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAu_ShouldIncludeNationalRules_ForYear2026()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU");
+
+			Assert.IsTrue(results.Any(d => d.Name == "New Year's Day" && d.Date == new DateTime(2026, 1, 1)));
+			Assert.IsTrue(results.Any(d => d.Name == "Australia Day" && d.Date == new DateTime(2026, 1, 26)));
+			Assert.IsTrue(results.Any(d => d.Name == "Anzac Day" && d.Date == new DateTime(2026, 4, 25)));
+			Assert.IsTrue(results.Any(d => d.Name == "Christmas Day" && d.Date == new DateTime(2026, 12, 25)));
+		}
+
+		/// <summary>
+		/// Verifies that when Australia Day falls on a Sunday (26 January 2020), the service emits both the original date and a substitute
+		/// non-working Monday observance, with the adjusted occurrence carrying an <see cref="NotableDate.AdjustmentReason" />.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenAustraliaDayFallsOnSunday_ShouldEmitMondaySubstitute()
+		{
+			var service = BuildAuService();
+
+			var occurrences = service.GetNotableDates(2020, "AU")
+				.Where(d => d.Name == "Australia Day")
+				.OrderBy(d => d.Date)
+				.ToList();
+
+			Assert.AreEqual(2, occurrences.Count);
+			Assert.AreEqual(new DateTime(2020, 1, 26), occurrences[0].Date);
+			Assert.IsFalse(occurrences[0].WasAdjusted);
+			Assert.AreEqual(new DateTime(2020, 1, 27), occurrences[1].Date);
+			Assert.IsTrue(occurrences[1].WasAdjusted);
+			Assert.AreEqual(DayOfWeek.Monday, occurrences[1].Date.DayOfWeek);
+		}
+
+		/// <summary>
+		/// Verifies that querying the Victorian subdivision returns the Victorian Labour Day on the second Monday of March without
+		/// returning the New South Wales Labour Day, demonstrating that subdivision-scoped rules survive the composite-key flatten.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAuVic_ShouldIncludeVictoriaLabourDay_AndExcludeNswLabourDay()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU-VIC");
+
+			var labourDay = results.SingleOrDefault(d => d.Name == "Labour Day");
+			Assert.IsNotNull(labourDay);
+			Assert.AreEqual("AU-VIC", labourDay!.TerritoryCode);
+			Assert.AreEqual(new DateTime(2026, 3, 9), labourDay.Date);
+		}
+
+		/// <summary>
+		/// Verifies the mirror case: querying the New South Wales subdivision returns the NSW Labour Day on the first Monday of October
+		/// and not the Victorian variant.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAuNsw_ShouldIncludeNswLabourDay_AndExcludeVictoriaLabourDay()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU-NSW");
+
+			var labourDay = results.SingleOrDefault(d => d.Name == "Labour Day");
+			Assert.IsNotNull(labourDay);
+			Assert.AreEqual("AU-NSW", labourDay!.TerritoryCode);
+			Assert.AreEqual(new DateTime(2026, 10, 5), labourDay.Date);
+		}
+
+		/// <summary>
+		/// Verifies that every notable date returned for the AU country scope carries a non-null <see cref="NotableDate.TerritoryCode" />,
+		/// and that the set of distinct territory codes spans the country plus all eight state and territory subdivisions. This is the
+		/// contract that lets callers delineate national entries from subdivision-specific ones in the produced list.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAu_ShouldPreserveTerritoryCodeOnEveryEntry_ForDelineation()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU");
+
+			Assert.IsTrue(results.Count > 0);
+			Assert.IsTrue(results.All(d => !string.IsNullOrEmpty(d.TerritoryCode)),
+				"Every Australian notable date must carry its originating TerritoryCode so callers can delineate national from subdivision entries.");
+
+			var distinctTerritories = results
+				.Select(d => d.TerritoryCode!)
+				.Distinct()
+				.OrderBy(t => t, StringComparer.Ordinal)
+				.ToArray();
+
+			CollectionAssert.AreEquivalent(ExpectedTerritories, distinctTerritories);
+		}
+
+		/// <summary>
+		/// Verifies that the Queensland King's Birthday resolves to the first Monday of October for years from 2016 onwards, reflecting
+		/// the statutory change that moved the holiday out of June.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAuQld_ShouldResolveKingsBirthdayToOctober_ForYear2026()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU-QLD");
+
+			var kingsBirthday = results.SingleOrDefault(d => d.Name == "King's Birthday");
+			Assert.IsNotNull(kingsBirthday);
+			Assert.AreEqual(new DateTime(2026, 10, 5), kingsBirthday!.Date);
+		}
+
+		/// <summary>
+		/// Verifies that Reconciliation Day, introduced in the ACT in 2018, is suppressed for any year before 2018 by the rule's
+		/// <c>firstYear</c> bound.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAuAct_ForYear2017_ShouldNotIncludeReconciliationDay()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2017, "AU-ACT");
+
+			Assert.IsFalse(results.Any(d => d.Name == "Reconciliation Day"));
+		}
+
+		/// <summary>
+		/// Verifies that Reconciliation Day appears for the ACT from 2018 onwards and resolves to a Monday in late May.
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenQueryingAuAct_ForYear2018_ShouldIncludeReconciliationDay()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2018, "AU-ACT");
+
+			var reconciliation = results.SingleOrDefault(d => d.Name == "Reconciliation Day");
+			Assert.IsNotNull(reconciliation);
+			Assert.AreEqual(new DateTime(2018, 5, 28), reconciliation!.Date);
+			Assert.AreEqual(DayOfWeek.Monday, reconciliation.Date.DayOfWeek);
+		}
+
+		/// <summary>
+		/// Verifies that Melbourne Cup Day for Victoria resolves to the first Tuesday of November (3 November in 2026), equivalent to the
+		/// statutory definition "the Tuesday in the week in which the first Tuesday in November occurs".
+		/// </summary>
+		[TestMethod]
+		public void GetNotableDates_WhenMelbourneCupDay_ForYear2026_ShouldResolveToFirstTuesdayOfNovember()
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, "AU-VIC");
+
+			var melbourneCup = results.SingleOrDefault(d => d.Name == "Melbourne Cup Day");
+			Assert.IsNotNull(melbourneCup);
+			Assert.AreEqual(new DateTime(2026, 11, 3), melbourneCup!.Date);
+			Assert.AreEqual(DayOfWeek.Tuesday, melbourneCup.Date.DayOfWeek);
+		}
+
+		/// <summary>
+		/// Verifies that querying NSW for 2026 reports the substitute Monday after Boxing Day as a non-working day, since 26 December
+		/// 2026 falls on a Saturday and the national Boxing Day rule rolls weekend occurrences forward.
+		/// </summary>
+		[TestMethod]
+		public void IsNonWorkingDay_WhenBoxingDayOnSaturday_ShouldReturnTrueForSubstituteMonday_ForAuNsw()
+		{
+			var service = BuildAuService();
+
+			// 26 December 2026 is a Saturday; the next non-weekend day is Monday 28 December.
+			Assert.IsTrue(service.IsNonWorkingDay(new DateTime(2026, 12, 28), "AU-NSW"));
+		}
+
+		/// <summary>
+		/// Verifies that querying any Australian subdivision returns the country-level Anzac Day on 25 April, demonstrating that the
+		/// territory containment match expands the parent country's rules into every subdivision.
+		/// </summary>
+		[TestMethod]
+		[DataRow("AU-NSW")]
+		[DataRow("AU-VIC")]
+		[DataRow("AU-QLD")]
+		[DataRow("AU-SA")]
+		[DataRow("AU-WA")]
+		[DataRow("AU-TAS")]
+		[DataRow("AU-NT")]
+		[DataRow("AU-ACT")]
+		public void GetNotableDates_WhenQueryingAnySubdivision_ShouldIncludeNationalAnzacDay_ForYear2026(string subdivision)
+		{
+			var service = BuildAuService();
+
+			var results = service.GetNotableDates(2026, subdivision);
+
+			var anzacDay = results.SingleOrDefault(d => d.Name == "Anzac Day");
+			Assert.IsNotNull(anzacDay, $"Anzac Day should be visible to subdivision {subdivision}.");
+			Assert.AreEqual("AU", anzacDay!.TerritoryCode);
+			Assert.AreEqual(new DateTime(2026, 4, 25), anzacDay.Date);
+		}
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceNotableDateRuleProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceNotableDateRuleProviderTests.cs
@@ -14,6 +14,7 @@ namespace Bodu.Globalization.Calendar
 		private const string UsResource = "Bodu.Globalization.Calendar.Resources.US.xml";
 		private const string GbResource = "Bodu.Globalization.Calendar.Resources.GB.xml";
 		private const string FrResource = "Bodu.Globalization.Calendar.Resources.FR.xml";
+		private const string AuResource = "Bodu.Globalization.Calendar.Resources.AU.xml";
 		private const string DefaultResource = "Bodu.Globalization.Calendar.NotableDates.xml";
 
 		/// <summary>
@@ -142,6 +143,99 @@ namespace Bodu.Globalization.Calendar
 			Assert.IsTrue(rules.Any(r => r.Name == "Halloween"));
 			Assert.IsFalse(rules.Any(r => r.Name == "Independence Day"), "Country-specific rules should not appear in the default composite.");
 			Assert.IsFalse(rules.Any(r => r.Name == "Bastille Day"));
+		}
+
+		/// <summary>
+		/// Verifies that loading the AU resource pulls in the cherry-picked Common and Christian rules together with the locally declared
+		/// national and state-specific rules, and excludes any rule the AU file did not opt in to.
+		/// </summary>
+		[TestMethod]
+		public void LoadRules_WhenLoadingAuResource_ShouldIncludeCherryPickedAndLocalRules()
+		{
+			var provider = new XmlResourceNotableDateRuleProvider(AuResource);
+
+			var rules = provider.LoadRules().ToList();
+
+			// Cherry-picked from Common
+			Assert.IsTrue(rules.Any(r => r.Name == "Valentine's Day" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Halloween" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Remembrance Day" && r.TerritoryCode == "AU"));
+
+			// Cherry-picked from Christian
+			Assert.IsTrue(rules.Any(r => r.Name == "Easter Sunday" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Good Friday" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Easter Saturday" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Easter Monday" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Christmas Day" && r.TerritoryCode == "AU"));
+
+			// Locally declared national
+			Assert.IsTrue(rules.Any(r => r.Name == "New Year's Day" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Australia Day" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Anzac Day" && r.TerritoryCode == "AU"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Boxing Day" && r.TerritoryCode == "AU"));
+
+			// Locally declared subdivision-scoped (one example per state/territory)
+			Assert.IsTrue(rules.Any(r => r.Name == "Bank Holiday" && r.TerritoryCode == "AU-NSW"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Melbourne Cup Day" && r.TerritoryCode == "AU-VIC"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Royal Queensland Show" && r.TerritoryCode == "AU-QLD"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Adelaide Cup Day" && r.TerritoryCode == "AU-SA"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Western Australia Day" && r.TerritoryCode == "AU-WA"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Eight Hours Day" && r.TerritoryCode == "AU-TAS"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Picnic Day" && r.TerritoryCode == "AU-NT"));
+			Assert.IsTrue(rules.Any(r => r.Name == "Canberra Day" && r.TerritoryCode == "AU-ACT"));
+
+			// Not opted in: should be absent
+			Assert.IsFalse(rules.Any(r => r.Name == "International Workers' Day"));
+			Assert.IsFalse(rules.Any(r => r.Name == "Whit Monday"));
+			Assert.IsFalse(rules.Any(r => r.Name == "All Saints' Day"));
+		}
+
+		/// <summary>
+		/// Verifies that the AU resource preserves multiple rules sharing the same canonical name (e.g. "Labour Day" and "King's
+		/// Birthday") when they are scoped to different subdivisions, since the override pipeline keys by composite (name, territory).
+		/// </summary>
+		[TestMethod]
+		public void LoadRules_WhenLoadingAuResource_ShouldYieldDistinctLabourDayAndKingsBirthdayRulesPerSubdivision()
+		{
+			var provider = new XmlResourceNotableDateRuleProvider(AuResource);
+
+			var rules = provider.LoadRules().ToList();
+
+			var labourDayTerritories = rules
+				.Where(r => r.Name == "Labour Day")
+				.Select(r => r.TerritoryCode)
+				.OrderBy(t => t, StringComparer.Ordinal)
+				.ToList();
+
+			CollectionAssert.AreEquivalent(
+				new[] { "AU-ACT", "AU-NSW", "AU-QLD", "AU-SA", "AU-VIC", "AU-WA" },
+				labourDayTerritories);
+
+			var kingsBirthdayTerritories = rules
+				.Where(r => r.Name == "King's Birthday")
+				.Select(r => r.TerritoryCode)
+				.OrderBy(t => t, StringComparer.Ordinal)
+				.ToList();
+
+			CollectionAssert.AreEquivalent(
+				new[] { "AU-ACT", "AU-NSW", "AU-NT", "AU-QLD", "AU-SA", "AU-TAS", "AU-VIC", "AU-WA" },
+				kingsBirthdayTerritories);
+		}
+
+		/// <summary>
+		/// Verifies that Anzac Day in the AU resource is scoped to the country (territory <c>"AU"</c>) and is flagged as a non-working
+		/// day, so that all subdivisions inherit it via the subdivision-aware containment match in <see cref="NotableDateService" />.
+		/// </summary>
+		[TestMethod]
+		public void LoadRules_WhenLoadingAuResource_ShouldTagAnzacDayAsNationalNonWorkingDay()
+		{
+			var provider = new XmlResourceNotableDateRuleProvider(AuResource);
+
+			var anzacDay = provider.LoadRules().Single(r => r.Name == "Anzac Day");
+
+			Assert.AreEqual("AU", anzacDay.TerritoryCode);
+			Assert.AreEqual(true, anzacDay.IsNonWorkingDay);
+			Assert.IsTrue(anzacDay.Tags.Contains("NationalHoliday"));
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Summary

Adds an `AU.xml` embedded rule resource for `Bodu.Globalization.Calendar`, sitting alongside the existing `US.xml` / `GB.xml` / `FR.xml` catalogues. Covers the full Australian public-holiday set with explicit country-vs-state/territory delineation:

- **National (`territory="AU"`)**: New Year's Day, Australia Day, Anzac Day, Christmas Day, Boxing Day, Good Friday, Easter Saturday, Easter Sunday, Easter Monday, Christmas Eve, Valentine's Day, April Fool's Day, Halloween, Remembrance Day.
- **NSW**: King's Birthday, Bank Holiday, Labour Day.
- **VIC**: Labour Day, King's Birthday, AFL Grand Final Friday (approximated), Melbourne Cup Day.
- **QLD**: Labour Day, King's Birthday (Oct from 2016+), Royal Queensland Show.
- **SA**: Adelaide Cup Day, King's Birthday, Labour Day, Proclamation Day.
- **WA**: Labour Day, Western Australia Day, King's Birthday (approximated as last Mon Sep).
- **TAS**: Eight Hours Day, King's Birthday, Recreation Day.
- **NT**: May Day, King's Birthday, Picnic Day.
- **ACT**: Canberra Day, Reconciliation Day (`firstYear=2018`), King's Birthday, Labour Day.

## Delineation

No public API change. Every emitted `NotableDate` carries its originating `TerritoryCode` (`"AU"` for national, `"AU-NSW"` etc. for subdivisions), and the existing composite-key override flatten in `NotableDateService.ApplyOverrides` already preserves multiple `Labour Day` / `King's Birthday` rules across states. Callers delineate via:

```csharp
var all      = service.GetNotableDates(2026, "AU");
var national = all.Where(n => n.TerritoryCode == "AU");
var perState = all.Where(n => n.TerritoryCode is { Length: > 3 } c && c.StartsWith("AU-"))
                  .GroupBy(n => n.TerritoryCode!);
```

A query for any subdivision (`"AU-VIC"` etc.) returns the union of national rules and that subdivision's own rules — both retain their original `TerritoryCode` for downstream grouping or labelling.

## Files

- `Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/AU.xml` (new)
- `Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj` — register `AU.xml` as embedded resource
- `Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceNotableDateRuleProviderTests.cs` — load-shape tests
- `Bodu.Globalization.Calendar/test/Globalization.Calendar/AustralianNotableDatesTests.cs` (new) — behavioural tests

## Test plan

- [ ] `dotnet build Bodu.sln` succeeds without warnings (analysers treat doc warnings as errors).
- [ ] `dotnet test Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj --settings test.runsettings` passes, including:
  - Three new `XmlResourceNotableDateRuleProviderTests` for AU load shape, distinct per-subdivision Labour Day / King's Birthday, and Anzac Day national tagging.
  - All `AustralianNotableDatesTests` cases (national fixed dates, Australia Day weekend substitute for 2020, VIC/NSW Labour Day delineation, per-subdivision Anzac Day visibility, QLD October King's Birthday, ACT Reconciliation Day `firstYear` bound, Melbourne Cup, Boxing Day weekend substitute).
- [ ] Existing `XmlResourceNotableDateRuleProviderTests`, `NotableDateServiceTests`, `NotableDateRuleParserTests`, and `NotableDateAdjusterTests` remain green (no regressions).

> Note: this sandbox has no .NET SDK installed, so build/test must be verified by CI on this PR.

https://claude.ai/code/session_01D6RS2dSvzv2dn8jzMzBFjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6RS2dSvzv2dn8jzMzBFjE)_