### PR TITLE
fix(Calendar): correct Hebrew notable-date test expectations for 2024…

### DIFF
--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/HebrewNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/HebrewNotableDateAlgorithmTests.cs
@@ -68,7 +68,7 @@ public sealed class HebrewNotableDateAlgorithmTests
 	/// </summary>
 	[DataRow(2022, 9, 26)]
 	[DataRow(2023, 9, 16)]
-	[DataRow(2024, 10, 2)]
+	[DataRow(2024, 10, 3)]
 	[TestMethod]
 	public void GetDate_WhenRoshHashanah_ShouldReturnExpectedDate(int year, int expectedMonth, int expectedDay)
 	{
@@ -86,7 +86,7 @@ public sealed class HebrewNotableDateAlgorithmTests
 	/// </summary>
 	[DataRow(2022, 10, 5)]
 	[DataRow(2023, 9, 25)]
-	[DataRow(2024, 10, 11)]
+	[DataRow(2024, 10, 12)]
 	[TestMethod]
 	public void GetDate_WhenYomKippur_ShouldReturnExpectedDate(int year, int expectedMonth, int expectedDay)
 	{
@@ -103,7 +103,7 @@ public sealed class HebrewNotableDateAlgorithmTests
 	/// </summary>
 	[DataRow(2022, 4, 16)]
 	[DataRow(2023, 4, 6)]
-	[DataRow(2024, 4, 22)]
+	[DataRow(2024, 4, 23)]
 	[TestMethod]
 	public void GetDate_WhenPassover_ShouldReturnExpectedDate(int year, int expectedMonth, int expectedDay)
 	{
@@ -136,7 +136,7 @@ public sealed class HebrewNotableDateAlgorithmTests
 	/// Verifies that Purim via <see cref="HebrewMonth.LastAdar" /> (14 of last Adar) returns known correct dates
 	/// in both leap and non-leap Hebrew years.
 	/// </summary>
-	[DataRow(2022, 3, 17)]   // Hebrew 5782 — non-leap year
+	[DataRow(2022, 3, 17)]   // Hebrew 5782 — leap year (Adar II)
 	[DataRow(2023, 3, 7)]    // Hebrew 5783 — non-leap year
 	[DataRow(2024, 3, 24)]   // Hebrew 5784 — leap year (Adar II)
 	[TestMethod]
@@ -157,11 +157,13 @@ public sealed class HebrewNotableDateAlgorithmTests
 	[TestMethod]
 	public void GetDate_WhenAdarIIInNonLeapYear_ShouldReturnNull()
 	{
-		// Hebrew year 5782 (2021–2022) and 5783 (2022–2023) are non-leap years.
+		// Gregorian 2025 spans Hebrew 5785 (2024–2025) and 5786 (2025–2026), both non-leap.
+		// Gregorian 2026 spans 5786 and 5787 (leap), but Adar II 5787 falls in 2027,
+		// so neither candidate Hebrew year contributes an Adar II date inside 2026.
 		var sut = new HebrewNotableDateAlgorithm(HebrewMonth.AdarII, 14);
 
-		Assert.IsNull(sut.GetDate(2022));
-		Assert.IsNull(sut.GetDate(2023));
+		Assert.IsNull(sut.GetDate(2025));
+		Assert.IsNull(sut.GetDate(2026));
 	}
 
 	/// <summary>


### PR DESCRIPTION
… and Adar II

The 2024 rows for Rosh Hashanah, Yom Kippur, and Passover were typed using the sundown-eve convention but HebrewCalendar.ToDateTime returns the daytime Gregorian date, so each was off by one day. The Adar II "non-leap" test used Gregorian 2022, but Hebrew 5782 is in fact a leap year — its Adar II resolves to 17 Mar 2022, which is also why the LastAdar Purim row for 2022 succeeds. Switch the negative test to Gregorian 2025/2026 (whose overlapping Hebrew years contribute no Adar II to those Gregorian years) and correct the misleading 5782 comment on the Purim row.

https://claude.ai/code/session_01NURPcm4aBAuMcPHbfWqcED