### PR TITLE
docs: expand per-algorithm hashing guides across both packages

### DIFF
--- a/docs/guides/cryptography/cubehash.md
+++ b/docs/guides/cryptography/cubehash.md
@@ -1,0 +1,126 @@
+---
+title: Using CubeHash
+---
+
+# Using CubeHash
+
+CubeHash is Daniel J. Bernstein's 2008 submission to the NIST SHA-3 competition. It is a sponge-style hash built from a single simple permutation ("Cube"), parameterised by round counts and block size so you can dial the speed / margin trade-off. The default configuration reproduces the **CubeHash 16/32–512** variant submitted to the SHA-3 contest.
+
+The type is <xref:Bodu.Security.Cryptography.CubeHash>, and it derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>.
+
+## Tunable parameters at a glance
+
+| Property | Default | Range | Notes |
+|---|---|---|---|
+| `HashSize` | 512 bits | 8–512, multiple of 8 (`CubeHash.MinHashSize` / `MaxHashSize`) | Output width. |
+| `TransformBlockSize` | 32 bytes | 1–128 (`MinInputBlockSize` / `MaxInputBlockSize`) | Bytes absorbed per permutation call. Larger = faster per byte. |
+| `Rounds` | 16 | 1–4096 (`MinRounds` / `MaxRounds`) | Permutation rounds between blocks. More rounds = more margin, slower. |
+| `InitializationRounds` | 16 | 1–4096 | Permutation rounds during init. |
+| `FinalizationRounds` | 32 | 1–4096 | Permutation rounds after the last block. |
+
+The published naming convention is **CubeHash `r+b`/`w+f`-`h`** — initialisation rounds `i`, transform rounds `r`, block size `b`, finalisation rounds `f`, output bits `h`. `AlgorithmName` reflects the current configuration, e.g. `"CubeHash16+16/32+32-512"`.
+
+## Pattern 1 — default CubeHash (the SHA-3 submission)
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var cube = new CubeHash();              // default 512-bit output, 16/32-512 parameters
+byte[] digest = cube.ComputeHash(data);       // 64 bytes
+```
+
+This is the configuration referenced by most published CubeHash test vectors.
+
+## Pattern 2 — a shorter digest
+
+Reduce the hash size before hashing begins:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var cube = new CubeHash { HashSize = 256 };   // 32-byte digest
+byte[] digest = cube.ComputeHash(data);
+```
+
+`HashSize` must be a multiple of 8 between 8 and 512. It is only settable before the first `ComputeHash` / `TransformBlock` — changing it mid-stream would invalidate the state, so the setter throws once hashing has started.
+
+## Pattern 3 — trading speed for margin
+
+Increase the transform rounds or the block size to move along the speed / margin curve:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+// Faster: larger blocks, fewer rounds between them.
+using var fast = new CubeHash
+{
+    TransformBlockSize = 64,
+    Rounds             = 8,
+    HashSize           = 256,
+};
+
+// More conservative margin: smaller blocks, more rounds.
+using var safe = new CubeHash
+{
+    TransformBlockSize = 16,
+    Rounds             = 32,
+    FinalizationRounds = 64,
+    HashSize           = 512,
+};
+```
+
+All four round-count properties (`Rounds`, `InitializationRounds`, `FinalizationRounds`) and `TransformBlockSize` are only settable before the first `ComputeHash` / `TransformBlock`. The `AlgorithmName` surfaces the effective parameters:
+
+```csharp
+Console.WriteLine(fast.AlgorithmName);   // e.g. "CubeHash16+8/64+32-256"
+Console.WriteLine(safe.AlgorithmName);   // e.g. "CubeHash16+32/16+64-512"
+```
+
+## Pattern 4 — streaming
+
+CubeHash plugs into the BCL streaming shape:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var cube = new CubeHash();
+
+using var stream = File.OpenRead("archive.bin");
+byte[] digest = cube.ComputeHash(stream);
+```
+
+`CanReuseTransform` is `true`, so the same `CubeHash` instance can hash multiple independent inputs in a loop — call `Initialize()` between messages, or just let the next `ComputeHash` reset the state for you.
+
+## Pattern 5 — matching published test vectors
+
+The CubeHash test-vector files in the NIST competition submission use the notation `CubeHash i+r/b+f-h`. To reproduce a specific vector, set all four parameters plus `HashSize`:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+// CubeHash 16+32/32+32-256 — a common reference configuration.
+using var cube = new CubeHash
+{
+    InitializationRounds = 16,
+    Rounds               = 32,
+    TransformBlockSize   = 32,
+    FinalizationRounds   = 32,
+    HashSize             = 256,
+};
+```
+
+## When to use CubeHash
+
+- **Research** into sponge constructions, SHA-3 alternatives, or round-count vs speed trade-offs.
+- **Interoperability** with systems that use a specific CubeHash parameterisation.
+
+For new work without an interoperability requirement, the BCL's SHA-2 and SHA-3 families are hardware-accelerated and have broader analysis behind them. CubeHash's value is its knob-turnable parameter space — useful when that is specifically what you want.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — where CubeHash sits next to Tiger, SipHash, Snefru, and the non-cryptographic families.
+- [Using Tiger](tiger.md), [Using Snefru](snefru.md) — the other cryptographic digests in this package.
+- [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md).

--- a/docs/guides/cryptography/hashing.md
+++ b/docs/guides/cryptography/hashing.md
@@ -6,6 +6,15 @@ title: Using hashes and checksums
 
 **Bodu.Security.Cryptography** ships the library's keyed hashes (SipHash), one-time authenticators (Poly1305), cryptographic digests (Tiger, Snefru, CubeHash), and Merkle-tree hashing. All of them plug into the standard <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contract.
 
+This page is the cross-cutting overview — how the families relate, which to choose for which job, and how to verify a digest safely. For the full per-algorithm walk-throughs, see:
+
+- [Using SipHash](siphash.md) — keyed short-input PRF.
+- [Using Poly1305](poly1305.md) — one-time authenticator.
+- [Using Tiger](tiger.md) — 128 / 160 / 192-bit cryptographic digest.
+- [Using CubeHash](cubehash.md) — SHA-3 submission with tunable rounds and block size.
+- [Using Snefru](snefru.md) — legacy 128 / 256-bit digest (interop only).
+- [Using Merkle trees](merkle-trees.md) — tree-structured streaming integrity.
+
 > **Looking for CRC, Fletcher, Adler, FNV, CityHash, Pearson, Bernstein, BKDR, SDBM, JSHash, Elf64, ApHash, or Pjw32?** Those non-cryptographic families live in the companion <xref:Bodu.IO.Hashing> package, built on <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>. See the [Bodu.IO.Hashing guides](../io-hashing/).
 
 ## Pick the right tool

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -55,9 +55,18 @@ All five share the same high-level shape: a `SymmetricAlgorithm` (or `TweakableS
 
 ## Hashing
 
-[Using hashes and checksums](hashing.md) — concrete recipes for the classic non-cryptographic families (Adler, FNV, CityHash), keyed short-input hashes (SipHash), cryptographic digests (Tiger), and streaming integrity with `MerkleTreeHash` / `ParallelMerkleTreeHash`.
+Start with [Using hashes and checksums](hashing.md) for the cross-cutting picture — how the keyed, cryptographic, and Merkle-tree primitives relate, how to compute and verify digests, and when each one is the right tool. Then pick the per-algorithm page you need:
 
-For CRC and Fletcher checksums on `System.IO.Hashing.NonCryptographicHashAlgorithm`, see the [Bodu.IO.Hashing guides](../io-hashing/).
+| Type | Shape | Guide |
+|---|---|---|
+| `SipHash64` / `SipHash128` | Keyed PRF — hash-flooding defence | [Using SipHash](siphash.md) |
+| `Poly1305` | One-time authenticator | [Using Poly1305](poly1305.md) |
+| `Tiger` | 128 / 160 / 192-bit cryptographic digest | [Using Tiger](tiger.md) |
+| `CubeHash` | SHA-3 submission, tunable rounds and block size | [Using CubeHash](cubehash.md) |
+| `Snefru128` / `Snefru256` | Legacy cryptographic digest — interop only | [Using Snefru](snefru.md) |
+| `MerkleTreeHash` / `ParallelMerkleTreeHash` | Tree-structured streaming integrity | [Using Merkle trees](merkle-trees.md) |
+
+For non-cryptographic checksums and fingerprints (CRC, Fletcher, Adler, FNV, CityHash, Pearson, and the classic string hashes) on `System.IO.Hashing.NonCryptographicHashAlgorithm`, see the [Bodu.IO.Hashing guides](../io-hashing/).
 
 ## Related concepts
 

--- a/docs/guides/cryptography/merkle-trees.md
+++ b/docs/guides/cryptography/merkle-trees.md
@@ -1,0 +1,131 @@
+---
+title: Using Merkle trees
+---
+
+# Using Merkle trees
+
+A Merkle tree takes a stream, chops it into fixed-size leaves, hashes each leaf, then hashes groups of child hashes together, level by level, until one root hash remains. The root changes if any byte of the input changes — but because the tree is built bottom-up, you can also prove a single chunk's integrity without rehashing the whole stream.
+
+**Bodu.Security.Cryptography** ships two implementations:
+
+| Type | Shape | When to reach for it |
+|---|---|---|
+| <xref:Bodu.Security.Cryptography.MerkleTreeHash> | Synchronous, single-threaded | Simple, deterministic. Fine for most files and everyday use. |
+| <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Asynchronous, level-worker pipeline | Large inputs where leaf hashing and internal-node reduction should overlap. |
+
+Neither is itself a `HashAlgorithm` — both are composition wrappers that take a **factory** for the underlying hash (SHA-256, Tiger, anything that derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>) and orchestrate the tree on top of it.
+
+![Merkle tree construction](../../images/diagrams/merkle-tree.svg)
+
+## Pattern 1 — a simple Merkle root
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+using var merkle = new MerkleTreeHash(
+    algorithmFactory: () => SHA256.Create(),
+    blockSize:        4096,    // 4 KiB leaves
+    fanOut:           2);      // binary tree
+
+using var stream = File.OpenRead("archive.bin");
+byte[] root = merkle.ComputeHash(stream);
+```
+
+Each leaf is a SHA-256 of a 4 KiB block of the input. Each internal node is a SHA-256 of the concatenation of its two child hashes. The root changes if any byte of the file changes — that's the property a Merkle tree gives you over a flat hash.
+
+## Pattern 2 — wider fan-out
+
+A larger `fanOut` reduces tree depth (fewer levels of hashing), at the cost of more bytes concatenated per internal node:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+using var merkle = new MerkleTreeHash(
+    algorithmFactory: () => SHA256.Create(),
+    blockSize:        8192,
+    fanOut:           4);      // quaternary tree — shallower, wider internal nodes
+```
+
+Four child hashes concatenated is 4 × 32 = 128 bytes of input per internal SHA-256, still well inside one SHA-256 block.
+
+## Pattern 3 — a Tiger Tree Hash
+
+The TTH construction uses Tiger at the leaves and internal nodes, with domain-separation bytes (`0x00` for leaves, `0x01` for internal nodes) prepended to each hash input. The Bodu `MerkleTreeHash` does not prepend those separator bytes for you — if you need the exact TTH wire format, wrap the factory and prefix the bytes yourself. For a plain Merkle-over-Tiger digest, this is all you need:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var merkle = new MerkleTreeHash(
+    algorithmFactory: () => new Tiger(),
+    blockSize:        1024,
+    fanOut:           2);
+
+using var stream = File.OpenRead("archive.bin");
+byte[] tigerMerkleRoot = merkle.ComputeHash(stream);   // 24-byte root
+```
+
+## Pattern 4 — the parallel pipeline
+
+<xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> overlaps leaf production (reading + hashing input chunks) with internal-node reduction (grouping child hashes and hashing them into a parent). It exposes an **async** surface because the pipeline drives itself from a producer/consumer queue:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+using var merkle = new ParallelMerkleTreeHash(
+    algorithmFactory: () => SHA256.Create(),
+    blockSize:        4096,
+    fanOut:           2);
+
+using var stream = File.OpenRead("large-archive.bin");
+byte[] root = await merkle.ComputeHashAsync(stream, diagnostics: null, CancellationToken.None);
+```
+
+The parallel version produces the same root as the sequential one when called with the same `(algorithmFactory, blockSize, fanOut)` — the parallelism is in *how* the tree is built, not *what* tree is built. The level-worker / dispatcher layout is drawn in the [`ParallelMerkleTreeHash` class documentation](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
+
+![Parallel Merkle tree pipeline](../../images/diagrams/parallel-merkle-tree.svg)
+
+## Pattern 5 — capturing diagnostics
+
+`ParallelMerkleTreeHash.ComputeHashAsync` accepts an optional <xref:Bodu.Security.Cryptography.MerkleTreeDiagnostics> that records every node the pipeline built — level, index, child hashes, and the produced hash value. Useful when you want to visualise the tree, cross-check an implementation against a known-good one, or produce a Merkle proof for a specific leaf:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+var diagnostics = new MerkleTreeDiagnostics();
+
+using var merkle = new ParallelMerkleTreeHash(
+    algorithmFactory: () => SHA256.Create(),
+    blockSize:        4096,
+    fanOut:           2);
+
+byte[] root = await merkle.ComputeHashAsync(stream, diagnostics, CancellationToken.None);
+
+for (int level = 0; level < diagnostics.GetLevelCount(); level++)
+{
+    IReadOnlyList<MerkleTreeDiagnosticNode> nodes = diagnostics.GetLevel(level);
+    Console.WriteLine($"level {level}: {nodes.Count} nodes");
+}
+
+// Or dump the whole tree to a writer (one line per node):
+diagnostics.WriteTo(Console.Out);
+```
+
+Diagnostics are optional; pass `null` when you don't need them and the pipeline avoids the book-keeping overhead entirely. For strict equivalence checks, `diagnostics.Validate(() => SHA256.Create(), out var errors)` re-derives each internal node from its children and reports any that don't match.
+
+## When to use a Merkle tree
+
+- **Partial verification.** You want to prove that byte range `[N, M)` of a large file matches the original, without rehashing the whole file. The Merkle tree lets you do that with a logarithmic-size proof.
+- **Content addressing.** Git, IPFS, and BitTorrent all use Merkle (or Merkle-like) trees so that identical sub-contents can be deduplicated and so that corruption is detected at the chunk level.
+- **Streaming integrity.** You want to authenticate chunks of a stream as they arrive, without waiting for the whole thing to buffer.
+
+For a single end-to-end file digest where partial verification is not a requirement, a plain <xref:Bodu.Security.Cryptography.Tiger> or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> is simpler and does not need a tree.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — where Merkle trees sit alongside the other families.
+- [Using Tiger](tiger.md) — a common leaf-hash choice for content-addressed systems.
+- [`MerkleTreeHash` class doc](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) · [`ParallelMerkleTreeHash` class doc](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).

--- a/docs/guides/cryptography/poly1305.md
+++ b/docs/guides/cryptography/poly1305.md
@@ -1,0 +1,95 @@
+---
+title: Using Poly1305
+---
+
+# Using Poly1305
+
+Poly1305 is a one-time authenticator designed by Daniel J. Bernstein. Given a **fresh 32-byte key** and a message, it produces a 128-bit tag whose forgery probability — over the choice of key — is bounded by `(message_length / 16) · 2⁻¹⁰²`. That bound only holds while the key is used **exactly once**; reusing a Poly1305 key across two messages is a complete break.
+
+In practice Poly1305 is almost always used as the MAC half of an AEAD construction — most famously **ChaCha20-Poly1305** (RFC 8439), where the per-message Poly1305 key is derived by encrypting a block of zeros with ChaCha20 under a nonce.
+
+The type is <xref:Bodu.Security.Cryptography.Poly1305>, and it derives from <xref:System.Security.Cryptography.KeyedHashAlgorithm?displayProperty=nameWithType>.
+
+> [!IMPORTANT]
+> Poly1305 is a **one-shot authenticator**. `CanReuseTransform` is `false`, which is how the type signals at the API level that a key must not be used twice. Do not store a long-lived Poly1305 key — derive a fresh one per message.
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Key | 256 bits (32 bytes — `Poly1305.KeySize`) | Must be fresh per message. Low 16 bytes are clamped per RFC 8439. |
+| Tag | 128 bits (16 bytes) | Fixed. |
+| Block | 16 bytes | Fixed (the 130-bit arithmetic core). |
+
+## Pattern 1 — one-shot MAC
+
+The constructor already generates a fresh random key; for a real system you'll typically override that with a key derived from the stream cipher you're pairing with.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] message = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var poly = new Poly1305 { Key = perMessageKey };   // 32 bytes, fresh per message
+byte[] tag = poly.ComputeHash(message);                  // 16 bytes
+```
+
+`ComputeHash` may be called **once** per instance. Attempting to hash a second message will throw — deterministically, because `CanReuseTransform` is `false`. If you need to authenticate several messages, construct a new `Poly1305` for each one (or use Poly1305 only as the MAC inside an AEAD layer).
+
+## Pattern 2 — the ChaCha20-Poly1305 construction
+
+RFC 8439 defines the now-ubiquitous AEAD pairing: derive the per-message Poly1305 key by encrypting a 32-byte block of zeros with ChaCha20 under the same nonce, then authenticate the AEAD layout (AAD ‖ ciphertext ‖ lengths) with Poly1305.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+// Fresh per-message inputs
+byte[] chachaKey = LoadSharedKey();    // 32 bytes, long-lived
+byte[] nonce     = GenerateNonce();    // 12 bytes, unique per (key, message)
+
+// 1. Derive the Poly1305 key from the first 32 bytes of the ChaCha20 keystream.
+byte[] polyKey = ChaCha20Keystream(chachaKey, nonce, counter: 0).AsSpan(0, 32).ToArray();
+
+// 2. Encrypt the plaintext with ChaCha20 (counter = 1).
+byte[] ciphertext = ChaCha20Encrypt(chachaKey, nonce, counter: 1, plaintext);
+
+// 3. Build the Poly1305 input per RFC 8439 §2.8:
+//     AAD ‖ pad16(AAD) ‖ ciphertext ‖ pad16(ciphertext) ‖ len(AAD)₆₄ ‖ len(ciphertext)₆₄
+byte[] input = BuildRfc8439Input(aad, ciphertext);
+
+using var poly = new Poly1305 { Key = polyKey };
+byte[] tag = poly.ComputeHash(input);                    // 16-byte authentication tag
+```
+
+The key point: `polyKey` is fresh per message — it's a function of `(chachaKey, nonce)`. If the nonce is unique under a given long-lived key, the Poly1305 key is unique too, and the one-time property holds.
+
+(`ChaCha20Keystream`, `ChaCha20Encrypt`, and `BuildRfc8439Input` are placeholders here — use whichever ChaCha20 implementation you already depend on; the BCL's <xref:System.Security.Cryptography.ChaCha20Poly1305?displayProperty=nameWithType> gives you the whole AEAD in one step if you don't need to decompose the construction.)
+
+## Pattern 3 — verifying in constant time
+
+Compare a Poly1305 tag with <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*> or the `VerifyHash` helper from `Bodu.Security.Cryptography.Extensions`:
+
+```csharp
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+using var poly = new Poly1305 { Key = perMessageKey };
+bool authentic = poly.VerifyHash(aeadInput, receivedTag);
+```
+
+A `SequenceEqual` comparison leaks timing information and is unsafe for MAC verification — an attacker who can measure verification time can recover the tag byte-by-byte.
+
+## What Poly1305 is not
+
+- **Not a general-purpose MAC.** A single key authenticates a single message. For a long-lived MAC key, use HMAC (<xref:System.Security.Cryptography.HMACSHA256?displayProperty=nameWithType>) or KMAC.
+- **Not a hash.** Without a key, Poly1305 is trivially collidable. It is a **keyed** authenticator by construction.
+- **Not a standalone AEAD.** The authenticator alone provides integrity; pair it with a cipher (ChaCha20, or another stream-style primitive) to get confidentiality.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — where Poly1305 sits alongside SipHash, Tiger, and the non-cryptographic families.
+- [Using SipHash](siphash.md) — the keyed short-input hash; reusable key, not a one-shot.
+- [AEAD modes guide](aead-modes.md) — AES-based authenticated encryption in this package.
+- [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md).

--- a/docs/guides/cryptography/siphash.md
+++ b/docs/guides/cryptography/siphash.md
@@ -1,0 +1,133 @@
+---
+title: Using SipHash
+---
+
+# Using SipHash
+
+SipHash is a family of **keyed** pseudo-random functions designed by Aumasson and Bernstein for one specific job: defeating hash-flooding attacks on hash tables. It takes a 128-bit secret key and a message of any length, and produces a fixed-size digest that is prohibitively expensive to collide without knowledge of the key.
+
+**Bodu.Security.Cryptography** ships two widths:
+
+| Type | Output | Parameterisation (default) | When to reach for it |
+|---|---|---|---|
+| <xref:Bodu.Security.Cryptography.SipHash64> | 64 bits | SipHash-2-4 | The standard choice — hash-table keys, sharding, short fingerprints. |
+| <xref:Bodu.Security.Cryptography.SipHash128> | 128 bits | SipHash-2-4 | Longer output for content-addressing or de-duplication where 64 bits is uncomfortable. |
+
+Both derive from a shared `SipHash<T>` base and inherit from <xref:System.Security.Cryptography.KeyedHashAlgorithm?displayProperty=nameWithType>. The key is exactly **16 bytes** (the `SipHash<T>.KeySize` constant) — shorter or longer keys are rejected at configuration time.
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| `Key` | 128 bits (16 bytes) | Fixed by `SipHash<T>.KeySize`. Generate once, store in your process / vault. |
+| Output (`SipHash64`) | 64 bits (8 bytes) | — |
+| Output (`SipHash128`) | 128 bits (16 bytes) | — |
+| `CompressionRounds` | `>= 2` (default 2) | Inner rounds per 8-byte block. |
+| `FinalizationRounds` | `>= 4` (default 4) | Rounds applied once at the end. |
+
+## Pattern 1 — one-shot keyed hash
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+
+// 128-bit key — generated once, stored in your process / vault.
+byte[] key = new byte[SipHash64.KeySize];
+RandomNumberGenerator.Fill(key);
+
+byte[] message = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var sip = new SipHash64 { Key = key };
+byte[] digest = sip.ComputeHash(message);           // 8 bytes
+ulong  fingerprint = BitConverter.ToUInt64(digest);
+```
+
+Swap `SipHash64` for `SipHash128` when you need 128 bits of output; everything else stays the same.
+
+## Pattern 2 — the streaming `ComputeHash` / `TransformBlock` lifecycle
+
+SipHash inherits the standard BCL <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contract, so all the usual streaming affordances apply:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var sip = new SipHash128 { Key = key };
+
+using var stream = File.OpenRead("message.bin");
+byte[] digest = sip.ComputeHash(stream);
+```
+
+You can also drive it block-by-block with `TransformBlock` / `TransformFinalBlock`, or — simplest of all — with `ComputeHash(ReadOnlySpan<byte>)` from the BCL span overload.
+
+## Pattern 3 — adjusting the round count
+
+SipHash's two round parameters are the speed / margin trade-off: more rounds, more conservative margin, slower throughput. The defaults (`CompressionRounds = 2`, `FinalizationRounds = 4`) give you the published **SipHash-2-4**, which is what every standard library and protocol uses.
+
+```csharp
+// SipHash-4-8 — extra margin at roughly half the speed.
+using var sip = new SipHash64
+{
+    Key                 = key,
+    CompressionRounds   = 4,
+    FinalizationRounds  = 8,
+};
+```
+
+Both rounds must be set **before** the first `TransformBlock` / `ComputeHash` — the setters throw once hashing has started, since changing the schedule mid-stream would invalidate state. The reported `AlgorithmName` includes the parameterisation (e.g. `"SipHash-4-8-128"`), which is useful in logs and interop headers.
+
+```csharp
+using var sip = new SipHash128 { Key = key, CompressionRounds = 4, FinalizationRounds = 8 };
+Console.WriteLine(sip.AlgorithmName);   // "SipHash-4-8-128"
+```
+
+## Pattern 4 — bucketing or sharding
+
+A common use is to pick a bucket or shard from a user-controlled key. The key into SipHash must be **fixed process-wide** (so results are stable) and **secret** (so an attacker cannot pre-compute colliding inputs):
+
+```csharp
+using Bodu.Security.Cryptography;
+
+byte[] ShardKey()
+{
+    // Load once from a vault at startup. Do NOT regenerate per request.
+    return LoadSecretFromVault(name: "sharding-key-v1");
+}
+
+int ShardFor(ReadOnlySpan<byte> routeKey, int shardCount)
+{
+    using var sip = new SipHash64 { Key = ShardKey() };
+    byte[] digest = sip.ComputeHash(routeKey.ToArray());
+    ulong h = BitConverter.ToUInt64(digest);
+    return (int)(h % (ulong)shardCount);
+}
+```
+
+This is the canonical "use SipHash, not a non-cryptographic hash" case. An attacker who wants to overload a specific shard would have to invert SipHash without the key — which is what the algorithm is designed to prevent.
+
+## Pattern 5 — verifying in constant time
+
+When you compare a computed digest against a trusted one (e.g. a MAC check), **do not use `SequenceEqual`** — timing differences leak information. Use the BCL's fixed-time comparison, or the `VerifyHash` helper from `Bodu.Security.Cryptography.Extensions`:
+
+```csharp
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+using var sip = new SipHash64 { Key = key };
+bool ok = sip.VerifyHash(message, expectedDigest);
+```
+
+See the [hashing overview](hashing.md#pattern-4--verifying-a-hash) for the general pattern.
+
+## What SipHash is not
+
+- **Not a MAC for long messages.** SipHash was built specifically for short inputs; if you need a MAC over files or network frames, reach for HMAC-SHA-256 (<xref:System.Security.Cryptography.HMACSHA256?displayProperty=nameWithType>) or <xref:Bodu.Security.Cryptography.Poly1305>.
+- **Not a cryptographic hash.** SipHash is a PRF — it resists collision and preimage only while the key stays secret. For a keyless collision-resistant digest, use SHA-256 or <xref:Bodu.Security.Cryptography.Tiger>.
+- **Not deterministic across keys.** Two instances with different keys produce unrelated outputs for the same input. That is the point.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — how SipHash fits alongside cryptographic digests and non-cryptographic fingerprints.
+- [Using Tiger](tiger.md) — a keyless cryptographic digest when you don't have a secret to carry around.
+- [Using Poly1305](poly1305.md) — one-time authenticator that pairs with a stream cipher (the classic Poly1305/ChaCha20 AEAD construction).
+- [Bodu.IO.Hashing — FNV, CityHash, Adler](../io-hashing/) — the non-keyed, non-adversarial alternatives for trusted inputs.

--- a/docs/guides/cryptography/snefru.md
+++ b/docs/guides/cryptography/snefru.md
@@ -1,0 +1,71 @@
+---
+title: Using Snefru
+---
+
+# Using Snefru
+
+Snefru is a 1990 cryptographic hash by Ralph Merkle, named after the Egyptian pharaoh. It runs a block-mix function over the input and keeps the low half of the state as output. **Bodu.Security.Cryptography** ships both published widths:
+
+| Type | Output | Block size |
+|---|---|---|
+| <xref:Bodu.Security.Cryptography.Snefru128> | 128 bits | 48 bytes |
+| <xref:Bodu.Security.Cryptography.Snefru256> | 256 bits | 32 bytes |
+
+Both derive from a shared `Snefru<T>` base, which in turn derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>.
+
+> [!IMPORTANT]
+> Snefru is **cryptographically broken**. Eli Biham showed practical collisions on Snefru-2 (the published 2-pass variant) in 2008. The implementation in this package is provided for **interoperability with legacy systems and for research**, not for protecting real data. For any new work where you need a cryptographic hash, use the BCL's <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> / <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType>, or <xref:Bodu.Security.Cryptography.Tiger> if you need 192-bit output.
+
+## Pattern 1 — compute a digest
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var snefru = new Snefru256();
+byte[] digest   = snefru.ComputeHash(data);   // 32 bytes
+string hex      = Convert.ToHexString(digest);
+```
+
+Swap `Snefru256` for `Snefru128` for a 16-byte digest.
+
+## Pattern 2 — streaming
+
+Snefru inherits the standard BCL streaming shape:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var snefru = new Snefru256();
+using var stream = File.OpenRead("archive.bin");
+byte[] digest = snefru.ComputeHash(stream);
+```
+
+You can also drive it block-by-block via `TransformBlock` / `TransformFinalBlock`.
+
+## Pattern 3 — the two widths
+
+The two classes are completely independent — the block size differs (48 bytes for Snefru-128, 32 bytes for Snefru-256), and the outputs are not truncations of one another. Pick the width your interoperating system specifies.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var snefru128 = new Snefru128();   // 128-bit output, 48-byte blocks
+using var snefru256 = new Snefru256();   // 256-bit output, 32-byte blocks
+```
+
+## When to use Snefru
+
+- **Interoperability** with a legacy system that already uses Snefru (rare — Snefru is mostly of historical interest).
+- **Research** into early hash-function design, or as a test case for cryptanalysis tooling.
+
+For everything else, pick a modern digest. The [hashing overview](hashing.md) lists the options in this package; for brand-new work, the BCL's SHA-2 family is the right default.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — how Snefru compares to the other hashes in this package.
+- [Using Tiger](tiger.md) — another classic cryptographic hash with wider deployment.
+- [Using CubeHash](cubehash.md) — a modern, highly tunable cryptographic hash (SHA-3 finalist).
+- [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md).

--- a/docs/guides/cryptography/tiger.md
+++ b/docs/guides/cryptography/tiger.md
@@ -1,0 +1,123 @@
+---
+title: Using Tiger
+---
+
+# Using Tiger
+
+<xref:Bodu.Security.Cryptography.Tiger> is a 1995 cryptographic hash by Anderson and Biham, optimised for 64-bit platforms and widely deployed in file-transfer and content-addressing systems (most famously Direct Connect's Tiger Tree Hash). It processes 64-byte blocks and produces a **192-bit digest by default**, with 160-bit and 128-bit truncations available.
+
+Tiger derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, so any API that accepts a standard .NET hash accepts Tiger.
+
+> For new work where interoperability isn't a constraint, prefer the BCL's hardware-accelerated <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> or <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType>. Use Tiger when you need to match an existing Tiger-based system, or as part of a Tiger Tree Hash (see the Merkle tree guide).
+
+## Fixed sizes at a glance
+
+| Parameter | Size | Notes |
+|---|---|---|
+| Block size | 64 bytes (512 bits) | Fixed. |
+| Output | 192 bits (default), 160 bits, or 128 bits | Configurable via `HashSize`. |
+| Variant | `TigerHashingVariant.Tiger` (padding byte `0x01`) or `.Tiger2` (padding byte `0x80`) | Default is `Tiger`. |
+
+## Pattern 1 — a default 192-bit digest
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var tiger = new Tiger();                  // 192-bit, Tiger variant
+byte[] digest   = tiger.ComputeHash(data);      // 24 bytes
+string hex      = Convert.ToHexString(digest);
+```
+
+This matches the digest that a reference Tiger implementation would produce for the same input — 24 bytes, in the standard output layout.
+
+## Pattern 2 — choose a truncation
+
+Tiger accepts three output widths. 192 is the "real" Tiger; 160 and 128 are truncations of the same 192-bit internal state, useful when an external protocol fixes the digest size.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var tiger128 = new Tiger(hashSize: 128);  // 16-byte digest
+using var tiger160 = new Tiger(hashSize: 160);  // 20-byte digest
+using var tiger192 = new Tiger(hashSize: 192);  // 24-byte digest (the default)
+```
+
+`HashSize` is also settable on an existing instance, but only **before** the first block is processed:
+
+```csharp
+using var tiger = new Tiger { HashSize = 160 };
+byte[] digest = tiger.ComputeHash(data);
+```
+
+Attempting to change `HashSize` after `ComputeHash` / `TransformBlock` has begun throws — the schedule is fixed at the first call.
+
+## Pattern 3 — Tiger vs Tiger2
+
+Tiger's original specification used a padding byte of `0x01`. A later clarification (Tiger2) changed the padding byte to `0x80` to match the convention used by SHA-2 and other Merkle-Damgård hashes. The two variants produce **different digests** for the same input.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var tiger  = new Tiger  { Variant = TigerHashingVariant.Tiger  };   // default
+using var tiger2 = new Tiger  { Variant = TigerHashingVariant.Tiger2 };
+
+byte[] d1 = tiger .ComputeHash(data);
+byte[] d2 = tiger2.ComputeHash(data);
+// d1 != d2 — different padding byte → different digest.
+```
+
+Match the variant to whatever the interoperating system speaks. `AlgorithmName` reflects the configured hash size (it follows the `Tiger/{bits}` convention regardless of variant; include the variant alongside it when logging):
+
+```csharp
+using var tiger = new Tiger { Variant = TigerHashingVariant.Tiger2, HashSize = 160 };
+Console.WriteLine($"{tiger.AlgorithmName} ({tiger.Variant})");   // "Tiger/160 (Tiger2)"
+```
+
+## Pattern 4 — streaming a file
+
+Tiger plugs into any BCL API that takes a `HashAlgorithm`:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var tiger = new Tiger();
+
+using var stream = File.OpenRead("archive.bin");
+byte[] digest = tiger.ComputeHash(stream);
+```
+
+For larger files where you want to verify ranges of the file without rehashing the whole thing, pair Tiger with <xref:Bodu.Security.Cryptography.MerkleTreeHash> to build a Tiger Tree Hash — see the [Merkle trees guide](merkle-trees.md).
+
+## Pattern 5 — verifying a digest
+
+Compare digests in constant time. The `VerifyHash` helper in `Bodu.Security.Cryptography.Extensions` wraps <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*>:
+
+```csharp
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+byte[] expected = LoadExpectedDigest("report.pdf");
+
+using var tiger = new Tiger();
+bool ok = tiger.VerifyHash(fileBytes, expected);
+```
+
+A plain `SequenceEqual` leaks timing information and is unsafe when the result drives an authentication decision.
+
+## When to use Tiger
+
+- **Interoperability** with systems that already use Tiger — Direct Connect, the `tth:` URN scheme, older archive formats.
+- **Tiger Tree Hash** (Merkle tree of Tiger leaves) for content-addressable stores — pair with <xref:Bodu.Security.Cryptography.MerkleTreeHash>.
+- **Educational** or research settings where the round structure and S-boxes are the object of study.
+
+For new work without an interoperability constraint, prefer SHA-2 or SHA-3 from the BCL — both are hardware-accelerated on modern CPUs and have broader analysis behind them.
+
+## Where to go next
+
+- [Hashing overview](hashing.md) — where Tiger sits alongside SipHash, Snefru, CubeHash, and the non-cryptographic families.
+- [Merkle trees guide](merkle-trees.md) — build a Tiger Tree Hash over a stream.
+- [Using SipHash](siphash.md) — keyed short-input hash, for hash-table DoS resistance.
+- [Using CubeHash](cubehash.md), [Using Snefru](snefru.md) — other cryptographic digests in this package.

--- a/docs/guides/cryptography/toc.yml
+++ b/docs/guides/cryptography/toc.yml
@@ -13,6 +13,20 @@
   href: padding.md
 - name: Hashing and checksums
   href: hashing.md
+- name: Hashing algorithms
+  items:
+    - name: Using SipHash
+      href: siphash.md
+    - name: Using Poly1305
+      href: poly1305.md
+    - name: Using Tiger
+      href: tiger.md
+    - name: Using CubeHash
+      href: cubehash.md
+    - name: Using Snefru
+      href: snefru.md
+    - name: Using Merkle trees
+      href: merkle-trees.md
 - name: Symmetric algorithms
   items:
     - name: Threefish-256

--- a/docs/guides/io-hashing/adler.md
+++ b/docs/guides/io-hashing/adler.md
@@ -1,0 +1,108 @@
+---
+title: Using Adler
+---
+
+# Using Adler
+
+The Adler checksum — introduced by Mark Adler for zlib — maintains two running sums, **A** and **B**, reduced modulo a prime. It is cheap, position-dependent (so it catches transpositions), and the canonical <xref:Bodu.IO.Hashing.Adler32> is the checksum embedded in every zlib stream.
+
+**Bodu.IO.Hashing** provides three variants:
+
+| Type | Width | Modulus | Intended use |
+|---|---|---|---|
+| <xref:Bodu.IO.Hashing.Adler32> | 32 bits | 65521 (largest prime below 2¹⁶) | Canonical Adler-32 — zlib, PNG, rsync. |
+| <xref:Bodu.IO.Hashing.Adler32C> | 32 bits | 65536 | SIMD-friendly variant; faster on vector pipelines, **not** wire-compatible with Adler-32. |
+| <xref:Bodu.IO.Hashing.Adler64> | 64 bits | 4294967291 (largest prime below 2³²) | Extended width for long buffers where a 32-bit space is uncomfortable. |
+
+All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> via a shared `Adler<T>` base.
+
+## Pattern 1 — compute a digest in one call
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var adler = new Adler32();
+adler.Append(data);
+byte[] digest = adler.GetCurrentHash();
+string hex    = Convert.ToHexString(digest);   // 4 bytes, 8 hex characters
+```
+
+Swap `Adler32` for `Adler64` when you need the wider space, or for `Adler32C` when you want the SIMD-friendly modulus and don't need interoperability with zlib.
+
+## Pattern 2 — the `Append` / `GetCurrentHash` / `Reset` lifecycle
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var adler = new Adler32();
+
+adler.Append(chunk1);                       // update A and B
+adler.Append(chunk2);
+byte[] partial = adler.GetCurrentHash();    // snapshot, non-destructive
+adler.Append(chunk3);                       // state preserved after GetCurrentHash
+byte[] full = adler.GetCurrentHash();
+
+adler.Reset();                              // A = 1, B = 0 — zlib's canonical initial state
+```
+
+`GetCurrentHash` finalises on a copy of the accumulators, so calling it mid-stream is cheap and safe.
+
+## Pattern 3 — streaming a file
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var adler = new Adler32();
+
+using (FileStream fs = File.OpenRead("archive.bin"))
+{
+    byte[] buffer = new byte[64 * 1024];
+    int read;
+    while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+    {
+        adler.Append(buffer.AsSpan(0, read));
+    }
+}
+
+byte[] fingerprint = adler.GetCurrentHash();
+```
+
+There is no restriction on chunk size — the two-sum update is byte-by-byte internally, so arbitrary boundaries are safe.
+
+## Pattern 4 — wire-compatible zlib checksum
+
+A zlib stream carries an Adler-32 trailer in **big-endian** byte order. `GetCurrentHash` returns the digest in the BCL-standard big-endian layout already, so you can write it to the stream directly:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var adler = new Adler32();
+adler.Append(deflateOutput);
+
+// 4-byte big-endian Adler-32 trailer, per RFC 1950 §2.2.
+byte[] trailer = adler.GetCurrentHash();
+outputStream.Write(trailer);
+```
+
+## Picking a variant
+
+- **Need interoperability with zlib, PNG, rsync, or any tool that speaks RFC 1950?** Use <xref:Bodu.IO.Hashing.Adler32>. The modulus (65521) and initial state (`A=1, B=0`) are fixed by the specification.
+- **Hashing large buffers in a hot loop on a SIMD-capable CPU?** Use <xref:Bodu.IO.Hashing.Adler32C>. The power-of-two modulus removes the `% 65521` reduction and lets auto-vectorisation stay vectorised. The digest is **not** interchangeable with Adler-32.
+- **Checksumming very long streams where a 32-bit space is uncomfortable?** Use <xref:Bodu.IO.Hashing.Adler64>. Four bytes of digest become eight.
+
+## Adler vs Fletcher vs CRC
+
+- **Adler** is position-dependent and fast; weaker than CRC on short inputs (the first few bytes leave `A` small, so `B` grows slowly).
+- **Fletcher** uses a similar twin-accumulator structure with word-sized rather than byte-sized updates; comparable error-detection on uncorrelated noise, slightly different distribution.
+- **CRC** is polynomial-arithmetic over GF(2); better at catching the kind of burst errors common on physical links, and it is what wire formats usually specify.
+
+All three are **non-cryptographic** — none of them resists a motivated adversary. If you need authentication, see the [cryptography hashing guide](../cryptography/hashing.md).
+
+## Where to go next
+
+- [Using Fletcher](fletcher.md) — the other twin-accumulator family.
+- [Using CRC](crc.md) — the polynomial-arithmetic family.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/cityhash.md
+++ b/docs/guides/io-hashing/cityhash.md
@@ -1,0 +1,104 @@
+---
+title: Using CityHash
+---
+
+# Using CityHash
+
+CityHash is Google's family of fast, high-quality non-cryptographic hash functions. Each variant is carefully tuned for the input lengths it is asked to hash — short-key paths avoid loops entirely, medium-length paths use Murmur-style mixing, and long-input paths split the buffer into 64-byte chunks that are mixed in parallel. The result is a hash that is substantially faster than FNV or Adler on long inputs while distributing at least as well on short ones.
+
+**Bodu.IO.Hashing** ships three widths:
+
+| Type | Width | Notes |
+|---|---|---|
+| <xref:Bodu.IO.Hashing.CityHash32> | 32 bits | Small, fast, drop-in replacement for FNV-1a-32 as a hash-table function. |
+| <xref:Bodu.IO.Hashing.CityHash64> | 64 bits | The most common CityHash choice — 64-bit fingerprints for de-duplication, sharding, content addressing. |
+| <xref:Bodu.IO.Hashing.CityHash128> | 128 bits | Longer fingerprint space, still cheaper than a cryptographic digest. |
+
+All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> via a shared `CityHash<T>` base.
+
+## Pattern 1 — compute a digest in one call
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var city = new CityHash64();
+city.Append(data);
+byte[] digest = city.GetCurrentHash();
+string hex    = Convert.ToHexString(digest);   // 8 bytes, 16 hex characters
+```
+
+Substitute `CityHash32` or `CityHash128` when the width needs to change.
+
+## Pattern 2 — 64-bit fingerprint for deduplication or sharding
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+ulong FingerprintFor(ReadOnlySpan<byte> data)
+{
+    using var city = new CityHash64();
+    city.Append(data);
+    return BitConverter.ToUInt64(city.GetCurrentHash());
+}
+
+int shardFor = (int)(FingerprintFor(recordBytes) % (ulong)shardCount);
+```
+
+The distribution is good enough that `% shardCount` gives very close to uniform spread. The hash is **not** keyed — do not use this for adversary-facing sharding where crafted input could be used to overload a shard.
+
+## Pattern 3 — `Append` / `GetCurrentHash` / `Reset`
+
+CityHash's reference implementation is a one-shot algorithm: it reads the whole buffer, decides which length-specialised path to take, and returns a result. To plug that into the streaming <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract, the Bodu implementation **buffers the appended bytes** and applies the final mixing on `GetCurrentHash`.
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var city = new CityHash64();
+
+city.Append(chunk1);                       // stored
+city.Append(chunk2);                       // stored
+byte[] partial = city.GetCurrentHash();    // snapshot — mixes the buffered bytes
+city.Append(chunk3);                       // state preserved after GetCurrentHash
+byte[] full = city.GetCurrentHash();
+
+city.Reset();                              // discards the buffer
+```
+
+The practical consequence is that memory use grows linearly with the amount of data appended between `Reset` calls. If you need to hash a long stream without buffering, reach for <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Crc>, or one of the <xref:Bodu.IO.Hashing.Fletcher32>-family types — they update in place.
+
+## Pattern 4 — file hashing
+
+For files that comfortably fit in memory (tens or hundreds of MB), the streaming form is fine:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var city = new CityHash64();
+
+using (var stream = File.OpenRead("asset.bin"))
+    city.Append(stream);
+
+byte[] fingerprint = city.GetCurrentHash();
+```
+
+For very large files where you do not want the whole buffer in memory, do the hashing chunk-by-chunk with an incremental non-cryptographic algorithm (<xref:Bodu.IO.Hashing.Crc>, <xref:Bodu.IO.Hashing.Fnv1a64>) or use a Merkle tree — see the [cryptography hashing guide](../cryptography/hashing.md) for the `MerkleTreeHash` pattern.
+
+## CityHash vs the other non-cryptographic hashes in this package
+
+- **vs <xref:Bodu.IO.Hashing.Fnv1a64>** — CityHash is faster on long inputs (SIMD-friendly); FNV uses constant memory regardless of input size.
+- **vs <xref:Bodu.IO.Hashing.Adler32>** — Adler is tuned for short checksums and has a fixed 4-byte digest. CityHash dominates for general-purpose in-memory fingerprinting.
+- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is defined by wire specifications and has provable burst-error detection; CityHash is a better default when you control both endpoints and want the best speed/quality trade-off.
+- **vs <xref:Bodu.Security.Cryptography.SipHash64>** — SipHash is keyed and resists adversarial collisions; CityHash does not. Use SipHash whenever untrusted input can reach the hash function.
+
+CityHash is **not cryptographic**. An attacker who can choose inputs can construct collisions trivially. Do not use it to authenticate or to key-derive.
+
+## Where to go next
+
+- [Using FNV](fnv.md) — the simpler, streaming-friendly alternative.
+- [Using Adler](adler.md), [Using CRC](crc.md), [Using Fletcher](fletcher.md) — the checksum families.
+- [Cryptography hashing guide](../cryptography/hashing.md) — when you need SipHash's adversarial resistance or a cryptographic digest.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/fnv.md
+++ b/docs/guides/io-hashing/fnv.md
@@ -1,0 +1,117 @@
+---
+title: Using FNV
+---
+
+# Using FNV
+
+Fowler–Noll–Vo is a simple, very fast non-cryptographic hash: each input byte multiplies the running state by a prime and then XORs (FNV-1a) or XORs first then multiplies (FNV-1). It has excellent distribution for short strings and is the default hash in a long list of scripting languages, serialisers, and hash tables.
+
+**Bodu.IO.Hashing** ships the four canonical widths and variants:
+
+| Type | Width | Variant | When to reach for it |
+|---|---|---|---|
+| <xref:Bodu.IO.Hashing.Fnv132> | 32 bits | FNV-1 | Classic FNV-1 — legacy interop only. |
+| <xref:Bodu.IO.Hashing.Fnv1a32> | 32 bits | FNV-1a | General-purpose 32-bit fingerprint; the default choice at this width. |
+| <xref:Bodu.IO.Hashing.Fnv164> | 64 bits | FNV-1 | 64-bit FNV-1 — legacy interop only. |
+| <xref:Bodu.IO.Hashing.Fnv1a64> | 64 bits | FNV-1a | General-purpose 64-bit fingerprint; the default choice at this width. |
+
+All four derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> via a shared `Fnv<TSelf>` base, and all four expose the same API.
+
+> **FNV-1a is preferred over FNV-1.** The two variants differ only in the order of the XOR and multiplication — FNV-1a's "XOR first, multiply second" has better avalanche on short inputs and is what most reference implementations choose today. Use FNV-1 only when you need bit-for-bit compatibility with an existing system.
+
+## Pattern 1 — compute a digest in one call
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var fnv = new Fnv1a64();
+fnv.Append(data);
+byte[] digest = fnv.GetCurrentHash();
+string hex    = Convert.ToHexString(digest);   // 8 bytes, 16 hex characters
+```
+
+Substitute `Fnv1a32`, `Fnv164`, or `Fnv132` as needed.
+
+## Pattern 2 — fingerprint a short string for a hash table
+
+The canonical use of FNV is as a hash-table function. The 32-bit width is usually enough for in-process tables; reach for 64 bits when you want to keep the collision probability vanishingly small at a few million entries.
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+int FingerprintFor(string key)
+{
+    using var fnv = new Fnv1a32();
+    fnv.Append(Encoding.UTF8.GetBytes(key));
+    return BitConverter.ToInt32(fnv.GetCurrentHash());
+}
+```
+
+FNV is **not** keyed. An adversary who can choose inputs can construct collisions trivially — do not use it on data that crosses a trust boundary. For that case, use <xref:Bodu.Security.Cryptography.SipHash64>; see the [cryptography hashing guide](../cryptography/hashing.md).
+
+## Pattern 3 — `AlgorithmName` for logs and diagnostics
+
+Each FNV type exposes an `AlgorithmName` string that captures the variant and width, which is handy for logging or on-wire format headers:
+
+```csharp
+using var fnv = new Fnv1a64();
+Console.WriteLine(fnv.AlgorithmName);   // "FNV-1a-64"
+```
+
+## Pattern 4 — streaming a file
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var fnv = new Fnv1a64();
+
+using (FileStream fs = File.OpenRead("archive.bin"))
+{
+    byte[] buffer = new byte[64 * 1024];
+    int read;
+    while ((read = fs.Read(buffer, 0, buffer.Length)) > 0)
+    {
+        fnv.Append(buffer.AsSpan(0, read));
+    }
+}
+
+byte[] fingerprint = fnv.GetCurrentHash();
+```
+
+The update is byte-by-byte internally, so any chunking works — including buffers that cross record boundaries.
+
+## Pattern 5 — `Append` / `GetCurrentHash` / `Reset`
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var fnv = new Fnv1a64();
+
+fnv.Append(header);
+fnv.Append(body);
+byte[] mid = fnv.GetCurrentHash();    // snapshot, non-destructive
+fnv.Append(trailer);
+byte[] full = fnv.GetCurrentHash();
+
+fnv.Reset();                          // back to FNV offset basis
+```
+
+`Reset` restores the algorithm's published offset basis (`0x811C9DC5` for 32-bit, `0xCBF29CE484222325` for 64-bit). You cannot change the offset basis — if you need a different seed, pre-mix the seed bytes into the input before the first `Append`.
+
+## FNV vs the other non-cryptographic hashes in this package
+
+- **vs <xref:Bodu.IO.Hashing.Adler32>** — FNV distributes shorter inputs more evenly; Adler is marginally faster on long buffers and is the checksum specified by zlib / PNG.
+- **vs <xref:Bodu.IO.Hashing.CityHash64>** — CityHash is substantially faster on long inputs (SIMD-friendly by design) and distributes better on both short and long data. FNV wins on code simplicity and on determinism across languages/libraries.
+- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is specified for wire formats and has provably good burst-error detection; FNV is a better default for in-memory fingerprinting where you control both ends.
+- **vs <xref:Bodu.Security.Cryptography.SipHash64>** — SipHash is keyed and resists adversarial collisions; FNV does not. Pick SipHash whenever untrusted input can reach the hash function.
+
+## Where to go next
+
+- [Using CityHash](cityhash.md) — the SIMD-friendly modern alternative.
+- [Using Adler](adler.md) — twin-accumulator checksum with the same `NonCryptographicHashAlgorithm` shape.
+- [Cryptography hashing guide](../cryptography/hashing.md) — when FNV is not enough.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/index.md
+++ b/docs/guides/io-hashing/index.md
@@ -4,9 +4,9 @@ title: Bodu.IO.Hashing guides
 
 # Bodu.IO.Hashing guides
 
-Recipe-style walk-throughs for the **Bodu.IO.Hashing** package — the full CRC RevEng catalogue and the Fletcher family, built on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract.
+Recipe-style walk-throughs for the **Bodu.IO.Hashing** package — non-cryptographic checksums and fingerprints built on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract.
 
-If you're looking for the generated API reference, see the [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md).
+If you're looking for the generated API reference, see the [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md). For keyed or cryptographic hashes (SipHash, Poly1305, Tiger, CubeHash, Merkle trees), see the [Bodu.Security.Cryptography hashing guides](../cryptography/hashing.md).
 
 ## Start here
 
@@ -18,28 +18,76 @@ If you're looking for the generated API reference, see the [Bodu.IO.Hashing name
 </div>
 
 <div class="bodu-card">
+  <h3><a href="crc-catalogue.html">CRC catalogue</a></h3>
+  <p>The full table of named CRC standards, mechanically derived from the <a href="https://reveng.sourceforge.io/crc-catalogue/all.htm">CRC RevEng catalogue</a> — name, width, class, enum value, and every published alias.</p>
+</div>
+
+<div class="bodu-card">
   <h3><a href="fletcher.html">Using Fletcher</a></h3>
   <p>Choosing between Fletcher-16 / 32 / 64, the <code>Append</code> / <code>GetCurrentHash</code> / <code>Reset</code> lifecycle, the twin-accumulator structure, and when to prefer CRC instead.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="crc-catalogue.html">CRC catalogue</a></h3>
-  <p>The full table of named CRC standards, mechanically derived from the <a href="https://reveng.sourceforge.io/crc-catalogue/all.htm">CRC RevEng catalogue</a> — name, width, class, enum value, and every published alias.</p>
+  <h3><a href="adler.html">Using Adler</a></h3>
+  <p>Adler-32 for zlib-compatible checksums, Adler-32C for SIMD-friendly throughput, and Adler-64 for very long streams — twin-accumulator checksums with a prime modulus.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="fnv.html">Using FNV</a></h3>
+  <p>FNV-1 and FNV-1a at 32-bit and 64-bit widths — the simple, fast, textbook fingerprint for in-memory hash tables and short keys.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="cityhash.html">Using CityHash</a></h3>
+  <p>32-, 64-, and 128-bit CityHash — Google's SIMD-friendly fingerprint for long inputs. Faster and better-distributed than FNV on large buffers, at the cost of in-memory buffering.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="pearson.html">Using Pearson</a></h3>
+  <p>Pearson's table-driven hash with output widths from 8 bits to 2048 bits, four built-in permutation tables, and a user-defined table option.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="string-hashes.html">Classic string hashes</a></h3>
+  <p>Bernstein (djb2), BKDR, SDBM, JSHash, Elf64, ApHash, PJW — the one-liner hash functions from compilers, textbooks, and early web servers.</p>
 </div>
 
 </div>
 
-## Picking the right checksum
+## Picking the right hash
 
 | If you need… | Reach for | Why |
 |---|---|---|
-| A standard on-the-wire checksum (zlib / PNG / Ethernet / PKZIP) | <xref:Bodu.IO.Hashing.Crc> + <xref:Bodu.IO.Hashing.CrcStandard.CRC32_ISOHDLC> | Canonical CRC-32; the result is interoperable with every tool that speaks one of the listed formats. |
+| A standard on-the-wire checksum (zlib / PNG / Ethernet / PKZIP) | <xref:Bodu.IO.Hashing.Crc> + <xref:Bodu.IO.Hashing.CrcStandard.CRC32_ISOHDLC>, or <xref:Bodu.IO.Hashing.Adler32> | Canonical wire formats; the result is interoperable with every tool that speaks the format. |
 | A modern hardware-friendly 32-bit CRC (iSCSI, Btrfs, NVMe, SCTP) | <xref:Bodu.IO.Hashing.Crc> + <xref:Bodu.IO.Hashing.CrcStandard.CRC32_ISCSI> | Castagnoli polynomial; better error-detection properties than ISO-HDLC and the choice for modern protocols. |
 | A short, cheap checksum that still catches transpositions | <xref:Bodu.IO.Hashing.Fletcher16> / <xref:Bodu.IO.Hashing.Fletcher32> / <xref:Bodu.IO.Hashing.Fletcher64> | Twin-accumulator design detects swaps that a simple sum or XOR misses. |
+| A fast, streaming-friendly fingerprint for short keys | <xref:Bodu.IO.Hashing.Fnv1a32> / <xref:Bodu.IO.Hashing.Fnv1a64> | Constant-memory, portable, same result everywhere. |
+| The fastest in-memory fingerprint you can get | <xref:Bodu.IO.Hashing.CityHash64> / <xref:Bodu.IO.Hashing.CityHash128> | SIMD-friendly design with excellent distribution; buffers the input in memory. |
+| An output width that isn't a native integer size | <xref:Bodu.IO.Hashing.Pearson> | 8–2048 bits in 8-bit steps, parallel accumulators per byte. |
 | An obscure standard from a serial protocol or silicon datasheet | <xref:Bodu.IO.Hashing.Crc> + one of the 113 entries in [the catalogue](crc-catalogue.md) | Every canonical RevEng entry is reachable through <xref:Bodu.IO.Hashing.CrcStandards>, including aliases. |
 | A hash that's safe against an adversary (not just noise) | Not here — see <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.Tiger>, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> | Everything in this library is **non-cryptographic**. Attackers can forge collisions trivially. |
 
+## One shape, many algorithms
+
+Everything in this package derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>, so the lifecycle is identical regardless of which algorithm you pick:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var hash = new Crc();      // or Fletcher32, Adler32, Fnv1a64, CityHash64, …
+
+hash.Append(chunk1);
+hash.Append(chunk2);
+byte[] partial = hash.GetCurrentHash();   // snapshot, non-destructive
+hash.Append(chunk3);
+byte[] full = hash.GetCurrentHash();
+
+hash.Reset();                              // back to the initial state
+```
+
+Only CRC currently implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> (reverse-finalise an earlier digest, append new bytes, finalise again) — see the [CRC guide](crc.md#pattern-6--resume-from-a-stored-digest).
+
 ## Cross-references
 
-- [Bodu.Security.Cryptography hashing guide](../cryptography/hashing.md) — keyed hashes (SipHash), cryptographic digests (Tiger), Merkle trees, verifying hashes in constant time.
+- [Bodu.Security.Cryptography hashing guide](../cryptography/hashing.md) — keyed hashes (SipHash), cryptographic digests (Tiger, CubeHash, Snefru), one-time authenticators (Poly1305), and Merkle trees.
 - [Bodu.IO.Hashing API reference](../../apidoc/Bodu.IO.Hashing.md) — namespace overview with key types.

--- a/docs/guides/io-hashing/pearson.md
+++ b/docs/guides/io-hashing/pearson.md
@@ -1,0 +1,125 @@
+---
+title: Using Pearson
+---
+
+# Using Pearson
+
+Peter Pearson's 1990 hash is a table-driven function with a single simple rule: for each input byte `b`, set `h = T[h XOR b]`, where `T` is a **permutation** of the 256 byte values. The permutation's quality defines the hash's distribution, and because the update is one indexed XOR per byte, it is both very fast and very easy to extend to arbitrary output widths by running several parallel accumulators with shifted starting states.
+
+**Bodu.IO.Hashing** provides a single <xref:Bodu.IO.Hashing.Pearson> type with:
+
+- An output size configurable from **8 bits to 2048 bits** in 8-bit steps.
+- A choice of four built-in permutation tables, plus a **user-defined** table.
+
+The type derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
+
+## Pattern 1 — the canonical 8-bit Pearson
+
+The parameterless constructor gives you the classic single-byte Pearson hash with Pearson's original permutation table.
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("example");
+
+using var pearson = new Pearson();        // 8-bit output, Pearson's canonical table
+pearson.Append(data);
+byte[] digest = pearson.GetCurrentHash();  // 1 byte
+```
+
+An 8-bit hash is only useful as a coarse bucket index — 256 distinct buckets before guaranteed collisions. For anything more interesting, pick a wider width.
+
+## Pattern 2 — a wider output
+
+Any width from 8 to 2048 bits in 8-bit steps is supported. The implementation runs one parallel accumulator per output byte, each seeded with a different offset into the table; their concatenation is the final digest.
+
+```csharp
+using Bodu.IO.Hashing;
+
+// 128-bit Pearson with the canonical permutation.
+using var pearson = new Pearson(hashSizeBits: 128, tableType: PearsonTableType.Pearson);
+pearson.Append(data);
+byte[] digest = pearson.GetCurrentHash();  // 16 bytes
+```
+
+`hashSizeBits` must be a multiple of 8 between `Pearson.MinHashSizeBits` (8) and `Pearson.MaxHashSizeBits` (2048).
+
+## Pattern 3 — pick a permutation table
+
+The table defines the hash. Bodu ships five choices:
+
+| `PearsonTableType` | Source |
+|---|---|
+| `Pearson` | Pearson's original 1990 table — the historically canonical choice. |
+| `AESSBox` | The AES S-box, used as a permutation (it already is one). |
+| `CRC32HighByte` | The high byte of the standard CRC-32 lookup table. |
+| `SHA256Constants` | A permutation derived from SHA-256's round constants. |
+| `UserDefined` | A 256-byte permutation you supply. |
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var pearson = new Pearson(hashSizeBits: 64, tableType: PearsonTableType.AESSBox);
+```
+
+All four built-in tables are **permutations** — every byte 0–255 appears exactly once. This is the property Pearson relies on; it is checked at construction time, so a table with duplicates or missing values is rejected.
+
+## Pattern 4 — a user-supplied table
+
+Pass a 256-byte permutation directly to the constructor:
+
+```csharp
+using Bodu.IO.Hashing;
+
+byte[] permutation = BuildMyPermutation();   // must be a permutation of 0..255
+
+using var pearson = new Pearson(hashSizeBits: 256, permutationTable: permutation);
+```
+
+Constructing `Pearson` with `permutationTable`:
+
+- Validates that the array is exactly 256 bytes long and is a valid permutation (every value 0–255 appears exactly once).
+- Clones the array, so later mutation of your buffer does not affect the hash.
+- Reports `TableType == PearsonTableType.UserDefined`.
+
+You can read the table back (as a clone) through the `Table` property — handy for round-tripping the configuration or for diagnostics:
+
+```csharp
+byte[] tableCopy = pearson.Table;
+```
+
+## Pattern 5 — `Append` / `GetCurrentHash` / `Reset`
+
+Pearson follows the standard `NonCryptographicHashAlgorithm` lifecycle:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var pearson = new Pearson(hashSizeBits: 64, tableType: PearsonTableType.Pearson);
+
+pearson.Append(chunk1);
+pearson.Append(chunk2);
+byte[] partial = pearson.GetCurrentHash();   // snapshot, non-destructive
+pearson.Append(chunk3);
+byte[] full = pearson.GetCurrentHash();
+
+pearson.Reset();                             // back to the initial offsets
+```
+
+`GetCurrentHash` finalises on a copy, so mid-stream snapshots are cheap and do not disturb in-progress hashing.
+
+## Pearson vs the other non-cryptographic hashes
+
+- **vs <xref:Bodu.IO.Hashing.Fnv1a32>** — FNV-1a has better distribution on short inputs and no table memory footprint. Pearson wins when you need a specific output width (e.g. 96 or 160 bits) without stretching a native-width hash.
+- **vs <xref:Bodu.IO.Hashing.CityHash64>** — CityHash is much faster on long inputs and distributes better. Reach for Pearson when you want the table to be a tunable parameter — e.g. in academic work on hash-function quality.
+- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is specified for wire formats and has provable burst-error detection. Pearson is a general-purpose fingerprint, not a checksum with error-detection guarantees.
+
+Pearson is **not cryptographic**. Choosing a different table does not make it adversary-resistant — an attacker who knows the table can construct collisions immediately. For adversarial settings, use <xref:Bodu.Security.Cryptography.SipHash64>.
+
+## Where to go next
+
+- [Using FNV](fnv.md), [Using CityHash](cityhash.md) — faster, table-free alternatives.
+- [Classic string hashes](string-hashes.md) — Bernstein, BKDR, SDBM, Elf64, and siblings with a similar "one-liner" feel.
+- [Cryptography hashing guide](../cryptography/hashing.md) — when Pearson is not enough.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/string-hashes.md
+++ b/docs/guides/io-hashing/string-hashes.md
@@ -1,0 +1,122 @@
+---
+title: Classic string hashes
+---
+
+# Classic string hashes
+
+A collection of the classic "one-liner" hash functions that appear in textbooks, compilers, and early web servers. They all produce a 32-bit or 64-bit output, none of them takes a key, and their public API is identical — configure any optional seed, call `Append` to feed data, and call `GetCurrentHash` to read the digest.
+
+**None of these are cryptographic.** They are in the package for interoperability with legacy systems, for teaching purposes, and for use inside a trust boundary where collision-DoS is not a concern. For anything adversary-facing, use <xref:Bodu.Security.Cryptography.SipHash64>; see the [cryptography hashing guide](../cryptography/hashing.md).
+
+## The family at a glance
+
+| Type | Width | Seed / configuration | Origin |
+|---|---|---|---|
+| <xref:Bodu.IO.Hashing.Bernstein> | 32 bits | `InitialValue` (default `5381`), `UseModifiedAlgorithm` (xor vs add) | Daniel J. Bernstein's "djb2", posted to `comp.lang.c`. |
+| <xref:Bodu.IO.Hashing.BKDR> | 32 bits | `Seed` — one of a published set of odd multipliers | Kernighan & Ritchie, *The C Programming Language*. |
+| <xref:Bodu.IO.Hashing.SDBM> | 32 bits | None | The SDBM public-domain database. |
+| <xref:Bodu.IO.Hashing.JSHash> | 32 bits | None (seed `0x4E67C6A7`) | Justin Sobel's JavaScript-origin hash. |
+| <xref:Bodu.IO.Hashing.Elf64> | 64 bits | `Seed` (default `0`) | The ELF symbol-table hash, widened to 64 bits. |
+| <xref:Bodu.IO.Hashing.ApHash> | 32 bits | None (seed `0xAAAAAAAA`) | Arash Partow's hash. |
+| <xref:Bodu.IO.Hashing.Pjw32> | 32 bits | None | Peter Weinberger's PJW hash (AT&T compiler). |
+
+All seven derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
+
+## Pattern 1 — a default-configured hash
+
+Every type has a parameterless constructor that uses the historically canonical parameters for that function:
+
+```csharp
+using System.Text;
+using Bodu.IO.Hashing;
+
+byte[] data = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var hash = new Bernstein();             // djb2 — seed 5381, XOR form
+hash.Append(data);
+byte[] digest = hash.GetCurrentHash();
+uint h = BitConverter.ToUInt32(digest);
+```
+
+Swap `Bernstein` for any of the others — the API is the same.
+
+## Pattern 2 — Bernstein (djb2), add vs XOR
+
+Bernstein's original posting used addition (`h = h * 33 + c`). The XOR form (`h = h * 33 ^ c`) distributes slightly better on ASCII input and is what most later ports use. `Bernstein` exposes both through `UseModifiedAlgorithm`.
+
+```csharp
+using Bodu.IO.Hashing;
+
+// Original: h = (h * 33) + c
+using var original = new Bernstein(Bernstein.DefaultInitialValue, useModifiedAlgorithm: false);
+
+// "djb2a":  h = (h * 33) ^ c — the common modern variant
+using var modified = new Bernstein(Bernstein.DefaultInitialValue, useModifiedAlgorithm: true);
+
+// Or set the properties before the first Append
+using var alt = new Bernstein { InitialValue = 0, UseModifiedAlgorithm = true };
+```
+
+Both properties are only settable **before** the first `Append` — changing them mid-stream would invalidate the running state, so the setters throw once input has been fed.
+
+## Pattern 3 — BKDR's published multiplier set
+
+BKDR is a family: the multiplier is a repeating-digit odd number from the published set (`31`, `131`, `1313`, `13131`, `131313`, `1313131`, `13131313`, `131313131`, `1313131313`). The default is `BKDR.DefaultSeed` (`131`):
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var bkdr = new BKDR(seed: 1313);         // must be one of the published values
+bkdr.Append(Encoding.UTF8.GetBytes("example"));
+byte[] digest = bkdr.GetCurrentHash();
+```
+
+Passing a value outside the published set throws — the seed is a property of the published "standard BKDR family", not an arbitrary multiplier.
+
+## Pattern 4 — Elf64 with a custom seed
+
+`Elf64` widens the classic ELF symbol-table hash to 64 bits and exposes a seed so you can salt it for separate hash-table lanes:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var elf = new Elf64(seed: 0xDEADBEEFUL);
+elf.Append(Encoding.UTF8.GetBytes("/usr/bin/ls"));
+byte[] digest = elf.GetCurrentHash();
+```
+
+The seed is **not a key** — it does not provide adversarial resistance. It only re-origins the accumulator so two parallel tables get independent distributions.
+
+## Pattern 5 — `Append` / `GetCurrentHash` / `Reset`
+
+Every type in this family behaves identically under the `NonCryptographicHashAlgorithm` contract:
+
+```csharp
+using Bodu.IO.Hashing;
+
+using var hash = new SDBM();
+
+hash.Append(header);
+hash.Append(body);
+byte[] partial = hash.GetCurrentHash();    // snapshot, non-destructive
+hash.Append(trailer);
+byte[] full = hash.GetCurrentHash();
+
+hash.Reset();                              // back to the configured seed / initial state
+```
+
+## Picking a function
+
+- **Hashing identifiers inside a compiler or symbol table?** `Pjw32` or `Elf64` — these are the functions you'll meet in the original source.
+- **Quick hash-table function in throwaway code?** `Bernstein` with `UseModifiedAlgorithm = true` is simple, well-known, and distributes reasonably.
+- **Hashing user-controlled input?** None of these — reach for <xref:Bodu.Security.Cryptography.SipHash64>.
+- **Reproducing a known published digest from another tool?** Match on algorithm, width, seed, and (for Bernstein) the add-vs-XOR variant.
+
+For general-purpose fingerprinting where quality and speed both matter, **`CityHash64`** and **`Fnv1a64`** outperform everything in this family — see the [CityHash](cityhash.md) and [FNV](fnv.md) guides.
+
+## Where to go next
+
+- [Using FNV](fnv.md), [Using CityHash](cityhash.md) — modern non-cryptographic hashes with better distribution.
+- [Using Pearson](pearson.md) — table-driven classic hash with configurable output width.
+- [Cryptography hashing guide](../cryptography/hashing.md) — when a classic hash is not enough.
+- [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/toc.yml
+++ b/docs/guides/io-hashing/toc.yml
@@ -1,0 +1,19 @@
+# ./<Project Root Dir>/docs/guides/io-hashing/toc.yml
+- name: Overview
+  href: index.md
+- name: Using CRC
+  href: crc.md
+- name: CRC catalogue
+  href: crc-catalogue.md
+- name: Using Fletcher
+  href: fletcher.md
+- name: Using Adler
+  href: adler.md
+- name: Using FNV
+  href: fnv.md
+- name: Using CityHash
+  href: cityhash.md
+- name: Using Pearson
+  href: pearson.md
+- name: Classic string hashes
+  href: string-hashes.md

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -6,10 +6,20 @@
       href: io-hashing/index.md
     - name: Using CRC
       href: io-hashing/crc.md
-    - name: Using Fletcher
-      href: io-hashing/fletcher.md
     - name: CRC catalogue
       href: io-hashing/crc-catalogue.md
+    - name: Using Fletcher
+      href: io-hashing/fletcher.md
+    - name: Using Adler
+      href: io-hashing/adler.md
+    - name: Using FNV
+      href: io-hashing/fnv.md
+    - name: Using CityHash
+      href: io-hashing/cityhash.md
+    - name: Using Pearson
+      href: io-hashing/pearson.md
+    - name: Classic string hashes
+      href: io-hashing/string-hashes.md
 - name: Bodu.Security.Cryptography
   href: cryptography/
   items:
@@ -25,8 +35,22 @@
       href: cryptography/composing-primitives.md
     - name: Padding
       href: cryptography/padding.md
-    - name: Hashing
+    - name: Hashing and checksums
       href: cryptography/hashing.md
+    - name: Hashing algorithms
+      items:
+        - name: Using SipHash
+          href: cryptography/siphash.md
+        - name: Using Poly1305
+          href: cryptography/poly1305.md
+        - name: Using Tiger
+          href: cryptography/tiger.md
+        - name: Using CubeHash
+          href: cryptography/cubehash.md
+        - name: Using Snefru
+          href: cryptography/snefru.md
+        - name: Using Merkle trees
+          href: cryptography/merkle-trees.md
     - name: Symmetric algorithms
       items:
         - name: Threefish-256


### PR DESCRIPTION
Adds recipe-style walk-throughs for every remaining hashing algorithm so each public type has its own guide page alongside the existing CRC and Fletcher coverage.

New Bodu.IO.Hashing guides:
- adler.md      Adler32 / Adler32C / Adler64
- fnv.md        Fnv132 / Fnv1a32 / Fnv164 / Fnv1a64
- cityhash.md   CityHash32 / CityHash64 / CityHash128
- pearson.md    Pearson with 8–2048-bit output and built-in / custom tables
- string-hashes.md  Bernstein, BKDR, SDBM, JSHash, Elf64, ApHash, Pjw32

New Bodu.Security.Cryptography guides:
- siphash.md      SipHash64 / SipHash128 with rounds and key lifecycle
- poly1305.md     Poly1305 one-time authenticator (including the RFC 8439 construction)
- tiger.md        Tiger / Tiger2 with configurable output width
- cubehash.md     CubeHash with tunable rounds and block size
- snefru.md       Snefru128 / Snefru256 (legacy interop only)
- merkle-trees.md MerkleTreeHash / ParallelMerkleTreeHash including diagnostics

Also refreshes the shared guides for consistency:
- io-hashing/index.md   adds a card per new guide and a unified decision matrix
- cryptography/index.md adds a hashing-algorithm table linking to the new pages
- cryptography/hashing.md cross-links the new per-algorithm walk-throughs
- toc.yml (top level), cryptography/toc.yml, new io-hashing/toc.yml