### PR TITLE
feat(Bodu.IO.Hashing): add ISBN, GTIN, ISO 7064 (IBAN/LEI), and finan…

### DIFF
--- a/Bodu.Core/src/ThrowHelper.CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.CallerExpression.cs
@@ -1202,6 +1202,34 @@ public static partial class ThrowHelper
     }
 
     /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not an ASCII uppercase
+    /// alphanumeric character, that is, a character in the range <c>'0'</c> (U+0030) to <c>'9'</c> (U+0039) or
+    /// <c>'A'</c> (U+0041) to <c>'Z'</c> (U+005A) inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is outside the inclusive ranges <c>'0'</c> to <c>'9'</c> and
+    /// <c>'A'</c> to <c>'Z'</c>.
+    /// </exception>
+    /// <remarks>
+    /// Useful for validating inputs to algorithms that operate on uppercase alphanumeric identifiers, such as
+    /// ISO 7064 MOD 97-10 (IBAN / LEI), ISIN, SEDOL, and CUSIP. Lowercase letters are <b>not</b> accepted — the
+    /// caller is expected to normalise before validation.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiAlphanumericUppercase(
+        char value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if ((uint)(value - '0') > 9u && (uint)(value - 'A') > 25u)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not an ASCII uppercase alphanumeric character ('0' to '9' or 'A' to 'Z').");
+    }
+
+    /// <summary>
     /// Throws an <see cref="ArgumentNullException"/> if <paramref name="value"/> is <see langword="null"/>.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>

--- a/Bodu.Core/src/ThrowHelper.NetStandard.cs
+++ b/Bodu.Core/src/ThrowHelper.NetStandard.cs
@@ -728,6 +728,31 @@ public static partial class ThrowHelper
     }
 
     /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not an ASCII uppercase
+    /// alphanumeric character, that is, a character in the range <c>'0'</c> (U+0030) to <c>'9'</c> (U+0039) or
+    /// <c>'A'</c> (U+0041) to <c>'Z'</c> (U+005A) inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is outside the inclusive ranges <c>'0'</c> to <c>'9'</c> and
+    /// <c>'A'</c> to <c>'Z'</c>.
+    /// </exception>
+    /// <remarks>
+    /// Useful for validating inputs to algorithms that operate on uppercase alphanumeric identifiers, such as
+    /// ISO 7064 MOD 97-10 (IBAN / LEI), ISIN, SEDOL, and CUSIP. Lowercase letters are <b>not</b> accepted — the
+    /// caller is expected to normalise before validation.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiAlphanumericUppercase(char value)
+    {
+        if ((uint)(value - '0') > 9u && (uint)(value - 'A') > 25u)
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not an ASCII uppercase alphanumeric character ('0' to '9' or 'A' to 'Z').");
+    }
+
+    /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />.
     /// </summary>
     /// <typeparam name="T">The type of the object.</typeparam>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/AbaRoutingNumber.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/AbaRoutingNumber.cs
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AbaRoutingNumber.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 9-digit American Bankers Association (ABA) routing transit number using the
+/// weighted modulus-10 scheme specified by the US Federal Reserve. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ABA scheme applies the cyclic weight pattern <c>{3, 7, 1}</c> to the first eight digits (weights
+/// <c>3, 7, 1, 3, 7, 1, 3, 7</c> from left to right). The check digit is chosen so that the full nine-digit
+/// sequence yields a weighted sum that is a multiple of ten.
+/// </para>
+/// <para>
+/// The static helpers on this type enforce a strict 8-digit body length (9-digit full sequence) to match the
+/// ABA specification; the streaming surface is length-agnostic to permit chunked input.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"01100001"</c> — the leading 8 digits of the Federal Reserve Bank of
+/// Boston's routing number — the computed check digit is <c>'5'</c>, and the resulting sequence
+/// <c>"011000015"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class AbaRoutingNumber
+    : CheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>8</c> decimal digits.</summary>
+    public const int BodyLength = 8;
+
+    /// <summary>The required full-sequence length of <c>9</c> decimal digits.</summary>
+    public const int SequenceLength = 9;
+
+    // Weights applied from the left of the body toward the right. Position 0 weight 3, position 1 weight 7,
+    // position 2 weight 1, repeating. The dual-hypothesis trick used by the ISBN-13 family does not apply here
+    // — the cycle period is 3, so a streaming consumer cannot weigh incoming digits until the final body
+    // length is known. To preserve the streaming contract (Append / GetCurrentCheckDigit at any point), the
+    // implementation buffers the running list of digit values (at most 8) and recomputes the weighted sum on
+    // each GetCurrentCheckDigit call. This is acceptably cheap given the tiny fixed body length.
+    private readonly List<int> _digits = new(BodyLength);
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AbaRoutingNumber" /> class.
+    /// </summary>
+    public AbaRoutingNumber()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ABA";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            _digits.Add(ch - '0');
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _digits.Clear();
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        ReadOnlySpan<int> weights = [7, 3, 1];
+        int count = _digits.Count;
+        int sum = 0;
+        for (int i = count - 1, j = 0; i >= 0; i--, j++)
+            sum += _digits[i] * weights[j % 3];
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the ABA routing-number check digit for the supplied body of decimal digits without allocating a
+    /// streaming instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use; <see cref="IsValid(ReadOnlySpan{char})" />
+    /// enforces the strict <see cref="SequenceLength" /> domain contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeAba(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising an eight-digit body followed by a trailing ABA
+    /// check digit, is consistent.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as
+    /// valid under the ABA scheme; otherwise, <see langword="false" /> — including the case where the length is
+    /// wrong or a non-digit character is present.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        if (digitsIncludingCheck.IsEmpty) return true;
+        if (digitsIncludingCheck.Length != SequenceLength) return false;
+        return WeightedMod10.IsValidAba(digitsIncludingCheck);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Alphanumeric.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Alphanumeric.cs
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Alphanumeric.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Provides shared helpers for expanding and validating the ASCII uppercase alphanumeric alphabet used by ISO 7064
+/// MOD 97-10, IBAN, LEI, ISIN, SEDOL, and CUSIP.
+/// </summary>
+/// <remarks>
+/// Letter values follow the convention mandated by ISO 7064 and ISO 13616 where <c>'A'</c> expands to 10,
+/// <c>'B'</c> to 11, and so on through <c>'Z'</c> to 35. CUSIP additionally defines sentinels for the punctuation
+/// characters <c>'*'</c> (36), <c>'@'</c> (37), and <c>'#'</c> (38).
+/// </remarks>
+internal static class Alphanumeric
+{
+    /// <summary>
+    /// Expands an ASCII uppercase alphanumeric character to its numeric value. <c>'0'</c>–<c>'9'</c> map to 0–9
+    /// and <c>'A'</c>–<c>'Z'</c> map to 10–35.
+    /// </summary>
+    /// <param name="ch">The character to expand.</param>
+    /// <returns>The integer value in the range 0 to 35.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="ch" /> is not an ASCII decimal digit or uppercase letter.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ExpandLetterDigit(char ch)
+    {
+        if ((uint)(ch - '0') <= 9u) return ch - '0';
+        if ((uint)(ch - 'A') <= 25u) return ch - 'A' + 10;
+        ThrowHelper.ThrowIfNotAsciiAlphanumericUppercase(ch);
+        return -1;
+    }
+
+    /// <summary>
+    /// Expands an ASCII uppercase alphanumeric character, or one of the CUSIP punctuation sentinels
+    /// (<c>'*'</c>=36, <c>'@'</c>=37, <c>'#'</c>=38), to its numeric value.
+    /// </summary>
+    /// <param name="ch">The character to expand.</param>
+    /// <returns>The integer value in the range 0 to 38.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="ch" /> is not a recognised CUSIP character.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static int ExpandCusip(char ch)
+    {
+        if ((uint)(ch - '0') <= 9u) return ch - '0';
+        if ((uint)(ch - 'A') <= 25u) return ch - 'A' + 10;
+        if (ch == '*') return 36;
+        if (ch == '@') return 37;
+        if (ch == '#') return 38;
+        throw new ArgumentOutOfRangeException(
+            nameof(ch),
+            ch,
+            $"Character '{ch}' (U+{(int)ch:X4}) is not a valid CUSIP character ('0'-'9', 'A'-'Z', '*', '@', or '#').");
+    }
+
+    /// <summary>
+    /// Validates that every character in <paramref name="value" /> is an ASCII decimal digit or uppercase letter.
+    /// </summary>
+    /// <param name="value">The character sequence to validate.</param>
+    /// <param name="paramName">The parameter name used in any thrown exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when any element of <paramref name="value" /> is not a recognised alphanumeric character.
+    /// </exception>
+    public static void ValidateAlphanumeric(ReadOnlySpan<char> value, string paramName)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            char ch = value[i];
+            if ((uint)(ch - '0') > 9u && (uint)(ch - 'A') > 25u)
+                throw new ArgumentOutOfRangeException(
+                    paramName,
+                    ch,
+                    $"Character '{ch}' (U+{(int)ch:X4}) is not an ASCII uppercase alphanumeric character ('0' to '9' or 'A' to 'Z').");
+        }
+    }
+
+    /// <summary>
+    /// Validates that every character in <paramref name="value" /> is a recognised CUSIP character.
+    /// </summary>
+    /// <param name="value">The character sequence to validate.</param>
+    /// <param name="paramName">The parameter name used in any thrown exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when any element of <paramref name="value" /> is not a recognised CUSIP character.
+    /// </exception>
+    public static void ValidateCusip(ReadOnlySpan<char> value, string paramName)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            char ch = value[i];
+            if ((uint)(ch - '0') <= 9u) continue;
+            if ((uint)(ch - 'A') <= 25u) continue;
+            if (ch == '*' || ch == '@' || ch == '#') continue;
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                ch,
+                $"Character '{ch}' (U+{(int)ch:X4}) is not a valid CUSIP character ('0'-'9', 'A'-'Z', '*', '@', or '#').");
+        }
+    }
+
+    /// <summary>
+    /// Validates that every character in <paramref name="value" /> is a recognised SEDOL character, i.e. an
+    /// ASCII decimal digit or an uppercase consonant (vowels <c>'A'</c>, <c>'E'</c>, <c>'I'</c>, <c>'O'</c>, and
+    /// <c>'U'</c> are disallowed).
+    /// </summary>
+    /// <param name="value">The character sequence to validate.</param>
+    /// <param name="paramName">The parameter name used in any thrown exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when any element of <paramref name="value" /> is not a recognised SEDOL character.
+    /// </exception>
+    public static void ValidateSedol(ReadOnlySpan<char> value, string paramName)
+    {
+        for (int i = 0; i < value.Length; i++)
+        {
+            char ch = value[i];
+            if ((uint)(ch - '0') <= 9u) continue;
+            if ((uint)(ch - 'A') <= 25u && !IsVowel(ch)) continue;
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                ch,
+                $"Character '{ch}' (U+{(int)ch:X4}) is not a valid SEDOL character ('0'-'9' or uppercase consonant; vowels A/E/I/O/U are not permitted).");
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the supplied ASCII character is an uppercase Latin vowel.
+    /// </summary>
+    /// <param name="ch">The character to test.</param>
+    /// <returns><see langword="true" /> if <paramref name="ch" /> is one of <c>'A'</c>, <c>'E'</c>, <c>'I'</c>, <c>'O'</c>, or <c>'U'</c>; otherwise, <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsVowel(char ch) =>
+        ch == 'A' || ch == 'E' || ch == 'I' || ch == 'O' || ch == 'U';
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithm.cs
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AlphanumericCheckDigitAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Represents the abstract base class from which single-character check-digit algorithms that operate on a wider
+/// input alphabet, or whose check character may be the sentinel <c>'X'</c>, derive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Parallel in design to <see cref="CheckDigitAlgorithm" />, this base relaxes two constraints: the input may be
+/// any subset of ASCII declared by <see cref="InputAlphabet" /> (decimal digits, or decimal digits and uppercase
+/// Latin letters), and the emitted check character may be any value of <see cref="OutputAlphabet" /> — notably
+/// including the <c>'X'</c> sentinel used by ISBN-10 and ISO 7064 MOD 11-2 to represent the check value ten.
+/// </para>
+/// <para>
+/// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and
+/// <see cref="GetCurrentCheckDigit" /> — mirrors the familiar hash-algorithm idiom. Reading the current check
+/// character is non-destructive and idempotent. Concrete implementations document their empty-body behaviour.
+/// </para>
+/// <para>
+/// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
+/// </para>
+/// <note type="important">Check-digit algorithms are error-detection primitives, <b>not</b> cryptographic
+/// functions. They must <b>not</b> be used for password hashing, digital signatures, or integrity validation in
+/// security-sensitive applications.</note>
+/// </remarks>
+public abstract class AlphanumericCheckDigitAlgorithm
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AlphanumericCheckDigitAlgorithm" /> class.
+    /// </summary>
+    protected AlphanumericCheckDigitAlgorithm()
+    {
+    }
+
+    /// <summary>
+    /// Gets the canonical name of the algorithm, suitable for diagnostic output and logging.
+    /// </summary>
+    /// <returns>A short, stable identifier such as <c>"ISBN-10"</c>, <c>"ISIN"</c>, or <c>"SEDOL"</c>.</returns>
+    public abstract string AlgorithmName { get; }
+
+    /// <summary>
+    /// Gets the subset of ASCII from which this algorithm accepts body characters.
+    /// </summary>
+    /// <returns>The declared input alphabet.</returns>
+    public abstract CheckDigitInputAlphabet InputAlphabet { get; }
+
+    /// <summary>
+    /// Gets the subset of ASCII from which this algorithm may emit its check character.
+    /// </summary>
+    /// <returns>The declared output alphabet.</returns>
+    public abstract CheckDigitOutputAlphabet OutputAlphabet { get; }
+
+    /// <summary>
+    /// Absorbs the supplied characters into the running check-character state.
+    /// </summary>
+    /// <param name="body">
+    /// The characters to append. Each element must belong to <see cref="InputAlphabet" />. An empty span is a
+    /// permitted no-op.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside <see cref="InputAlphabet" />.
+    /// </exception>
+    public abstract void Append(ReadOnlySpan<char> body);
+
+    /// <summary>
+    /// Absorbs a single character into the running check-character state.
+    /// </summary>
+    /// <param name="ch">The character to append. Must belong to <see cref="InputAlphabet" />.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="ch" /> is outside <see cref="InputAlphabet" />.
+    /// </exception>
+    public void Append(char ch) =>
+        Append([ch]);
+
+    /// <summary>
+    /// Resets the algorithm to its initial state, discarding any characters previously absorbed.
+    /// </summary>
+    /// <remarks>Equivalent in behaviour to constructing a fresh instance of the same concrete type.</remarks>
+    public abstract void Reset();
+
+    /// <summary>
+    /// Returns the check character computed for the body absorbed since the last <see cref="Reset" /> (or since
+    /// construction).
+    /// </summary>
+    /// <returns>
+    /// The check character as an ASCII character drawn from <see cref="OutputAlphabet" />.
+    /// </returns>
+    /// <remarks>This call is non-destructive; the running state is unaffected and the method may be invoked any
+    /// number of times with identical results between appends.</remarks>
+    public abstract char GetCurrentCheckDigit();
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CheckDigitInputAlphabet.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CheckDigitInputAlphabet.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitInputAlphabet.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Identifies the alphabet from which a check-digit or check-character algorithm accepts its body input.
+/// </summary>
+/// <remarks>
+/// Consumed by <see cref="AlphanumericCheckDigitAlgorithm" /> and <see cref="MultiCharCheckDigitAlgorithm" /> so
+/// that test harnesses and diagnostic surfaces can reason about the valid input set without inspecting the
+/// concrete algorithm.
+/// </remarks>
+public enum CheckDigitInputAlphabet
+{
+    /// <summary>
+    /// ASCII decimal digits only (<c>'0'</c> to <c>'9'</c>).
+    /// </summary>
+    DecimalDigits,
+
+    /// <summary>
+    /// ASCII decimal digits (<c>'0'</c> to <c>'9'</c>) and uppercase Latin letters (<c>'A'</c> to <c>'Z'</c>).
+    /// </summary>
+    AlphanumericUppercase,
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CheckDigitOutputAlphabet.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CheckDigitOutputAlphabet.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CheckDigitOutputAlphabet.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Identifies the alphabet from which a single-character check-digit algorithm may emit its check character.
+/// </summary>
+/// <remarks>
+/// Consumed by <see cref="AlphanumericCheckDigitAlgorithm" />. Multi-character algorithms defined via
+/// <see cref="MultiCharCheckDigitAlgorithm" /> emit decimal digits only and therefore do not use this enumeration.
+/// </remarks>
+public enum CheckDigitOutputAlphabet
+{
+    /// <summary>
+    /// ASCII decimal digits only (<c>'0'</c> to <c>'9'</c>).
+    /// </summary>
+    DecimalDigits,
+
+    /// <summary>
+    /// ASCII decimal digits (<c>'0'</c> to <c>'9'</c>) plus the sentinel <c>'X'</c> used to represent the
+    /// check value ten in schemes such as ISBN-10 and ISO 7064 MOD 11-2.
+    /// </summary>
+    DecimalDigitsOrX,
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Cusip.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Cusip.cs
@@ -1,0 +1,151 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Cusip.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 9-character Committee on Uniform Securities Identification Procedures (CUSIP)
+/// identifier using the Luhn-style weighted modulus-10 scheme specified by the American Bankers Association.
+/// This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// CUSIP body characters are drawn from the decimal digits (<c>'0'</c>–<c>'9'</c>), uppercase Latin letters
+/// (<c>'A'</c>–<c>'Z'</c>, with values 10–35), and the historical sentinels <c>'*'</c>=36, <c>'@'</c>=37 and
+/// <c>'#'</c>=38. The body is eight characters; the ninth character is the check digit.
+/// </para>
+/// <para>
+/// Each body character's numeric value is multiplied by a positional weight (<c>1</c> at even left-to-right
+/// indices, <c>2</c> at odd indices). The resulting product is split into its tens and units digits, which are
+/// summed before being added to the running total. The check digit is chosen so that the total is a multiple of
+/// ten.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"03783310"</c> — Apple Inc. — the computed check digit is <c>'0'</c>,
+/// and the resulting CUSIP <c>"037833100"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Cusip
+    : AlphanumericCheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>8</c> characters.</summary>
+    public const int BodyLength = 8;
+
+    /// <summary>The required full-sequence length of <c>9</c> characters.</summary>
+    public const int SequenceLength = 9;
+
+    private int _sum;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Cusip" /> class.
+    /// </summary>
+    public Cusip()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "CUSIP";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override CheckDigitOutputAlphabet OutputAlphabet => CheckDigitOutputAlphabet.DecimalDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int sum = _sum;
+        int count = _count;
+
+        for (int i = 0; i < body.Length; i++)
+        {
+            int value = Alphanumeric.ExpandCusip(body[i]);
+            int weight = (count & 1) == 0 ? 1 : 2;
+            int product = value * weight;
+            sum += (product / 10) + (product % 10);
+            count++;
+        }
+
+        _sum = sum;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sum = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit() =>
+        (char)('0' + ((10 - (_sum % 10)) % 10));
+
+    /// <summary>
+    /// Computes the CUSIP check digit for the supplied body without allocating a streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters. Each must be a valid CUSIP character.</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside the CUSIP alphabet.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> body)
+    {
+        int sum = 0;
+        for (int i = 0; i < body.Length; i++)
+        {
+            int value = Alphanumeric.ExpandCusip(body[i]);
+            int weight = (i & 1) == 0 ? 1 : 2;
+            int product = value * weight;
+            sum += (product / 10) + (product % 10);
+        }
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising an eight-character body followed by a single-digit
+    /// CUSIP check, is consistent.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete nine-character CUSIP.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under CUSIP; otherwise,
+    /// <see langword="false" /> — including the case where the length is wrong, any body character is outside
+    /// the CUSIP alphabet, or the check character is not a decimal digit.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.Length != SequenceLength) return false;
+
+        int sum = 0;
+        for (int i = 0; i < BodyLength; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            int value;
+            if ((uint)(ch - '0') <= 9u) value = ch - '0';
+            else if ((uint)(ch - 'A') <= 25u) value = ch - 'A' + 10;
+            else if (ch == '*') value = 36;
+            else if (ch == '@') value = 37;
+            else if (ch == '#') value = 38;
+            else return false;
+
+            int weight = (i & 1) == 0 ? 1 : 2;
+            int product = value * weight;
+            sum += (product / 10) + (product % 10);
+        }
+
+        char checkChar = valueIncludingCheck[BodyLength];
+        if ((uint)(checkChar - '0') > 9u) return false;
+        sum += checkChar - '0';
+
+        return sum % 10 == 0;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Ean13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Ean13.cs
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ean13.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 13-digit European Article Number / Global Trade Item Number-13 barcode using the
+/// EAN-13 weighted modulus-10 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// EAN-13 and ISBN-13 share the same weight pattern — alternating 1 and 3 over the twelve body digits with the
+/// rightmost data digit carrying weight 3 — so a 13-digit ISBN is also a valid EAN-13. The static helpers on this
+/// type enforce a strict 12-digit body length (13-digit full sequence) to make downstream callers' intent
+/// explicit; the streaming surface is length-agnostic.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"501234567890"</c>, the computed check digit is <c>'0'</c>, and the
+/// resulting EAN-13 <c>"5012345678900"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Ean13
+    : CheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>12</c> decimal digits.</summary>
+    public const int BodyLength = 12;
+
+    /// <summary>The required full-sequence length of <c>13</c> decimal digits.</summary>
+    public const int SequenceLength = 13;
+
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Ean13" /> class.
+    /// </summary>
+    public Ean13()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "EAN-13";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int tripled = v * 3;
+
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += tripled;
+            }
+            else
+            {
+                sumEven += tripled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the EAN-13 check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use; <see cref="IsValid(ReadOnlySpan{char})" />
+    /// enforces the strict <see cref="SequenceLength" /> domain contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeIsbn13(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a twelve-digit body followed by a trailing EAN-13
+    /// check digit, is consistent.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as
+    /// valid under EAN-13; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="digitsIncludingCheck" /> has the wrong length or contains a non-digit character.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        if (digitsIncludingCheck.IsEmpty) return true;
+        if (digitsIncludingCheck.Length != SequenceLength) return false;
+        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Ean8.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Ean8.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ean8.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of an 8-digit European Article Number / Global Trade Item Number-8 barcode using the
+/// EAN-8 weighted modulus-10 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// EAN-8 shares its weight pattern with ISBN-13 / EAN-13 / UPC-A / GTIN-14: alternating 1 and 3 applied from the
+/// check digit leftward. The static helpers on this type enforce a strict 7-digit body length (8-digit full
+/// sequence); the streaming surface is length-agnostic.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"7351353"</c>, the computed check digit is <c>'7'</c>, and the
+/// resulting EAN-8 <c>"73513537"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Ean8
+    : CheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>7</c> decimal digits.</summary>
+    public const int BodyLength = 7;
+
+    /// <summary>The required full-sequence length of <c>8</c> decimal digits.</summary>
+    public const int SequenceLength = 8;
+
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Ean8" /> class.
+    /// </summary>
+    public Ean8()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "EAN-8";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int tripled = v * 3;
+
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += tripled;
+            }
+            else
+            {
+                sumEven += tripled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the EAN-8 check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use; <see cref="IsValid(ReadOnlySpan{char})" />
+    /// enforces the strict <see cref="SequenceLength" /> domain contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeIsbn13(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a seven-digit body followed by a trailing EAN-8
+    /// check digit, is consistent.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as
+    /// valid under EAN-8; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        if (digitsIncludingCheck.IsEmpty) return true;
+        if (digitsIncludingCheck.Length != SequenceLength) return false;
+        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Gtin14.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Gtin14.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Gtin14.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 14-digit Global Trade Item Number (GTIN-14) barcode using the GTIN-14 weighted
+/// modulus-10 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// GTIN-14 — the logistics-tier GS1 identifier derived by prefixing an EAN-13 with a single indicator digit —
+/// shares its weight pattern with EAN-13, UPC-A, and ISBN-13. The static helpers on this type enforce a strict
+/// 13-digit body length (14-digit full sequence); the streaming surface is length-agnostic.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"1061414100041"</c>, the computed check digit is <c>'5'</c>, and the
+/// resulting GTIN-14 <c>"10614141000415"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Gtin14
+    : CheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>13</c> decimal digits.</summary>
+    public const int BodyLength = 13;
+
+    /// <summary>The required full-sequence length of <c>14</c> decimal digits.</summary>
+    public const int SequenceLength = 14;
+
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Gtin14" /> class.
+    /// </summary>
+    public Gtin14()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "GTIN-14";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int tripled = v * 3;
+
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += tripled;
+            }
+            else
+            {
+                sumEven += tripled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the GTIN-14 check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use; <see cref="IsValid(ReadOnlySpan{char})" />
+    /// enforces the strict <see cref="SequenceLength" /> domain contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeIsbn13(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a thirteen-digit body followed by a trailing
+    /// GTIN-14 check digit, is consistent.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as
+    /// valid under GTIN-14; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        if (digitsIncludingCheck.IsEmpty) return true;
+        if (digitsIncludingCheck.Length != SequenceLength) return false;
+        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iban.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iban.cs
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iban.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the two-digit check sequence of an International Bank Account Number (IBAN) using the ISO 13616
+/// algorithm atop ISO 7064 MOD 97-10. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An IBAN takes the textual form <c>CCDDBBAN</c> where <c>CC</c> is a two-letter ISO 3166 country code,
+/// <c>DD</c> is a two-digit check, and <c>BBAN</c> is the Basic Bank Account Number specific to the issuing
+/// country. To compute or validate the check, the first four characters are moved to the end (<c>BBAN + CC + DD</c>),
+/// letters are expanded to their numeric value (<c>'A'</c>=10 … <c>'Z'</c>=35), and the resulting decimal string
+/// is evaluated under ISO 7064 MOD 97-10.
+/// </para>
+/// <para>
+/// The streaming surface accepts a body comprising <c>CC + BBAN</c> — that is, the IBAN with the check placeholder
+/// <i>omitted</i> — and produces the two check digits via <see cref="GetCurrentCheckDigits(Span{char})" />.
+/// <see cref="IsValid(ReadOnlySpan{char})" /> accepts the complete <c>CC + DD + BBAN</c> form; whitespace and
+/// other formatting characters are <b>not</b> tolerated, in keeping with ISO 13616 strict mode. Callers should
+/// normalise textual IBANs (for example, by removing spaces) before passing them in.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"GBWEST12345698765432"</c>, the computed check is <c>"82"</c>, and the
+/// resulting IBAN <c>"GB82WEST12345698765432"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Iban
+    : MultiCharCheckDigitAlgorithm
+{
+    /// <summary>The fixed check-code length of <c>2</c> decimal digits.</summary>
+    public const int CheckDigits = 2;
+
+    /// <summary>The length of the country-code prefix (<c>2</c> letters).</summary>
+    public const int CountryCodeLength = 2;
+
+    private char _cc0;
+    private char _cc1;
+    private int _consumed;
+    private int _rBban;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Iban" /> class.
+    /// </summary>
+    public Iban()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "IBAN";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override int CheckLength => CheckDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int consumed = _consumed;
+        int r = _rBban;
+
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if ((uint)(ch - '0') > 9u && (uint)(ch - 'A') > 25u)
+                ThrowHelper.ThrowIfNotAsciiAlphanumericUppercase(ch, nameof(body));
+
+            if (consumed == 0)
+            {
+                _cc0 = ch;
+            }
+            else if (consumed == 1)
+            {
+                _cc1 = ch;
+            }
+            else
+            {
+                r = FoldChar(r, ch);
+            }
+
+            consumed++;
+        }
+
+        _consumed = consumed;
+        _rBban = r;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _cc0 = default;
+        _cc1 = default;
+        _consumed = 0;
+        _rBban = 0;
+    }
+
+    /// <inheritdoc />
+    public override int GetCurrentCheckDigits(Span<char> destination)
+    {
+        if (destination.Length < CheckLength)
+            throw new ArgumentException($"Destination span must be at least {CheckLength} characters long.", nameof(destination));
+
+        int r = _rBban;
+        if (_consumed >= 1) r = FoldChar(r, _cc0);
+        if (_consumed >= 2) r = FoldChar(r, _cc1);
+
+        // Fold in the two trailing placeholder zero digits.
+        r = (r * 100) % 97;
+        int check = (98 - r) % 97;
+        destination[0] = (char)('0' + (check / 10));
+        destination[1] = (char)('0' + (check % 10));
+        return CheckLength;
+    }
+
+    /// <summary>
+    /// Computes the IBAN check digits for the supplied country-code-plus-BBAN body without allocating a
+    /// streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters — the complete IBAN minus its two-digit check sequence.</param>
+    /// <returns>The check code as a two-character string of ASCII decimal digits.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside the alphanumeric uppercase alphabet.
+    /// </exception>
+    public static string Compute(ReadOnlySpan<char> body)
+    {
+        Iban iban = new();
+        iban.Append(body);
+        return iban.GetCurrentCheckDigits();
+    }
+
+    /// <summary>
+    /// Determines whether the supplied IBAN, in its contiguous (unspaced) canonical form, is consistent under
+    /// ISO 13616.
+    /// </summary>
+    /// <param name="iban">
+    /// The complete IBAN in canonical form — two-letter country code, two-digit check, then the BBAN — with no
+    /// internal whitespace or formatting characters.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the IBAN is empty, or if it is at least four characters long, alphanumeric,
+    /// and its rearranged decimal expansion has remainder <c>1</c> modulo 97; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> iban)
+    {
+        if (iban.IsEmpty) return true;
+        if (iban.Length < 4) return false;
+
+        // Positions 2 and 3 must be ASCII decimal digits (the check code).
+        if ((uint)(iban[2] - '0') > 9u || (uint)(iban[3] - '0') > 9u) return false;
+
+        // Rearrangement: BBAN + CC + DD — stream through MOD 97-10.
+        int r = 0;
+        for (int i = 4; i < iban.Length; i++)
+        {
+            if (!TryFold(ref r, iban[i])) return false;
+        }
+
+        for (int i = 0; i < 4; i++)
+        {
+            if (!TryFold(ref r, iban[i])) return false;
+        }
+
+        return r == 1;
+    }
+
+    private static int FoldChar(int r, char ch)
+    {
+        if ((uint)(ch - '0') <= 9u)
+            return ((r * 10) + (ch - '0')) % 97;
+        return ((r * 100) + (ch - 'A' + 10)) % 97;
+    }
+
+    private static bool TryFold(ref int r, char ch)
+    {
+        if ((uint)(ch - '0') <= 9u)
+        {
+            r = ((r * 10) + (ch - '0')) % 97;
+            return true;
+        }
+
+        if ((uint)(ch - 'A') <= 25u)
+        {
+            r = ((r * 100) + (ch - 'A' + 10)) % 97;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn10.cs
@@ -1,0 +1,161 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Isbn10.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check character of a 10-character International Standard Book Number using the ISBN-10 weighted
+/// modulus-11 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// ISBN-10, in use prior to the global migration to ISBN-13 in 2007, applies weights <c>10, 9, 8, 7, 6, 5, 4, 3, 2</c>
+/// to the nine body digits from left to right. The weighted sum is taken modulo eleven; the check character is
+/// chosen so that the complete weighted sum over ten positions (including the check at weight one) is a multiple
+/// of eleven. When the required check value is ten, the sentinel <c>'X'</c> is emitted.
+/// </para>
+/// <para>
+/// <b>Worked examples.</b> For the body <c>"030640615"</c>, the computed check character is <c>'2'</c>
+/// (<c>0306406152</c>). For the body <c>"043942089"</c>, the computed check character is <c>'X'</c>
+/// (<c>043942089X</c>), demonstrating the <c>'X'</c>-for-ten sentinel.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Isbn10
+    : AlphanumericCheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>9</c> decimal digits.</summary>
+    public const int BodyLength = 9;
+
+    /// <summary>The required full-sequence length of <c>10</c> characters.</summary>
+    public const int SequenceLength = 10;
+
+    private int _sum;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Isbn10" /> class.
+    /// </summary>
+    public Isbn10()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ISBN-10";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.DecimalDigits;
+
+    /// <inheritdoc />
+    public override CheckDigitOutputAlphabet OutputAlphabet => CheckDigitOutputAlphabet.DecimalDigitsOrX;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int sum = _sum;
+        int count = _count;
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(body));
+
+            // ISBN-10 weight for the digit at zero-based left-to-right position k is (10 - k). At k = 9 the
+            // weight would be 1 (the check position), which this streaming API does not reach; beyond k = 9 the
+            // weight becomes non-positive and the algorithm's guarantees no longer hold. Callers invoking with
+            // bodies longer than 9 digits do so outside the ISBN-10 specification.
+            sum += (10 - count) * (ch - '0');
+            count++;
+        }
+
+        _sum = sum;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sum = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int check = (11 - (((_sum % 11) + 11) % 11)) % 11;
+        return check == 10 ? 'X' : (char)('0' + check);
+    }
+
+    /// <summary>
+    /// Computes the ISBN-10 check character for the supplied body of decimal digits without allocating a
+    /// streaming instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check character as an ASCII digit <c>'0'</c> to <c>'9'</c>, or the sentinel <c>'X'</c> for the value ten.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use;
+    /// <see cref="IsValid(ReadOnlySpan{char})" /> enforces the strict <see cref="SequenceLength" /> domain
+    /// contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits)
+    {
+        int sum = 0;
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            sum += (10 - i) * (ch - '0');
+        }
+
+        int check = (11 - (((sum % 11) + 11) % 11)) % 11;
+        return check == 10 ? 'X' : (char)('0' + check);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a nine-digit body followed by a trailing ISBN-10
+    /// check character, is consistent.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete ten-character sequence.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISBN-10; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="valueIncludingCheck" /> has the wrong
+    /// length or contains an unrecognised character.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.Length != SequenceLength) return false;
+
+        int sum = 0;
+        for (int i = 0; i < SequenceLength; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            int value;
+            if ((uint)(ch - '0') <= 9u)
+            {
+                value = ch - '0';
+            }
+            else if (i == SequenceLength - 1 && ch == 'X')
+            {
+                value = 10;
+            }
+            else
+            {
+                return false;
+            }
+
+            sum += (10 - i) * value;
+        }
+
+        return sum % 11 == 0;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn13.cs
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Isbn13.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 13-digit International Standard Book Number using the ISBN-13 weighted
+/// modulus-10 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The ISBN-13 check scheme, introduced in 2007 by the International ISBN Agency, alternates weights of 1 and 3
+/// across the twelve body digits — the rightmost data digit receives weight 3 — and the check digit is chosen so
+/// that the resulting weighted sum is a multiple of ten.
+/// </para>
+/// <para>
+/// The same algorithm underpins the EAN-13, UPC-A, GTIN-8, and GTIN-14 barcode families — see <see cref="Ean13" />
+/// and its siblings for strict-length variants.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"978030640615"</c>, the computed check digit is <c>'7'</c>, and the
+/// resulting ISBN-13 <c>"9780306406157"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Isbn13
+    : CheckDigitAlgorithm
+{
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Isbn13" /> class.
+    /// </summary>
+    public Isbn13()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ISBN-13";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int tripled = v * 3;
+
+            // Dual-hypothesis accumulator. The rightmost data digit always carries weight 3, so whether the
+            // digit at body-index i carries weight 1 or weight 3 depends on whether the final body length N
+            // is even or odd. _sumEvenHypothesis assumes N is even; _sumOddHypothesis assumes N is odd.
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += tripled;
+            }
+            else
+            {
+                sumEven += tripled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the ISBN-13 check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeIsbn13(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a twelve-digit body followed by a trailing ISBN-13
+    /// check digit, is consistent — that is, whether the weighted sum evaluates to a multiple of ten.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISBN-13; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
+    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
+        WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isin.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isin.cs
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Isin.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 12-character International Securities Identification Number (ISIN) using the
+/// Luhn-based scheme defined by ISO 6166. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An ISIN comprises a two-letter country code, a nine-character national security identifier, and a single
+/// trailing check digit. To compute the check, every body character is expanded to its numeric value (digits as
+/// themselves, <c>'A'</c>–<c>'Z'</c> to 10–35) and the concatenated string of resulting digits is fed to the
+/// standard Luhn algorithm.
+/// </para>
+/// <para>
+/// Because each letter contributes two digits while each numeral contributes one, the effective digit stream
+/// length varies by country-code and body composition. The streaming surface nevertheless preserves
+/// prefix-equivalence with <see cref="Compute(ReadOnlySpan{char})" />.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"US037833100"</c> — Apple Inc. — the computed check digit is <c>'5'</c>,
+/// and the resulting ISIN <c>"US0378331005"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Isin
+    : AlphanumericCheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>11</c> characters.</summary>
+    public const int BodyLength = 11;
+
+    /// <summary>The required full-sequence length of <c>12</c> characters.</summary>
+    public const int SequenceLength = 12;
+
+    private readonly Luhn _luhn = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Isin" /> class.
+    /// </summary>
+    public Isin()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ISIN";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override CheckDigitOutputAlphabet OutputAlphabet => CheckDigitOutputAlphabet.DecimalDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if ((uint)(ch - '0') <= 9u)
+            {
+                _luhn.Append(ch);
+            }
+            else if ((uint)(ch - 'A') <= 25u)
+            {
+                int value = ch - 'A' + 10;
+                _luhn.Append((char)('0' + (value / 10)));
+                _luhn.Append((char)('0' + (value % 10)));
+            }
+            else
+            {
+                ThrowHelper.ThrowIfNotAsciiAlphanumericUppercase(ch, nameof(body));
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _luhn.Reset();
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit() =>
+        _luhn.GetCurrentCheckDigit();
+
+    /// <summary>
+    /// Computes the ISIN check digit for the supplied body without allocating a streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters. Each must be an ASCII decimal digit or uppercase Latin letter.</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside <c>'0'</c>–<c>'9'</c> and
+    /// <c>'A'</c>–<c>'Z'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> body)
+    {
+        Isin isin = new();
+        isin.Append(body);
+        return isin.GetCurrentCheckDigit();
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising an eleven-character body followed by a single-digit
+    /// ISIN check, is consistent.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete twelve-character ISIN.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISIN; otherwise,
+    /// <see langword="false" /> — including the case where the length is wrong, any body character is outside
+    /// the alphanumeric uppercase alphabet, or the check character is not a decimal digit.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.Length != SequenceLength) return false;
+
+        // Short-circuit obvious rejections before allocating.
+        for (int i = 0; i < SequenceLength; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u && (uint)(ch - 'A') > 25u) return false;
+        }
+
+        if ((uint)(valueIncludingCheck[SequenceLength - 1] - '0') > 9u) return false;
+
+        char computed = Compute(valueIncludingCheck[..^1]);
+        return computed == valueIncludingCheck[SequenceLength - 1];
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod11_2.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod11_2.cs
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7064Mod11_2.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the single-character check of a decimal string using the ISO 7064 <c>MOD 11-2</c> pure algorithm.
+/// This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>MOD 11-2</c> is the pure ISO 7064 system that uses modulus eleven with radix two. It operates on an
+/// arbitrary sequence of decimal digits and emits a single check character drawn from the alphabet
+/// <c>'0'</c>–<c>'9'</c> plus the sentinel <c>'X'</c> used to represent the value ten.
+/// </para>
+/// <para>
+/// The working digit is initialised to zero, and for each body digit <c>a</c> it is updated as
+/// <c>p ← ((p + a) × 2) mod 11</c>. The check character is chosen so that <c>(p + c) mod 11 = 1</c>, i.e.
+/// <c>c = (12 - p) mod 11</c>; the sequence <c>body + c</c> is valid when the same identity holds.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"0794"</c>, the computed check character is <c>'0'</c>, and the
+/// resulting sequence <c>"07940"</c> is therefore valid under <c>MOD 11-2</c>.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Iso7064Mod11_2
+    : AlphanumericCheckDigitAlgorithm
+{
+    private int _p;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Iso7064Mod11_2" /> class.
+    /// </summary>
+    public Iso7064Mod11_2()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ISO 7064 MOD 11-2";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.DecimalDigits;
+
+    /// <inheritdoc />
+    public override CheckDigitOutputAlphabet OutputAlphabet => CheckDigitOutputAlphabet.DecimalDigitsOrX;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int p = _p;
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(body));
+
+            p = ((p + (ch - '0')) * 2) % 11;
+        }
+
+        _p = p;
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _p = 0;
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int c = (12 - _p) % 11;
+        return c == 10 ? 'X' : (char)('0' + c);
+    }
+
+    /// <summary>
+    /// Computes the ISO 7064 MOD 11-2 check character for the supplied body of decimal digits without allocating
+    /// a streaming instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check character, either an ASCII decimal digit or the sentinel <c>'X'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> digits)
+    {
+        int p = 0;
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            p = ((p + (ch - '0')) * 2) % 11;
+        }
+
+        int c = (12 - p) % 11;
+        return c == 10 ? 'X' : (char)('0' + c);
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by a trailing ISO 7064 MOD 11-2
+    /// check character, is consistent.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete sequence including the trailing check character.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under MOD 11-2; otherwise,
+    /// <see langword="false" /> — including the case where any non-final character is not a decimal digit or the
+    /// final character is neither a decimal digit nor <c>'X'</c>.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+
+        int last = valueIncludingCheck.Length - 1;
+        int p = 0;
+        for (int i = 0; i < last; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            p = ((p + (ch - '0')) * 2) % 11;
+        }
+
+        char checkChar = valueIncludingCheck[last];
+        int checkValue;
+        if ((uint)(checkChar - '0') <= 9u) checkValue = checkChar - '0';
+        else if (checkChar == 'X') checkValue = 10;
+        else return false;
+
+        return (p + checkValue) % 11 == 1;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod97_10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod97_10.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7064Mod97_10.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the 2-character check code of an alphanumeric string using the ISO 7064 <c>MOD 97-10</c> pure
+/// algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <c>MOD 97-10</c> is the pure ISO 7064 system that uses modulus ninety-seven with radix ten. It underpins the
+/// International Bank Account Number (IBAN, ISO 13616), the Legal Entity Identifier (LEI, ISO 17442), and the
+/// Committee on Uniform Securities Identification Procedures (CUSIP) check computation used for Legal-Entity
+/// Identifier issuance. Letters in the body are expanded by value <c>'A'</c>=10 … <c>'Z'</c>=35 before being
+/// absorbed.
+/// </para>
+/// <para>
+/// The running remainder <c>r</c> is initialised to zero. Each body character is absorbed as <c>r ← (r·10 + a) mod 97</c>
+/// for a decimal digit or <c>r ← (r·100 + a) mod 97</c> for an uppercase letter (whose value is two decimal
+/// digits). The two-digit check code is <c>(98 - (r · 100) mod 97) mod 97</c>, formatted as two ASCII decimal
+/// digits; the complete sequence <c>body + check</c> is valid when its running remainder, including the check
+/// code, equals <c>1</c>.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"794"</c>, the computed check code is <c>"44"</c>, and the resulting
+/// sequence <c>"79444"</c> is therefore valid under MOD 97-10.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Iso7064Mod97_10
+    : MultiCharCheckDigitAlgorithm
+{
+    /// <summary>The fixed check-code length of <c>2</c> decimal digits.</summary>
+    public const int CheckDigits = 2;
+
+    private int _r;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Iso7064Mod97_10" /> class.
+    /// </summary>
+    public Iso7064Mod97_10()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "ISO 7064 MOD 97-10";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override int CheckLength => CheckDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int r = _r;
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if ((uint)(ch - '0') <= 9u)
+            {
+                r = ((r * 10) + (ch - '0')) % 97;
+            }
+            else if ((uint)(ch - 'A') <= 25u)
+            {
+                r = ((r * 100) + (ch - 'A' + 10)) % 97;
+            }
+            else
+            {
+                ThrowHelper.ThrowIfNotAsciiAlphanumericUppercase(ch, nameof(body));
+            }
+        }
+
+        _r = r;
+    }
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _r = 0;
+
+    /// <inheritdoc />
+    public override int GetCurrentCheckDigits(Span<char> destination)
+    {
+        if (destination.Length < CheckLength)
+            throw new ArgumentException($"Destination span must be at least {CheckLength} characters long.", nameof(destination));
+
+        int full = (_r * 100) % 97;
+        int check = (98 - full) % 97;
+        destination[0] = (char)('0' + (check / 10));
+        destination[1] = (char)('0' + (check % 10));
+        return CheckLength;
+    }
+
+    /// <summary>
+    /// Computes the ISO 7064 MOD 97-10 check code for the supplied body without allocating a streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters. Each must be an ASCII decimal digit or uppercase Latin letter.</param>
+    /// <returns>The check code as a string of two ASCII decimal digits.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside the alphanumeric uppercase alphabet.
+    /// </exception>
+    public static string Compute(ReadOnlySpan<char> body)
+    {
+        Iso7064Mod97_10 engine = new();
+        engine.Append(body);
+        return engine.GetCurrentCheckDigits();
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by a two-digit MOD 97-10 check code,
+    /// is consistent — that is, whether its running remainder (with letters expanded and the check code absorbed)
+    /// equals <c>1</c>.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete sequence including the trailing check code.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under MOD 97-10; otherwise,
+    /// <see langword="false" /> — including the case where any character is outside the alphanumeric uppercase
+    /// alphabet.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+
+        int r = 0;
+        for (int i = 0; i < valueIncludingCheck.Length; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            if ((uint)(ch - '0') <= 9u)
+            {
+                r = ((r * 10) + (ch - '0')) % 97;
+            }
+            else if ((uint)(ch - 'A') <= 25u)
+            {
+                r = ((r * 100) + (ch - 'A' + 10)) % 97;
+            }
+            else
+            {
+                return false;
+            }
+        }
+
+        return r == 1;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Lei.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Lei.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Lei.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the two-digit check sequence of a Legal Entity Identifier (LEI) as specified by ISO 17442. This
+/// class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A Legal Entity Identifier is a twenty-character alphanumeric code comprising an eighteen-character body
+/// followed by a two-digit check. The check is evaluated using ISO 7064 MOD 97-10 directly over the body,
+/// without the IBAN-style rearrangement: letters are expanded by value <c>'A'</c>=10 … <c>'Z'</c>=35, the
+/// resulting decimal string is folded through modulus ninety-seven, and the check is chosen so that the running
+/// remainder of the complete twenty-character sequence equals <c>1</c>.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"54930084UKLVMY22DS"</c>, the computed check is <c>"16"</c>, and the
+/// resulting LEI <c>"54930084UKLVMY22DS16"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Lei
+    : MultiCharCheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>18</c> characters.</summary>
+    public const int BodyLength = 18;
+
+    /// <summary>The required full-sequence length of <c>20</c> characters.</summary>
+    public const int SequenceLength = 20;
+
+    /// <summary>The fixed check-code length of <c>2</c> decimal digits.</summary>
+    public const int CheckDigits = 2;
+
+    private readonly Iso7064Mod97_10 _engine = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Lei" /> class.
+    /// </summary>
+    public Lei()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "LEI";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override int CheckLength => CheckDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body) =>
+        _engine.Append(body);
+
+    /// <inheritdoc />
+    public override void Reset() =>
+        _engine.Reset();
+
+    /// <inheritdoc />
+    public override int GetCurrentCheckDigits(Span<char> destination) =>
+        _engine.GetCurrentCheckDigits(destination);
+
+    /// <summary>
+    /// Computes the LEI check digits for the supplied body without allocating a streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters. Each must be an ASCII decimal digit or uppercase Latin letter.</param>
+    /// <returns>The check code as a two-character string of ASCII decimal digits.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside the alphanumeric uppercase alphabet.
+    /// </exception>
+    public static string Compute(ReadOnlySpan<char> body) =>
+        Iso7064Mod97_10.Compute(body);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising an eighteen-character body followed by a two-digit
+    /// LEI check, is consistent under ISO 17442.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete twenty-character LEI.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid; otherwise, <see langword="false" />
+    /// — including the case where any character is outside the alphanumeric uppercase alphabet or the check
+    /// characters are not decimal digits.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck) =>
+        Iso7064Mod97_10.IsValid(valueIncludingCheck);
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithm.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiCharCheckDigitAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Represents the abstract base class from which check-digit algorithms that emit a fixed-length multi-character
+/// check code — most notably ISO 7064 MOD 97-10 and its derivatives (IBAN, LEI) — derive.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Parallel in design to <see cref="CheckDigitAlgorithm" />, this base generalises the output from a single
+/// character to a run of <see cref="CheckLength" /> decimal digits, and broadens the input to whichever subset
+/// of ASCII the concrete algorithm accepts via <see cref="InputAlphabet" />.
+/// </para>
+/// <para>
+/// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and the two
+/// <c>GetCurrentCheckDigits</c> overloads — mirrors the familiar hash-algorithm idiom. Reading the current check
+/// code is non-destructive and idempotent. Concrete implementations document their empty-body behaviour.
+/// </para>
+/// <para>
+/// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
+/// </para>
+/// <note type="important">Check-digit algorithms are error-detection primitives, <b>not</b> cryptographic
+/// functions. They must <b>not</b> be used for password hashing, digital signatures, or integrity validation in
+/// security-sensitive applications.</note>
+/// </remarks>
+public abstract class MultiCharCheckDigitAlgorithm
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MultiCharCheckDigitAlgorithm" /> class.
+    /// </summary>
+    protected MultiCharCheckDigitAlgorithm()
+    {
+    }
+
+    /// <summary>
+    /// Gets the canonical name of the algorithm, suitable for diagnostic output and logging.
+    /// </summary>
+    /// <returns>A short, stable identifier such as <c>"ISO 7064 MOD 97-10"</c>, <c>"IBAN"</c>, or <c>"LEI"</c>.</returns>
+    public abstract string AlgorithmName { get; }
+
+    /// <summary>
+    /// Gets the subset of ASCII from which this algorithm accepts body characters.
+    /// </summary>
+    /// <returns>The declared input alphabet.</returns>
+    public abstract CheckDigitInputAlphabet InputAlphabet { get; }
+
+    /// <summary>
+    /// Gets the fixed number of decimal-digit characters emitted as the trailing check code.
+    /// </summary>
+    /// <returns>A positive integer; for example, <c>2</c> for ISO 7064 MOD 97-10.</returns>
+    public abstract int CheckLength { get; }
+
+    /// <summary>
+    /// Absorbs the supplied characters into the running check-code state.
+    /// </summary>
+    /// <param name="body">
+    /// The characters to append. Each element must belong to <see cref="InputAlphabet" />. An empty span is a
+    /// permitted no-op.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains any character outside <see cref="InputAlphabet" />.
+    /// </exception>
+    public abstract void Append(ReadOnlySpan<char> body);
+
+    /// <summary>
+    /// Absorbs a single character into the running check-code state.
+    /// </summary>
+    /// <param name="ch">The character to append. Must belong to <see cref="InputAlphabet" />.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="ch" /> is outside <see cref="InputAlphabet" />.
+    /// </exception>
+    public void Append(char ch) =>
+        Append([ch]);
+
+    /// <summary>
+    /// Resets the algorithm to its initial state, discarding any characters previously absorbed.
+    /// </summary>
+    /// <remarks>Equivalent in behaviour to constructing a fresh instance of the same concrete type.</remarks>
+    public abstract void Reset();
+
+    /// <summary>
+    /// Writes the current check code into the supplied destination span.
+    /// </summary>
+    /// <param name="destination">
+    /// The span to receive the trailing check characters. Must be at least <see cref="CheckLength" /> in length.
+    /// </param>
+    /// <returns>The number of characters written, always equal to <see cref="CheckLength" />.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="destination" /> is shorter than <see cref="CheckLength" />.
+    /// </exception>
+    /// <remarks>This call is non-destructive; the running state is unaffected and the method may be invoked any
+    /// number of times with identical results between appends.</remarks>
+    public abstract int GetCurrentCheckDigits(Span<char> destination);
+
+    /// <summary>
+    /// Returns the current check code as a newly allocated <see cref="string" />.
+    /// </summary>
+    /// <returns>A string of length <see cref="CheckLength" /> containing the trailing check characters.</returns>
+    /// <remarks>
+    /// Allocating convenience wrapper over <see cref="GetCurrentCheckDigits(Span{char})" />. Prefer the span
+    /// overload in hot paths where the allocation is undesirable.
+    /// </remarks>
+    public string GetCurrentCheckDigits()
+    {
+        Span<char> buffer = stackalloc char[CheckLength];
+        GetCurrentCheckDigits(buffer);
+        return new string(buffer);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Sedol.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Sedol.cs
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Sedol.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 7-character Stock Exchange Daily Official List (SEDOL) identifier using the
+/// weighted modulus-10 scheme defined by the London Stock Exchange. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// SEDOL identifiers comprise six body characters followed by a single numeric check digit. Body characters are
+/// drawn from the decimal digits and the uppercase Latin consonants — vowels (<c>A</c>, <c>E</c>, <c>I</c>,
+/// <c>O</c>, <c>U</c>) are <b>not</b> permitted in any body position and will cause input-validation exceptions.
+/// </para>
+/// <para>
+/// The weight pattern <c>{1, 3, 1, 7, 3, 9}</c> is applied from left to right across the six body characters;
+/// each character's numeric value (digits: <c>0</c>–<c>9</c>; letters: <c>A</c>=10 … <c>Z</c>=35) is multiplied
+/// by its position weight. The check digit is chosen so the weighted sum is a multiple of ten.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"B0WNLY"</c>, the computed check digit is <c>'7'</c>, and the
+/// resulting SEDOL <c>"B0WNLY7"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class Sedol
+    : AlphanumericCheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>6</c> characters.</summary>
+    public const int BodyLength = 6;
+
+    /// <summary>The required full-sequence length of <c>7</c> characters.</summary>
+    public const int SequenceLength = 7;
+
+    private static readonly int[] Weights = [1, 3, 1, 7, 3, 9];
+
+    private int _sum;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Sedol" /> class.
+    /// </summary>
+    public Sedol()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "SEDOL";
+
+    /// <inheritdoc />
+    public override CheckDigitInputAlphabet InputAlphabet => CheckDigitInputAlphabet.AlphanumericUppercase;
+
+    /// <inheritdoc />
+    public override CheckDigitOutputAlphabet OutputAlphabet => CheckDigitOutputAlphabet.DecimalDigits;
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> body)
+    {
+        int sum = _sum;
+        int count = _count;
+
+        for (int i = 0; i < body.Length; i++)
+        {
+            char ch = body[i];
+            if (Alphanumeric.IsVowel(ch) || ((uint)(ch - '0') > 9u && (uint)(ch - 'A') > 25u))
+                throw new ArgumentOutOfRangeException(
+                    nameof(body),
+                    ch,
+                    $"Character '{ch}' (U+{(int)ch:X4}) is not a valid SEDOL character ('0'-'9' or uppercase consonant; vowels A/E/I/O/U are not permitted).");
+
+            int weight = count < Weights.Length ? Weights[count] : 1;
+            sum += Alphanumeric.ExpandLetterDigit(ch) * weight;
+            count++;
+        }
+
+        _sum = sum;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sum = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit() =>
+        (char)('0' + ((10 - (_sum % 10)) % 10));
+
+    /// <summary>
+    /// Computes the SEDOL check digit for the supplied body without allocating a streaming instance.
+    /// </summary>
+    /// <param name="body">The body characters. Each must be an ASCII decimal digit or uppercase consonant.</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="body" /> contains a vowel or a character outside the SEDOL alphabet.
+    /// </exception>
+    public static char Compute(ReadOnlySpan<char> body)
+    {
+        Alphanumeric.ValidateSedol(body, nameof(body));
+
+        int sum = 0;
+        for (int i = 0; i < body.Length; i++)
+        {
+            int weight = i < Weights.Length ? Weights[i] : 1;
+            sum += Alphanumeric.ExpandLetterDigit(body[i]) * weight;
+        }
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a six-character body followed by a single-digit
+    /// SEDOL check, is consistent.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The complete seven-character SEDOL.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid under SEDOL; otherwise,
+    /// <see langword="false" /> — including the case where the length is wrong, any body character is a vowel or
+    /// non-alphanumeric, or the check character is not a decimal digit.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.Length != SequenceLength) return false;
+
+        int sum = 0;
+        for (int i = 0; i < BodyLength; i++)
+        {
+            char ch = valueIncludingCheck[i];
+            if (Alphanumeric.IsVowel(ch)) return false;
+            int v;
+            if ((uint)(ch - '0') <= 9u) v = ch - '0';
+            else if ((uint)(ch - 'A') <= 25u) v = ch - 'A' + 10;
+            else return false;
+
+            sum += v * Weights[i];
+        }
+
+        char checkChar = valueIncludingCheck[BodyLength];
+        if ((uint)(checkChar - '0') > 9u) return false;
+        sum += checkChar - '0';
+
+        return sum % 10 == 0;
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/UpcA.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/UpcA.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="UpcA.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Computes the check digit of a 12-digit Universal Product Code (UPC-A) barcode using the UPC-A weighted
+/// modulus-10 algorithm. This class cannot be inherited.
+/// </summary>
+/// <remarks>
+/// <para>
+/// UPC-A shares its weight pattern with EAN-13 and ISBN-13; a UPC-A value is exactly an EAN-13 whose country
+/// prefix is a leading zero. The static helpers on this type enforce a strict 11-digit body length (12-digit
+/// full sequence); the streaming surface is length-agnostic.
+/// </para>
+/// <para>
+/// <b>Worked example.</b> For the body <c>"03600029145"</c>, the computed check digit is <c>'2'</c>, and the
+/// resulting UPC-A <c>"036000291452"</c> is therefore valid.
+/// </para>
+/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
+/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// </remarks>
+public sealed class UpcA
+    : CheckDigitAlgorithm
+{
+    /// <summary>The required body length of <c>11</c> decimal digits.</summary>
+    public const int BodyLength = 11;
+
+    /// <summary>The required full-sequence length of <c>12</c> decimal digits.</summary>
+    public const int SequenceLength = 12;
+
+    private int _sumEvenHypothesis;
+    private int _sumOddHypothesis;
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpcA" /> class.
+    /// </summary>
+    public UpcA()
+    {
+    }
+
+    /// <inheritdoc />
+    public override string AlgorithmName => "UPC-A";
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<char> digits)
+    {
+        int sumEven = _sumEvenHypothesis;
+        int sumOdd = _sumOddHypothesis;
+        int count = _count;
+
+        for (int i = 0; i < digits.Length; i++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+            int tripled = v * 3;
+
+            if ((count & 1) == 0)
+            {
+                sumEven += v;
+                sumOdd += tripled;
+            }
+            else
+            {
+                sumEven += tripled;
+                sumOdd += v;
+            }
+
+            count++;
+        }
+
+        _sumEvenHypothesis = sumEven;
+        _sumOddHypothesis = sumOdd;
+        _count = count;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sumEvenHypothesis = 0;
+        _sumOddHypothesis = 0;
+        _count = 0;
+    }
+
+    /// <inheritdoc />
+    public override char GetCurrentCheckDigit()
+    {
+        int sum = (_count & 1) == 0 ? _sumEvenHypothesis : _sumOddHypothesis;
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Computes the UPC-A check digit for the supplied body of decimal digits without allocating a streaming
+    /// instance.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit (<c>'0'</c> to <c>'9'</c>).</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-tolerant to support streaming and partial-body use; <see cref="IsValid(ReadOnlySpan{char})" />
+    /// enforces the strict <see cref="SequenceLength" /> domain contract for full validation.
+    /// </remarks>
+    public static char Compute(ReadOnlySpan<char> digits) =>
+        WeightedMod10.ComputeIsbn13(digits);
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising an eleven-digit body followed by a trailing UPC-A
+    /// check digit, is consistent.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as
+    /// valid under UPC-A; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        if (digitsIncludingCheck.IsEmpty) return true;
+        if (digitsIncludingCheck.Length != SequenceLength) return false;
+        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/WeightedMod10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/WeightedMod10.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WeightedMod10.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Provides shared streaming and one-shot math for the weighted modulus-10 check-digit family used by ISBN-13,
+/// GTIN (EAN / UPC-A), and ABA routing numbers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The algorithms in this family all take the form:
+/// </para>
+/// <para>
+/// <c>sum = Σ w_i · d_i  mod 10</c>, <c>check = (10 - sum) mod 10</c>
+/// </para>
+/// <para>
+/// where <c>w_i</c> is a fixed-period weight pattern indexed from the <em>right-hand</em> data digit. ISBN-13 /
+/// GTIN use the two-element pattern <c>{3, 1}</c> (the check position itself is implicitly weight 1); ABA routing
+/// uses the three-element pattern <c>{1, 7, 3}</c> cycling from the check position.
+/// </para>
+/// <para>
+/// For the two-weight ISBN/GTIN case a dual-hypothesis accumulator analogous to <see cref="Luhn" /> lets a
+/// streaming consumer expose <see cref="AlphanumericCheckDigitAlgorithm.GetCurrentCheckDigit" /> at every prefix
+/// length without buffering. The three-weight ABA case is length-locked at 8 body digits so a simple single-sum
+/// streaming accumulator suffices.
+/// </para>
+/// </remarks>
+internal static class WeightedMod10
+{
+    /// <summary>
+    /// Computes the ISBN-13 / GTIN check digit for the supplied body using weights <c>{3, 1}</c> applied from the
+    /// right-hand data digit toward the left.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit.</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    public static char ComputeIsbn13(ReadOnlySpan<char> digits)
+    {
+        int sum = 0;
+        for (int i = digits.Length - 1, j = 0; i >= 0; i--, j++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            int v = ch - '0';
+
+            // The check position is the rightmost (j = 0) with implicit weight 1; the rightmost data digit
+            // therefore receives weight 3, the next weight 1, and so on alternating 3/1 toward the left.
+            sum += (j & 1) == 0 ? v * 3 : v;
+        }
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by its trailing check digit, is
+    /// consistent under the ISBN-13 / GTIN weight pattern <c>{3, 1}</c>.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid; otherwise, <see langword="false" />
+    /// — including the case where <paramref name="digitsIncludingCheck" /> contains a character outside the range
+    /// <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValidIsbn13(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        int sum = 0;
+        for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
+        {
+            char ch = digitsIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            int v = ch - '0';
+
+            // Including the check position itself, positions j = 0, 2, 4, ... carry weight 1 while j = 1, 3, 5,
+            // ... carry weight 3. When the sum is a multiple of 10 the sequence is internally consistent.
+            sum += (j & 1) == 0 ? v : v * 3;
+        }
+
+        return sum % 10 == 0;
+    }
+
+    /// <summary>
+    /// Computes the ABA routing-number check digit for the supplied 8-digit body using weights <c>{1, 7, 3}</c>
+    /// applied cyclically from the right-hand data digit toward the left.
+    /// </summary>
+    /// <param name="digits">The body characters. Each must be an ASCII decimal digit.</param>
+    /// <returns>The check digit as an ASCII character in the range <c>'0'</c> to <c>'9'</c>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="digits" /> contains any character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// </exception>
+    /// <remarks>
+    /// This helper is length-agnostic; length enforcement is the responsibility of callers that treat the body
+    /// length as part of their contract (for example, <see cref="AbaRoutingNumber" /> requires eight digits).
+    /// </remarks>
+    public static char ComputeAba(ReadOnlySpan<char> digits)
+    {
+        // From the right-hand data digit toward the left the ABA pattern is {1, 7, 3}. From the check position
+        // itself toward the left the pattern is {3, 1, 7, 3, 1, 7, 3, 1, 7}; including the check position makes
+        // the total sum a multiple of ten for a consistent sequence.
+        ReadOnlySpan<int> weights = [7, 3, 1];
+        int sum = 0;
+        for (int i = digits.Length - 1, j = 0; i >= 0; i--, j++)
+        {
+            char ch = digits[i];
+            if ((uint)(ch - '0') > 9u)
+                ThrowHelper.ThrowIfNotAsciiDecimalDigit(ch, nameof(digits));
+
+            sum += (ch - '0') * weights[j % 3];
+        }
+
+        return (char)('0' + ((10 - (sum % 10)) % 10));
+    }
+
+    /// <summary>
+    /// Determines whether the supplied sequence, comprising a body followed by its trailing check digit, is
+    /// consistent under the ABA routing-number weight pattern <c>{3, 7, 1}</c>.
+    /// </summary>
+    /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
+    /// <returns>
+    /// <see langword="true" /> if the sequence is empty or evaluates as valid; otherwise, <see langword="false" />
+    /// — including the case where <paramref name="digitsIncludingCheck" /> contains a character outside the range
+    /// <c>'0'</c> to <c>'9'</c>.
+    /// </returns>
+    public static bool IsValidAba(ReadOnlySpan<char> digitsIncludingCheck)
+    {
+        ReadOnlySpan<int> weights = [1, 7, 3];
+        int sum = 0;
+        for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
+        {
+            char ch = digitsIncludingCheck[i];
+            if ((uint)(ch - '0') > 9u) return false;
+
+            sum += (ch - '0') * weights[j % 3];
+        }
+
+        return sum % 10 == 0;
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AbaRoutingNumberTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AbaRoutingNumberTests.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AbaRoutingNumberTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="AbaRoutingNumber" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class AbaRoutingNumberTests : CheckDigitAlgorithmTests<AbaRoutingNumberTests, AbaRoutingNumber>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ABA",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",                  Body = "",         ExpectedCheck = '0' },
+            new() { Name = "FrbBostonRoutingBody",   Body = "01100001", ExpectedCheck = '5' },
+            new() { Name = "FrbNewYorkRoutingBody",  Body = "02100008", ExpectedCheck = '9' },
+            new() { Name = "AllZeros",               Body = "00000000", ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        AbaRoutingNumber.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        AbaRoutingNumber.IsValid(digitsIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="AbaRoutingNumber.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length
+    /// is not exactly <see cref="AbaRoutingNumber.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(AbaRoutingNumber.IsValid("0110000150".AsSpan()));
+        Assert.IsFalse(AbaRoutingNumber.IsValid("01100001".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that a real-world Federal Reserve Bank routing number round-trips through
+    /// <see cref="AbaRoutingNumber.IsValid(ReadOnlySpan{char})" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_FrbBostonRoutingNumber_ShouldReturnTrue()
+    {
+        Assert.IsTrue(AbaRoutingNumber.IsValid("011000015".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithmSpecification.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithmSpecification.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AlphanumericCheckDigitAlgorithmSpecification.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.CheckDigits;
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Describes the expected observable properties of an <see cref="AlphanumericCheckDigitAlgorithm" />
+/// implementation for use in behavioural and known-answer tests.
+/// </summary>
+/// <remarks>
+/// Instances are supplied by derived test classes via
+/// <see cref="AlphanumericCheckDigitAlgorithmTests{TTest, TAlgorithm}.GetSpecification" /> and drive assertions
+/// common across every algorithm sharing the alphanumeric base.
+/// </remarks>
+public sealed record AlphanumericCheckDigitAlgorithmSpecification
+{
+    /// <summary>
+    /// Gets the expected <see cref="AlphanumericCheckDigitAlgorithm.AlgorithmName" /> string.
+    /// </summary>
+    /// <returns>The canonical algorithm name, e.g. <c>"ISBN-10"</c>.</returns>
+    public required string AlgorithmName { get; init; }
+
+    /// <summary>
+    /// Gets the expected <see cref="AlphanumericCheckDigitAlgorithm.InputAlphabet" /> value.
+    /// </summary>
+    /// <returns>The declared input alphabet for the algorithm under test.</returns>
+    public required CheckDigitInputAlphabet InputAlphabet { get; init; }
+
+    /// <summary>
+    /// Gets the expected <see cref="AlphanumericCheckDigitAlgorithm.OutputAlphabet" /> value.
+    /// </summary>
+    /// <returns>The declared output alphabet for the algorithm under test.</returns>
+    public required CheckDigitOutputAlphabet OutputAlphabet { get; init; }
+
+    /// <summary>
+    /// Gets the check character expected for an empty body, or <see langword="null" /> to indicate that the
+    /// algorithm throws on empty input.
+    /// </summary>
+    /// <returns>An ASCII character, or <see langword="null" />. Defaults to <c>'0'</c>.</returns>
+    public char? EmptyCheckDigit { get; init; } = '0';
+
+    /// <summary>
+    /// Gets the known-answer vectors to exercise.
+    /// </summary>
+    /// <returns>A non-empty list of <see cref="CheckDigitKnownAnswer" /> entries.</returns>
+    public required IReadOnlyList<CheckDigitKnownAnswer> KnownAnswers { get; init; }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithmTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AlphanumericCheckDigitAlgorithmTests.cs
@@ -1,0 +1,329 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AlphanumericCheckDigitAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Provides a reusable base class for verifying correctness and consistency of
+/// <see cref="AlphanumericCheckDigitAlgorithm" /> implementations.
+/// </summary>
+/// <typeparam name="TTest">The concrete test type inheriting this class.</typeparam>
+/// <typeparam name="TAlgorithm">The alphanumeric check-digit algorithm under test.</typeparam>
+/// <remarks>
+/// The harness drives assertions that every such algorithm must satisfy — algorithm name / alphabet exposure,
+/// streaming-equivalence with the static <c>Compute</c> helper at every prefix, idempotent
+/// <c>GetCurrentCheckDigit</c> reads, <c>Reset</c> semantics, round-trip between <c>Compute</c> and
+/// <c>IsValid</c>, rejection of out-of-alphabet input, and a data-driven set of known-answer vectors supplied
+/// through <see cref="GetSpecification" />.
+/// </remarks>
+public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgorithm>
+    where TTest : AlphanumericCheckDigitAlgorithmTests<TTest, TAlgorithm>, new()
+    where TAlgorithm : AlphanumericCheckDigitAlgorithm, new()
+{
+    /// <summary>
+    /// Returns the <see cref="AlphanumericCheckDigitAlgorithmSpecification" /> describing the algorithm's expected
+    /// properties and known-answer vectors.
+    /// </summary>
+    /// <returns>A non-null specification; its <c>KnownAnswers</c> must be non-empty.</returns>
+    protected abstract AlphanumericCheckDigitAlgorithmSpecification GetSpecification();
+
+    /// <summary>
+    /// Creates a new instance of <typeparamref name="TAlgorithm" /> in its initial state.
+    /// </summary>
+    /// <returns>A fresh algorithm instance.</returns>
+    protected virtual TAlgorithm CreateAlgorithm() => new();
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>Compute</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="body">The body characters.</param>
+    /// <returns>The check character.</returns>
+    protected abstract char ComputeStatic(ReadOnlySpan<char> body);
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>IsValid</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The full sequence including the trailing check character.</param>
+    /// <returns><see langword="true" /> if the sequence is valid under the algorithm; otherwise, <see langword="false" />.</returns>
+    protected abstract bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck);
+
+    /// <summary>
+    /// Returns an ordered dataset of known-answer vectors for use with MSTest data-driven tests.
+    /// </summary>
+    /// <returns>
+    /// An enumerable sequence of <c>object[]</c> arrays in the form <c>{ name, body, expectedCheck }</c>.
+    /// </returns>
+    public static IEnumerable<object[]> KnownAnswerData()
+    {
+        AlphanumericCheckDigitAlgorithmSpecification spec = new TTest().GetSpecification();
+        foreach (CheckDigitKnownAnswer vector in spec.KnownAnswers)
+            yield return new object[] { vector.Name, vector.Body, vector.ExpectedCheck };
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm exposes the algorithm name, input alphabet, and output
+    /// alphabet declared in the specification.
+    /// </summary>
+    [TestMethod]
+    public void Properties_WhenQueried_ShouldMatchSpecification()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        AlphanumericCheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        Assert.AreEqual(spec.AlgorithmName, algorithm.AlgorithmName);
+        Assert.AreEqual(spec.InputAlphabet, algorithm.InputAlphabet);
+        Assert.AreEqual(spec.OutputAlphabet, algorithm.OutputAlphabet);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm reports the empty-body check character declared in the
+    /// specification, when one is declared.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigit_WhenJustConstructed_ShouldReturnEmptyCheckDigit()
+    {
+        AlphanumericCheckDigitAlgorithmSpecification spec = GetSpecification();
+        if (spec.EmptyCheckDigit is not char expected) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        Assert.AreEqual(expected, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body in a single call produces the check character recorded for that
+    /// known-answer vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body one character at a time produces the same check character as a single
+    /// span-based call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        foreach (char ch in body)
+            algorithm.Append(ch);
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body in two chunks produces the same check character as appending it in one
+    /// call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        if (body.Length < 2) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        int split = body.Length / 2;
+
+        algorithm.Append(body.AsSpan(0, split));
+        algorithm.Append(body.AsSpan(split));
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that appending an empty span leaves the running check character unchanged.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenSpanIsEmpty_ShouldLeaveCheckDigitUnchanged()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("123".AsSpan());
+        char initial = algorithm.GetCurrentCheckDigit();
+
+        algorithm.Append(ReadOnlySpan<char>.Empty);
+
+        Assert.AreEqual(initial, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that streaming the body one character at a time and reading <c>GetCurrentCheckDigit</c> matches
+    /// the static <c>Compute</c> result at every prefix length.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The full body characters.</param>
+    /// <param name="expectedCheck">The expected check character (unused).</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void GetCurrentCheckDigit_AtEveryPrefixLength_ShouldAgreeWithStaticCompute(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        _ = expectedCheck;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        for (int i = 0; i < body.Length; i++)
+        {
+            algorithm.Append(body[i]);
+            char streaming = algorithm.GetCurrentCheckDigit();
+            char fromCompute = ComputeStatic(body.AsSpan(0, i + 1));
+            Assert.AreEqual(fromCompute, streaming, $"Prefix length {i + 1} (\"{body[..(i + 1)]}\").");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that reading the current check character twice in succession — with no intervening appends —
+    /// yields the same value, proving the getter is non-destructive.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigit_WhenReadRepeatedly_ShouldReturnSameValue()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("123".AsSpan());
+
+        char first = algorithm.GetCurrentCheckDigit();
+        char second = algorithm.GetCurrentCheckDigit();
+        char third = algorithm.GetCurrentCheckDigit();
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(second, third);
+    }
+
+    /// <summary>
+    /// Verifies that the static <c>Compute</c> helper returns the expected check character for every
+    /// known-answer vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The expected check character.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Compute_WhenKnownAnswer_ShouldReturnExpectedCheckDigit(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        Assert.AreEqual(expectedCheck, ComputeStatic(body.AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that appending the algorithm's own computed check character to the body always yields a sequence
+    /// that <c>IsValid</c> accepts.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The expected check character.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenSequenceIncludesComputedCheckDigit_ShouldReturnTrue(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        string full = body + expectedCheck;
+        Assert.IsTrue(IsValidStatic(full.AsSpan()), $"Expected '{full}' to be valid.");
+    }
+
+    /// <summary>
+    /// Verifies that substituting the trailing check character for a different digit (or the sentinel
+    /// <c>'X'</c> when applicable) makes <c>IsValid</c> reject the sequence.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The correct check character.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenCheckDigitIsTampered_ShouldReturnFalse(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        AlphanumericCheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        for (char c = '0'; c <= '9'; c++)
+        {
+            if (c == expectedCheck) continue;
+            string bad = body + c;
+            Assert.IsFalse(IsValidStatic(bad.AsSpan()), $"Expected '{bad}' to be invalid (swap of check digit).");
+        }
+
+        if (spec.OutputAlphabet == CheckDigitOutputAlphabet.DecimalDigitsOrX && expectedCheck != 'X')
+        {
+            string bad = body + 'X';
+            Assert.IsFalse(IsValidStatic(bad.AsSpan()), $"Expected '{bad}' to be invalid (swap of check digit to X).");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <c>Reset</c> after an Append restores the algorithm to the empty-body check character
+    /// declared in the specification (when one is declared).
+    /// </summary>
+    [TestMethod]
+    public void Reset_AfterAppend_ShouldRestoreEmptyCheckDigit()
+    {
+        AlphanumericCheckDigitAlgorithmSpecification spec = GetSpecification();
+        if (spec.EmptyCheckDigit is not char expected) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("123".AsSpan());
+        algorithm.Reset();
+
+        Assert.AreEqual(expected, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that Reset between two append runs discards the first run's accumulated state so that only the
+    /// second run contributes to the final check character.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append in the second run.</param>
+    /// <param name="expectedCheck">The check character the algorithm is expected to emit for the second run.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, char expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append("987".AsSpan());
+        algorithm.Reset();
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigit());
+    }
+
+    /// <summary>
+    /// Verifies that <c>Append</c> rejects characters that fall outside the declared input alphabet.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenCharacterIsOutsideInputAlphabet_ShouldThrowArgumentOutOfRangeException()
+    {
+        AlphanumericCheckDigitAlgorithmSpecification spec = GetSpecification();
+        char invalid = spec.InputAlphabet == CheckDigitInputAlphabet.DecimalDigits ? 'A' : '!';
+
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Append(new[] { '1', invalid, '2' }.AsSpan());
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CusipTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Cusip" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class CusipTests : AlphanumericCheckDigitAlgorithmTests<CusipTests, Cusip>
+{
+    /// <inheritdoc />
+    protected override AlphanumericCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "CUSIP",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        OutputAlphabet = CheckDigitOutputAlphabet.DecimalDigits,
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",             Body = "",         ExpectedCheck = '0' },
+            new() { Name = "AppleInc",          Body = "03783310", ExpectedCheck = '0' },
+            new() { Name = "MicrosoftCorp",     Body = "59491810", ExpectedCheck = '4' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> body) =>
+        Cusip.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Cusip.IsValid(valueIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Cusip.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Cusip.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Cusip.IsValid("0378331000".AsSpan()));
+        Assert.IsFalse(Cusip.IsValid("03783310".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Cusip.Compute(ReadOnlySpan{char})" /> accepts the historical CUSIP sentinels
+    /// <c>'*'</c>, <c>'@'</c>, and <c>'#'</c> without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Compute_WhenBodyContainsCusipSentinels_ShouldNotThrow()
+    {
+        _ = Cusip.Compute("1234567*".AsSpan());
+        _ = Cusip.Compute("1234567@".AsSpan());
+        _ = Cusip.Compute("1234567#".AsSpan());
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Ean13Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Ean13Tests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ean13Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Ean13" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class Ean13Tests : CheckDigitAlgorithmTests<Ean13Tests, Ean13>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "EAN-13",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",          Body = "",              ExpectedCheck = '0' },
+            new() { Name = "WikipediaEAN13", Body = "501234567890",  ExpectedCheck = '0' },
+            new() { Name = "BookIsbnShape",  Body = "978030640615",  ExpectedCheck = '7' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Ean13.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Ean13.IsValid(digitsIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Ean13.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Ean13.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Ean13.IsValid("5012345678900X".AsSpan()));
+        Assert.IsFalse(Ean13.IsValid("501234567890".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Ean8Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Ean8Tests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Ean8Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Ean8" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class Ean8Tests : CheckDigitAlgorithmTests<Ean8Tests, Ean8>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "EAN-8",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",         Body = "",        ExpectedCheck = '0' },
+            new() { Name = "WikipediaEAN8", Body = "7351353", ExpectedCheck = '7' },
+            new() { Name = "AllZeros",      Body = "0000000", ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Ean8.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Ean8.IsValid(digitsIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Ean8.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Ean8.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Ean8.IsValid("735135370".AsSpan()));
+        Assert.IsFalse(Ean8.IsValid("7351353".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Gtin14Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Gtin14Tests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Gtin14Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Gtin14" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class Gtin14Tests : CheckDigitAlgorithmTests<Gtin14Tests, Gtin14>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "GTIN-14",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",         Body = "",               ExpectedCheck = '0' },
+            new() { Name = "GS1Example",    Body = "1061414100041",  ExpectedCheck = '5' },
+            new() { Name = "AllZeros",      Body = "0000000000000",  ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Gtin14.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Gtin14.IsValid(digitsIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Gtin14.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Gtin14.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Gtin14.IsValid("106141410004150".AsSpan()));
+        Assert.IsFalse(Gtin14.IsValid("1061414100041".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IbanTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IbanTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IbanTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Iban" /> check-code algorithm.
+/// </summary>
+[TestClass]
+public sealed class IbanTests : MultiCharCheckDigitAlgorithmTests<IbanTests, Iban>
+{
+    /// <inheritdoc />
+    protected override MultiCharCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "IBAN",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        CheckLength = 2,
+        KnownAnswers =
+        [
+            new() { Name = "WikipediaGB",  Body = "GBWEST12345698765432",        ExpectedCheck = "82" },
+            new() { Name = "WikipediaDE",  Body = "DE370400440532013000",        ExpectedCheck = "89" },
+            new() { Name = "WikipediaFR",  Body = "FR20041010050500013M02606",  ExpectedCheck = "14" },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override string ComputeStatic(ReadOnlySpan<char> body) =>
+        Iban.Compute(body);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// The base harness supplies <c>body + check</c> concatenated. For IBAN, the check digits live in positions 2
+    /// and 3 of the canonical form (not at the end); this override rearranges <c>CC + BBAN + DD</c> into the
+    /// canonical <c>CC + DD + BBAN</c> before calling <see cref="Iban.IsValid(ReadOnlySpan{char})" />.
+    /// </remarks>
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck)
+    {
+        if (valueIncludingCheck.Length < 4) return Iban.IsValid(valueIncludingCheck);
+
+        int bodyLen = valueIncludingCheck.Length - 2;
+        char[] canonical = new char[valueIncludingCheck.Length];
+        valueIncludingCheck.Slice(0, 2).CopyTo(canonical);                        // CC
+        valueIncludingCheck.Slice(bodyLen, 2).CopyTo(canonical.AsSpan(2));        // DD
+        valueIncludingCheck.Slice(2, bodyLen - 2).CopyTo(canonical.AsSpan(4));    // BBAN
+        return Iban.IsValid(canonical.AsSpan());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> accepts the canonical IBAN text form.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenCanonicalIbanIsValid_ShouldReturnTrue()
+    {
+        Assert.IsTrue(Iban.IsValid("GB82WEST12345698765432".AsSpan()));
+        Assert.IsTrue(Iban.IsValid("DE89370400440532013000".AsSpan()));
+        Assert.IsTrue(Iban.IsValid("FR1420041010050500013M02606".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> rejects an IBAN with whitespace in the
+    /// conventional grouped display form.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenIbanContainsWhitespace_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Iban.IsValid("GB82 WEST 1234 5698 7654 32".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> rejects an IBAN whose check digits are
+    /// tampered.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenCheckDigitsTampered_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Iban.IsValid("GB83WEST12345698765432".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> rejects an IBAN where the check positions
+    /// are not decimal digits.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenCheckPositionsAreLetters_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Iban.IsValid("GBXXWEST12345698765432".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Isbn10Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Isbn10" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class Isbn10Tests : AlphanumericCheckDigitAlgorithmTests<Isbn10Tests, Isbn10>
+{
+    /// <inheritdoc />
+    protected override AlphanumericCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ISBN-10",
+        InputAlphabet = CheckDigitInputAlphabet.DecimalDigits,
+        OutputAlphabet = CheckDigitOutputAlphabet.DecimalDigitsOrX,
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",                   Body = "",          ExpectedCheck = '0' },
+            new() { Name = "HarryPotterPhilosophers", Body = "043942089", ExpectedCheck = 'X' },
+            new() { Name = "WikipediaIsbn10",         Body = "030640615", ExpectedCheck = '2' },
+            new() { Name = "AllZeros",                Body = "000000000", ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> body) =>
+        Isbn10.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Isbn10.IsValid(valueIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Isbn10.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Isbn10.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Isbn10.IsValid("03064061520".AsSpan()));
+        Assert.IsFalse(Isbn10.IsValid("030640615".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Isbn10.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose <c>'X'</c>
+    /// sentinel appears somewhere other than the final check position.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenXAppearsInBody_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Isbn10.IsValid("X306406152".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn13Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn13Tests.cs
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Isbn13Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Isbn13" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class Isbn13Tests : CheckDigitAlgorithmTests<Isbn13Tests, Isbn13>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ISBN-13",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",               Body = "",              ExpectedCheck = '0' },
+            new() { Name = "SingleZero",          Body = "0",             ExpectedCheck = '0' },
+            new() { Name = "WikipediaISBN13",     Body = "978030640615",  ExpectedCheck = '7' },
+            new() { Name = "KnuthVolume1",        Body = "978020137962",  ExpectedCheck = '4' },
+            new() { Name = "AllZeros",            Body = "000000000000",  ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        Isbn13.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        Isbn13.IsValid(digitsIncludingCheck);
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IsinTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Isin" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class IsinTests : AlphanumericCheckDigitAlgorithmTests<IsinTests, Isin>
+{
+    /// <inheritdoc />
+    protected override AlphanumericCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ISIN",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        OutputAlphabet = CheckDigitOutputAlphabet.DecimalDigits,
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",         Body = "",            ExpectedCheck = '0' },
+            new() { Name = "AppleUS",       Body = "US037833100", ExpectedCheck = '5' },
+            new() { Name = "BritishGB",     Body = "GB000263494", ExpectedCheck = '6' },
+            new() { Name = "NumericOnly",   Body = "00000000000", ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> body) =>
+        Isin.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Isin.IsValid(valueIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Isin.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Isin.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Isin.IsValid("US03783310050".AsSpan()));
+        Assert.IsFalse(Isin.IsValid("US037833100".AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Isin.IsValid(ReadOnlySpan{char})" /> rejects a full ISIN whose check character
+    /// is a letter rather than a digit.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenCheckCharacterIsLetter_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Isin.IsValid("US037833100A".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod11_2Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod11_2Tests.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7064Mod11_2Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Iso7064Mod11_2" /> check-character algorithm.
+/// </summary>
+[TestClass]
+public sealed class Iso7064Mod11_2Tests : AlphanumericCheckDigitAlgorithmTests<Iso7064Mod11_2Tests, Iso7064Mod11_2>
+{
+    /// <inheritdoc />
+    protected override AlphanumericCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ISO 7064 MOD 11-2",
+        InputAlphabet = CheckDigitInputAlphabet.DecimalDigits,
+        OutputAlphabet = CheckDigitOutputAlphabet.DecimalDigitsOrX,
+        EmptyCheckDigit = '1',
+        KnownAnswers =
+        [
+            new() { Name = "StandardExample",     Body = "0794",      ExpectedCheck = '0' },
+            new() { Name = "SingleZero",          Body = "0",         ExpectedCheck = '1' },
+            new() { Name = "SingleOne",           Body = "1",         ExpectedCheck = 'X' },
+            new() { Name = "LongerNumeric",       Body = "1234567890", ExpectedCheck = '8' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> body) =>
+        Iso7064Mod11_2.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Iso7064Mod11_2.IsValid(valueIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Iso7064Mod11_2.IsValid(ReadOnlySpan{char})" /> accepts the sentinel <c>'X'</c>
+    /// in the trailing check position and rejects it elsewhere.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenCheckPositionIsX_ShouldBeInterpretedAsTen()
+    {
+        // '1' computes to 'X'; concatenated sequence is therefore valid.
+        Assert.IsTrue(Iso7064Mod11_2.IsValid("1X".AsSpan()));
+        Assert.IsFalse(Iso7064Mod11_2.IsValid("X1".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod97_10Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod97_10Tests.cs
@@ -1,0 +1,40 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Iso7064Mod97_10Tests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Iso7064Mod97_10" /> check-code algorithm.
+/// </summary>
+[TestClass]
+public sealed class Iso7064Mod97_10Tests : MultiCharCheckDigitAlgorithmTests<Iso7064Mod97_10Tests, Iso7064Mod97_10>
+{
+    /// <inheritdoc />
+    protected override MultiCharCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "ISO 7064 MOD 97-10",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        CheckLength = 2,
+        EmptyCheckDigits = "01",
+        KnownAnswers =
+        [
+            new() { Name = "StandardExampleNumeric", Body = "794",                ExpectedCheck = "44" },
+            new() { Name = "IbanRearranged",         Body = "WEST12345698765432GB", ExpectedCheck = "82" },
+            new() { Name = "LeiBody",                Body = "54930084UKLVMY22DS",   ExpectedCheck = "16" },
+            new() { Name = "AllLetters",             Body = "ABCDEFGHIJ",           ExpectedCheck = "46" },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override string ComputeStatic(ReadOnlySpan<char> body) =>
+        Iso7064Mod97_10.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Iso7064Mod97_10.IsValid(valueIncludingCheck);
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/LeiTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/LeiTests.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="LeiTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Lei" /> check-code algorithm.
+/// </summary>
+[TestClass]
+public sealed class LeiTests : MultiCharCheckDigitAlgorithmTests<LeiTests, Lei>
+{
+    /// <inheritdoc />
+    protected override MultiCharCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "LEI",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        CheckLength = 2,
+        EmptyCheckDigits = "01",
+        KnownAnswers =
+        [
+            new() { Name = "GleifExample",   Body = "54930084UKLVMY22DS", ExpectedCheck = "16" },
+            new() { Name = "NumericBody",    Body = "123456789012345678", ExpectedCheck = "88" },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override string ComputeStatic(ReadOnlySpan<char> body) =>
+        Lei.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Lei.IsValid(valueIncludingCheck);
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithmSpecification.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithmSpecification.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiCharCheckDigitAlgorithmSpecification.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.CheckDigits;
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Describes the expected observable properties of a <see cref="MultiCharCheckDigitAlgorithm" /> implementation
+/// for use in behavioural and known-answer tests.
+/// </summary>
+/// <remarks>
+/// Instances are supplied by derived test classes via
+/// <see cref="MultiCharCheckDigitAlgorithmTests{TTest, TAlgorithm}.GetSpecification" /> and drive assertions
+/// common across every algorithm sharing the multi-character base.
+/// </remarks>
+public sealed record MultiCharCheckDigitAlgorithmSpecification
+{
+    /// <summary>
+    /// Gets the expected <see cref="MultiCharCheckDigitAlgorithm.AlgorithmName" /> string.
+    /// </summary>
+    /// <returns>The canonical algorithm name, e.g. <c>"ISO 7064 MOD 97-10"</c>.</returns>
+    public required string AlgorithmName { get; init; }
+
+    /// <summary>
+    /// Gets the expected <see cref="MultiCharCheckDigitAlgorithm.InputAlphabet" /> value.
+    /// </summary>
+    /// <returns>The declared input alphabet for the algorithm under test.</returns>
+    public required CheckDigitInputAlphabet InputAlphabet { get; init; }
+
+    /// <summary>
+    /// Gets the expected <see cref="MultiCharCheckDigitAlgorithm.CheckLength" /> value.
+    /// </summary>
+    /// <returns>The number of trailing check characters the algorithm emits.</returns>
+    public required int CheckLength { get; init; }
+
+    /// <summary>
+    /// Gets the check code expected for an empty body, or <see langword="null" /> to indicate that the algorithm
+    /// throws on empty input.
+    /// </summary>
+    /// <returns>A string of length <see cref="CheckLength" />, or <see langword="null" />.</returns>
+    public string? EmptyCheckDigits { get; init; }
+
+    /// <summary>
+    /// Gets the known-answer vectors to exercise.
+    /// </summary>
+    /// <returns>A non-empty list of <see cref="MultiCharCheckDigitKnownAnswer" /> entries.</returns>
+    public required IReadOnlyList<MultiCharCheckDigitKnownAnswer> KnownAnswers { get; init; }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithmTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitAlgorithmTests.cs
@@ -1,0 +1,321 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiCharCheckDigitAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Provides a reusable base class for verifying correctness and consistency of
+/// <see cref="MultiCharCheckDigitAlgorithm" /> implementations.
+/// </summary>
+/// <typeparam name="TTest">The concrete test type inheriting this class.</typeparam>
+/// <typeparam name="TAlgorithm">The multi-character check-digit algorithm under test.</typeparam>
+/// <remarks>
+/// The harness drives assertions that every such algorithm must satisfy — algorithm name / alphabet /
+/// check-length exposure, streaming-equivalence with the static <c>Compute</c> helper at every prefix, idempotent
+/// <c>GetCurrentCheckDigits</c> reads, <c>Reset</c> semantics, round-trip between <c>Compute</c> and
+/// <c>IsValid</c>, rejection of out-of-alphabet input, and a data-driven set of known-answer vectors supplied
+/// through <see cref="GetSpecification" />.
+/// </remarks>
+public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorithm>
+    where TTest : MultiCharCheckDigitAlgorithmTests<TTest, TAlgorithm>, new()
+    where TAlgorithm : MultiCharCheckDigitAlgorithm, new()
+{
+    /// <summary>
+    /// Returns the <see cref="MultiCharCheckDigitAlgorithmSpecification" /> describing the algorithm's expected
+    /// properties and known-answer vectors.
+    /// </summary>
+    /// <returns>A non-null specification; its <c>KnownAnswers</c> must be non-empty.</returns>
+    protected abstract MultiCharCheckDigitAlgorithmSpecification GetSpecification();
+
+    /// <summary>
+    /// Creates a new instance of <typeparamref name="TAlgorithm" /> in its initial state.
+    /// </summary>
+    /// <returns>A fresh algorithm instance.</returns>
+    protected virtual TAlgorithm CreateAlgorithm() => new();
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>Compute</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="body">The body characters.</param>
+    /// <returns>The expected check code as a string of <c>CheckLength</c> decimal digits.</returns>
+    protected abstract string ComputeStatic(ReadOnlySpan<char> body);
+
+    /// <summary>
+    /// Invokes the algorithm's static <c>IsValid</c> helper. Derived classes forward to the concrete type.
+    /// </summary>
+    /// <param name="valueIncludingCheck">The full sequence including the trailing check code.</param>
+    /// <returns><see langword="true" /> if the sequence is valid under the algorithm; otherwise, <see langword="false" />.</returns>
+    protected abstract bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck);
+
+    /// <summary>
+    /// Returns an ordered dataset of known-answer vectors for use with MSTest data-driven tests.
+    /// </summary>
+    /// <returns>
+    /// An enumerable sequence of <c>object[]</c> arrays in the form <c>{ name, body, expectedCheck }</c>.
+    /// </returns>
+    public static IEnumerable<object[]> KnownAnswerData()
+    {
+        MultiCharCheckDigitAlgorithmSpecification spec = new TTest().GetSpecification();
+        foreach (MultiCharCheckDigitKnownAnswer vector in spec.KnownAnswers)
+            yield return new object[] { vector.Name, vector.Body, vector.ExpectedCheck };
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm exposes the algorithm name, input alphabet, and check
+    /// length declared in the specification.
+    /// </summary>
+    [TestMethod]
+    public void Properties_WhenQueried_ShouldMatchSpecification()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        MultiCharCheckDigitAlgorithmSpecification spec = GetSpecification();
+
+        Assert.AreEqual(spec.AlgorithmName, algorithm.AlgorithmName);
+        Assert.AreEqual(spec.InputAlphabet, algorithm.InputAlphabet);
+        Assert.AreEqual(spec.CheckLength, algorithm.CheckLength);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed algorithm reports the empty-body check code declared in the
+    /// specification, when one is declared.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigits_WhenJustConstructed_ShouldReturnEmptyCheckDigits()
+    {
+        MultiCharCheckDigitAlgorithmSpecification spec = GetSpecification();
+        if (spec.EmptyCheckDigits is not string expected) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        Assert.AreEqual(expected, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body in a single call produces the check code recorded for that known-answer
+    /// vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body one character at a time produces the same check code as a single
+    /// span-based call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        foreach (char ch in body)
+            algorithm.Append(ch);
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that appending a body in two chunks produces the same check code as appending it in one call.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append.</param>
+    /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        if (body.Length < 2) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        int split = body.Length / 2;
+
+        algorithm.Append(body.AsSpan(0, split));
+        algorithm.Append(body.AsSpan(split));
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that reading the current check code twice in succession — with no intervening appends — yields
+    /// the same value, proving the getter is non-destructive.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigits_WhenReadRepeatedly_ShouldReturnSameValue()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("12345".AsSpan());
+
+        string first = algorithm.GetCurrentCheckDigits();
+        string second = algorithm.GetCurrentCheckDigits();
+        string third = algorithm.GetCurrentCheckDigits();
+
+        Assert.AreEqual(first, second);
+        Assert.AreEqual(second, third);
+    }
+
+    /// <summary>
+    /// Verifies that the span and string overloads of <c>GetCurrentCheckDigits</c> agree.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (unused).</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The expected check code (unused in this cross-check).</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void GetCurrentCheckDigits_SpanAndStringOverloads_ShouldAgree(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        _ = expectedCheck;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append(body.AsSpan());
+
+        Span<char> buffer = stackalloc char[algorithm.CheckLength];
+        int written = algorithm.GetCurrentCheckDigits(buffer);
+
+        Assert.AreEqual(algorithm.CheckLength, written);
+        Assert.AreEqual(algorithm.GetCurrentCheckDigits(), new string(buffer));
+    }
+
+    /// <summary>
+    /// Verifies that the static <c>Compute</c> helper returns the expected check code for every known-answer
+    /// vector.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The expected check code.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Compute_WhenKnownAnswer_ShouldReturnExpectedCheckDigits(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        Assert.AreEqual(expectedCheck, ComputeStatic(body.AsSpan()));
+    }
+
+    /// <summary>
+    /// Verifies that appending the algorithm's own computed check code to the body always yields a sequence
+    /// that <c>IsValid</c> accepts.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The expected check code.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenSequenceIncludesComputedCheckDigits_ShouldReturnTrue(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        string full = body + expectedCheck;
+        Assert.IsTrue(IsValidStatic(full.AsSpan()), $"Expected '{full}' to be valid.");
+    }
+
+    /// <summary>
+    /// Verifies that substituting one character of the trailing check code for a different digit makes
+    /// <c>IsValid</c> reject the sequence.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector.</param>
+    /// <param name="body">The body characters.</param>
+    /// <param name="expectedCheck">The correct check code.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void IsValid_WhenLastCheckDigitIsTampered_ShouldReturnFalse(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        char lastExpected = expectedCheck[^1];
+        for (char c = '0'; c <= '9'; c++)
+        {
+            if (c == lastExpected) continue;
+            string bad = body + expectedCheck[..^1] + c;
+            Assert.IsFalse(IsValidStatic(bad.AsSpan()), $"Expected '{bad}' to be invalid (swap of last check digit).");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <c>Reset</c> after an Append restores the algorithm to the empty-body check code declared
+    /// in the specification (when one is declared).
+    /// </summary>
+    [TestMethod]
+    public void Reset_AfterAppend_ShouldRestoreEmptyCheckDigits()
+    {
+        MultiCharCheckDigitAlgorithmSpecification spec = GetSpecification();
+        if (spec.EmptyCheckDigits is not string expected) return;
+
+        TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append("1234".AsSpan());
+        algorithm.Reset();
+
+        Assert.AreEqual(expected, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that Reset between two append runs discards the first run's accumulated state so that only the
+    /// second run contributes to the final check code.
+    /// </summary>
+    /// <param name="name">A descriptive name for the vector (used in test output).</param>
+    /// <param name="body">The body characters to append in the second run.</param>
+    /// <param name="expectedCheck">The check code the algorithm is expected to emit for the second run.</param>
+    [TestMethod]
+    [DynamicData(nameof(KnownAnswerData), DynamicDataSourceType.Method)]
+    public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, string expectedCheck)
+    {
+        _ = name;
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        algorithm.Append("123456".AsSpan());
+        algorithm.Reset();
+        algorithm.Append(body.AsSpan());
+
+        Assert.AreEqual(expectedCheck, algorithm.GetCurrentCheckDigits());
+    }
+
+    /// <summary>
+    /// Verifies that <c>Append</c> rejects characters that fall outside the declared input alphabet.
+    /// </summary>
+    [TestMethod]
+    public void Append_WhenCharacterIsOutsideInputAlphabet_ShouldThrowArgumentOutOfRangeException()
+    {
+        MultiCharCheckDigitAlgorithmSpecification spec = GetSpecification();
+        char invalid = spec.InputAlphabet == CheckDigitInputAlphabet.DecimalDigits ? 'A' : '!';
+
+        TAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Append(new[] { '1', invalid, '2' }.AsSpan());
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetCurrentCheckDigits</c> throws <see cref="ArgumentException" /> when the destination
+    /// span is shorter than <c>CheckLength</c>.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentCheckDigits_WhenDestinationTooSmall_ShouldThrowArgumentException()
+    {
+        TAlgorithm algorithm = CreateAlgorithm();
+        char[] tooSmall = new char[algorithm.CheckLength - 1];
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            algorithm.GetCurrentCheckDigits(tooSmall.AsSpan());
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitKnownAnswer.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/MultiCharCheckDigitKnownAnswer.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiCharCheckDigitKnownAnswer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing.Checksums;
+
+/// <summary>
+/// Represents a single known-answer test vector for a <see cref="MultiCharCheckDigitAlgorithm" />, pairing a body
+/// of alphanumeric characters with the expected multi-character check code produced by the algorithm under test.
+/// </summary>
+public sealed record MultiCharCheckDigitKnownAnswer
+{
+    /// <summary>
+    /// Gets a short descriptive name used in test output to identify the vector.
+    /// </summary>
+    /// <returns>A non-empty descriptive label such as <c>"WikipediaIbanGB"</c>.</returns>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Gets the body characters (without the trailing check code) that the algorithm is expected to process.
+    /// </summary>
+    /// <returns>A non-null string drawn from the algorithm's declared input alphabet.</returns>
+    public required string Body { get; init; }
+
+    /// <summary>
+    /// Gets the expected check code produced by the algorithm for the <see cref="Body" />.
+    /// </summary>
+    /// <returns>A string of ASCII decimal digits whose length matches the algorithm's <c>CheckLength</c>.</returns>
+    public required string ExpectedCheck { get; init; }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SedolTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="Sedol" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class SedolTests : AlphanumericCheckDigitAlgorithmTests<SedolTests, Sedol>
+{
+    /// <inheritdoc />
+    protected override AlphanumericCheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "SEDOL",
+        InputAlphabet = CheckDigitInputAlphabet.AlphanumericUppercase,
+        OutputAlphabet = CheckDigitOutputAlphabet.DecimalDigits,
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",            Body = "",       ExpectedCheck = '0' },
+            new() { Name = "NumericBody",      Body = "026349", ExpectedCheck = '4' },
+            new() { Name = "AlphanumericBody", Body = "B0WNLY", ExpectedCheck = '7' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> body) =>
+        Sedol.Compute(body);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> valueIncludingCheck) =>
+        Sedol.IsValid(valueIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="Sedol.Compute(ReadOnlySpan{char})" /> rejects a body that contains a vowel.
+    /// </summary>
+    /// <param name="vowel">The vowel character to exercise.</param>
+    [DataRow('A')]
+    [DataRow('E')]
+    [DataRow('I')]
+    [DataRow('O')]
+    [DataRow('U')]
+    [DataTestMethod]
+    public void Compute_WhenBodyContainsVowel_ShouldThrowArgumentOutOfRangeException(char vowel)
+    {
+        string body = new string(new[] { '1', vowel, '2', '3', '4', '5' });
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = Sedol.Compute(body.AsSpan());
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Sedol.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="Sedol.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Sedol.IsValid("B0WNLY7X".AsSpan()));
+        Assert.IsFalse(Sedol.IsValid("B0WNLY".AsSpan()));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/UpcATests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/UpcATests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="UpcATests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.IO.Hashing.CheckDigits;
+
+/// <summary>
+/// Contains unit tests for the <see cref="UpcA" /> check-digit algorithm.
+/// </summary>
+[TestClass]
+public sealed class UpcATests : CheckDigitAlgorithmTests<UpcATests, UpcA>
+{
+    /// <inheritdoc />
+    protected override CheckDigitAlgorithmSpecification GetSpecification() => new()
+    {
+        AlgorithmName = "UPC-A",
+        EmptyCheckDigit = '0',
+        KnownAnswers =
+        [
+            new() { Name = "Empty",          Body = "",            ExpectedCheck = '0' },
+            new() { Name = "WikipediaUPCA",  Body = "03600029145", ExpectedCheck = '2' },
+            new() { Name = "AllZeros",       Body = "00000000000", ExpectedCheck = '0' },
+        ],
+    };
+
+    /// <inheritdoc />
+    protected override char ComputeStatic(ReadOnlySpan<char> digits) =>
+        UpcA.Compute(digits);
+
+    /// <inheritdoc />
+    protected override bool IsValidStatic(ReadOnlySpan<char> digitsIncludingCheck) =>
+        UpcA.IsValid(digitsIncludingCheck);
+
+    /// <summary>
+    /// Verifies that <see cref="UpcA.IsValid(ReadOnlySpan{char})" /> rejects a sequence whose length is not
+    /// exactly <see cref="UpcA.SequenceLength" />.
+    /// </summary>
+    [TestMethod]
+    public void IsValid_WhenSequenceLengthIsWrong_ShouldReturnFalse()
+    {
+        Assert.IsFalse(UpcA.IsValid("0360002914520".AsSpan()));
+        Assert.IsFalse(UpcA.IsValid("03600029145".AsSpan()));
+    }
+}


### PR DESCRIPTION
…cial-identifier check algorithms

Adds eleven new check-digit / check-character algorithms plus the minimal base-class infrastructure they require. All live under Bodu.IO.Hashing.Checksums alongside the existing Luhn / Damm / Verhoeff algorithms.

Algorithms:

- Decimal input, single-digit output (extend CheckDigitAlgorithm):
  - Isbn13            ISBN-13 weighted mod-10 (weights 1,3 alternating)
  - Ean8 / UpcA /     Strict-length variants of the same GTIN weighted mod-10 family
    Ean13 / Gtin14
  - AbaRoutingNumber  US Federal Reserve 9-digit routing number (weights 3,7,1 cyclic)

- Single character output, decimal input or alphanumeric input (extend new AlphanumericCheckDigitAlgorithm):
  - Isbn10            ISBN-10 weighted mod-11 (output 0-9 or 'X')
  - Iso7064Mod11_2    ISO 7064 MOD 11-2 pure algorithm (output 0-9 or 'X')
  - Sedol             UK SEDOL (weights 1,3,1,7,3,9,1; rejects vowels)
  - Cusip             US securities CUSIP (Luhn-style after letter expansion)
  - Isin              ISO 6166 ISIN (Luhn after A-Z -> 10-35 expansion)

- Multi-character output (extend new MultiCharCheckDigitAlgorithm):
  - Iso7064Mod97_10   ISO 7064 MOD 97-10 pure algorithm (2-digit check)
  - Iban              ISO 13616 IBAN (MOD 97-10 with country-code rearrangement)
  - Lei               ISO 17442 LEI (MOD 97-10 applied directly)

Infrastructure:

- Two new abstract base classes mirroring CheckDigitAlgorithm's streaming surface:
  - AlphanumericCheckDigitAlgorithm: wider input/output alphabets, single-char output
  - MultiCharCheckDigitAlgorithm: fixed-length multi-character check code
- Supporting enums CheckDigitInputAlphabet and CheckDigitOutputAlphabet.
- Internal Alphanumeric helper centralising letter-to-digit expansion and guards for the ISO 7064 / ISIN / CUSIP / SEDOL alphabets.
- Internal WeightedMod10 helper for the shared ISBN-13 / GTIN / ABA weighted mod-10 math.
- New ThrowHelper.ThrowIfNotAsciiAlphanumericUppercase in Bodu.Core (both CallerExpression and NetStandard partials).

Tests: full MSTest parity with the existing CheckDigitAlgorithmTests harness. Two new parametrised test bases (AlphanumericCheckDigitAlgorithmTests, MultiCharCheckDigitAlgorithmTests) plus per-algorithm test classes with published known-answer vectors (Apple ISIN/CUSIP, FRB Boston routing, GB/DE/FR IBANs, GLEIF LEI examples, Wikipedia EAN/UPC/ISBN).

Design decisions (user-confirmed):
- Separate sealed type per GTIN variant (Ean8/UpcA/Ean13/Gtin14) rather than one length-configurable class.
- Strict IsValid length enforcement on domain identifiers (ABA 9 digits, IBAN canonical form with no whitespace, SEDOL vowel-free).
- Compute helpers remain length-tolerant to support streaming and partial-body use.

Note: Pre-existing namespace inconsistencies in Damm.cs and Verhoeff.cs on master (they declare Bodu.IO.Hashing.CheckDigits and Bodu.IO.CheckDigits respectively, rather than the Bodu.IO.Hashing.Checksums of the rename) are left untouched as a follow-up.

https://claude.ai/code/session_01Qx43ziAW31rkinv92xUJJz