### PR TITLE
Fix lunar month mapping for Chinese lunisolar calendar leap months

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/ChineseLunisolarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/ChineseLunisolarNotableDateAlgorithm.cs
@@ -24,6 +24,13 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// the result may also fall within the same year or very early in the following year, depending on the calendar alignment.
 /// </para>
 /// <para>
+/// <paramref name="lunarMonth" /> is interpreted as the conventional ordinal lunar month (1 = first, 2 = second, …, 12 = twelfth)
+/// and the algorithm transparently skips any intercalary leap month inserted by the lunisolar calendar. For example, in a year with
+/// a leap fourth month, the fifth conventional lunar month corresponds to <see cref="SysGlobal.ChineseLunisolarCalendar" /> month 6.
+/// This ensures festivals such as the Dragon Boat Festival (5/5), Mid-Autumn Festival (8/15), and Double Ninth Festival (9/9)
+/// resolve to the correct Gregorian date in leap lunar years.
+/// </para>
+/// <para>
 /// The supported range is determined by <see cref="SysGlobal.ChineseLunisolarCalendar.MinSupportedDateTime" /> and
 /// <see cref="SysGlobal.ChineseLunisolarCalendar.MaxSupportedDateTime" />, which covers Gregorian years 1901–2100.
 /// </para>
@@ -83,14 +90,21 @@ public sealed class ChineseLunisolarNotableDateAlgorithm
 			return null;
 
 		int monthsInYear = ChineseCalendar.GetMonthsInYear(year);
-		if (_lunarMonth > monthsInYear)
+		int leapMonth = ChineseCalendar.GetLeapMonth(year);
+
+		// GetLeapMonth returns the position (1-based) of the intercalary month within the lunisolar
+		// calendar's consecutive 1..N month numbering, or 0 when the year is not a leap lunar year.
+		// To map a conventional ordinal lunar month onto the calendar's numbering we shift by one
+		// for any month whose position falls at or after the leap slot.
+		int calendarMonth = (leapMonth > 0 && _lunarMonth >= leapMonth) ? _lunarMonth + 1 : _lunarMonth;
+		if (calendarMonth > monthsInYear)
 			return null;
 
-		int daysInMonth = ChineseCalendar.GetDaysInMonth(year, _lunarMonth);
+		int daysInMonth = ChineseCalendar.GetDaysInMonth(year, calendarMonth);
 		if (_lunarDay > daysInMonth)
 			return null;
 
-		DateTime result = ChineseCalendar.ToDateTime(year, _lunarMonth, _lunarDay, 0, 0, 0, 0);
+		DateTime result = ChineseCalendar.ToDateTime(year, calendarMonth, _lunarDay, 0, 0, 0, 0);
 
 		SysGlobal.Calendar targetCalendar = calendar ?? new SysGlobal.GregorianCalendar();
 


### PR DESCRIPTION
## Summary
This PR fixes the handling of lunar month parameters in `ChineseLunisolarNotableDateAlgorithm` to correctly account for intercalary leap months in the Chinese lunisolar calendar. Previously, the algorithm did not properly map conventional lunar month ordinals to the calendar's internal month numbering when a leap month was present.

## Key Changes
- **Added leap month detection**: The algorithm now calls `ChineseCalendar.GetLeapMonth()` to identify if the target year contains an intercalary month and its position.
- **Implemented month mapping logic**: Conventional lunar months (1-12) are now transparently mapped to the calendar's internal month numbering by shifting the month index by 1 when the conventional month falls at or after the leap month position.
- **Updated documentation**: Added comprehensive XML documentation explaining how conventional lunar months are interpreted and how leap months are handled transparently.
- **Applied mapping consistently**: The calculated `calendarMonth` is now used in all subsequent operations (`GetDaysInMonth()` and `ToDateTime()`).

## Implementation Details
The fix ensures that lunar festivals like the Dragon Boat Festival (5/5), Mid-Autumn Festival (8/15), and Double Ninth Festival (9/9) resolve to the correct Gregorian dates even in leap lunar years. For example, in a year with a leap fourth month, the conventional fifth lunar month correctly maps to the calendar's sixth month position.

The mapping logic is straightforward: if a leap month exists and the conventional month index is at or after the leap month position, increment the calendar month by 1; otherwise, use the conventional month directly.

https://claude.ai/code/session_015NmDPBsR5c7JUnRxVyNkEb