### PR TITLE
docs: refresh DocFX site for four-project solution, add Bodu.IO.Hashing guides

### DIFF
--- a/docs/apidoc/Bodu.Globalization.Calendar.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.md
@@ -8,20 +8,35 @@ uid: Bodu.Globalization.Calendar
 
 **Bodu.Globalization.Calendar** resolves culturally and algorithmically significant dates — holidays, observances, and recurring notable dates — across a mixture of definition styles: fixed dates, rule-based recurrences (e.g. *fourth Thursday in November*), offsets from other notable dates, and dynamic calculators (e.g. the Gregorian Computus for Easter).
 
-Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you need Easter Sunday in year *N*, or when a business-day rule shifts a fixed holiday because it fell on a weekend, or when you need a cached, culture-aware calendar of notable dates for a range of years.
+Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you need Easter Sunday in year *N*, when a business-day rule shifts a fixed holiday because it fell on a weekend, or when you need a cached, culture-aware calendar of notable dates for a range of years driven from an XML rule source.
 
 ## Key types
 
-- <xref:Bodu.Globalization.Calendar.NotableDateService> — the main entry point. Manages a catalogue of notable-date definitions and materialises <xref:Bodu.Globalization.Calendar.NotableDate> instances for a year or range, caching results and generating beyond the initial bounds on demand.
-- <xref:Bodu.Globalization.Calendar.NotableDateResolver> — resolves the base date of a definition according to its type (fixed, rule-based, offset-based, or dynamic) and its dependencies on other definitions.
-- <xref:Bodu.Globalization.Calendar.NotableDate> — the materialised result: the calculated occurrence plus metadata (name, <xref:Bodu.Globalization.Calendar.NotableDateKind>, cultural applicability, and original pre-adjustment date if a rollover rule moved it).
-- <xref:Bodu.Globalization.Calendar.NotableDateKind> — categorisation: Holiday, Observance, Remembrance, Cultural, Christian, Other, or None.
-- <xref:Bodu.Globalization.Calendar.INotableDateCalculator> — the contract for year-keyed date computation, implemented by the calculators below and by any custom calculator you add.
+**Entry points and results**
 
-**Calculators** (in <xref:Bodu.Globalization.Calendar.Calculators>)
+- <xref:Bodu.Globalization.Calendar.NotableDateService> — the main entry point (and sole <xref:Bodu.Globalization.Calendar.INotableDateService> implementation). Composes a rule provider, calculator registry, adjustment-handler registry, and collision resolver to materialise <xref:Bodu.Globalization.Calendar.NotableDate> instances for a year or range, with internal caching.
+- <xref:Bodu.Globalization.Calendar.NotableDate> — the materialised result record: the resolved occurrence plus metadata (name, <xref:Bodu.Globalization.Calendar.NotableDateCategory>, cultural applicability via <xref:Bodu.Globalization.Calendar.TerritoryCode>, and the original pre-adjustment date if a rollover rule moved it).
+- <xref:Bodu.Globalization.Calendar.NotableDateCategory> — categorisation: Holiday, Observance, Remembrance, Cultural, Christian, Other, or None.
 
+**Rules and resolution**
+
+- <xref:Bodu.Globalization.Calendar.NotableDateRule> — an immutable rule record describing how a notable date is defined (fixed, rule-based, offset-based, or delegated to a named calculator).
+- <xref:Bodu.Globalization.Calendar.NotableDateRuleResolver> — resolves the base date of a rule according to its type and its dependencies on other rules.
+- <xref:Bodu.Globalization.Calendar.NotableDateRuleParser> — parses rule expressions from the XML source into strongly-typed <xref:Bodu.Globalization.Calendar.NotableDateRule> instances.
+- <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider> — plug-points for the rule source (built-in XML, overlays, custom).
+- <xref:Bodu.Globalization.Calendar.INotableDateProvider>, <xref:Bodu.Globalization.Calendar.INotableDateNameLocalizer> — extension surfaces for custom date sources and culture-specific naming.
+- <xref:Bodu.Globalization.Calendar.INotableDateCollisionResolver>, <xref:Bodu.Globalization.Calendar.DefaultNotableDateCollisionResolver> — decide what happens when two rules resolve to the same date.
+
+**Dynamic calculators**
+
+- <xref:Bodu.Globalization.Calendar.INotableDateCalculator>, <xref:Bodu.Globalization.Calendar.INotableDateCalculatorRegistry>, <xref:Bodu.Globalization.Calendar.NotableDateCalculatorRegistry> — the contract and registry for year-keyed date computation.
 - <xref:Bodu.Globalization.Calendar.Calculators.EasterSundayNotableDateCalculator> — Gregorian Computus from 1583 onwards; falls back to the Julian algorithm for earlier years. Results are cached per year.
 - <xref:Bodu.Globalization.Calendar.Calculators.LunarNewYearNotableDateCalculator> — Lunar New Year from lunar-calendar computation.
+
+**Adjustment pipeline**
+
+- <xref:Bodu.Globalization.Calendar.NotableDateAdjuster>, <xref:Bodu.Globalization.Calendar.IAdjustmentHandler>, <xref:Bodu.Globalization.Calendar.IAdjustmentHandlerRegistry>, <xref:Bodu.Globalization.Calendar.AdjustmentHandlerRegistry> — apply observance rules (e.g. *if a fixed holiday falls on a Saturday, observe it on the preceding Friday*) after the base date is resolved.
+- <xref:Bodu.Globalization.Calendar.AdjustmentTrigger>, <xref:Bodu.Globalization.Calendar.AdjustmentAction>, <xref:Bodu.Globalization.Calendar.AdjustmentReason>, <xref:Bodu.Globalization.Calendar.ObservanceAdjustment> — the adjustment-rule vocabulary.
 
 ## Example
 
@@ -38,6 +53,6 @@ DateTime goodFriday2026 = easter2026.AddDays(-2);
 ## Notes
 
 - **Thread safety.** Calculators cache their results per year internally and are **safe for concurrent reads** after any first-compute. A `NotableDateService` built with a stable set of definitions may be shared across requests.
-- **Culture and adjustment.** A `NotableDate` tracks both its original calculated date and its adjusted date — so a rule like "if a fixed holiday falls on a Saturday, observe it on the preceding Friday" is applied transparently while still preserving the original for audit and display.
-- **Target frameworks.** This library multi-targets `net6.0`, `net7.0`, and `net8.0` — the widest reach of any library in the Bodu solution.
-- **Extensibility.** Implement <xref:Bodu.Globalization.Calendar.INotableDateCalculator> to add your own dynamic calculator (e.g. Orthodox Easter, Rosh Hashanah, Diwali) and register it with <xref:Bodu.Globalization.Calendar.NotableDateService> alongside the built-in fixed, rule-based, and offset-based definitions.
+- **Culture and adjustment.** A <xref:Bodu.Globalization.Calendar.NotableDate> tracks both its original calculated date and its adjusted date — so a rule like "if a fixed holiday falls on a Saturday, observe it on the preceding Friday" is applied transparently while still preserving the original for audit and display.
+- **Target framework.** `net8.0`.
+- **Extensibility.** Implement <xref:Bodu.Globalization.Calendar.INotableDateCalculator> to add your own dynamic calculator (e.g. Orthodox Easter, Rosh Hashanah, Diwali) and register it with <xref:Bodu.Globalization.Calendar.NotableDateService> alongside the built-in fixed, rule-based, and offset-based definitions — or plug a custom <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider> to source rules from somewhere other than the embedded XML.

--- a/docs/apidoc/Bodu.IO.Hashing.md
+++ b/docs/apidoc/Bodu.IO.Hashing.md
@@ -1,0 +1,64 @@
+---
+uid: Bodu.IO.Hashing
+---
+
+![Bodu.IO.Hashing](~/images/hero-io.svg)
+
+## Purpose
+
+**Bodu.IO.Hashing** is a focused library of **non-cryptographic** hashes and checksums built on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract. It covers two families in depth: the full **CRC RevEng catalogue** (widths 1–64 bits) and the **Fletcher** checksum family (16, 32, 64 bits).
+
+Reach for this library when you need a fast, deterministic checksum for error detection, file integrity, framing, fingerprinting, or cache keying — and when you want the result to drop straight into any API that accepts <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>. If you need cryptographic integrity (against an active attacker, not just noise on the wire), see <xref:Bodu.Security.Cryptography> instead.
+
+## Key types
+
+**CRC family**
+
+- <xref:Bodu.IO.Hashing.Crc> — the single CRC engine. Configured with a <xref:Bodu.IO.Hashing.CrcStandard>, it handles widths from 1 to 64 bits, honours polynomial, initial value, input / output reflection, and final XOR, and ships with a shared lookup-table cache.
+- <xref:Bodu.IO.Hashing.CrcStandard> — an immutable parameter set: name, width, polynomial, initial value, reflect-in, reflect-out, XOR-out. Exposes common standards as named properties (`CRC32_ISOHDLC`, `CRC32_ISCSI`, `CRC16_MODBUS`, `CRC64_XZ`, …) and provides `FromName` / `TryFromName` over canonical names and published aliases.
+- <xref:Bodu.IO.Hashing.CrcStandards> — an enum covering every canonical CRC RevEng entry (113 standards as of the last catalogue fetch).
+- <xref:Bodu.IO.Hashing.CrcLookupTableCache> — thread-safe cache of 256-entry lookup tables, keyed by (width, polynomial, reflect-in), shared process-wide through <xref:Bodu.IO.Hashing.Crc.GlobalCache>.
+- <xref:Bodu.IO.Hashing.CrcLookupTableBuilder> — builds a lookup table from parameters; used by the cache on first miss.
+
+**Fletcher family**
+
+- <xref:Bodu.IO.Hashing.Fletcher16> — 16-bit position-dependent checksum; 1-byte block.
+- <xref:Bodu.IO.Hashing.Fletcher32> — 32-bit position-dependent checksum; 2-byte block.
+- <xref:Bodu.IO.Hashing.Fletcher64> — 64-bit position-dependent checksum; 4-byte block.
+
+**Building blocks**
+
+- <xref:Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm`1> — an abstract CRTP base for block-oriented non-cryptographic hashes. Provides residual-buffering, finalisation, and clone semantics that the Fletcher family builds on.
+- <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — a contract for hashes that can reconstruct their state from a previously finalised digest and continue appending new data, implemented by <xref:Bodu.IO.Hashing.Crc>.
+
+## Example
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+// CRC-32/ISO-HDLC — the canonical zlib / PNG / Ethernet CRC.
+using var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+crc.Append(data);
+string crc32 = Convert.ToHexString(crc.GetCurrentHash());
+
+// Fletcher-32 — position-dependent, drops into anything that takes a NonCryptographicHashAlgorithm.
+using var fletcher = new Fletcher32();
+fletcher.Append(data);
+string fl32 = Convert.ToHexString(fletcher.GetCurrentHash());
+
+// Resume a CRC from a previously stored digest and keep hashing.
+byte[] previous = crc32.AsSpan().ToArray();           // already-finalised digest bytes
+byte[] combined = crc.ComputeHashFrom(previous, Encoding.UTF8.GetBytes(" jumps over"));
+```
+
+## Notes
+
+- **Not cryptographically secure.** Every algorithm here is designed for error detection and hash-table distribution, not authentication. An attacker who can choose the input can trivially forge the output. Pair with a MAC or signature if integrity against an adversary matters — see <xref:Bodu.Security.Cryptography.SipHash64> for a keyed short-input hash, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> for a full cryptographic digest.
+- **Shared lookup tables.** <xref:Bodu.IO.Hashing.Crc> instances with identical (width, polynomial, reflect-in) triples share a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Crc.GlobalCache>. Constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
+- **Non-destructive `GetCurrentHash`.** Calling <xref:System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash*> snapshots the accumulator and applies the final reflect / XOR / width-mask on the copy, so in-progress hashing is not disturbed. Call it as many times as you like.
+- **Resumable.** <xref:Bodu.IO.Hashing.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — reverse-finalise a stored digest, append further data, re-finalise. Handy for chunked streams where re-reading earlier bytes is expensive.
+- **Determinism and portability.** All algorithms produce identical byte-for-byte output across platforms and architectures for the same input and configuration.
+- **See also:** the [Using CRC](../guides/io-hashing/crc.md) and [Using Fletcher](../guides/io-hashing/fletcher.md) guides, and the [full CRC catalogue](../guides/io-hashing/crc-catalogue.md).

--- a/docs/apidoc/Bodu.Security.Cryptography.md
+++ b/docs/apidoc/Bodu.Security.Cryptography.md
@@ -6,9 +6,11 @@ uid: Bodu.Security.Cryptography
 
 ## Purpose
 
-**Bodu.Security.Cryptography** is a small, self-contained collection of managed block-cipher and hash / checksum implementations that plug into the standard .NET cryptography contracts (<xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> and <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType>).
+**Bodu.Security.Cryptography** is a small, self-contained collection of managed block-cipher and keyed / cryptographic hash implementations that plug into the standard .NET cryptography contracts (<xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> and <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType>).
 
-Reach for this library when you need a tweakable block cipher that isn't in the BCL (Threefish), a fast non-cryptographic checksum for framing or fingerprinting (Fletcher, Adler, FNV-1a), a collision-resistant keyed hash for hash-table protection (SipHash), a 64-bit-optimised cryptographic hash (Tiger), or a reference Skipjack implementation for research.
+Reach for this library when you need a tweakable block cipher that isn't in the BCL (Threefish), a keyed collision-resistant short-input hash for hash-table protection (SipHash), a 64-bit-optimised cryptographic digest (Tiger), a fast non-cryptographic fingerprint in the classic families (FNV-1a, Adler), authenticated-encryption mode transforms for AES, or a Merkle-tree hash for streaming integrity with per-chunk verifiability.
+
+For CRC and Fletcher checksums, see <xref:Bodu.IO.Hashing> — the non-cryptographic, <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>-based companion library.
 
 ## Key types
 
@@ -17,45 +19,63 @@ Reach for this library when you need a tweakable block cipher that isn't in the 
 - <xref:Bodu.Security.Cryptography.Threefish256> — the tweakable 256-bit block / 256-bit key variant of the Threefish cipher family.
 - <xref:Bodu.Security.Cryptography.Threefish512> — 512-bit blocks and keys; the cipher underlying the Skein hash function.
 - <xref:Bodu.Security.Cryptography.Threefish1024> — 1024-bit blocks and keys for scenarios requiring larger block sizes.
+- <xref:Bodu.Security.Cryptography.Blowfish> — 64-bit block / 32–448-bit key cipher. Well-studied legacy algorithm; prefer Threefish or the BCL's AES for new designs.
 - <xref:Bodu.Security.Cryptography.Skipjack> — NSA-designed 64-bit block, 80-bit key cipher. **Historical / research only.**
 
-**Hashes and checksums**
+**Cipher modes and authenticated encryption**
 
-- <xref:Bodu.Security.Cryptography.Fletcher32> — position-dependent 32-bit checksum (part of the <xref:Bodu.Security.Cryptography.Fletcher> family).
-- <xref:Bodu.Security.Cryptography.Adler32> — fast 32-bit checksum in the Adler family; SIMD- and scalar-path implementations.
+- <xref:Bodu.Security.Cryptography.CipherBlockMode> — the library's extended block-mode enum (ECB / CBC / CFB / OFB / CTR).
+- <xref:Bodu.Security.Cryptography.BlockCipherModeFactory>, <xref:Bodu.Security.Cryptography.PaddingFactory> — compose any <xref:Bodu.Security.Cryptography.IBlockCipher> with a mode and a padding strategy.
+- <xref:Bodu.Security.Cryptography.AesBlockCipher> — an <xref:Bodu.Security.Cryptography.IBlockCipher> adapter over the BCL's AES, used to drive the AEAD transforms.
+- <xref:Bodu.Security.Cryptography.GcmModeTransform>, <xref:Bodu.Security.Cryptography.CcmModeTransform>, <xref:Bodu.Security.Cryptography.OcbModeTransform>, <xref:Bodu.Security.Cryptography.EaxModeTransform>, <xref:Bodu.Security.Cryptography.SivModeTransform>, <xref:Bodu.Security.Cryptography.GcmSivModeTransform> — AEAD mode transforms for AES.
+
+**Keyed and cryptographic hashes**
+
 - <xref:Bodu.Security.Cryptography.SipHash64> — keyed 64-bit hash, collision-resistant for hash-table protection; configurable compression and finalisation rounds.
-- <xref:Bodu.Security.Cryptography.Fnv1a32> — fast, non-cryptographic FNV-1a 32-bit hash for checksums, fingerprints, and hash tables.
+- <xref:Bodu.Security.Cryptography.SipHash128> — 128-bit SipHash variant for longer-output keyed hashing.
 - <xref:Bodu.Security.Cryptography.Tiger> — cryptographic hash by Anderson and Biham optimised for 64-bit platforms; supports 128 / 160 / 192-bit output with Tiger or Tiger2 padding.
+- <xref:Bodu.Security.Cryptography.Poly1305> — one-time authenticator; pairs with a stream cipher for a MAC-with-AEAD construction.
+- <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> — Merkle-tree hashing over a stream, for partial re-verification of large inputs.
+
+**Classic non-cryptographic hashes**
+
+- <xref:Bodu.Security.Cryptography.Adler32>, <xref:Bodu.Security.Cryptography.Adler32C>, <xref:Bodu.Security.Cryptography.Adler64> — fast running-sum checksums in the Adler family.
+- <xref:Bodu.Security.Cryptography.Fnv1a32>, <xref:Bodu.Security.Cryptography.Fnv1a64>, <xref:Bodu.Security.Cryptography.Fnv132>, <xref:Bodu.Security.Cryptography.Fnv164> — FNV-1 and FNV-1a family; cheap string / byte-stream hashes for tables and fingerprints.
+- <xref:Bodu.Security.Cryptography.CityHash32>, <xref:Bodu.Security.Cryptography.CityHash64> — Google's CityHash family for 32 / 64-bit non-cryptographic hashing.
+- Classic string hashes: <xref:Bodu.Security.Cryptography.Bernstein>, <xref:Bodu.Security.Cryptography.BKDR>, <xref:Bodu.Security.Cryptography.SDBM>, <xref:Bodu.Security.Cryptography.JSHash>, <xref:Bodu.Security.Cryptography.ApHash>, <xref:Bodu.Security.Cryptography.Pjw32>, <xref:Bodu.Security.Cryptography.Elf64>, <xref:Bodu.Security.Cryptography.Pearson>.
 
 **Helpers**
 
-- <xref:Bodu.Security.Cryptography.CryptoHelpers> — secure-zeroisation, padding / de-padding, cryptographically secure random generation, bit reflection, and argument validation helpers intended for internal and consumer use.
+- <xref:Bodu.Security.Cryptography.CryptoHelpers> — secure zeroisation, padding / de-padding, cryptographically secure random generation, bit reflection, and argument validation helpers intended for internal and consumer use.
 
 ## Example
 
 ```csharp
+using System.Security.Cryptography;
 using System.Text;
 using Bodu.Security.Cryptography;
 
-// Non-cryptographic checksum: standard HashAlgorithm contract.
 byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
 
-using var fletcher = new Fletcher32();
-string hex = Convert.ToHexString(fletcher.ComputeHash(data));
+// Fast non-cryptographic fingerprint — still on the standard HashAlgorithm contract.
+using var fnv = new Fnv1a64();
+string fnvHex = Convert.ToHexString(fnv.ComputeHash(data));
 
-// Keyed hash for a hash-table against collision attacks.
+// Keyed hash for a hash-table protected against collision attacks.
 byte[] key = RandomNumberGenerator.GetBytes(16);
 using var sip = new SipHash64 { Key = key };
-ulong digest = BitConverter.ToUInt64(sip.ComputeHash(data), 0);
+ulong slot = BitConverter.ToUInt64(sip.ComputeHash(data));
 ```
 
 ## Notes
 
 - **Security caveats.**
   - <xref:Bodu.Security.Cryptography.Skipjack> is provided for historical and research purposes. It has an 80-bit key and a 64-bit block; **do not use it for new systems**.
-  - <xref:Bodu.Security.Cryptography.Fletcher32>, <xref:Bodu.Security.Cryptography.Adler32>, and <xref:Bodu.Security.Cryptography.Fnv1a32> are **non-cryptographic**. They are appropriate for error detection and hash-table distribution, not for authentication or integrity against an active attacker.
+  - <xref:Bodu.Security.Cryptography.Blowfish> is well-studied but dated; prefer Threefish or the BCL's AES for new designs — its 64-bit block limits the safe encryption volume per key.
+  - <xref:Bodu.Security.Cryptography.Adler32>, <xref:Bodu.Security.Cryptography.Fnv1a32>, <xref:Bodu.Security.Cryptography.CityHash64>, and the other classic non-cryptographic hashes in this namespace are **not cryptographic**. They are appropriate for error detection, fingerprinting, and hash-table distribution — not for authentication or integrity against an active attacker.
   - <xref:Bodu.Security.Cryptography.SipHash64> is keyed and collision-resistant but short-output; use it for hash-table protection and message authentication over small inputs, not as a drop-in for a MAC like HMAC-SHA256.
   - <xref:Bodu.Security.Cryptography.Tiger> is a classic cryptographic hash. Prefer BCL-provided SHA-2 / SHA-3 for new designs; use Tiger for interoperability with existing Tiger-based systems.
 - **Thread safety.** Instances of the cipher and hash types follow the standard .NET convention: **not thread-safe** during a single `TransformBlock` / `ComputeHash` / encryption session. Create one instance per logical operation, or synchronise externally.
 - **Allocation discipline.** Hot-path types allocate their working buffers in the constructor and reuse them; `CryptoHelpers.ClearIfNotNull` (and equivalents) zero secret material at disposal time.
 - **Determinism and portability.** All algorithms produce identical byte-for-byte output across platforms and architectures for the same input and configuration.
+- **See also:** <xref:Bodu.IO.Hashing> for CRC and Fletcher checksums on the <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract.

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -6,14 +6,22 @@ Narrative documentation and library overviews complement the auto-generated [API
 
 Each library has a dedicated overview page that introduces its purpose, lists its key types, and shows a minimal usage example before handing off to the API reference.
 
-- **[Bodu.Core — collections, buffers, and text utilities](../api/Bodu.Collections.Generic.html)**
+- **[Bodu.Core — collections, buffers, and text utilities](../apidoc/Bodu.Collections.Generic.md)**
   Fixed-capacity circular buffers (single-threaded and lock-free), evicting dictionary with six policies, buffer conversion, array and base-encoding utilities, and centralised argument validation.
 
-- **[Bodu.Security.Cryptography — ciphers, hashes, and checksums](../api/Bodu.Security.Cryptography.html)**
-  Managed block ciphers (Threefish 256 / 512 / 1024, Skipjack) and hashes and checksums (Fletcher, Adler, SipHash, FNV-1a, Tiger) that plug into the standard .NET cryptography contracts.
+- **[Bodu.IO.Hashing — CRC and Fletcher checksums](../apidoc/Bodu.IO.Hashing.md)**
+  Non-cryptographic checksums on `System.IO.Hashing.NonCryptographicHashAlgorithm` — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher 16 / 32 / 64 family, with shared lookup-table caching and resumable hashing.
 
-- **[Bodu.Globalization.Calendar — notable dates](../api/Bodu.Globalization.Calendar.html)**
-  Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators, including Gregorian-computus Easter and lunar-calendar Lunar New Year.
+- **[Bodu.Security.Cryptography — ciphers, hashes, and Merkle trees](../apidoc/Bodu.Security.Cryptography.md)**
+  Managed block ciphers (Threefish 256 / 512 / 1024, Blowfish, Skipjack), AEAD mode transforms for AES, keyed and cryptographic hashes (SipHash, Tiger), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV, CityHash) that plug into the standard .NET cryptography contracts.
+
+- **[Bodu.Globalization.Calendar — notable dates](../apidoc/Bodu.Globalization.Calendar.md)**
+  Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators — including Gregorian-computus Easter and lunar-calendar Lunar New Year — driven from a pluggable XML rule source and an observance-adjustment pipeline.
+
+## Guides
+
+- **[Bodu.IO.Hashing guides](../guides/io-hashing/)** — *Using CRC*, *Using Fletcher*, and the full CRC catalogue.
+- **[Bodu.Security.Cryptography guides](../guides/cryptography/)** — encryption basics, cipher block modes, AEAD, padding, composing primitives, keyed and cryptographic hashing.
 
 ## Project documentation
 

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -1,11 +1,10 @@
 # Getting started
 
-This page walks through installing each of the three Bodu libraries and running a minimal example that exercises the headline type of each.
+This page walks through installing each of the four Bodu libraries and running a minimal example that exercises the headline type of each.
 
 ## Prerequisites
 
-- The **.NET 8 SDK** (required for `Bodu.Core` and `Bodu.Security.Cryptography`).
-- `Bodu.Globalization.Calendar` also targets `net6.0` and `net7.0`, so either of those SDKs is sufficient for that package alone.
+- The **.NET 8 SDK** — every package in the solution targets `net8.0`.
 
 Verify your SDK:
 
@@ -19,6 +18,7 @@ Each package is independent; install only what you need.
 
 ```bash
 dotnet add package Bodu.Core
+dotnet add package Bodu.IO.Hashing
 dotnet add package Bodu.Security.Cryptography
 dotnet add package Bodu.Globalization.Calendar
 ```
@@ -45,22 +45,55 @@ int oldest = buffer.Dequeue(); // 2
 
 See also: <xref:Bodu.Collections.Generic.CircularBuffer`1>, <xref:Bodu.Collections.Generic.EvictingDictionary`2>, <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer`1>.
 
-### Bodu.Security.Cryptography — a Fletcher-32 checksum
+### Bodu.IO.Hashing — a CRC-32 checksum
 
 ```csharp
 using System.Text;
-using Bodu.Security.Cryptography;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+crc.Append(data);
+string hex = Convert.ToHexString(crc.GetCurrentHash());
+```
+
+`Crc` derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> and is configured with a named <xref:Bodu.IO.Hashing.CrcStandard> — `CRC32_ISOHDLC` here is the canonical zlib / PNG / Ethernet CRC-32. Swap it for `CRC32_ISCSI`, `CRC16_MODBUS`, `CRC64_XZ`, or any of the 113 entries in the [CRC catalogue](../guides/io-hashing/crc-catalogue.md).
+
+### Bodu.IO.Hashing — a Fletcher-32 checksum
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
 
 byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
 
 using var fletcher = new Fletcher32();
-byte[] checksum = fletcher.ComputeHash(data);
-string hex = Convert.ToHexString(checksum);
+fletcher.Append(data);
+byte[] checksum = fletcher.GetCurrentHash();
 ```
 
-`Fletcher32` derives from `System.Security.Cryptography.HashAlgorithm`, so it drops into any API that expects a standard .NET hash.
+`Fletcher32` is a 32-bit position-dependent checksum — the twin-accumulator structure catches transpositions that a simple sum misses.
 
-See also: <xref:Bodu.Security.Cryptography.Threefish256>, <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.Tiger>.
+See also: <xref:Bodu.IO.Hashing.Crc>, <xref:Bodu.IO.Hashing.CrcStandard>, <xref:Bodu.IO.Hashing.Fletcher16>, <xref:Bodu.IO.Hashing.Fletcher64>, <xref:Bodu.IO.Hashing.IResumableHashAlgorithm>.
+
+### Bodu.Security.Cryptography — a keyed SipHash
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+byte[] key  = RandomNumberGenerator.GetBytes(16);
+
+using var sip = new SipHash64 { Key = key };
+ulong digest = BitConverter.ToUInt64(sip.ComputeHash(data));
+```
+
+`SipHash64` derives from `System.Security.Cryptography.HashAlgorithm`, so it drops into any API that expects a standard .NET hash. It is keyed and collision-resistant, which makes it suitable for protecting hash tables against collision-DoS attacks.
+
+See also: <xref:Bodu.Security.Cryptography.Threefish256>, <xref:Bodu.Security.Cryptography.Tiger>, <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.Fnv1a64>.
 
 ### Bodu.Globalization.Calendar — resolve Easter Sunday
 
@@ -70,16 +103,21 @@ using Bodu.Globalization.Calendar.Calculators;
 var calculator = new EasterSundayNotableDateCalculator();
 DateTime easter2026 = calculator.Calculate(2026);
 // 2026-04-05
+
+// Good Friday is always two days before Easter.
+DateTime goodFriday2026 = easter2026.AddDays(-2);
 ```
 
 The calculator uses the Gregorian Computus for years from 1583 onward and falls back to the Julian algorithm for earlier years.
 
-See also: <xref:Bodu.Globalization.Calendar.NotableDateService>, <xref:Bodu.Globalization.Calendar.Calculators.LunarNewYearNotableDateCalculator>.
+See also: <xref:Bodu.Globalization.Calendar.NotableDateService>, <xref:Bodu.Globalization.Calendar.Calculators.LunarNewYearNotableDateCalculator>, <xref:Bodu.Globalization.Calendar.NotableDateRule>.
 
 ## Where to go next
 
 - **[Introduction](introduction.md)** — project overview and design principles.
-- **[Bodu.Core overview](../api/Bodu.Collections.Generic.html)** — collections, buffers, text utilities.
-- **[Bodu.Security.Cryptography overview](../api/Bodu.Security.Cryptography.html)** — ciphers, hashes, checksums.
-- **[Bodu.Globalization.Calendar overview](../api/Bodu.Globalization.Calendar.html)** — notable dates and calculators.
+- **[Bodu.Core overview](../apidoc/Bodu.Collections.Generic.md)** — collections, buffers, text utilities.
+- **[Bodu.IO.Hashing overview](../apidoc/Bodu.IO.Hashing.md)** — CRC and Fletcher checksums.
+- **[Bodu.Security.Cryptography overview](../apidoc/Bodu.Security.Cryptography.md)** — ciphers, keyed and cryptographic hashes, Merkle trees.
+- **[Bodu.Globalization.Calendar overview](../apidoc/Bodu.Globalization.Calendar.md)** — notable dates and calculators.
 - **[API reference](../api/)** — full auto-generated type-by-type documentation.
+- **Guides:** [Bodu.IO.Hashing](../guides/io-hashing/) · [Bodu.Security.Cryptography](../guides/cryptography/).

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -1,16 +1,17 @@
 # Introduction
 
-**Bodu** is a solution that ships three independent .NET NuGet packages, each focused on a narrow, well-defined problem domain. The packages share nothing at runtime — each is self-contained — but share a single set of source and documentation conventions, a single analyzer and test configuration, and a single quality bar.
+**Bodu** is a solution that ships four independent .NET NuGet packages, each focused on a narrow, well-defined problem domain. The packages share nothing at runtime — each is self-contained — but share a single set of source and documentation conventions, a single analyzer and test configuration, and a single quality bar.
 
 ## The libraries
 
-| Package | Purpose | Target frameworks |
+| Package | Purpose | Target framework |
 |---|---|---|
-| **Bodu.Core** | Fixed-capacity collections, buffer conversion helpers, array and text extensions, argument-validation helpers. | `net8.0` |
-| **Bodu.Security.Cryptography** | Managed block ciphers and non-cryptographic / cryptographic hashes and checksums. | `net8.0` |
-| **Bodu.Globalization.Calendar** | Notable-date resolution and dynamic calendar calculators (Easter, Lunar New Year). | `net6.0`, `net7.0`, `net8.0` |
+| **Bodu.Core** | Fixed-capacity collections (circular buffer, evicting dictionary), buffer conversion helpers, array and text extensions, argument-validation helpers. | `net8.0` |
+| **Bodu.IO.Hashing** | Non-cryptographic checksums on `System.IO.Hashing.NonCryptographicHashAlgorithm` — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher 16 / 32 / 64 family, with shared lookup-table caching and resumable hashing. | `net8.0` |
+| **Bodu.Security.Cryptography** | Managed block ciphers (Threefish, Blowfish, Skipjack), AEAD mode transforms for AES, keyed and cryptographic hashes (SipHash, Tiger), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV, CityHash). | `net8.0` |
+| **Bodu.Globalization.Calendar** | Notable-date resolution and dynamic calendar calculators (Easter, Lunar New Year), driven from a pluggable XML rule source with an observance-adjustment pipeline. | `net8.0` |
 
-Each package is versioned and released independently. Take the one you need and ignore the others — there are no cross-package runtime dependencies.
+Each package is versioned and released independently. Take the one you need and ignore the others — there are no cross-package runtime dependencies. `Bodu.IO.Hashing` and `Bodu.Security.Cryptography` both depend on `Bodu.Core` for shared argument-validation helpers.
 
 ## Design principles
 
@@ -19,7 +20,16 @@ Each package is versioned and released independently. Take the one you need and 
 - **Analyzer-clean.** The solution runs StyleCop.Analyzers, Roslynator, the .NET analyzers, AsyncFixer, and Microsoft.VisualStudio.Threading.Analyzers at build time. Doc-comment warnings (including `CS1591`) are treated as errors.
 - **Deterministic builds** produce reproducible package outputs.
 - **Documentation-first.** Every public type and member carries XML documentation in British English, and that documentation is the source of truth for this site. The API reference you see here is generated directly from the source.
-- **MIT licensed**, no external runtime dependencies.
+- **MIT licensed**, no external runtime dependencies beyond the BCL.
+
+## Cryptographic vs non-cryptographic hashing
+
+This solution deliberately splits hashing across two packages:
+
+- **`Bodu.IO.Hashing`** — non-cryptographic checksums (CRC, Fletcher) on the BCL's <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract. Use for error detection, file integrity against noise, framing, fingerprinting, and hash-table distribution.
+- **`Bodu.Security.Cryptography`** — keyed and cryptographic hashes (SipHash, Tiger, Merkle tree) on <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, plus the classic non-cryptographic families (Adler, FNV, CityHash) that were written before the split. Use for authentication, signatures, content addressing, and collision-resistant keying.
+
+If you don't know which to reach for, start with the [introduction to hashing and checksums](../guides/io-hashing/) and follow the decision table there.
 
 ## Testing and conventions
 
@@ -29,4 +39,4 @@ The solution uses **MSTest** with a partial-class test layout that mirrors the s
 
 - **[Getting started](getting-started.md)** — prerequisites, install commands, and a one-minute sample from each library.
 - **[API reference](../api/)** — the full auto-generated type-by-type documentation.
-- Library overviews: [Bodu.Core](../api/Bodu.Collections.Generic.html) · [Bodu.Security.Cryptography](../api/Bodu.Security.Cryptography.html) · [Bodu.Globalization.Calendar](../api/Bodu.Globalization.Calendar.html).
+- Library overviews: [Bodu.Core](../apidoc/Bodu.Collections.Generic.md) · [Bodu.IO.Hashing](../apidoc/Bodu.IO.Hashing.md) · [Bodu.Security.Cryptography](../apidoc/Bodu.Security.Cryptography.md) · [Bodu.Globalization.Calendar](../apidoc/Bodu.Globalization.Calendar.md).

--- a/docs/guides/cryptography/hashing.md
+++ b/docs/guides/cryptography/hashing.md
@@ -4,40 +4,42 @@ title: Using hashes and checksums
 
 # Using hashes and checksums
 
-**Bodu.Security.Cryptography** ships a broad family of hashes and checksums that plug into the standard <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contract. This page sorts them by use-case and shows a minimal recipe for each.
+**Bodu.Security.Cryptography** ships a broad family of hashes that plug into the standard <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contract: keyed hashes (SipHash), cryptographic digests (Tiger), Merkle-tree hashing, and the classic non-cryptographic families that predate the BCL's own non-cryptographic surface (Adler, FNV, CityHash, and the Bernstein / BKDR / SDBM / JSHash / Elf64 / ApHash / Pjw32 / Pearson string hashes).
+
+> **Looking for CRC or Fletcher?** Those moved to the **Bodu.IO.Hashing** package, which builds on <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>. See the [Bodu.IO.Hashing guides](../io-hashing/).
 
 ## Pick the right tool
 
 | If you need… | Use | Why |
 |---|---|---|
-| A fast error-detection checksum for network framing, file integrity, etc. | <xref:Bodu.Security.Cryptography.Fletcher32>, <xref:Bodu.Security.Cryptography.Adler32>, <xref:Bodu.Security.Cryptography.Fnv1a32>, <xref:Bodu.Security.Cryptography.Crc> | Cheap, well-spread, **not** cryptographic. |
-| A hash-table key or a short fingerprint, resistant to collision DoS | <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.SipHash128> | Keyed, collision-resistant for short inputs. |
+| A fast non-cryptographic fingerprint for hash tables, bucketing, caches | <xref:Bodu.Security.Cryptography.Adler32>, <xref:Bodu.Security.Cryptography.Fnv1a32>, <xref:Bodu.Security.Cryptography.Fnv1a64>, <xref:Bodu.Security.Cryptography.CityHash64> | Cheap, well-spread, **not** cryptographic. |
+| A hash-table key or short fingerprint, resistant to collision-DoS | <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.SipHash128> | Keyed, collision-resistant for short inputs. |
 | A cryptographic digest for signatures, fingerprints, or content addressing | <xref:Bodu.Security.Cryptography.Tiger>, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> (BCL) | Collision-resistant against active attackers. |
-| A rolling integrity check over a long stream or file, with partial re-verification | <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Subtree recomputation without rehashing the whole input. |
+| A rolling integrity check over a long stream with partial re-verification | <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Subtree recomputation without rehashing the whole input. |
+| An on-the-wire CRC (zlib, PNG, Modbus, iSCSI, …) or a Fletcher checksum | <xref:Bodu.IO.Hashing.Crc>, <xref:Bodu.IO.Hashing.Fletcher32> | Non-cryptographic, `System.IO.Hashing` contract — see the [Bodu.IO.Hashing guides](../io-hashing/). |
 
-The library also includes a number of classic non-cryptographic hashes (<xref:Bodu.Security.Cryptography.Bernstein>, <xref:Bodu.Security.Cryptography.BKDR>, <xref:Bodu.Security.Cryptography.SDBM>, <xref:Bodu.Security.Cryptography.JSHash>, <xref:Bodu.Security.Cryptography.Elf64>) which follow the same `HashAlgorithm` pattern shown below.
+## Pattern 1 — a classic non-cryptographic fingerprint
 
-## Pattern 1 — a non-cryptographic checksum
+Adler, FNV, and CityHash all derive from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, so they drop into any API that accepts a standard .NET hash.
 
 ```csharp
-using System.Security.Cryptography;
 using System.Text;
 using Bodu.Security.Cryptography;
 
 byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
 
-using var hash = new Fletcher32();
-byte[] digest = hash.ComputeHash(data);
-string hex    = Convert.ToHexString(digest);   // 4-byte value as 8 hex characters
+using var fnv = new Fnv1a64();
+byte[] digest = fnv.ComputeHash(data);
+string hex    = Convert.ToHexString(digest);   // 8-byte value, 16 hex characters
 ```
 
-The same shape works for `Adler32`, `Adler64`, `Fletcher16`, `Fletcher32`, `Fletcher64`, `Fnv1a32`, `Fnv1a64`, `CityHash64`, `CrcStandard`, and the classic hashes listed above. They all derive from `HashAlgorithm`, so any API that accepts a `HashAlgorithm` accepts them.
+The same shape works for `Adler32`, `Adler64`, `Fnv1a32`, `Fnv1a64`, `CityHash32`, `CityHash64`, and the classic string hashes listed above.
 
-**What they're not.** These are error-detection and distribution tools. An attacker who can freely modify a message can trivially forge the checksum. Pair them with a signature or a MAC if you need integrity against an adversary.
+**What they're not.** These are non-cryptographic — they are error-detection and distribution tools, not authentication tools. An attacker who can freely modify a message can trivially forge the digest. Pair them with a signature or a MAC if you need integrity against an adversary.
 
 ## Pattern 2 — a keyed hash (SipHash)
 
-SipHash was designed to keep hash tables safe from collision-DoS attacks. It takes a secret key, and a knowledge-of-the-key adversary still cannot produce collisions efficiently.
+SipHash was designed to keep hash tables safe from collision-DoS attacks. It takes a secret key, and even an adversary who knows the algorithm cannot produce collisions efficiently without the key.
 
 ```csharp
 using System.Security.Cryptography;
@@ -54,7 +56,7 @@ ulong slotHash = BitConverter.ToUInt64(digest);
 // Use the output as a stable 64-bit hash for routing / bucketing.
 ```
 
-`SipHash128` gives you a 128-bit output for use cases that care about longer collision resistance. Both types expose `CompressionRounds` and `FinalizationRounds` if you need to trade speed for margin (defaults are the standard 2-4 SipHash).
+`SipHash128` gives you a 128-bit output for use cases that care about longer collision resistance. Both types expose `CompressionRounds` and `FinalizationRounds` if you need to trade speed for margin (defaults are the standard SipHash-2-4 parameterisation).
 
 ## Pattern 3 — a cryptographic digest
 
@@ -122,4 +124,5 @@ For large inputs where you want to overlap leaf hashing with tree reduction, use
 
 - [Encryption basics](encryption-basics.md) — symmetric encryption in this library.
 - [Cipher block modes](cipher-modes.md) — ECB / CBC / CFB / OFB / CTR with worked examples.
+- [Bodu.IO.Hashing guides](../io-hashing/) — CRC and Fletcher checksums on `System.IO.Hashing.NonCryptographicHashAlgorithm`.
 - [MerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) · [ParallelMerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -1,12 +1,12 @@
 ---
-title: Cryptography guides
+title: Bodu.Security.Cryptography guides
 ---
 
-# Cryptography guides
+# Bodu.Security.Cryptography guides
 
 Recipe-style walk-throughs for using **Bodu.Security.Cryptography** in real applications — encrypting and decrypting data with the right mode, padding, and IV; and choosing the right hash for the job.
 
-If you're looking for the generated API reference, see the [Bodu.Security.Cryptography namespace page](../../api/Bodu.Security.Cryptography.html).
+If you're looking for the generated API reference, see the [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md). For non-cryptographic checksums (CRC, Fletcher), see the [Bodu.IO.Hashing guides](../io-hashing/).
 
 ## Start here
 
@@ -55,7 +55,9 @@ All five share the same high-level shape: a `SymmetricAlgorithm` (or `TweakableS
 
 ## Hashing
 
-[Using hashes and checksums](hashing.md) — concrete recipes for non-cryptographic checksums (Fletcher, Adler, FNV, CRC), keyed short-input hashes (SipHash), cryptographic digests (Tiger), and streaming integrity with `MerkleTreeHash` / `ParallelMerkleTreeHash`.
+[Using hashes and checksums](hashing.md) — concrete recipes for the classic non-cryptographic families (Adler, FNV, CityHash), keyed short-input hashes (SipHash), cryptographic digests (Tiger), and streaming integrity with `MerkleTreeHash` / `ParallelMerkleTreeHash`.
+
+For CRC and Fletcher checksums on `System.IO.Hashing.NonCryptographicHashAlgorithm`, see the [Bodu.IO.Hashing guides](../io-hashing/).
 
 ## Related concepts
 

--- a/docs/guides/io-hashing/crc-catalogue.md
+++ b/docs/guides/io-hashing/crc-catalogue.md
@@ -4,7 +4,9 @@ title: CRC catalogue
 
 # CRC catalogue
 
-The <xref:Bodu.Security.Cryptography.CrcStandard> type exposes a broad catalogue of named CRC parameter sets that can be passed to <xref:Bodu.Security.Cryptography.Crc> for CRC computation. The catalogue is mechanically derived from the **CRC RevEng** project.
+The <xref:Bodu.IO.Hashing.CrcStandard> type (in the **Bodu.IO.Hashing** package) exposes a broad catalogue of named CRC parameter sets that can be passed to <xref:Bodu.IO.Hashing.Crc> for CRC computation. The catalogue is mechanically derived from the **CRC RevEng** project.
+
+For walk-through usage of the CRC engine, see [Using CRC](crc.md).
 
 ## Attribution
 
@@ -18,7 +20,7 @@ The catalogue is distributed as part of the CRC RevEng project at <https://reven
 
 ## Accessing standards
 
-The catalogue is a **lazy-materialised data table**. Loading <xref:Bodu.Security.Cryptography.CrcStandard> allocates only the packed spec rows and the per-entry cache slots — individual <xref:Bodu.Security.Cryptography.CrcStandard> instances are constructed on first access and then memoised, so a process that uses only a handful of standards pays for only a handful of allocations.
+The catalogue is a **lazy-materialised data table**. Loading <xref:Bodu.IO.Hashing.CrcStandard> allocates only the packed spec rows and the per-entry cache slots — individual <xref:Bodu.IO.Hashing.CrcStandard> instances are constructed on first access and then memoised, so a process that uses only a handful of standards pays for only a handful of allocations.
 
 Three entry points:
 
@@ -43,13 +45,13 @@ foreach (CrcStandard std in CrcStandard.All) { ... }
 
 ## Support policy
 
-`CrcStandard` represents all scalar parameters as <xref:System.UInt64>, so the library can materialise any CRC of width 1–64 bits. Entries whose width exceeds 64 bits are listed below for completeness but are **not** exposed by <xref:Bodu.Security.Cryptography.CrcStandards> and cannot be constructed through `CrcStandard`.
+`CrcStandard` represents all scalar parameters as <xref:System.UInt64>, so the library can materialise any CRC of width 1–64 bits. Entries whose width exceeds 64 bits are listed below for completeness but are **not** exposed by <xref:Bodu.IO.Hashing.CrcStandards> and cannot be constructed through `CrcStandard`.
 
 Aliases share a single catalogue instance with their canonical standard. `CrcStandard.FromName` resolves both canonical and alias names, so `FromName("CRC-32")` and `FromName("CRC-32/ISO-HDLC")` return the same instance.
 
 ## Common standards (strongly-typed)
 
-These are exposed as `public static CrcStandard` properties on <xref:Bodu.Security.Cryptography.CrcStandard> for convenience — the underlying cache is still shared with the enum-based lookup.
+These are exposed as `public static CrcStandard` properties on <xref:Bodu.IO.Hashing.CrcStandard> for convenience — the underlying cache is still shared with the enum-based lookup.
 
 | Name | Width | Property | Aliases |
 |---|---:|---|---|

--- a/docs/guides/io-hashing/crc.md
+++ b/docs/guides/io-hashing/crc.md
@@ -1,0 +1,138 @@
+---
+title: Using CRC
+---
+
+# Using CRC
+
+**Bodu.IO.Hashing** ships a single <xref:Bodu.IO.Hashing.Crc> engine that can compute any CRC of widths 1–64 bits. The parameters — polynomial, initial value, input / output reflection, XOR-out — are packed into an immutable <xref:Bodu.IO.Hashing.CrcStandard> that you pass to the constructor.
+
+![Table-driven CRC pipeline](../../images/diagrams/crc-pipeline.svg)
+
+## Pattern 1 — a named standard
+
+The most common standards are exposed as strongly-typed properties. This is the shortest path to a working CRC.
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+crc.Append(data);
+string hex = Convert.ToHexString(crc.GetCurrentHash());
+```
+
+The default constructor `new Crc()` is equivalent to `new Crc(CrcStandard.CRC32_ISOHDLC)` — the canonical zlib / PNG / Ethernet / PKZIP CRC-32.
+
+## Pattern 2 — pick from the enum
+
+For anything outside the short list of strongly-typed properties, use the <xref:Bodu.IO.Hashing.CrcStandards> enum. Every canonical CRC RevEng entry has a member.
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var crc16 = new Crc(CrcStandard.Get(CrcStandards.CRC16_XMODEM));
+using var crc8  = new Crc(CrcStandard.Get(CrcStandards.CRC8_SAEJ1850));
+```
+
+Instances are memoised inside <xref:Bodu.IO.Hashing.CrcStandard>, so repeated calls to `Get` for the same entry return the same reference.
+
+## Pattern 3 — look up by name (including aliases)
+
+Canonical names and every published alias resolve to the same standard.
+
+```csharp
+using var a = new Crc(CrcStandard.FromName("CRC-32/ISO-HDLC"));
+using var b = new Crc(CrcStandard.FromName("PKZIP"));          // same underlying instance
+```
+
+`FromName` is ordinal and case-sensitive. `TryFromName` returns `false` instead of throwing when the name is unknown, which is the safer choice for user-supplied configuration.
+
+## Pattern 4 — a custom parameter set
+
+If your target isn't in the catalogue, construct a <xref:Bodu.IO.Hashing.CrcStandard> directly.
+
+```csharp
+using Bodu.IO.Hashing;
+
+// A hypothetical 12-bit CRC for a bespoke serial frame.
+var custom = new CrcStandard(
+    name:         "CRC-12/MY-PROTOCOL",
+    size:         12,
+    polynomial:   0x80F,
+    initialValue: 0xFFF,
+    reflectIn:    false,
+    reflectOut:   false,
+    xOrOut:       0x000);
+
+using var crc = new Crc(custom);
+```
+
+Widths 1–64 bits are supported. `CrcStandard` validates the width at construction time.
+
+## Pattern 5 — streaming over bytes
+
+Because <xref:Bodu.IO.Hashing.Crc> derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>, the BCL streaming helpers apply. Call `Append` as many times as you like, then `GetCurrentHash` to finalise.
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var crc = new Crc(CrcStandard.CRC32_ISCSI);
+
+using (FileStream fs = File.OpenRead("archive.bin"))
+{
+    byte[] buffer = new byte[64 * 1024];
+    int read;
+    while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+    {
+        crc.Append(buffer.AsSpan(0, read));
+    }
+}
+
+byte[] fingerprint = crc.GetCurrentHash();
+```
+
+`GetCurrentHash` is **non-destructive** — finalisation (output reflection, XOR-out, width-masking) is applied to a snapshot of the accumulator, so you can call it repeatedly without disturbing in-progress hashing. To restart from the initial value, call `Reset`.
+
+## Pattern 6 — resume from a stored digest
+
+<xref:Bodu.IO.Hashing.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm>, which lets you reverse-finalise a digest you computed earlier, append new bytes, and finalise again. Handy for append-only logs and chunked uploads where rehashing the whole input is expensive.
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+using var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+
+byte[] firstDigest = crc.ComputeHash(Encoding.UTF8.GetBytes("the quick brown fox"));
+
+// Later — resume from firstDigest, append a continuation, and finalise.
+byte[] combined = crc.ComputeHashFrom(
+    previousHash: firstDigest,
+    newData:      Encoding.UTF8.GetBytes(" jumps over the lazy dog"));
+```
+
+The combined digest is identical to what you'd get from a single pass over the concatenated input.
+
+## Pattern 7 — sharing lookup tables
+
+Every `Crc` instance with the same (width, polynomial, reflect-in) triple shares a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Crc.GlobalCache>. This means constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
+
+```csharp
+using Bodu.IO.Hashing;
+
+// Process-wide cache, shared across instances.
+CrcLookupTableCache cache = Crc.GlobalCache;
+
+// Replace the cache for a test, a benchmark, or isolation between tenants.
+Crc.GlobalCache = new CrcLookupTableCache();
+```
+
+In practice you'll rarely need to touch the cache directly — the default behaviour is what you want.
+
+## Where to go next
+
+- [Using Fletcher](fletcher.md) — the other checksum family in this package.
+- [CRC catalogue](crc-catalogue.md) — the full table of 113 named standards.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/fletcher.md
+++ b/docs/guides/io-hashing/fletcher.md
@@ -1,0 +1,89 @@
+---
+title: Using Fletcher
+---
+
+# Using Fletcher
+
+The Fletcher checksum family maintains two running accumulators, **A** and **B**, both reduced modulo a prime near 2^(N ⁄ 2). Each input word updates `A = (A + word) mod M`, then `B = (B + A) mod M`. The final output is `B ‖ A` truncated to the chosen width. Because `B` depends on the running `A`, Fletcher catches transpositions — swapping two words changes `B` even though the sum is unchanged — which a simple additive checksum misses.
+
+![Fletcher twin-accumulator structure](../../images/diagrams/fletcher-accumulators.svg)
+
+**Bodu.IO.Hashing** provides three widths: <xref:Bodu.IO.Hashing.Fletcher16>, <xref:Bodu.IO.Hashing.Fletcher32>, and <xref:Bodu.IO.Hashing.Fletcher64>. All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
+
+## Pattern 1 — compute a digest in one call
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var fletcher = new Fletcher32();
+fletcher.Append(data);
+byte[] digest = fletcher.GetCurrentHash();
+string hex = Convert.ToHexString(digest);  // 4 bytes, 8 hex characters
+```
+
+Swap `Fletcher32` for `Fletcher16` or `Fletcher64` depending on how much collision space you need.
+
+## Pattern 2 — the `Append` / `GetCurrentHash` / `Reset` lifecycle
+
+The BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> exposes three methods that Fletcher honours verbatim:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var fletcher = new Fletcher64();
+
+fletcher.Append(chunk1);                  // update A and B
+fletcher.Append(chunk2);                  // continue
+byte[] partial = fletcher.GetCurrentHash(); // snapshot, non-destructive
+fletcher.Append(chunk3);                  // still works — GetCurrentHash did not change state
+byte[] full = fletcher.GetCurrentHash();
+
+fletcher.Reset();                         // back to zeroed A and B
+```
+
+`GetCurrentHash` finalises on a copy of the accumulators, so calling it mid-stream is cheap and safe.
+
+## Pattern 3 — streaming over a file
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var fletcher = new Fletcher32();
+
+using (FileStream fs = File.OpenRead("archive.bin"))
+{
+    byte[] buffer = new byte[64 * 1024];
+    int read;
+    while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+    {
+        fletcher.Append(buffer.AsSpan(0, read));
+    }
+}
+
+byte[] fingerprint = fletcher.GetCurrentHash();
+```
+
+Fletcher's block size is fixed by the width (Fletcher-16 works in 1-byte words, Fletcher-32 in 2-byte words, Fletcher-64 in 4-byte words). Partial final blocks are zero-padded before the last update — the algorithm handles this internally.
+
+## Picking a width
+
+| Width | Use when | Notes |
+|---|---|---|
+| <xref:Bodu.IO.Hashing.Fletcher16> | Tiny frames, embedded protocols, when 16 bits of collision space is enough. | 1-byte blocks, fastest; same collision properties as CRC-16 for short inputs. |
+| <xref:Bodu.IO.Hashing.Fletcher32> | General-purpose file and buffer checksums; the most common choice. | 2-byte blocks; comparable to CRC-32 for error detection on uncorrelated noise, cheaper to compute. |
+| <xref:Bodu.IO.Hashing.Fletcher64> | Large buffers where a 32-bit space is uncomfortable. | 4-byte blocks; rarely needed, but useful for very long streams. |
+
+## Fletcher vs CRC
+
+- **CRC** is defined by polynomial arithmetic over GF(2). It is better at detecting bursts of errors that align with its polynomial structure. Reach for it when you need to match a standard on the wire (zlib, PNG, Modbus, etc.).
+- **Fletcher** is defined by two running sums. It is cheaper to compute on a general-purpose CPU and still catches transpositions. Reach for it when you control both endpoints and want a simple, fast, position-dependent checksum.
+
+Both are **non-cryptographic** — neither resists a motivated adversary. If you need authentication, see the [cryptography hashing guide](../cryptography/hashing.md) (SipHash, Tiger, Merkle trees).
+
+## Where to go next
+
+- [Using CRC](crc.md) — the other checksum family in this package.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/index.md
+++ b/docs/guides/io-hashing/index.md
@@ -1,0 +1,45 @@
+---
+title: Bodu.IO.Hashing guides
+---
+
+# Bodu.IO.Hashing guides
+
+Recipe-style walk-throughs for the **Bodu.IO.Hashing** package — the full CRC RevEng catalogue and the Fletcher family, built on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract.
+
+If you're looking for the generated API reference, see the [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md).
+
+## Start here
+
+<div class="bodu-cards">
+
+<div class="bodu-card">
+  <h3><a href="crc.html">Using CRC</a></h3>
+  <p>Named standards (<code>CRC32_ISOHDLC</code>, <code>CRC16_MODBUS</code>, <code>CRC64_XZ</code>, …), the <code>CrcStandards</code> enum, <code>FromName</code>, custom parameter sets, shared lookup-table caches, resumable hashing, and streaming over a <code>Stream</code>.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="fletcher.html">Using Fletcher</a></h3>
+  <p>Choosing between Fletcher-16 / 32 / 64, the <code>Append</code> / <code>GetCurrentHash</code> / <code>Reset</code> lifecycle, the twin-accumulator structure, and when to prefer CRC instead.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="crc-catalogue.html">CRC catalogue</a></h3>
+  <p>The full table of named CRC standards, mechanically derived from the <a href="https://reveng.sourceforge.io/crc-catalogue/all.htm">CRC RevEng catalogue</a> — name, width, class, enum value, and every published alias.</p>
+</div>
+
+</div>
+
+## Picking the right checksum
+
+| If you need… | Reach for | Why |
+|---|---|---|
+| A standard on-the-wire checksum (zlib / PNG / Ethernet / PKZIP) | <xref:Bodu.IO.Hashing.Crc> + <xref:Bodu.IO.Hashing.CrcStandard.CRC32_ISOHDLC> | Canonical CRC-32; the result is interoperable with every tool that speaks one of the listed formats. |
+| A modern hardware-friendly 32-bit CRC (iSCSI, Btrfs, NVMe, SCTP) | <xref:Bodu.IO.Hashing.Crc> + <xref:Bodu.IO.Hashing.CrcStandard.CRC32_ISCSI> | Castagnoli polynomial; better error-detection properties than ISO-HDLC and the choice for modern protocols. |
+| A short, cheap checksum that still catches transpositions | <xref:Bodu.IO.Hashing.Fletcher16> / <xref:Bodu.IO.Hashing.Fletcher32> / <xref:Bodu.IO.Hashing.Fletcher64> | Twin-accumulator design detects swaps that a simple sum or XOR misses. |
+| An obscure standard from a serial protocol or silicon datasheet | <xref:Bodu.IO.Hashing.Crc> + one of the 113 entries in [the catalogue](crc-catalogue.md) | Every canonical RevEng entry is reachable through <xref:Bodu.IO.Hashing.CrcStandards>, including aliases. |
+| A hash that's safe against an adversary (not just noise) | Not here — see <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.Tiger>, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> | Everything in this library is **non-cryptographic**. Attackers can forge collisions trivially. |
+
+## Cross-references
+
+- [Bodu.Security.Cryptography hashing guide](../cryptography/hashing.md) — keyed hashes (SipHash), cryptographic digests (Tiger), Merkle trees, verifying hashes in constant time.
+- [Bodu.IO.Hashing API reference](../../apidoc/Bodu.IO.Hashing.md) — namespace overview with key types.

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -1,5 +1,16 @@
 # ./<Project Root Dir>/docs/guides/toc.yml
-- name: Cryptography
+- name: Bodu.IO.Hashing
+  href: io-hashing/
+  items:
+    - name: Overview
+      href: io-hashing/index.md
+    - name: Using CRC
+      href: io-hashing/crc.md
+    - name: Using Fletcher
+      href: io-hashing/fletcher.md
+    - name: CRC catalogue
+      href: io-hashing/crc-catalogue.md
+- name: Bodu.Security.Cryptography
   href: cryptography/
   items:
     - name: Overview
@@ -14,10 +25,8 @@
       href: cryptography/composing-primitives.md
     - name: Padding
       href: cryptography/padding.md
-    - name: Hashing and checksums
+    - name: Hashing
       href: cryptography/hashing.md
-    - name: CRC catalogue
-      href: cryptography/crc-catalogue.md
     - name: Symmetric algorithms
       items:
         - name: Threefish-256

--- a/docs/images/diagrams/crc-pipeline.svg
+++ b/docs/images/diagrams/crc-pipeline.svg
@@ -1,0 +1,136 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" role="img" aria-labelledby="crc-title crc-desc">
+  <title id="crc-title">Table-driven CRC pipeline</title>
+  <desc id="crc-desc">A table-driven CRC pipeline: each message byte is XORed with the low byte of the accumulator, the resulting index looks up a precomputed word in the 256-entry table, the accumulator shifts right by eight, and the table word is XORed back in. After the final byte, the accumulator is XORed with XOR-out, reflected (if configured), and masked to the CRC width.</desc>
+
+  <defs>
+    <style>
+      .bg { fill: #0F172A; }
+      .panel { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .header { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .title { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .formula { fill: #94A3B8; font: italic 12px/1 "Cambria",Georgia,serif; }
+      .label { fill: #F8FAFC; font: 700 13px/1 "Segoe UI",Arial,sans-serif; }
+      .sub { fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; }
+      .sub-muted { fill: #94A3B8; font: 400 10.5px/1 "Segoe UI",Arial,sans-serif; }
+      .cipher-e { fill: #3B82F6; stroke: #60A5FA; stroke-width: 1; }
+      .accum { fill: #14B8A6; stroke: #2DD4BF; stroke-width: 1; }
+      .byte { fill: #F59E0B; }
+      .tableblock { fill: #A78BFA; stroke: #C4B5FD; stroke-width: 1; }
+      .tag { fill: #FBBF24; stroke: #F59E0B; stroke-width: 1; }
+      .wire { stroke: #CBD5E1; stroke-width: 1.6; fill: none; }
+      .wire-byte { stroke: #FBBF24; stroke-width: 1.6; fill: none; }
+      .wire-lookup { stroke: #C4B5FD; stroke-width: 1.6; fill: none; }
+      .xor { fill: #0F172A; stroke: #F8FAFC; stroke-width: 1.6; }
+      .xor-sym { fill: #F8FAFC; font: 700 14px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .cipher-text { fill: #F8FAFC; font: 700 14px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .reg-cell { fill: #1E293B; stroke: #60A5FA; stroke-width: 1.2; }
+      .reg-text { fill: #E2E8F0; font: 700 11px/1 "Consolas","Menlo",monospace; text-anchor: middle; }
+    </style>
+    <marker id="arr-d" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#FBBF24"/>
+    </marker>
+    <marker id="arr-p" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#C4B5FD"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="320"/>
+
+  <g transform="translate(10 10)">
+    <rect class="panel" width="800" height="300" rx="8"/>
+    <rect class="header" width="800" height="30" rx="8"/>
+    <rect class="header" y="22" width="800" height="8"/>
+    <text class="title" x="16" y="20">Table-driven CRC — one byte per iteration</text>
+    <text class="formula" x="800" y="20" text-anchor="end" dx="-16">reg ← (reg » 8) ⊕ table[(byte ⊕ reg) &amp; 0xFF]</text>
+
+    <!-- incoming byte on the left -->
+    <g transform="translate(70 90)">
+      <rect class="byte" x="-34" y="-13" width="68" height="26" rx="4"/>
+      <text class="label" x="0" y="5" text-anchor="middle" fill="#0F172A">byte b</text>
+    </g>
+    <text class="sub-muted" x="16" y="130" text-anchor="start">(reflect-in if set)</text>
+
+    <!-- XOR mixer: b ⊕ low(reg) -->
+    <g transform="translate(230 90)">
+      <circle class="xor" cx="0" cy="0" r="14"/>
+      <text class="xor-sym" x="0" y="5">⊕</text>
+    </g>
+    <line class="wire-byte" x1="104" y1="90" x2="213" y2="90" marker-end="url(#arr-b)"/>
+
+    <!-- accumulator register on the right top -->
+    <g transform="translate(590 80)">
+      <rect class="panel" x="-110" y="-24" width="220" height="48" rx="6"/>
+      <text class="sub" x="-104" y="-6">accumulator (reg)</text>
+      <g>
+        <rect class="reg-cell" x="-100" y="0"  width="30" height="20" rx="3"/>
+        <rect class="reg-cell" x="-68"  y="0"  width="30" height="20" rx="3"/>
+        <rect class="reg-cell" x="-36"  y="0"  width="30" height="20" rx="3"/>
+        <rect class="reg-cell" x="-4"   y="0"  width="30" height="20" rx="3"/>
+        <rect class="reg-cell" x="28"   y="0"  width="30" height="20" rx="3"/>
+        <rect class="reg-cell" x="60"   y="0"  width="30" height="20" rx="3"/>
+      </g>
+      <g class="reg-text">
+        <text x="-85" y="14">07</text>
+        <text x="-53" y="14">6D</text>
+        <text x="-21" y="14">C4</text>
+        <text x="11"  y="14">19</text>
+        <text x="43"  y="14">99</text>
+        <text x="75"  y="14">09</text>
+      </g>
+    </g>
+
+    <!-- low byte tap from accumulator back to XOR -->
+    <path class="wire" d="M 500 90 C 430 90, 320 90, 244 90" stroke-dasharray="4 3"/>
+    <text class="sub-muted" x="400" y="82" text-anchor="middle">low byte of reg</text>
+
+    <!-- lookup index wire to the table -->
+    <g transform="translate(360 150)">
+      <rect class="cipher-e" x="-44" y="-14" width="88" height="28" rx="5"/>
+      <text class="cipher-text" x="0" y="5">index &amp; 0xFF</text>
+    </g>
+    <path class="wire-byte" d="M 230 104 L 230 150 L 316 150" marker-end="url(#arr-b)"/>
+
+    <!-- table -->
+    <g transform="translate(560 170)">
+      <rect class="panel" x="0" y="0" width="170" height="110" rx="8"/>
+      <rect class="header" x="0" y="0" width="170" height="22" rx="8"/>
+      <rect class="header" x="0" y="14" width="170" height="8"/>
+      <text class="label" x="85" y="16" text-anchor="middle" font-size="12">table[256]</text>
+      <g class="sub-muted" font-family="'Consolas','Menlo',monospace" font-size="10">
+        <text x="10" y="38">1A</text><text x="46" y="38">2D1C6E23</text>
+        <text x="10" y="54">1B</text><text x="46" y="54">5AB5CB18</text>
+        <text x="10" y="70" fill="#60A5FA">1C</text><text x="46" y="70" fill="#60A5FA">072DB8A5</text>
+        <text x="10" y="86">1D</text><text x="46" y="86">6CB4BBBE</text>
+        <text x="10" y="102">1E</text><text x="46" y="102">0DC0E0DA</text>
+      </g>
+    </g>
+    <path class="wire-lookup" d="M 404 150 L 490 150 L 490 210 L 556 210" marker-end="url(#arr-p)"/>
+
+    <!-- shift + XOR combine -->
+    <g transform="translate(360 220)">
+      <circle class="xor" cx="0" cy="0" r="14"/>
+      <text class="xor-sym" x="0" y="5">⊕</text>
+    </g>
+    <!-- reg » 8 path -->
+    <path class="wire" d="M 590 104 L 590 130 L 470 130 L 470 220 L 374 220" marker-end="url(#arr-d)"/>
+    <text class="sub-muted" x="468" y="124">reg » 8</text>
+
+    <!-- table word into lower XOR -->
+    <path class="wire-lookup" d="M 560 220 L 374 220" marker-end="url(#arr-p)"/>
+    <text class="sub-muted" x="480" y="213" text-anchor="middle">table[idx]</text>
+
+    <!-- back into accumulator -->
+    <path class="wire" d="M 346 220 L 210 220 L 210 104 L 480 104" stroke-dasharray="4 3"/>
+    <text class="sub-muted" x="214" y="240" text-anchor="start">updated reg (loop for next byte)</text>
+
+    <!-- Finalisation strip -->
+    <g transform="translate(40 262)">
+      <rect class="tag" x="0" y="-14" width="720" height="28" rx="4" opacity="0.92"/>
+      <text class="label" x="12" y="5" fill="#0F172A">Finalise:</text>
+      <text class="sub" x="90" y="5" fill="#0F172A">reg ⊕= XOR-out &#160;·&#160; reflect-out if set &#160;·&#160; mask to width N (1 ≤ N ≤ 64) &#160;·&#160; emit as big-endian bytes</text>
+    </g>
+  </g>
+</svg>

--- a/docs/images/diagrams/fletcher-accumulators.svg
+++ b/docs/images/diagrams/fletcher-accumulators.svg
@@ -1,0 +1,106 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 300" role="img" aria-labelledby="fl-title fl-desc">
+  <title id="fl-title">Fletcher checksum — twin accumulators A and B</title>
+  <desc id="fl-desc">The Fletcher checksum maintains two running accumulators, A and B, both reduced modulo a prime near 2^(N/2). For each input word, A accumulates the word and B accumulates the running A. The output is B concatenated with A, truncated to the chosen width (16, 32, or 64 bits). The position-dependent coupling of B on A is what gives Fletcher its detection power.</desc>
+
+  <defs>
+    <style>
+      .bg { fill: #0F172A; }
+      .panel { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .header { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .title { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .formula { fill: #94A3B8; font: italic 12px/1 "Cambria",Georgia,serif; }
+      .label { fill: #F8FAFC; font: 700 13px/1 "Segoe UI",Arial,sans-serif; }
+      .sub { fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; }
+      .sub-muted { fill: #94A3B8; font: 400 10.5px/1 "Segoe UI",Arial,sans-serif; }
+      .band-a { fill: #14B8A6; stroke: #2DD4BF; stroke-width: 1; }
+      .band-b { fill: #A78BFA; stroke: #C4B5FD; stroke-width: 1; }
+      .byte { fill: #F59E0B; }
+      .tag { fill: #FBBF24; stroke: #F59E0B; stroke-width: 1; }
+      .wire { stroke: #CBD5E1; stroke-width: 1.6; fill: none; }
+      .wire-a { stroke: #2DD4BF; stroke-width: 1.8; fill: none; }
+      .wire-b { stroke: #C4B5FD; stroke-width: 1.8; fill: none; }
+      .wire-word { stroke: #FBBF24; stroke-width: 1.6; fill: none; }
+      .plus { fill: #0F172A; stroke: #F8FAFC; stroke-width: 1.6; }
+      .plus-sym { fill: #F8FAFC; font: 700 14px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .band-text { fill: #0F172A; font: 700 13px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+    </style>
+    <marker id="arr-d2" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="arr-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="arr-b" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#C4B5FD"/>
+    </marker>
+    <marker id="arr-w" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#FBBF24"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="300"/>
+
+  <g transform="translate(10 10)">
+    <rect class="panel" width="800" height="280" rx="8"/>
+    <rect class="header" width="800" height="30" rx="8"/>
+    <rect class="header" y="22" width="800" height="8"/>
+    <text class="title" x="16" y="20">Fletcher — twin accumulators A, B (mod M)</text>
+    <text class="formula" x="800" y="20" text-anchor="end" dx="-16">A ← (A + wᵢ) mod M;   B ← (B + A) mod M;   output = (B « N⁄2) | A</text>
+
+    <!-- incoming words -->
+    <g transform="translate(60 150)">
+      <rect class="byte" x="-36" y="-14" width="72" height="28" rx="4"/>
+      <text class="label" x="0" y="5" text-anchor="middle" fill="#0F172A">word wᵢ</text>
+    </g>
+    <text class="sub-muted" x="24" y="188">block size = N⁄16 bytes</text>
+
+    <!-- A band -->
+    <g transform="translate(260 80)">
+      <rect class="band-a" x="0" y="0" width="200" height="44" rx="6"/>
+      <text class="band-text" x="100" y="27">A = (A + wᵢ) mod M</text>
+    </g>
+    <line class="wire-word" x1="96" y1="145" x2="240" y2="100" marker-end="url(#arr-w)"/>
+
+    <!-- B band -->
+    <g transform="translate(260 170)">
+      <rect class="band-b" x="0" y="0" width="200" height="44" rx="6"/>
+      <text class="band-text" x="100" y="27">B = (B + A) mod M</text>
+    </g>
+
+    <!-- A feeds B -->
+    <path class="wire-a" d="M 360 128 L 360 166" marker-end="url(#arr-a)"/>
+    <text class="sub" x="368" y="150">carry A</text>
+
+    <!-- self loops on A and B -->
+    <path class="wire-a" d="M 260 102 C 230 102, 230 126, 260 126" stroke-dasharray="4 3" marker-end="url(#arr-a)"/>
+    <text class="sub-muted" x="220" y="118" text-anchor="end">Aₚᵣₑᵥ</text>
+    <path class="wire-b" d="M 260 192 C 230 192, 230 216, 260 216" stroke-dasharray="4 3" marker-end="url(#arr-b)"/>
+    <text class="sub-muted" x="220" y="208" text-anchor="end">Bₚᵣₑᵥ</text>
+
+    <!-- output combine -->
+    <g transform="translate(530 146)">
+      <circle class="plus" cx="0" cy="0" r="14"/>
+      <text class="plus-sym" x="0" y="5">«</text>
+    </g>
+    <line class="wire-a" x1="460" y1="102" x2="520" y2="140" marker-end="url(#arr-a)"/>
+    <line class="wire-b" x1="460" y1="192" x2="520" y2="152" marker-end="url(#arr-b)"/>
+
+    <!-- final output -->
+    <g transform="translate(680 146)">
+      <rect class="tag" x="-60" y="-16" width="120" height="32" rx="5"/>
+      <text class="label" x="0" y="6" text-anchor="middle" fill="#0F172A">output B‖A</text>
+    </g>
+    <line class="wire" x1="544" y1="146" x2="618" y2="146" marker-end="url(#arr-d2)"/>
+
+    <!-- width legend -->
+    <g transform="translate(640 60)">
+      <text class="sub" x="0" y="0">Widths:</text>
+      <text class="sub-muted" x="0" y="18">Fletcher-16 — M = 2^8  − 1</text>
+      <text class="sub-muted" x="0" y="34">Fletcher-32 — M = 2^16 − 1</text>
+      <text class="sub-muted" x="0" y="50">Fletcher-64 — M = 2^32 − 1</text>
+    </g>
+
+    <!-- footer note -->
+    <text class="sub" x="20" y="256">Position-dependent: swapping two words changes B but not A, so Fletcher detects transpositions that a simple sum misses.</text>
+  </g>
+</svg>

--- a/docs/images/hero-io.svg
+++ b/docs/images/hero-io.svg
@@ -1,0 +1,108 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.IO.Hashing — CRC and Fletcher checksums">
+  <title>Bodu.IO.Hashing</title>
+  <defs>
+    <linearGradient id="io-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="io-cell" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#io-bg)"/>
+
+  <!-- shift-register row: 8 bit-cells -->
+  <g transform="translate(40 80)" font-family="'Consolas','Menlo',monospace" font-size="13" font-weight="700">
+    <g stroke="#3B82F6" stroke-width="1.5" fill="url(#io-cell)">
+      <rect x="0"   y="0" width="30" height="34" rx="4"/>
+      <rect x="32"  y="0" width="30" height="34" rx="4"/>
+      <rect x="64"  y="0" width="30" height="34" rx="4"/>
+      <rect x="96"  y="0" width="30" height="34" rx="4"/>
+      <rect x="128" y="0" width="30" height="34" rx="4"/>
+      <rect x="160" y="0" width="30" height="34" rx="4"/>
+      <rect x="192" y="0" width="30" height="34" rx="4"/>
+      <rect x="224" y="0" width="30" height="34" rx="4"/>
+    </g>
+    <g fill="#F8FAFC" text-anchor="middle">
+      <text x="15"  y="22">1</text>
+      <text x="47"  y="22">0</text>
+      <text x="79"  y="22">1</text>
+      <text x="111" y="22">1</text>
+      <text x="143" y="22">0</text>
+      <text x="175" y="22">1</text>
+      <text x="207" y="22">0</text>
+      <text x="239" y="22">1</text>
+    </g>
+  </g>
+
+  <!-- XOR tap markers above cells -->
+  <g transform="translate(40 74)" fill="none" stroke="#60A5FA" stroke-width="1.5">
+    <circle cx="47"  cy="0" r="5"/>
+    <line x1="43" y1="0" x2="51" y2="0"/>
+    <line x1="47" y1="-4" x2="47" y2="4"/>
+    <circle cx="143" cy="0" r="5"/>
+    <line x1="139" y1="0" x2="147" y2="0"/>
+    <line x1="143" y1="-4" x2="143" y2="4"/>
+    <circle cx="207" cy="0" r="5"/>
+    <line x1="203" y1="0" x2="211" y2="0"/>
+    <line x1="207" y1="-4" x2="207" y2="4"/>
+  </g>
+
+  <!-- feedback arc from tail back to head -->
+  <g fill="none" stroke="#60A5FA" stroke-width="2" stroke-linecap="round">
+    <path d="M 294 97 C 320 97, 330 58, 310 48 C 260 30, 120 30, 70 48 C 50 56, 48 68, 48 78" />
+    <polygon points="48,82 44,72 52,72" fill="#60A5FA" stroke="none"/>
+  </g>
+  <text x="180" y="42" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="11" text-anchor="middle" opacity="0.9">feedback · polynomial</text>
+
+  <!-- incoming byte stream on the left -->
+  <g fill="#94A3B8" font-family="'Consolas','Menlo',monospace" font-size="11" opacity="0.8">
+    <text x="18" y="140" text-anchor="start">in »</text>
+  </g>
+  <g stroke="#F8FAFC" stroke-width="2" fill="none" stroke-linecap="round">
+    <line x1="40" y1="136" x2="38" y2="136"/>
+  </g>
+  <g fill="#F8FAFC" font-family="'Consolas','Menlo',monospace" font-size="11" opacity="0.85">
+    <text x="42" y="140">a7 f3 18 c2 9d 44 e1 05</text>
+  </g>
+
+  <!-- lookup table tower on the right -->
+  <g transform="translate(340 48)" font-family="'Consolas','Menlo',monospace" font-size="10">
+    <rect x="0" y="0" width="100" height="124" rx="8" fill="#1E293B" stroke="#334155" stroke-width="1.5"/>
+    <rect x="0" y="0" width="100" height="20" rx="8" fill="#3B82F6"/>
+    <rect x="0" y="12" width="100" height="8" fill="#3B82F6"/>
+    <text x="50" y="14" fill="#F8FAFC" text-anchor="middle" font-weight="700">table[256]</text>
+    <g stroke="#334155" stroke-width="1">
+      <line x1="0"  y1="40"  x2="100" y2="40"/>
+      <line x1="0"  y1="58"  x2="100" y2="58"/>
+      <line x1="0"  y1="76"  x2="100" y2="76"/>
+      <line x1="0"  y1="94"  x2="100" y2="94"/>
+      <line x1="0"  y1="112" x2="100" y2="112"/>
+    </g>
+    <g fill="#E2E8F0">
+      <text x="8"  y="35">00</text>
+      <text x="40" y="35">00000000</text>
+      <text x="8"  y="53">01</text>
+      <text x="40" y="53">77073096</text>
+      <text x="8"  y="71">02</text>
+      <text x="40" y="71">ee0e612c</text>
+      <text x="8"  y="89">03</text>
+      <text x="40" y="89">990951ba</text>
+      <text x="8"  y="107">04</text>
+      <text x="40" y="107">076dc419</text>
+      <text x="8"  y="120" fill="#60A5FA">…</text>
+    </g>
+  </g>
+
+  <!-- wire from tail of register into table -->
+  <g fill="none" stroke="#F8FAFC" stroke-width="2" stroke-linecap="round" opacity="0.85">
+    <path d="M 294 100 L 340 100"/>
+    <polygon points="340,100 332,96 332,104" fill="#F8FAFC" stroke="none"/>
+  </g>
+
+  <!-- output crc tag below the register -->
+  <g transform="translate(40 134)" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="11">
+    <text x="0" y="22" opacity="0.9">» crc32 = ec6c0f7d</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,10 @@ _disableBreadcrumb: true
 
 <div class="bodu-hero">
   <h1>Bodu</h1>
-  <p class="tagline">A suite of small, focused .NET libraries for collections, cryptography, and calendar computation.</p>
+  <p class="tagline">A suite of small, focused .NET libraries for collections, non-cryptographic hashing, cryptography, and calendar computation.</p>
 </div>
 
-Three independent NuGet packages that share a single solution, a single set of conventions, and a single bar for quality: nullable-enabled, analyzer-clean, deterministic builds, and framework-style XML documentation.
+Four independent NuGet packages that share a single solution, a single set of conventions, and a single bar for quality: nullable-enabled, analyzer-clean, deterministic builds, and framework-style XML documentation.
 
 ## Libraries
 
@@ -40,19 +40,29 @@ Three independent NuGet packages that share a single solution, a single set of c
 </div>
 
 <div class="bodu-card">
+  <img src="images/hero-io.svg" alt="Bodu.IO.Hashing" />
+  <h3>Bodu.IO.Hashing</h3>
+  <p>Non-cryptographic checksums built on <code>System.IO.Hashing.NonCryptographicHashAlgorithm</code> — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher family (16 / 32 / 64 bits), with shared lookup-table caching and resumable hashing.</p>
+  <div class="bodu-card-links">
+    <a href="api/Bodu.IO.Hashing.html">Overview</a>
+    <a href="guides/io-hashing/">Guides</a>
+  </div>
+</div>
+
+<div class="bodu-card">
   <img src="images/hero-crypto.svg" alt="Bodu.Security.Cryptography" />
   <h3>Bodu.Security.Cryptography</h3>
-  <p>Managed block ciphers (Threefish 256 / 512 / 1024, Skipjack) and a family of hashes and checksums (Fletcher, Adler, SipHash, FNV-1a, Tiger) built on the <code>HashAlgorithm</code> and <code>SymmetricAlgorithm</code> contracts.</p>
+  <p>Managed block ciphers (Threefish 256 / 512 / 1024, Blowfish, Skipjack), AEAD mode transforms for AES, keyed and cryptographic hashes (SipHash, Tiger), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV-1a, CityHash).</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.Security.Cryptography.html">Overview</a>
-    <a href="api/Bodu.Security.Cryptography.html">API reference</a>
+    <a href="guides/cryptography/">Guides</a>
   </div>
 </div>
 
 <div class="bodu-card">
   <img src="images/hero-calendar.svg" alt="Bodu.Globalization.Calendar" />
   <h3>Bodu.Globalization.Calendar</h3>
-  <p>Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators — including Gregorian-computus Easter and lunar-calendar Lunar New Year.</p>
+  <p>Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators — including Gregorian-computus Easter and lunar-calendar Lunar New Year — driven by a pluggable XML rule source and adjustment pipeline.</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.Globalization.Calendar.html">Overview</a>
     <a href="api/Bodu.Globalization.Calendar.html">API reference</a>
@@ -67,6 +77,7 @@ Three independent NuGet packages that share a single solution, a single set of c
 
 ```bash
 dotnet add package Bodu.Core
+dotnet add package Bodu.IO.Hashing
 dotnet add package Bodu.Security.Cryptography
 dotnet add package Bodu.Globalization.Calendar
 ```


### PR DESCRIPTION
## Summary

- Adds **Bodu.IO.Hashing** to the landing page, introduction, getting-started, articles index, and guides TOC. The DocFX site was authored when only three projects existed and had no mention of the fourth package.
- New namespace overview (`docs/apidoc/Bodu.IO.Hashing.md`) and three new recipe-style guide pages: **Using CRC**, **Using Fletcher**, and the (relocated) **CRC catalogue**. The catalogue move is recorded as a git rename with an in-place namespace rewrite (`Bodu.Security.Cryptography.Crc*` → `Bodu.IO.Hashing.Crc*`).
- New graphics: a hero SVG (`hero-io.svg`) matching the existing trio, plus two inline diagrams — a table-driven CRC pipeline (`crc-pipeline.svg`) and the Fletcher twin-accumulator structure (`fletcher-accumulators.svg`).
- Retires stale `Bodu.Security.Cryptography.Crc` / `CrcStandard` / `Fletcher` references in the cryptography apidoc, hashing guide, and getting-started page — those types moved to `Bodu.IO.Hashing`. `grep -RIn "Bodu\.Security\.Cryptography\.\(Crc\|CrcStandard\|Fletcher\)" docs/` now returns zero hits.
- Refreshes the calendar apidoc: `NotableDateKind` → `NotableDateCategory`, plus the new rule / adjustment / provider surface (`NotableDateRule`, `NotableDateAdjuster`, `IAdjustmentHandler`, `INotableDateProvider`, `XmlResourceNotableDateRuleProvider`, …).
- Normalises target frameworks to `net8.0` across the site (Calendar no longer multi-targets).
- Renames the top-level Guides TOC branches to their package names (`Bodu.IO.Hashing`, `Bodu.Security.Cryptography`) for symmetry.

## Test plan

- [ ] Run `docfx docs/docfx.json` locally and confirm there are no broken-`xref` warnings on the touched files. The existing `metadata.src` glob `**/src/*.csproj` already picks up the new `Bodu.IO.Hashing.csproj`, so the `api/Bodu.IO.Hashing.html` pages should be emitted automatically.
- [ ] Open `_site/index.html` and confirm the four hero cards render and the Bodu.IO.Hashing card links into the new namespace overview and guides.
- [ ] Browse Guides → Bodu.IO.Hashing → each of Overview / Using CRC / Using Fletcher / CRC catalogue, then Guides → Bodu.Security.Cryptography → confirm the CRC catalogue is no longer listed there.
- [ ] Spot-check the catalogue page — three named standards (CRC-32/ISO-HDLC, CRC-16/MODBUS, CRC-64/XZ) should now resolve to `Bodu.IO.Hashing.*` pages.
- [ ] Render the four hero SVGs side-by-side to confirm palette, corner-radius, and proportions match.

https://claude.ai/code/session_01D5cY8nZASHFEZy5P2Jttdb

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5cY8nZASHFEZy5P2Jttdb)_