### PR TITLE
feat(core): extend IComparableExtensions with ordering, Min/Max, IsEqualTo and AtLeast/AtMost helpers

### DIFF
--- a/Bodu.Core/src/Extensions/IComparableExtensions.AtLeast.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.AtLeast.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.AtLeast.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Raises a value to a specified inclusive lower bound, returning the bound when the value falls below it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to coerce, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to coerce.</param>
+    /// <param name="min">The inclusive lower bound.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="min"/>; otherwise, <paramref name="min"/>.
+    /// </returns>
+    /// <remarks>
+    /// This is a one-sided form of <see cref="Clamp{T}(T, T?, T?)"/> for cases where only a floor is required.
+    /// Equivalent to <c>Math.Max(value, min)</c> for numeric types.
+    /// </remarks>
+    public static T AtLeast<T>(this T value, T min)
+        where T : IComparable<T> =>
+            value.CompareTo(min) >= 0 ? value : min;
+
+    /// <summary>
+    /// Raises a value to a specified inclusive lower bound using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to coerce.</typeparam>
+    /// <param name="value">The value to coerce.</param>
+    /// <param name="min">The inclusive lower bound.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="min"/> under the specified comparer;
+    /// otherwise, <paramref name="min"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>This is a one-sided form of <see cref="Clamp{T}(T, T?, T?, IComparer{T})"/> for cases where only a floor is required.</remarks>
+    public static T AtLeast<T>(this T value, T min, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, min) >= 0 ? value : min;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.AtMost.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.AtMost.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.AtMost.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Lowers a value to a specified inclusive upper bound, returning the bound when the value exceeds it.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to coerce, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to coerce.</param>
+    /// <param name="max">The inclusive upper bound.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="max"/>; otherwise, <paramref name="max"/>.
+    /// </returns>
+    /// <remarks>
+    /// This is a one-sided form of <see cref="Clamp{T}(T, T?, T?)"/> for cases where only a ceiling is required.
+    /// Equivalent to <c>Math.Min(value, max)</c> for numeric types.
+    /// </remarks>
+    public static T AtMost<T>(this T value, T max)
+        where T : IComparable<T> =>
+            value.CompareTo(max) <= 0 ? value : max;
+
+    /// <summary>
+    /// Lowers a value to a specified inclusive upper bound using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to coerce.</typeparam>
+    /// <param name="value">The value to coerce.</param>
+    /// <param name="max">The inclusive upper bound.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="max"/> under the specified comparer;
+    /// otherwise, <paramref name="max"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>This is a one-sided form of <see cref="Clamp{T}(T, T?, T?, IComparer{T})"/> for cases where only a ceiling is required.</remarks>
+    public static T AtMost<T>(this T value, T max, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, max) <= 0 ? value : max;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsEqualTo.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsEqualTo.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsEqualTo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether two values are equal under the ordering defined by a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <param name="comparer">The comparer whose ordering is used to determine equality.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="comparer"/> compares <paramref name="value"/> and <paramref name="other"/> as
+    /// equal (that is, <see cref="IComparer{T}.Compare(T, T)"/> returns zero); otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>
+    /// Comparer-defined equality is distinct from <see cref="object.Equals(object)"/>. A case-insensitive
+    /// <see cref="StringComparer"/>, for example, considers <c>"Hello"</c> and <c>"hello"</c> equal even though
+    /// <see cref="string.Equals(string)"/> does not. For the default equality semantics of <typeparamref name="T"/>
+    /// use <see cref="object.Equals(object)"/> or <see cref="IEquatable{T}.Equals(T)"/> directly.
+    /// </remarks>
+    public static bool IsEqualTo<T>(this T value, T other, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, other) == 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsGreaterThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is strictly greater than a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly greater than <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThan<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) > 0;
+
+    /// <summary>
+    /// Determines whether a value is strictly greater than a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly greater than <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThan<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) > 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsGreaterThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is greater than or equal to a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is greater than or equal to <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThanOrEqual<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) >= 0;
+
+    /// <summary>
+    /// Determines whether a value is greater than or equal to a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is greater than or equal to <paramref name="other"/> based on the
+    /// specified comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsGreaterThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) >= 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsLessThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is strictly less than a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly less than <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThan<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) < 0;
+
+    /// <summary>
+    /// Determines whether a value is strictly less than a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is strictly less than <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThan<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) < 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.IsLessThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Determines whether a value is less than or equal to a specified reference value.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is less than or equal to <paramref name="other"/>; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThanOrEqual<T>(this T value, T? other)
+        where T : IComparable<T> =>
+            other is not null && value.CompareTo(other) <= 0;
+
+    /// <summary>
+    /// Determines whether a value is less than or equal to a specified reference value using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the value to compare.</typeparam>
+    /// <param name="value">The value to test.</param>
+    /// <param name="other">The reference value to compare against.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> is less than or equal to <paramref name="other"/> based on the specified
+    /// comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
+    public static bool IsLessThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
+        where T : struct =>
+            comparer is null
+                ? throw new ArgumentNullException(nameof(comparer))
+                : other is not null && comparer.Compare(value, other.Value) <= 0;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.Max.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Returns the larger of two values using their natural ordering.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="other"/>; otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <remarks>When the two values compare equal, <paramref name="value"/> is returned.</remarks>
+    public static T Max<T>(this T value, T other)
+        where T : IComparable<T> =>
+            value.CompareTo(other) >= 0 ? value : other;
+
+    /// <summary>
+    /// Returns the larger of two values using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares greater than or equal to <paramref name="other"/> under the specified comparer;
+    /// otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
+    public static T Max<T>(this T value, T other, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, other) >= 0 ? value : other;
+}

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensions.Min.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public static partial class IComparableExtensions
+{
+    /// <summary>
+    /// Returns the smaller of two values using their natural ordering.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare, which must implement <see cref="IComparable{T}"/>.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="other"/>; otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <remarks>When the two values compare equal, <paramref name="value"/> is returned.</remarks>
+    public static T Min<T>(this T value, T other)
+        where T : IComparable<T> =>
+            value.CompareTo(other) <= 0 ? value : other;
+
+    /// <summary>
+    /// Returns the smaller of two values using a custom <see cref="IComparer{T}"/>.
+    /// </summary>
+    /// <typeparam name="T">The type of the values to compare.</typeparam>
+    /// <param name="value">The first value.</param>
+    /// <param name="other">The second value.</param>
+    /// <param name="comparer">The comparer to use for comparing values.</param>
+    /// <returns>
+    /// <paramref name="value"/> if it compares less than or equal to <paramref name="other"/> under the specified comparer;
+    /// otherwise, <paramref name="other"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
+    /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
+    public static T Min<T>(this T value, T other, IComparer<T> comparer) =>
+        comparer is null
+            ? throw new ArgumentNullException(nameof(comparer))
+            : comparer.Compare(value, other) <= 0 ? value : other;
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.AtLeast.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.AtLeast.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.AtLeast.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // AtLeast<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>AtLeast</c> returns the value when it is at or above the floor, and returns the floor otherwise.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 5, 10, DisplayName = "Value above floor returns value")]
+    [DataRow(5, 5, 5, DisplayName = "Value on floor returns value")]
+    [DataRow(0, 5, 5, DisplayName = "Value below floor returns floor")]
+    public void AtLeast_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int min, int expected)
+    {
+        Assert.AreEqual(expected, value.AtLeast(min));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AtLeast</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", "banana", DisplayName = "String above floor returns value")]
+    [DataRow("aardvark", "apple", "apple", DisplayName = "String below floor returns floor")]
+    public void AtLeast_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string min, string expected)
+    {
+        Assert.AreEqual(expected, value.AtLeast(min));
+    }
+
+    // =========================================================================
+    // AtLeast<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>AtLeast</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically smaller value is treated as the floor.
+    /// </summary>
+    [TestMethod]
+    public void AtLeast_WhenUsingReverseComparer_ShouldRespectComparerOrdering()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        // Under a reverse comparer, 1 is "greater than" 10, so 1 is already at or above the floor (10).
+        Assert.AreEqual(1, 1.AtLeast(10, comparer));
+
+        // Under a reverse comparer, 20 is "less than" 10, so 20 is below the floor and is raised to 10.
+        Assert.AreEqual(10, 20.AtLeast(10, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void AtLeast_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.AtLeast(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.AtMost.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.AtMost.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.AtMost.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // AtMost<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>AtMost</c> returns the value when it is at or below the ceiling, and returns the ceiling otherwise.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 5, 0, DisplayName = "Value below ceiling returns value")]
+    [DataRow(5, 5, 5, DisplayName = "Value on ceiling returns value")]
+    [DataRow(10, 5, 5, DisplayName = "Value above ceiling returns ceiling")]
+    public void AtMost_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int max, int expected)
+    {
+        Assert.AreEqual(expected, value.AtMost(max));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AtMost</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("aardvark", "apple", "aardvark", DisplayName = "String below ceiling returns value")]
+    [DataRow("banana", "apple", "apple", DisplayName = "String above ceiling returns ceiling")]
+    public void AtMost_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string max, string expected)
+    {
+        Assert.AreEqual(expected, value.AtMost(max));
+    }
+
+    // =========================================================================
+    // AtMost<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>AtMost</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically larger value is treated as the ceiling.
+    /// </summary>
+    [TestMethod]
+    public void AtMost_WhenUsingReverseComparer_ShouldRespectComparerOrdering()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        // Under a reverse comparer, 20 is "less than" 10, so 20 is already at or below the ceiling (10).
+        Assert.AreEqual(20, 20.AtMost(10, comparer));
+
+        // Under a reverse comparer, 1 is "greater than" 10, so 1 is above the ceiling and is lowered to 10.
+        Assert.AreEqual(10, 1.AtMost(10, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void AtMost_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.AtMost(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsEqualTo.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsEqualTo.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsEqualTo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsEqualTo<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsEqualTo</c> returns <see langword="true"/> when the default comparer reports equality
+    /// and <see langword="false"/> otherwise.
+    /// </summary>
+    [TestMethod]
+    public void IsEqualTo_WhenUsingDefaultComparer_ShouldReflectNaturalEquality()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsTrue(5.IsEqualTo(5, comparer));
+        Assert.IsFalse(5.IsEqualTo(6, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsEqualTo</c> treats values as equal when a case-insensitive <see cref="StringComparer"/>
+    /// reports zero, even though <see cref="string.Equals(string)"/> would not.
+    /// </summary>
+    [TestMethod]
+    public void IsEqualTo_WhenUsingCaseInsensitiveComparer_ShouldTreatDifferentCasingAsEqual()
+    {
+        IComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
+
+        Assert.IsTrue("Hello".IsEqualTo("hello", comparer));
+        Assert.IsFalse("Hello".IsEqualTo("world", comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsEqualTo_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsEqualTo(5, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThan.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThan.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsGreaterThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsGreaterThan<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> reports whether an integer value is strictly greater than a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 5, true, DisplayName = "Value above reference returns true")]
+    [DataRow(5, 5, false, DisplayName = "Value equal to reference returns false")]
+    [DataRow(0, 5, false, DisplayName = "Value below reference returns false")]
+    public void IsGreaterThan_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", true, DisplayName = "String after reference returns true")]
+    [DataRow("apple", "apple", false, DisplayName = "String equal to reference returns false")]
+    [DataRow("aardvark", "apple", false, DisplayName = "String before reference returns false")]
+    public void IsGreaterThan_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThan</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsGreaterThan(other));
+    }
+
+    // =========================================================================
+    // IsGreaterThan<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsGreaterThan</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically smaller values are treated as greater.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(1.IsGreaterThan(5, comparer));
+        Assert.IsFalse(5.IsGreaterThan(5, comparer));
+        Assert.IsFalse(10.IsGreaterThan(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsGreaterThan(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThan_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsGreaterThan(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThanOrEqual.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsGreaterThanOrEqual.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsGreaterThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsGreaterThanOrEqual<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> reports whether an integer value is greater than or equal to a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 5, true, DisplayName = "Value above reference returns true")]
+    [DataRow(5, 5, true, DisplayName = "Value equal to reference returns true")]
+    [DataRow(0, 5, false, DisplayName = "Value below reference returns false")]
+    public void IsGreaterThanOrEqual_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", true, DisplayName = "String after reference returns true")]
+    [DataRow("apple", "apple", true, DisplayName = "String equal to reference returns true")]
+    [DataRow("aardvark", "apple", false, DisplayName = "String before reference returns false")]
+    public void IsGreaterThanOrEqual_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsGreaterThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsGreaterThanOrEqual</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsGreaterThanOrEqual(other));
+    }
+
+    // =========================================================================
+    // IsGreaterThanOrEqual<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsGreaterThanOrEqual</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically smaller or equal values are treated as greater-or-equal.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(1.IsGreaterThanOrEqual(5, comparer));
+        Assert.IsTrue(5.IsGreaterThanOrEqual(5, comparer));
+        Assert.IsFalse(10.IsGreaterThanOrEqual(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsGreaterThanOrEqual(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsGreaterThanOrEqual_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsGreaterThanOrEqual(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThan.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThan.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsLessThan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsLessThan<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> reports whether an integer value is strictly less than a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 5, true, DisplayName = "Value below reference returns true")]
+    [DataRow(5, 5, false, DisplayName = "Value equal to reference returns false")]
+    [DataRow(10, 5, false, DisplayName = "Value above reference returns false")]
+    public void IsLessThan_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("aardvark", "apple", true, DisplayName = "String before reference returns true")]
+    [DataRow("apple", "apple", false, DisplayName = "String equal to reference returns false")]
+    [DataRow("banana", "apple", false, DisplayName = "String after reference returns false")]
+    public void IsLessThan_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThan(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThan</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsLessThan(other));
+    }
+
+    // =========================================================================
+    // IsLessThan<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsLessThan</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically greater values are treated as less.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(10.IsLessThan(5, comparer));
+        Assert.IsFalse(5.IsLessThan(5, comparer));
+        Assert.IsFalse(1.IsLessThan(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsLessThan(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThan_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsLessThan(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThanOrEqual.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsLessThanOrEqual.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.IsLessThanOrEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // IsLessThanOrEqual<T>(T, T?)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> reports whether an integer value is less than or equal to a reference value
+    /// for representative above, equal, and below cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 5, true, DisplayName = "Value below reference returns true")]
+    [DataRow(5, 5, true, DisplayName = "Value equal to reference returns true")]
+    [DataRow(10, 5, false, DisplayName = "Value above reference returns false")]
+    public void IsLessThanOrEqual_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("aardvark", "apple", true, DisplayName = "String before reference returns true")]
+    [DataRow("apple", "apple", true, DisplayName = "String equal to reference returns true")]
+    [DataRow("banana", "apple", false, DisplayName = "String after reference returns false")]
+    public void IsLessThanOrEqual_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, bool expected)
+    {
+        Assert.AreEqual(expected, value.IsLessThanOrEqual(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsLessThanOrEqual</c> returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenOtherIsNull_ShouldReturnFalse()
+    {
+        string? other = null;
+
+        Assert.IsFalse("anything".IsLessThanOrEqual(other));
+    }
+
+    // =========================================================================
+    // IsLessThanOrEqual<T>(T, T?, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>IsLessThanOrEqual</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer, numerically greater or equal values are treated as less-or-equal.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenUsingReverseComparer_ShouldReturnExpectedResult()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.IsTrue(10.IsLessThanOrEqual(5, comparer));
+        Assert.IsTrue(5.IsLessThanOrEqual(5, comparer));
+        Assert.IsFalse(1.IsLessThanOrEqual(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload returns <see langword="false"/> when the reference value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenOtherIsNull_ForComparerOverload_ShouldReturnFalse()
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.IsFalse(5.IsLessThanOrEqual(null, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void IsLessThanOrEqual_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.IsLessThanOrEqual(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.Max.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.Max.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.Max.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // Max<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>Max</c> returns the larger of two integer values for representative orderings,
+    /// and returns the receiver when the two values compare equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5, 1, 5, DisplayName = "Receiver larger returns receiver")]
+    [DataRow(1, 5, 5, DisplayName = "Argument larger returns argument")]
+    [DataRow(5, 5, 5, DisplayName = "Equal values return receiver")]
+    public void Max_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, int expected)
+    {
+        Assert.AreEqual(expected, value.Max(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Max</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("banana", "apple", "banana", DisplayName = "Receiver larger returns receiver")]
+    [DataRow("apple", "banana", "banana", DisplayName = "Argument larger returns argument")]
+    public void Max_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, string expected)
+    {
+        Assert.AreEqual(expected, value.Max(other));
+    }
+
+    // =========================================================================
+    // Max<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>Max</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically smaller value is considered the maximum.
+    /// </summary>
+    [TestMethod]
+    public void Max_WhenUsingReverseComparer_ShouldReturnSmallestNumeric()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.AreEqual(1, 1.Max(10, comparer));
+        Assert.AreEqual(1, 10.Max(1, comparer));
+        Assert.AreEqual(5, 5.Max(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Max_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.Max(10, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.Min.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.Min.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IComparableExtensionsTests.Min.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Extensions;
+
+public partial class IComparableExtensionsTests
+{
+    // =========================================================================
+    // Min<T>(T, T)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that <c>Min</c> returns the smaller of two integer values for representative orderings,
+    /// and returns the receiver when the two values compare equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, 5, 1, DisplayName = "Receiver smaller returns receiver")]
+    [DataRow(5, 1, 1, DisplayName = "Argument smaller returns argument")]
+    [DataRow(5, 5, 5, DisplayName = "Equal values return receiver")]
+    public void Min_WhenEvaluatingIntegerValues_ShouldReturnExpectedResult(int value, int other, int expected)
+    {
+        Assert.AreEqual(expected, value.Min(other));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Min</c> works correctly with a reference type (string) using natural ordering.
+    /// </summary>
+    [TestMethod]
+    [DataRow("apple", "banana", "apple", DisplayName = "Receiver smaller returns receiver")]
+    [DataRow("banana", "apple", "apple", DisplayName = "Argument smaller returns argument")]
+    public void Min_WhenEvaluatingStringValues_ShouldReturnExpectedResult(string value, string other, string expected)
+    {
+        Assert.AreEqual(expected, value.Min(other));
+    }
+
+    // =========================================================================
+    // Min<T>(T, T, IComparer<T>)
+    // =========================================================================
+
+    /// <summary>
+    /// Verifies that the comparer overload of <c>Min</c> honours the supplied comparer's ordering.
+    /// Under a reverse comparer the numerically larger value is considered the minimum.
+    /// </summary>
+    [TestMethod]
+    public void Min_WhenUsingReverseComparer_ShouldReturnLargestNumeric()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        Assert.AreEqual(10, 10.Min(1, comparer));
+        Assert.AreEqual(10, 1.Min(10, comparer));
+        Assert.AreEqual(5, 5.Min(5, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that a null comparer passed to the comparer overload throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Min_WhenComparerIsNull_ShouldThrowArgumentNullException()
+    {
+        IComparer<int>? comparer = null;
+
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = 5.Min(1, comparer!);
+        });
+
+        Assert.AreEqual("comparer", ex.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary

Rounds out `Bodu.Extensions.IComparableExtensions` with a solid first set of
comparison helpers, each as its own partial file nested under
`IComparableExtensions.cs` (and matching test partials under
`IComparableExtensionsTests.cs`).

New methods (all with a plain `IComparable<T>` overload plus an `IComparer<T>`
overload, except where noted):

- `IsGreaterThan`, `IsGreaterThanOrEqual`, `IsLessThan`, `IsLessThanOrEqual`
- `Min`, `Max`
- `AtLeast`, `AtMost` — one-sided coercion (floor / ceiling)
- `IsEqualTo` — **comparer-only**; enables comparer-based equality such as
  `StringComparer.OrdinalIgnoreCase`, which is distinct from `object.Equals`.
  No non-comparer overload because that would just wrap `Equals`.

Design decisions aligned with the existing file:

- **Null ⇒ `false`** on predicates, matching `IsBetween` / `IsOutside`
  (no `ArgumentNullException`).
- **Four named methods instead of a `bool inclusive` parameter** — avoids the
  boolean-trap and aligns with `System.Linq.Expressions` naming.
- **`IsWithin` intentionally skipped** — duplicates the established `IsBetween`.
- Comparer overloads use `where T : struct` where the parameter uses `T?`,
  and unconstrained `T` otherwise, matching `Clamp` / `IsBetween` / `IsOutside`.

No existing public surface is modified.

## Test plan

- [x] Source files follow the established file-scoped-namespace / no-regions /
      expression-bodied style; British English XML docs mirror existing
      partials.
- [x] Test partials cover value-type (int), reference-type (string),
      null-argument, custom-comparer (reverse ordering), and null-comparer
      cases.
- [ ] CI `Build and Test` workflow passes on this PR (this is what I'm
      asking GitHub to run — sandbox has no .NET SDK).

https://claude.ai/code/session_01N6YXmx4LfkkfHcuhXgAbE7

---
_Generated by [Claude Code](https://claude.ai/code/session_01N6YXmx4LfkkfHcuhXgAbE7)_