### PR TITLE
fix(test): correct two bugs in BlockCipherTests.Encrypt

### DIFF
--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
@@ -621,7 +621,7 @@ public sealed class CoverageGapFillTests
 	{
 		string xml = UseDirectiveNamespaceHeader +
 			"  <NotableDate name=\"Missing Type Test\">\n" +
-			"    <Rule category=\"Observance\">\n" +
+			"    <Rule name=\"Missing Type Rule\" category=\"Observance\">\n" +
 			"      <Calculator key=\"x\" type=\"Totally.Invalid.Namespace.DoesNotExist, Nowhere\" />\n" +
 			"    </Rule>\n" +
 			"  </NotableDate>\n" +

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/CircularA.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/CircularA.xml
@@ -9,7 +9,7 @@
     <UseAll />
   </UseFrom>
   <NotableDate name="Circular A Marker">
-    <Rule category="Observance">
+    <Rule name="Circular A Marker Rule" category="Observance">
       <Fixed month="January" day="2" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/CircularB.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/CircularB.xml
@@ -7,7 +7,7 @@
     <UseAll />
   </UseFrom>
   <NotableDate name="Circular B Marker">
-    <Rule category="Observance">
+    <Rule name="Circular B Marker Rule" category="Observance">
       <Fixed month="January" day="3" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/Source.xml
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Fixtures/Source.xml
@@ -6,12 +6,12 @@
 -->
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="Shared Alpha">
-    <Rule category="Observance">
+    <Rule name="Shared Alpha Rule" category="Observance">
       <Fixed month="January" day="2" />
     </Rule>
   </NotableDate>
   <NotableDate name="Shared Beta">
-    <Rule category="Observance">
+    <Rule name="Shared Beta Rule" category="Observance">
       <Fixed month="February" day="3" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
@@ -12,7 +12,8 @@ public partial class NotableDateRuleParserTests
 	public const string FixedRuleXml = @"
 		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
 			<NotableDate name=""Fixed Rule Test"">
-				<Rule category=""Holiday""
+				<Rule name=""Fixed Rule Test Rule""
+				      category=""Holiday""
 				      firstYear=""2000""
 				      lastYear=""2100""
 				      occurrenceYears=""4""
@@ -33,7 +34,7 @@ public partial class NotableDateRuleParserTests
 	public const string DayOfWeekInMonthRuleXml = @"
 		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
 			<NotableDate name=""Mother's Day Test"">
-				<Rule category=""Observance"">
+				<Rule name=""Mother's Day Observance Rule"" category=""Observance"">
 					<DayOfWeekInMonth month=""May"" dayOfWeek=""Sunday"" weekOrdinal=""Second"" />
 				</Rule>
 			</NotableDate>
@@ -42,7 +43,7 @@ public partial class NotableDateRuleParserTests
 	public const string CalculatorRuleXml = @"
 		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
 			<NotableDate name=""Easter Sunday Test"">
-				<Rule category=""Observance"" firstYear=""1583"">
+				<Rule name=""Easter Sunday Calculator Rule"" category=""Observance"" firstYear=""1583"">
 					<Calculator key=""easter-sunday"" />
 				</Rule>
 			</NotableDate>
@@ -51,7 +52,7 @@ public partial class NotableDateRuleParserTests
 	public const string OffsetFromAnchorRuleXml = @"
 		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
 			<NotableDate name=""Good Friday Test"">
-				<Rule category=""Holiday"">
+				<Rule name=""Good Friday Offset Rule"" category=""Holiday"">
 					<OffsetFromAnchor name=""Easter Sunday"" offset=""-2"" />
 				</Rule>
 			</NotableDate>
@@ -60,23 +61,23 @@ public partial class NotableDateRuleParserTests
 	public const string MultiRuleXml = @"
 		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
 			<NotableDate name=""New Year's Day"">
-				<Rule category=""Holiday"" nonWorking=""true"">
+				<Rule name=""New Year's Day Rule"" category=""Holiday"" nonWorking=""true"">
 					<Fixed month=""January"" day=""1"" />
 					<Adjustment key=""weekend-roll"" when=""IfWeekend"" action=""MoveToNextWeekday"" priority=""1"" />
 				</Rule>
 			</NotableDate>
 			<NotableDate name=""Easter Sunday"">
-				<Rule category=""Observance"" firstYear=""1583"">
+				<Rule name=""Easter Sunday Rule"" category=""Observance"" firstYear=""1583"">
 					<Calculator key=""easter-sunday"" />
 				</Rule>
 			</NotableDate>
 			<NotableDate name=""Good Friday"">
-				<Rule category=""Holiday"" firstYear=""1583"" nonWorking=""true"">
+				<Rule name=""Good Friday Rule"" category=""Holiday"" firstYear=""1583"" nonWorking=""true"">
 					<OffsetFromAnchor name=""Easter Sunday"" offset=""-2"" />
 				</Rule>
 			</NotableDate>
 			<NotableDate name=""Anzac Day"">
-				<Rule category=""Remembrance"" territory=""AU,NZ"" nonWorking=""true"">
+				<Rule name=""Anzac Day Rule"" category=""Remembrance"" territory=""AU,NZ"" nonWorking=""true"">
 					<Fixed month=""April"" day=""25"" />
 				</Rule>
 			</NotableDate>
@@ -92,7 +93,7 @@ public partial class NotableDateRuleParserTests
 				<Use name=""Christmas Day"" as=""Christmas"" territory=""US"" nonWorking=""true"" priority=""5"" />
 			</UseFrom>
 			<NotableDate name=""Independence Day"">
-				<Rule category=""Holiday"" territory=""US"" nonWorking=""true"">
+				<Rule name=""Independence Day Rule"" category=""Holiday"" territory=""US"" nonWorking=""true"">
 					<Fixed month=""July"" day=""4"" />
 				</Rule>
 			</NotableDate>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/UseDirectiveInheritanceTests.cs
@@ -36,7 +36,7 @@ public sealed class UseDirectiveInheritanceTests
 	{
 		var xml = NamespaceHeader +
 			"  <NotableDate name=\"Test\">\n" +
-			"    <Rule category=\"Holiday\">\n" +
+			"    <Rule name=\"Test Rule\" category=\"Holiday\">\n" +
 			"      <Fixed month=\"January\" day=\"1\" />\n" +
 			"      <Adjustment when=\"IfWeekend\" action=\"MoveToNextWeekday\" />\n" +
 			"    </Rule>\n" +

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.Encrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.Encrypt.cs
@@ -63,7 +63,7 @@ public abstract partial class BlockCipherTests<TTest, TCipher, TVariant>
     }
 
     /// <summary>
-    /// Verifies that decryption does not alter the input span.
+    /// Verifies that encryption does not alter the input span.
     /// </summary>
     [TestMethod]
     public void Encrypt_WhenCalled_ShouldNotModifyInputBuffer()
@@ -73,7 +73,7 @@ public abstract partial class BlockCipherTests<TTest, TCipher, TVariant>
         byte[] input = original.ToArray();
         byte[] output = new byte[cipher.BlockSize];
 
-        cipher.Decrypt(input, output);
+        cipher.Encrypt(input, output);
 
         CollectionAssert.AreEqual(original, input); // input must be unchanged
     }
@@ -199,6 +199,6 @@ public abstract partial class BlockCipherTests<TTest, TCipher, TVariant>
         byte[] actual = new byte[cipher.BlockSize];
         cipher.Decrypt(encrypted, actual);
 
-        CollectionAssert.AreEqual(actual, actual, $"Cipher mismatch for {testName} using variant '{variant}'.");
+        CollectionAssert.AreEqual(input, actual, $"Cipher mismatch for {testName} using variant '{variant}'.");
     }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs in `BlockCipherTests.Encrypt.cs` that were present in the base test class shared by all block cipher tests (Twofish, Serpent, Blowfish, etc.):

- **`Encrypt_WhenCalled_ShouldNotModifyInputBuffer`**: was calling `cipher.Decrypt(input, output)` instead of `cipher.Encrypt(input, output)`. The test was not exercising the method named in the test, and its summary incorrectly said "decryption".
- **`EncryptDecrypt_WithValidInput_ShouldRoundtrip`**: was comparing `actual` to `actual` (`CollectionAssert.AreEqual(actual, actual, ...)`) instead of `input` to `actual`. The self-comparison always trivially passed and never verified that decrypt(encrypt(x)) == x.

## Test plan

- [ ] CI build passes
- [ ] All `TwofishBlockCipherTests` pass including KAT vectors and roundtrip
- [ ] All other `BlockCipherTests`-derived tests (Serpent, Blowfish, Skipjack, etc.) pass

https://claude.ai/code/session_01Vbh1MkmbL6VQBxrLqAJnit

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vbh1MkmbL6VQBxrLqAJnit)_