### PR TITLE
fix(Core): handle CalendarWeekendDefinition.None in IsWeekend switch

### DIFF
--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
@@ -64,6 +64,7 @@ public static partial class DateTimeExtensions
             CalendarWeekendDefinition.ThursdayFriday => dayOfWeek is DayOfWeek.Thursday or DayOfWeek.Friday,
             CalendarWeekendDefinition.SundayOnly => dayOfWeek == DayOfWeek.Sunday,
             CalendarWeekendDefinition.FridayOnly => dayOfWeek == DayOfWeek.Friday,
+            CalendarWeekendDefinition.None => false,
             CalendarWeekendDefinition.Custom when provider is not null => provider.IsWeekend(dayOfWeek),
 
             _ => throw new ArgumentOutOfRangeException(

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.!TestData.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.!TestData.cs
@@ -2188,6 +2188,15 @@ public partial class DateTimeExtensionsTests
         yield return new object[] { new DateTime(2024, 04, 19), CalendarWeekendDefinition.FridayOnly, null, true }; // Friday
         yield return new object[] { new DateTime(2024, 04, 20), CalendarWeekendDefinition.FridayOnly, null, false }; // Saturday
 
+        // CalendarWeekendDefinition.None means no day of the week is a weekend, so every day must evaluate to false.
+        yield return new object[] { new DateTime(2024, 04, 21), CalendarWeekendDefinition.None, null, false }; // Sunday
+        yield return new object[] { new DateTime(2024, 04, 22), CalendarWeekendDefinition.None, null, false }; // Monday
+        yield return new object[] { new DateTime(2024, 04, 23), CalendarWeekendDefinition.None, null, false }; // Tuesday
+        yield return new object[] { new DateTime(2024, 04, 24), CalendarWeekendDefinition.None, null, false }; // Wednesday
+        yield return new object[] { new DateTime(2024, 04, 25), CalendarWeekendDefinition.None, null, false }; // Thursday
+        yield return new object[] { new DateTime(2024, 04, 26), CalendarWeekendDefinition.None, null, false }; // Friday
+        yield return new object[] { new DateTime(2024, 04, 27), CalendarWeekendDefinition.None, null, false }; // Saturday
+
         yield return new object[] { new DateTime(2024, 04, 19), CalendarWeekendDefinition.Custom, typeof(FridayOnlyWeekendProvider), true };
         yield return new object[] { new DateTime(2024, 04, 20), CalendarWeekendDefinition.Custom, typeof(FridayOnlyWeekendProvider), false };
     }

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsWeekend.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsWeekend.cs
@@ -54,4 +54,23 @@ public partial class DateTimeExtensionsTests
         });
     }
 
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// returns <see langword="false" /> for every day of the week when called with
+    /// <see cref="CalendarWeekendDefinition.None" />, matching the enum's documented contract that no standard weekend is defined.
+    /// </summary>
+    [TestMethod]
+    [DataRow(DayOfWeek.Sunday)]
+    [DataRow(DayOfWeek.Monday)]
+    [DataRow(DayOfWeek.Tuesday)]
+    [DataRow(DayOfWeek.Wednesday)]
+    [DataRow(DayOfWeek.Thursday)]
+    [DataRow(DayOfWeek.Friday)]
+    [DataRow(DayOfWeek.Saturday)]
+    public void IsWeekend_WhenNoneAndAnyDay_ShouldReturnFalse(DayOfWeek day)
+    {
+        bool actual = DateTimeExtensions.IsWeekend(day, CalendarWeekendDefinition.None);
+
+        Assert.IsFalse(actual, $"CalendarWeekendDefinition.None must classify every day as a weekday, but {day} was classified as weekend.");
+    }
 }


### PR DESCRIPTION
## Summary
- `DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)` had no switch arm for `CalendarWeekendDefinition.None`, so calling it with `None` fell through to the default arm and threw `ArgumentOutOfRangeException("The value 'None' is not a defined member of the CalendarWeekendDefinition enumeration.")`. This contradicts the enum's own documentation: `None = 5  // No standard weekend is defined (all days may be working or off depending on context).`
- Add the missing arm: `CalendarWeekendDefinition.None => false`. `IsWeekday` and the `NextWeekday` / `PreviousWeekday` extensions inherit the fix because they call through to `IsWeekend`.

## Test plan
- New focused test `IsWeekend_WhenNoneAndAnyDay_ShouldReturnFalse` with one `[DataRow]` per day of the week, asserting `false` for each.
- Seven new entries in `WeekendTestData()` so the existing parametric test `IsWeekend_WhenUsingStandardWeekend_ShouldReturnExpected` covers `None` for every day.
- `dotnet build Bodu.Core/test/Bodu.Core.Test.csproj`
- `dotnet test Bodu.Core/test/Bodu.Core.Test.csproj --settings test.runsettings`

## Discovery
Surfaced while writing service-level edge-case tests for `NotableDateService` in #77; that PR avoids `None` by using `Custom` + a never-weekend provider so it can land independently of this fix.

https://claude.ai/code/session_01SUsHFYNd4nWDTBXtsPAs8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUsHFYNd4nWDTBXtsPAs8p)_