### PR TITLE
feat(calendar): extensible inheritance model for &lt;Use&gt; cherry-pick directives

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
@@ -1,0 +1,191 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRuleMerger.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Applies a <see cref="NotableDateRuleUseDirective" /> to an inherited <see cref="NotableDateRule" />, producing the merged rule
+/// that flows through the flatten pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Extracted from <see cref="XmlResourceNotableDateRuleProvider" /> so the merge algorithm can be tested in isolation without
+/// bootstrapping an assembly loader. The algorithm is purely functional — it does not read any external state — and matches the
+/// contract documented on <see cref="NotableDateRuleOverrideBody" />:
+/// </para>
+/// <list type="number">
+/// <item><description>Scalar fields: override body wins over flat <c>&lt;Use&gt;</c> attributes; flat attributes win over the inherited value.</description></item>
+/// <item><description>Name: override body's name wins, then the flat <c>as</c> attribute's local name, then the inherited name.</description></item>
+/// <item><description>Tags: additive union with the inherited set (set semantics, case-insensitive duplicates coalesced). <c>clearTags</c> discards the inherited baseline first.</description></item>
+/// <item><description>Adjustments: merge by <see cref="ObservanceAdjustment.Key" /> — matching keys replace in place, new keys append. <c>clearAdjustments</c> discards the inherited baseline first.</description></item>
+/// <item><description>Strategy: replaces wholesale when the override body declares one, otherwise inherited.</description></item>
+/// </list>
+/// </remarks>
+internal static class NotableDateRuleMerger
+{
+	/// <summary>
+	/// Returns a copy of <paramref name="source" /> with every override from <paramref name="directive" /> applied.
+	/// </summary>
+	/// <param name="source">The inherited rule being re-used.</param>
+	/// <param name="directive">The cherry-pick directive specifying the override.</param>
+	/// <returns>The merged rule.</returns>
+	public static NotableDateRule Apply(NotableDateRule source, NotableDateRuleUseDirective directive)
+	{
+		var body = directive.OverrideBody;
+
+		var merged = source with
+		{
+			Name = ResolveName(source.Name, directive.LocalName, body?.Name),
+			Category = body?.Category ?? directive.Category ?? source.Category,
+			TerritoryCode = body?.TerritoryCode ?? directive.TerritoryCode ?? source.TerritoryCode,
+			IsNonWorkingDay = body?.IsNonWorkingDay ?? directive.IsNonWorkingDay ?? source.IsNonWorkingDay,
+			FirstYear = body?.FirstYear ?? directive.FirstYear ?? source.FirstYear,
+			LastYear = body?.LastYear ?? directive.LastYear ?? source.LastYear,
+			OccurrenceYears = body?.OccurrenceYears ?? directive.OccurrenceYears ?? source.OccurrenceYears,
+			DurationDays = body?.DurationDays ?? directive.DurationDays ?? source.DurationDays,
+			Priority = body?.Priority ?? directive.Priority ?? source.Priority,
+			Comment = body?.Comment ?? directive.Comment ?? source.Comment,
+			CalendarType = body?.CalendarType ?? source.CalendarType,
+			Tags = MergeTags(source.Tags, body?.Tags ?? ImmutableArray<string>.Empty, directive.ClearTags),
+			Adjustments = MergeAdjustments(source.Adjustments, body?.Adjustments ?? ImmutableArray<ObservanceAdjustment>.Empty, directive.ClearAdjustments),
+		};
+
+		if (body?.Strategy is { } overrideStrategy)
+		{
+			merged = ApplyStrategyOverride(merged, overrideStrategy, body);
+		}
+
+		return merged;
+	}
+
+	private static string ResolveName(string sourceName, string? flatLocalName, string? bodyName)
+	{
+		if (!string.IsNullOrWhiteSpace(bodyName))
+			return bodyName!;
+		if (!string.IsNullOrWhiteSpace(flatLocalName))
+			return flatLocalName!;
+		return sourceName;
+	}
+
+	private static ImmutableHashSet<string> MergeTags(
+		ImmutableHashSet<string> inherited,
+		ImmutableArray<string> overrideTags,
+		bool clearTags)
+	{
+		var baseline = clearTags
+			? ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase)
+			: inherited;
+
+		if (overrideTags.IsDefaultOrEmpty)
+			return baseline;
+
+		var builder = baseline.ToBuilder();
+		foreach (var tag in overrideTags)
+		{
+			if (!string.IsNullOrWhiteSpace(tag))
+				builder.Add(tag);
+		}
+
+		return builder.ToImmutable();
+	}
+
+	private static ImmutableArray<ObservanceAdjustment> MergeAdjustments(
+		ImmutableArray<ObservanceAdjustment> inherited,
+		ImmutableArray<ObservanceAdjustment> overrideAdjustments,
+		bool clearAdjustments)
+	{
+		var baseline = clearAdjustments || inherited.IsDefault
+			? ImmutableArray<ObservanceAdjustment>.Empty
+			: inherited;
+
+		if (overrideAdjustments.IsDefaultOrEmpty)
+			return baseline;
+
+		var builder = baseline.ToBuilder();
+
+		foreach (var overrideAdjustment in overrideAdjustments)
+		{
+			var existingIndex = IndexOfKey(builder, overrideAdjustment.Key);
+			if (existingIndex >= 0)
+			{
+				builder[existingIndex] = overrideAdjustment;
+			}
+			else
+			{
+				builder.Add(overrideAdjustment);
+			}
+		}
+
+		return builder.ToImmutable();
+	}
+
+	private static int IndexOfKey(ImmutableArray<ObservanceAdjustment>.Builder builder, string key)
+	{
+		for (int i = 0; i < builder.Count; i++)
+		{
+			if (string.Equals(builder[i].Key, key, StringComparison.OrdinalIgnoreCase))
+				return i;
+		}
+
+		return -1;
+	}
+
+	private static NotableDateRule ApplyStrategyOverride(NotableDateRule rule, DateResolutionStrategy strategy, NotableDateRuleOverrideBody body) =>
+		strategy switch
+		{
+			DateResolutionStrategy.Fixed => rule with
+			{
+				Strategy = strategy,
+				Month = body.Month,
+				Day = body.Day,
+				DayOfWeek = null,
+				WeekOrdinal = null,
+				AnchorRuleName = null,
+				OffsetDays = null,
+				CalculatorKey = null,
+				CalculatorType = null,
+			},
+			DateResolutionStrategy.DayOfWeekInMonth => rule with
+			{
+				Strategy = strategy,
+				Month = body.Month,
+				Day = null,
+				DayOfWeek = body.DayOfWeek,
+				WeekOrdinal = body.WeekOrdinal,
+				AnchorRuleName = null,
+				OffsetDays = null,
+				CalculatorKey = null,
+				CalculatorType = null,
+			},
+			DateResolutionStrategy.OffsetFromAnchor => rule with
+			{
+				Strategy = strategy,
+				Month = null,
+				Day = null,
+				DayOfWeek = null,
+				WeekOrdinal = null,
+				AnchorRuleName = body.AnchorRuleName,
+				OffsetDays = body.OffsetDays,
+				CalculatorKey = null,
+				CalculatorType = null,
+			},
+			DateResolutionStrategy.Calculator => rule with
+			{
+				Strategy = strategy,
+				Month = null,
+				Day = null,
+				DayOfWeek = null,
+				WeekOrdinal = null,
+				AnchorRuleName = null,
+				OffsetDays = null,
+				CalculatorKey = body.CalculatorKey,
+				CalculatorType = body.CalculatorType,
+			},
+			_ => rule,
+		};
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleOverrideBody.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleOverrideBody.cs
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRuleOverrideBody.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using System.Collections.Immutable;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Specifies the override payload carried by the optional <c>&lt;Rule&gt;</c> child of a <c>&lt;Use&gt;</c> cherry-pick directive, used
+/// to extend or replace fields on the inherited <see cref="NotableDateRule" /> without redeclaring the rule in full.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every property is nullable or a default-empty immutable collection. Any property left at its default is interpreted as
+/// "inherit from the source rule"; any property with a value overrides the corresponding field during merge:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="Tags" /> are merged additively with the inherited set (set semantics, duplicates coalesced).</description></item>
+/// <item><description><see cref="Adjustments" /> are merged by <see cref="ObservanceAdjustment.Key" />: matching keys replace the inherited entry in place, new keys append to the end.</description></item>
+/// <item><description><see cref="Strategy" /> plus its attendant fields replace the inherited strategy wholesale when present.</description></item>
+/// <item><description>All scalar fields win over the flat attributes declared directly on the enclosing <c>&lt;Use&gt;</c>; this is the innermost-wins rule.</description></item>
+/// </list>
+/// </remarks>
+public sealed record NotableDateRuleOverrideBody
+{
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.Name" />.
+	/// </summary>
+	public string? Name { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.Category" />.
+	/// </summary>
+	public NotableDateCategory? Category { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.TerritoryCode" />.
+	/// </summary>
+	public string? TerritoryCode { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.IsNonWorkingDay" />.
+	/// </summary>
+	public bool? IsNonWorkingDay { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.FirstYear" />.
+	/// </summary>
+	public int? FirstYear { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.LastYear" />.
+	/// </summary>
+	public int? LastYear { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.OccurrenceYears" />.
+	/// </summary>
+	public int? OccurrenceYears { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.DurationDays" />.
+	/// </summary>
+	public int? DurationDays { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.Priority" />.
+	/// </summary>
+	public int? Priority { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.Comment" />.
+	/// </summary>
+	public string? Comment { get; init; }
+
+	/// <summary>
+	/// Gets the override for <see cref="NotableDateRule.CalendarType" />.
+	/// </summary>
+	public Type? CalendarType { get; init; }
+
+	/// <summary>
+	/// Gets the replacement <see cref="DateResolutionStrategy" />, or <see langword="null" /> to inherit the source strategy.
+	/// </summary>
+	public DateResolutionStrategy? Strategy { get; init; }
+
+	/// <summary>
+	/// Gets the month component used by <see cref="DateResolutionStrategy.Fixed" /> and <see cref="DateResolutionStrategy.DayOfWeekInMonth" />.
+	/// </summary>
+	public int? Month { get; init; }
+
+	/// <summary>
+	/// Gets the day-of-month used by <see cref="DateResolutionStrategy.Fixed" />.
+	/// </summary>
+	public int? Day { get; init; }
+
+	/// <summary>
+	/// Gets the day-of-week used by <see cref="DateResolutionStrategy.DayOfWeekInMonth" />.
+	/// </summary>
+	public DayOfWeek? DayOfWeek { get; init; }
+
+	/// <summary>
+	/// Gets the week ordinal used by <see cref="DateResolutionStrategy.DayOfWeekInMonth" />.
+	/// </summary>
+	public WeekOfMonthOrdinal? WeekOrdinal { get; init; }
+
+	/// <summary>
+	/// Gets the anchor rule name used by <see cref="DateResolutionStrategy.OffsetFromAnchor" />.
+	/// </summary>
+	public string? AnchorRuleName { get; init; }
+
+	/// <summary>
+	/// Gets the day offset used by <see cref="DateResolutionStrategy.OffsetFromAnchor" />.
+	/// </summary>
+	public int? OffsetDays { get; init; }
+
+	/// <summary>
+	/// Gets the calculator registry key used by <see cref="DateResolutionStrategy.Calculator" />.
+	/// </summary>
+	public string? CalculatorKey { get; init; }
+
+	/// <summary>
+	/// Gets the calculator CLR type used by <see cref="DateResolutionStrategy.Calculator" />.
+	/// </summary>
+	public Type? CalculatorType { get; init; }
+
+	/// <summary>
+	/// Gets the tags authored on the override. These merge additively with the inherited rule's tags.
+	/// </summary>
+	public ImmutableArray<string> Tags { get; init; } = ImmutableArray<string>.Empty;
+
+	/// <summary>
+	/// Gets the adjustments authored on the override. These merge with inherited adjustments by <see cref="ObservanceAdjustment.Key" />.
+	/// </summary>
+	public ImmutableArray<ObservanceAdjustment> Adjustments { get; init; } = ImmutableArray<ObservanceAdjustment>.Empty;
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -141,12 +141,17 @@ public static class NotableDateRuleParser
 
     /// <summary>
     /// Parses a single &lt;Use&gt; directive element into a
-    /// <see cref="NotableDateRuleUseDirective" />.
+    /// <see cref="NotableDateRuleUseDirective" />, including the optional nested &lt;Rule&gt;
+    /// override body and the <c>clearTags</c> / <c>clearAdjustments</c> flags.
     /// </summary>
     /// <param name="useElement">The &lt;Use&gt; XML element.</param>
     /// <returns>The parsed use directive.</returns>
-	private static NotableDateRuleUseDirective ParseUseDirective(XElement useElement) =>
-		new(
+	private static NotableDateRuleUseDirective ParseUseDirective(XElement useElement)
+	{
+		var overrideRuleElement = useElement.Element(Namespace + "Rule");
+		var overrideBody = overrideRuleElement is null ? null : ParseOverrideBody(overrideRuleElement);
+
+		return new NotableDateRuleUseDirective(
 			SourceRuleName: GetRequiredAttribute(useElement, "name"),
 			LocalName: GetOptionalAttribute(useElement, "as"),
 			Category: ParseOptionalEnum<NotableDateCategory>(useElement, "category"),
@@ -157,7 +162,113 @@ public static class NotableDateRuleParser
 			OccurrenceYears: ParseOptionalInt(useElement, "occurrenceYears"),
 			DurationDays: ParseOptionalInt(useElement, "durationDays"),
 			Priority: ParseOptionalInt(useElement, "priority"),
-			Comment: GetOptionalAttribute(useElement, "comment"));
+			Comment: GetOptionalAttribute(useElement, "comment"),
+			ClearTags: ParseOptionalBool(useElement, "clearTags") ?? false,
+			ClearAdjustments: ParseOptionalBool(useElement, "clearAdjustments") ?? false,
+			OverrideBody: overrideBody);
+	}
+
+    /// <summary>
+    /// Parses the nested &lt;Rule&gt; override body inside a &lt;Use&gt; directive into a
+    /// <see cref="NotableDateRuleOverrideBody" />.
+    /// </summary>
+    /// <remarks>
+    /// The nested form is structurally identical to a standalone &lt;Rule&gt; but every child
+    /// element is optional: the strategy may be absent (inherit the source strategy), and Tag
+    /// and Adjustment children are accumulated for merging by the flatten pipeline.
+    /// </remarks>
+	private static NotableDateRuleOverrideBody ParseOverrideBody(XElement ruleElement)
+	{
+		var strategyElement = ruleElement.Elements()
+			.FirstOrDefault(e => IsStrategyElement(e.Name.LocalName));
+
+		DateResolutionStrategy? strategy = strategyElement is null
+			? null
+			: strategyElement.Name.LocalName switch
+			{
+				"Fixed" => DateResolutionStrategy.Fixed,
+				"DayOfWeekInMonth" => DateResolutionStrategy.DayOfWeekInMonth,
+				"Calculator" => DateResolutionStrategy.Calculator,
+				"OffsetFromAnchor" => DateResolutionStrategy.OffsetFromAnchor,
+				_ => throw new InvalidOperationException($"Unknown strategy element '{strategyElement.Name.LocalName}' on override rule.")
+			};
+
+		var body = new NotableDateRuleOverrideBody
+		{
+			Name = GetOptionalAttribute(ruleElement, "name"),
+			Category = ParseOptionalEnum<NotableDateCategory>(ruleElement, "category"),
+			TerritoryCode = GetOptionalAttribute(ruleElement, "territory"),
+			IsNonWorkingDay = ParseOptionalBool(ruleElement, "nonWorking"),
+			FirstYear = ParseOptionalInt(ruleElement, "firstYear"),
+			LastYear = ParseOptionalInt(ruleElement, "lastYear"),
+			OccurrenceYears = ParseOptionalInt(ruleElement, "occurrenceYears"),
+			DurationDays = ParseOptionalInt(ruleElement, "durationDays"),
+			Priority = ParseOptionalInt(ruleElement, "priority"),
+			Comment = GetOptionalAttribute(ruleElement, "comment"),
+			CalendarType = ParseOptionalType<SysGlobal.Calendar>(ruleElement, "calendarType"),
+			Strategy = strategy,
+			Tags = ruleElement.Elements(Namespace + "Tag")
+				.Select(t => t.Value)
+				.Where(t => !string.IsNullOrWhiteSpace(t))
+				.ToImmutableArray(),
+			Adjustments = ruleElement.Elements(Namespace + "Adjustment")
+				.Select(ParseAdjustment)
+				.ToImmutableArray(),
+		};
+
+		if (strategyElement is not null)
+			body = ApplyStrategySpecificsToBody(body, strategyElement);
+
+		EnsureUniqueAdjustmentKeys(body.Adjustments, ruleElement);
+		return body;
+	}
+
+    /// <summary>
+    /// Applies the strategy-specific attributes on <paramref name="strategyElement" /> to the
+    /// override body. Mirrors <see cref="ApplyStrategySpecifics(NotableDateRule, XElement)" />
+    /// but writes to a <see cref="NotableDateRuleOverrideBody" />.
+    /// </summary>
+	private static NotableDateRuleOverrideBody ApplyStrategySpecificsToBody(NotableDateRuleOverrideBody body, XElement strategyElement) =>
+		body.Strategy switch
+		{
+			DateResolutionStrategy.Fixed => body with
+			{
+				Month = ParseMonth(GetRequiredAttribute(strategyElement, "month")),
+				Day = int.Parse(GetRequiredAttribute(strategyElement, "day"), CultureInfo.InvariantCulture),
+			},
+			DateResolutionStrategy.DayOfWeekInMonth => body with
+			{
+				Month = ParseMonth(GetRequiredAttribute(strategyElement, "month")),
+				DayOfWeek = ParseRequiredEnum<DayOfWeek>(strategyElement, "dayOfWeek"),
+				WeekOrdinal = ParseRequiredEnum<WeekOfMonthOrdinal>(strategyElement, "weekOrdinal"),
+			},
+			DateResolutionStrategy.OffsetFromAnchor => body with
+			{
+				AnchorRuleName = GetRequiredAttribute(strategyElement, "name"),
+				OffsetDays = int.Parse(GetRequiredAttribute(strategyElement, "offset"), CultureInfo.InvariantCulture),
+			},
+			DateResolutionStrategy.Calculator => body with
+			{
+				CalculatorKey = GetOptionalAttribute(strategyElement, "key"),
+				CalculatorType = ParseOptionalType<INotableDateCalculator>(strategyElement, "type"),
+			},
+			_ => body,
+		};
+
+    /// <summary>
+    /// Enforces the per-rule uniqueness invariant on adjustment keys — the same invariant the
+    /// merge pipeline relies on when deciding between replace and append semantics.
+    /// </summary>
+	private static void EnsureUniqueAdjustmentKeys(ImmutableArray<ObservanceAdjustment> adjustments, XElement contextElement)
+	{
+		var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+		foreach (var adjustment in adjustments)
+		{
+			if (!seen.Add(adjustment.Key))
+				throw new InvalidOperationException(
+					$"Duplicate adjustment key '{adjustment.Key}' on element '{contextElement.Name.LocalName}'. Keys must be unique within a single rule or override body.");
+		}
+	}
 
     /// <summary>
     /// Expands a single &lt;NotableDate&gt; XML element into its one-or-more
@@ -184,6 +295,12 @@ public static class NotableDateRuleParser
 				_ => throw new InvalidOperationException($"Unknown strategy element '{strategyElement.Name.LocalName}' on rule '{name}'.")
 			};
 
+			var adjustments = ruleElement.Elements(Namespace + "Adjustment")
+				.Select(ParseAdjustment)
+				.ToImmutableArray();
+
+			EnsureUniqueAdjustmentKeys(adjustments, ruleElement);
+
 			var rule = new NotableDateRule
 			{
 				Name = GetOptionalAttribute(ruleElement, "name") ?? name,
@@ -202,9 +319,7 @@ public static class NotableDateRuleParser
 					.Where(t => !string.IsNullOrWhiteSpace(t))
 					.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),
 				Comment = GetOptionalAttribute(ruleElement, "comment"),
-				Adjustments = ruleElement.Elements(Namespace + "Adjustment")
-					.Select(ParseAdjustment)
-					.ToImmutableArray(),
+				Adjustments = adjustments,
 			};
 
 			yield return ApplyStrategySpecifics(rule, strategyElement);
@@ -262,6 +377,7 @@ public static class NotableDateRuleParser
 	private static ObservanceAdjustment ParseAdjustment(XElement element) =>
 		new()
 		{
+			Key = GetRequiredAttribute(element, "key"),
 			Trigger = ParseRequiredEnum<AdjustmentTrigger>(element, "when"),
 			Action = ParseRequiredEnum<AdjustmentAction>(element, "action"),
 			DayOfWeek = ParseOptionalEnum<DayOfWeek>(element, "dayOfWeek"),

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
@@ -10,20 +10,24 @@ namespace Bodu.Globalization.Calendar;
 
 
 /// <summary>
-/// Specifies a single cherry-pick of a <see cref="NotableDateRule" /> from another resource, optionally renaming and overriding
-/// scalar properties on the inherited rule.
+/// Specifies a single cherry-pick of a <see cref="NotableDateRule" /> from another resource, optionally renaming the rule,
+/// overriding scalar properties on the inherited rule, and carrying a richer <see cref="OverrideBody" /> that can replace the
+/// strategy, add tags, or merge adjustments by key.
 /// </summary>
 /// <param name="SourceRuleName">The name of the rule to pull from the source resource. Matched case-insensitively.</param>
 /// <param name="LocalName">Optional local name. When supplied, the imported rule is exposed under this name instead of <paramref name="SourceRuleName" />.</param>
-/// <param name="Category">Optional category override.</param>
-/// <param name="TerritoryCode">Optional territory override.</param>
-/// <param name="IsNonWorkingDay">Optional non-working day override.</param>
+/// <param name="Category">Optional category override applied at the <c>&lt;Use&gt;</c> flat-attribute level.</param>
+/// <param name="TerritoryCode">Optional territory override applied at the <c>&lt;Use&gt;</c> flat-attribute level.</param>
+/// <param name="IsNonWorkingDay">Optional non-working day override applied at the <c>&lt;Use&gt;</c> flat-attribute level.</param>
 /// <param name="FirstYear">Optional inclusive first year override.</param>
 /// <param name="LastYear">Optional inclusive last year override.</param>
 /// <param name="OccurrenceYears">Optional recurrence cadence override.</param>
 /// <param name="DurationDays">Optional duration-in-days override.</param>
 /// <param name="Priority">Optional collision priority override.</param>
 /// <param name="Comment">Optional comment override.</param>
+/// <param name="ClearTags">When <see langword="true" />, inherited tags are discarded before the override's tags are applied.</param>
+/// <param name="ClearAdjustments">When <see langword="true" />, inherited adjustments are discarded before the override's adjustments are applied.</param>
+/// <param name="OverrideBody">Optional override body supplied via a nested <c>&lt;Rule&gt;</c> child. Fields on the body win over the flat attributes where both are present.</param>
 public sealed record NotableDateRuleUseDirective(
 	string SourceRuleName,
 	string? LocalName = null,
@@ -35,4 +39,7 @@ public sealed record NotableDateRuleUseDirective(
 	int? OccurrenceYears = null,
 	int? DurationDays = null,
 	int? Priority = null,
-	string? Comment = null);
+	string? Comment = null,
+	bool ClearTags = false,
+	bool ClearAdjustments = false,
+	NotableDateRuleOverrideBody? OverrideBody = null);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
@@ -44,13 +44,25 @@
   <!-- ============================================================
        Use: cherry-picks a single notable date rule by name from
        the enclosing UseFrom's source resource. Any scalar attribute
-       declared here overrides the inherited value; tags and
-       adjustments are inherited unchanged. The optional 'as'
-       attribute renames the rule locally.
+       declared here overrides the inherited value. A nested Rule
+       child provides an extensible override body: it may override
+       any scalar, replace the strategy element, add Tag children
+       (union-merged with inherited tags), or add Adjustment
+       children (merged by key). The optional clearTags and
+       clearAdjustments flags discard the inherited set before the
+       override is applied. When both a flat attribute on Use and
+       the nested Rule specify the same scalar, the nested Rule
+       wins (innermost-wins). The optional 'as' attribute renames
+       the rule locally.
        ============================================================ -->
   <xs:complexType name="Use">
+    <xs:sequence>
+      <xs:element name="Rule" type="nd:OverrideRule" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
     <xs:attribute name="name" type="xs:string" use="required" />
     <xs:attribute name="as" type="xs:string" use="optional" />
+    <xs:attribute name="clearTags" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="clearAdjustments" type="xs:boolean" use="optional" default="false" />
     <xs:attribute name="category" type="nd:notableDateCategory" use="optional" />
     <xs:attribute name="territory" type="nd:territory" use="optional" />
     <xs:attribute name="nonWorking" type="xs:boolean" use="optional" />
@@ -125,9 +137,75 @@
   </xs:complexType>
 
   <!-- ============================================================
+       OverrideRule: the payload form used inside a <Use> directive.
+       Mirrors Rule but relaxes two constraints: the strategy choice
+       is optional (a Use may add tags or adjustments without
+       replacing the inherited strategy), and no attribute is
+       required. Any field present here overrides the inherited
+       value; fields left absent fall through from the inherited
+       rule. Tag children merge additively with inherited tags;
+       Adjustment children merge by key (replace-if-matched,
+       append-if-new).
+       ============================================================ -->
+  <xs:complexType name="OverrideRule">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="1">
+        <xs:element name="Fixed">
+          <xs:complexType>
+            <xs:attribute name="day" type="nd:day" use="required" />
+            <xs:attribute name="month" type="nd:monthName" use="required" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="DayOfWeekInMonth">
+          <xs:complexType>
+            <xs:attribute name="month" type="nd:monthName" use="required" />
+            <xs:attribute name="dayOfWeek" type="nd:dayOfWeek" use="required" />
+            <xs:attribute name="weekOrdinal" type="nd:weekOrdinal" use="required" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="OffsetFromAnchor">
+          <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required" />
+            <xs:attribute name="offset" type="xs:int" use="required" />
+          </xs:complexType>
+        </xs:element>
+        <xs:element name="Calculator">
+          <xs:complexType>
+            <xs:attribute name="key" type="xs:string" use="optional" />
+            <xs:attribute name="type" type="nd:assemblyTypeName" use="optional" />
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+
+      <xs:element name="Tag" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
+      <xs:element name="Adjustment" type="nd:Adjustment" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+
+    <xs:attribute name="name" type="xs:string" use="optional" />
+    <xs:attribute name="category" type="nd:notableDateCategory" use="optional" />
+    <xs:attribute name="nonWorking" type="xs:boolean" use="optional" />
+    <xs:attribute name="firstYear" type="xs:unsignedShort" use="optional" />
+    <xs:attribute name="lastYear" type="xs:unsignedShort" use="optional" />
+    <xs:attribute name="occurrenceYears" type="xs:positiveInteger" use="optional" />
+    <xs:attribute name="durationDays" type="xs:positiveInteger" use="optional" />
+    <xs:attribute name="priority" type="xs:int" use="optional" />
+    <xs:attribute name="calendarType" type="nd:assemblyTypeName" use="optional" />
+    <xs:attribute name="territory" type="nd:territory" use="optional" />
+    <xs:attribute name="comment" type="xs:string" use="optional" />
+  </xs:complexType>
+
+  <!-- ============================================================
        Adjustment: a conditional date shift attached to a Rule.
+       The required 'key' attribute identifies the adjustment for
+       inheritance merging: when a <Use> override declares an
+       Adjustment with a key already present on the inherited
+       rule, the override replaces it in place; otherwise it is
+       appended. Keys are author-defined and should be unique
+       within a single rule's adjustment sequence; convention is
+       kebab-case (e.g. "weekend-roll", "boxing-day-monday-sub").
        ============================================================ -->
   <xs:complexType name="Adjustment">
+    <xs:attribute name="key" type="xs:string" use="required" />
     <xs:attribute name="when" type="nd:adjustmentTrigger" use="required" />
     <xs:attribute name="action" type="nd:adjustmentAction" use="required" />
     <xs:attribute name="dayOfWeek" type="nd:dayOfWeek" use="optional" />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
@@ -26,6 +26,23 @@ namespace Bodu.Globalization.Calendar;
 public sealed record ObservanceAdjustment
 {
 	/// <summary>
+	/// Gets the identifier used to merge this adjustment with inherited adjustments during <c>&lt;Use&gt;</c> directive resolution.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// When a <c>&lt;Use&gt;</c> override declares an adjustment whose <see cref="Key" /> matches one already on the inherited rule, the
+	/// override replaces the inherited entry at its current position; otherwise the override is appended. Keys are author-defined
+	/// strings, unique within a single rule's <see cref="NotableDateRule.Adjustments" /> sequence, and are by convention kebab-case
+	/// (for example <c>"weekend-roll"</c>, <c>"boxing-day-monday-sub"</c>, <c>"anzac-day-wa-observance"</c>).
+	/// </para>
+	/// <para>
+	/// The value is informational at run time — the <see cref="NotableDateAdjuster" /> evaluation pipeline does not consult
+	/// <see cref="Key" /> once the rule set has been flattened.
+	/// </para>
+	/// </remarks>
+	public required string Key { get; init; }
+
+	/// <summary>
 	/// Gets the condition that determines whether the adjustment activates for a given calculated date.
 	/// </summary>
 	public AdjustmentTrigger Trigger { get; init; }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/AU.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/AU.xml
@@ -33,6 +33,13 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <UseFrom resource="Bodu.Globalization.Calendar.Resources.Common.xml">
+    <!-- New Year's Day is inherited from Common and tagged locally as a national holiday via the nested Rule override. The
+         inherited Fixed January 1 strategy and the weekend-roll adjustment carry through unchanged. -->
+    <Use name="New Year's Day">
+      <Rule territory="AU" nonWorking="true">
+        <Tag>NationalHoliday</Tag>
+      </Rule>
+    </Use>
     <Use name="Valentine's Day" territory="AU" />
     <Use name="April Fool's Day" territory="AU" />
     <Use name="Halloween" territory="AU" />
@@ -52,20 +59,12 @@
   <!-- National (territory="AU")                                    -->
   <!-- ============================================================ -->
 
-  <NotableDate name="New Year's Day">
-    <Rule category="Holiday" territory="AU" nonWorking="true">
-      <Fixed month="January" day="1" />
-      <Tag>NationalHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
-    </Rule>
-  </NotableDate>
-
   <NotableDate name="Australia Day">
     <Rule category="Holiday" territory="AU" nonWorking="true"
           comment="Public holiday since 1994; substitute Monday observed when 26 January falls on a weekend.">
       <Fixed month="January" day="26" />
       <Tag>NationalHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -81,7 +80,7 @@
     <Rule category="Holiday" territory="AU" nonWorking="true">
       <Fixed month="December" day="26" />
       <Tag>NationalHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -203,7 +202,7 @@
           comment="Observed on 26 December in lieu of Boxing Day in South Australia.">
       <Fixed month="December" day="26" />
       <Tag>StateHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/Christian.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/Christian.xml
@@ -96,7 +96,7 @@
     <Rule category="Holiday" nonWorking="true">
       <Fixed month="December" day="25" />
       <Tag>Christian</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 </NotableDates>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/Common.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/Common.xml
@@ -10,7 +10,7 @@
   <NotableDate name="New Year's Day">
     <Rule category="Holiday" nonWorking="true">
       <Fixed month="January" day="1" />
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/GB.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/GB.xml
@@ -31,7 +31,7 @@
     <Rule category="Holiday" territory="GB" nonWorking="true">
       <Fixed month="January" day="1" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -40,7 +40,7 @@
     <Rule category="Holiday" territory="GB-SCT" nonWorking="true">
       <Fixed month="January" day="2" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -55,7 +55,7 @@
     <Rule category="Holiday" territory="GB-NIR" nonWorking="true">
       <Fixed month="March" day="17" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -86,7 +86,7 @@
     <Rule category="Holiday" territory="GB-NIR" nonWorking="true">
       <Fixed month="July" day="12" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -116,7 +116,7 @@
     <Rule category="Holiday" territory="GB-SCT" nonWorking="true">
       <Fixed month="November" day="30" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -125,7 +125,7 @@
     <Rule category="Holiday" territory="GB" nonWorking="true">
       <Fixed month="December" day="26" />
       <Tag>BankHoliday</Tag>
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 </NotableDates>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/US.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/US.xml
@@ -60,7 +60,7 @@
   <NotableDate name="Juneteenth">
     <Rule category="Holiday" territory="US" nonWorking="true" firstYear="2021">
       <Fixed month="June" day="19" />
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -74,7 +74,7 @@
   <NotableDate name="Independence Day">
     <Rule category="Holiday" territory="US" nonWorking="true">
       <Fixed month="July" day="4" />
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
@@ -96,7 +96,7 @@
   <NotableDate name="Veterans Day">
     <Rule category="Holiday" territory="US" nonWorking="true">
       <Fixed month="November" day="11" />
-      <Adjustment when="IfWeekend" action="MoveToNextWeekday" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
@@ -164,28 +164,15 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
 		new(rule.Name, rule.TerritoryCode);
 
     /// <summary>
-    /// Returns a copy of <paramref name="source" /> with any field overrides from
-    /// <paramref name="directive" /> applied (name, territory, observance adjustment, etc.).
+    /// Returns a copy of <paramref name="source" /> with every override from <paramref name="directive" /> applied via
+    /// <see cref="NotableDateRuleMerger.Apply" />. The merge algorithm lives in a dedicated helper so it can be exercised in
+    /// isolation without bootstrapping an assembly loader.
     /// </summary>
     /// <param name="source">The base rule being re-used.</param>
     /// <param name="directive">The &lt;Use&gt; directive specifying overrides.</param>
     /// <returns>The overridden rule.</returns>
-	private static NotableDateRule ApplyOverrides(NotableDateRule source, NotableDateRuleUseDirective directive)
-	{
-		return source with
-		{
-			Name = string.IsNullOrWhiteSpace(directive.LocalName) ? source.Name : directive.LocalName!,
-			Category = directive.Category ?? source.Category,
-			TerritoryCode = directive.TerritoryCode ?? source.TerritoryCode,
-			IsNonWorkingDay = directive.IsNonWorkingDay ?? source.IsNonWorkingDay,
-			FirstYear = directive.FirstYear ?? source.FirstYear,
-			LastYear = directive.LastYear ?? source.LastYear,
-			OccurrenceYears = directive.OccurrenceYears ?? source.OccurrenceYears,
-			DurationDays = directive.DurationDays ?? source.DurationDays,
-			Priority = directive.Priority ?? source.Priority,
-			Comment = directive.Comment ?? source.Comment,
-		};
-	}
+	private static NotableDateRule ApplyOverrides(NotableDateRule source, NotableDateRuleUseDirective directive) =>
+		NotableDateRuleMerger.Apply(source, directive);
 
 	/// <summary>
 	/// Compound dedupe key used inside the flatten pipeline. Two rules with the same name but different territories survive as

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAdjusterTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAdjusterTests.cs
@@ -47,6 +47,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Always,
 			Action = AdjustmentAction.AddDays,
 			OffsetDays = 3,
@@ -68,6 +69,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfWeekend,
 			Action = AdjustmentAction.MoveToNextWeekday,
 		};
@@ -88,6 +90,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfWeekend,
 			Action = AdjustmentAction.MoveToNextWeekday,
 		};
@@ -106,6 +109,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfDayOfWeek,
 			DayOfWeek = DayOfWeek.Friday,
 			Action = AdjustmentAction.AddDays,
@@ -128,6 +132,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster(isNonWorking: (d, t, c) => true);
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfNonWorkingDay,
 			Action = AdjustmentAction.AddDays,
 			OffsetDays = 2,
@@ -148,6 +153,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfLeapYear,
 			Action = AdjustmentAction.None,
 		};
@@ -168,6 +174,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfBeforeFixedDate,
 			Action = AdjustmentAction.AddDays,
 			OffsetDays = 7,
@@ -191,6 +198,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster();
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.IfNthOccurrenceInMonth,
 			Action = AdjustmentAction.None,
 			WeekOrdinal = WeekOfMonthOrdinal.Second,
@@ -216,6 +224,7 @@ public sealed class NotableDateAdjusterTests
 
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Always,
 			Action = AdjustmentAction.MoveToNextNonWorkingDay,
 		};
@@ -239,6 +248,7 @@ public sealed class NotableDateAdjusterTests
 
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Always,
 			Action = AdjustmentAction.ReplaceWithNamedDate,
 			TargetRuleName = "Boxing Day",
@@ -262,6 +272,7 @@ public sealed class NotableDateAdjusterTests
 		var adjuster = CreateAdjuster(handlers: registry);
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Custom,
 			Action = AdjustmentAction.Custom,
 			HandlerKey = "shift-by-five",
@@ -281,6 +292,7 @@ public sealed class NotableDateAdjusterTests
 	{
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Always,
 			Action = AdjustmentAction.None,
 			EffectiveFromYear = 2030,
@@ -299,6 +311,7 @@ public sealed class NotableDateAdjusterTests
 	{
 		var adjustment = new ObservanceAdjustment
 		{
+			Key = "test",
 			Trigger = AdjustmentTrigger.Always,
 			Action = AdjustmentAction.None,
 			TerritoryCode = "AU",

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
@@ -25,7 +25,7 @@ public partial class NotableDateRuleParserTests
 					<Fixed month=""January"" day=""1"" />
 					<Tag>Public</Tag>
 					<Tag>Civic</Tag>
-					<Adjustment when=""IfWeekend"" action=""MoveToNextWeekday"" priority=""10"" />
+					<Adjustment key=""weekend-roll"" when=""IfWeekend"" action=""MoveToNextWeekday"" priority=""10"" />
 				</Rule>
 			</NotableDate>
 		</NotableDates>";
@@ -62,7 +62,7 @@ public partial class NotableDateRuleParserTests
 			<NotableDate name=""New Year's Day"">
 				<Rule category=""Holiday"" nonWorking=""true"">
 					<Fixed month=""January"" day=""1"" />
-					<Adjustment when=""IfWeekend"" action=""MoveToNextWeekday"" priority=""1"" />
+					<Adjustment key=""weekend-roll"" when=""IfWeekend"" action=""MoveToNextWeekday"" priority=""1"" />
 				</Rule>
 			</NotableDate>
 			<NotableDate name=""Easter Sunday"">

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
@@ -69,6 +69,7 @@ public sealed class NotableDateServiceTests
 		{
 			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
 			{
+				Key = "test",
 				Trigger = AdjustmentTrigger.IfWeekend,
 				Action = AdjustmentAction.MoveToNextWeekday,
 			}),

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using Bodu.Extensions;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Xml.Schema;
@@ -42,7 +43,7 @@ public sealed class UseDirectiveInheritanceTests
 			"  </NotableDate>\n" +
 			"</NotableDates>";
 
-		Assert.ThrowsException<XmlSchemaValidationException>(() => NotableDateRuleParser.ParseDocument(xml));
+		Assert.ThrowsExactly<XmlSchemaValidationException>(() => NotableDateRuleParser.ParseDocument(xml));
 	}
 
 	/// <summary>
@@ -117,7 +118,7 @@ public sealed class UseDirectiveInheritanceTests
 			"  </UseFrom>\n" +
 			"</NotableDates>";
 
-		Assert.ThrowsException<InvalidOperationException>(() => NotableDateRuleParser.ParseDocument(xml));
+		Assert.ThrowsExactly<InvalidOperationException>(() => NotableDateRuleParser.ParseDocument(xml));
 	}
 
 	// ------------------------------------------------------------------------------------------

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
@@ -1,0 +1,377 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="UseDirectiveInheritanceTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using System.Linq;
+using System.Xml.Schema;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the extensible inheritance model for <c>&lt;Use&gt;</c> cherry-pick directives: nested <c>&lt;Rule&gt;</c> override body
+/// parsing, additive <c>&lt;Tag&gt;</c> merging, keyed <c>&lt;Adjustment&gt;</c> merging with replace-or-append semantics, and the
+/// <c>clearTags</c> / <c>clearAdjustments</c> opt-in reset flags. Parser coverage exercises the XML shape; merger coverage
+/// exercises the pure merge algorithm via <see cref="NotableDateRuleMerger" />.
+/// </summary>
+[TestClass]
+public sealed class UseDirectiveInheritanceTests
+{
+	private const string NamespaceHeader =
+		"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" +
+		"<NotableDates xmlns=\"urn:bodu:globalization:calendar\">\n";
+
+	// ------------------------------------------------------------------------------------------
+	// Parser: XML shape
+	// ------------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that an <c>&lt;Adjustment&gt;</c> element without a <c>key</c> attribute fails schema validation at parse time.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenAdjustmentMissingKey_ShouldThrowSchemaValidationException()
+	{
+		var xml = NamespaceHeader +
+			"  <NotableDate name=\"Test\">\n" +
+			"    <Rule category=\"Holiday\">\n" +
+			"      <Fixed month=\"January\" day=\"1\" />\n" +
+			"      <Adjustment when=\"IfWeekend\" action=\"MoveToNextWeekday\" />\n" +
+			"    </Rule>\n" +
+			"  </NotableDate>\n" +
+			"</NotableDates>";
+
+		Assert.ThrowsException<XmlSchemaValidationException>(() => NotableDateRuleParser.ParseDocument(xml));
+	}
+
+	/// <summary>
+	/// Verifies that a <c>&lt;Use&gt;</c> directive carrying a nested <c>&lt;Rule&gt;</c> is captured on the parsed directive's
+	/// <see cref="NotableDateRuleUseDirective.OverrideBody" /> and records the body's scalar override, tags, and adjustments.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenUseHasNestedRuleBody_ShouldPopulateOverrideBody()
+	{
+		var xml = NamespaceHeader +
+			"  <UseFrom resource=\"Bodu.Globalization.Calendar.Resources.Common.xml\">\n" +
+			"    <Use name=\"New Year's Day\" clearAdjustments=\"true\">\n" +
+			"      <Rule territory=\"AU\" nonWorking=\"true\">\n" +
+			"        <Tag>NationalHoliday</Tag>\n" +
+			"        <Adjustment key=\"weekend-roll\" when=\"IfWeekend\" action=\"MoveToNextWeekday\" />\n" +
+			"      </Rule>\n" +
+			"    </Use>\n" +
+			"  </UseFrom>\n" +
+			"</NotableDates>";
+
+		var document = NotableDateRuleParser.ParseDocument(xml);
+		var directive = document.UseGroups[0].Uses[0];
+
+		Assert.AreEqual("New Year's Day", directive.SourceRuleName);
+		Assert.IsTrue(directive.ClearAdjustments);
+		Assert.IsNotNull(directive.OverrideBody);
+		Assert.AreEqual("AU", directive.OverrideBody!.TerritoryCode);
+		Assert.AreEqual(true, directive.OverrideBody.IsNonWorkingDay);
+		CollectionAssert.Contains(directive.OverrideBody.Tags.ToArray(), "NationalHoliday");
+		Assert.AreEqual(1, directive.OverrideBody.Adjustments.Length);
+		Assert.AreEqual("weekend-roll", directive.OverrideBody.Adjustments[0].Key);
+	}
+
+	/// <summary>
+	/// Verifies that an override body with no strategy element records a null <see cref="NotableDateRuleOverrideBody.Strategy" />,
+	/// signalling to the merger that the inherited strategy should be kept intact.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenUseHasNestedRuleWithoutStrategy_ShouldLeaveStrategyNull()
+	{
+		var xml = NamespaceHeader +
+			"  <UseFrom resource=\"Bodu.Globalization.Calendar.Resources.Common.xml\">\n" +
+			"    <Use name=\"Halloween\">\n" +
+			"      <Rule territory=\"AU\">\n" +
+			"        <Tag>Cultural</Tag>\n" +
+			"      </Rule>\n" +
+			"    </Use>\n" +
+			"  </UseFrom>\n" +
+			"</NotableDates>";
+
+		var directive = NotableDateRuleParser.ParseDocument(xml).UseGroups[0].Uses[0];
+
+		Assert.IsNotNull(directive.OverrideBody);
+		Assert.IsNull(directive.OverrideBody!.Strategy);
+	}
+
+	/// <summary>
+	/// Verifies that two override adjustments sharing the same key inside one <c>&lt;Use&gt;</c> directive are rejected at parse
+	/// time, protecting the uniqueness invariant the merge algorithm relies on.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenOverrideDeclaresDuplicateAdjustmentKeys_ShouldThrow()
+	{
+		var xml = NamespaceHeader +
+			"  <UseFrom resource=\"Bodu.Globalization.Calendar.Resources.Common.xml\">\n" +
+			"    <Use name=\"New Year's Day\">\n" +
+			"      <Rule territory=\"AU\">\n" +
+			"        <Adjustment key=\"dup\" when=\"Always\" action=\"None\" />\n" +
+			"        <Adjustment key=\"dup\" when=\"IfWeekend\" action=\"None\" />\n" +
+			"      </Rule>\n" +
+			"    </Use>\n" +
+			"  </UseFrom>\n" +
+			"</NotableDates>";
+
+		Assert.ThrowsException<InvalidOperationException>(() => NotableDateRuleParser.ParseDocument(xml));
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Merger: algorithm
+	// ------------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that applying a directive with no override body falls back to the legacy flat-attribute behaviour — existing
+	/// cherry-picks in US.xml / GB.xml / FR.xml / AU.xml continue to produce the same merged rule.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenDirectiveHasNoOverrideBody_ShouldApplyFlatAttributesOnly()
+	{
+		var source = SampleSourceRule();
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			TerritoryCode: "AU",
+			IsNonWorkingDay: true);
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual("AU", merged.TerritoryCode);
+		Assert.AreEqual(true, merged.IsNonWorkingDay);
+		Assert.AreEqual(source.Strategy, merged.Strategy);
+		CollectionAssert.AreEquivalent(source.Tags.ToArray(), merged.Tags.ToArray());
+		CollectionAssert.AreEqual(source.Adjustments.ToArray(), merged.Adjustments.ToArray());
+	}
+
+	/// <summary>
+	/// Verifies that override tags merge additively with inherited tags under set semantics.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenOverrideBodyAddsTag_ShouldUnionWithInheritedTags()
+	{
+		var source = SampleSourceRule() with { Tags = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "Christian") };
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Tags = ImmutableArray.Create("NationalHoliday"),
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		CollectionAssert.AreEquivalent(new[] { "Christian", "NationalHoliday" }, merged.Tags.ToArray());
+	}
+
+	/// <summary>
+	/// Verifies that an override adjustment with a key matching one on the inherited rule replaces it in place, preserving its
+	/// position in the sequence.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenOverrideAdjustmentKeyMatchesInherited_ShouldReplaceInPlace()
+	{
+		var inherited = new ObservanceAdjustment
+		{
+			Key = "weekend-roll",
+			Trigger = AdjustmentTrigger.IfWeekend,
+			Action = AdjustmentAction.MoveToNextWeekday,
+		};
+		var source = SampleSourceRule() with { Adjustments = ImmutableArray.Create(inherited) };
+
+		var overrideAdjustment = new ObservanceAdjustment
+		{
+			Key = "weekend-roll",
+			Trigger = AdjustmentTrigger.IfWeekend,
+			Action = AdjustmentAction.MoveToPreviousWeekday,
+		};
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Adjustments = ImmutableArray.Create(overrideAdjustment),
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual(1, merged.Adjustments.Length);
+		Assert.AreEqual(AdjustmentAction.MoveToPreviousWeekday, merged.Adjustments[0].Action);
+	}
+
+	/// <summary>
+	/// Verifies that an override adjustment carrying a new key is appended to the inherited adjustment list.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenOverrideAdjustmentHasNewKey_ShouldAppend()
+	{
+		var inherited = new ObservanceAdjustment
+		{
+			Key = "weekend-roll",
+			Trigger = AdjustmentTrigger.IfWeekend,
+			Action = AdjustmentAction.MoveToNextWeekday,
+		};
+		var source = SampleSourceRule() with { Adjustments = ImmutableArray.Create(inherited) };
+
+		var extra = new ObservanceAdjustment
+		{
+			Key = "extra",
+			Trigger = AdjustmentTrigger.Always,
+			Action = AdjustmentAction.None,
+		};
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Adjustments = ImmutableArray.Create(extra),
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual(2, merged.Adjustments.Length);
+		Assert.AreEqual("weekend-roll", merged.Adjustments[0].Key);
+		Assert.AreEqual("extra", merged.Adjustments[1].Key);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateRuleUseDirective.ClearAdjustments" /> discards the inherited adjustment list before the
+	/// override is applied.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenClearAdjustmentsTrue_ShouldDropInheritedBeforeMerging()
+	{
+		var inherited = new ObservanceAdjustment
+		{
+			Key = "weekend-roll",
+			Trigger = AdjustmentTrigger.IfWeekend,
+			Action = AdjustmentAction.MoveToNextWeekday,
+		};
+		var source = SampleSourceRule() with { Adjustments = ImmutableArray.Create(inherited) };
+
+		var custom = new ObservanceAdjustment
+		{
+			Key = "custom",
+			Trigger = AdjustmentTrigger.Always,
+			Action = AdjustmentAction.None,
+		};
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			ClearAdjustments: true,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Adjustments = ImmutableArray.Create(custom),
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual(1, merged.Adjustments.Length);
+		Assert.AreEqual("custom", merged.Adjustments[0].Key);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateRuleUseDirective.ClearTags" /> with override tags yields a rule whose tags are exactly
+	/// the override set (inherited tags discarded).
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenClearTagsTrue_ShouldReplaceInheritedTags()
+	{
+		var source = SampleSourceRule() with
+		{
+			Tags = ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, "Christian", "Easter"),
+		};
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			ClearTags: true,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Tags = ImmutableArray.Create("Secular"),
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		CollectionAssert.AreEquivalent(new[] { "Secular" }, merged.Tags.ToArray());
+	}
+
+	/// <summary>
+	/// Verifies that an override body with no declared strategy preserves the inherited strategy and its strategy-specific fields.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenOverrideBodyHasNoStrategy_ShouldKeepInheritedStrategy()
+	{
+		var source = SampleSourceRule();
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				TerritoryCode = "AU",
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual(source.Strategy, merged.Strategy);
+		Assert.AreEqual(source.Month, merged.Month);
+		Assert.AreEqual(source.Day, merged.Day);
+	}
+
+	/// <summary>
+	/// Verifies that an override body that declares a new strategy replaces the inherited strategy wholesale and clears the stale
+	/// strategy-specific fields that no longer apply.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenOverrideBodyDeclaresNewStrategy_ShouldReplaceAndClearStaleFields()
+	{
+		var source = SampleSourceRule(); // Fixed strategy with Month=1, Day=1
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				Strategy = DateResolutionStrategy.DayOfWeekInMonth,
+				Month = 1,
+				DayOfWeek = DayOfWeek.Monday,
+				WeekOrdinal = WeekOfMonthOrdinal.First,
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual(DateResolutionStrategy.DayOfWeekInMonth, merged.Strategy);
+		Assert.AreEqual(1, merged.Month);
+		Assert.AreEqual(DayOfWeek.Monday, merged.DayOfWeek);
+		Assert.AreEqual(WeekOfMonthOrdinal.First, merged.WeekOrdinal);
+		Assert.IsNull(merged.Day, "Fixed.Day should be cleared when the strategy changes.");
+	}
+
+	/// <summary>
+	/// Verifies the innermost-wins rule: when a flat <c>&lt;Use&gt;</c> attribute and a nested <c>&lt;Rule&gt;</c> body both
+	/// specify the same scalar, the body value wins.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenFlatAndBodyBothSpecifyTerritory_ShouldUseBody()
+	{
+		var source = SampleSourceRule();
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			TerritoryCode: "AU",
+			OverrideBody: new NotableDateRuleOverrideBody
+			{
+				TerritoryCode = "NZ",
+			});
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual("NZ", merged.TerritoryCode);
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Test fixtures
+	// ------------------------------------------------------------------------------------------
+
+	private static NotableDateRule SampleSourceRule() => new()
+	{
+		Name = "New Year's Day",
+		Strategy = DateResolutionStrategy.Fixed,
+		Category = NotableDateCategory.Holiday,
+		Month = 1,
+		Day = 1,
+		IsNonWorkingDay = true,
+	};
+}


### PR DESCRIPTION
## Summary

Extends `<Use>` cherry-pick directives with an inheritance model that lets them add tags, replace or append adjustments by key, and override the strategy — without having to redeclare the rule in full. The original motivator was AU.xml locally redeclaring New Year's Day just to add a `NationalHoliday` tag to a rule already perfectly defined in `Common.xml`.

## Schema (`NotableDates.xsd`)

- **`<Adjustment>` gains a required `key`** — author-defined string, kebab-case by convention (`weekend-roll`, `boxing-day-monday-sub`). Used by the merger to decide replace vs append.
- **`<Use>` gains an optional nested `<Rule>`** of a new `OverrideRule` type (Rule-shaped, but optional strategy), plus boolean `clearTags` / `clearAdjustments` attributes.
- The existing flat-attribute `<Use name="..." territory="..." />` form continues to work unchanged — this is a pure extension.

## Merge algorithm (`NotableDateRuleMerger.Apply`)

| Field | Semantics |
|---|---|
| Scalars | override body > flat `<Use>` attributes > inherited |
| Name | body name > flat `as` local name > inherited |
| Tags | additive union with inherited; `clearTags` discards baseline first |
| Adjustments | merged by `Key` (replace-if-matched, append-if-new); `clearAdjustments` discards baseline first |
| Strategy | replaced wholesale when override declares one; stale strategy-specific fields cleared |

Extracted into a standalone `internal static class NotableDateRuleMerger` so the pure algorithm is unit-testable without bootstrapping the XML assembly-loader.

## Migration

Every `<Adjustment>` in the catalogue (16 elements across Common / Christian / GB / US / AU) was the same `IfWeekend + MoveToNextWeekday` pattern and now carries `key="weekend-roll"`. Existing programmatic `ObservanceAdjustment` constructions in `NotableDateAdjusterTests` / `NotableDateServiceTests` carry `Key = "test"` (14 sites patched mechanically).

## Demonstration in AU.xml

The local `New Year's Day` redeclaration is gone. Replaced by:

```xml
<Use name="New Year's Day">
  <Rule territory="AU" nonWorking="true">
    <Tag>NationalHoliday</Tag>
  </Rule>
</Use>
```

The inherited `<Fixed month="January" day="1" />` strategy and the `weekend-roll` adjustment carry through automatically. Existing AU behavioural tests remain green by construction.

## Test plan

- [ ] `dotnet build Bodu.sln` clean.
- [ ] New `UseDirectiveInheritanceTests` (15 cases) all pass — covers missing `key` → schema error, override body parsing, duplicate-key rejection, tag union, adjustment replace-by-key and append-by-new-key, `clearAdjustments` with and without override, `clearTags` replace-entire-set, inherited-strategy preservation, strategy wholesale replacement with stale-field clearing, and innermost-wins on scalar collision.
- [ ] `XmlResourceNotableDateRuleProviderTests` (existing) green — regression guard that all country resources still load.
- [ ] `AustralianNotableDatesTests` (existing) green — regression guard that AU's migration to nested-Rule cherry-pick produces the same dates, territories, and adjustments as before.
- [ ] `NotableDateAdjusterTests` and `NotableDateServiceTests` (existing) green after the mechanical `Key = "test"` additions.

## Files

**Added**
- `Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs`
- `Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleOverrideBody.cs`
- `Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs`

**Modified**
- `NotableDates.xsd` — `key` on Adjustment, nested-Rule + clear flags on Use, new OverrideRule type
- `ObservanceAdjustment.cs` — required `Key` property
- `NotableDateRuleUseDirective.cs` — `ClearTags`, `ClearAdjustments`, `OverrideBody`
- `NotableDateRuleParser.cs` — parse nested Rule override, clear flags, adjustment keys; enforce key uniqueness on main-Rule path
- `XmlResourceNotableDateRuleProvider.cs` — `ApplyOverrides` now delegates to the new merger
- `Resources/{Common,Christian,GB,US,AU}.xml` — `key="weekend-roll"` migration
- `Resources/AU.xml` — NYD migrated to nested-Rule cherry-pick
- `NotableDateAdjusterTests.cs`, `NotableDateServiceTests.cs` — `Key = "test"` on test-only constructions

https://claude.ai/code/session_01D6RS2dSvzv2dn8jzMzBFjE

---
_Generated by [Claude Code](https://claude.ai/code/session_01D6RS2dSvzv2dn8jzMzBFjE)_