### PR TITLE
feat(core): extend IComparableExtensions with IsGreater/IsLess/Min/Max

### DIFF
--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsGreaterThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is strictly greater than a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly greater than <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThan<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) > 0;
+
+    /// <summary>
+    /// Determines whether a value is strictly greater than a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly greater than <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThan<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) > 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsGreaterThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is greater than or equal to a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is greater than or equal to <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThanOrEqual<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) >= 0;
+
+    /// <summary>
+    /// Determines whether a value is greater than or equal to a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is greater than or equal to <paramref name="other"/> based on the
+    /// specified comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) >= 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsLessThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is strictly less than a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly less than <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThan<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) < 0;
+
+    /// <summary>
+    /// Determines whether a value is strictly less than a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly less than <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThan<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) < 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsLessThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is less than or equal to a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is less than or equal to <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThanOrEqual<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) <= 0;
+
+    /// <summary>
+    /// Determines whether a value is less than or equal to a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is less than or equal to <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) <= 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.Max.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Returns the larger of two values using their natural ordering.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="other"/>; otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <remarks>When the two values compare equal, <paramref name="value"/> is returned.</remarks>
+    public static T Max<T>(this T value, T other)
+        where T : IComparable<T> =>
+            value.CompareTo(other) >= 0 ? value : other;
+
+    /// <summary>
+    /// Returns the larger of two values using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="other"/> under the specified comparer;
+    /// otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
+    public static T Max<T>(this T value, T other, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, other) >= 0 ? value : other;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.Min.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Returns the smaller of two values using their natural ordering.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="other"/>; otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <remarks>When the two values compare equal, <paramref name="value"/> is returned.</remarks>
+    public static T Min<T>(this T value, T other)
+        where T : IComparable<T> =>
+            value.CompareTo(other) <= 0 ? value : other;
+
+    /// <summary>
+    /// Returns the smaller of two values using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="other"/> under the specified comparer;
+    /// otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
+    public static T Min<T>(this T value, T other, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, other) <= 0 ? value : other;
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThan.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThan.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsGreaterThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsGreaterThan<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> reports whether an integer value is strictly greater than a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 5, true, DisplayName = "Value above reference returns true")]
+    [DataRow(5, 5, false, DisplayName = "Value equal to reference returns false")]
+    [DataRow(0, 5, false, DisplayName = "Value below reference returns false")]
+    public void IsGreaterThan_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", true, DisplayName = "String after reference returns true")]
+    [DataRow("apple", "apple", false, DisplayName = "String equal to reference returns false")]
+    [DataRow("aardvark", "apple", false, DisplayName = "String before reference returns false")]
+    public void IsGreaterThan_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsGreaterThan(other));
+    }
+
+    // =========================================================================
+    // IsGreaterThan<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsGreaterThan</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically smaller values are treated as greater.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(1.IsGreaterThan(5, comparer));
+        Assert.IsFalse(5.IsGreaterThan(5, comparer));
+        Assert.IsFalse(10.IsGreaterThan(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsGreaterThan(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsGreaterThan(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThanOrEqual.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThanOrEqual.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsGreaterThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsGreaterThanOrEqual<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> reports whether an integer value is greater than or equal to a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 5, true, DisplayName = "Value above reference returns true")]
+    [DataRow(5, 5, true, DisplayName = "Value equal to reference returns true")]
+    [DataRow(0, 5, false, DisplayName = "Value below reference returns false")]
+    public void IsGreaterThanOrEqual_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", true, DisplayName = "String after reference returns true")]
+    [DataRow("apple", "apple", true, DisplayName = "String equal to reference returns true")]
+    [DataRow("aardvark", "apple", false, DisplayName = "String before reference returns false")]
+    public void IsGreaterThanOrEqual_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsGreaterThanOrEqual(other));
+    }
+
+    // =========================================================================
+    // IsGreaterThanOrEqual<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsGreaterThanOrEqual</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically smaller or equal values are treated as greater-or-equal.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(1.IsGreaterThanOrEqual(5, comparer));
+        Assert.IsTrue(5.IsGreaterThanOrEqual(5, comparer));
+        Assert.IsFalse(10.IsGreaterThanOrEqual(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsGreaterThanOrEqual(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsGreaterThanOrEqual(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThan.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThan.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsLessThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsLessThan<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> reports whether an integer value is strictly less than a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 5, true, DisplayName = "Value below reference returns true")]
+    [DataRow(5, 5, false, DisplayName = "Value equal to reference returns false")]
+    [DataRow(10, 5, false, DisplayName = "Value above reference returns false")]
+    public void IsLessThan_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("aardvark", "apple", true, DisplayName = "String before reference returns true")]
+    [DataRow("apple", "apple", false, DisplayName = "String equal to reference returns false")]
+    [DataRow("banana", "apple", false, DisplayName = "String after reference returns false")]
+    public void IsLessThan_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsLessThan(other));
+    }
+
+    // =========================================================================
+    // IsLessThan<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsLessThan</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically greater values are treated as less.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(10.IsLessThan(5, comparer));
+        Assert.IsFalse(5.IsLessThan(5, comparer));
+        Assert.IsFalse(1.IsLessThan(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsLessThan(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsLessThan(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThanOrEqual.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThanOrEqual.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsLessThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsLessThanOrEqual<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> reports whether an integer value is less than or equal to a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 5, true, DisplayName = "Value below reference returns true")]
+    [DataRow(5, 5, true, DisplayName = "Value equal to reference returns true")]
+    [DataRow(10, 5, false, DisplayName = "Value above reference returns false")]
+    public void IsLessThanOrEqual_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("aardvark", "apple", true, DisplayName = "String before reference returns true")]
+    [DataRow("apple", "apple", true, DisplayName = "String equal to reference returns true")]
+    [DataRow("banana", "apple", false, DisplayName = "String after reference returns false")]
+    public void IsLessThanOrEqual_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsLessThanOrEqual(other));
+    }
+
+    // =========================================================================
+    // IsLessThanOrEqual<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsLessThanOrEqual</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically greater or equal values are treated as less-or-equal.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(10.IsLessThanOrEqual(5, comparer));
+        Assert.IsTrue(5.IsLessThanOrEqual(5, comparer));
+        Assert.IsFalse(1.IsLessThanOrEqual(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsLessThanOrEqual(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsLessThanOrEqual(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.Max.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.Max.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.Max.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // Max<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>Max</c> returns the larger of two integer values for representative orderings,
+    /// and returns the receiver when the two values compare equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5, 1, 5, DisplayName = "Receiver larger returns receiver")]
+    [DataRow(1, 5, 5, DisplayName = "Argument larger returns argument")]
+    [DataRow(5, 5, 5, DisplayName = "Equal values return receiver")]
+    public void Max_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, int expected)
+    {
+        Assert.AreEqual(expected, value.Max(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Max</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", "banana", DisplayName = "Receiver larger returns receiver")]
+    [DataRow("apple", "banana", "banana", DisplayName = "Argument larger returns argument")]
+    public void Max_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, string expected)
+    {
+        Assert.AreEqual(expected, value.Max(other));
+    }
+
+    // =========================================================================
+    // Max<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>Max</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically smaller value is considered the maximum.
+    /// </summary>
+    [TestMethod]
+    public void Max_WhenUsingReverseComparer_ShouldReturnSmallestNumeric()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.AreEqual(1, 1.Max(10, comparer));
+        Assert.AreEqual(1, 10.Max(1, comparer));
+        Assert.AreEqual(5, 5.Max(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Max_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.Max(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.Min.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.Min.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.Min.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // Min<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>Min</c> returns the smaller of two integer values for representative orderings,
+    /// and returns the receiver when the two values compare equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, 5, 1, DisplayName = "Receiver smaller returns receiver")]
+    [DataRow(5, 1, 1, DisplayName = "Argument smaller returns argument")]
+    [DataRow(5, 5, 5, DisplayName = "Equal values return receiver")]
+    public void Min_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, int expected)
+    {
+        Assert.AreEqual(expected, value.Min(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Min</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("apple", "banana", "apple", DisplayName = "Receiver smaller returns receiver")]
+    [DataRow("banana", "apple", "apple", DisplayName = "Argument smaller returns argument")]
+    public void Min_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, string expected)
+    {
+        Assert.AreEqual(expected, value.Min(other));
+    }
+
+    // =========================================================================
+    // Min<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>Min</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically larger value is considered the minimum.
+    /// </summary>
+    [TestMethod]
+    public void Min_WhenUsingReverseComparer_ShouldReturnLargestNumeric()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.AreEqual(10, 10.Min(1, comparer));
+        Assert.AreEqual(10, 1.Min(10, comparer));
+        Assert.AreEqual(5, 5.Min(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Min_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.Min(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}


### PR DESCRIPTION
Adds six comparison helpers to the existing IComparableExtensions class, each as its own partial file nested under IComparableExtensions.cs:

  IsGreaterThan, IsGreaterThanOrEqual,
  IsLessThan,    IsLessThanOrEqual,
  Min,           Max

Every method has a plain IComparable<T> overload and a matching IComparer<T> overload, mirroring the dual-overload pattern used by Clamp / IsBetween / IsOutside. Null handling on the predicates matches the existing convention (null argument returns false, does not throw).

Tests are added as parallel partials under IComparableExtensionsTests, covering value-type, reference-type, null, custom-comparer, and null-comparer cases.

No existing public surface is modified. IsWithin was intentionally skipped because it duplicates the established IsBetween.

https://claude.ai/code/session_01N6YXmx4LfkkfHcuhXgAbE7