### PR TITLE
feat(Bodu.IO.Hashing): add SuperFastHash

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SuperFastHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Buffers.Binary;
+using System.IO;
+using System.IO.Hashing;
+using System.Runtime.CompilerServices;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Computes a 32-bit non-cryptographic hash using Paul Hsieh's <c>SuperFastHash</c> algorithm, intended for
+/// hash-table keying. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The algorithm seeds the running hash with the total length of the input and therefore requires the entire
+/// payload to be visible before finalisation. Appended bytes are accumulated in an internal buffer and the
+/// full compute is executed each time the current hash is requested. The finalised 32-bit value is written to
+/// the output buffer in little-endian byte order.
+/// </para>
+/// <para>
+/// Because the implementation buffers its input, memory use grows linearly with the total number of bytes
+/// appended between calls to <see cref="Reset" />. The algorithm is well suited to short keys — its intended
+/// use case — but should be avoided for very large streams where a block-oriented, fixed-memory hash would be
+/// more appropriate.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
+/// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class SuperFastHash
+    : NonCryptographicHashAlgorithm
+{
+    private const int HashLength = 4;
+
+    private readonly MemoryStream _buffer = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SuperFastHash" /> class.
+    /// </summary>
+    public SuperFastHash()
+        : base(HashLength)
+    {
+    }
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<byte> source) =>
+        this._buffer.Write(source);
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        this._buffer.SetLength(0);
+
+    /// <inheritdoc />
+    protected override void GetCurrentHashCore(Span<byte> destination)
+    {
+        ReadOnlySpan<byte> data = this._buffer.GetBuffer().AsSpan(0, (int)this._buffer.Length);
+        BinaryPrimitives.WriteUInt32LittleEndian(destination, Compute(data));
+    }
+
+    /// <summary>
+    /// Computes Paul Hsieh's SuperFastHash over the supplied payload and returns the finalised 32-bit value.
+    /// </summary>
+    /// <param name="data">The input bytes to hash.</param>
+    /// <returns>The 32-bit SuperFastHash value. Returns <c>0</c> when <paramref name="data" /> is empty.</returns>
+    /// <remarks>
+    /// The pre-avalanche loop consumes the payload in 4-byte blocks, reading each half as a little-endian
+    /// 16-bit word. Any residual 1, 2, or 3 trailing bytes are folded in by a dedicated tail branch, and the
+    /// final avalanche mixes the result prior to return. The odd-byte tail branches sign-extend the trailing
+    /// byte via <see cref="sbyte" /> to match Hsieh's reference C <c>(signed char)</c> behaviour.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static uint Compute(ReadOnlySpan<byte> data)
+    {
+        if (data.IsEmpty)
+            return 0;
+
+        uint hash = (uint)data.Length;
+        int rem = data.Length & 3;
+        int blocks = data.Length >> 2;
+        int i = 0;
+
+        for (int b = 0; b < blocks; b++)
+        {
+            ushort w0 = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(i, 2));
+            ushort w1 = BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(i + 2, 2));
+
+            hash += w0;
+            uint tmp = ((uint)w1 << 11) ^ hash;
+            hash = (hash << 16) ^ tmp;
+            hash += hash >> 11;
+
+            i += 4;
+        }
+
+        switch (rem)
+        {
+            case 3:
+                hash += BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(i, 2));
+                hash ^= hash << 16;
+                hash ^= (uint)((sbyte)data[i + 2]) << 18;
+                hash += hash >> 11;
+                break;
+
+            case 2:
+                hash += BinaryPrimitives.ReadUInt16LittleEndian(data.Slice(i, 2));
+                hash ^= hash << 11;
+                hash += hash >> 17;
+                break;
+
+            case 1:
+                hash += (uint)(sbyte)data[i];
+                hash ^= hash << 10;
+                hash += hash >> 1;
+                break;
+        }
+
+        hash ^= hash << 3;
+        hash += hash >> 5;
+        hash ^= hash << 4;
+        hash += hash >> 17;
+        hash ^= hash << 25;
+        hash += hash >> 6;
+
+        return hash;
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/SuperFastHashTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/SuperFastHashTests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SuperFastHashTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Contains unit tests for the <see cref="SuperFastHash" /> hash algorithm.
+/// </summary>
+[TestClass]
+public sealed partial class SuperFastHashTests
+    : NonCryptographicHashAlgorithmTests<SuperFastHashTests, SuperFastHash, SingleTestVariant>
+{
+    /// <inheritdoc />
+    protected override SuperFastHash CreateAlgorithm(SingleTestVariant variant) => new();
+
+    /// <inheritdoc />
+    protected override NonCryptographicHashAlgorithmSpecification GetSpecification(SingleTestVariant variant) =>
+        new()
+        {
+            HashLengthInBytes = 4,
+            BoundaryLengths = new[] { 1, 2, 3, 4, 5, 7, 8, 16, 64 },
+            LongInputLength = 200,
+            MinNonZeroBytesForLongInput = 2,
+            KnownAnswers = new()
+            {
+                Empty = "00000000",
+                Abc = "39B3AA2F",
+                QuickBrownFox = "E37CBF05",
+                Zeros16 = "D6705481",
+                Sequential0To255 = "73746413",
+            },
+        };
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// Entries are the SuperFastHash digests, in little-endian byte order, for incremental inputs
+    /// <c>[]</c>, <c>[0x00]</c>, <c>[0x00, 0x01]</c>, … <c>[0x00 .. 0x0E]</c>.
+    /// </remarks>
+    protected override IEnumerable<string> GetIncrementalHashValue(SingleTestVariant variant) => new[]
+    {
+        "00000000", "5A595355", "94A0EA00", "7C80828E", "EF71151F", "0A834E96",
+        "623C7A3D", "2794B36B", "AA876FB6", "92324598", "5CF6B891", "9F18F1ED",
+        "2D50A77C", "0CFAF828", "4D958D23", "AACF3EBF",
+    };
+}


### PR DESCRIPTION
Integrate Paul Hsieh's 32-bit non-cryptographic SuperFastHash alongside JSHash, Fletcher, and FNV. The algorithm seeds its running hash with the total input length, so Append buffers bytes into a MemoryStream and the full compute runs at GetCurrentHash time; Reset reuses the buffer capacity by truncating its length. The finalised uint32 is written little-endian, matching the existing non-crypto hash convention in this project.

Tests derive from NonCryptographicHashAlgorithmTests<...> and pin known answers for Empty/ABC/QuickBrownFox/Zeros16/Sequential0..254 plus the 16-entry incremental [0x00..0x0E] sequence. Vectors were produced by a spec-faithful C# port and cross-checked against an independent Python port, both built directly from Hsieh's reference algorithm.

https://claude.ai/code/session_01Huvh2biads9ynHNZN9k8rx