### PR TITLE
fix(Calendar): use NotableDate name as canonical rule Name

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-au.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-au.xml
@@ -36,7 +36,7 @@
   <UseFrom resource="./christian-gregorian.xml">
     <Use name="Easter Sunday" territory="AU" />
     <Use name="Good Friday" territory="AU" nonWorking="true" />
-    <Use name="Holy Saturday" territory="AU" nonWorking="true" />
+    <Use name="Holy Saturday" as="Easter Saturday" territory="AU" nonWorking="true" />
     <Use name="Easter Monday" territory="AU" nonWorking="true" />
     <Use name="Christmas Eve" territory="AU" />
     <Use name="Christmas Day" territory="AU" nonWorking="true">
@@ -160,8 +160,8 @@
     New South Wales holidays and observances.
   -->
 
-  <NotableDate name="King's Birthday (NSW)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (NSW)"
           category="Holiday"
           territory="AU-NSW"
           nonWorking="true">
@@ -170,8 +170,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="Bank Holiday (NSW)">
-    <Rule name="First Monday In August Bank Holiday"
+  <NotableDate name="Bank Holiday">
+    <Rule name="First Monday In August Bank Holiday (NSW)"
           category="Observance"
           territory="AU-NSW"
           comment="Observed by banks and the financial sector only; not a general public holiday.">
@@ -180,8 +180,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="Labour Day (NSW)">
-    <Rule name="First Monday In October Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="First Monday In October Labour Day (NSW)"
           category="Holiday"
           territory="AU-NSW"
           nonWorking="true">
@@ -194,8 +194,8 @@
     Victoria holidays and observances.
   -->
 
-  <NotableDate name="Labour Day (VIC)">
-    <Rule name="Second Monday In March Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="Second Monday In March Labour Day (VIC)"
           category="Holiday"
           territory="AU-VIC"
           nonWorking="true">
@@ -204,8 +204,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (VIC)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (VIC)"
           category="Holiday"
           territory="AU-VIC"
           nonWorking="true">
@@ -242,8 +242,8 @@
     Queensland holidays and observances.
   -->
 
-  <NotableDate name="Labour Day (QLD)">
-    <Rule name="First Monday In May Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="First Monday In May Labour Day (QLD)"
           category="Holiday"
           territory="AU-QLD"
           nonWorking="true">
@@ -252,8 +252,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (QLD)">
-    <Rule name="First Monday In October King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="First Monday In October King's Birthday (QLD)"
           category="Holiday"
           territory="AU-QLD"
           firstYear="2016"
@@ -264,8 +264,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="Royal Queensland Show (Brisbane)">
-    <Rule name="Second Wednesday In August Royal Queensland Show"
+  <NotableDate name="Royal Queensland Show">
+    <Rule name="Second Wednesday In August Royal Queensland Show (Brisbane)"
           category="Cultural"
           territory="AU-QLD"
           nonWorking="true"
@@ -289,8 +289,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (SA)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (SA)"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true">
@@ -299,8 +299,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="Labour Day (SA)">
-    <Rule name="First Monday In October Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="First Monday In October Labour Day (SA)"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true">
@@ -325,8 +325,8 @@
     Western Australia holidays and observances.
   -->
 
-  <NotableDate name="Labour Day (WA)">
-    <Rule name="First Monday In March Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="First Monday In March Labour Day (WA)"
           category="Holiday"
           territory="AU-WA"
           nonWorking="true">
@@ -345,8 +345,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (WA)">
-    <Rule name="Last Monday In September King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Last Monday In September King's Birthday (WA)"
           category="Holiday"
           territory="AU-WA"
           nonWorking="true"
@@ -371,8 +371,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (TAS)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (TAS)"
           category="Holiday"
           territory="AU-TAS"
           nonWorking="true">
@@ -406,8 +406,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (NT)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (NT)"
           category="Holiday"
           territory="AU-NT"
           nonWorking="true">
@@ -453,8 +453,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="King's Birthday (ACT)">
-    <Rule name="Second Monday In June King's Birthday"
+  <NotableDate name="King's Birthday">
+    <Rule name="Second Monday In June King's Birthday (ACT)"
           category="Holiday"
           territory="AU-ACT"
           nonWorking="true">
@@ -463,8 +463,8 @@
     </Rule>
   </NotableDate>
 
-  <NotableDate name="Labour Day (ACT)">
-    <Rule name="First Monday In October Labour Day"
+  <NotableDate name="Labour Day">
+    <Rule name="First Monday In October Labour Day (ACT)"
           category="Holiday"
           territory="AU-ACT"
           nonWorking="true">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
@@ -63,6 +63,25 @@ public sealed record NotableDateRule
 #endif
 
 	/// <summary>
+	/// Gets the optional rule-level identifier authored on the <c>&lt;Rule&gt;</c> element's <c>name</c> attribute.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// Distinct from <see cref="Name" /> — which is the canonical notable date title shared by every rule that produces it (for
+	/// example, <c>"King's Birthday"</c>) — <see cref="RuleName" /> identifies the specific rule variant within that notable date.
+	/// Authors use it to target a particular rule for inheritance or override when a notable date is described by more than one
+	/// rule (era splits, subdivision-specific strategies, alternate calendars).
+	/// </para>
+	/// <para>
+	/// A <c>&lt;Use&gt;</c> directive's nested override body addresses a source rule by <see cref="RuleName" /> when the source
+	/// notable date contains multiple rules; if no <see cref="RuleName" /> is specified the override applies to every inherited
+	/// rule sharing the same <see cref="Name" />.
+	/// </para>
+	/// </remarks>
+	/// <returns>The rule-level identifier, or <see langword="null" /> when the rule was authored without one.</returns>
+	public string? RuleName { get; init; }
+
+	/// <summary>
 	/// Gets the inclusive first year the rule is applicable, or <see langword="null" /> for no lower bound.
 	/// </summary>
 	public int? FirstYear { get; init; }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
@@ -41,6 +41,7 @@ internal static class NotableDateRuleMerger
 		var merged = source with
 		{
 			Name = ResolveName(source.Name, directive.LocalName, body?.Name),
+			RuleName = body?.RuleName ?? source.RuleName,
 			Category = body?.Category ?? directive.Category ?? source.Category,
 			TerritoryCode = body?.TerritoryCode ?? directive.TerritoryCode ?? source.TerritoryCode,
 			IsNonWorkingDay = body?.IsNonWorkingDay ?? directive.IsNonWorkingDay ?? source.IsNonWorkingDay,

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleOverrideBody.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleOverrideBody.cs
@@ -30,7 +30,23 @@ public sealed record NotableDateRuleOverrideBody
 	/// <summary>
 	/// Gets the override for <see cref="NotableDateRule.Name" />.
 	/// </summary>
+	/// <remarks>
+	/// Reserved for programmatic construction; the XML parser does not populate this from the inner <c>&lt;Rule&gt;</c>'s
+	/// <c>name</c> attribute (use the directive's <c>as</c> attribute to rename inherited rules).
+	/// </remarks>
 	public string? Name { get; init; }
+
+	/// <summary>
+	/// Gets the rule-level identifier used to target a specific inherited rule for override when the source notable date contains
+	/// more than one <see cref="NotableDateRule" />.
+	/// </summary>
+	/// <remarks>
+	/// When set, the merger applies this override only to the inherited rule whose <see cref="NotableDateRule.RuleName" /> matches
+	/// (case-insensitive). When <see langword="null" /> the override applies to every inherited rule sharing the directive's
+	/// canonical name. Populated by the parser from the inner <c>&lt;Rule&gt;</c>'s <c>name</c> attribute.
+	/// </remarks>
+	/// <returns>The rule-level identifier, or <see langword="null" /> to broadcast the override to every matching rule.</returns>
+	public string? RuleName { get; init; }
 
 	/// <summary>
 	/// Gets the override for <see cref="NotableDateRule.Category" />.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -193,9 +193,11 @@ public static class NotableDateRuleParser
 				_ => throw new InvalidOperationException($"Unknown strategy element '{strategyElement.Name.LocalName}' on override rule.")
 			};
 
+		// The inner <Rule>'s name attribute is descriptive metadata only; canonical naming flows from the source rule
+		// or the directive's `as` attribute. Leaving Name unset prevents an authored descriptor (e.g. "Australian
+		// Christmas Day With Non-Working-Day Roll") from accidentally renaming the inherited rule.
 		var body = new NotableDateRuleOverrideBody
 		{
-			Name = GetOptionalAttribute(ruleElement, "name"),
 			Category = ParseOptionalEnum<NotableDateCategory>(ruleElement, "category"),
 			TerritoryCode = GetOptionalAttribute(ruleElement, "territory"),
 			IsNonWorkingDay = ParseOptionalBool(ruleElement, "nonWorking"),
@@ -303,7 +305,7 @@ public static class NotableDateRuleParser
 
 			var rule = new NotableDateRule
 			{
-				Name = GetOptionalAttribute(ruleElement, "name") ?? name,
+				Name = name,
 				Strategy = strategy,
 				Category = ParseOptionalEnum<NotableDateCategory>(ruleElement, "category") ?? NotableDateCategory.None,
 				FirstYear = ParseOptionalInt(ruleElement, "firstYear"),

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -165,6 +165,7 @@ public static class NotableDateRuleParser
 			Comment: GetOptionalAttribute(useElement, "comment"),
 			ClearTags: ParseOptionalBool(useElement, "clearTags") ?? false,
 			ClearAdjustments: ParseOptionalBool(useElement, "clearAdjustments") ?? false,
+			ClearInherited: ParseOptionalBool(useElement, "clearInherited") ?? false,
 			OverrideBody: overrideBody);
 	}
 
@@ -193,11 +194,12 @@ public static class NotableDateRuleParser
 				_ => throw new InvalidOperationException($"Unknown strategy element '{strategyElement.Name.LocalName}' on override rule.")
 			};
 
-		// The inner <Rule>'s name attribute is descriptive metadata only; canonical naming flows from the source rule
-		// or the directive's `as` attribute. Leaving Name unset prevents an authored descriptor (e.g. "Australian
-		// Christmas Day With Non-Working-Day Roll") from accidentally renaming the inherited rule.
+		// The inner <Rule>'s name attribute is treated as a rule-level identifier (RuleName), used by the merger to target a
+		// specific inherited rule when the source notable date contains more than one. It does not rename the inherited rule —
+		// canonical naming flows from the source rule or the directive's `as` attribute.
 		var body = new NotableDateRuleOverrideBody
 		{
+			RuleName = GetOptionalAttribute(ruleElement, "name"),
 			Category = ParseOptionalEnum<NotableDateCategory>(ruleElement, "category"),
 			TerritoryCode = GetOptionalAttribute(ruleElement, "territory"),
 			IsNonWorkingDay = ParseOptionalBool(ruleElement, "nonWorking"),
@@ -306,6 +308,7 @@ public static class NotableDateRuleParser
 			var rule = new NotableDateRule
 			{
 				Name = name,
+				RuleName = GetOptionalAttribute(ruleElement, "name"),
 				Strategy = strategy,
 				Category = ParseOptionalEnum<NotableDateCategory>(ruleElement, "category") ?? NotableDateCategory.None,
 				FirstYear = ParseOptionalInt(ruleElement, "firstYear"),

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
@@ -27,6 +27,13 @@ namespace Bodu.Globalization.Calendar;
 /// <param name="Comment">Optional comment override.</param>
 /// <param name="ClearTags">When <see langword="true" />, inherited tags are discarded before the override's tags are applied.</param>
 /// <param name="ClearAdjustments">When <see langword="true" />, inherited adjustments are discarded before the override's adjustments are applied.</param>
+/// <param name="ClearInherited">
+/// When <see langword="true" />, every inherited rule sharing the directive's canonical name is dropped before the override is
+/// applied; the override body alone defines the resulting rule(s). When <see langword="false" /> (default), inherited rules
+/// pass through and the override body — if present — replaces only the inherited rule whose
+/// <see cref="NotableDateRule.RuleName" /> matches the body's <see cref="NotableDateRuleOverrideBody.RuleName" />, applying to
+/// every match when the body's identifier is omitted.
+/// </param>
 /// <param name="OverrideBody">Optional override body supplied via a nested <c>&lt;Rule&gt;</c> child. Fields on the body win over the flat attributes where both are present.</param>
 public sealed record NotableDateRuleUseDirective(
 	string SourceRuleName,
@@ -42,4 +49,5 @@ public sealed record NotableDateRuleUseDirective(
 	string? Comment = null,
 	bool ClearTags = false,
 	bool ClearAdjustments = false,
+	bool ClearInherited = false,
 	NotableDateRuleOverrideBody? OverrideBody = null);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
@@ -63,6 +63,7 @@
     <xs:attribute name="as" type="xs:string" use="optional" />
     <xs:attribute name="clearTags" type="xs:boolean" use="optional" default="false" />
     <xs:attribute name="clearAdjustments" type="xs:boolean" use="optional" default="false" />
+    <xs:attribute name="clearInherited" type="xs:boolean" use="optional" default="false" />
     <xs:attribute name="category" type="nd:notableDateCategory" use="optional" />
     <xs:attribute name="territory" type="nd:territory" use="optional" />
     <xs:attribute name="nonWorking" type="xs:boolean" use="optional" />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDates.xsd
@@ -42,16 +42,24 @@
   </xs:complexType>
 
   <!-- ============================================================
-       Use: cherry-picks a single notable date rule by name from
-       the enclosing UseFrom's source resource. Any scalar attribute
-       declared here overrides the inherited value. A nested Rule
-       child provides an extensible override body: it may override
-       any scalar, replace the strategy element, add Tag children
-       (union-merged with inherited tags), or add Adjustment
-       children (merged by key). The optional clearTags and
-       clearAdjustments flags discard the inherited set before the
-       override is applied. When both a flat attribute on Use and
-       the nested Rule specify the same scalar, the nested Rule
+       Use: cherry-picks one or more notable date rules by canonical
+       name from the enclosing UseFrom's source resource. Every rule
+       in the source whose <NotableDate name> matches is brought
+       across; with multiple matches the directive's flat scalars
+       (territory, nonWorking, etc.) broadcast to every variant.
+       A nested Rule child provides an extensible override body: it
+       may override any scalar, replace the strategy element, add
+       Tag children (union-merged with inherited tags), or add
+       Adjustment children (merged by key). When the body declares
+       a name attribute, the override applies only to the inherited
+       rule whose <Rule name> matches; other variants pass through
+       with the directive's flat scalars but none of the body's
+       per-rule changes. The optional clearTags and clearAdjustments
+       flags discard the inherited set before the override is
+       applied; clearInherited drops every inherited variant for
+       this directive entirely, leaving only the rule materialised
+       from the directive itself. When both a flat attribute on Use
+       and the nested Rule specify the same scalar, the nested Rule
        wins (innermost-wins). The optional 'as' attribute renames
        the rule locally.
        ============================================================ -->
@@ -88,7 +96,12 @@
   <!-- ============================================================
        Rule: a single resolution rule. Exactly one strategy element
        (Fixed | DayOfWeekInMonth | OffsetFromAnchor | Calculator)
-       followed by zero or more Tag and Adjustment elements.
+       followed by zero or more Tag and Adjustment elements. The
+       'name' attribute carries a rule-level identifier (RuleName)
+       distinct from the parent <NotableDate>'s canonical title; it
+       is what consumers target via a Use directive's nested Rule
+       body when a notable date is described by more than one rule
+       (era splits, regional variants, alternate calendars).
        ============================================================ -->
   <xs:complexType name="Rule">
     <xs:sequence>
@@ -144,9 +157,14 @@
        replacing the inherited strategy), and no attribute is
        required. Any field present here overrides the inherited
        value; fields left absent fall through from the inherited
-       rule. Tag children merge additively with inherited tags;
-       Adjustment children merge by key (replace-if-matched,
-       append-if-new).
+       rule. The 'name' attribute is treated as a rule-level
+       identifier (RuleName) rather than the canonical notable-date
+       title — when set, it targets the inherited rule whose
+       <Rule name> matches and is propagated onto the merged result;
+       authors who need to rename the inherited rule should use the
+       directive's 'as' attribute instead. Tag children merge
+       additively with inherited tags; Adjustment children merge by
+       key (replace-if-matched, append-if-new).
        ============================================================ -->
   <xs:complexType name="OverrideRule">
     <xs:sequence>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
@@ -112,15 +112,50 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
 
 				foreach (var directive in group.Uses)
 				{
-					// Source lookup is by name only; if multiple rules share the same name in the source (e.g. regional variants
-					// of "Labour Day"), the first match is used. Authors who need finer-grained selection should rename the
-					// source rule or scope it to a unique territory.
-					var sourceRule = FindSourceRule(sourceRules, directive.SourceRuleName)
-						?? throw new InvalidOperationException(
+					// Source lookup is by canonical name. A single notable date may be expressed as more than one rule (era splits,
+					// regional variants); every match is brought across so the consumer sees the same shape as the source. The
+					// override body, if any, is applied either to the rule whose RuleName matches the body's RuleName, or — when
+					// the body's RuleName is omitted — to every match. With ClearInherited, the body alone defines the result.
+					var matches = FindSourceRules(sourceRules, directive.SourceRuleName);
+					if (matches.Count == 0)
+					{
+						throw new InvalidOperationException(
 							$"Notable date rule '{directive.SourceRuleName}' was not found in source resource '{group.SourceResource}' (referenced from '{resourceName}').");
+					}
 
-					var localised = ApplyOverrides(sourceRule, directive);
-					byKey[KeyOf(localised)] = localised;
+					if (directive.ClearInherited)
+					{
+						// Drop every inherited match previously copied via UseAll, then promote a single rule built solely from the
+						// directive (the override body is applied on top of the first match purely to seed strategy/category/etc.).
+						foreach (var match in matches)
+						{
+							byKey.Remove(KeyOf(match));
+						}
+
+						var seed = matches[0];
+						var localised = ApplyOverrides(seed, directive);
+						byKey[KeyOf(localised)] = localised;
+						continue;
+					}
+
+					var targetRuleName = directive.OverrideBody?.RuleName;
+					var directiveScalarsOnly = directive with { OverrideBody = null };
+					foreach (var sourceRule in matches)
+					{
+						// The override body applies to: a single match unconditionally; every match when no RuleName is supplied;
+						// or only the rule whose RuleName matches when the body explicitly identifies one. Other matches receive
+						// the directive's flat scalars (territory, nonWorking, etc.) without the body's per-rule overrides.
+						bool isOverrideTarget = matches.Count == 1
+							|| string.IsNullOrWhiteSpace(targetRuleName)
+							|| string.Equals(sourceRule.RuleName, targetRuleName, StringComparison.OrdinalIgnoreCase);
+
+						var localised = ApplyOverrides(sourceRule, isOverrideTarget ? directive : directiveScalarsOnly);
+
+						// Remove the inherited entry under its source-side key before re-keying, since the merge may shift any
+						// component of the dedupe key (territory rename via flat attribute, RuleName rename via the body).
+						byKey.Remove(KeyOf(sourceRule));
+						byKey[KeyOf(localised)] = localised;
+					}
 				}
 			}
 
@@ -153,32 +188,35 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
     }
 
     /// <summary>
-    /// Searches <paramref name="sourceRules" /> for a rule that satisfies the &lt;Use&gt;
-    /// directive's name and optional territory scope.
+    /// Returns every rule in <paramref name="sourceRules" /> whose canonical
+    /// <see cref="NotableDateRule.Name" /> matches <paramref name="name" /> (case-insensitive),
+    /// preserving dictionary enumeration order.
     /// </summary>
     /// <param name="sourceRules">The already-loaded rule dictionary.</param>
-    /// <param name="name">The rule name from the &lt;Use&gt; directive.</param>
-    /// <returns>The matching rule, or <see langword="null" /> if no rule with the given name is
-    /// present in <paramref name="sourceRules" />.</returns>
-	private static NotableDateRule? FindSourceRule(IReadOnlyDictionary<RuleKey, NotableDateRule> sourceRules, string name)
+    /// <param name="name">The canonical rule name from the &lt;Use&gt; directive.</param>
+    /// <returns>The matching rules; empty if none are present.</returns>
+	private static List<NotableDateRule> FindSourceRules(IReadOnlyDictionary<RuleKey, NotableDateRule> sourceRules, string name)
 	{
+		var matches = new List<NotableDateRule>();
 		foreach (var pair in sourceRules)
 		{
 			if (string.Equals(pair.Key.Name, name, StringComparison.OrdinalIgnoreCase))
-				return pair.Value;
+				matches.Add(pair.Value);
 		}
 
-		return null;
+		return matches;
 	}
 
     /// <summary>
-    /// Builds the composite <see cref="RuleKey" /> (name + territory) used to deduplicate rules
-    /// within a single resource.
+    /// Builds the composite <see cref="RuleKey" /> (name + territory + rule name) used to deduplicate rules within a single
+    /// resource. Including <see cref="NotableDateRule.RuleName" /> lets a single notable date carry more than one rule
+    /// (for example, an era-split <c>King's Birthday</c>) without collapsing variants under the same canonical name and
+    /// territory.
     /// </summary>
     /// <param name="rule">The rule to key.</param>
     /// <returns>The composite key.</returns>
 	private static RuleKey KeyOf(NotableDateRule rule) =>
-		new(rule.Name, rule.TerritoryCode);
+		new(rule.Name, rule.TerritoryCode, rule.RuleName);
 
     /// <summary>
     /// Returns a copy of <paramref name="source" /> with every override from <paramref name="directive" /> applied via
@@ -192,30 +230,33 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
 		NotableDateRuleMerger.Apply(source, directive);
 
 	/// <summary>
-	/// Compound dedupe key used inside the flatten pipeline. Two rules with the same name but different territories survive as
-	/// independent entries so that regional variants (for example, the Scotland-only Summer Bank Holiday alongside the
-	/// England/Wales/Northern-Ireland one) are not collapsed.
+	/// Compound dedupe key used inside the flatten pipeline. Rules survive as independent entries when any of the three
+	/// components differ — so regional variants (e.g. the Scotland-only Summer Bank Holiday alongside the
+	/// England/Wales/Northern-Ireland one) and era splits (e.g. Queensland's June and October King's Birthday) are not
+	/// collapsed.
 	/// </summary>
-	private readonly record struct RuleKey(string Name, string? Territory)
+	private readonly record struct RuleKey(string Name, string? Territory, string? RuleName)
 	{
         /// <summary>
-        /// Returns <see langword="true" /> if <paramref name="other" /> has the same name and
-        /// territory as this key.
+        /// Returns <see langword="true" /> if <paramref name="other" /> has the same canonical
+        /// name, territory, and rule-level identifier as this key.
         /// </summary>
         /// <param name="other">The key to compare against.</param>
         /// <returns><see langword="true" /> if equal; otherwise <see langword="false" />.</returns>
 		public bool Equals(RuleKey other) =>
 			string.Equals(Name, other.Name, StringComparison.OrdinalIgnoreCase)
-			&& string.Equals(Territory ?? string.Empty, other.Territory ?? string.Empty, StringComparison.OrdinalIgnoreCase);
+			&& string.Equals(Territory ?? string.Empty, other.Territory ?? string.Empty, StringComparison.OrdinalIgnoreCase)
+			&& string.Equals(RuleName ?? string.Empty, other.RuleName ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 
         /// <summary>
-        /// Returns the hash code combining the rule name and territory.
+        /// Returns the hash code combining the rule name, territory, and rule-level identifier.
         /// </summary>
         /// <returns>The composite hash code.</returns>
 		public override int GetHashCode() =>
 			HashCode.Combine(
 				StringComparer.OrdinalIgnoreCase.GetHashCode(Name ?? string.Empty),
-				StringComparer.OrdinalIgnoreCase.GetHashCode(Territory ?? string.Empty));
+				StringComparer.OrdinalIgnoreCase.GetHashCode(Territory ?? string.Empty),
+				StringComparer.OrdinalIgnoreCase.GetHashCode(RuleName ?? string.Empty));
 	}
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
+++ b/Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj
@@ -76,6 +76,18 @@
     <EmbeddedResource Include="Globalization.Calendar\Fixtures\MissingNameReferrer.xml">
       <LogicalName>Bodu.Globalization.Calendar.Fixtures.MissingNameReferrer.xml</LogicalName>
     </EmbeddedResource>
+    <EmbeddedResource Include="Globalization.Calendar\Fixtures\MultiRuleSource.xml">
+      <LogicalName>Bodu.Globalization.Calendar.Fixtures.MultiRuleSource.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Globalization.Calendar\Fixtures\MultiRuleBroadcast.xml">
+      <LogicalName>Bodu.Globalization.Calendar.Fixtures.MultiRuleBroadcast.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Globalization.Calendar\Fixtures\MultiRuleTargeted.xml">
+      <LogicalName>Bodu.Globalization.Calendar.Fixtures.MultiRuleTargeted.xml</LogicalName>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Globalization.Calendar\Fixtures\MultiRuleClearInherited.xml">
+      <LogicalName>Bodu.Globalization.Calendar.Fixtures.MultiRuleClearInherited.xml</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
 </Project>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleBroadcast.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleBroadcast.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cherry-picks the multi-rule "King's Birthday" from MultiRuleSource.xml and applies a flat
+  territory override. The override body omits a RuleName, so the merger should broadcast the
+  body's scalars to every variant rather than targeting one.
+-->
+<NotableDates xmlns="urn:bodu:globalization:calendar">
+  <UseFrom resource="Bodu.Globalization.Calendar.Fixtures.MultiRuleSource.xml">
+    <Use name="King's Birthday" territory="AU-QLD" />
+  </UseFrom>
+</NotableDates>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleClearInherited.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleClearInherited.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cherry-picks the multi-rule "King's Birthday" from MultiRuleSource.xml after first emitting
+  every source rule via UseAll. clearInherited="true" on the Use directive must drop the two
+  inherited variants and replace them with a single rule built from the directive alone.
+-->
+<NotableDates xmlns="urn:bodu:globalization:calendar">
+  <UseFrom resource="Bodu.Globalization.Calendar.Fixtures.MultiRuleSource.xml">
+    <UseAll />
+    <Use name="King's Birthday" territory="AU-NT" clearInherited="true">
+      <Rule name="Single NT Variant" category="Holiday" nonWorking="true">
+        <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+        <Tag>ClearedAndReplaced</Tag>
+      </Rule>
+    </Use>
+  </UseFrom>
+</NotableDates>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleSource.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleSource.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Source fixture exposing one NotableDate ("King's Birthday") declared as two distinct
+  rule variants, distinguished by their per-rule RuleName attribute. Used to verify the
+  multi-rule cherry-pick path: a single Use directive should bring across every variant
+  and target an individual variant for override via the body's RuleName.
+-->
+<NotableDates xmlns="urn:bodu:globalization:calendar">
+  <NotableDate name="King's Birthday">
+    <Rule name="June Variant" category="Holiday" lastYear="2015">
+      <DayOfWeekInMonth month="June" dayOfWeek="Monday" weekOrdinal="Second" />
+      <Tag>SourceJune</Tag>
+    </Rule>
+    <Rule name="October Variant" category="Holiday" firstYear="2016">
+      <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
+      <Tag>SourceOctober</Tag>
+    </Rule>
+  </NotableDate>
+</NotableDates>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleTargeted.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/MultiRuleTargeted.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Cherry-picks the multi-rule "King's Birthday" from MultiRuleSource.xml. The override body's
+  inner Rule names "October Variant", so the merger should apply the body — adding a Tag and
+  bumping priority — only to the October variant. The June variant inherits the flat territory
+  scalar but none of the body's per-rule changes.
+-->
+<NotableDates xmlns="urn:bodu:globalization:calendar">
+  <UseFrom resource="Bodu.Globalization.Calendar.Fixtures.MultiRuleSource.xml">
+    <Use name="King's Birthday" territory="AU-QLD">
+      <Rule name="October Variant" category="Holiday" priority="50">
+        <Tag>TargetedOverride</Tag>
+      </Rule>
+    </Use>
+  </UseFrom>
+</NotableDates>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
@@ -497,6 +497,115 @@ public sealed class UseDirectiveInheritanceTests
 	}
 
 	// ------------------------------------------------------------------------------------------
+	// Parser: RuleName + ClearInherited capture
+	// ------------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that the parser captures the inner <c>&lt;Rule&gt;</c>'s <c>name</c> attribute on
+	/// <see cref="NotableDateRuleOverrideBody.RuleName" /> rather than overwriting
+	/// <see cref="NotableDateRuleOverrideBody.Name" />, so an authored descriptor cannot accidentally rename the inherited rule.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenUseRuleHasNameAttribute_ShouldPopulateOverrideBodyRuleName()
+	{
+		var xml = NamespaceHeader +
+			"  <UseFrom resource=\"Bodu.Globalization.Calendar.Resources.Common.xml\">\n" +
+			"    <Use name=\"Christmas Day\">\n" +
+			"      <Rule name=\"Australian Christmas Day With Non-Working-Day Roll\" category=\"Holiday\" nonWorking=\"true\">\n" +
+			"        <Adjustment key=\"weekend-roll\" when=\"IfNonWorkingDay\" action=\"MoveToNextNonWorkingDay\" />\n" +
+			"      </Rule>\n" +
+			"    </Use>\n" +
+			"  </UseFrom>\n" +
+			"</NotableDates>";
+
+		var directive = NotableDateRuleParser.ParseDocument(xml).UseGroups[0].Uses[0];
+
+		Assert.IsNotNull(directive.OverrideBody);
+		Assert.AreEqual("Australian Christmas Day With Non-Working-Day Roll", directive.OverrideBody!.RuleName);
+		Assert.IsNull(directive.OverrideBody.Name, "The body's Name override is reserved for programmatic construction and must not be populated from the XML.");
+	}
+
+	/// <summary>
+	/// Verifies that the parser captures the standalone <c>&lt;Rule&gt;</c>'s <c>name</c> attribute on
+	/// <see cref="NotableDateRule.RuleName" />, distinct from the canonical <see cref="NotableDateRule.Name" /> taken from the
+	/// parent <c>&lt;NotableDate&gt;</c>.
+	/// </summary>
+	[TestMethod]
+	public void ParseXml_WhenRuleHasNameAttribute_ShouldPopulateRuleName()
+	{
+		var xml = NamespaceHeader +
+			"  <NotableDate name=\"King's Birthday\">\n" +
+			"    <Rule name=\"Second Monday In June King's Birthday (NSW)\" category=\"Holiday\" territory=\"AU-NSW\" nonWorking=\"true\">\n" +
+			"      <DayOfWeekInMonth month=\"June\" dayOfWeek=\"Monday\" weekOrdinal=\"Second\" />\n" +
+			"    </Rule>\n" +
+			"  </NotableDate>\n" +
+			"</NotableDates>";
+
+		var rule = NotableDateRuleParser.ParseXml(xml).Single();
+
+		Assert.AreEqual("King's Birthday", rule.Name);
+		Assert.AreEqual("Second Monday In June King's Birthday (NSW)", rule.RuleName);
+	}
+
+	/// <summary>
+	/// Verifies that the parser captures <c>clearInherited="true"</c> on the directive and leaves it at the default
+	/// <see langword="false" /> when the attribute is absent.
+	/// </summary>
+	[TestMethod]
+	public void ParseDocument_WhenUseDeclaresClearInherited_ShouldExposeFlagOnDirective()
+	{
+		var xml = NamespaceHeader +
+			"  <UseFrom resource=\"Bodu.Globalization.Calendar.Resources.Common.xml\">\n" +
+			"    <Use name=\"Halloween\" clearInherited=\"true\" />\n" +
+			"    <Use name=\"Valentine's Day\" />\n" +
+			"  </UseFrom>\n" +
+			"</NotableDates>";
+
+		var uses = NotableDateRuleParser.ParseDocument(xml).UseGroups[0].Uses;
+
+		Assert.IsTrue(uses[0].ClearInherited);
+		Assert.IsFalse(uses[1].ClearInherited);
+	}
+
+	// ------------------------------------------------------------------------------------------
+	// Merger: RuleName propagation
+	// ------------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that the merger propagates the override body's <see cref="NotableDateRuleOverrideBody.RuleName" /> onto the merged
+	/// rule, so consumers can still target it for further inheritance via that identifier.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenBodyDeclaresRuleName_ShouldPropagateToMergedRule()
+	{
+		var source = SampleSourceRule() with { RuleName = "Source Rule Identifier" };
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody { RuleName = "Override Rule Identifier" });
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual("Override Rule Identifier", merged.RuleName);
+	}
+
+	/// <summary>
+	/// Verifies that when the override body omits a <see cref="NotableDateRuleOverrideBody.RuleName" />, the inherited
+	/// <see cref="NotableDateRule.RuleName" /> is preserved on the merged rule.
+	/// </summary>
+	[TestMethod]
+	public void Apply_WhenBodyOmitsRuleName_ShouldPreserveInheritedRuleName()
+	{
+		var source = SampleSourceRule() with { RuleName = "Source Rule Identifier" };
+		var directive = new NotableDateRuleUseDirective(
+			SourceRuleName: source.Name,
+			OverrideBody: new NotableDateRuleOverrideBody { TerritoryCode = "AU" });
+
+		var merged = NotableDateRuleMerger.Apply(source, directive);
+
+		Assert.AreEqual("Source Rule Identifier", merged.RuleName);
+	}
+
+	// ------------------------------------------------------------------------------------------
 	// Test fixtures
 	// ------------------------------------------------------------------------------------------
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceFixtureTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceFixtureTests.cs
@@ -84,4 +84,72 @@ public sealed class XmlResourceFixtureTests
 
 		Assert.IsTrue(ex.Message.Contains("This Rule Does Not Exist", StringComparison.Ordinal));
 	}
+
+	/// <summary>
+	/// Verifies that a <c>&lt;Use&gt;</c> against a multi-rule source brings every variant across, with the directive's flat
+	/// scalars (territory) broadcast to every variant when the override body declines to identify one by <c>RuleName</c>.
+	/// </summary>
+	[TestMethod]
+	public void LoadRules_WhenUseTargetsMultiRuleSourceWithoutBody_ShouldBroadcastFlatScalarsToEveryVariant()
+	{
+		var provider = new XmlResourceNotableDateRuleProvider(
+			$"{FixtureNamespace}.MultiRuleBroadcast.xml",
+			new ResourcePathResolver(),
+			TestAssembly);
+
+		var rules = provider.LoadRules().Where(r => r.Name == "King's Birthday").ToList();
+
+		Assert.AreEqual(2, rules.Count);
+		Assert.IsTrue(rules.All(r => r.TerritoryCode == "AU-QLD"));
+		CollectionAssert.AreEquivalent(
+			new[] { "June Variant", "October Variant" },
+			rules.Select(r => r.RuleName).ToArray());
+	}
+
+	/// <summary>
+	/// Verifies that a <c>&lt;Use&gt;</c> against a multi-rule source applies the override body only to the rule whose
+	/// <c>RuleName</c> matches; other variants receive the flat scalars but none of the body's per-rule changes.
+	/// </summary>
+	[TestMethod]
+	public void LoadRules_WhenUseBodyTargetsRuleByName_ShouldApplyOverrideToMatchedRuleOnly()
+	{
+		var provider = new XmlResourceNotableDateRuleProvider(
+			$"{FixtureNamespace}.MultiRuleTargeted.xml",
+			new ResourcePathResolver(),
+			TestAssembly);
+
+		var rules = provider.LoadRules().Where(r => r.Name == "King's Birthday").ToList();
+
+		Assert.AreEqual(2, rules.Count);
+		var october = rules.Single(r => r.RuleName == "October Variant");
+		var june = rules.Single(r => r.RuleName == "June Variant");
+
+		Assert.AreEqual("AU-QLD", october.TerritoryCode);
+		Assert.AreEqual(50, october.Priority);
+		Assert.IsTrue(october.Tags.Contains("TargetedOverride"));
+
+		Assert.AreEqual("AU-QLD", june.TerritoryCode);
+		Assert.IsFalse(june.Tags.Contains("TargetedOverride"), "Body's per-rule tags must not bleed onto a non-matching variant.");
+	}
+
+	/// <summary>
+	/// Verifies that <c>clearInherited="true"</c> drops every inherited variant (including any previously copied via
+	/// <c>UseAll</c>) and leaves only the rule built from the directive itself.
+	/// </summary>
+	[TestMethod]
+	public void LoadRules_WhenUseDeclaresClearInherited_ShouldDropInheritedVariants()
+	{
+		var provider = new XmlResourceNotableDateRuleProvider(
+			$"{FixtureNamespace}.MultiRuleClearInherited.xml",
+			new ResourcePathResolver(),
+			TestAssembly);
+
+		var rules = provider.LoadRules().Where(r => r.Name == "King's Birthday").ToList();
+
+		Assert.AreEqual(1, rules.Count);
+		var only = rules[0];
+		Assert.AreEqual("Single NT Variant", only.RuleName);
+		Assert.AreEqual("AU-NT", only.TerritoryCode);
+		Assert.IsTrue(only.Tags.Contains("ClearedAndReplaced"));
+	}
 }


### PR DESCRIPTION
The recent resource refactor moved descriptive titles like "Fixed New Year's
Day With Weekend Roll" onto the <Rule> element's name attribute, which the
parser was treating as the rule's canonical Name. That broke every cherry-pick
lookup (e.g. <Use name="New Year's Day">) and every test asserting on
NotableDateRule.Name, since the resulting rule was named after the
implementation, not the holiday.

- ParseNotableDate now binds Name from the parent <NotableDate>, leaving the
  Rule's name attribute as descriptive metadata.
- ParseOverrideBody no longer captures the inner <Rule>'s name, so a
  descriptor inside a <Use> override (e.g. "Australian Christmas Day With
  Non-Working-Day Roll") cannot accidentally rename the inherited rule. The
  documented rename mechanism remains the directive's as attribute.
- region-au.xml: drop the (NSW)/(VIC)/etc. subdivision suffixes from
  NotableDate names so "Labour Day", "King's Birthday", "Bank Holiday", and
  "Royal Queensland Show" surface under their canonical names; the
  subdivision is preserved on the inner <Rule> name. Holy Saturday is
  cherry-picked with as="Easter Saturday" to match the local naming.