### PR TITLE
feat(test): add SymmetricAlgorithmSpecification and specification-driven base class tests

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlowfishTests.cs
@@ -8,7 +8,17 @@ namespace Bodu.Security.Cryptography;
 
 [TestClass]
 public sealed partial class BlowfishTests
-    : SymmetricAlgorithmTests<Blowfish>
+    : SymmetricAlgorithmTests<BlowfishTests, Blowfish>
 {
+    /// <inheritdoc />
     protected override Blowfish CreateAlgorithm() => Blowfish.Create();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 64,
+            DefaultKeySizeBits = 128,
+            LegalKeySizesBits = [32, 128, 256, 448],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent1024TweakableAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent1024TweakableAlgorithmTests.cs
@@ -17,4 +17,13 @@ public partial class Serpent1024TweakableAlgorithmTests
 {
     /// <inheritdoc />
     protected override Serpent1024 CreateAlgorithm() => new Serpent1024();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 1024,
+            DefaultKeySizeBits = 1024,
+            LegalKeySizesBits = [1024],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent256TweakableAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent256TweakableAlgorithmTests.cs
@@ -17,4 +17,13 @@ public partial class Serpent256TweakableAlgorithmTests
 {
     /// <inheritdoc />
     protected override Serpent256 CreateAlgorithm() => new Serpent256();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 256,
+            DefaultKeySizeBits = 256,
+            LegalKeySizesBits = [256],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent512TweakableAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Serpent512TweakableAlgorithmTests.cs
@@ -17,4 +17,13 @@ public partial class Serpent512TweakableAlgorithmTests
 {
     /// <inheritdoc />
     protected override Serpent512 CreateAlgorithm() => new Serpent512();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 512,
+            DefaultKeySizeBits = 512,
+            LegalKeySizesBits = [512],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SimpleReversingSymmetricAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SimpleReversingSymmetricAlgorithmTests.cs
@@ -8,7 +8,17 @@ namespace Bodu.Security.Cryptography;
 
 [TestClass]
 public partial class SimpleReversingSymmetricAlgorithmTests
-    : SymmetricAlgorithmTests<SimpleReversingSymmetricAlgorithm>
+    : SymmetricAlgorithmTests<SimpleReversingSymmetricAlgorithmTests, SimpleReversingSymmetricAlgorithm>
 {
+    /// <inheritdoc />
     protected override SimpleReversingSymmetricAlgorithm CreateAlgorithm() => new SimpleReversingSymmetricAlgorithm();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 128,
+            DefaultKeySizeBits = 128,
+            LegalKeySizesBits = [8, 128, 256, 2048],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SimpleReversingTweakableSymmetricAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SimpleReversingTweakableSymmetricAlgorithmTests.cs
@@ -12,4 +12,13 @@ public partial class SimpleReversingTweakableSymmetricAlgorithmTests
 {
     /// <inheritdoc />
     protected override SimpleReversingTweakableSymmetricAlgorithm CreateAlgorithm() => new SimpleReversingTweakableSymmetricAlgorithm();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 128,
+            DefaultKeySizeBits = 128,
+            LegalKeySizesBits = [8, 128, 256, 2048],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackAlgorithmTests.cs
@@ -7,7 +7,18 @@
 namespace Bodu.Security.Cryptography;
 
 [TestClass]
-public sealed partial class SkipjackAlgorithmTests : SymmetricAlgorithmTests<Skipjack>
+public sealed partial class SkipjackAlgorithmTests
+    : SymmetricAlgorithmTests<SkipjackAlgorithmTests, Skipjack>
 {
+    /// <inheritdoc />
     protected override Skipjack CreateAlgorithm() => new Skipjack();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 64,
+            DefaultKeySizeBits = 80,
+            LegalKeySizesBits = [80],
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmSpecification.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmSpecification.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SymmetricAlgorithmSpecification.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Describes the expected observable properties of a single <typeparamref name="TAlgorithm" /> implementation for use in
+/// constructor and behavioural tests.
+/// </summary>
+public sealed record SymmetricAlgorithmSpecification
+{
+    /// <summary>Gets the expected <see cref="SymmetricAlgorithm.BlockSize" /> in bits.</summary>
+    public required int BlockSizeBits { get; init; }
+
+    /// <summary>Gets the expected default <see cref="SymmetricAlgorithm.KeySize" /> in bits on a freshly constructed instance.</summary>
+    public required int DefaultKeySizeBits { get; init; }
+
+    /// <summary>
+    /// Gets the set of key sizes in bits to exercise in parameterised encryptor and decryptor tests. For algorithms with a
+    /// fixed key size, this should list each discrete legal size. For algorithms with a broad key-size range, a representative
+    /// subset covering the minimum, maximum, and at least one intermediate size is sufficient.
+    /// </summary>
+    public required IReadOnlyList<int> LegalKeySizesBits { get; init; }
+
+    /// <summary>
+    /// Gets the expected default <see cref="SymmetricAlgorithm.Mode" /> on a freshly constructed instance.
+    /// Defaults to <see cref="CipherMode.CBC" />.
+    /// </summary>
+    public CipherMode DefaultMode { get; init; } = CipherMode.CBC;
+
+    /// <summary>
+    /// Gets the expected default <see cref="SymmetricAlgorithm.Padding" /> on a freshly constructed instance.
+    /// Defaults to <see cref="PaddingMode.PKCS7" />.
+    /// </summary>
+    public PaddingMode DefaultPadding { get; init; } = PaddingMode.PKCS7;
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.CreateDecryptor.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.CreateDecryptor.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that setting <see cref="SymmetricAlgorithm.CreateDecryptor" /> after the algorithm has been disposed throws

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.CreateEncryptor.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.CreateEncryptor.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that setting <see cref="SymmetricAlgorithm.CreateEncryptor" /> after the algorithm has been disposed throws

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Dispose.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Dispose.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that attempting to create a cryptographic transform on a disposed

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.FeedbackSize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.FeedbackSize.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that setting an invalid feedback size throws a CryptographicException.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.GenerateIV.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.GenerateIV.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that <see cref="SymmetricAlgorithm.GenerateIV" /> creates a key of expected length.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.GenerateKey.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.GenerateKey.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that <see cref="SymmetricAlgorithm.GenerateKey" /> creates a key of expected length.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.IV.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.IV.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that the IV property is not null upon algorithm creation.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Key.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Key.cs
@@ -8,7 +8,7 @@ using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that the Key property is not null upon algorithm creation.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.LegalBlockSizes.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.LegalBlockSizes.cs
@@ -6,7 +6,7 @@
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that <see cref="SymmetricAlgorithm.LegalBlockSizes" /> returns a new instance each call.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.LegalKeySizes.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.LegalKeySizes.cs
@@ -6,7 +6,7 @@
 
 namespace Bodu.Security.Cryptography;
 
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
 {
     /// <summary>
     /// Verifies that <see cref="SymmetricAlgorithm.LegalKeySizes" /> returns a new instance each call.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Specification.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Specification.cs
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SymmetricAlgorithmTests.Specification.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that a freshly constructed <typeparamref name="TAlgorithm" /> instance reports the block size declared in
+    /// <see cref="SymmetricAlgorithmSpecification.BlockSizeBits" />.
+    /// </summary>
+    [TestMethod]
+    public void BlockSize_WhenCreated_ShouldMatchSpecification()
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        SymmetricAlgorithmSpecification spec = GetSpecification();
+        Assert.AreEqual(spec.BlockSizeBits, algorithm.BlockSize);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed <typeparamref name="TAlgorithm" /> instance reports the key size declared in
+    /// <see cref="SymmetricAlgorithmSpecification.DefaultKeySizeBits" />.
+    /// </summary>
+    [TestMethod]
+    public void KeySize_WhenCreated_ShouldMatchSpecification()
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        SymmetricAlgorithmSpecification spec = GetSpecification();
+        Assert.AreEqual(spec.DefaultKeySizeBits, algorithm.KeySize);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed <typeparamref name="TAlgorithm" /> instance reports the cipher mode declared in
+    /// <see cref="SymmetricAlgorithmSpecification.DefaultMode" />.
+    /// </summary>
+    [TestMethod]
+    public void Mode_WhenCreated_ShouldMatchSpecification()
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        SymmetricAlgorithmSpecification spec = GetSpecification();
+        Assert.AreEqual(spec.DefaultMode, algorithm.Mode);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed <typeparamref name="TAlgorithm" /> instance reports the padding mode declared in
+    /// <see cref="SymmetricAlgorithmSpecification.DefaultPadding" />.
+    /// </summary>
+    [TestMethod]
+    public void Padding_WhenCreated_ShouldMatchSpecification()
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        SymmetricAlgorithmSpecification spec = GetSpecification();
+        Assert.AreEqual(spec.DefaultPadding, algorithm.Padding);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SymmetricAlgorithm.CreateEncryptor(byte[], byte[])" /> succeeds and returns a non-null
+    /// transform for each key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    public void CreateEncryptor_ForEachLegalKeySize_ShouldSucceed(int keySizeBits)
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.KeySize = keySizeBits;
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        using ICryptoTransform transform = algorithm.CreateEncryptor(algorithm.Key, algorithm.IV);
+        Assert.IsNotNull(transform);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SymmetricAlgorithm.CreateDecryptor(byte[], byte[])" /> succeeds and returns a non-null
+    /// transform for each key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    public void CreateDecryptor_ForEachLegalKeySize_ShouldSucceed(int keySizeBits)
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.KeySize = keySizeBits;
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        using ICryptoTransform transform = algorithm.CreateDecryptor(algorithm.Key, algorithm.IV);
+        Assert.IsNotNull(transform);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SymmetricAlgorithm.CreateEncryptor(byte[], byte[])" /> throws
+    /// <see cref="CryptographicException" /> when the supplied IV is one byte shorter than the block size, exercised for each
+    /// key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    public void CreateEncryptor_WhenIvIsTooShort_ForEachLegalKeySize_ShouldThrowCryptographicException(int keySizeBits)
+    {
+        using TAlgorithm algorithm = CreateAlgorithm();
+        algorithm.KeySize = keySizeBits;
+        algorithm.GenerateKey();
+
+        byte[] badIv = new byte[(algorithm.BlockSize / 8) - 1];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            using var _ = algorithm.CreateEncryptor(algorithm.Key, badIv);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Specification.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.Specification.cs
@@ -63,7 +63,7 @@ public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
     /// transform for each key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    [DynamicData(nameof(LegalKeySizesBitsData))]
     public void CreateEncryptor_ForEachLegalKeySize_ShouldSucceed(int keySizeBits)
     {
         using TAlgorithm algorithm = CreateAlgorithm();
@@ -80,7 +80,7 @@ public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
     /// transform for each key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    [DynamicData(nameof(LegalKeySizesBitsData))]
     public void CreateDecryptor_ForEachLegalKeySize_ShouldSucceed(int keySizeBits)
     {
         using TAlgorithm algorithm = CreateAlgorithm();
@@ -98,7 +98,7 @@ public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
     /// key size listed in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(LegalKeySizesBitsData), DynamicDataSourceType.Method)]
+    [DynamicData(nameof(LegalKeySizesBitsData))]
     public void CreateEncryptor_WhenIvIsTooShort_ForEachLegalKeySize_ShouldThrowCryptographicException(int keySizeBits)
     {
         using TAlgorithm algorithm = CreateAlgorithm();

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.cs
@@ -9,9 +9,11 @@ namespace Bodu.Security.Cryptography;
 /// <summary>
 /// Provides unit tests for symmetric algorithms to verify encryption, decryption, and property behaviours.
 /// </summary>
+/// <typeparam name="TTest">The concrete test class, used to resolve specification data for <see cref="DynamicDataAttribute" /> sources.</typeparam>
 /// <typeparam name="TAlgorithm">The type of symmetric algorithm under test.</typeparam>
 [TestClass]
-public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
+public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
+    where TTest : SymmetricAlgorithmTests<TTest, TAlgorithm>, new()
     where TAlgorithm : System.Security.Cryptography.SymmetricAlgorithm
 {
     /// <summary>
@@ -19,4 +21,19 @@ public abstract partial class SymmetricAlgorithmTests<TAlgorithm>
     /// </summary>
     /// <returns>An instance of the symmetric algorithm.</returns>
     protected abstract TAlgorithm CreateAlgorithm();
+
+    /// <summary>
+    /// Returns the <see cref="SymmetricAlgorithmSpecification" /> describing the expected observable properties of
+    /// <typeparamref name="TAlgorithm" />.
+    /// </summary>
+    /// <returns>A <see cref="SymmetricAlgorithmSpecification" /> instance populated with the expected values.</returns>
+    protected abstract SymmetricAlgorithmSpecification GetSpecification();
+
+    /// <summary>
+    /// Returns one row per entry in <see cref="SymmetricAlgorithmSpecification.LegalKeySizesBits" /> for use as a
+    /// <see cref="DynamicDataAttribute" /> source in parameterised tests.
+    /// </summary>
+    /// <returns>A sequence of single-element arrays, each containing a key size in bits.</returns>
+    public static IEnumerable<object[]> LegalKeySizesBitsData() =>
+        new TTest().GetSpecification().LegalKeySizesBits.Select(k => new object[] { k });
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/TweakableSymmetricAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/TweakableSymmetricAlgorithmTests.cs
@@ -12,7 +12,7 @@ namespace Bodu.Security.Cryptography;
 /// <typeparam name="TAlgorithm">The type of symmetric algorithm under test.</typeparam>
 [TestClass]
 public abstract partial class TweakableSymmetricAlgorithmTests<TTest, TAlgorithm>
-    : SymmetricAlgorithmTests<TAlgorithm>
+    : SymmetricAlgorithmTests<TTest, TAlgorithm>
     where TTest : TweakableSymmetricAlgorithmTests<TTest, TAlgorithm>, new()
     where TAlgorithm : Security.Cryptography.TweakableSymmetricAlgorithm
 {

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/TwoFishTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/TwoFishTests.cs
@@ -8,7 +8,17 @@ namespace Bodu.Security.Cryptography;
 
 [TestClass]
 public sealed partial class TwofishTests
-    : SymmetricAlgorithmTests<Twofish>
+    : SymmetricAlgorithmTests<TwofishTests, Twofish>
 {
+    /// <inheritdoc />
     protected override Twofish CreateAlgorithm() => Twofish.Create();
+
+    /// <inheritdoc />
+    protected override SymmetricAlgorithmSpecification GetSpecification() =>
+        new SymmetricAlgorithmSpecification
+        {
+            BlockSizeBits = 128,
+            DefaultKeySizeBits = 256,
+            LegalKeySizesBits = [128, 192, 256],
+        };
 }


### PR DESCRIPTION
## Summary

- Introduces `SymmetricAlgorithmSpecification` — a sealed record describing expected `BlockSizeBits`, `DefaultKeySizeBits`, `LegalKeySizesBits`, `DefaultMode`, and `DefaultPadding` for a symmetric algorithm, mirroring the existing `HashAlgorithmSpecification` / `BlockCipherSpecification` pattern.
- Refactors `SymmetricAlgorithmTests<TAlgorithm>` to `SymmetricAlgorithmTests<TTest, TAlgorithm>`, adding the self-referential `TTest` type parameter (same CRTP pattern as `BlockCipherTests<TTest, TCipher, TVariant>`) and two new members: `protected abstract GetSpecification()` and `public static LegalKeySizesBitsData()` for `DynamicData` sources.
- Adds `SymmetricAlgorithmTests.Specification.cs` with seven specification-driven tests that run automatically against every concrete algorithm: four default-property assertions (`BlockSize`, `KeySize`, `Mode`, `Padding`) and three parameterised tests over `LegalKeySizesBits` (`CreateEncryptor` success, `CreateDecryptor` success, IV-too-short throws `CryptographicException`).
- Updates all ten existing `SymmetricAlgorithmTests` partial files and `TweakableSymmetricAlgorithmTests` to the new signature.
- Implements `GetSpecification()` in all eight concrete test classes: Twofish (128/192/256-bit), Skipjack (80-bit), Blowfish (32/128/256/448-bit representatives), SimpleReversingSymmetricAlgorithm (8/128/256/2048-bit representatives), Serpent256/512/1024 (single fixed sizes), and SimpleReversingTweakableSymmetricAlgorithm.

## Test plan

- [ ] Build succeeds with no errors or warnings
- [ ] All existing tests pass
- [ ] New specification-driven tests pass for all eight concrete algorithm test classes
- [ ] Parameterised `DynamicData` tests enumerate the correct key sizes per algorithm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TjVKdF5e4ydL1Q4BksEDWH)_