### PR TITLE
Add HebrewNotableDateAlgorithmPlugin for Jewish holiday resolution

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/HebrewNotableDateAlgorithmPlugin.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/HebrewNotableDateAlgorithmPlugin.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HebrewNotableDateAlgorithmPlugin.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar.Algorithms;
+
+namespace Bodu.Globalization.Calendar.Plugins;
+
+/// <summary>
+/// Provides the built-in <see cref="INotableDateAlgorithmPlugin" /> that supplies <see cref="HebrewNotableDateAlgorithm" />
+/// instances for the seven Jewish observances declared in the embedded <c>global-jewish.xml</c> rule resource.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Pass an instance of this plugin to <see cref="NotableDateService" /> through its <c>plugins</c> parameter to make the
+/// Hebrew observances declared in <c>global-jewish.xml</c> resolvable without requiring callers to populate an
+/// <see cref="INotableDateAlgorithmRegistry" /> by hand.
+/// </para>
+/// <para>
+/// The plugin contributes one algorithm per registered key:
+/// </para>
+/// <list type="bullet">
+///   <item><description><c>rosh-hashanah</c> — 1 Tishrei.</description></item>
+///   <item><description><c>yom-kippur</c> — 10 Tishrei.</description></item>
+///   <item><description><c>sukkot</c> — 15 Tishrei.</description></item>
+///   <item><description><c>hanukkah</c> — 25 Kislev.</description></item>
+///   <item><description><c>purim</c> — 14 of the last Adar (Adar I in standard years, Adar II in leap years).</description></item>
+///   <item><description><c>passover</c> — 15 Nisan.</description></item>
+///   <item><description><c>shavuot</c> — 6 Sivan.</description></item>
+/// </list>
+/// <para>
+/// Multi-day spans (Sukkot, Hanukkah, Passover) are expressed by <c>durationDays</c> on the originating rule, not by this
+/// plugin; each algorithm only resolves the anchor (first) day. Caller-supplied registrations on the same key take
+/// precedence over the entries contributed here when both are configured.
+/// </para>
+/// </remarks>
+public sealed class HebrewNotableDateAlgorithmPlugin : INotableDateAlgorithmPlugin
+{
+	/// <summary>
+	/// The stable plugin identifier reported through <see cref="Name" />.
+	/// </summary>
+	public const string PluginName = "Bodu.Globalization.Calendar.Hebrew";
+
+	private static readonly KeyValuePair<string, INotableDateAlgorithm>[] s_algorithms =
+	{
+		new("rosh-hashanah", new HebrewNotableDateAlgorithm(HebrewMonth.Tishri, 1)),
+		new("yom-kippur",    new HebrewNotableDateAlgorithm(HebrewMonth.Tishri, 10)),
+		new("sukkot",        new HebrewNotableDateAlgorithm(HebrewMonth.Tishri, 15)),
+		new("hanukkah",      new HebrewNotableDateAlgorithm(HebrewMonth.Kislev, 25)),
+		new("purim",         new HebrewNotableDateAlgorithm(HebrewMonth.LastAdar, 14)),
+		new("passover",      new HebrewNotableDateAlgorithm(HebrewMonth.Nisan, 15)),
+		new("shavuot",       new HebrewNotableDateAlgorithm(HebrewMonth.Sivan, 6)),
+	};
+
+	/// <inheritdoc />
+	public string Name => PluginName;
+
+	/// <inheritdoc />
+	public Version Version { get; } = new(1, 0, 0);
+
+	/// <inheritdoc />
+	public IEnumerable<KeyValuePair<string, INotableDateAlgorithm>> GetAlgorithms() => s_algorithms;
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Plugins/HebrewNotableDateAlgorithmPluginTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Plugins/HebrewNotableDateAlgorithmPluginTests.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HebrewNotableDateAlgorithmPluginTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using Bodu.Globalization.Calendar.Algorithms;
+
+namespace Bodu.Globalization.Calendar.Plugins;
+
+/// <summary>
+/// Verifies the wiring of <see cref="HebrewNotableDateAlgorithmPlugin" />: that it advertises the seven Jewish-calendar
+/// algorithm keys consumed by the embedded <c>global-jewish.xml</c> resource and that those algorithms resolve correctly
+/// when composed into a <see cref="NotableDateService" />.
+/// </summary>
+[TestClass]
+public sealed class HebrewNotableDateAlgorithmPluginTests
+{
+	private const string JewishResourceName = "Bodu/Globalization/Calendar/Resources/global-jewish.xml";
+
+	private static readonly string[] s_expectedKeys =
+	{
+		"rosh-hashanah",
+		"yom-kippur",
+		"sukkot",
+		"hanukkah",
+		"purim",
+		"passover",
+		"shavuot",
+	};
+
+	/// <summary>
+	/// Verifies that the plugin advertises the stable name and version expected by the host.
+	/// </summary>
+	[TestMethod]
+	public void Metadata_ShouldExposeStableNameAndVersion()
+	{
+		var sut = new HebrewNotableDateAlgorithmPlugin();
+
+		Assert.AreEqual("Bodu.Globalization.Calendar.Hebrew", sut.Name);
+		Assert.AreEqual(new Version(1, 0, 0), sut.Version);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="HebrewNotableDateAlgorithmPlugin.GetAlgorithms" /> contributes exactly the seven keys
+	/// referenced by the embedded <c>global-jewish.xml</c> resource and that no key is registered more than once.
+	/// </summary>
+	[TestMethod]
+	public void GetAlgorithms_ShouldContributeAllJewishHolidayKeysWithoutDuplicates()
+	{
+		var sut = new HebrewNotableDateAlgorithmPlugin();
+
+		var registrations = sut.GetAlgorithms().ToList();
+		var keys = registrations.Select(p => p.Key).ToList();
+
+		CollectionAssert.AreEquivalent(s_expectedKeys, keys);
+		Assert.AreEqual(s_expectedKeys.Length, keys.Distinct(StringComparer.OrdinalIgnoreCase).Count());
+		Assert.IsTrue(registrations.All(p => p.Value is HebrewNotableDateAlgorithm));
+	}
+
+	/// <summary>
+	/// Verifies that each contributed algorithm is bound to the correct Hebrew month and day by resolving each one for
+	/// the year 2024 against the values produced directly by an equivalently configured
+	/// <see cref="HebrewNotableDateAlgorithm" />.
+	/// </summary>
+	[DataRow("rosh-hashanah", HebrewMonth.Tishri, 1)]
+	[DataRow("yom-kippur", HebrewMonth.Tishri, 10)]
+	[DataRow("sukkot", HebrewMonth.Tishri, 15)]
+	[DataRow("hanukkah", HebrewMonth.Kislev, 25)]
+	[DataRow("purim", HebrewMonth.LastAdar, 14)]
+	[DataRow("passover", HebrewMonth.Nisan, 15)]
+	[DataRow("shavuot", HebrewMonth.Sivan, 6)]
+	[TestMethod]
+	public void GetAlgorithms_WhenResolvedForYear_ShouldMatchDirectAlgorithmDate(string key, HebrewMonth month, int day)
+	{
+		var sut = new HebrewNotableDateAlgorithmPlugin();
+
+		var registration = sut.GetAlgorithms().Single(p => string.Equals(p.Key, key, StringComparison.OrdinalIgnoreCase));
+		var expected = new HebrewNotableDateAlgorithm(month, day).GetDate(2024);
+		var actual = registration.Value.GetDate(2024);
+
+		Assert.IsNotNull(expected);
+		Assert.IsNotNull(actual);
+		Assert.AreEqual(expected!.Value, actual!.Value);
+	}
+
+	/// <summary>
+	/// Verifies the end-to-end wiring: when the plugin is supplied to <see cref="NotableDateService" /> together with the
+	/// embedded <c>global-jewish.xml</c> rule resource, every Jewish holiday named by that resource is resolved into a
+	/// <see cref="NotableDate" /> for the requested year.
+	/// </summary>
+	[TestMethod]
+	public void NotableDateService_WhenLoadingGlobalJewishWithPlugin_ShouldResolveAllSevenHolidays()
+	{
+		var provider = new XmlResourceNotableDateRuleProvider(JewishResourceName, new ResourcePathResolver());
+
+		var service = new NotableDateService(
+			ruleProviders: new[] { (INotableDateRuleProvider)provider },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+			plugins: new[] { (INotableDatePlugin)new HebrewNotableDateAlgorithmPlugin() });
+
+		var results = service.GetNotableDates(2024);
+		var resolvedNames = results.Select(r => r.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+		Assert.IsTrue(resolvedNames.Contains("Rosh Hashanah"));
+		Assert.IsTrue(resolvedNames.Contains("Yom Kippur"));
+		Assert.IsTrue(resolvedNames.Contains("Sukkot"));
+		Assert.IsTrue(resolvedNames.Contains("Hanukkah"));
+		Assert.IsTrue(resolvedNames.Contains("Purim"));
+		Assert.IsTrue(resolvedNames.Contains("Passover"));
+		Assert.IsTrue(resolvedNames.Contains("Shavuot"));
+	}
+
+	/// <summary>
+	/// Verifies that a known anchor date — Rosh Hashanah 2024 falling on 3 October — flows from the plugin through the
+	/// service unchanged, confirming that the algorithm keyed under <c>rosh-hashanah</c> is the one being invoked.
+	/// </summary>
+	[TestMethod]
+	public void NotableDateService_WhenResolvingRoshHashanah2024_ShouldReturnThirdOfOctober()
+	{
+		var provider = new XmlResourceNotableDateRuleProvider(JewishResourceName, new ResourcePathResolver());
+
+		var service = new NotableDateService(
+			ruleProviders: new[] { (INotableDateRuleProvider)provider },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+			plugins: new[] { (INotableDatePlugin)new HebrewNotableDateAlgorithmPlugin() });
+
+		NotableDate? roshHashanah = service.GetNotableDates(2024)
+			.FirstOrDefault(r => string.Equals(r.Name, "Rosh Hashanah", StringComparison.OrdinalIgnoreCase));
+
+		Assert.IsNotNull(roshHashanah);
+		Assert.AreEqual(new DateTime(2024, 10, 3), roshHashanah!.Date);
+	}
+}


### PR DESCRIPTION
## Summary
This PR introduces a new plugin that enables the `NotableDateService` to resolve Jewish holidays from the embedded `global-jewish.xml` resource without requiring manual algorithm registration.

## Key Changes
- **HebrewNotableDateAlgorithmPlugin**: A new `INotableDateAlgorithmPlugin` implementation that contributes seven pre-configured `HebrewNotableDateAlgorithm` instances for Jewish observances:
  - Rosh Hashanah (1 Tishrei)
  - Yom Kippur (10 Tishrei)
  - Sukkot (15 Tishrei)
  - Hanukkah (25 Kislev)
  - Purim (14 LastAdar)
  - Passover (15 Nisan)
  - Shavuot (6 Sivan)

- **Comprehensive test suite**: Added `HebrewNotableDateAlgorithmPluginTests` with full coverage including:
  - Plugin metadata validation (name and version)
  - Algorithm registration verification (all seven keys present, no duplicates)
  - Individual algorithm correctness for each holiday
  - End-to-end integration testing with `NotableDateService`
  - Anchor date verification (Rosh Hashanah 2024 = October 3)

## Implementation Details
- The plugin uses a static array of pre-instantiated algorithm pairs for efficiency
- Multi-day holiday spans (Sukkot, Hanukkah, Passover) are handled via `durationDays` in the rule definitions, not the plugin
- Caller-supplied registrations take precedence over plugin-contributed entries
- Plugin is versioned at 1.0.0 with stable identifier `Bodu.Globalization.Calendar.Hebrew`

https://claude.ai/code/session_0125xqkkvr84oYmZZEfXgiW3