### PR TITLE
fix(Bodu.IO.Hashing): correct operand order in Verhoeff streaming Append

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CheckDigits/Verhoeff.cs
@@ -33,9 +33,12 @@ public sealed partial class Verhoeff : CheckDigitAlgorithm
     // Eight parallel accumulators allow the streaming Append surface to compute the check digit without
     // buffering digits. _c[k] holds the Verhoeff running value 'c' under the hypothesis that the most
     // recently appended digit occupies right-index k in the final sequence. Update: on each append of v,
-    //   newC[k] = d[_c[(k + 1) & 7], p[k, v]]
-    // because shifting in a new most-recent digit demotes every existing digit by one right-index, so the
-    // previous state under hypothesis (k+1) becomes the input for the new state under hypothesis k.
+    //   newC[k] = d[p[k, v], _c[(k + 1) & 7]]
+    // because shifting in a new most-recent digit demotes every existing digit by one right-index. The
+    // previous state under hypothesis (k+1) is the product of the older digits' permutation values, and
+    // the new digit's permutation value p[k, v] is left-multiplied onto it — matching the left-to-right
+    // accumulation of the static rtl walk c_{i+1} = d[c_i, p[j, digit]]. D5 is non-abelian, so operand
+    // order is load-bearing.
     private readonly byte[] _c = new byte[8];
 
     /// <summary>
@@ -60,7 +63,7 @@ public sealed partial class Verhoeff : CheckDigitAlgorithm
 
             int v = ch - '0';
             for (int k = 0; k < 8; k++)
-                next[k] = D[_c[(k + 1) & 7], P[k, v]];
+                next[k] = D[P[k, v], _c[(k + 1) & 7]];
 
             next.CopyTo(_c);
         }


### PR DESCRIPTION
The 8-accumulator streaming update in Verhoeff.Append had the operands of the D5 group multiplication reversed. Because D5 is non-abelian, D[_c[(k+1) & 7], P[k, v]] is not equivalent to D[P[k, v], _c[(k+1) & 7]], so the streaming check digit disagreed with the (correct) static Compute result for any body length >= 2. The single-digit case coincidentally worked because D[x, 0] = D[0, x] = x.

Deriving the update from the static rtl walk c_{i+1} = D[c_i, P[j, digit]] as a left-to-right group accumulation shows the correct rule is

  newC[k] = D[P[k, v], _c[(k + 1) & 7]]

— the new digit's permutation value is the LEFT operand, and the previous state under hypothesis (k+1) is the RIGHT operand.

Hand-verified against Wikipedia's 236 -> 3 example and the 12345 -> 1 known-answer vector at every prefix length.