### PR TITLE
feat(Bodu.IO.Hashing): add Damm, Luhn, Verhoeff check-digit algorithms

### DIFF
--- a/Bodu.Core/src/ThrowHelper.CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.CallerExpression.cs
@@ -1180,6 +1180,28 @@ public static partial class ThrowHelper
     }
 
     /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not an ASCII decimal
+    /// digit character, that is, a character in the range <c>'0'</c> (U+0030) to <c>'9'</c> (U+0039) inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is outside the inclusive range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>Useful for validating inputs to algorithms that operate on decimal digit strings, such as check-digit algorithms.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiDecimalDigit(
+        char value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if ((uint)(value - '0') > 9u)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not an ASCII decimal digit ('0' to '9').");
+    }
+
+    /// <summary>
     /// Throws an <see cref="ArgumentNullException"/> if <paramref name="value"/> is <see langword="null"/>.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>

--- a/Bodu.Core/src/ThrowHelper.NetStandard.cs
+++ b/Bodu.Core/src/ThrowHelper.NetStandard.cs
@@ -710,6 +710,24 @@ public static partial class ThrowHelper
     }
 
     /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not an ASCII decimal
+    /// digit character, that is, a character in the range <c>'0'</c> (U+0030) to <c>'9'</c> (U+0039) inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is outside the inclusive range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiDecimalDigit(char value)
+    {
+        if ((uint)(value - '0') > 9u)
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not an ASCII decimal digit ('0' to '9').");
+    }
+
+    /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/CheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/CheckDigitAlgorithm.cs
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Represents the abstract base class from which all decimal check-digit algorithms in this library derive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A check-digit algorithm consumes a sequence of decimal digits (<c>'0'</c> to <c>'9'</c>) and yields a single
+/// trailing digit that, when appended to the body, allows the concatenated sequence to be validated. Unlike the
+/// byte-stream oriented <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />, this class operates on
+/// <see cref="char" /> sequences natively and emits a single <see cref="char" /> result — matching the domain of
+/// card numbers, national identifiers, and serial codes on which these algorithms are typically applied.
+/// </para>
+/// <para>
+/// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and
+/// <see cref="GetCurrentCheckDigit" /> — mirrors the familiar hash-algorithm idiom. Reading the current check
+/// digit is non-destructive and idempotent. On an empty body every built-in algorithm in this library returns
+/// the digit <c>'0'</c>; concrete implementations document any exception.
+/// </para>
+/// <para>
+/// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
+/// </para>
+/// <note type="important">Check-digit algorithms are error-detection primitives, <b>not</b> cryptographic
+/// functions. They must <b>not</b> be used for password hashing, digital signatures, or integrity validation in
+/// security-sensitive applications.</note>
+/// </remarks>
+public abstract class CheckDigitAlgorithm
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CheckDigitAlgorithm" /> class.
+    /// </summary>
+    protected CheckDigitAlgorithm()
+    {
+    }
+
+    /// <summary>
+    /// Gets the canonical name of the algorithm, suitable for diagnostic output and logging.
+    /// </summary>
+    /// <returns>A short, stable identifier such as <c>"Luhn"</c>, <c>"Damm"</c>, or <c>"Verhoeff"</c>.</returns>
+    public abstract string AlgorithmName { get; }
+
+    /// <summary>
+    /// Absorbs the supplied decimal digits into the running check-digit state.
+    /// </summary>
+    /// <param name="digits">
+    /// The characters to append. Each element must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).
+    /// An empty span is a permitted no-op.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public abstract void Append(ReadOnlySpan<char> digits);
+
+    /// <summary>
+    /// Absorbs a single decimal digit into the running check-digit state.
+    /// </summary>
+    /// <param name="digit">The character to append. Must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digit" /> is outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public void Append(char digit) =>
+        Append([digit]);
+
+    /// <summary>
+    /// Resets the algorithm to its initial state, discarding any digits previously absorbed.
+    /// </summary>
+    /// <remarks>Equivalent in behaviour to constructing a fresh instance of the same concrete type.</remarks>
+    public abstract void Reset();
+
+    /// <summary>
+    /// Returns the check digit computed for the body absorbed since the last <see cref="Reset" /> (or since
+    /// construction).
+    /// </summary>
+    /// <returns>
+    /// The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>. For an empty body all
+    /// built-in algorithms return <c>'0'</c>.
+    /// </returns>
+    /// <remarks>This call is non-destructive; the running state is unaffected and the method may be invoked any
+    /// number of times with identical results between appends.</remarks>
+    public abstract char GetCurrentCheckDigit();
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Damm.Table.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Damm.Table.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Damm.Table.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public sealed partial class Damm
+{
+    // Standard totally antisymmetric quasigroup of order 10 proposed by H. Michael Damm (2004).
+    // Indexed as Table[interim, digit]. Row 0 column d gives the check digit of a single-digit body 'd'.
+    private static readonly byte[,] Table = new byte[10, 10]
+    {
+        { 0, 3, 1, 7, 5, 9, 8, 6, 4, 2 },
+        { 7, 0, 9, 2, 1, 5, 4, 8, 6, 3 },
+        { 4, 2, 0, 6, 8, 7, 1, 3, 5, 9 },
+        { 1, 7, 5, 0, 9, 8, 3, 4, 2, 6 },
+        { 6, 1, 2, 3, 0, 4, 5, 9, 7, 8 },
+        { 3, 6, 7, 4, 2, 0, 9, 5, 8, 1 },
+        { 5, 8, 6, 9, 7, 2, 0, 1, 3, 4 },
+        { 8, 9, 4, 5, 3, 6, 2, 0, 1, 7 },
+        { 9, 4, 3, 8, 6, 1, 7, 2, 0, 5 },
+        { 2, 5, 8, 1, 4, 3, 6, 7, 9, 0 },
+    };
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Damm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Damm.cs
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Damm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Computes the check digit of a decimal string using the <c>Damm</c> algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Damm algorithm was presented by H. Michael Damm in 2004. It evaluates a running <i>interim</i> digit by
+/// repeatedly indexing into a carefully chosen 10×10 <i>totally antisymmetric</i> quasigroup — a table with no
+/// fixed points on its diagonal and no partial idempotent entries. The final interim is the check digit.
+/// </para>
+/// <para>
+/// Damm detects <b>all</b> single-digit substitution errors and <b>all</b> adjacent-digit transpositions — the
+/// latter without the <c>09 ↔ 90</c> exception that Luhn suffers from. Validation is especially clean: a
+/// sequence (body followed by its check digit) is valid if and only if its final interim is zero.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"572"</c>, the computed check digit is <c>'4'</c>, and the resulting
+/// sequence <c>"5724"</c> is therefore valid under Damm.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed partial class Damm : CheckDigitAlgorithm
+{
+    private byte _interim;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Damm" /> class.
+    /// </summary>
+    public Damm()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "Damm";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        byte interim = _interim;
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            interim = Table[interim, ch - '0'];
+        }
+
+        _interim = interim;
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _interim = 0;
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit() =>
+        (char)('0' + _interim);
+
+    /// <summary>
+    /// Computes the Damm check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> digits)
+    {
+        byte interim = 0;
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            interim = Table[interim, ch - '0'];
+        }
+
+        return (char)('0' + interim);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by a trailing Damm check digit, is
+    /// valid — that is, whether the final interim evaluates to zero.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Damm; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
+    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        byte interim = 0;
+        for (int i = 0; i < digitsIncludingCheck.Length; i++)
+        {
+            char ch = digitsIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            interim = Table[interim, ch - '0'];
+        }
+
+        return interim == 0;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Luhn.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Luhn.cs
@@ -1,0 +1,167 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Luhn.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Computes the check digit of a decimal string using the <c>Luhn</c> (<c>mod 10</c>) algorithm. This class cannot
+/// be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Luhn algorithm — sometimes called the <i>modulus 10</i> or <i>mod 10</i> algorithm — was designed by Hans
+/// Peter Luhn at IBM in 1954 and entered the public domain shortly afterwards. It is the check-digit scheme used
+/// by most credit card numbers, many national identification numbers, IMEI numbers, and numerous other serial
+/// encodings.
+/// </para>
+/// <para>
+/// Working right-to-left over the sequence, every second digit (starting with the digit immediately to the left
+/// of the check digit) is doubled. When doubling produces a two-digit value, the digits are summed — equivalently
+/// one subtracts nine. The check digit is the value that makes the total sum divisible by ten.
+/// </para>
+/// <para>
+/// Luhn catches all single-digit substitution errors and all adjacent-digit transpositions <i>except</i> the
+/// transposition <c>09 ↔ 90</c>, which preserves the digit sum. It does not reliably detect other mutations such
+/// as twin errors (<c>aa → bb</c>).
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"7992739871"</c>, the computed check digit is <c>'3'</c>, and the
+/// resulting sequence <c>"79927398713"</c> is therefore valid under Luhn.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Luhn : CheckDigitAlgorithm
+{
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Luhn" /> class.
+    /// </summary>
+    public Luhn()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "Luhn";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int doubled = v * 2;
+            if (doubled > 9) doubled -= 9;
+
+            // _sumEvenHypothesis (body length N will be even): body[i] is doubled iff i is odd.
+            // _sumOddHypothesis  (body length N will be odd):  body[i] is doubled iff i is even.
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += doubled;
+            }
+            else
+            {
+                sumEven += doubled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the Luhn check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> digits)
+    {
+        int sum = 0;
+        for (int i = digits.Length - 1, j = 2; i >= 0; i--, j++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            if ((j & 1) == 0)
+            {
+                v *= 2;
+                if (v > 9) v -= 9;
+            }
+
+            sum += v;
+        }
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by a trailing Luhn check digit, is
+    /// consistent — that is, whether the digit sum evaluates to a multiple of ten.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Luhn; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
+    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        int sum = 0;
+        for (int i = digitsIncludingCheck.Length - 1, j = 1; i >= 0; i--, j++)
+        {
+            char ch = digitsIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            int v = ch - '0';
+            if ((j & 1) == 0)
+            {
+                v *= 2;
+                if (v > 9) v -= 9;
+            }
+
+            sum += v;
+        }
+
+        return sum % 10 == 0;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.Tables.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.Tables.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Verhoeff.Tables.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public sealed partial class Verhoeff
+{
+    // D5 dihedral multiplication table.
+    private static readonly byte[,] D = new byte[10, 10]
+    {
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+        { 1, 2, 3, 4, 0, 6, 7, 8, 9, 5 },
+        { 2, 3, 4, 0, 1, 7, 8, 9, 5, 6 },
+        { 3, 4, 0, 1, 2, 8, 9, 5, 6, 7 },
+        { 4, 0, 1, 2, 3, 9, 5, 6, 7, 8 },
+        { 5, 9, 8, 7, 6, 0, 4, 3, 2, 1 },
+        { 6, 5, 9, 8, 7, 1, 0, 4, 3, 2 },
+        { 7, 6, 5, 9, 8, 2, 1, 0, 4, 3 },
+        { 8, 7, 6, 5, 9, 3, 2, 1, 0, 4 },
+        { 9, 8, 7, 6, 5, 4, 3, 2, 1, 0 },
+    };
+
+    // Multiplicative inverse in D5: Inv[x] is the element y such that D[x, y] = 0.
+    private static readonly byte[] Inv = { 0, 4, 3, 2, 1, 5, 6, 7, 8, 9 };
+
+    // Position-dependent permutation table. Row index is (position mod 8); column is the digit value.
+    private static readonly byte[,] P = new byte[8, 10]
+    {
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 },
+        { 1, 5, 7, 6, 2, 8, 3, 0, 9, 4 },
+        { 5, 8, 0, 3, 7, 9, 6, 1, 4, 2 },
+        { 8, 9, 1, 6, 0, 4, 3, 5, 2, 7 },
+        { 9, 4, 5, 3, 1, 2, 6, 8, 7, 0 },
+        { 4, 2, 8, 6, 5, 7, 3, 9, 0, 1 },
+        { 2, 7, 9, 3, 8, 0, 6, 4, 1, 5 },
+        { 7, 0, 4, 6, 9, 1, 3, 2, 5, 8 },
+    };
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.cs
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Verhoeff.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Computes the check digit of a decimal string using the <c>Verhoeff</c> algorithm. This class cannot be
+/// inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The Verhoeff algorithm, published by the Dutch mathematician Jacobus Verhoeff in 1969, was the first
+/// decimal-digit check-sum capable of detecting all single-digit substitution errors <i>and</i> all adjacent-digit
+/// transpositions. It achieves this by combining a position-dependent permutation with multiplication in the
+/// dihedral group <i>D</i><sub>5</sub>, the group of symmetries of a regular pentagon.
+/// </para>
+/// <para>
+/// In addition to single-digit and adjacent-transposition errors, Verhoeff also catches the common
+/// <i>twin</i> errors (<c>aa → bb</c>) and a significant proportion of other mutation classes.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"236"</c>, the computed check digit is <c>'3'</c>, and the resulting
+/// sequence <c>"2363"</c> is therefore valid under Verhoeff.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed partial class Verhoeff : CheckDigitAlgorithm
+{
+    // Eight parallel accumulators allow the streaming Append surface to compute the check digit without
+    // buffering digits. _c[k] holds the Verhoeff running value 'c' under the hypothesis that the most
+    // recently appended digit occupies right-index k in the final sequence. Update: on each append of v,
+    //   newC[k] = d[_c[(k + 1) & 7], p[k, v]]
+    // because shifting in a new most-recent digit demotes every existing digit by one right-index, so the
+    // previous state under hypothesis (k+1) becomes the input for the new state under hypothesis k.
+    private readonly byte[] _c = new byte[8];
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Verhoeff" /> class.
+    /// </summary>
+    public Verhoeff()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "Verhoeff";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        Span<byte> next = stackalloc byte[8];
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            for (int k = 0; k < 8; k++)
+                next[k] = D[_c[(k + 1) & 7], P[k, v]];
+
+            next.CopyTo(_c);
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        Array.Clear(_c);
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit() =>
+        (char)('0' + Inv[_c[1]]);
+
+    /// <summary>
+    /// Computes the Verhoeff check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> digits)
+    {
+        byte c = 0;
+        for (int i = digits.Length - 1, j = 1; i >= 0; i--, j++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            c = D[c, P[j & 7, ch - '0']];
+        }
+
+        return (char)('0' + Inv[c]);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by a trailing Verhoeff check digit,
+    /// is valid — that is, whether the final running value evaluates to zero.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Verhoeff; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
+    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        byte c = 0;
+        for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
+        {
+            char ch = digitsIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            c = D[c, P[j & 7, ch - '0']];
+        }
+
+        return c == 0;
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmSpecification.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmSpecification.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmSpecification.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Describes the expected observable properties of a <see cref="CheckDigitAlgorithm" /> implementation for use in
+/// behavioural and known-answer tests.
+/// </summary>
+/// <remarks>
+/// Instances are supplied by derived test classes via
+/// <see cref="CheckDigitAlgorithmTests{TTest, TAlgorithm}.GetSpecification" /> and drive assertions common across
+/// every check-digit algorithm under test — algorithm-name exposure, empty-body behaviour, and known-answer
+/// evaluation.
+/// </remarks>
+public sealed record CheckDigitAlgorithmSpecification
+{
+    /// <summary>
+    /// Gets the expected <see cref="CheckDigitAlgorithm.AlgorithmName" /> string.
+    /// </summary>
+    /// <returns>The canonical algorithm name, e.g. <c>"Luhn"</c>.</returns>
+    public required string AlgorithmName { get; init; }
+
+    /// <summary>
+    /// Gets the check digit expected for an empty body.
+    /// </summary>
+    /// <returns>An ASCII character in the range <c>'0'</c> to <c>'9'</c>. Defaults to <c>'0'</c>.</returns>
+    public char EmptyCheckDigit { get; init; } = '0';
+
+    /// <summary>
+    /// Gets the known-answer vectors to exercise.
+    /// </summary>
+    /// <returns>A non-empty list of <see cref="CheckDigitKnownAnswer" /> entries.</returns>
+    public required IReadOnlyList<CheckDigitKnownAnswer> KnownAnswers { get; init; }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Append.cs
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.Append.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that appending a body in a single call produces the check digit recorded for that known-answer
+    /// vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body digits to append.</param>
+    /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body one character at a time via the single-char overload produces the same
+    /// check digit as a single span-based call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body digits to append.</param>
+    /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        foreach (char ch in body)
+            algorithm.Append(ch);
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body in two chunks produces the same check digit as appending it in one call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body digits to append.</param>
+    /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        if (body.Length < 2) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        int split = body.Length / 2;
+
+        algorithm.Append(body.AsSpan(0, split));
+        algorithm.Append(body.AsSpan(split));
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending an empty span leaves the running check digit unchanged.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenSpanIsEmpty_ShouldLeaveCheckDigitUnchanged()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        char initial = algorithm.GetCurrentCheckDigit();
+
+        algorithm.Append(ReadOnlySpan<char>.Empty);
+
+        Assert.AreEqual(initial, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that streaming a prefix of a known-answer body and reading <c>GetCurrentCheckDigit</c> matches
+    /// the static <c>Compute</c> result for the same prefix — cross-checking streaming parity with the
+    /// allocate-free path at intermediate body lengths.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The full body digits.</param>
+    /// <param name="expectedCheck">The expected check digit for the full body (unused in this test).</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void GetCurrentCheckDigit_AtEveryPrefixLength_ShouldAgreeWithStaticCompute(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        _ = expectedCheck;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        for (int i = 0; i < body.Length; i++)
+        {
+            algorithm.Append(body[i]);
+            char streaming = algorithm.GetCurrentCheckDigit();
+            char fromCompute = ComputeStatic(body.AsSpan(0, i + 1));
+            Assert.AreEqual(fromCompute, streaming, $"Prefix length {i + 1} (\"{body[..(i + 1)]}\").");
+        }
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Compute.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Compute.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.Compute.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that the static <c>Compute</c> helper returns the expected check digit for every known-answer
+    /// vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body digits.</param>
+    /// <param name="expectedCheck">The expected check digit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Compute_WhenKnownAnswer_ShouldReturnExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        Assert.AreEqual(expectedCheck, ComputeStatic(body.AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that the static <c>Compute</c> helper agrees with the streaming algorithm for every known-answer
+    /// vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body digits.</param>
+    /// <param name="expectedCheck">The expected check digit (unused; cross-comparison is between Compute and Append).</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Compute_WhenInvokedForKnownAnswer_ShouldAgreeWithStreamingAppend(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        _ = expectedCheck;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(algorithm.GetCurrentCheckDigit(), ComputeStatic(body.AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Compute</c> on an empty span returns the empty-body check digit declared in the
+    /// specification.
+    /// </summary>
+    [TestMethod]
+    public void Compute_WhenBodyIsEmpty_ShouldReturnEmptyCheckDigit()
+    {
+        CheckDigitAlgorithmSpecification spec = GetSpecification();
+        Assert.AreEqual(spec.EmptyCheckDigit, ComputeStatic(ReadOnlySpan<char>.Empty));
+    }
+
+    /// <summary>
+    /// Verifies that <c>Compute</c> rejects non-digit characters with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Compute_WhenBodyContainsNonDigit_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = ComputeStatic("12a45".AsSpan());
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Ctors.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Ctors.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.Ctors.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm exposes the algorithm name declared in the specification.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenQueried_ShouldMatchSpecification()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        CheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        Assert.AreEqual(spec.AlgorithmName, algorithm.AlgorithmName);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm reports the empty-body check digit declared in the
+    /// specification.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigit_WhenJustConstructed_ShouldReturnEmptyCheckDigit()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        CheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        Assert.AreEqual(spec.EmptyCheckDigit, algorithm.GetCurrentCheckDigit());
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.GetCurrentCheckDigit.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.GetCurrentCheckDigit.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.GetCurrentCheckDigit.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that reading the current check digit twice in succession — with no intervening appends — yields
+    /// the same value, proving the getter is non-destructive.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigit_WhenReadRepeatedly_ShouldReturnSameValue()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("12345".AsSpan());
+
+        char first = algorithm.GetCurrentCheckDigit();
+        char second = algorithm.GetCurrentCheckDigit();
+        char third = algorithm.GetCurrentCheckDigit();
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(second, third);
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Guards.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Guards.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.Guards.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that <see cref="CheckDigitAlgorithm.Append(ReadOnlySpan{char})" /> rejects any character outside
+    /// the inclusive range <c>'0'</c> to <c>'9'</c> with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    /// <param name="invalid">The offending character to exercise.</param>
+    [DataRow('/')]
+    [DataRow(':')]
+    [DataRow(' ')]
+    [DataRow('-')]
+    [DataRow('a')]
+    [DataRow('Z')]
+    [DataRow('\0')]
+    [DataTestMethod]
+    public void Append_WhenCharacterIsNotAnAsciiDigit_ShouldThrowArgumentOutOfRangeException(char invalid)
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Append(new[] { '1', invalid, '2' }.AsSpan());
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the single-character Append overload also rejects non-digit input.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenSingleCharacterIsNotAnAsciiDigit_ShouldThrowArgumentOutOfRangeException()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Append('x');
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.IsValid.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that appending the algorithm's own computed check digit to the body always yields a sequence
+    /// that <c>IsValid</c> accepts.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body digits.</param>
+    /// <param name="expectedCheck">The expected check digit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenSequenceIncludesComputedCheckDigit_ShouldReturnTrue(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        string full = body + expectedCheck;
+        Assert.IsTrue(IsValidStatic(full.AsSpan()), $"Expected '{full}' to be valid.");
+    }
+
+    /// <summary>
+    /// Verifies that substituting the trailing check digit for a different digit makes <c>IsValid</c> reject
+    /// the sequence.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body digits.</param>
+    /// <param name="expectedCheck">The correct check digit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenCheckDigitIsTampered_ShouldReturnFalse(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        for (char c = '0'; c <= '9'; c++)
+        {
+            if (c == expectedCheck) continue;
+            string bad = body + c;
+            Assert.IsFalse(IsValidStatic(bad.AsSpan()), $"Expected '{bad}' to be invalid (swap of check digit).");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsValid</c> returns <see langword="false" /> — without throwing — when the input
+    /// contains a non-digit character.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenInputContainsNonDigit_ShouldReturnFalse()
+    {
+        Assert.IsFalse(IsValidStatic("123a5".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsValid</c> accepts the empty span as vacuously valid — the natural limit of the
+    /// algorithm's identity when no digits have been absorbed.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenInputIsEmpty_ShouldReturnTrue()
+    {
+        Assert.IsTrue(IsValidStatic(ReadOnlySpan<char>.Empty));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Reset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.Reset.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.Reset.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that <see cref="CheckDigitAlgorithm.Reset" /> after an Append restores the algorithm to the
+    /// empty-body check digit declared in the specification.
+    /// </summary>
+    [TestMethod]
+    public void Reset_AfterAppend_ShouldRestoreEmptyCheckDigit()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        CheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        algorithm.Append("987654".AsSpan());
+        algorithm.Reset();
+
+        Assert.AreEqual(spec.EmptyCheckDigit, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that Reset between two append runs discards the first run's accumulated state so that only the
+    /// second run contributes to the final check digit.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body digits to append in the second run.</param>
+    /// <param name="expectedCheck">The check digit the algorithm is expected to emit for the second run.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append("0987654321".AsSpan());
+        algorithm.Reset();
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitAlgorithmTests.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Provides a reusable base class for verifying correctness and consistency of
+/// <see cref="CheckDigitAlgorithm" /> implementations.
+/// </summary>
+/// <typeparam name="TTest">The concrete test type inheriting this class.</typeparam>
+/// <typeparam name="TAlgorithm">The check-digit algorithm under test.</typeparam>
+/// <remarks>
+/// The harness drives assertions that every check-digit algorithm must satisfy — streaming-equivalence with the
+/// static <c>Compute</c> helper, idempotent <c>GetCurrentCheckDigit</c> reads, <c>Reset</c> semantics,
+/// round-trip between <c>Compute</c> and <c>IsValid</c>, digit-only input validation, and a data-driven set of
+/// known-answer vectors supplied through
+/// <see cref="GetSpecification" />.
+/// </remarks>
+public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
+    where TTest : CheckDigitAlgorithmTests<TTest, TAlgorithm>, new()
+    where TAlgorithm : CheckDigitAlgorithm, new()
+{
+    /// <summary>
+    /// Returns the <see cref="CheckDigitAlgorithmSpecification" /> describing the algorithm's expected
+    /// properties and known-answer vectors.
+    /// </summary>
+    /// <returns>A non-null specification; <see cref="CheckDigitAlgorithmSpecification.KnownAnswers" /> must be non-empty.</returns>
+    protected abstract CheckDigitAlgorithmSpecification GetSpecification();
+
+    /// <summary>
+    /// Creates a new instance of <typeparamref name="TAlgorithm" /> in its initial state.
+    /// </summary>
+    /// <returns>A fresh algorithm instance.</returns>
+    protected virtual TAlgorithm CreateAlgorithm() => new();
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>Compute</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="digits">The body digits.</param>
+    /// <returns>The check digit as a character.</returns>
+    protected abstract char ComputeStatic(ReadOnlySpan<char> digits);
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>IsValid</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The full sequence including the trailing check digit.</param>
+    /// <returns><see langword="true" /> if the sequence is valid under the algorithm; otherwise, <see langword="false" />.</returns>
+    protected abstract bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck);
+
+    /// <summary>
+    /// Returns an ordered dataset of known-answer vectors for use with MSTest data-driven tests.
+    /// </summary>
+    /// <returns>
+    /// An enumerable sequence of <c>object[]</c> arrays in the form <c>{ name, body, expectedCheck }</c>.
+    /// </returns>
+    public static IEnumerable<object[]> KnownAnswerData()
+    {
+        CheckDigitAlgorithmSpecification spec = new TTest().GetSpecification();
+        foreach (CheckDigitKnownAnswer vector in spec.KnownAnswers)
+            yield return new object[] { vector.Name, vector.Body, vector.ExpectedCheck };
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitKnownAnswer.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/CheckDigitKnownAnswer.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitKnownAnswer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Represents a single known-answer test vector for a <see cref="CheckDigitAlgorithm" />, pairing a body of
+/// decimal digits with the expected check digit produced by the algorithm under test.
+/// </summary>
+public sealed record CheckDigitKnownAnswer
+{
+    /// <summary>
+    /// Gets a short descriptive name used in test output to identify the vector.
+    /// </summary>
+    /// <returns>A non-empty descriptive label such as <c>"WikipediaExample"</c>.</returns>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the body digits (without the check digit) that the algorithm is expected to process.
+    /// </summary>
+    /// <returns>A string consisting exclusively of ASCII decimal digits <c>'0'</c> to <c>'9'</c>.</returns>
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// Gets the expected check digit produced by the algorithm for the <see cref="Body" />.
+    /// </summary>
+    /// <returns>An ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    public required char ExpectedCheck { get; init; }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/DammTests.ErrorDetection.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/DammTests.ErrorDetection.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DammTests.ErrorDetection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public sealed partial class DammTests
+{
+    private const string SingleDigitSeedBody = "572";
+
+    /// <summary>
+    /// Verifies that Damm detects every single-digit substitution error in the canonical seed sequence.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAnySingleDigitIsSubstituted_ShouldReturnFalse()
+    {
+        char check = Damm.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+
+        Assert.IsTrue(Damm.IsValid(valid.AsSpan()), "Precondition: baseline must be valid.");
+
+        char[] buffer = valid.ToCharArray();
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            char original = buffer[i];
+            for (char c = '0'; c <= '9'; c++)
+            {
+                if (c == original) continue;
+                buffer[i] = c;
+                Assert.IsFalse(
+                    Damm.IsValid(buffer),
+                    $"Substitution of '{original}' with '{c}' at index {i} ({new string(buffer)}) must be rejected.");
+            }
+
+            buffer[i] = original;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Damm detects <i>every</i> adjacent-digit transposition — without exception — in the
+    /// canonical seed sequence. Unlike Luhn, Damm has no known transposition blind spot.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAdjacentDigitsAreTransposed_ShouldReturnFalse()
+    {
+        char check = Damm.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+        char[] buffer = valid.ToCharArray();
+
+        for (int i = 0; i < buffer.Length - 1; i++)
+        {
+            if (buffer[i] == buffer[i + 1]) continue;
+
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+            Assert.IsFalse(
+                Damm.IsValid(buffer),
+                $"Transposition at index {i} ({new string(buffer)}) must be rejected by Damm.");
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+        }
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/DammTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/DammTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DammTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Damm" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed partial class DammTests : CheckDigitAlgorithmTests<DammTests, Damm>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "Damm",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",            Body = "",      ExpectedCheck = '0' },
+            new() { Name = "SingleZero",       Body = "0",     ExpectedCheck = '0' },
+            new() { Name = "SingleOne",        Body = "1",     ExpectedCheck = '3' },
+            new() { Name = "WikipediaExample", Body = "572",   ExpectedCheck = '4' },
+            new() { Name = "AscendingRun",     Body = "12345", ExpectedCheck = '9' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Damm.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Damm.IsValid(digitsIncludingCheck);
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/LuhnTests.ErrorDetection.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/LuhnTests.ErrorDetection.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="LuhnTests.ErrorDetection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public sealed partial class LuhnTests
+{
+    private const string SingleDigitSeedBody = "7992739871";
+
+    /// <summary>
+    /// Verifies that Luhn detects every single-digit substitution error — for each position in the body, every
+    /// distinct replacement digit invalidates the resulting sequence.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAnySingleDigitIsSubstituted_ShouldReturnFalse()
+    {
+        char check = Luhn.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+
+        Assert.IsTrue(Luhn.IsValid(valid.AsSpan()), "Precondition: baseline must be valid.");
+
+        char[] buffer = valid.ToCharArray();
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            char original = buffer[i];
+            for (char c = '0'; c <= '9'; c++)
+            {
+                if (c == original) continue;
+                buffer[i] = c;
+                Assert.IsFalse(
+                    Luhn.IsValid(buffer),
+                    $"Substitution of '{original}' with '{c}' at index {i} ({new string(buffer)}) must be rejected.");
+            }
+
+            buffer[i] = original;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Luhn detects every adjacent-digit transposition error in the seed sequence, <i>except</i>
+    /// the well-documented exception in which the two digits sum to nine and differ by nine — namely the
+    /// swap of <c>'0'</c> and <c>'9'</c>.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAdjacentDigitsAreTransposed_ShouldReturnFalseExceptFor09Transposition()
+    {
+        char check = Luhn.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+        char[] buffer = valid.ToCharArray();
+
+        for (int i = 0; i < buffer.Length - 1; i++)
+        {
+            if (buffer[i] == buffer[i + 1]) continue;
+
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+
+            bool isValid = Luhn.IsValid(buffer);
+            bool isZeroNineSwap = (buffer[i] == '0' && buffer[i + 1] == '9') || (buffer[i] == '9' && buffer[i + 1] == '0');
+
+            if (isZeroNineSwap)
+                Assert.IsTrue(isValid, $"The 0<->9 transposition at index {i} ({new string(buffer)}) is the documented Luhn exception and should remain valid.");
+            else
+                Assert.IsFalse(isValid, $"Transposition at index {i} ({new string(buffer)}) must be rejected.");
+
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the documented Luhn blind-spot: swapping adjacent <c>'0'</c> and <c>'9'</c> preserves the
+    /// weighted digit sum, so the resulting transposition is not detected.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenZeroAndNineAreTransposed_ShouldRemainValid()
+    {
+        Assert.IsTrue(Luhn.IsValid("091".AsSpan()), "Precondition: '091' is a valid Luhn sequence.");
+        Assert.IsTrue(Luhn.IsValid("901".AsSpan()), "Transposing the adjacent 0 and 9 of '091' must remain valid under Luhn — the documented blind spot.");
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/LuhnTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/LuhnTests.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="LuhnTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Luhn" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed partial class LuhnTests : CheckDigitAlgorithmTests<LuhnTests, Luhn>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "Luhn",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",            Body = "",                ExpectedCheck = '0' },
+            new() { Name = "SingleZero",       Body = "0",               ExpectedCheck = '0' },
+            new() { Name = "SingleOne",        Body = "1",               ExpectedCheck = '8' },
+            new() { Name = "WikipediaExample", Body = "7992739871",      ExpectedCheck = '3' },
+            new() { Name = "VisaTestCardBody", Body = "411111111111111", ExpectedCheck = '1' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Luhn.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Luhn.IsValid(digitsIncludingCheck);
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/VerhoeffTests.ErrorDetection.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/VerhoeffTests.ErrorDetection.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="VerhoeffTests.ErrorDetection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+public sealed partial class VerhoeffTests
+{
+    private const string SingleDigitSeedBody = "1428570";
+
+    /// <summary>
+    /// Verifies that Verhoeff detects every single-digit substitution error in the canonical seed sequence.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAnySingleDigitIsSubstituted_ShouldReturnFalse()
+    {
+        char check = Verhoeff.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+
+        Assert.IsTrue(Verhoeff.IsValid(valid.AsSpan()), "Precondition: baseline must be valid.");
+
+        char[] buffer = valid.ToCharArray();
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            char original = buffer[i];
+            for (char c = '0'; c <= '9'; c++)
+            {
+                if (c == original) continue;
+                buffer[i] = c;
+                Assert.IsFalse(
+                    Verhoeff.IsValid(buffer),
+                    $"Substitution of '{original}' with '{c}' at index {i} ({new string(buffer)}) must be rejected.");
+            }
+
+            buffer[i] = original;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Verhoeff detects <i>every</i> adjacent-digit transposition — without exception — in the
+    /// canonical seed sequence.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAdjacentDigitsAreTransposed_ShouldReturnFalse()
+    {
+        char check = Verhoeff.Compute(SingleDigitSeedBody.AsSpan());
+        string valid = SingleDigitSeedBody + check;
+        char[] buffer = valid.ToCharArray();
+
+        for (int i = 0; i < buffer.Length - 1; i++)
+        {
+            if (buffer[i] == buffer[i + 1]) continue;
+
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+            Assert.IsFalse(
+                Verhoeff.IsValid(buffer),
+                $"Transposition at index {i} ({new string(buffer)}) must be rejected by Verhoeff.");
+            (buffer[i], buffer[i + 1]) = (buffer[i + 1], buffer[i]);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that Verhoeff detects the <i>twin</i> error class — pairs of equal adjacent digits substituted
+    /// by a pair of different equal digits, for example <c>"aa"</c> to <c>"bb"</c>.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenAdjacentTwinDigitsAreSubstituted_ShouldReturnFalse()
+    {
+        const string twinSeedBody = "33";
+        char check = Verhoeff.Compute(twinSeedBody.AsSpan());
+        string valid = twinSeedBody + check;
+
+        Assert.IsTrue(Verhoeff.IsValid(valid.AsSpan()), "Precondition: twin-seed baseline must be valid.");
+
+        for (char c = '0'; c <= '9'; c++)
+        {
+            if (c == '3') continue;
+            string twin = new string(c, 2) + valid[2];
+            Assert.IsFalse(
+                Verhoeff.IsValid(twin.AsSpan()),
+                $"Twin substitution '33' -> '{c}{c}' ({twin}) must be rejected by Verhoeff.");
+        }
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/VerhoeffTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/CheckDigits/VerhoeffTests.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="VerhoeffTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Verhoeff" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed partial class VerhoeffTests : CheckDigitAlgorithmTests<VerhoeffTests, Verhoeff>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "Verhoeff",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",            Body = "",      ExpectedCheck = '0' },
+            new() { Name = "SingleZero",       Body = "0",     ExpectedCheck = '4' },
+            new() { Name = "WikipediaExample", Body = "236",   ExpectedCheck = '3' },
+            new() { Name = "AscendingRun",     Body = "12345", ExpectedCheck = '1' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Verhoeff.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Verhoeff.IsValid(digitsIncludingCheck);
+}


### PR DESCRIPTION
## Summary

Adds three decimal check-digit algorithms (Damm, Luhn, Verhoeff) to `Bodu.IO.Hashing` under a new `Bodu.IO.Hashing.CheckDigits` namespace. These are compact error-detection primitives for card numbers, national identifiers, and serial codes.

### Why a new abstraction

Check-digit algorithms consume decimal digits (`'0'`–`'9'`) and emit a single digit. They don't map cleanly onto `System.IO.Hashing.NonCryptographicHashAlgorithm`, which is byte-stream-oriented with multi-byte output. Rather than wedge them into that contract, this PR introduces a parallel abstract class `CheckDigitAlgorithm` that takes `ReadOnlySpan<char>` natively. It lives alongside Fletcher/Adler/FNV/CRC in `Bodu.IO.Hashing` (not in `Bodu.Security.Cryptography`, which is reserved for keyed/crypto primitives).

### What's new

**`Bodu.IO.Hashing.CheckDigits`:**
- `CheckDigitAlgorithm` — abstract base: `Append(ReadOnlySpan<char>)`, `Append(char)`, `Reset`, `GetCurrentCheckDigit`, `AlgorithmName`.
- `Luhn` — IBM mod-10; dual parity-hypothesis sums allow non-destructive reads at any intermediate body length.
- `Damm` — running interim against the 2004 totally-antisymmetric quasigroup (10×10 table partial).
- `Verhoeff` — eight parallel D5 accumulators (no body buffering), with `d`/`inv`/`p` tables.

Each concrete algorithm also exposes allocation-free static helpers:
```csharp
public static char Compute(ReadOnlySpan<char> digits);
public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck);
```
`Compute` rejects non-digit input via `ArgumentOutOfRangeException`; `IsValid` returns `false` on non-digit input (predicate semantics). Empty body returns `'0'`; empty `IsValid` returns `true` (vacuously).

**`Bodu.Core`:**
- `ThrowHelper.ThrowIfNotAsciiDecimalDigit(char, ...)` — centralised guard used by all three algorithms.

**Tests:**
- Mirror harness `CheckDigitAlgorithmTests<TTest, TAlgorithm>` with partials for Ctors, Append, GetCurrentCheckDigit, Reset, Compute, IsValid, and Guards.
- Per-algorithm test classes with known-answer vectors sourced from the respective Wikipedia articles (Luhn `79927398713 → 3`, Damm `572 → 4`, Verhoeff `236 → 3`), plus a Visa-style test for Luhn.
- Algorithm-specific error-detection tests:
  - **Damm** and **Verhoeff**: every single-digit substitution and every adjacent transposition in the seed sequence must be rejected.
  - **Verhoeff**: additionally catches twin errors (`aa → bb`).
  - **Luhn**: same, with the documented `0↔9` blind-spot explicitly tested and asserted to remain undetected.

## Test plan

- [ ] `dotnet build Bodu.sln` is clean (CI treats StyleCop/Roslynator/CS1591 as errors)
- [ ] `dotnet test` for `Bodu.IO.Hashing.Test` — new tests green
- [ ] Existing `NonCryptographicHashAlgorithm`-based tests unchanged (no refactor to shared harness)
- [ ] Wikipedia round-trips:
  - `Luhn.Compute("7992739871") == '3'` and `Luhn.IsValid("79927398713")`
  - `Damm.Compute("572") == '4'` and `Damm.IsValid("5724")`
  - `Verhoeff.Compute("236") == '3'` and `Verhoeff.IsValid("2363")`

https://claude.ai/code/session_01MVgTa1PChQFx8b5aZiZvTF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MVgTa1PChQFx8b5aZiZvTF)_