### PR TITLE
Fix flaky statistical shuffle tests (issue #55)

### DIFF
--- a/Bodu.Core/test/Collections.Generic/ShuffleHelpersTests.Shuffle.cs
+++ b/Bodu.Core/test/Collections.Generic/ShuffleHelpersTests.Shuffle.cs
@@ -204,8 +204,9 @@ public partial class ShuffleHelpersTests
     }
 
     /// <summary>
-    /// Runs 20,000 in-place shuffles of a 10-element array to validate statistical uniformity of output positions. Each value should
-    /// appear roughly equally in each position, with no more than 2 statistically significant outliers.
+    /// Runs 20,000 in-place shuffles of a 10-element array to validate statistical uniformity of output positions. Uses a fixed-seed
+    /// <see cref="XorShiftRandom" /> to ensure deterministic, reproducible results. Each value should appear roughly equally in each
+    /// position, with no more than 2 statistically significant outliers.
     /// </summary>
     [TestMethod]
     public void Shuffle_WhenRepeated_ShouldDistributeItemsStatistically()
@@ -214,16 +215,33 @@ public partial class ShuffleHelpersTests
         const int size = 10;
         var tracker = new int[size, size];
         var original = Enumerable.Range(0, size).ToArray();
+        var rng = new XorShiftRandom(12345);
 
         for (int r = 0; r < runs; r++)
         {
             var buffer = original.ToArray();
-            ShuffleHelpers.Shuffle(buffer, new SystemRandomAdapter());
+            ShuffleHelpers.Shuffle(buffer, rng);
 
             for (int i = 0; i < size; i++)
                 tracker[i, buffer[i]]++;
         }
 
         AssertStatisticalUniformity(tracker, size, label: nameof(ShuffleHelpers.Shuffle));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ShuffleHelpers.Shuffle" /> produces the same permutation when called with an identically seeded
+    /// <see cref="XorShiftRandom" />, confirming deterministic behaviour.
+    /// </summary>
+    [TestMethod]
+    public void Shuffle_WithFixedSeed_ShouldProduceDeterministicOutput()
+    {
+        int[] buffer1 = Enumerable.Range(1, 10).ToArray();
+        int[] buffer2 = Enumerable.Range(1, 10).ToArray();
+
+        ShuffleHelpers.Shuffle(buffer1, new XorShiftRandom(42));
+        ShuffleHelpers.Shuffle(buffer2, new XorShiftRandom(42));
+
+        CollectionAssert.AreEqual(buffer1, buffer2);
     }
 }

--- a/Bodu.Core/test/Collections.Generic/ShuffleHelpersTests.ShuffleAndYield.cs
+++ b/Bodu.Core/test/Collections.Generic/ShuffleHelpersTests.ShuffleAndYield.cs
@@ -283,25 +283,40 @@ public partial class ShuffleHelpersTests
     }
 
     /// <summary>
-    /// Runs 20,000 shuffles using ShuffleAndYield of a 10-element array to validate statistical uniformity of output positions. Each
-    /// value should appear roughly equally in each position, with no more than 2 statistically significant outliers.
+    /// Runs 20,000 shuffles using ShuffleAndYield of a 10-element array to validate statistical uniformity of output positions. Uses a
+    /// fixed-seed <see cref="XorShiftRandom" /> to ensure deterministic, reproducible results. Each value should appear roughly equally
+    /// in each position, with no more than 2 statistically significant outliers.
     /// </summary>
     [TestMethod]
-    [Ignore("Flaky: statistical ±3σ bound intermittently exceeded — tracked by bslater/bodu#55.")]
     public void ShuffleAndYield_WhenRepeated_ShouldDistributeItemsStatistically()
     {
         const int runs = 20000;
         const int size = 10;
         var tracker = new int[size, size];
         var original = Enumerable.Range(0, size).ToArray();
+        var rng = new XorShiftRandom(12345);
 
         for (int r = 0; r < runs; r++)
         {
-            var shuffled = ShuffleHelpers.ShuffleAndYield(original, new SystemRandomAdapter(), size).ToArray();
+            var shuffled = ShuffleHelpers.ShuffleAndYield(original, rng, size).ToArray();
             for (int i = 0; i < size; i++)
                 tracker[i, shuffled[i]]++;
         }
 
         AssertStatisticalUniformity(tracker, size, label: nameof(ShuffleHelpers.ShuffleAndYield));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ShuffleHelpers.ShuffleAndYield" /> produces the same output sequence when called with an identically
+    /// seeded <see cref="XorShiftRandom" />, confirming deterministic behaviour.
+    /// </summary>
+    [TestMethod]
+    public void ShuffleAndYield_WithFixedSeed_ShouldProduceDeterministicOutput()
+    {
+        var buffer = Enumerable.Range(1, 10).ToArray();
+        int[] result1 = ShuffleHelpers.ShuffleAndYield(buffer, new XorShiftRandom(42), buffer.Length).ToArray();
+        int[] result2 = ShuffleHelpers.ShuffleAndYield(buffer, new XorShiftRandom(42), buffer.Length).ToArray();
+
+        CollectionAssert.AreEqual(result1, result2);
     }
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the non-deterministic `SystemRandomAdapter` (time-seeded `new Random()`) with a fixed-seed `XorShiftRandom(12345)` in both statistical distribution tests, eliminating the ±3σ flakiness described in #55
- Removes the `[Ignore]` suppression from `ShuffleAndYield_WhenRepeated_ShouldDistributeItemsStatistically`
- Proactively applies the same fix to `Shuffle_WhenRepeated_ShouldDistributeItemsStatistically`, which has the same latent flakiness
- Adds a `*_WithFixedSeed_ShouldProduceDeterministicOutput` regression test to each file, verifying that identical seeds produce identical shuffle output

## Approach

A single `XorShiftRandom(12345)` instance is created **outside** the 20,000-iteration loop and reused across all runs. The PRNG state advances naturally with each shuffle call, so each run receives a different (but fully deterministic) sequence of random numbers — preserving the statistical validity of the uniformity check while making the result reproducible.

## Test plan

- [ ] `ShuffleAndYield_WhenRepeated_ShouldDistributeItemsStatistically` passes (no longer ignored)
- [ ] `Shuffle_WhenRepeated_ShouldDistributeItemsStatistically` passes
- [ ] `ShuffleAndYield_WithFixedSeed_ShouldProduceDeterministicOutput` passes
- [ ] `Shuffle_WithFixedSeed_ShouldProduceDeterministicOutput` passes
- [ ] All other `ShuffleHelpersTests` pass
- [ ] Full solution build and test suite green

Closes #55

https://claude.ai/code/session_015AMrYCcvUJ2HXoiXi5zDSB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015AMrYCcvUJ2HXoiXi5zDSB)_