### PR TITLE
feat(Bodu.Security.Cryptography): add Whirlpool hash with all three p…

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.Constants.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.Constants.cs
@@ -1,0 +1,189 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Whirlpool.Constants.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public sealed partial class Whirlpool
+{
+    /// <summary>
+    /// The number of rounds used by the internal <c>W</c> block cipher in every published revision of Whirlpool.
+    /// </summary>
+    private const int RoundCount = 10;
+
+    /// <summary>
+    /// The reduction polynomial for the Galois field <c>GF(2^8)</c> used by Whirlpool:
+    /// <c>x^8 + x^4 + x^3 + x^2 + 1</c>.
+    /// </summary>
+    private const int GaloisReductionPolynomial = 0x11D;
+
+    /// <summary>
+    /// The 256-entry S-box of the original <c>Whirlpool-0</c> function, reproduced verbatim from the 2000
+    /// <c>NESSIE</c> submission.
+    /// </summary>
+    private static readonly byte[] SBoxWhirlpool0 =
+    {
+        0x68, 0xD0, 0xEB, 0x2B, 0x48, 0x9D, 0x6A, 0xE4, 0xE3, 0xA3, 0x56, 0x81, 0x7D, 0xF1, 0x85, 0x9E,
+        0x2C, 0x8E, 0x78, 0xCA, 0x17, 0xA9, 0x61, 0xD5, 0x5D, 0x0B, 0x8C, 0x3C, 0x77, 0x51, 0x22, 0x42,
+        0x3F, 0x54, 0x41, 0x80, 0xCC, 0x86, 0xB3, 0x18, 0x2E, 0x57, 0x06, 0x62, 0xF4, 0x36, 0xD1, 0x6B,
+        0x1B, 0x65, 0x75, 0x10, 0xDA, 0x49, 0x26, 0xF9, 0xCB, 0x66, 0xE7, 0xBA, 0xAE, 0x50, 0x52, 0xAB,
+        0x05, 0xF0, 0x0D, 0x73, 0x3B, 0x04, 0x20, 0xFE, 0xDD, 0xF5, 0xB4, 0x5F, 0x0A, 0xB5, 0xC0, 0xA0,
+        0x71, 0xA5, 0x2D, 0x60, 0x72, 0x93, 0x39, 0x08, 0x83, 0x21, 0x5C, 0x87, 0xB1, 0xE0, 0x00, 0xC3,
+        0x12, 0x91, 0x8A, 0x02, 0x1C, 0xE6, 0x45, 0xC2, 0xC4, 0xFD, 0xBF, 0x44, 0xA1, 0x4C, 0x33, 0xC5,
+        0x84, 0x23, 0x7C, 0xB0, 0x25, 0x15, 0x35, 0x69, 0xFF, 0x94, 0x4D, 0x70, 0xA2, 0xAF, 0xCD, 0xD6,
+        0x6C, 0xB7, 0xF8, 0x09, 0xF3, 0x67, 0xA4, 0xEA, 0xEC, 0xB6, 0xD4, 0xD2, 0x14, 0x1E, 0xE1, 0x24,
+        0x38, 0xC6, 0xDB, 0x4B, 0x7A, 0x3A, 0xDE, 0x5E, 0xDF, 0x95, 0xFC, 0xAA, 0xD7, 0xCE, 0x07, 0x0F,
+        0x3D, 0x58, 0x9A, 0x98, 0x9C, 0xF2, 0xA7, 0x11, 0x7E, 0x8B, 0x43, 0x03, 0xE2, 0xDC, 0xE5, 0xB2,
+        0x4E, 0xC7, 0x6D, 0xE9, 0x27, 0x40, 0xD8, 0x37, 0x92, 0x8F, 0x01, 0x1D, 0x53, 0x3E, 0x59, 0xC1,
+        0x4F, 0x32, 0x16, 0xFA, 0x74, 0xFB, 0x63, 0x9F, 0x34, 0x1A, 0x2A, 0x5A, 0x8D, 0xC9, 0xCF, 0xF6,
+        0x90, 0x28, 0x88, 0x9B, 0x31, 0x0E, 0xBD, 0x4A, 0xE8, 0x96, 0xA6, 0x0C, 0xC8, 0x79, 0xBC, 0xBE,
+        0xEF, 0x6E, 0x46, 0x97, 0x5B, 0xED, 0x19, 0xD9, 0xAC, 0x99, 0xA8, 0x29, 0x64, 0x1F, 0xAD, 0x55,
+        0x13, 0xBB, 0xF7, 0x6F, 0xB9, 0x47, 0x2F, 0xEE, 0xB8, 0x7B, 0x89, 0x30, 0xD3, 0x7F, 0x76, 0x82,
+    };
+
+    /// <summary>
+    /// The <c>E</c> mini-box used to construct the <c>Whirlpool-T</c> and <c>Whirlpool</c> S-box.
+    /// </summary>
+    private static readonly byte[] MiniBoxE =
+    {
+        0x1, 0xB, 0x9, 0xC, 0xD, 0x6, 0xF, 0x3, 0xE, 0x8, 0x7, 0x4, 0xA, 0x2, 0x5, 0x0,
+    };
+
+    /// <summary>
+    /// The <c>R</c> mini-box used to construct the <c>Whirlpool-T</c> and <c>Whirlpool</c> S-box.
+    /// </summary>
+    private static readonly byte[] MiniBoxR =
+    {
+        0x7, 0xC, 0xB, 0xD, 0xE, 0x4, 0x9, 0xF, 0x6, 0x3, 0x8, 0xA, 0x2, 0x5, 0x1, 0x0,
+    };
+
+    /// <summary>
+    /// The diffusion matrix coefficients common to <c>Whirlpool-0</c> and <c>Whirlpool-T</c>, expressed in the
+    /// order <c>(c0, c1, …, c7)</c> used by <see cref="BuildMultiplicationTable" />.
+    /// </summary>
+    private static readonly byte[] MdsOriginal =
+    {
+        0x01, 0x01, 0x03, 0x01, 0x05, 0x08, 0x09, 0x05,
+    };
+
+    /// <summary>
+    /// The diffusion matrix coefficients used by the final <c>Whirlpool</c> function, expressed in the order
+    /// <c>(c0, c1, …, c7)</c> used by <see cref="BuildMultiplicationTable" />.
+    /// </summary>
+    private static readonly byte[] MdsFinal =
+    {
+        0x01, 0x01, 0x04, 0x01, 0x08, 0x05, 0x02, 0x09,
+    };
+
+    /// <summary>
+    /// Constructs the <c>Whirlpool-T</c> / <c>Whirlpool</c> S-box from the <c>E</c>, <c>E^-1</c> and <c>R</c>
+    /// mini-boxes.
+    /// </summary>
+    /// <returns>A 256-byte array containing the full 8-bit S-box.</returns>
+    /// <remarks>
+    /// The mini-box construction is the one published with <c>Whirlpool-T</c> in 2001 and retained by the
+    /// standardised <c>Whirlpool</c> function in 2003. Each input byte is split into two 4-bit halves which
+    /// are routed through <c>E</c>, <c>E^-1</c> and <c>R</c> in the pattern described in the original paper.
+    /// </remarks>
+    private static byte[] BuildMiniBoxSBox()
+    {
+        byte[] einv = new byte[16];
+        for (int i = 0; i < MiniBoxE.Length; i++)
+            einv[MiniBoxE[i]] = (byte)i;
+
+        byte[] sbox = new byte[256];
+        for (int i = 0; i < 256; i++)
+        {
+            int left = MiniBoxE[i >> 4];
+            int right = einv[i & 0xF];
+            int mid = MiniBoxR[left ^ right];
+            sbox[i] = (byte)((MiniBoxE[left ^ mid] << 4) | einv[right ^ mid]);
+        }
+
+        return sbox;
+    }
+
+    /// <summary>
+    /// Multiplies two bytes in the Whirlpool Galois field <c>GF(2^8)</c> defined by
+    /// <c>x^8 + x^4 + x^3 + x^2 + 1</c>.
+    /// </summary>
+    /// <param name="x">The left multiplicand, treated as an unsigned 8-bit value.</param>
+    /// <param name="y">The right multiplicand, treated as an unsigned 8-bit value.</param>
+    /// <returns>The product <c>x · y</c> reduced modulo <see cref="GaloisReductionPolynomial" />.</returns>
+    private static byte GaloisMultiply(byte x, byte y)
+    {
+        int a = x;
+        int b = y;
+        int result = 0;
+
+        while (b != 0)
+        {
+            if ((b & 1) != 0)
+                result ^= a;
+
+            int highBit = a & 0x80;
+            a = (a << 1) & 0xFF;
+            if (highBit != 0)
+                a ^= GaloisReductionPolynomial & 0xFF;
+
+            b >>= 1;
+        }
+
+        return (byte)result;
+    }
+
+    /// <summary>
+    /// Builds the flat 8 × 256 multiplication table used by <see cref="RoundFunction" /> for the supplied
+    /// <paramref name="sbox" /> and diffusion coefficients <paramref name="mds" />.
+    /// </summary>
+    /// <param name="sbox">The 256-byte S-box selected for the configured variant.</param>
+    /// <param name="mds">The eight-byte diffusion row for the configured variant.</param>
+    /// <returns>
+    /// A flat <see cref="ulong" /> array of length <c>8 × 256</c>, indexed as <c>[column &lt;&lt; 8 | value]</c>,
+    /// where each entry is the diffusion-weighted S-box output rotated so it can be XORed directly into the
+    /// corresponding state word.
+    /// </returns>
+    private static ulong[] BuildMultiplicationTable(byte[] sbox, byte[] mds)
+    {
+        ulong[] table = new ulong[8 * 256];
+
+        for (int i = 0; i < 256; i++)
+        {
+            ulong vector = 0;
+            for (int j = 0; j < 8; j++)
+                vector |= (ulong)GaloisMultiply(sbox[i], mds[j]) << ((7 - j) * 8);
+
+            for (int j = 0; j < 8; j++)
+                table[(j << 8) | i] = System.Numerics.BitOperations.RotateRight(vector, j * 8);
+        }
+
+        return table;
+    }
+
+    /// <summary>
+    /// Builds the ten 64-bit round constants for the <c>W</c> key schedule using the supplied
+    /// <paramref name="sbox" />.
+    /// </summary>
+    /// <param name="sbox">The 256-byte S-box selected for the configured variant.</param>
+    /// <returns>An array of ten big-endian packed round constants.</returns>
+    /// <remarks>
+    /// Each round constant packs eight consecutive S-box outputs into the first column of the round key; the
+    /// remaining seven columns are zero by definition of the Whirlpool key schedule.
+    /// </remarks>
+    private static ulong[] BuildRoundConstants(byte[] sbox)
+    {
+        ulong[] rcon = new ulong[RoundCount];
+        for (int i = 0; i < RoundCount; i++)
+        {
+            ulong value = 0;
+            for (int j = 0; j < 8; j++)
+                value |= (ulong)sbox[(8 * i) + j] << ((7 - j) * 8);
+
+            rcon[i] = value;
+        }
+
+        return rcon;
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.Tables.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.Tables.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Whirlpool.Tables.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Threading;
+
+namespace Bodu.Security.Cryptography;
+
+public sealed partial class Whirlpool
+{
+    private static VariantTables? s_tablesInfo1;
+    private static VariantTables? s_tablesInfo2;
+    private static VariantTables? s_tablesInfo3;
+
+    /// <summary>
+    /// Returns the precomputed multiplication table and round keys for the requested
+    /// <paramref name="version" />, constructing them on first use.
+    /// </summary>
+    /// <param name="version">The Whirlpool revision whose tables are required.</param>
+    /// <returns>The cached <see cref="VariantTables" /> instance for <paramref name="version" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="version" /> is not a defined <see cref="WhirlpoolVersion" /> member.
+    /// </exception>
+    /// <remarks>
+    /// Each variant owns an independent multiplication table and round-key schedule derived from its own
+    /// S-box and diffusion matrix. The tables are immutable once built, so safe publication via a simple
+    /// <see cref="Interlocked.CompareExchange{T}(ref T, T, T)" /> is sufficient.
+    /// </remarks>
+    private static VariantTables GetTables(WhirlpoolVersion version)
+    {
+        switch (version)
+        {
+            case WhirlpoolVersion.WhirlpoolInfo1:
+                return s_tablesInfo1 ?? BuildAndCacheTables(ref s_tablesInfo1, SBoxWhirlpool0, MdsOriginal);
+
+            case WhirlpoolVersion.WhirlpoolInfo2:
+                return s_tablesInfo2 ?? BuildAndCacheTables(ref s_tablesInfo2, BuildMiniBoxSBox(), MdsOriginal);
+
+            case WhirlpoolVersion.WhirlpoolInfo3:
+                return s_tablesInfo3 ?? BuildAndCacheTables(ref s_tablesInfo3, BuildMiniBoxSBox(), MdsFinal);
+
+            default:
+                throw new ArgumentOutOfRangeException(nameof(version), version, null);
+        }
+    }
+
+    /// <summary>
+    /// Builds the multiplication table and round-key schedule for a variant and publishes the result to
+    /// the supplied cache slot.
+    /// </summary>
+    /// <param name="slot">The static cache slot that receives the constructed tables.</param>
+    /// <param name="sbox">The S-box selected for the variant.</param>
+    /// <param name="mds">The diffusion row selected for the variant.</param>
+    /// <returns>The freshly constructed or already-cached <see cref="VariantTables" /> instance.</returns>
+    private static VariantTables BuildAndCacheTables(ref VariantTables? slot, byte[] sbox, byte[] mds)
+    {
+        ulong[] mul = BuildMultiplicationTable(sbox, mds);
+        ulong[] constants = BuildRoundConstants(sbox);
+
+        ulong[][] roundKeys = new ulong[RoundCount][];
+        for (int i = 0; i < RoundCount; i++)
+        {
+            ulong[] rk = new ulong[8];
+            rk[0] = constants[i];
+            roundKeys[i] = rk;
+        }
+
+        VariantTables tables = new(mul, roundKeys);
+        return Interlocked.CompareExchange(ref slot, tables, null) ?? tables;
+    }
+
+    /// <summary>
+    /// Immutable carrier for the per-variant multiplication table and round-key schedule.
+    /// </summary>
+    private sealed class VariantTables
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="VariantTables" /> class.
+        /// </summary>
+        /// <param name="multiplication">The flat 8 × 256 multiplication table.</param>
+        /// <param name="roundKeys">The ten round keys, each holding the round constant in column 0.</param>
+        public VariantTables(ulong[] multiplication, ulong[][] roundKeys)
+        {
+            this.Multiplication = multiplication;
+            this.RoundKeys = roundKeys;
+        }
+
+        /// <summary>
+        /// Gets the flat 8 × 256 multiplication table consumed by the round function.
+        /// </summary>
+        /// <returns>The shared multiplication table for the variant.</returns>
+        public ulong[] Multiplication { get; }
+
+        /// <summary>
+        /// Gets the ten round keys driving the <c>W</c> key schedule. Each entry has the round constant in
+        /// index 0 and zeros elsewhere.
+        /// </summary>
+        /// <returns>The shared round-key schedule for the variant.</returns>
+        public ulong[][] RoundKeys { get; }
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -1,0 +1,309 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Whirlpool.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Computes a 512-bit cryptographic hash using the <c>Whirlpool</c> algorithm designed by Paulo S. L. M.
+/// Barreto and Vincent Rijmen. Supports all three published revisions: <c>Whirlpool-0</c> (2000),
+/// <c>Whirlpool-T</c> (2001) and the final <c>Whirlpool</c> function standardised by <c>ISO/IEC 10118-3</c>
+/// in 2003. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Whirlpool is a Merkle–Damgård construction wrapped around an internal 512-bit block cipher (<c>W</c>)
+/// that borrows the wide-trail design principles of the Rijndael family. Input is consumed in 64-byte
+/// blocks; the final message length (in bits) is appended in a 256-bit big-endian trailer after a single
+/// <c>0x80</c> padding byte, in the standard manner.
+/// </para>
+/// <para>
+/// The selected revision is controlled by <see cref="Version" />. The default is
+/// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />, which matches the <c>ISO/IEC 10118-3</c> standard.
+/// <see cref="Version" /> may be changed before any input has been consumed; attempting to change it once
+/// hashing has started throws <see cref="CryptographicUnexpectedOperationException" />. Calling
+/// <see cref="Initialize" /> returns the instance to the reconfigurable state.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using var whirlpool = new Whirlpool { Version = WhirlpoolVersion.WhirlpoolInfo3 };
+/// byte[] digest = whirlpool.ComputeHash(message);
+/// </code>
+/// </example>
+public sealed partial class Whirlpool
+    : BlockHashAlgorithm<Whirlpool>
+{
+    private const int BlockSizeBytesValue = 64;
+    private const int HashSizeBytesValue = 64;
+    private const int HashSizeBitsValue = HashSizeBytesValue * 8;
+    private const int LengthFieldBytes = 32;
+
+    private readonly ulong[] _state = new ulong[8];
+    private WhirlpoolVersion _version = WhirlpoolVersion.WhirlpoolInfo3;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Whirlpool" /> class configured for
+    /// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />, the standardised <c>ISO/IEC 10118-3</c> revision.
+    /// </summary>
+    public Whirlpool()
+        : base(BlockSizeBytesValue)
+    {
+        this.HashSizeValue = HashSizeBitsValue;
+    }
+
+    /// <inheritdoc />
+    public override bool CanReuseTransform => true;
+
+    /// <inheritdoc />
+    public override bool CanTransformMultipleBlocks => true;
+
+    /// <inheritdoc />
+    public override int InputBlockSize => BlockSizeBytesValue;
+
+    /// <inheritdoc />
+    public override int OutputBlockSize => HashSizeBytesValue;
+
+    /// <summary>
+    /// Gets or sets the published <see cref="WhirlpoolVersion" /> used to compute the hash value.
+    /// </summary>
+    /// <value>The Whirlpool revision selected for subsequent hashing operations.</value>
+    /// <returns>The currently configured Whirlpool revision.</returns>
+    /// <remarks>
+    /// <para>
+    /// The revision must be assigned before any input has been consumed. Once
+    /// <see cref="HashAlgorithm.TransformBlock" /> or any <c>ComputeHash</c> overload has started a
+    /// computation, the value becomes immutable until <see cref="Initialize" /> is called.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The assigned value is not a defined <see cref="WhirlpoolVersion" /> member.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The hash algorithm instance has been disposed.</exception>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// The hash computation has already started and the algorithm is no longer reconfigurable.
+    /// </exception>
+    public WhirlpoolVersion Version
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return this._version;
+        }
+
+        set
+        {
+            this.ThrowIfDisposed();
+            this.ThrowIfInvalidState();
+            ThrowHelper.ThrowIfEnumValueIsUndefined(value);
+
+            this._version = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        this.ThrowIfDisposed();
+        base.Initialize();
+        Array.Clear(this._state);
+    }
+
+    /// <summary>
+    /// Releases resources used by the algorithm and clears the internal state.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to
+    /// release only unmanaged resources.
+    /// </param>
+    protected override void Dispose(bool disposing)
+    {
+        if (this._disposed) return;
+
+        if (disposing)
+        {
+            CryptoHelpers.Clear(this._state);
+            CryptoHelpers.ClearAndNullify(ref this.HashValue);
+            this.HashSizeValue = 0;
+        }
+
+        this._disposed = true;
+        base.Dispose(disposing);
+    }
+
+    /// <inheritdoc />
+    protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength)
+    {
+        int inputLength = block.Length;
+
+        // Whirlpool appends 0x80, a sequence of zero bytes, and a 256-bit big-endian length trailer.
+        // A second padded block is required whenever the residual (including the 0x80 byte) does not
+        // leave room for the 32-byte length field in the same block.
+        bool needsSecondBlock = inputLength + 1 + LengthFieldBytes > BlockSizeBytesValue;
+        int totalLength = needsSecondBlock ? BlockSizeBytesValue * 2 : BlockSizeBytesValue;
+
+        byte[] padded = new byte[totalLength];
+        block.CopyTo(padded);
+        padded[inputLength] = 0x80;
+
+        // Only the low 64 bits of the bit count are populated; the upper 192 bits remain zero. This
+        // matches the behaviour of every widely deployed Whirlpool implementation.
+        ulong bitLength = messageLength * 8;
+        BinaryPrimitives.WriteUInt64BigEndian(padded.AsSpan(totalLength - 8), bitLength);
+
+        return padded;
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessBlock(ReadOnlySpan<byte> block)
+    {
+        VariantTables tables = GetTables(this._version);
+        ulong[] mul = tables.Multiplication;
+        ulong[][] rcon = tables.RoundKeys;
+
+        Span<ulong> message = stackalloc ulong[8];
+        Span<ulong> key = stackalloc ulong[8];
+        Span<ulong> state = stackalloc ulong[8];
+        Span<ulong> tempKey = stackalloc ulong[8];
+        Span<ulong> tempState = stackalloc ulong[8];
+
+        // Read the message block (big-endian) and initialise the round key from the hash state.
+        // The first sigma step XORs the message against the initial key to seed the cipher state.
+        for (int i = 0; i < 8; i++)
+        {
+            message[i] = BinaryPrimitives.ReadUInt64BigEndian(block.Slice(i * 8, 8));
+            key[i] = this._state[i];
+            state[i] = message[i] ^ key[i];
+        }
+
+        for (int r = 0; r < RoundCount; r++)
+        {
+            // Evolve the round key by one application of the non-linear round function with the
+            // variant-specific constant in column 0 and zeros elsewhere.
+            ApplyRound(key, rcon[r], tempKey, mul);
+            tempKey.CopyTo(key);
+
+            // Apply the same round function to the cipher state using the newly evolved round key.
+            ApplyRound(state, key, tempState, mul);
+            tempState.CopyTo(state);
+        }
+
+        // Miyaguchi–Preneel finalisation: H_{i+1} = W_{H_i}(M) ⊕ M ⊕ H_i.
+        for (int i = 0; i < 8; i++)
+            this._state[i] ^= state[i] ^ message[i];
+    }
+
+    /// <inheritdoc />
+    protected override byte[] ProcessFinalBlock()
+    {
+        byte[] output = new byte[HashSizeBytesValue];
+        for (int i = 0; i < 8; i++)
+            BinaryPrimitives.WriteUInt64BigEndian(output.AsSpan(i * 8, 8), this._state[i]);
+
+        return output;
+    }
+
+    /// <summary>
+    /// Applies one round of the Whirlpool <c>W</c> cipher to <paramref name="state" />, combining the
+    /// non-linear substitution, shift-column, MixRows and AddRoundKey operations via the precomputed
+    /// multiplication table <paramref name="mul" />.
+    /// </summary>
+    /// <param name="state">The eight 64-bit input words.</param>
+    /// <param name="roundKey">The eight 64-bit round-key words XORed into the round output.</param>
+    /// <param name="output">The span that receives the round output; must have length 8.</param>
+    /// <param name="mul">The flat 8 × 256 multiplication table for the active variant.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void ApplyRound(ReadOnlySpan<ulong> state, ReadOnlySpan<ulong> roundKey, Span<ulong> output, ulong[] mul)
+    {
+        const ulong M = 0xFF;
+        ulong s0 = state[0], s1 = state[1], s2 = state[2], s3 = state[3];
+        ulong s4 = state[4], s5 = state[5], s6 = state[6], s7 = state[7];
+
+        output[0] = mul[(s0 >> 56) & M]
+                  ^ mul[0x100 | ((s7 >> 48) & M)]
+                  ^ mul[0x200 | ((s6 >> 40) & M)]
+                  ^ mul[0x300 | ((s5 >> 32) & M)]
+                  ^ mul[0x400 | ((s4 >> 24) & M)]
+                  ^ mul[0x500 | ((s3 >> 16) & M)]
+                  ^ mul[0x600 | ((s2 >> 8) & M)]
+                  ^ mul[0x700 | (s1 & M)]
+                  ^ roundKey[0];
+
+        output[1] = mul[(s1 >> 56) & M]
+                  ^ mul[0x100 | ((s0 >> 48) & M)]
+                  ^ mul[0x200 | ((s7 >> 40) & M)]
+                  ^ mul[0x300 | ((s6 >> 32) & M)]
+                  ^ mul[0x400 | ((s5 >> 24) & M)]
+                  ^ mul[0x500 | ((s4 >> 16) & M)]
+                  ^ mul[0x600 | ((s3 >> 8) & M)]
+                  ^ mul[0x700 | (s2 & M)]
+                  ^ roundKey[1];
+
+        output[2] = mul[(s2 >> 56) & M]
+                  ^ mul[0x100 | ((s1 >> 48) & M)]
+                  ^ mul[0x200 | ((s0 >> 40) & M)]
+                  ^ mul[0x300 | ((s7 >> 32) & M)]
+                  ^ mul[0x400 | ((s6 >> 24) & M)]
+                  ^ mul[0x500 | ((s5 >> 16) & M)]
+                  ^ mul[0x600 | ((s4 >> 8) & M)]
+                  ^ mul[0x700 | (s3 & M)]
+                  ^ roundKey[2];
+
+        output[3] = mul[(s3 >> 56) & M]
+                  ^ mul[0x100 | ((s2 >> 48) & M)]
+                  ^ mul[0x200 | ((s1 >> 40) & M)]
+                  ^ mul[0x300 | ((s0 >> 32) & M)]
+                  ^ mul[0x400 | ((s7 >> 24) & M)]
+                  ^ mul[0x500 | ((s6 >> 16) & M)]
+                  ^ mul[0x600 | ((s5 >> 8) & M)]
+                  ^ mul[0x700 | (s4 & M)]
+                  ^ roundKey[3];
+
+        output[4] = mul[(s4 >> 56) & M]
+                  ^ mul[0x100 | ((s3 >> 48) & M)]
+                  ^ mul[0x200 | ((s2 >> 40) & M)]
+                  ^ mul[0x300 | ((s1 >> 32) & M)]
+                  ^ mul[0x400 | ((s0 >> 24) & M)]
+                  ^ mul[0x500 | ((s7 >> 16) & M)]
+                  ^ mul[0x600 | ((s6 >> 8) & M)]
+                  ^ mul[0x700 | (s5 & M)]
+                  ^ roundKey[4];
+
+        output[5] = mul[(s5 >> 56) & M]
+                  ^ mul[0x100 | ((s4 >> 48) & M)]
+                  ^ mul[0x200 | ((s3 >> 40) & M)]
+                  ^ mul[0x300 | ((s2 >> 32) & M)]
+                  ^ mul[0x400 | ((s1 >> 24) & M)]
+                  ^ mul[0x500 | ((s0 >> 16) & M)]
+                  ^ mul[0x600 | ((s7 >> 8) & M)]
+                  ^ mul[0x700 | (s6 & M)]
+                  ^ roundKey[5];
+
+        output[6] = mul[(s6 >> 56) & M]
+                  ^ mul[0x100 | ((s5 >> 48) & M)]
+                  ^ mul[0x200 | ((s4 >> 40) & M)]
+                  ^ mul[0x300 | ((s3 >> 32) & M)]
+                  ^ mul[0x400 | ((s2 >> 24) & M)]
+                  ^ mul[0x500 | ((s1 >> 16) & M)]
+                  ^ mul[0x600 | ((s0 >> 8) & M)]
+                  ^ mul[0x700 | (s7 & M)]
+                  ^ roundKey[6];
+
+        output[7] = mul[(s7 >> 56) & M]
+                  ^ mul[0x100 | ((s6 >> 48) & M)]
+                  ^ mul[0x200 | ((s5 >> 40) & M)]
+                  ^ mul[0x300 | ((s4 >> 32) & M)]
+                  ^ mul[0x400 | ((s3 >> 24) & M)]
+                  ^ mul[0x500 | ((s2 >> 16) & M)]
+                  ^ mul[0x600 | ((s1 >> 8) & M)]
+                  ^ mul[0x700 | (s0 & M)]
+                  ^ roundKey[7];
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/WhirlpoolVersion.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/WhirlpoolVersion.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WhirlpoolVersion.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Specifies the published revision of the <see cref="Whirlpool" /> hash algorithm selected by
+/// <see cref="Whirlpool.Version" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Whirlpool was proposed by Paulo S. L. M. Barreto and Vincent Rijmen in 2000 and revised twice before
+/// being standardised in <c>ISO/IEC 10118-3</c>. The three published revisions use the same overall
+/// Merkle–Damgård construction around the internal <c>W</c> block cipher but differ in the non-linear
+/// substitution layer and the linear diffusion matrix:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="WhirlpoolInfo1" /> — the <c>Whirlpool-0</c> function as originally submitted to
+/// <c>NESSIE</c> in 2000. It uses the original pseudo-random S-box and the original diffusion matrix.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="WhirlpoolInfo2" /> — the <c>Whirlpool-T</c> revision published in 2001. It replaces the
+/// S-box with the structured mini-box construction while retaining the original diffusion matrix.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="WhirlpoolInfo3" /> — the final <c>Whirlpool</c> function adopted by <c>ISO/IEC 10118-3</c>
+/// in 2003. It retains the mini-box S-box introduced in <c>Whirlpool-T</c> and uses the revised
+/// diffusion matrix with branch number nine.
+/// </description>
+/// </item>
+/// </list>
+/// <note type="important">Only <see cref="WhirlpoolInfo3" /> is the standardised variant. The earlier
+/// revisions are provided for interoperability with legacy data and academic study.</note>
+/// </remarks>
+public enum WhirlpoolVersion
+{
+    /// <summary>
+    /// The original <c>Whirlpool-0</c> function submitted to <c>NESSIE</c> in 2000, combining the
+    /// original pseudo-random S-box with the original diffusion matrix.
+    /// </summary>
+    WhirlpoolInfo1,
+
+    /// <summary>
+    /// The <c>Whirlpool-T</c> revision published in 2001, which adopts the structured mini-box S-box
+    /// but retains the original diffusion matrix.
+    /// </summary>
+    WhirlpoolInfo2,
+
+    /// <summary>
+    /// The final <c>Whirlpool</c> function adopted by <c>ISO/IEC 10118-3</c> in 2003, pairing the
+    /// mini-box S-box with the revised diffusion matrix.
+    /// </summary>
+    WhirlpoolInfo3,
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.Version.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.Version.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WhirlpoolTests.Version.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class WhirlpoolTests
+{
+    /// <summary>
+    /// Verifies that a freshly constructed <see cref="Whirlpool" /> defaults to
+    /// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenDefaultConstructed_ShouldReturnWhirlpoolInfo3()
+    {
+        using Whirlpool algorithm = new();
+
+        Assert.AreEqual(WhirlpoolVersion.WhirlpoolInfo3, algorithm.Version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.Version" /> can be reassigned before any input has been consumed.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenSetBeforeUse_ShouldBeRetained()
+    {
+        using Whirlpool algorithm = new() { Version = WhirlpoolVersion.WhirlpoolInfo1 };
+
+        Assert.AreEqual(WhirlpoolVersion.WhirlpoolInfo1, algorithm.Version);
+    }
+
+    /// <summary>
+    /// Verifies that assigning an undefined <see cref="WhirlpoolVersion" /> value throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenSetToUndefinedValue_ShouldThrowArgumentOutOfRange()
+    {
+        using Whirlpool algorithm = new();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Version = (WhirlpoolVersion)999;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that setting <see cref="Whirlpool.Version" /> after input has been consumed throws
+    /// <see cref="CryptographicUnexpectedOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenSetAfterHashingStarted_ShouldThrowExactly()
+    {
+        using Whirlpool algorithm = new();
+        algorithm.TransformBlock(new byte[] { 1, 2, 3 }, 0, 3, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.Version = WhirlpoolVersion.WhirlpoolInfo1;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.Initialize" /> returns the algorithm to the reconfigurable state
+    /// so <see cref="Whirlpool.Version" /> may be reassigned.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenSetAfterInitialize_ShouldBeAccepted()
+    {
+        using Whirlpool algorithm = new();
+        algorithm.TransformBlock(new byte[] { 1, 2, 3 }, 0, 3, null, 0);
+        algorithm.Initialize();
+
+        algorithm.Version = WhirlpoolVersion.WhirlpoolInfo2;
+
+        Assert.AreEqual(WhirlpoolVersion.WhirlpoolInfo2, algorithm.Version);
+    }
+
+    /// <summary>
+    /// Verifies that setting <see cref="Whirlpool.Version" /> on a disposed algorithm throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenSetAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        Whirlpool algorithm = new();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Version = WhirlpoolVersion.WhirlpoolInfo1;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="Whirlpool.Version" /> on a disposed algorithm throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Version_WhenReadAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        Whirlpool algorithm = new();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.Version;
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.cs
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WhirlpoolTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Whirlpool" /> hash algorithm.
+/// </summary>
+[TestClass]
+public partial class WhirlpoolTests
+{
+    /// <summary>
+    /// The canonical <c>Whirlpool</c> (ISO/IEC 10118-3) digest of the empty message.
+    /// </summary>
+    private const string EmptyDigestWhirlpoolFinal =
+        "19FA61D75522A4669B44E39C1D2E1726C530232130D407F89AFEE0964997F7A73E83BE698B288FEBCF88E3E03C4F0757EA8964E59B63D93708B138CC42A66EB3";
+
+    /// <summary>
+    /// Verifies that a freshly constructed <see cref="Whirlpool" /> exposes a 512-bit output size.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenDefaultConstructed_ShouldBe512()
+    {
+        using Whirlpool algorithm = new();
+
+        Assert.AreEqual(512, algorithm.HashSize);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.InputBlockSize" /> reports the 64-byte Whirlpool block size.
+    /// </summary>
+    [TestMethod]
+    public void InputBlockSize_WhenDefaultConstructed_ShouldBe64()
+    {
+        using Whirlpool algorithm = new();
+
+        Assert.AreEqual(64, algorithm.InputBlockSize);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.OutputBlockSize" /> reports the 64-byte Whirlpool digest size.
+    /// </summary>
+    [TestMethod]
+    public void OutputBlockSize_WhenDefaultConstructed_ShouldBe64()
+    {
+        using Whirlpool algorithm = new();
+
+        Assert.AreEqual(64, algorithm.OutputBlockSize);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.ComputeHash(byte[])" /> of an empty message matches the published
+    /// <c>ISO/IEC 10118-3</c> test vector when <see cref="Whirlpool.Version" /> is
+    /// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenEmptyInput_ForWhirlpoolInfo3_ShouldMatchIsoVector()
+    {
+        using Whirlpool algorithm = new();
+
+        byte[] digest = algorithm.ComputeHash(Array.Empty<byte>());
+
+        Assert.AreEqual(EmptyDigestWhirlpoolFinal, Convert.ToHexString(digest));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.ComputeHash(byte[])" /> of the single-byte input <c>"a"</c>
+    /// matches the published <c>ISO/IEC 10118-3</c> test vector when <see cref="Whirlpool.Version" /> is
+    /// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsLowercaseA_ForWhirlpoolInfo3_ShouldMatchIsoVector()
+    {
+        using Whirlpool algorithm = new();
+
+        byte[] digest = algorithm.ComputeHash(Encoding.ASCII.GetBytes("a"));
+
+        Assert.AreEqual(
+            "8ACA2602792AEC6F11A67206531FB7D7F0DFF59413145E6973C45001D0087B42D11BC645413AEFF63A42391A39145A591A92200D560195E53B478584FDAE231A",
+            Convert.ToHexString(digest));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Whirlpool.ComputeHash(byte[])" /> of <c>"abc"</c> matches the published
+    /// <c>ISO/IEC 10118-3</c> test vector when <see cref="Whirlpool.Version" /> is
+    /// <see cref="WhirlpoolVersion.WhirlpoolInfo3" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsAbc_ForWhirlpoolInfo3_ShouldMatchIsoVector()
+    {
+        using Whirlpool algorithm = new();
+
+        byte[] digest = algorithm.ComputeHash(Encoding.ASCII.GetBytes("abc"));
+
+        Assert.AreEqual(
+            "4E2448A4C6F486BB16B6562C73B4020BF3043E3A731BCE721AE1B303D97E6D4C7181EECA2FA2FBF6543A85BAAA75BF63C17B0AC8F75F4FE76FBB0B4E30BA9C36",
+            Convert.ToHexString(digest));
+    }
+
+    /// <summary>
+    /// Verifies that the digest of a fixed message is deterministic across repeated
+    /// <see cref="Whirlpool.ComputeHash(byte[])" /> invocations on the same instance.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledTwice_ShouldProduceEqualDigests()
+    {
+        using Whirlpool algorithm = new();
+
+        byte[] input = Encoding.ASCII.GetBytes("The quick brown fox jumps over the lazy dog");
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that each published <see cref="WhirlpoolVersion" /> produces a digest that differs from the
+    /// other two for a non-trivial input, confirming the S-box and MDS selection wiring.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenVersionDiffers_ShouldProduceDistinctDigests()
+    {
+        byte[] input = Encoding.ASCII.GetBytes("Whirlpool version routing test");
+
+        byte[] info1 = ComputeWith(WhirlpoolVersion.WhirlpoolInfo1, input);
+        byte[] info2 = ComputeWith(WhirlpoolVersion.WhirlpoolInfo2, input);
+        byte[] info3 = ComputeWith(WhirlpoolVersion.WhirlpoolInfo3, input);
+
+        CollectionAssert.AreNotEqual(info1, info2);
+        CollectionAssert.AreNotEqual(info2, info3);
+        CollectionAssert.AreNotEqual(info1, info3);
+
+        static byte[] ComputeWith(WhirlpoolVersion version, byte[] data)
+        {
+            using Whirlpool algorithm = new() { Version = version };
+            return algorithm.ComputeHash(data);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that streaming the input through <see cref="HashAlgorithm.TransformBlock" /> in arbitrary
+    /// chunk sizes produces the same digest as a single <see cref="Whirlpool.ComputeHash(byte[])" /> call.
+    /// </summary>
+    [TestMethod]
+    public void TransformBlock_WhenInputIsStreamed_ShouldMatchSinglePassDigest()
+    {
+        byte[] input = new byte[200];
+        for (int i = 0; i < input.Length; i++)
+            input[i] = (byte)i;
+
+        using Whirlpool reference = new();
+        byte[] expected = reference.ComputeHash(input);
+
+        using Whirlpool streaming = new();
+        int offset = 0;
+        int[] chunkSizes = { 1, 7, 63, 64, 65, 1 };
+
+        foreach (int chunk in chunkSizes)
+        {
+            int size = Math.Min(chunk, input.Length - offset);
+            streaming.TransformBlock(input, offset, size, null, 0);
+            offset += size;
+        }
+
+        streaming.TransformFinalBlock(input, offset, input.Length - offset);
+
+        CollectionAssert.AreEqual(expected, streaming.Hash);
+    }
+}


### PR DESCRIPTION
…ublished revisions

Adds a Whirlpool cryptographic hash algorithm built on BlockHashAlgorithm<T>. A new WhirlpoolVersion enum selects between the 2000 NESSIE submission (WhirlpoolInfo1 / Whirlpool-0), the 2001 revision (WhirlpoolInfo2 / Whirlpool-T) and the 2003 ISO/IEC 10118-3 standard (WhirlpoolInfo3 / Whirlpool), each with its own S-box and diffusion matrix.

Whirlpool.Version mirrors the Elf64.Seed / Tiger.Variant semantics: it can be reassigned until input has been consumed, after which it throws CryptographicUnexpectedOperationException. Initialize restores the algorithm to the reconfigurable state.

Known-answer tests cover the ISO/IEC 10118-3 empty, "a" and "abc" vectors; additional tests confirm streaming parity with single-pass ComputeHash and that each WhirlpoolVersion produces a distinct digest.

https://claude.ai/code/session_019FWKb5pmVq4nDzj5Mp5k4u