### PR TITLE
fix(Calendar): move all UseFrom imports before NotableDate declarations

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-au.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-au.xml
@@ -47,6 +47,19 @@
   </UseFrom>
 
   <!--
+    Imported family observances.
+
+    Mother's Day uses the global second-Sunday-in-May form, consistent with
+    Australian practice. Father's Day falls on the first Sunday in September
+    in Australia, which differs from the global third-Sunday-in-June default,
+    so it is defined separately below.
+  -->
+
+  <UseFrom resource="./global-family.xml">
+    <Use name="Mother's Day" territory="AU" />
+  </UseFrom>
+
+  <!--
     National Australian holidays and observances.
   -->
 
@@ -85,19 +98,6 @@
       <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
     </Rule>
   </NotableDate>
-
-  <!--
-    Imported family observances.
-
-    Mother's Day uses the global second-Sunday-in-May form, consistent with
-    Australian practice. Father's Day falls on the first Sunday in September
-    in Australia, which differs from the global third-Sunday-in-June default,
-    so it is defined separately below.
-  -->
-
-  <UseFrom resource="./global-family.xml">
-    <Use name="Mother's Day" territory="AU" />
-  </UseFrom>
 
   <!--
     Widely observed Australian cultural and family observances.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-ca.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-ca.xml
@@ -53,6 +53,15 @@
   </UseFrom>
 
   <!--
+    Imported family observances.
+  -->
+
+  <UseFrom resource="./global-family.xml">
+    <Use name="Mother's Day" territory="CA" />
+    <Use name="Father's Day" territory="CA" />
+  </UseFrom>
+
+  <!--
     National Canadian holidays and observances.
   -->
 
@@ -108,15 +117,6 @@
       <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
     </Rule>
   </NotableDate>
-
-  <!--
-    Imported family observances.
-  -->
-
-  <UseFrom resource="./global-family.xml">
-    <Use name="Mother's Day" territory="CA" />
-    <Use name="Father's Day" territory="CA" />
-  </UseFrom>
 
   <!--
     Widely observed Canadian cultural and family observances.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-de.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-de.xml
@@ -50,6 +50,15 @@
   </UseFrom>
 
   <!--
+    Imported family observances.
+  -->
+
+  <UseFrom resource="./global-family.xml">
+    <Use name="Mother's Day" territory="DE" />
+    <Use name="Father's Day" territory="DE" />
+  </UseFrom>
+
+  <!--
     National German holidays (observed in all sixteen federal states).
   -->
 
@@ -178,13 +187,5 @@
     </Rule>
   </NotableDate>
 
-  <!--
-    Imported family observances.
-  -->
-
-  <UseFrom resource="./global-family.xml">
-    <Use name="Mother's Day" territory="DE" />
-    <Use name="Father's Day" territory="DE" />
-  </UseFrom>
 
 </NotableDates>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-fr.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-fr.xml
@@ -39,6 +39,19 @@
   </UseFrom>
 
   <!--
+    Imported family observances.
+
+    Father's Day uses the global third-Sunday-in-June form, consistent with
+    French practice. Mother's Day falls on the last Sunday in May in France,
+    which differs from the global second-Sunday-in-May default, so it is
+    defined separately below.
+  -->
+
+  <UseFrom resource="./global-family.xml">
+    <Use name="Father's Day" territory="FR" />
+  </UseFrom>
+
+  <!--
     National French holidays and observances.
   -->
 
@@ -102,19 +115,6 @@
       <Tag>National</Tag>
     </Rule>
   </NotableDate>
-
-  <!--
-    Imported family observances.
-
-    Father's Day uses the global third-Sunday-in-June form, consistent with
-    French practice. Mother's Day falls on the last Sunday in May in France,
-    which differs from the global second-Sunday-in-May default, so it is
-    defined separately below.
-  -->
-
-  <UseFrom resource="./global-family.xml">
-    <Use name="Father's Day" territory="FR" />
-  </UseFrom>
 
   <!--
     Widely observed French cultural and family observances.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-nz.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/region-nz.xml
@@ -62,6 +62,19 @@
   </UseFrom>
 
   <!--
+    Imported family observances.
+
+    Mother's Day uses the global second-Sunday-in-May form, consistent with
+    New Zealand practice. Father's Day falls on the first Sunday in September
+    in New Zealand, which differs from the global third-Sunday-in-June default,
+    so it is defined separately below.
+  -->
+
+  <UseFrom resource="./global-family.xml">
+    <Use name="Mother's Day" territory="NZ" />
+  </UseFrom>
+
+  <!--
     National New Zealand holidays and observances.
   -->
 
@@ -135,19 +148,6 @@
       <Tag>NationalHoliday</Tag>
     </Rule>
   </NotableDate>
-
-  <!--
-    Imported family observances.
-
-    Mother's Day uses the global second-Sunday-in-May form, consistent with
-    New Zealand practice. Father's Day falls on the first Sunday in September
-    in New Zealand, which differs from the global third-Sunday-in-June default,
-    so it is defined separately below.
-  -->
-
-  <UseFrom resource="./global-family.xml">
-    <Use name="Mother's Day" territory="NZ" />
-  </UseFrom>
 
   <!--
     Widely observed New Zealand cultural observances.


### PR DESCRIPTION
## Summary

- Fixes `XmlSchemaValidationException` that caused all `AustralianNotableDatesTests` and `XmlResourceNotableDateRuleProviderTests` to fail after PR #92 was merged

## Root cause

The XSD schema's `xs:sequence` content model for `<NotableDates>` requires all `<UseFrom>` import blocks to precede all `<NotableDate>` declarations. Five region resource files had a `<UseFrom resource="./global-family.xml">` block interspersed after local `<NotableDate>` entries — introduced when family observances were extracted into a shared resource in an earlier commit — causing:

```
XmlSchemaValidationException: The element 'NotableDates' has invalid child element 'UseFrom'.
List of possible elements expected: 'NotableDate'.
```

## Fix

Moved the family import block to the imports section at the top of each affected file, keeping all `<UseFrom>` directives before all `<NotableDate>` declarations as the schema requires. No rule logic is changed.

| File | Change |
|---|---|
| `region-au.xml` | Family `<UseFrom>` moved above Australia Day |
| `region-ca.xml` | Family `<UseFrom>` moved above Victoria Day |
| `region-de.xml` | Family `<UseFrom>` moved above German Unity Day |
| `region-fr.xml` | Family `<UseFrom>` moved above Fête du Travail |
| `region-nz.xml` | Family `<UseFrom>` moved above Day after New Year's Day |

## Test plan

- [ ] All `AustralianNotableDatesTests` pass
- [ ] All `XmlResourceNotableDateRuleProviderTests` pass
- [ ] Full CI build-test green

https://claude.ai/code/session_01T2U9mgeMQAVq7vY5iBwjrh