### PR TITLE
fix(Calendar): correct compile and assertion errors in #98 follow-up tests

### DIFF
--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/GlobalJewishResourceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/GlobalJewishResourceTests.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Linq;
+using Bodu.Extensions;
 
 namespace Bodu.Globalization.Calendar;
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleResolverTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleResolverTests.cs
@@ -606,7 +606,7 @@ public sealed class NotableDateRuleResolverTests
 
 		DateTime? result = resolver.ResolveAnchorDate(rule, 2025);
 
-		Assert.AreEqual(new DateTime(2025, 9, 1), result);
+		Assert.AreEqual(new DateTime(2025, 9, 9), result);
 		Assert.AreEqual("Custom", StringMonthAlgorithm.LastMonthToken);
 	}
 


### PR DESCRIPTION
## Summary

Two follow-up fixes for the global-jewish Algorithm wiring merged in #98:

- `GlobalJewishResourceTests.cs` was missing `using Bodu.Extensions;`, so `CalendarWeekendDefinition` failed to resolve and the test project would not build.
- `ResolveAnchorDate_WhenAlgorithmTypeHasStringIntCtor_ShouldActivateWithRawMonthToken` asserted the wrong expected date — `StringMonthAlgorithm.GetDate` hard-codes month=9 and uses the rule's day, so the expected `DateTime(2025, 9, 1)` should have been `DateTime(2025, 9, 9)`.

## Test plan

- [ ] Test project builds (`CalendarWeekendDefinition` resolves).
- [ ] `ResolveAnchorDate_WhenAlgorithmTypeHasStringIntCtor_ShouldActivateWithRawMonthToken` passes.
- [ ] No other test changes; everything else from #98 still green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0125xqkkvr84oYmZZEfXgiW3)_