### PR TITLE
test(Core): align Next/PreviousWeekday(None) tests with #79 IsWeekend(None) contract

### DIFF
--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.NextWeekday.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.NextWeekday.cs
@@ -56,19 +56,18 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="CalendarWeekendDefinition.None" /> throws <see cref="ArgumentOutOfRangeException" /> because the search loop has no weekend to skip.
+    /// Verifies that <see cref="DateOnlyExtensions.NextWeekday(DateOnly, CalendarWeekendDefinition)" />, when called with
+    /// <see cref="CalendarWeekendDefinition.None" />, advances by exactly one day. Because <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// classifies every day as a weekday under <c>None</c>, the search loop's first iteration moves the cursor forward one day and exits.
     /// </summary>
     [TestMethod]
-    public void NextWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException()
+    public void NextWeekday_WhenWeekendIsNone_ShouldAdvanceOneDay()
     {
-        // IsWeekend's switch does not handle CalendarWeekendDefinition.None explicitly, so it
-        // falls into the default AOOR branch during the search loop.
         DateOnly input = new DateOnly(2024, 4, 20);
 
-        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-        {
-            _ = input.NextWeekday(CalendarWeekendDefinition.None);
-        });
+        DateOnly actual = input.NextWeekday(CalendarWeekendDefinition.None);
+
+        Assert.AreEqual(input.AddDays(1), actual);
     }
 
     /// <summary>

--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.PreviousWeekday.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.PreviousWeekday.cs
@@ -54,19 +54,18 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="CalendarWeekendDefinition.None" /> throws <see cref="ArgumentOutOfRangeException" /> because the reverse search loop has no weekend to skip.
+    /// Verifies that <see cref="DateOnlyExtensions.PreviousWeekday(DateOnly, CalendarWeekendDefinition)" />, when called with
+    /// <see cref="CalendarWeekendDefinition.None" />, retreats by exactly one day. Because <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// classifies every day as a weekday under <c>None</c>, the reverse search loop's first iteration moves the cursor back one day and exits.
     /// </summary>
     [TestMethod]
-    public void PreviousWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException()
+    public void PreviousWeekday_WhenWeekendIsNone_ShouldRetreatOneDay()
     {
-        // IsWeekend's switch does not handle CalendarWeekendDefinition.None explicitly, so it
-        // falls into the default AOOR branch during the search loop.
         DateOnly input = new DateOnly(2024, 4, 21);
 
-        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-        {
-            _ = input.PreviousWeekday(CalendarWeekendDefinition.None);
-        });
+        DateOnly actual = input.PreviousWeekday(CalendarWeekendDefinition.None);
+
+        Assert.AreEqual(input.AddDays(-1), actual);
     }
 
     /// <summary>

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.NextWeekday.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.NextWeekday.cs
@@ -42,19 +42,18 @@ public partial class DateTimeExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="CalendarWeekendDefinition.None" /> throws <see cref="ArgumentOutOfRangeException" /> because the search loop has no weekend to skip.
+    /// Verifies that <see cref="DateTimeExtensions.NextWeekday(DateTime, CalendarWeekendDefinition)" />, when called with
+    /// <see cref="CalendarWeekendDefinition.None" />, advances by exactly one day. Because <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// classifies every day as a weekday under <c>None</c>, the search loop's first iteration moves the cursor forward one day and exits.
     /// </summary>
     [TestMethod]
-    public void NextWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException()
+    public void NextWeekday_WhenWeekendIsNone_ShouldAdvanceOneDay()
     {
-        // IsWeekend's switch does not handle CalendarWeekendDefinition.None explicitly, so it
-        // falls into the default AOOR branch during the search loop.
         DateTime input = new DateTime(2024, 4, 20);
 
-        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-        {
-            _ = input.NextWeekday(CalendarWeekendDefinition.None);
-        });
+        DateTime actual = input.NextWeekday(CalendarWeekendDefinition.None);
+
+        Assert.AreEqual(input.AddDays(1), actual);
     }
 
     /// <summary>

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.PreviousWeekday.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.PreviousWeekday.cs
@@ -42,19 +42,18 @@ public partial class DateTimeExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="CalendarWeekendDefinition.None" /> throws <see cref="ArgumentOutOfRangeException" /> because the reverse search loop has no weekend to skip.
+    /// Verifies that <see cref="DateTimeExtensions.PreviousWeekday(DateTime, CalendarWeekendDefinition)" />, when called with
+    /// <see cref="CalendarWeekendDefinition.None" />, retreats by exactly one day. Because <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// classifies every day as a weekday under <c>None</c>, the reverse search loop's first iteration moves the cursor back one day and exits.
     /// </summary>
     [TestMethod]
-    public void PreviousWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException()
+    public void PreviousWeekday_WhenWeekendIsNone_ShouldRetreatOneDay()
     {
-        // IsWeekend's switch does not handle CalendarWeekendDefinition.None explicitly, so it
-        // falls into the default AOOR branch during the search loop.
         DateTime input = new DateTime(2024, 4, 21);
 
-        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
-        {
-            _ = input.PreviousWeekday(CalendarWeekendDefinition.None);
-        });
+        DateTime actual = input.PreviousWeekday(CalendarWeekendDefinition.None);
+
+        Assert.AreEqual(input.AddDays(-1), actual);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
Follow-up to #79. PR #79 changed `IsWeekend(None)` from "throws `ArgumentOutOfRangeException`" to "returns `false`" so that `None` now means "no day is a weekend", but four pre-existing tests were left asserting the old throw behaviour and now fail on master:

- `DateTimeExtensionsTests.NextWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException`
- `DateTimeExtensionsTests.PreviousWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException`
- `DateOnlyExtensionsTests.NextWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException`
- `DateOnlyExtensionsTests.PreviousWeekday_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException`

Each docstring also explicitly described the bug as if correct (*"because the search loop has no weekend to skip"*). Update each test to assert the new contract: under `None`, the bounded search loop exits on its first iteration since `IsWeekend` always returns `false`, so `NextWeekday` advances by one day and `PreviousWeekday` retreats by one day.

## Test plan
- `dotnet build Bodu.Core/test/Bodu.Core.Test.csproj`
- `dotnet test Bodu.Core/test/Bodu.Core.Test.csproj --settings test.runsettings`
- All four renamed tests should pass; everything else stays green.

## Renames
- `*_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException` → `*_WhenWeekendIsNone_ShouldAdvanceOneDay` (NextWeekday)
- `*_WhenWeekendIsNone_ShouldThrowArgumentOutOfRangeException` → `*_WhenWeekendIsNone_ShouldRetreatOneDay` (PreviousWeekday)

https://claude.ai/code/session_01SUsHFYNd4nWDTBXtsPAs8p

---
_Generated by [Claude Code](https://claude.ai/code/session_01SUsHFYNd4nWDTBXtsPAs8p)_