### PR TITLE
docs: ASCON family guide suite (hashing, XOF, AEAD)

### DIFF
--- a/docs/guides/cryptography/ascon-aead.md
+++ b/docs/guides/cryptography/ascon-aead.md
@@ -1,0 +1,265 @@
+---
+title: ASCON authenticated encryption — AsconAead128
+---
+
+# ASCON authenticated encryption — AsconAead128
+
+**Authenticated encryption with associated data (AEAD)** combines confidentiality with
+integrity: the recipient can verify that neither the ciphertext nor the associated metadata has
+been altered since the sender encrypted it.
+
+<xref:Bodu.Security.Cryptography.AsconAead128> implements `ASCON-AEAD128` as standardised in
+NIST SP 800-232. It uses a 128-bit key, a 128-bit nonce, and appends a 128-bit authentication
+tag to every encrypted message.
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `AsconAead128.KeyBytes` | 16 | Key length in bytes (128 bits). |
+| `AsconAead128.NonceBytes` | 16 | Nonce length in bytes (128 bits). Must be unique per message. |
+| `AsconAead128.TagBytes` | 16 | Authentication tag length in bytes (128 bits). |
+
+## How it works
+
+ASCON-AEAD128 is a sponge-based AEAD built on the same 320-bit state and Ascon-p permutation
+used by the hash and XOF variants. Every encryption proceeds through four fixed phases:
+
+1. **Initialisation** — the state is loaded as `[IV ‖ K₀ ‖ K₁ ‖ N₀ ‖ N₁]` and Ascon-p12 is
+   applied, followed by XORing the key into state words S₃ and S₄.
+2. **Associated-data absorption** — each 16-byte block of AAD is absorbed with Ascon-p8 between
+   blocks. A domain-separation constant (XOR of 1 into S₄) is always applied after the AD phase,
+   even when AD is empty.
+3. **Encryption / decryption** — plaintext or ciphertext is processed in 16-byte blocks with
+   Ascon-p8 between blocks. The final partial block is Ascon-padded and absorbed without a
+   trailing permutation.
+4. **Finalisation** — the key is injected into the state, Ascon-p12 is applied, and the
+   128-bit tag is extracted by XORing the key into state words S₃ and S₄.
+
+## The single-use instance contract
+
+Every `AsconAead128` instance is **single-use** — one key/nonce pair, one message. The mandatory
+call sequence is:
+
+1. `new AsconAead128(key, nonce)` — construct.
+2. `ProcessAssociatedData(aad)` — always call this, even with an empty span.
+3. `Encrypt(plaintext, output)` **or** `Decrypt(ciphertextWithTag, output)` — one call only.
+4. `Dispose()` — let the `using` statement handle this.
+
+Skipping `ProcessAssociatedData` throws `InvalidOperationException`. Calling it a second time on
+the same instance also throws. Construct a new instance for every message.
+
+## Pattern 1 — encrypt with no associated data
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] key       = RandomNumberGenerator.GetBytes(AsconAead128.KeyBytes);
+byte[] nonce     = RandomNumberGenerator.GetBytes(AsconAead128.NonceBytes);
+byte[] plaintext = Encoding.UTF8.GetBytes("secret payload");
+
+// Output buffer: ciphertext is the same length as plaintext, tag follows immediately.
+byte[] cipherWithTag = new byte[plaintext.Length + AsconAead128.TagBytes];
+
+using (var enc = new AsconAead128(key, nonce))
+{
+    enc.ProcessAssociatedData(ReadOnlySpan<byte>.Empty);
+    enc.Encrypt(plaintext, cipherWithTag);
+}
+```
+
+`Encrypt` returns the total number of bytes written (`plaintext.Length + TagBytes`).
+
+## Pattern 2 — decrypt and verify
+
+`Decrypt` throws <xref:System.Security.Cryptography.CryptographicException> if the authentication
+tag does not match. The output buffer is zeroed before the exception is thrown, so no
+unauthenticated bytes can escape the method.
+
+```csharp
+byte[] recovered = new byte[cipherWithTag.Length - AsconAead128.TagBytes];
+
+try
+{
+    using (var dec = new AsconAead128(key, nonce))
+    {
+        dec.ProcessAssociatedData(ReadOnlySpan<byte>.Empty);
+        dec.Decrypt(cipherWithTag, recovered);
+    }
+    // recovered == original plaintext
+}
+catch (CryptographicException)
+{
+    // Tag did not verify — the ciphertext, tag, or AAD has been tampered with.
+    // recovered is zeroed. Do not use it.
+}
+```
+
+> [!WARNING]
+> **Never act on output from `Decrypt` before it returns.** Only read `recovered` after
+> `Decrypt` has returned without throwing. The method zeroes the output buffer before throwing
+> on a tag mismatch — unauthenticated bytes never escape, but the buffer contents are undefined
+> until the method returns normally.
+
+## Pattern 3 — with associated data
+
+Associated data is authenticated but **not** encrypted. Use it for any metadata that must travel
+alongside the ciphertext in the clear but must not be tampered with — packet headers, record
+types, user IDs, protocol framing.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] key       = RandomNumberGenerator.GetBytes(AsconAead128.KeyBytes);
+byte[] nonce     = RandomNumberGenerator.GetBytes(AsconAead128.NonceBytes);
+byte[] aad       = Encoding.UTF8.GetBytes("user-id:42|record-type:invoice");
+byte[] plaintext = GetInvoiceBytes();
+
+byte[] cipherWithTag = new byte[plaintext.Length + AsconAead128.TagBytes];
+
+using (var enc = new AsconAead128(key, nonce))
+{
+    enc.ProcessAssociatedData(aad);
+    enc.Encrypt(plaintext, cipherWithTag);
+}
+
+// Decryption must supply the same AAD. Supplying different AAD causes
+// Decrypt to throw CryptographicException — even if the ciphertext is intact.
+byte[] recovered = new byte[plaintext.Length];
+using (var dec = new AsconAead128(key, nonce))
+{
+    dec.ProcessAssociatedData(aad);
+    dec.Decrypt(cipherWithTag, recovered);
+}
+```
+
+The AAD is public — it does not need to be secret. Its integrity is protected by the tag.
+
+## Pattern 4 — multi-block plaintext
+
+The rate is 16 bytes (128 bits). Plaintexts longer than 16 bytes are automatically split into
+full blocks with Ascon-p8 applied between them; the API is unchanged regardless of plaintext
+length.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+byte[] key   = RandomNumberGenerator.GetBytes(AsconAead128.KeyBytes);
+byte[] nonce = RandomNumberGenerator.GetBytes(AsconAead128.NonceBytes);
+
+// 537 bytes — 33 full 16-byte blocks plus a 9-byte final partial block.
+byte[] plaintext = new byte[537];
+RandomNumberGenerator.Fill(plaintext);
+
+byte[] cipherWithTag = new byte[plaintext.Length + AsconAead128.TagBytes];
+using (var enc = new AsconAead128(key, nonce))
+{
+    enc.ProcessAssociatedData(ReadOnlySpan<byte>.Empty);
+    int written = enc.Encrypt(plaintext, cipherWithTag);
+    // written == plaintext.Length + AsconAead128.TagBytes
+}
+```
+
+## Pattern 5 — encrypting an empty plaintext
+
+An empty plaintext produces only the 16-byte authentication tag:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+byte[] tag = new byte[AsconAead128.TagBytes];
+
+using (var enc = new AsconAead128(key, nonce))
+{
+    enc.ProcessAssociatedData(aad);
+    enc.Encrypt(ReadOnlySpan<byte>.Empty, tag);
+}
+```
+
+This pattern is useful for authenticating metadata alone, with no payload.
+
+## Pattern 6 — key and nonce generation
+
+Keys must be generated from a cryptographically secure random source and kept secret:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+// Generated once (per session, per record, or per application — depends on your key management).
+byte[] key = RandomNumberGenerator.GetBytes(AsconAead128.KeyBytes);
+
+// Generated fresh for every message. Never reuse a (key, nonce) pair.
+byte[] nonce = RandomNumberGenerator.GetBytes(AsconAead128.NonceBytes);
+```
+
+A 128-bit random nonce has negligible collision probability for fewer than approximately 2⁶⁴
+messages under the same key. For higher message volumes, use a counter instead:
+
+```csharp
+// 128-bit counter encoded into the nonce. Increment for every message; never wrap.
+byte[] nonce = new byte[AsconAead128.NonceBytes];
+BinaryPrimitives.WriteUInt64LittleEndian(nonce, messageCounter++);
+```
+
+Either approach is valid. The critical invariant is that `(key, nonce)` must never repeat across
+two distinct messages under the same key.
+
+## Pattern 7 — span-based constructors
+
+The primary constructor accepts `ReadOnlySpan<byte>` for zero-allocation key/nonce loading.
+The array-based overload (`byte[]`, `byte[]`) is provided for convenience when you already have
+managed arrays:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+// Span constructor — no defensive copy of a managed array.
+ReadOnlySpan<byte> keySpan   = stackalloc byte[AsconAead128.KeyBytes];
+ReadOnlySpan<byte> nonceSpan = stackalloc byte[AsconAead128.NonceBytes];
+using var enc = new AsconAead128(keySpan, nonceSpan);
+
+// Array constructor — null-check included; a span is taken from the array internally.
+byte[] keyArr   = new byte[AsconAead128.KeyBytes];
+byte[] nonceArr = new byte[AsconAead128.NonceBytes];
+using var enc2  = new AsconAead128(keyArr, nonceArr);
+```
+
+Both constructors reject keys or nonces that are not exactly 16 bytes, throwing
+`ArgumentException`.
+
+## Security requirements
+
+| Requirement | Detail |
+|---|---|
+| **Key secrecy** | The key must never be disclosed. Exposure breaks both confidentiality and authenticity. |
+| **Nonce uniqueness** | Never encrypt two distinct messages under the same `(key, nonce)` pair. Nonce reuse leaks the XOR of the two plaintexts and enables tag forgery. |
+| **Constant-time tag check** | `Decrypt` uses `CryptographicOperations.FixedTimeEquals` internally. Do not extract and compare tags manually with `SequenceEqual`. |
+| **Single-use instances** | Construct a new `AsconAead128` for each message. Calling `Encrypt` or `Decrypt` twice on the same instance is not supported — `ProcessAssociatedData` throws on a second call. |
+| **Reject on tag mismatch** | When `Decrypt` throws `CryptographicException`, discard the entire message. Do not retry with a different key or partial output. |
+
+## ASCON-AEAD128 vs AES-GCM
+
+| Consideration | `AsconAead128` | AES-GCM (BCL `AesGcm`) |
+|---|---|---|
+| NIST standard | SP 800-232 (2025) | SP 800-38D |
+| Key / nonce size | 128 bit / 128 bit | 128–256 bit / 96 bit |
+| Tag size | 128 bits (fixed) | 96–128 bits (configurable) |
+| Hardware acceleration | Software only on most platforms | AES-NI + PCLMULQDQ on x86-64; hardware on ARM |
+| Nonce reuse consequence | Catastrophic (XOR leak + forgery) | Catastrophic (GHASH key recovered) |
+| State size | 320 bits (40 bytes) | AES key schedule + GHASH state |
+| Throughput (software) | Competitive on constrained hardware | Fast with hardware; slow in software |
+
+Use `AsconAead128` when you need a NIST-approved AEAD that runs well in software on any
+platform, or when targeting hardware without AES-GCM acceleration. Use the BCL's `AesGcm` or
+the library's `GcmModeTransform` when throughput on AES-NI hardware is the priority.
+
+## Where to go next
+
+- [ASCON overview](ascon.md) — the full family and which algorithm to pick.
+- [ASCON hashing](ascon-hashing.md) — fixed-length 256-bit digest patterns.
+- [ASCON XOF](ascon-xof.md) — variable-length output with `AsconXof128` and `AsconCxof128`.
+- [AEAD modes guide](aead-modes.md) — AES-based AEAD (GCM, CCM, OCB3, SIV, GCM-SIV).
+- API reference: <xref:Bodu.Security.Cryptography.AsconAead128> · <xref:Bodu.Security.Cryptography.IAeadBlockCipherModeTransform>

--- a/docs/guides/cryptography/ascon-hashing.md
+++ b/docs/guides/cryptography/ascon-hashing.md
@@ -1,0 +1,208 @@
+---
+title: ASCON hashing — AsconHash256 and AsconHashA256
+---
+
+# ASCON hashing — AsconHash256 and AsconHashA256
+
+`ASCON-HASH256` and `ASCON-HASHA256` are the two fixed-output hash algorithms in the ASCON
+family, standardised in NIST SP 800-232. Both are sponge constructions built on a 320-bit
+internal state with an 8-byte (64-bit) absorption rate, and both produce a **256-bit (32-byte)
+digest**. The family was designed for constrained hardware — but the same properties that make
+it attractive there (compact state, simple round function, well-studied security margin) make it
+a sound choice in software as well.
+
+**Bodu.Security.Cryptography** ships two concrete types:
+
+| Type | Algorithm name | Absorption rounds | Squeeze rounds | Characteristics |
+|---|---|---|---|---|
+| <xref:Bodu.Security.Cryptography.AsconHash256> | `ASCON-HASH256` | 12 (Ascon-p12) | 12 | Maximum security margin — the conservative default. |
+| <xref:Bodu.Security.Cryptography.AsconHashA256> | `ASCON-HASHA256` | 8 (Ascon-p8) | 12 | Higher throughput — reduced, but still substantial, absorption-phase margin. |
+
+Both derive from `BlockHashAlgorithm<T>`, which in turn derives from
+<xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, so they slot
+into any API that accepts a standard .NET hash algorithm.
+
+## Fixed parameters at a glance
+
+| Parameter | Value | Notes |
+|---|---|---|
+| State size | 320 bits (40 bytes) | Fixed by the ASCON specification. |
+| Rate (absorption block) | 64 bits (8 bytes) | Bytes consumed per permutation call. |
+| Output | 256 bits (32 bytes) | Fixed; no truncation variants. |
+| Absorption rounds — `AsconHash256` | 12 per block | Conservative margin throughout. |
+| Absorption rounds — `AsconHashA256` | 8 per block | Reduced absorption work; squeeze unchanged. |
+
+## Pattern 1 — one-shot hash with ASCON-HASH256
+
+`AsconHash256` is the conservative choice. It uses 12 permutation rounds at every stage, giving
+the widest cryptanalytic margin in the family.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data    = Encoding.UTF8.GetBytes("the quick brown fox");
+using var hash = new AsconHash256();
+byte[] digest  = hash.ComputeHash(data);    // 32 bytes
+string hex     = Convert.ToHexString(digest);
+```
+
+`CanReuseTransform` is `true` on both types, so the same instance can hash multiple independent
+messages without being recreated — `ComputeHash` resets the state automatically.
+
+## Pattern 2 — ASCON-HASHA256 for throughput-sensitive paths
+
+`AsconHashA256` uses 8 permutation rounds per absorbed block instead of 12. The API is
+identical; only the round count (and therefore the throughput and absorption-phase margin) differs.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] data    = Encoding.UTF8.GetBytes("the quick brown fox");
+using var hash = new AsconHashA256();
+byte[] digest  = hash.ComputeHash(data);
+```
+
+`AlgorithmName` reports `"ASCON-HASHA256"` automatically, so logs and manifests carry the
+variant name without any extra bookkeeping.
+
+## Pattern 3 — choosing between the two variants
+
+Both variants share the same state size, output width, padding rule, and API shape. The only
+difference is the number of Ascon-p rounds applied per absorbed 8-byte block.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+// Conservative — 12 absorption rounds.
+// Prefer for signatures, long-lived commitments, content-addressing,
+// or wherever throughput is not the primary constraint.
+using var conservative = new AsconHash256();
+
+// Performance — 8 absorption rounds.
+// Prefer when hashing many inputs in a hot path (deduplication,
+// per-request cache-key generation) and the throughput difference matters.
+using var performance = new AsconHashA256();
+
+Console.WriteLine(conservative.AlgorithmName);    // "ASCON-HASH256"
+Console.WriteLine(performance.AlgorithmName);     // "ASCON-HASHA256"
+```
+
+The 12-round variant applies 50 % more permutation work per absorbed block, giving deeper
+cryptanalytic margin. The 8-round variant reduces absorption work in exchange for higher
+throughput; the squeeze phase retains 12 rounds in both cases, so finalisation is equally strong
+in both variants.
+
+When in doubt, use `AsconHash256`. Switch to `AsconHashA256` only when profiling shows the
+difference is measurable in your workload.
+
+## Pattern 4 — streaming a file
+
+Both types inherit `ComputeHash(Stream)` from
+<xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var hash   = new AsconHash256();
+using var stream = File.OpenRead("document.pdf");
+byte[]    digest = hash.ComputeHash(stream);
+```
+
+For a block-by-block pipeline, drive the standard BCL `TransformBlock` / `TransformFinalBlock`
+contract directly:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var hash   = new AsconHash256();
+byte[]    buffer = new byte[8192];
+int       read;
+
+using (var stream = File.OpenRead("document.pdf"))
+{
+    while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
+        hash.TransformBlock(buffer, 0, read, null, 0);
+}
+
+hash.TransformFinalBlock([], 0, 0);
+byte[] digest = hash.Hash!;
+```
+
+`CanReuseTransform` being `true` means the instance resets automatically at the next
+`ComputeHash` call, or you can call `Initialize()` explicitly between messages.
+
+## Pattern 5 — hashing multiple messages with one instance
+
+Because `CanReuseTransform` is `true`, a single instance can be reused across a batch:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+byte[][] messages = GetMessageBatch();
+byte[][] digests  = new byte[messages.Length][];
+
+using var hash = new AsconHash256();
+for (int i = 0; i < messages.Length; i++)
+    digests[i] = hash.ComputeHash(messages[i]);
+```
+
+Each `ComputeHash` call resets the internal state before processing the next message.
+
+## Pattern 6 — verifying a digest in constant time
+
+Always compare digests in constant time. Use the BCL's
+<xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*> directly, or the
+`VerifyHash` extension method from `Bodu.Security.Cryptography.Extensions`:
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+byte[] expected = LoadExpectedDigest();
+byte[] computed;
+
+using var hash = new AsconHash256();
+computed = hash.ComputeHash(fileBytes);
+
+bool ok = CryptographicOperations.FixedTimeEquals(computed, expected);
+```
+
+A plain `SequenceEqual` or `==` comparison leaks timing information and is unsafe whenever the
+comparison result drives an authentication or integrity decision.
+
+## Pattern 7 — reading the algorithm name at runtime
+
+Both types report their canonical NIST algorithm identifier through the `AlgorithmName` property:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var h256  = new AsconHash256();
+using var ha256 = new AsconHashA256();
+
+Console.WriteLine(h256.AlgorithmName);     // "ASCON-HASH256"
+Console.WriteLine(ha256.AlgorithmName);    // "ASCON-HASHA256"
+```
+
+This is useful for constructing audit log entries, manifest files, or HTTP response headers that
+need to identify the algorithm used.
+
+## When to use ASCON hashing
+
+| Scenario | Recommendation |
+|---|---|
+| Standards-backed 256-bit digest | `AsconHash256` — NIST SP 800-232 approved |
+| Content addressing or deduplication | Either; 256-bit output gives strong collision resistance |
+| Constrained hardware, no SHA-2 acceleration | `AsconHashA256` — efficient software permutation |
+| High-throughput pipeline on x86-64 with SHA extensions | Prefer `SHA256` (BCL, hardware-accelerated); fall back to `AsconHashA256` if ASCON is required |
+| Long-lived commitment (signatures, audit trails) | `AsconHash256` — 12-round margin throughout |
+
+## Where to go next
+
+- [ASCON overview](ascon.md) — the full family and which algorithm to pick.
+- [ASCON XOF](ascon-xof.md) — for variable-length output (`AsconXof128`, `AsconCxof128`).
+- [ASCON AEAD](ascon-aead.md) — for authenticated encryption (`AsconAead128`).
+- [Hashing overview](hashing.md) — how ASCON sits alongside SipHash, Tiger, CubeHash, and the non-cryptographic families.
+- API reference: <xref:Bodu.Security.Cryptography.AsconHash256> · <xref:Bodu.Security.Cryptography.AsconHashA256>

--- a/docs/guides/cryptography/ascon-xof.md
+++ b/docs/guides/cryptography/ascon-xof.md
@@ -1,0 +1,247 @@
+---
+title: ASCON extendable output — AsconXof128 and AsconCxof128
+---
+
+# ASCON extendable output — AsconXof128 and AsconCxof128
+
+An **extendable output function (XOF)** is a hash with no fixed output length. You absorb any
+amount of input, then squeeze out as many bytes as you need — 32, 64, or a million. ASCON-XOF128
+and ASCON-CXOF128 are the XOF members of the ASCON family, standardised in NIST SP 800-232.
+
+**Bodu.Security.Cryptography** provides two concrete types, both inheriting from the abstract
+`AsconXof<T>` base:
+
+| Type | Algorithm name | Customisation | Typical use |
+|---|---|---|---|
+| <xref:Bodu.Security.Cryptography.AsconXof128> | `ASCON-XOF128` | None | General-purpose variable-length output, key derivation, stream seed. |
+| <xref:Bodu.Security.Cryptography.AsconCxof128> | `ASCON-CXOF128` | Optional customisation string | Multiple independent output functions from the same primitive. |
+
+## Fixed parameters
+
+| Parameter | Value | Notes |
+|---|---|---|
+| State size | 320 bits (40 bytes) | Shared across the full ASCON family. |
+| Rate (absorption and squeeze block) | 64 bits (8 bytes) | Eight bytes processed per permutation call. |
+| Absorption rounds | 8 (Ascon-p8) | Applied after each absorbed block. |
+| Transition permutation | 12 (Ascon-p12) | Always applied once when switching from absorb to squeeze. |
+| Squeeze permutation | 8 (Ascon-p8) | Applied between successive squeeze blocks. |
+
+## The absorb-then-squeeze lifecycle
+
+Both types follow the same three-phase lifecycle:
+
+1. **Absorb** — call `Absorb(ReadOnlySpan<byte>)` zero or more times to feed input data.
+2. **Squeeze** — call `Squeeze(Span<byte>)` one or more times to read output bytes.
+3. **Reset** — call `Initialize()` to discard all state and start a fresh message.
+
+`Absorb` after `Squeeze` has started throws `InvalidOperationException`. Call `Initialize()` to
+reset. For `AsconCxof128`, there is a fourth phase before absorption: an optional call to
+`Customize`.
+
+## Pattern 1 — producing output of a fixed length
+
+The simplest path: absorb a message, squeeze an exact number of bytes.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] message = Encoding.UTF8.GetBytes("the quick brown fox");
+
+using var xof  = new AsconXof128();
+xof.Absorb(message);
+byte[] output  = xof.GetHash(64);    // squeeze exactly 64 bytes
+```
+
+`GetHash(int length)` is a convenience wrapper around `Squeeze` that allocates and returns a new
+array. The instance transitions to the squeezing phase on the first call; subsequent calls to
+`Squeeze` continue from where the last call left off.
+
+## Pattern 2 — one-shot static method
+
+For a single-pass operation that does not need a reusable instance, use the static `HashData`
+method:
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] message = Encoding.UTF8.GetBytes("the quick brown fox");
+byte[] output  = AsconXof128.HashData(message, outputLength: 32);
+```
+
+`HashData` constructs a temporary instance internally, absorbs the source, squeezes the
+requested number of bytes, and returns them. It is equivalent to the three-step instance API in
+a single call.
+
+## Pattern 3 — deriving multiple keys from one input
+
+Because squeezing is incremental, a single absorbed input can produce non-overlapping byte
+streams for different purposes without rehashing.
+
+```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+// Derive per-session key material from a shared secret and a session ID.
+byte[] sharedSecret = LoadSharedSecret();
+byte[] sessionId    = GetSessionId();
+
+using var xof = new AsconXof128();
+xof.Absorb(sharedSecret);
+xof.Absorb(sessionId);      // absorb can be called multiple times
+
+byte[] encKey = new byte[32];   // 256-bit encryption key
+byte[] macKey = new byte[32];   // 256-bit MAC key
+byte[] iv     = new byte[16];   // 128-bit IV
+
+xof.Squeeze(encKey);    // first 32 bytes of XOF output
+xof.Squeeze(macKey);    // next 32 bytes — independent of encKey
+xof.Squeeze(iv);        // next 16 bytes
+```
+
+The three slices are deterministic and non-overlapping for the same inputs. This is the XOF
+alternative to HKDF-Expand: a single absorbed PRK produces an unlimited number of output bytes,
+each region serving a separate purpose.
+
+## Pattern 4 — incremental absorption
+
+Call `Absorb` as many times as needed. The sponge buffers partial blocks internally, so calls do
+not need to align to the 8-byte rate.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var xof = new AsconXof128();
+
+foreach (byte[] chunk in GetMessageChunks())
+    xof.Absorb(chunk);
+
+byte[] digest = xof.GetHash(32);
+```
+
+The result is identical to absorbing all chunks concatenated in a single call.
+
+## Pattern 5 — incremental squeezing
+
+Squeeze as many or as few bytes per call as you like. Each call continues from where the last
+left off.
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var xof = new AsconXof128();
+xof.Absorb(seed);
+
+byte[] block = new byte[8];
+for (int i = 0; i < 1024; i++)
+{
+    xof.Squeeze(block);
+    ProcessBlock(block, i);
+}
+```
+
+This is useful for generating large amounts of deterministic pseudo-random material from a fixed
+seed — effectively a stream cipher output.
+
+## Pattern 6 — CXOF128 with a customisation string
+
+`AsconCxof128` extends the XOF lifecycle with an optional customisation step before absorption.
+Two instances with different customisation strings produce completely independent outputs for the
+same absorbed input.
+
+```csharp
+using System.Text;
+using Bodu.Security.Cryptography;
+
+byte[] message = Encoding.UTF8.GetBytes("the quick brown fox");
+
+// Derive an encryption key — customisation string identifies the context.
+using var encXof = new AsconCxof128();
+encXof.Customize(Encoding.UTF8.GetBytes("enc-key-v1"));
+encXof.Absorb(message);
+byte[] encKey = encXof.GetHash(32);
+
+// Derive a MAC key — different customisation string, independent output.
+using var macXof = new AsconCxof128();
+macXof.Customize(Encoding.UTF8.GetBytes("mac-key-v1"));
+macXof.Absorb(message);
+byte[] macKey = macXof.GetHash(32);
+
+// encKey != macKey, even though message is identical.
+```
+
+Call `Customize` **before** any call to `Absorb`. Calling it afterwards, or calling it a second
+time on the same instance, throws `InvalidOperationException`. Call `Initialize()` to reset and
+allow a fresh `Customize`.
+
+### Customisation string semantics
+
+The customisation string is absorbed into the sponge using the standard Ascon padding rule, and
+then a domain-separation constant (XOR of 1 into state word S₄) is injected before the message
+absorption phase begins. This ensures:
+
+- Two instances with different customisation strings produce unrelated output.
+- An instance with an empty customisation string produces output that differs from
+  `AsconXof128` for the same message (because the domain-separation constant is always applied).
+- The customisation string may be public — it is not a secret.
+
+## Pattern 7 — empty customisation string (not the same as no customisation)
+
+Calling `Customize(ReadOnlySpan<byte>.Empty)` still applies the ASCON-CXOF128 domain separation.
+The output differs from `AsconXof128` even with no customisation bytes:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+byte[] message = [0x01, 0x02, 0x03, 0x04];
+
+using AsconCxof128 cxof = new AsconCxof128();
+cxof.Customize(ReadOnlySpan<byte>.Empty);   // empty string — domain separation still applied
+cxof.Absorb(message);
+byte[] cxofOutput = cxof.GetHash(32);
+
+byte[] xofOutput = AsconXof128.HashData(message, 32);
+
+// cxofOutput != xofOutput
+```
+
+If `Customize` is not called at all, `AsconCxof128` operates without the customisation domain
+separation — identically to a plain `AsconXof128` for the same absorbed input. The
+customisation step is optional by design.
+
+## Pattern 8 — reusing an instance
+
+Call `Initialize()` to reset the sponge and reuse the instance for a new message:
+
+```csharp
+using Bodu.Security.Cryptography;
+
+using var xof = new AsconXof128();
+
+for (int i = 0; i < messages.Length; i++)
+{
+    xof.Initialize();
+    xof.Absorb(messages[i]);
+    digests[i] = xof.GetHash(32);
+}
+```
+
+For `AsconCxof128`, `Initialize()` also clears the customisation state, so `Customize` can be
+called again on the reset instance.
+
+## Algorithm selection
+
+| If you need… | Reach for |
+|---|---|
+| Variable-length output from a single input | `AsconXof128` |
+| Multiple independent output streams for different application domains | `AsconCxof128` with distinct customisation strings |
+| A fixed 256-bit digest | `AsconHash256` or `AsconHashA256` |
+| Output derived from multiple pieces of context | Call `Absorb` multiple times on one `AsconXof128` instance |
+
+## Where to go next
+
+- [ASCON overview](ascon.md) — the full family and which algorithm to choose.
+- [ASCON hashing](ascon-hashing.md) — fixed-length 256-bit digest patterns.
+- [ASCON AEAD](ascon-aead.md) — authenticated encryption with `AsconAead128`.
+- API reference: <xref:Bodu.Security.Cryptography.AsconXof128> · <xref:Bodu.Security.Cryptography.AsconCxof128>

--- a/docs/guides/cryptography/ascon.md
+++ b/docs/guides/cryptography/ascon.md
@@ -1,149 +1,137 @@
 ---
-title: Using ASCON-HASH256 and ASCON-HASHA256
+title: Using ASCON
 ---
 
-# Using ASCON-HASH256 and ASCON-HASHA256
+# Using ASCON
 
-ASCON-HASH256 and ASCON-HASHA256 are the two fixed-output hash algorithms from the **ASCON** family, standardised by NIST in SP 800-232. Both are sponge constructions built on a 320-bit internal state with an 8-byte (64-bit) absorption rate, and both produce a **256-bit (32-byte) digest**. The family was designed for constrained hardware — but the same properties that make it attractive there (small state, simple round function, well-studied security) make it a sound choice in software as well.
+**ASCON** is a family of lightweight cryptographic algorithms standardised by NIST in
+[SP 800-232](https://doi.org/10.6028/NIST.SP.800-232) (August 2025). All members of the family
+share a single 320-bit sponge state — five 64-bit words — and a common permutation called
+Ascon-p. The permutation is compact enough to run on the smallest microcontrollers, yet resists
+all known distinguishing attacks and has a well-studied, wide peer-reviewed security margin.
 
-**Bodu.Security.Cryptography** ships two concrete types:
+**Bodu.Security.Cryptography** ships all four NIST-defined algorithm types:
 
-| Type | Algorithm name | Absorption rounds | Final-block rounds | Characteristics |
-|---|---|---|---|---|
-| <xref:Bodu.Security.Cryptography.AsconHash256> | `ASCON-HASH256` | 12 (Ascon-p12) | 12 | Maximum security margin — the conservative default. |
-| <xref:Bodu.Security.Cryptography.AsconHashA256> | `ASCON-HASHA256` | 8 (Ascon-p8) | 12 | Higher throughput — reduced but still substantial security margin. |
+| Type | Algorithm name | Category | What it does |
+|---|---|---|---|
+| <xref:Bodu.Security.Cryptography.AsconHash256> | `ASCON-HASH256` | Hash | Fixed-length 256-bit digest. Conservative 12-round absorption. |
+| <xref:Bodu.Security.Cryptography.AsconHashA256> | `ASCON-HASHA256` | Hash | Fixed-length 256-bit digest. 8-round absorption for higher throughput. |
+| <xref:Bodu.Security.Cryptography.AsconXof128> | `ASCON-XOF128` | XOF | Variable-length output — squeeze any number of bytes from a single absorbed message. |
+| <xref:Bodu.Security.Cryptography.AsconCxof128> | `ASCON-CXOF128` | XOF | Variable-length output with a customisation string — separates output domains from the same primitive. |
+| <xref:Bodu.Security.Cryptography.AsconAead128> | `ASCON-AEAD128` | AEAD | Authenticated encryption — 128-bit key, 128-bit nonce, 128-bit authentication tag. |
 
-Both derive from `BlockHashAlgorithm<T>`, which in turn derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, so they slot into any API that accepts a standard .NET hash.
+## Choosing the right algorithm
 
-## Fixed parameters at a glance
-
-| Parameter | Value | Notes |
+| If you need… | Reach for | Why |
 |---|---|---|
-| State size | 320 bits (40 bytes) | Fixed by the ASCON specification. |
-| Rate (absorption block) | 64 bits (8 bytes) | Bytes consumed per permutation call. |
-| Output | 256 bits (32 bytes) | Fixed; no truncation variants. |
-| Permutation rounds — `AsconHash256` | 12 per absorbed block; 12 for final block | Conservative margin throughout. |
-| Permutation rounds — `AsconHashA256` | 8 per absorbed block; 12 for final block | Reduced absorption work, unchanged squeeze. |
+| A fixed-length 256-bit digest (conservative) | `AsconHash256` | 12-round absorption throughout — maximum security margin. |
+| A fixed-length 256-bit digest (throughput) | `AsconHashA256` | 8-round absorption — faster on large inputs; squeeze phase is unchanged. |
+| An output of arbitrary length — key derivation, stream seed | `AsconXof128` | Squeeze as many bytes as needed from one absorbed input. |
+| Multiple independent output functions from one primitive | `AsconCxof128` | A customisation string domain-separates the output; same primitive, different contexts. |
+| Encrypt-and-authenticate a message | `AsconAead128` | Sponge-based AEAD with a 128-bit key and tag; no separate MAC step required. |
 
-## Pattern 1 — one-shot hash with ASCON-HASH256
+When in doubt: reach for `AsconHash256` for hashing and `AsconAead128` for authenticated encryption.
 
-`AsconHash256` is the conservative choice. It uses 12 permutation rounds at every stage, matching the security margin of the original ASCON submission.
+## The shared permutation
+
+All five types use the same Ascon-p permutation. Each call applies a configurable number of
+identical rounds (up to 12) to the 320-bit state. Each round is:
+
+1. **Constant addition** — XOR a round-dependent constant into state word S₂ to break round
+   symmetry.
+2. **Substitution** — a 5-bit S-box applied simultaneously in bit-sliced fashion across all 64
+   bit-columns of the state, providing non-linearity.
+3. **Linear diffusion** — each word is XORed with two rotated copies of itself using
+   word-specific rotation constants, spreading any change across the full state.
+
+The round count is the throughput / margin trade-off. Absorption phases use 12 rounds
+(`AsconHash256`) or 8 rounds (`AsconHashA256`, `AsconXof128`, `AsconCxof128`, `AsconAead128`).
+Squeeze phases and AEAD finalisation always use 12 rounds, so the output step carries the full
+security margin in every variant.
+
+## Quick-start examples
+
+### Hash
 
 ```csharp
 using System.Text;
 using Bodu.Security.Cryptography;
 
-byte[] data   = Encoding.UTF8.GetBytes("the quick brown fox");
-
-using var hash   = new AsconHash256();
-byte[]    digest = hash.ComputeHash(data);          // 32 bytes
-string    hex    = Convert.ToHexString(digest);
+byte[] data    = Encoding.UTF8.GetBytes("the quick brown fox");
+using var hash = new AsconHash256();
+byte[] digest  = hash.ComputeHash(data);    // always 32 bytes
+string hex     = Convert.ToHexString(digest);
 ```
 
-`CanReuseTransform` is `true` on both types, so the same instance can hash multiple independent messages in a loop without being recreated or re-initialised.
-
-## Pattern 2 — ASCON-HASHA256 for throughput-sensitive paths
-
-`AsconHashA256` uses 8 permutation rounds per absorbed block instead of 12. The API is identical — only the number of internal rounds (and therefore the throughput and security margin) differs.
+### XOF — deriving two keys from one input
 
 ```csharp
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography;
+
+byte[] ikm = RandomNumberGenerator.GetBytes(32);
+
+using var xof = new AsconXof128();
+xof.Absorb(ikm);
+
+byte[] encKey = new byte[32];
+byte[] macKey = new byte[32];
+xof.Squeeze(encKey);    // first 32 bytes of XOF output
+xof.Squeeze(macKey);    // next 32 bytes — independent of encKey
+```
+
+### AEAD — encrypt and authenticate
+
+```csharp
+using System.Security.Cryptography;
 using System.Text;
 using Bodu.Security.Cryptography;
 
-byte[] data   = Encoding.UTF8.GetBytes("the quick brown fox");
+byte[] key       = RandomNumberGenerator.GetBytes(AsconAead128.KeyBytes);
+byte[] nonce     = RandomNumberGenerator.GetBytes(AsconAead128.NonceBytes);
+byte[] plaintext = Encoding.UTF8.GetBytes("secret payload");
+byte[] aad       = Encoding.UTF8.GetBytes("request-id:abc123");
 
-using var hash   = new AsconHashA256();
-byte[]    digest = hash.ComputeHash(data);
-```
-
-`AlgorithmName` reports `"ASCON-HASHA256"` automatically, so logs and manifests carry the variant name without any extra bookkeeping.
-
-## Pattern 3 — choosing between the two variants
-
-Both variants share the same state size, output width, padding rule, and API shape. The sole difference is the number of Ascon-p rounds applied between each 8-byte absorbed block.
-
-```csharp
-using Bodu.Security.Cryptography;
-
-// Conservative: 12 absorption rounds.
-// Prefer for signatures, long-lived commitments, content-addressing,
-// or wherever throughput is not the primary constraint.
-using var conservative = new AsconHash256();
-
-// Performance: 8 absorption rounds.
-// Prefer when hashing many inputs in a hot path (deduplication,
-// per-request cache-key generation) and the throughput difference matters.
-using var performance = new AsconHashA256();
-
-Console.WriteLine(conservative.AlgorithmName);   // "ASCON-HASH256"
-Console.WriteLine(performance.AlgorithmName);    // "ASCON-HASHA256"
-```
-
-The 12-round variant applies 50 % more permutation work per absorbed block, giving deeper cryptanalytic margin. The 8-round variant reduces that work in exchange for higher throughput; the squeeze phase retains 12 rounds in both cases, so the finalisation step is equally strong.
-
-When in doubt, use `AsconHash256`. Switch to `AsconHashA256` only when profiling shows the difference is measurable in your workload.
-
-## Pattern 4 — streaming a file
-
-Both types inherit `ComputeHash(Stream)` from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>:
-
-```csharp
-using Bodu.Security.Cryptography;
-
-using var hash   = new AsconHash256();
-using var stream = File.OpenRead("document.pdf");
-byte[]    digest = hash.ComputeHash(stream);
-```
-
-For a block-by-block pipeline, drive the standard BCL `TransformBlock` / `TransformFinalBlock` contract directly:
-
-```csharp
-using Bodu.Security.Cryptography;
-
-using var hash   = new AsconHash256();
-byte[]    buffer = new byte[8192];
-int       read;
-
-using (var stream = File.OpenRead("document.pdf"))
+// Encrypt — output is ciphertext || 16-byte tag
+byte[] cipherWithTag = new byte[plaintext.Length + AsconAead128.TagBytes];
+using (var enc = new AsconAead128(key, nonce))
 {
-    while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)
-        hash.TransformBlock(buffer, 0, read, null, 0);
+    enc.ProcessAssociatedData(aad);
+    enc.Encrypt(plaintext, cipherWithTag);
 }
 
-hash.TransformFinalBlock([], 0, 0);
-byte[] digest = hash.Hash!;
+// Decrypt — throws CryptographicException if tampered
+byte[] recovered = new byte[plaintext.Length];
+using (var dec = new AsconAead128(key, nonce))
+{
+    dec.ProcessAssociatedData(aad);
+    dec.Decrypt(cipherWithTag, recovered);
+}
 ```
 
-`CanReuseTransform` being `true` means the instance resets automatically at the next `ComputeHash` call, or you can call `Initialize()` explicitly between messages.
+## When to reach for ASCON
 
-## Pattern 5 — verifying a digest in constant time
+ASCON is a good choice when:
 
-Always compare digests in constant time. The `VerifyHash` helper in `Bodu.Security.Cryptography.Extensions` wraps <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*>:
+- You need a **NIST-approved algorithm** (SP 800-232, 2025) alongside or instead of SHA-2 or AES.
+- You are targeting **constrained hardware** — microcontrollers, IoT devices, FPGAs — where the
+  320-bit ASCON state (40 bytes) fits in registers and the simple permutation is efficient even
+  without hardware acceleration.
+- You need **variable-length output** without a full key derivation framework; `AsconXof128` and
+  `AsconCxof128` provide this directly with a well-understood security model.
+- You want a **single primitive family** that covers hashing, XOF, and AEAD — reducing
+  cryptographic surface area and simplifying key management.
 
-```csharp
-using Bodu.Security.Cryptography;
-using Bodu.Security.Cryptography.Extensions;
-
-byte[] expected = LoadExpectedDigest("document.pdf");
-
-using var hash = new AsconHash256();
-bool ok = hash.VerifyHash(fileBytes, expected);
-```
-
-A plain `SequenceEqual` comparison leaks timing information to a side-channel observer and is unsafe when the comparison result drives an authentication or integrity decision.
-
-## When to use ASCON
-
-- **Standards compliance** — both variants are NIST-approved (SP 800-232), making them appropriate for contexts that require a formally standardised algorithm beyond SHA-2.
-- **Content addressing or deduplication** — 256-bit output gives strong collision resistance with a compact 32-byte footprint.
-- **Constrained environments** — the 320-bit state and simple permutation are designed for embedded and IoT targets where SHA-2 hardware acceleration is unavailable.
-- **Performance-sensitive paths without hardware acceleration** — `AsconHashA256` can outperform software SHA-2 on targets where AES-NI is absent, because the Ascon-p permutation is efficient in software.
-
-On x86-64 with AES-NI available, the BCL's hardware-accelerated <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> will generally outperform software ASCON. Use ASCON when you need a standards-backed alternative, are targeting hardware without SHA-2 acceleration, or have an interoperability requirement that specifies the ASCON family specifically.
+On x86-64 targets with AES-NI and SHA extensions, the BCL's hardware-accelerated
+<xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> and `AesGcm` will
+typically outperform software ASCON in raw throughput. Use ASCON when standards compliance,
+portability, or XOF/AEAD requirements point to it — not primarily for throughput on
+well-provisioned servers.
 
 ## Where to go next
 
-- [Hashing overview](hashing.md) — how ASCON sits alongside Tiger, SipHash, CubeHash, and the non-cryptographic families.
-- [Using Tiger](tiger.md) — a 192-bit cryptographic digest optimised for 64-bit software with a long track record.
-- [Using CubeHash](cubehash.md) — another sponge-style hash with tunable round counts; useful for research into the speed / margin trade-off.
-- [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md).
+- [ASCON hashing](ascon-hashing.md) — full pattern guide for `AsconHash256` and `AsconHashA256`.
+- [ASCON extendable output (XOF)](ascon-xof.md) — all patterns for `AsconXof128` and `AsconCxof128`.
+- [ASCON authenticated encryption (AEAD)](ascon-aead.md) — all patterns for `AsconAead128`.
+- [NIST SP 800-232](https://doi.org/10.6028/NIST.SP.800-232) — the normative specification.
+- API reference: <xref:Bodu.Security.Cryptography.AsconHash256> · <xref:Bodu.Security.Cryptography.AsconXof128> · <xref:Bodu.Security.Cryptography.AsconAead128>

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -28,6 +28,11 @@ If you're looking for the generated API reference, see the [Bodu.Security.Crypto
 </div>
 
 <div class="bodu-card">
+  <h3><a href="ascon.html">ASCON family</a></h3>
+  <p>All five NIST SP 800-232 algorithms — <code>AsconHash256</code>, <code>AsconHashA256</code>, <code>AsconXof128</code>, <code>AsconCxof128</code>, and <code>AsconAead128</code> — with algorithm selection guidance and quick-start examples.</p>
+</div>
+
+<div class="bodu-card">
   <h3><a href="padding.html">Padding</a></h3>
   <p>PKCS7, Zeros, and None — how each one pads, when it round-trips cleanly, and when it silently loses bytes.</p>
 </div>
@@ -64,7 +69,8 @@ Start with [Using hashes and checksums](hashing.md) for the cross-cutting pictur
 | `Tiger` | 128 / 160 / 192-bit cryptographic digest | [Using Tiger](tiger.md) |
 | `CubeHash` | SHA-3 submission, tunable rounds and block size | [Using CubeHash](cubehash.md) |
 | `Snefru128` / `Snefru256` | Legacy cryptographic digest — interop only | [Using Snefru](snefru.md) |
-| `AsconHash256` / `AsconHashA256` | NIST SP 800-232 sponge digest — 256-bit output, two margin/throughput variants | [Using ASCON](ascon.md) |
+| `AsconHash256` / `AsconHashA256` | NIST SP 800-232 sponge digest — 256-bit output, two margin/throughput variants | [ASCON hashing](ascon-hashing.md) |
+| `AsconXof128` / `AsconCxof128` | NIST SP 800-232 extendable output — squeeze any number of bytes; CXOF128 adds a customisation string | [ASCON XOF](ascon-xof.md) |
 | `MerkleTreeHash` / `ParallelMerkleTreeHash` | Tree-structured streaming integrity | [Using Merkle trees](merkle-trees.md) |
 
 For non-cryptographic checksums and fingerprints (CRC, Fletcher, Adler, FNV, CityHash, Pearson, and the classic string hashes) on `System.IO.Hashing.NonCryptographicHashAlgorithm`, see the [Bodu.IO.Hashing guides](../io-hashing/).
@@ -77,4 +83,15 @@ For non-cryptographic checksums and fingerprints (CRC, Fletcher, Adler, FNV, Cit
 
 ## Authenticated encryption
 
-For authenticated-encryption-with-associated-data (AEAD), pair the public <xref:Bodu.Security.Cryptography.AesBlockCipher> with one of the mode transforms — `GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`, `SivModeTransform`, or `GcmSivModeTransform` — and call through the one-shot <xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions> helpers. The [AEAD modes guide](aead-modes.md) walks through each mode end-to-end.
+For authenticated-encryption-with-associated-data (AEAD), you have two families of algorithms:
+
+**AES-based AEAD** — pair <xref:Bodu.Security.Cryptography.AesBlockCipher> with one of the
+five mode transforms (`GcmModeTransform`, `CcmModeTransform`, `OcbModeTransform`,
+`SivModeTransform`, or `GcmSivModeTransform`) and call through the one-shot
+<xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions> helpers.
+The [AEAD modes guide](aead-modes.md) walks through each mode end-to-end.
+
+**ASCON-AEAD128** — <xref:Bodu.Security.Cryptography.AsconAead128> is a sponge-based AEAD
+(NIST SP 800-232) that requires no separate block cipher. Use it when you need a
+standards-backed AEAD with a compact software footprint or when targeting hardware without
+AES-NI. See the [ASCON AEAD guide](ascon-aead.md).

--- a/docs/guides/cryptography/toc.yml
+++ b/docs/guides/cryptography/toc.yml
@@ -11,6 +11,16 @@
   href: composing-primitives.md
 - name: Padding
   href: padding.md
+- name: ASCON family
+  items:
+    - name: Overview
+      href: ascon.md
+    - name: Hashing
+      href: ascon-hashing.md
+    - name: Extendable output (XOF)
+      href: ascon-xof.md
+    - name: Authenticated encryption (AEAD)
+      href: ascon-aead.md
 - name: Hashing and checksums
   href: hashing.md
 - name: Hashing algorithms
@@ -25,8 +35,6 @@
       href: cubehash.md
     - name: Using Snefru
       href: snefru.md
-    - name: Using ASCON
-      href: ascon.md
     - name: Using Merkle trees
       href: merkle-trees.md
 - name: Symmetric algorithms

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -37,6 +37,16 @@
       href: cryptography/padding.md
     - name: Hashing and checksums
       href: cryptography/hashing.md
+    - name: ASCON family
+      items:
+        - name: Overview
+          href: cryptography/ascon.md
+        - name: Hashing
+          href: cryptography/ascon-hashing.md
+        - name: Extendable output (XOF)
+          href: cryptography/ascon-xof.md
+        - name: Authenticated encryption (AEAD)
+          href: cryptography/ascon-aead.md
     - name: Hashing algorithms
       items:
         - name: Using SipHash


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Adds a full documentation suite for the ASCON family (NIST SP 800-232) to the DocFX static site.

- **`ascon.md`** (rewritten) — family overview with algorithm-selection table, the shared Ascon-p permutation explained, quick-start examples for all five algorithm types, and guidance on when to reach for ASCON vs SHA-2 / AES-GCM
- **`ascon-hashing.md`** (new) — seven patterns for `AsconHash256` and `AsconHashA256`: one-shot hash, throughput variant, choosing between variants, streaming a file, multi-message reuse, constant-time digest verification, and reading `AlgorithmName` at runtime
- **`ascon-xof.md`** (new) — eight patterns for `AsconXof128` and `AsconCxof128`: fixed-length output, one-shot static method, deriving multiple keys, incremental absorption, incremental squeezing, CXOF128 customisation strings, empty customisation string semantics, and instance reuse
- **`ascon-aead.md`** (new) — seven patterns for `AsconAead128`: encrypt, decrypt-and-verify, associated data, multi-block plaintext, empty plaintext (tag-only), key/nonce generation (random and counter strategies), and span-based constructors — plus a security requirements table and a side-by-side comparison with AES-GCM

### Navigation updates

- `cryptography/toc.yml` — ASCON extracted from "Hashing algorithms" into its own **ASCON family** top-level section with four sub-pages
- `guides/toc.yml` — ASCON family section mirrored at the parent guides level
- `cryptography/index.md` — new ASCON card in the "Start here" grid; `AsconXof128` / `AsconCxof128` added to the hashing table; authenticated-encryption section expanded to describe both the AES-based and ASCON-AEAD families

## Test plan

- [ ] DocFX build succeeds (`dotnet docfx docs/docfx.json`) with no broken xref warnings
- [ ] All four ASCON pages render correctly and navigation links resolve
- [ ] ASCON family section appears in the left-hand TOC under Bodu.Security.Cryptography
- [ ] "Start here" card on the cryptography index links to `ascon.html`
- [ ] CI `build-docs` check passes on this PR

https://claude.ai/code/session_01MUmcZA9eP8YBqstrp4FxtU
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MUmcZA9eP8YBqstrp4FxtU)_