### PR TITLE
fix(Bodu.IO.Hashing): drop Empty KA vector from strict-length check-d…

### DIFF
--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AbaRoutingNumberTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AbaRoutingNumberTests.cs
@@ -20,7 +20,6 @@ public sealed partial class AbaRoutingNumberTests
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",                  Body = "",         ExpectedCheck = '0' },
             new() { Name = "FrbBostonRoutingBody",   Body = "01100001", ExpectedCheck = '5' },
             new() { Name = "FrbNewYorkRoutingBody",  Body = "02100008", ExpectedCheck = '9' },
             new() { Name = "AllZeros",               Body = "00000000", ExpectedCheck = '0' },

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean13Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean13Tests.cs
@@ -19,7 +19,6 @@ public sealed class Ean13Tests : CheckDigitAlgorithmTests<Ean13Tests, Ean13>
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",          Body = "",              ExpectedCheck = '0' },
             new() { Name = "WikipediaEAN13", Body = "501234567890",  ExpectedCheck = '0' },
             new() { Name = "BookIsbnShape",  Body = "978030640615",  ExpectedCheck = '7' },
         ],

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean8Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean8Tests.cs
@@ -19,7 +19,6 @@ public sealed class Ean8Tests : CheckDigitAlgorithmTests<Ean8Tests, Ean8>
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",         Body = "",        ExpectedCheck = '0' },
             new() { Name = "WikipediaEAN8", Body = "7351353", ExpectedCheck = '7' },
             new() { Name = "AllZeros",      Body = "0000000", ExpectedCheck = '0' },
         ],

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Gtin14Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Gtin14Tests.cs
@@ -19,7 +19,6 @@ public sealed class Gtin14Tests : CheckDigitAlgorithmTests<Gtin14Tests, Gtin14>
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",         Body = "",               ExpectedCheck = '0' },
             new() { Name = "GS1Example",    Body = "1061414100041",  ExpectedCheck = '5' },
             new() { Name = "AllZeros",      Body = "0000000000000",  ExpectedCheck = '0' },
         ],

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/UpcATests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/UpcATests.cs
@@ -19,7 +19,6 @@ public sealed class UpcATests : CheckDigitAlgorithmTests<UpcATests, UpcA>
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",          Body = "",            ExpectedCheck = '0' },
             new() { Name = "WikipediaUPCA",  Body = "03600029145", ExpectedCheck = '2' },
             new() { Name = "AllZeros",       Body = "00000000000", ExpectedCheck = '0' },
         ],

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
@@ -23,7 +23,6 @@ public sealed class CusipTests : AlphanumericCheckDigitAlgorithmTests<CusipTests
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",             Body = "",         ExpectedCheck = '0' },
             new() { Name = "AppleInc",          Body = "03783310", ExpectedCheck = '0' },
             new() { Name = "MicrosoftCorp",     Body = "59491810", ExpectedCheck = '4' },
         ],

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
@@ -23,7 +23,6 @@ public sealed class Isbn10Tests : AlphanumericCheckDigitAlgorithmTests<Isbn10Tes
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",                   Body = "",          ExpectedCheck = '0' },
             new() { Name = "HarryPotterPhilosophers", Body = "043942089", ExpectedCheck = 'X' },
             new() { Name = "WikipediaIsbn10",         Body = "030640615", ExpectedCheck = '2' },
             new() { Name = "AllZeros",                Body = "000000000", ExpectedCheck = '0' },

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
@@ -23,7 +23,6 @@ public sealed class IsinTests : AlphanumericCheckDigitAlgorithmTests<IsinTests, 
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",         Body = "",            ExpectedCheck = '0' },
             new() { Name = "AppleUS",       Body = "US037833100", ExpectedCheck = '5' },
             new() { Name = "BritishGB",     Body = "GB000263494", ExpectedCheck = '6' },
             new() { Name = "NumericOnly",   Body = "00000000000", ExpectedCheck = '0' },

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
@@ -23,7 +23,6 @@ public sealed class SedolTests : AlphanumericCheckDigitAlgorithmTests<SedolTests
         EmptyCheckDigit = '0',
         KnownAnswers =
         [
-            new() { Name = "Empty",            Body = "",       ExpectedCheck = '0' },
             new() { Name = "NumericBody",      Body = "026349", ExpectedCheck = '4' },
             new() { Name = "AlphanumericBody", Body = "B0WNLY", ExpectedCheck = '7' },
         ],


### PR DESCRIPTION
…igit tests

Nine test classes with strict-length IsValid contracts included an "Empty" known-answer vector (Body="", ExpectedCheck='0'). The inherited test IsValid_WhenSequenceIncludesComputedCheckDigit_ShouldReturnTrue builds `full = body + expectedCheck = "0"` and asserts it validates, but the strict-length algorithms short-circuit on `length != SequenceLength` — correctly rejecting "0" as too short — causing 9 test failures.

The fix removes the "Empty" KA entry from the affected specs. EmptyCheckDigit = '0' remains declared so GetCurrentCheckDigit_WhenJustConstructed still verifies the streaming-empty-body contract; only the round-trip KA vector is dropped.

Affected files:
- Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean8Tests.cs
- Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Ean13Tests.cs
- Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/UpcATests.cs
- Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/Gtin14Tests.cs
- Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AbaRoutingNumberTests.cs
- Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
- Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
- Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
- Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs

Isbn13 / Iso7064Mod11_2 / Iso7064Mod97_10 / Lei are length-tolerant in IsValid and correctly validate the "0" and "01" empty-body round-trips, so their specs are unchanged.

https://claude.ai/code/session_01Qx43ziAW31rkinv92xUJJz