### PR TITLE
refactor(Security.Cryptography): split block hash base types into Merkle–Damgård and Blake-family lines

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -22,7 +22,8 @@ namespace Bodu.Security.Cryptography;
 /// 12 rounds of the BLAKE2 <c>G</c> mixing function per block.
 /// </para>
 /// <para>
-/// This implementation uses lookahead buffering: the final message block is not compressed until
+/// This implementation inherits its residual buffer, byte-counter and lookahead-buffering loop from
+/// <see cref="DeferredFinalBlockHashAlgorithm{T}" />: the final message block is not compressed until
 /// <see cref="HashAlgorithm.HashFinal" /> is called, at which point the <c>finalization</c> flag is set and the
 /// output bytes are serialised in little-endian order then truncated to the configured output length.
 /// </para>
@@ -37,7 +38,7 @@ namespace Bodu.Security.Cryptography;
 /// byte[] digest = blake2b.ComputeHash(message);
 /// </code>
 /// </example>
-public sealed class Blake2b : HashAlgorithm
+public sealed class Blake2b : DeferredFinalBlockHashAlgorithm<Blake2b>
 {
     /// <summary>
     /// The set of output sizes, in bits, accepted by this algorithm.
@@ -83,27 +84,6 @@ public sealed class Blake2b : HashAlgorithm
     private readonly ulong[] _h = new ulong[8];
 
     /// <summary>
-    /// The lookahead buffer holding bytes not yet compressed.
-    /// </summary>
-    private readonly byte[] _pendingBlock = new byte[BlockSizeBytesValue];
-
-    /// <summary>
-    /// The number of bytes currently held in <see cref="_pendingBlock" />.
-    /// </summary>
-    private int _pendingBytes;
-
-    /// <summary>
-    /// The total number of message bytes that have been fully compressed (not including bytes still pending in
-    /// <see cref="_pendingBlock" />).
-    /// </summary>
-    private ulong _totalCompressed;
-
-    /// <summary>
-    /// Indicates whether this instance has been disposed.
-    /// </summary>
-    private bool _disposed;
-
-    /// <summary>
     /// Initialises a new instance of the <see cref="Blake2b" /> class with a 512-bit output hash size.
     /// </summary>
     public Blake2b()
@@ -120,6 +100,7 @@ public sealed class Blake2b : HashAlgorithm
     /// <paramref name="hashSize" /> is not one of the supported output sizes.
     /// </exception>
     public Blake2b(int hashSize)
+        : base(BlockSizeBytesValue)
     {
         if (Array.IndexOf(ValidHashSizes, hashSize) < 0)
             throw new ArgumentOutOfRangeException(
@@ -186,99 +167,103 @@ public sealed class Blake2b : HashAlgorithm
     public override void Initialize()
     {
         this.ThrowIfDisposed();
-        this._pendingBytes = 0;
-        this._totalCompressed = 0UL;
-        Array.Clear(this._pendingBlock, 0, BlockSizeBytesValue);
-        this.InitializeState();
+        base.Initialize();
     }
 
-    /// <summary>
-    /// Releases resources used by the algorithm and clears the internal state.
-    /// </summary>
-    /// <param name="disposing">
-    /// <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to
-    /// release only unmanaged resources.
-    /// </param>
-    protected override void Dispose(bool disposing)
-    {
-        if (this._disposed) return;
+    /// <inheritdoc />
+    /// <remarks>
+    /// Restores the internal hash-state words to the BLAKE2b initialisation values for the configured output size.
+    /// Invoked from <see cref="DeferredFinalBlockHashAlgorithm{T}.Initialize" /> after the inherited residual buffer
+    /// and counter have been cleared.
+    /// </remarks>
+    protected override void OnInitialize() =>
+        this.InitializeState();
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Clears the chaining state, releases the framework <see cref="HashAlgorithm.HashValue" /> array, and zeros
+    /// <see cref="HashAlgorithm.HashSizeValue" />. The inherited residual buffer is cleared by the grandparent
+    /// before this hook runs.
+    /// </remarks>
+    protected override void OnDispose(bool disposing)
+    {
         if (disposing)
         {
             Array.Clear(this._h, 0, this._h.Length);
-            Array.Clear(this._pendingBlock, 0, this._pendingBlock.Length);
             CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this._pendingBytes = 0;
-            this._totalCompressed = 0UL;
             this.HashSizeValue = 0;
         }
-
-        this._disposed = true;
-        base.Dispose(disposing);
     }
 
     /// <summary>
-    /// Feeds <paramref name="cbSize" /> bytes of <paramref name="array" /> into the BLAKE2b compression pipeline.
+    /// Compresses a single 128-byte block using the BLAKE2b <c>F</c> compression function. Invoked by
+    /// <see cref="DeferredFinalBlockHashAlgorithm{T}" /> with <paramref name="isFinal" /> set to <see langword="true" />
+    /// for the last call (which inverts the finalisation flag word) and to <see langword="false" /> otherwise.
     /// </summary>
-    /// <param name="array">The input byte array. Must not be <see langword="null" />.</param>
-    /// <param name="ibStart">The zero-based offset in <paramref name="array" /> at which to begin reading.</param>
-    /// <param name="cbSize">The number of bytes to process.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
-    protected override void HashCore(byte[] array, int ibStart, int cbSize)
+    /// <param name="block">The 128-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">
+    /// The cumulative byte count <em>including</em> the bytes in <paramref name="block" />. Used as the per-block
+    /// counter (the BLAKE2 <c>t0</c> input).
+    /// </param>
+    /// <param name="isFinal">
+    /// <see langword="true" /> if this is the final block; causes the finalisation flag word to be inverted.
+    /// </param>
+    protected override void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
     {
-        ThrowHelper.ThrowIfNull(array);
-        this.ThrowIfDisposed();
-        this.HashCore(array.AsSpan(ibStart, cbSize));
-    }
+        // Read the 16 message words in little-endian order.
+        Span<ulong> m = stackalloc ulong[16];
+        for (int i = 0; i < 16; i++)
+            m[i] = BinaryPrimitives.ReadUInt64LittleEndian(block.Slice(i * 8, 8));
 
-    /// <summary>
-    /// Feeds the entirety of <paramref name="source" /> into the BLAKE2b compression pipeline.
-    /// </summary>
-    /// <param name="source">The input byte span to hash.</param>
-    protected override void HashCore(ReadOnlySpan<byte> source)
-    {
-        this.ThrowIfDisposed();
+        // Initialise the 16-element working vector.
+        Span<ulong> v = stackalloc ulong[16];
+        v[0] = this._h[0];
+        v[1] = this._h[1];
+        v[2] = this._h[2];
+        v[3] = this._h[3];
+        v[4] = this._h[4];
+        v[5] = this._h[5];
+        v[6] = this._h[6];
+        v[7] = this._h[7];
+        v[8] = s_iv[0];
+        v[9] = s_iv[1];
+        v[10] = s_iv[2];
+        v[11] = s_iv[3];
+        v[12] = s_iv[4] ^ totalBytesIncludingThisBlock;
+        v[13] = s_iv[5];          // counter high word (always 0 for messages < 2^64 bytes)
+        v[14] = s_iv[6];
+        v[15] = s_iv[7];
 
-        int pos = 0;
-        int remaining = source.Length;
+        if (isFinal)
+            v[14] = ~v[14];
 
-        while (remaining > 0)
+        // 12 rounds of G mixing.
+        for (int r = 0; r < 12; r++)
         {
-            // If the pending buffer is full and there is still more incoming data, compress it now.
-            // We must never compress the last block here; that is done in HashFinal with the finalization flag.
-            if (this._pendingBytes == BlockSizeBytesValue)
-            {
-                this.Compress(this._pendingBlock, this._totalCompressed + BlockSizeBytesValue, isFinal: false);
-                this._totalCompressed += BlockSizeBytesValue;
-                this._pendingBytes = 0;
-            }
+            byte[] s = s_sigma[r % 10];
 
-            int canCopy = Math.Min(BlockSizeBytesValue - this._pendingBytes, remaining);
-            source.Slice(pos, canCopy).CopyTo(this._pendingBlock.AsSpan(this._pendingBytes));
-            this._pendingBytes += canCopy;
-            pos += canCopy;
-            remaining -= canCopy;
+            G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+            G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+            G(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+            G(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+            G(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+            G(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+            G(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+            G(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
         }
+
+        // Fold the working vector back into the hash state.
+        for (int i = 0; i < 8; i++)
+            this._h[i] ^= v[i] ^ v[i + 8];
     }
 
-    /// <summary>
-    /// Finalises the BLAKE2b computation by padding and compressing the last block, then serialising the state.
-    /// </summary>
-    /// <returns>
-    /// A byte array of <see cref="HashAlgorithm.HashSize" /> / 8 bytes containing the computed digest.
-    /// </returns>
-    protected override byte[] HashFinal()
+    /// <inheritdoc />
+    /// <remarks>
+    /// Serialises the eight 64-bit state words in little-endian order and truncates the result to the configured
+    /// output length (which need not be a multiple of eight bytes).
+    /// </remarks>
+    protected override byte[] ProcessFinalBlock()
     {
-        this.ThrowIfDisposed();
-
-        // Zero-pad the remaining bytes in the pending block.
-        if (this._pendingBytes < BlockSizeBytesValue)
-            Array.Clear(this._pendingBlock, this._pendingBytes, BlockSizeBytesValue - this._pendingBytes);
-
-        ulong counter = this._totalCompressed + (ulong)this._pendingBytes;
-        this.Compress(this._pendingBlock, counter, isFinal: true);
-
-        // Serialise the eight state words in little-endian order and truncate to the configured output length.
         int outputBytes = this.HashSizeValue / 8;
         byte[] output = new byte[outputBytes];
         int wordCount = (outputBytes + 7) / 8;
@@ -317,63 +302,6 @@ public sealed class Blake2b : HashAlgorithm
     }
 
     /// <summary>
-    /// Compresses a single 128-byte block using the BLAKE2b <c>F</c> compression function.
-    /// </summary>
-    /// <param name="block">The 128-byte block to compress.</param>
-    /// <param name="counter">The number of message bytes consumed so far including this block.</param>
-    /// <param name="isFinal">
-    /// <see langword="true" /> if this is the final block; causes the finalization flag word to be inverted.
-    /// </param>
-    private void Compress(byte[] block, ulong counter, bool isFinal)
-    {
-        // Read the 16 message words in little-endian order.
-        Span<ulong> m = stackalloc ulong[16];
-        for (int i = 0; i < 16; i++)
-            m[i] = BinaryPrimitives.ReadUInt64LittleEndian(block.AsSpan(i * 8, 8));
-
-        // Initialise the 16-element working vector.
-        Span<ulong> v = stackalloc ulong[16];
-        v[0] = this._h[0];
-        v[1] = this._h[1];
-        v[2] = this._h[2];
-        v[3] = this._h[3];
-        v[4] = this._h[4];
-        v[5] = this._h[5];
-        v[6] = this._h[6];
-        v[7] = this._h[7];
-        v[8] = s_iv[0];
-        v[9] = s_iv[1];
-        v[10] = s_iv[2];
-        v[11] = s_iv[3];
-        v[12] = s_iv[4] ^ counter;
-        v[13] = s_iv[5];          // counter high word (always 0 for messages < 2^64 bytes)
-        v[14] = s_iv[6];
-        v[15] = s_iv[7];
-
-        if (isFinal)
-            v[14] = ~v[14];
-
-        // 12 rounds of G mixing.
-        for (int r = 0; r < 12; r++)
-        {
-            byte[] s = s_sigma[r % 10];
-
-            G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
-            G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
-            G(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
-            G(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
-            G(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
-            G(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
-            G(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
-            G(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
-        }
-
-        // Fold the working vector back into the hash state.
-        for (int i = 0; i < 8; i++)
-            this._h[i] ^= v[i] ^ v[i + 8];
-    }
-
-    /// <summary>
     /// Applies the BLAKE2b <c>G</c> mixing function to four elements of the working vector.
     /// </summary>
     /// <param name="v">The 16-element working vector.</param>
@@ -405,26 +333,4 @@ public sealed class Blake2b : HashAlgorithm
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ulong RotateRight(ulong value, int bits) =>
         (value >> bits) | (value << (64 - bits));
-
-    /// <summary>
-    /// Throws <see cref="ObjectDisposedException" /> if this instance has been disposed.
-    /// </summary>
-    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfDisposed() =>
-        ObjectDisposedException.ThrowIf(this._disposed, this);
-
-    /// <summary>
-    /// Throws <see cref="CryptographicUnexpectedOperationException" /> if the algorithm has already begun
-    /// processing input and can no longer be reconfigured.
-    /// </summary>
-    /// <exception cref="CryptographicUnexpectedOperationException">
-    /// A hash computation is already in progress.
-    /// </exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfInvalidState()
-    {
-        if (this.State != 0)
-            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_ReconfigurationNotAllowed);
-    }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -22,7 +22,8 @@ namespace Bodu.Security.Cryptography;
 /// applying 10 rounds of the BLAKE2 <c>G</c> mixing function per block.
 /// </para>
 /// <para>
-/// This implementation uses lookahead buffering: the final message block is not compressed until
+/// This implementation inherits its residual buffer, byte-counter and lookahead-buffering loop from
+/// <see cref="DeferredFinalBlockHashAlgorithm{T}" />: the final message block is not compressed until
 /// <see cref="HashAlgorithm.HashFinal" /> is called, at which point the <c>finalization</c> flag is set and the
 /// output bytes are serialised in little-endian order then truncated to the configured output length.
 /// </para>
@@ -37,7 +38,7 @@ namespace Bodu.Security.Cryptography;
 /// byte[] digest = blake2s.ComputeHash(message);
 /// </code>
 /// </example>
-public sealed class Blake2s : HashAlgorithm
+public sealed class Blake2s : DeferredFinalBlockHashAlgorithm<Blake2s>
 {
     /// <summary>
     /// The set of output sizes, in bits, accepted by this algorithm.
@@ -83,27 +84,6 @@ public sealed class Blake2s : HashAlgorithm
     private readonly uint[] _h = new uint[8];
 
     /// <summary>
-    /// The lookahead buffer holding bytes not yet compressed.
-    /// </summary>
-    private readonly byte[] _pendingBlock = new byte[BlockSizeBytesValue];
-
-    /// <summary>
-    /// The number of bytes currently held in <see cref="_pendingBlock" />.
-    /// </summary>
-    private int _pendingBytes;
-
-    /// <summary>
-    /// The total number of message bytes that have been fully compressed (not including bytes still pending in
-    /// <see cref="_pendingBlock" />).
-    /// </summary>
-    private ulong _totalCompressed;
-
-    /// <summary>
-    /// Indicates whether this instance has been disposed.
-    /// </summary>
-    private bool _disposed;
-
-    /// <summary>
     /// Initialises a new instance of the <see cref="Blake2s" /> class with a 256-bit output hash size.
     /// </summary>
     public Blake2s()
@@ -120,6 +100,7 @@ public sealed class Blake2s : HashAlgorithm
     /// <paramref name="hashSize" /> is not one of the supported output sizes.
     /// </exception>
     public Blake2s(int hashSize)
+        : base(BlockSizeBytesValue)
     {
         if (Array.IndexOf(ValidHashSizes, hashSize) < 0)
             throw new ArgumentOutOfRangeException(
@@ -186,99 +167,103 @@ public sealed class Blake2s : HashAlgorithm
     public override void Initialize()
     {
         this.ThrowIfDisposed();
-        this._pendingBytes = 0;
-        this._totalCompressed = 0UL;
-        Array.Clear(this._pendingBlock, 0, BlockSizeBytesValue);
-        this.InitializeState();
+        base.Initialize();
     }
 
-    /// <summary>
-    /// Releases resources used by the algorithm and clears the internal state.
-    /// </summary>
-    /// <param name="disposing">
-    /// <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to
-    /// release only unmanaged resources.
-    /// </param>
-    protected override void Dispose(bool disposing)
-    {
-        if (this._disposed) return;
+    /// <inheritdoc />
+    /// <remarks>
+    /// Restores the internal hash-state words to the BLAKE2s initialisation values for the configured output size.
+    /// Invoked from <see cref="DeferredFinalBlockHashAlgorithm{T}.Initialize" /> after the inherited residual buffer
+    /// and counter have been cleared.
+    /// </remarks>
+    protected override void OnInitialize() =>
+        this.InitializeState();
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Clears the chaining state, releases the framework <see cref="HashAlgorithm.HashValue" /> array, and zeros
+    /// <see cref="HashAlgorithm.HashSizeValue" />. The inherited residual buffer is cleared by the grandparent
+    /// before this hook runs.
+    /// </remarks>
+    protected override void OnDispose(bool disposing)
+    {
         if (disposing)
         {
             Array.Clear(this._h, 0, this._h.Length);
-            Array.Clear(this._pendingBlock, 0, this._pendingBlock.Length);
             CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this._pendingBytes = 0;
-            this._totalCompressed = 0UL;
             this.HashSizeValue = 0;
         }
-
-        this._disposed = true;
-        base.Dispose(disposing);
     }
 
     /// <summary>
-    /// Feeds <paramref name="cbSize" /> bytes of <paramref name="array" /> into the BLAKE2s compression pipeline.
+    /// Compresses a single 64-byte block using the BLAKE2s <c>F</c> compression function. Invoked by
+    /// <see cref="DeferredFinalBlockHashAlgorithm{T}" /> with <paramref name="isFinal" /> set to <see langword="true" />
+    /// for the last call (which inverts the finalisation flag word) and to <see langword="false" /> otherwise.
     /// </summary>
-    /// <param name="array">The input byte array. Must not be <see langword="null" />.</param>
-    /// <param name="ibStart">The zero-based offset in <paramref name="array" /> at which to begin reading.</param>
-    /// <param name="cbSize">The number of bytes to process.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
-    protected override void HashCore(byte[] array, int ibStart, int cbSize)
+    /// <param name="block">The 64-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">
+    /// The cumulative byte count <em>including</em> the bytes in <paramref name="block" />. Used as the per-block
+    /// counter (the BLAKE2 <c>t0</c> / <c>t1</c> input pair).
+    /// </param>
+    /// <param name="isFinal">
+    /// <see langword="true" /> if this is the final block; causes the finalisation flag word to be inverted.
+    /// </param>
+    protected override void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
     {
-        ThrowHelper.ThrowIfNull(array);
-        this.ThrowIfDisposed();
-        this.HashCore(array.AsSpan(ibStart, cbSize));
-    }
+        // Read the 16 message words in little-endian order.
+        Span<uint> m = stackalloc uint[16];
+        for (int i = 0; i < 16; i++)
+            m[i] = BinaryPrimitives.ReadUInt32LittleEndian(block.Slice(i * 4, 4));
 
-    /// <summary>
-    /// Feeds the entirety of <paramref name="source" /> into the BLAKE2s compression pipeline.
-    /// </summary>
-    /// <param name="source">The input byte span to hash.</param>
-    protected override void HashCore(ReadOnlySpan<byte> source)
-    {
-        this.ThrowIfDisposed();
+        // Initialise the 16-element working vector.
+        Span<uint> v = stackalloc uint[16];
+        v[0] = this._h[0];
+        v[1] = this._h[1];
+        v[2] = this._h[2];
+        v[3] = this._h[3];
+        v[4] = this._h[4];
+        v[5] = this._h[5];
+        v[6] = this._h[6];
+        v[7] = this._h[7];
+        v[8] = s_iv[0];
+        v[9] = s_iv[1];
+        v[10] = s_iv[2];
+        v[11] = s_iv[3];
+        v[12] = s_iv[4] ^ (uint)(totalBytesIncludingThisBlock & 0xFFFFFFFFUL);   // counter low word
+        v[13] = s_iv[5] ^ (uint)(totalBytesIncludingThisBlock >> 32);            // counter high word
+        v[14] = s_iv[6];
+        v[15] = s_iv[7];
 
-        int pos = 0;
-        int remaining = source.Length;
+        if (isFinal)
+            v[14] = ~v[14];
 
-        while (remaining > 0)
+        // 10 rounds of G mixing.
+        for (int r = 0; r < 10; r++)
         {
-            // If the pending buffer is full and there is still more incoming data, compress it now.
-            // We must never compress the last block here; that is done in HashFinal with the finalization flag.
-            if (this._pendingBytes == BlockSizeBytesValue)
-            {
-                this.Compress(this._pendingBlock, this._totalCompressed + BlockSizeBytesValue, isFinal: false);
-                this._totalCompressed += BlockSizeBytesValue;
-                this._pendingBytes = 0;
-            }
+            byte[] s = s_sigma[r % 10];
 
-            int canCopy = Math.Min(BlockSizeBytesValue - this._pendingBytes, remaining);
-            source.Slice(pos, canCopy).CopyTo(this._pendingBlock.AsSpan(this._pendingBytes));
-            this._pendingBytes += canCopy;
-            pos += canCopy;
-            remaining -= canCopy;
+            G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
+            G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
+            G(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
+            G(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
+            G(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
+            G(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
+            G(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
+            G(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
         }
+
+        // Fold the working vector back into the hash state.
+        for (int i = 0; i < 8; i++)
+            this._h[i] ^= v[i] ^ v[i + 8];
     }
 
-    /// <summary>
-    /// Finalises the BLAKE2s computation by padding and compressing the last block, then serialising the state.
-    /// </summary>
-    /// <returns>
-    /// A byte array of <see cref="HashAlgorithm.HashSize" /> / 8 bytes containing the computed digest.
-    /// </returns>
-    protected override byte[] HashFinal()
+    /// <inheritdoc />
+    /// <remarks>
+    /// Serialises the eight 32-bit state words in little-endian order and truncates the result to the configured
+    /// output length (which need not be a multiple of four bytes).
+    /// </remarks>
+    protected override byte[] ProcessFinalBlock()
     {
-        this.ThrowIfDisposed();
-
-        // Zero-pad the remaining bytes in the pending block.
-        if (this._pendingBytes < BlockSizeBytesValue)
-            Array.Clear(this._pendingBlock, this._pendingBytes, BlockSizeBytesValue - this._pendingBytes);
-
-        ulong counter = this._totalCompressed + (ulong)this._pendingBytes;
-        this.Compress(this._pendingBlock, counter, isFinal: true);
-
-        // Serialise the eight state words in little-endian order and truncate to the configured output length.
         int outputBytes = this.HashSizeValue / 8;
         byte[] output = new byte[outputBytes];
         int wordCount = (outputBytes + 3) / 4;
@@ -317,63 +302,6 @@ public sealed class Blake2s : HashAlgorithm
     }
 
     /// <summary>
-    /// Compresses a single 64-byte block using the BLAKE2s <c>F</c> compression function.
-    /// </summary>
-    /// <param name="block">The 64-byte block to compress.</param>
-    /// <param name="counter">The number of message bytes consumed so far including this block.</param>
-    /// <param name="isFinal">
-    /// <see langword="true" /> if this is the final block; causes the finalization flag word to be inverted.
-    /// </param>
-    private void Compress(byte[] block, ulong counter, bool isFinal)
-    {
-        // Read the 16 message words in little-endian order.
-        Span<uint> m = stackalloc uint[16];
-        for (int i = 0; i < 16; i++)
-            m[i] = BinaryPrimitives.ReadUInt32LittleEndian(block.AsSpan(i * 4, 4));
-
-        // Initialise the 16-element working vector.
-        Span<uint> v = stackalloc uint[16];
-        v[0] = this._h[0];
-        v[1] = this._h[1];
-        v[2] = this._h[2];
-        v[3] = this._h[3];
-        v[4] = this._h[4];
-        v[5] = this._h[5];
-        v[6] = this._h[6];
-        v[7] = this._h[7];
-        v[8] = s_iv[0];
-        v[9] = s_iv[1];
-        v[10] = s_iv[2];
-        v[11] = s_iv[3];
-        v[12] = s_iv[4] ^ (uint)(counter & 0xFFFFFFFFUL);   // counter low word
-        v[13] = s_iv[5] ^ (uint)(counter >> 32);            // counter high word
-        v[14] = s_iv[6];
-        v[15] = s_iv[7];
-
-        if (isFinal)
-            v[14] = ~v[14];
-
-        // 10 rounds of G mixing.
-        for (int r = 0; r < 10; r++)
-        {
-            byte[] s = s_sigma[r % 10];
-
-            G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
-            G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);
-            G(v, 2, 6, 10, 14, m[s[4]], m[s[5]]);
-            G(v, 3, 7, 11, 15, m[s[6]], m[s[7]]);
-            G(v, 0, 5, 10, 15, m[s[8]], m[s[9]]);
-            G(v, 1, 6, 11, 12, m[s[10]], m[s[11]]);
-            G(v, 2, 7, 8, 13, m[s[12]], m[s[13]]);
-            G(v, 3, 4, 9, 14, m[s[14]], m[s[15]]);
-        }
-
-        // Fold the working vector back into the hash state.
-        for (int i = 0; i < 8; i++)
-            this._h[i] ^= v[i] ^ v[i + 8];
-    }
-
-    /// <summary>
     /// Applies the BLAKE2s <c>G</c> mixing function to four elements of the working vector.
     /// </summary>
     /// <param name="v">The 16-element working vector.</param>
@@ -405,26 +333,4 @@ public sealed class Blake2s : HashAlgorithm
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static uint RotateRight(uint value, int bits) =>
         (value >> bits) | (value << (32 - bits));
-
-    /// <summary>
-    /// Throws <see cref="ObjectDisposedException" /> if this instance has been disposed.
-    /// </summary>
-    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfDisposed() =>
-        ObjectDisposedException.ThrowIf(this._disposed, this);
-
-    /// <summary>
-    /// Throws <see cref="CryptographicUnexpectedOperationException" /> if the algorithm has already begun
-    /// processing input and can no longer be reconfigured.
-    /// </summary>
-    /// <exception cref="CryptographicUnexpectedOperationException">
-    /// A hash computation is already in progress.
-    /// </exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfInvalidState()
-    {
-        if (this.State != 0)
-            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_ReconfigurationNotAllowed);
-    }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
@@ -1,10 +1,9 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="BlockHashAlgorithm.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using Bodu;
 using Bodu.Security.Cryptography;
@@ -12,15 +11,18 @@ using Bodu.Security.Cryptography;
 namespace Bodu.Security.Cryptography;
 
 /// <summary>
-/// Base class for hash algorithms that consume input in fixed-size blocks. Handles residual buffering, block alignment, total-length
-/// tracking, and final block padding on behalf of derived implementations.
+/// Base class for hash algorithms that consume input in fixed-size blocks and pad the final partial block before
+/// processing it (the Merkle&#8211;Damg&#229;rd shape). Handles block alignment and final-block padding orchestration on
+/// behalf of derived implementations; the residual buffer, running byte total, and disposal latch are inherited from
+/// <see cref="BufferedBlockHashAlgorithm{T}" />.
 /// </summary>
 /// <typeparam name="T">The concrete hash algorithm derived from this class. Must expose a public parameterless constructor.</typeparam>
 /// <remarks>
 /// <para>
-/// Input data is accumulated into an internal buffer until a complete block of <see cref="BlockSizeBytes" /> is available, at which
-/// point it is passed to <see cref="ProcessBlock" />. Any residual bytes left over at <see cref="HashAlgorithm.HashFinal" /> are
-/// padded via <see cref="PadBlock" /> before a final call to <see cref="ProcessFinalBlock" /> produces the digest.
+/// Input data is accumulated into the inherited residual buffer until a complete block of <see cref="BufferedBlockHashAlgorithm{T}.BlockSizeBytes" />
+/// is available, at which point it is passed to <see cref="ProcessBlock" />. Any residual bytes left over at
+/// <see cref="HashAlgorithm.HashFinal" /> are padded via <see cref="PadBlock" /> before a final call to
+/// <see cref="ProcessFinalBlock" /> produces the digest.
 /// </para>
 /// <para>Derived classes must implement the following:</para>
 /// <list type="bullet">
@@ -30,29 +32,9 @@ namespace Bodu.Security.Cryptography;
 /// </list>
 /// </remarks>
 public abstract class BlockHashAlgorithm<T>
-    : HashAlgorithm
+    : BufferedBlockHashAlgorithm<T>
     where T : BlockHashAlgorithm<T>, new()
 {
-    /// <summary>
-    /// The fixed size, in bytes, of each block processed by the algorithm.
-    /// </summary>
-    protected readonly int BlockSizeBytes; // Size of a single block (in bytes) to be processed per hash step
-
-    private readonly Memory<byte> _residualByteBuffer; // Temporary buffer to hold incomplete blocks between HashCore calls
-    private bool _disposed;
-    private int _residualBytes;                        // Number of bytes currently in the residual buffer
-    private ulong _totalLength;                        // Total length of data processed, used for padding
-
-    // Tracks whether Dispose() has been called
-
-#if !NET6_0_OR_GREATER
-
-    /// <summary>
-    /// Indicates whether the hash computation has been finalized. Used in .NET Standard environments.
-    /// </summary>
-    protected bool _finalized;
-#endif
-
     /// <summary>
     /// Initializes a new instance of the <see cref="BlockHashAlgorithm{T}" /> class using the specified input block size.
     /// </summary>
@@ -67,8 +49,10 @@ public abstract class BlockHashAlgorithm<T>
     /// accumulated for a full block.
     /// </para>
     /// <para>
-    /// This constructor allocates the internal buffer used to accumulate and align partial input segments across multiple calls to
-    /// <see cref="HashAlgorithm.TransformBlock" /> and <see cref="HashAlgorithm.TransformFinalBlock" />.
+    /// This constructor delegates to <see cref="BufferedBlockHashAlgorithm{T}" />, which allocates the residual buffer used to
+    /// accumulate and align partial input segments across multiple calls to
+    /// <see cref="HashAlgorithm.TransformBlock(byte[], int, int, byte[], int)" /> and
+    /// <see cref="HashAlgorithm.TransformFinalBlock(byte[], int, int)" />.
     /// </para>
     /// <para>
     /// The specified block size must match the expectations of the underlying algorithm implementation. For example, a SHA-like
@@ -77,10 +61,8 @@ public abstract class BlockHashAlgorithm<T>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="blockSize" /> is less than or equal to zero.</exception>
     protected BlockHashAlgorithm(int blockSize)
+        : base(blockSize)
     {
-        ThrowHelper.ThrowIfLessThanOrEqual(blockSize, 0);
-        this.BlockSizeBytes = blockSize;
-        this._residualByteBuffer = new byte[this.BlockSizeBytes];
     }
 
     /// <summary>
@@ -90,74 +72,12 @@ public abstract class BlockHashAlgorithm<T>
     protected virtual bool AllowUnalignedFinalBlock => false;
 
     /// <inheritdoc />
-    public override void Initialize()
-    {
-        // Clear internal buffers and reset state
-        this._residualByteBuffer.Span.Clear();
-        this._residualBytes = 0;
-        this._totalLength = 0;
-    }
-
-    /// <inheritdoc />
-    protected override void Dispose(bool disposing)
-    {
-        if (this._disposed) return;
-
-        if (disposing)
-        {
-            CryptoHelpers.Clear(this._residualByteBuffer);
-            this._residualBytes = 0;
-            this._totalLength = 0;
-        }
-
-        this._disposed = true;
-        base.Dispose(disposing);
-    }
-
-    /// <summary>
-    /// Processes a segment of the input byte array and feeds it into the hash computation pipeline. This method updates the internal
-    /// state of the algorithm by processing <paramref name="cbSize" /> bytes starting at the specified <paramref name="ibStart" /> offset.
-    /// </summary>
-    /// <param name="array">The input byte array containing the data to hash.</param>
-    /// <param name="ibStart">The zero-based index in <paramref name="array" /> at which to begin reading data.</param>
-    /// <param name="cbSize">The number of bytes to process from <paramref name="array" />.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// <para><paramref name="ibStart" /> is less than 0.</para>
-    /// <para>-or-</para>
-    /// <para><paramref name="cbSize" /> is less than 0.</para>
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="ibStart" /> and <paramref name="cbSize" /> specify a range that exceeds the length of <paramref name="array" />.
-    /// </exception>
-    /// <exception cref="CryptographicUnexpectedOperationException">
-    /// The hash algorithm has already been finalized and cannot accept more input data.
-    /// </exception>
     /// <remarks>
-    /// <para>
-    /// This method is part of the core hashing process and is automatically invoked by methods such as
-    /// <see cref="HashAlgorithm.TransformBlock(byte[], int, int, byte[], int)" /> and <see cref="HashAlgorithm.ComputeHash(byte[])" />.
-    /// It handles processing of raw byte array input and ensures the hash algorithm receives data in properly sized blocks.
-    /// </para>
-    /// <para>
-    /// This method internally buffers incomplete blocks between calls to ensure proper alignment. Full blocks are immediately
-    /// processed; any remaining bytes are stored until more data arrives or finalization occurs.
-    /// </para>
+    /// The Merkle&#8211;Damg&#229;rd base owns no algorithm-side state &#8212; the chaining variables, IV, and any
+    /// schedule live entirely in derived classes. The empty body satisfies the grandparent's abstract contract.
     /// </remarks>
-    protected override void HashCore(byte[] array, int ibStart, int cbSize)
+    protected override void OnInitialize()
     {
-        ThrowHelper.ThrowIfNull(array);
-        this.ThrowIfDisposed();
-
-#if !NET6_0_OR_GREATER
-    ThrowHelper.ThrowIfLessThan(ibStart, 0);
-    ThrowHelper.ThrowIfLessThan(cbSize, 0);
-    ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, ibStart, cbSize);
-    if (this._finalized)
-        throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_AlreadyFinalized);
-#endif
-
-        this.ProcessBlocks(array.AsSpan(ibStart, cbSize));
     }
 
     /// <summary>
@@ -210,7 +130,7 @@ public abstract class BlockHashAlgorithm<T>
 
         if (this.ShouldPadFinalBlock())
         {
-            var finalBlock = this.PadBlock(this._residualByteBuffer.Span.Slice(0, this._residualBytes), this._totalLength);
+            var finalBlock = this.PadBlock(this._residualBlock.Span.Slice(0, this._residualBytes), this._totalBytes);
 
             if (this.AllowUnalignedFinalBlock)
             {
@@ -224,7 +144,7 @@ public abstract class BlockHashAlgorithm<T>
         }
         else if (this._residualBytes > 0)
         {
-            this.ProcessBlock(this._residualByteBuffer.Span.Slice(0, this._residualBytes));
+            this.ProcessBlock(this._residualBlock.Span.Slice(0, this._residualBytes));
         }
 
         return this.ProcessFinalBlock();
@@ -279,34 +199,6 @@ public abstract class BlockHashAlgorithm<T>
     protected virtual bool ShouldPadFinalBlock() => true;
 
     /// <summary>
-    /// Throws an exception if the instance has been disposed.
-    /// </summary>
-    /// <exception cref="ObjectDisposedException">Thrown when the instance has already been disposed.</exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void ThrowIfDisposed()
-    {
-#if NET8_0_OR_GREATER
-        ObjectDisposedException.ThrowIf(this._disposed, this);
-#else
-    if (disposed)
-        throw new ObjectDisposedException(this.GetType().Name);
-#endif
-    }
-
-    /// <summary>
-    /// Throws if the algorithm has begun processing and can no longer be reconfigured.
-    /// </summary>
-    /// <exception cref="CryptographicUnexpectedOperationException">
-    /// Thrown if an attempt is made to change configuration after the algorithm has started.
-    /// </exception>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    protected void ThrowIfInvalidState()
-    {
-        if (this.State != 0)
-            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_ReconfigurationNotAllowed);
-    }
-
-    /// <summary>
     /// Processes a span of input bytes in fixed-size blocks, handling any residual bytes from previous invocations.
     /// </summary>
     /// <param name="buffer">The input span to process. May include incomplete blocks.</param>
@@ -317,9 +209,9 @@ public abstract class BlockHashAlgorithm<T>
     private void ProcessBlocks(ReadOnlySpan<byte> buffer)
     {
         int pos = 0;
-        this._totalLength += (ulong)buffer.Length;
+        this._totalBytes += (ulong)buffer.Length;
 
-        Span<byte> residualSpan = this._residualByteBuffer.Span;
+        Span<byte> residualSpan = this._residualBlock.Span;
 
         // Attempt to fill a partial residual block if it exists
         if (this._residualBytes > 0)
@@ -330,7 +222,7 @@ public abstract class BlockHashAlgorithm<T>
             {
                 // Complete residual block and process it
                 buffer.Slice(pos, remaining).CopyTo(residualSpan[this._residualBytes..]);
-                this.ProcessBlock(this._residualByteBuffer.Span);
+                this.ProcessBlock(this._residualBlock.Span);
                 this._residualBytes = 0;
                 pos += remaining;
             }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -1,0 +1,262 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BufferedBlockHashAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+using Bodu;
+using Bodu.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Provides the shared infrastructure for hash algorithms that consume input in fixed-size blocks. Owns the residual buffer,
+/// the running total of bytes consumed, the disposal latch, and the <see cref="HashAlgorithm.HashCore(byte[], int, int)" />
+/// to <see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> delegation.
+/// </summary>
+/// <typeparam name="T">The concrete hash algorithm derived from this class. Must expose a public parameterless constructor.</typeparam>
+/// <remarks>
+/// <para>
+/// This class is the common ancestor for both block-buffered patterns offered by the library:
+/// <see cref="BlockHashAlgorithm{T}" /> (Merkle&#8211;Damg&#229;rd-style; pads the final partial block before processing) and
+/// the Blake-family-style sibling that defers the final full block until <see cref="HashAlgorithm.HashFinal" /> so that
+/// a finalisation flag may be raised on the last compression call.
+/// </para>
+/// <para>
+/// The grandparent intentionally does <em>not</em> implement <see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> or
+/// <see cref="HashAlgorithm.HashFinal" />, because the buffering loops and finalisation shapes of the two derived patterns
+/// genuinely differ. Each derived base owns its own <see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> override and
+/// reads <see cref="BlockSizeBytes" />, <see cref="_residualBlock" />, <see cref="_residualBytes" /> and
+/// <see cref="_totalBytes" /> directly.
+/// </para>
+/// <para>Derived classes must implement the following:</para>
+/// <list type="bullet">
+/// <item><description><see cref="OnInitialize" /> resets any algorithm-specific state (chaining variables, IV, schedule).</description></item>
+/// <item><description><see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> consumes the input span using the buffering shape required by the algorithm family.</description></item>
+/// <item><description><see cref="HashAlgorithm.HashFinal" /> finalises the computation and returns the digest.</description></item>
+/// </list>
+/// </remarks>
+public abstract class BufferedBlockHashAlgorithm<T>
+    : HashAlgorithm
+    where T : BufferedBlockHashAlgorithm<T>, new()
+{
+    /// <summary>
+    /// The fixed size, in bytes, of each block consumed by the algorithm.
+    /// </summary>
+    protected readonly int BlockSizeBytes;
+
+    /// <summary>
+    /// Backing buffer that accumulates input bytes which do not yet form a complete block. Sized at
+    /// <see cref="BlockSizeBytes" /> at construction. Cleared by <see cref="Initialize" /> and overwritten with zeros
+    /// during disposal.
+    /// </summary>
+    protected readonly Memory<byte> _residualBlock;
+
+    /// <summary>
+    /// Number of bytes currently held in <see cref="_residualBlock" />. Always in the range <c>[0, BlockSizeBytes]</c>.
+    /// Reset to <c>0</c> by <see cref="Initialize" />.
+    /// </summary>
+    protected int _residualBytes;
+
+    /// <summary>
+    /// Running total of bytes consumed by the algorithm so far. Excludes any bytes still held in
+    /// <see cref="_residualBlock" /> when used by derived classes that update the total before processing each block.
+    /// Reset to <c>0</c> by <see cref="Initialize" />.
+    /// </summary>
+    protected ulong _totalBytes;
+
+    /// <summary>
+    /// Indicates whether <see cref="Dispose(bool)" /> has been called. Used to guard <see cref="ThrowIfDisposed" /> and
+    /// to suppress duplicate disposal work.
+    /// </summary>
+    private bool _disposed;
+
+#if !NET6_0_OR_GREATER
+
+    /// <summary>
+    /// Indicates whether the hash computation has been finalised. Used in .NET Standard environments to enforce the
+    /// "no input after finalisation" contract that .NET 6+ enforces in the framework itself.
+    /// </summary>
+    protected bool _finalized;
+#endif
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="BufferedBlockHashAlgorithm{T}" /> class with the specified input
+    /// block size.
+    /// </summary>
+    /// <param name="blockSize">
+    /// The fixed size, in bytes, of each block consumed by the algorithm. Must be greater than zero.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="blockSize" /> is less than or equal to zero.
+    /// </exception>
+    /// <remarks>
+    /// Allocates the residual buffer at <paramref name="blockSize" /> bytes. Derived classes are expected to call
+    /// their own <c>InitializeState()</c> equivalent from their constructor (and again from <see cref="OnInitialize" />)
+    /// so that the algorithm state matches the freshly-cleared residual buffer.
+    /// </remarks>
+    protected BufferedBlockHashAlgorithm(int blockSize)
+    {
+        ThrowHelper.ThrowIfLessThanOrEqual(blockSize, 0);
+        this.BlockSizeBytes = blockSize;
+        this._residualBlock = new byte[blockSize];
+    }
+
+    /// <summary>
+    /// Resets the algorithm to its initial state. Clears the residual buffer, resets the running byte total, and then
+    /// invokes <see cref="OnInitialize" /> so that derived classes may reset any algorithm-specific state such as
+    /// chaining variables or key-derived schedule.
+    /// </summary>
+    /// <remarks>
+    /// This method does not reset the <see cref="HashAlgorithm.State" /> property explicitly on .NET 6+ targets &#8212;
+    /// the framework manages that transition. On earlier targets, derived classes that need the already-finalised
+    /// guard should reset their <c>_finalized</c> backing field from their own <c>Initialize</c> override.
+    /// </remarks>
+    public override void Initialize()
+    {
+        this._residualBlock.Span.Clear();
+        this._residualBytes = 0;
+        this._totalBytes = 0UL;
+        this.OnInitialize();
+    }
+
+    /// <summary>
+    /// Hook invoked by <see cref="Initialize" /> after the shared residual buffer and counters have been cleared.
+    /// Derived classes implement this to reset their algorithm-specific state, for example chaining variables, the
+    /// initialisation vector, or key-derived schedule.
+    /// </summary>
+    /// <remarks>
+    /// By contract, when this method runs the residual buffer is empty, <see cref="_residualBytes" /> is <c>0</c>,
+    /// and <see cref="_totalBytes" /> is <c>0</c>. Implementations should not touch the buffer or the counter; doing
+    /// so risks desynchronising the two halves of the algorithm state.
+    /// </remarks>
+    protected abstract void OnInitialize();
+
+    /// <summary>
+    /// Releases the unmanaged resources used by the algorithm and zeros the residual buffer. Forwards to
+    /// <see cref="OnDispose(bool)" /> so that derived classes may clear any algorithm-specific secret material.
+    /// </summary>
+    /// <param name="disposing">
+    /// <see langword="true" /> to release both managed and unmanaged resources; <see langword="false" /> to release
+    /// only unmanaged resources.
+    /// </param>
+    /// <remarks>
+    /// The dispose latch ensures that subsequent calls are no-ops and that <see cref="OnDispose(bool)" /> runs at
+    /// most once. Derived classes should not check or set <see cref="_disposed" /> directly &#8212; instead they should
+    /// override <see cref="OnDispose(bool)" /> to clear their own state.
+    /// </remarks>
+    protected override void Dispose(bool disposing)
+    {
+        if (this._disposed) return;
+
+        if (disposing)
+        {
+            CryptoHelpers.Clear(this._residualBlock);
+            this._residualBytes = 0;
+            this._totalBytes = 0UL;
+            this.OnDispose(disposing);
+        }
+
+        this._disposed = true;
+        base.Dispose(disposing);
+    }
+
+    /// <summary>
+    /// Hook invoked by <see cref="Dispose(bool)" /> while <paramref name="disposing" /> is <see langword="true" /> and
+    /// before the dispose latch is set. Derived classes override this to overwrite any algorithm-specific secret
+    /// material such as chaining variables, key schedule, or precomputed state vectors.
+    /// </summary>
+    /// <param name="disposing">
+    /// Always <see langword="true" /> for the current call; the parameter is forwarded so that derived implementations
+    /// may follow the standard <see cref="IDisposable" /> pattern if they prefer.
+    /// </param>
+    /// <remarks>
+    /// The default implementation is a no-op so that derived classes with no algorithm-side secrets pay no overhead.
+    /// </remarks>
+    protected virtual void OnDispose(bool disposing)
+    {
+    }
+
+    /// <summary>
+    /// Consumes the supplied input span and updates the algorithm state. Derived classes implement the buffering
+    /// loop appropriate to their family (immediate-fire-on-full-block for Merkle&#8211;Damg&#229;rd hashes,
+    /// defer-on-full-block for Blake-family hashes).
+    /// </summary>
+    /// <param name="source">The input bytes to consume. May be empty, partial, exact-block, or multi-block in length.</param>
+    /// <remarks>
+    /// This overload is re-marked <c>abstract</c> by the grandparent to force every derived base to provide an
+    /// explicit implementation. Without this, the default <see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" />
+    /// implementation would allocate a temporary byte array and call back into
+    /// <see cref="HashCore(byte[], int, int)" />, producing infinite recursion through the grandparent's forwarding
+    /// override.
+    /// </remarks>
+    protected abstract override void HashCore(ReadOnlySpan<byte> source);
+
+    /// <summary>
+    /// Validates the supplied byte-array slice and forwards it to the
+    /// <see cref="HashCore(ReadOnlySpan{byte})" /> overload that derived classes implement.
+    /// </summary>
+    /// <param name="array">The input byte array containing the data to hash.</param>
+    /// <param name="ibStart">The zero-based index in <paramref name="array" /> at which to begin reading data.</param>
+    /// <param name="cbSize">The number of bytes to process from <paramref name="array" />.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <para><paramref name="ibStart" /> is less than zero.</para>
+    /// <para>-or-</para>
+    /// <para><paramref name="cbSize" /> is less than zero.</para>
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="ibStart" /> and <paramref name="cbSize" /> specify a range that exceeds the length of
+    /// <paramref name="array" />.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">The algorithm instance has been disposed.</exception>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// On target frameworks prior to .NET 6, the hash algorithm has already been finalised and cannot accept more
+    /// input data.
+    /// </exception>
+    protected override void HashCore(byte[] array, int ibStart, int cbSize)
+    {
+        ThrowHelper.ThrowIfNull(array);
+        this.ThrowIfDisposed();
+
+#if !NET6_0_OR_GREATER
+        ThrowHelper.ThrowIfLessThan(ibStart, 0);
+        ThrowHelper.ThrowIfLessThan(cbSize, 0);
+        ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, ibStart, cbSize);
+        if (this._finalized)
+            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_AlreadyFinalized);
+#endif
+
+        this.HashCore(array.AsSpan(ibStart, cbSize));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException" /> if the instance has been disposed.
+    /// </summary>
+    /// <exception cref="ObjectDisposedException">Thrown when the instance has already been disposed.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void ThrowIfDisposed()
+    {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this._disposed, this);
+#else
+        if (this._disposed)
+            throw new ObjectDisposedException(this.GetType().Name);
+#endif
+    }
+
+    /// <summary>
+    /// Throws if the algorithm has begun processing and can no longer be reconfigured.
+    /// </summary>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// Thrown if an attempt is made to change configuration after the algorithm has started.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    protected void ThrowIfInvalidState()
+    {
+        if (this.State != 0)
+            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_ReconfigurationNotAllowed);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
@@ -1,0 +1,173 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DeferredFinalBlockHashAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using Bodu;
+using Bodu.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Base class for hash algorithms that defer compression of the final full block until <see cref="HashAlgorithm.HashFinal" />
+/// so that a finalisation flag may be raised on the last compression call (the Blake-family shape). Owns the
+/// defer-on-full-block buffering loop and the zero-pad-then-finalise orchestration; the residual buffer, running
+/// byte counter, and disposal latch are inherited from <see cref="BufferedBlockHashAlgorithm{T}" />.
+/// </summary>
+/// <typeparam name="T">The concrete hash algorithm derived from this class. Must expose a public parameterless constructor.</typeparam>
+/// <remarks>
+/// <para>
+/// Unlike Merkle&#8211;Damg&#229;rd hashes, Blake-family compression functions take a per-block byte counter and an
+/// <c>isFinal</c> flag. The final compression call must carry both the actual total byte count of the message and
+/// <c>isFinal: true</c>. This base class implements the consequent invariant: a block that fills the residual buffer
+/// exactly is <em>not</em> compressed at the point it is filled, because the algorithm cannot yet tell whether the
+/// caller will supply more data. Compression of that block is deferred until either (a) the next
+/// <see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> call provides at least one more byte (in which case the
+/// pending block is compressed with <c>isFinal: false</c>) or (b) <see cref="HashAlgorithm.HashFinal" /> is called
+/// (in which case the pending block is compressed with <c>isFinal: true</c>).
+/// </para>
+/// <para>
+/// The inherited <see cref="BufferedBlockHashAlgorithm{T}._totalBytes" /> field stores the total number of bytes
+/// already <em>compressed</em> (i.e. consumed from the residual buffer by previous <see cref="ProcessBlock" />
+/// calls). Bytes still held in the residual buffer are <em>not</em> included in this total &#8212; they contribute to
+/// the counter only at the moment they are compressed.
+/// </para>
+/// <para>Derived classes must implement the following:</para>
+/// <list type="bullet">
+/// <item><description><see cref="OnInitialize" /> resets the algorithm-specific chaining variables to their initial state.</description></item>
+/// <item><description><see cref="ProcessBlock" /> compresses a single block, receiving the per-block counter and the finalisation flag.</description></item>
+/// <item><description><see cref="ProcessFinalBlock" /> extracts the digest from the chaining variables after the final compression has run.</description></item>
+/// </list>
+/// </remarks>
+public abstract class DeferredFinalBlockHashAlgorithm<T>
+    : BufferedBlockHashAlgorithm<T>
+    where T : DeferredFinalBlockHashAlgorithm<T>, new()
+{
+    /// <summary>
+    /// Initialises a new instance of the <see cref="DeferredFinalBlockHashAlgorithm{T}" /> class with the specified
+    /// input block size.
+    /// </summary>
+    /// <param name="blockSize">
+    /// The fixed size, in bytes, of each block consumed by the algorithm. Must be greater than zero.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="blockSize" /> is less than or equal to zero.
+    /// </exception>
+    protected DeferredFinalBlockHashAlgorithm(int blockSize)
+        : base(blockSize)
+    {
+    }
+
+    /// <summary>
+    /// Consumes the supplied input span using the deferred-final-block buffering rule. At the start of every iteration
+    /// of the inner loop, if the residual buffer is already full and the caller has supplied at least one more byte,
+    /// the held block is compressed with <c>isFinal: false</c> and the counter is advanced before the new byte is
+    /// copied in. Compression of a block that fills the buffer exactly is otherwise deferred to
+    /// <see cref="HashFinal" /> so that <c>isFinal: true</c> may be raised on it.
+    /// </summary>
+    /// <param name="source">The input bytes to consume. May be empty, partial, exact-block, or multi-block in length.</param>
+    /// <exception cref="ObjectDisposedException">The algorithm instance has been disposed.</exception>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// On target frameworks prior to .NET 6, the hash algorithm has already been finalised and cannot accept more input.
+    /// </exception>
+    protected override void HashCore(ReadOnlySpan<byte> source)
+    {
+        this.ThrowIfDisposed();
+
+#if !NET6_0_OR_GREATER
+    if (this._finalized)
+        throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_AlreadyFinalized);
+#endif
+
+        int pos = 0;
+        int remaining = source.Length;
+        Span<byte> residualSpan = this._residualBlock.Span;
+
+        while (remaining > 0)
+        {
+            // The block that fills the residual buffer must not be compressed at fill time, because it may turn out
+            // to be the final block and thus require isFinal: true. Compress it only when we know more data follows.
+            if (this._residualBytes == this.BlockSizeBytes)
+            {
+                this.ProcessBlock(residualSpan, this._totalBytes + (ulong)this.BlockSizeBytes, isFinal: false);
+                this._totalBytes += (ulong)this.BlockSizeBytes;
+                this._residualBytes = 0;
+            }
+
+            int canCopy = Math.Min(this.BlockSizeBytes - this._residualBytes, remaining);
+            source.Slice(pos, canCopy).CopyTo(residualSpan[this._residualBytes..]);
+            this._residualBytes += canCopy;
+            pos += canCopy;
+            remaining -= canCopy;
+        }
+    }
+
+    /// <summary>
+    /// Finalises the hash computation. Zero-pads the residual buffer (if not already full) up to the block size,
+    /// performs the final compression with <c>isFinal: true</c> and a counter equal to the total bytes consumed
+    /// (<see cref="BufferedBlockHashAlgorithm{T}._totalBytes" /> plus the residual byte count), and returns the
+    /// digest produced by <see cref="ProcessFinalBlock" />.
+    /// </summary>
+    /// <returns>The computed hash bytes as produced by <see cref="ProcessFinalBlock" />.</returns>
+    /// <exception cref="ObjectDisposedException">The algorithm instance has been disposed.</exception>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// On target frameworks prior to .NET 6, the hash computation has already been finalised.
+    /// </exception>
+    protected override byte[] HashFinal()
+    {
+        this.ThrowIfDisposed();
+
+#if !NET6_0_OR_GREATER
+    if (this._finalized)
+        throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_AlreadyFinalized);
+#endif
+
+        Span<byte> residualSpan = this._residualBlock.Span;
+
+        if (this._residualBytes < this.BlockSizeBytes)
+            residualSpan[this._residualBytes..].Clear();
+
+        ulong counter = this._totalBytes + (ulong)this._residualBytes;
+        this.ProcessBlock(residualSpan, counter, isFinal: true);
+
+        return this.ProcessFinalBlock();
+    }
+
+    /// <summary>
+    /// Compresses a single full block of input using the algorithm's internal compression function.
+    /// </summary>
+    /// <param name="block">
+    /// The input block to compress. Always exactly <see cref="BufferedBlockHashAlgorithm{T}.BlockSizeBytes" /> bytes
+    /// long, possibly zero-padded by <see cref="HashFinal" /> when <paramref name="isFinal" /> is <see langword="true" />.
+    /// </param>
+    /// <param name="totalBytesIncludingThisBlock">
+    /// The cumulative byte count <em>including</em> the bytes in <paramref name="block" /> being compressed. For
+    /// mid-stream blocks this equals the previous total plus
+    /// <see cref="BufferedBlockHashAlgorithm{T}.BlockSizeBytes" />; for the final compression it equals the previous
+    /// total plus the residual byte count (which may be in the range <c>[0, BlockSizeBytes]</c>).
+    /// </param>
+    /// <param name="isFinal">
+    /// <see langword="true" /> for the last compression call (raised by <see cref="HashFinal" />); otherwise
+    /// <see langword="false" />. Algorithms that maintain a finalisation flag should consult this parameter rather
+    /// than tracking message length internally.
+    /// </param>
+    /// <remarks>
+    /// Implementations must not retain a reference to the supplied span beyond the call &#8212; the underlying buffer
+    /// is the inherited residual buffer and may be overwritten by subsequent input.
+    /// </remarks>
+    protected abstract void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal);
+
+    /// <summary>
+    /// Extracts the digest from the algorithm's chaining variables after <see cref="ProcessBlock" /> has been called
+    /// with <c>isFinal: true</c> for the last time.
+    /// </summary>
+    /// <returns>A byte array containing the final computed hash value.</returns>
+    /// <remarks>
+    /// This method is invoked once per <see cref="HashAlgorithm.HashFinal" /> call, immediately after the final
+    /// compression. It reads from the internal hash state and serialises the result to a byte array in the format
+    /// expected by consumers of the algorithm (typically little-endian for Blake-family hashes).
+    /// </remarks>
+    protected abstract byte[] ProcessFinalBlock();
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BufferedBlockHashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BufferedBlockHashAlgorithmTests.cs
@@ -1,0 +1,202 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BufferedBlockHashAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Verifies the protocol contract exposed by <see cref="BufferedBlockHashAlgorithm{T}" />: constructor argument
+/// validation, residual-buffer / counter reset on <c>Initialize</c>, dispose-once semantics, secret-zeroing on
+/// disposal, and forwarding of the byte-array <c>HashCore</c> overload to the span overload.
+/// </summary>
+[TestClass]
+public sealed class BufferedBlockHashAlgorithmTests
+{
+    /// <summary>
+    /// Verifies that supplying a block size of zero to the constructor throws an
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenBlockSizeIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new MonitoringBufferedBlockHashAlgorithm(0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a negative block size to the constructor throws an
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenBlockSizeIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new MonitoringBufferedBlockHashAlgorithm(-1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a valid block size is stored verbatim and a residual buffer of the same length is allocated.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenBlockSizeIsValid_ShouldStoreBlockSizeAndAllocateResidualBuffer()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm(16);
+
+        Assert.AreEqual(16, sut.ConfiguredBlockSize);
+        Assert.AreEqual(16, sut.ResidualBufferSnapshot.Length);
+        Assert.AreEqual(0, sut.ResidualBytesSnapshot);
+        Assert.AreEqual(0UL, sut.TotalBytesSnapshot);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> invokes the
+    /// <see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> hook.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalled_ShouldInvokeOnInitialize()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm();
+        int baseline = sut.OnInitializeCallCount;
+
+        sut.Initialize();
+
+        Assert.AreEqual(baseline + 1, sut.OnInitializeCallCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> clears the residual buffer and resets
+    /// both the residual byte count and the running byte total to zero, regardless of any prior seeded state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterSeededState_ShouldClearResidualAndCounters()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm(8);
+        sut.SeedResidualState(new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 }, residualBytes: 5, totalBytes: 256UL);
+
+        sut.Initialize();
+
+        Assert.AreEqual(0, sut.ResidualBytesSnapshot);
+        Assert.AreEqual(0UL, sut.TotalBytesSnapshot);
+        CollectionAssert.AreEqual(new byte[8], sut.ResidualBufferSnapshot);
+    }
+
+    /// <summary>
+    /// Verifies that repeated calls to <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> invoke
+    /// <see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> on every call, ensuring derived state is rebuilt
+    /// each time.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledMultipleTimes_ShouldInvokeOnInitializeEachTime()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm();
+        int baseline = sut.OnInitializeCallCount;
+
+        sut.Initialize();
+        sut.Initialize();
+        sut.Initialize();
+
+        Assert.AreEqual(baseline + 3, sut.OnInitializeCallCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BufferedBlockHashAlgorithm{T}.Dispose(bool)" /> invokes
+    /// <see cref="BufferedBlockHashAlgorithm{T}.OnDispose(bool)" /> exactly once with <c>disposing == true</c>.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledOnce_ShouldInvokeOnDisposeWithDisposingTrue()
+    {
+        var sut = new MonitoringBufferedBlockHashAlgorithm();
+
+        sut.Dispose();
+
+        Assert.AreEqual(1, sut.OnDisposeCallCount);
+        Assert.IsTrue(sut.LastDisposeFlag == true);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="BufferedBlockHashAlgorithm{T}.Dispose(bool)" /> twice invokes
+    /// <see cref="BufferedBlockHashAlgorithm{T}.OnDispose(bool)" /> only once, in line with the standard
+    /// <see cref="IDisposable" /> idempotency contract.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldInvokeOnDisposeOnce()
+    {
+        var sut = new MonitoringBufferedBlockHashAlgorithm();
+
+        sut.Dispose();
+        sut.Dispose();
+
+        Assert.AreEqual(1, sut.OnDisposeCallCount);
+    }
+
+    /// <summary>
+    /// Verifies that disposal clears the residual buffer and resets both counters, ensuring that no secret material
+    /// survives in the buffer after the algorithm has been released.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalled_ShouldClearResidualAndCounters()
+    {
+        var sut = new MonitoringBufferedBlockHashAlgorithm(8);
+        sut.SeedResidualState(new byte[] { 9, 9, 9, 9, 9, 9, 9, 9 }, residualBytes: 8, totalBytes: 128UL);
+
+        sut.Dispose();
+
+        Assert.AreEqual(0, sut.ResidualBytesSnapshot);
+        Assert.AreEqual(0UL, sut.TotalBytesSnapshot);
+        CollectionAssert.AreEqual(new byte[8], sut.ResidualBufferSnapshot);
+    }
+
+    /// <summary>
+    /// Verifies that <c>HashCore(byte[], int, int)</c> throws <see cref="ArgumentNullException" /> when the input
+    /// array is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void HashCore_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm();
+
+        _ = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.InvokeHashCore(null!, 0, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>HashCore(byte[], int, int)</c> forwards to the span overload with the requested slice
+    /// length, so derived classes that override only the span overload still see input from the byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public void HashCore_WhenCalledWithSlice_ShouldForwardSliceLengthToSpanOverload()
+    {
+        using var sut = new MonitoringBufferedBlockHashAlgorithm();
+        byte[] input = new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+
+        sut.InvokeHashCore(input, ibStart: 2, cbSize: 5);
+        sut.InvokeHashCore(input, ibStart: 0, cbSize: 0);
+        sut.InvokeHashCore(input, ibStart: 0, cbSize: input.Length);
+
+        CollectionAssert.AreEqual(new[] { 5, 0, input.Length }, sut.CapturedSpanLengths);
+    }
+
+    /// <summary>
+    /// Verifies that <c>HashCore(byte[], int, int)</c> throws <see cref="ObjectDisposedException" /> after the
+    /// algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void HashCore_WhenCalledAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        var sut = new MonitoringBufferedBlockHashAlgorithm();
+        sut.Dispose();
+
+        _ = Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            sut.InvokeHashCore(new byte[1], 0, 1);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/DeferredFinalBlockHashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/DeferredFinalBlockHashAlgorithmTests.cs
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DeferredFinalBlockHashAlgorithmTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Verifies the deferred-final-block buffering contract exposed by
+/// <see cref="DeferredFinalBlockHashAlgorithm{T}" />: the rule that the residual block is not compressed at the
+/// point it fills (so that <c>isFinal: true</c> can be raised on it later), the per-block counter values, and the
+/// behaviour of the finalisation pad-and-compress step across empty, sub-block, exact-block, and multi-block inputs.
+/// </summary>
+[TestClass]
+public sealed class DeferredFinalBlockHashAlgorithmTests
+{
+    private const int BlockSize = 8;
+
+    /// <summary>
+    /// Verifies that hashing an empty input produces exactly one compression call with
+    /// <c>isFinal == true</c> and a counter of zero (no bytes have been processed).
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsEmpty_ShouldInvokeProcessBlockOnceWithFinalFlagAndZeroCounter()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+
+        _ = sut.ComputeHash(Array.Empty<byte>());
+
+        Assert.AreEqual(1, sut.ProcessBlockInvocations.Count);
+        Assert.IsTrue(sut.ProcessBlockInvocations[0].IsFinal);
+        Assert.AreEqual(0UL, sut.ProcessBlockInvocations[0].Counter);
+    }
+
+    /// <summary>
+    /// Verifies that an input of exactly one block is deferred until <c>HashFinal</c> and then compressed once with
+    /// <c>isFinal == true</c> and a counter equal to <see cref="BlockSize" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsExactlyOneBlock_ShouldInvokeProcessBlockOnceWithFinalFlagAndBlockSizeCounter()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+
+        _ = sut.ComputeHash(SequentialBytes(BlockSize));
+
+        Assert.AreEqual(1, sut.ProcessBlockInvocations.Count);
+        Assert.IsTrue(sut.ProcessBlockInvocations[0].IsFinal);
+        Assert.AreEqual((ulong)BlockSize, sut.ProcessBlockInvocations[0].Counter);
+    }
+
+    /// <summary>
+    /// Verifies that <c>BlockSize + 1</c> bytes produce two compression calls: the held first block fires with
+    /// <c>isFinal == false</c> and counter <see cref="BlockSize" />, and the trailing single byte fires from
+    /// <c>HashFinal</c> with <c>isFinal == true</c> and counter <c>BlockSize + 1</c>.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsBlockSizePlusOne_ShouldInvokeProcessBlockTwiceWithCorrectCountersAndFlags()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+
+        _ = sut.ComputeHash(SequentialBytes(BlockSize + 1));
+
+        Assert.AreEqual(2, sut.ProcessBlockInvocations.Count);
+
+        Assert.IsFalse(sut.ProcessBlockInvocations[0].IsFinal);
+        Assert.AreEqual((ulong)BlockSize, sut.ProcessBlockInvocations[0].Counter);
+
+        Assert.IsTrue(sut.ProcessBlockInvocations[1].IsFinal);
+        Assert.AreEqual((ulong)(BlockSize + 1), sut.ProcessBlockInvocations[1].Counter);
+    }
+
+    /// <summary>
+    /// Verifies that exactly two blocks of input fire the first compression with <c>isFinal == false</c> and the
+    /// second (deferred) compression with <c>isFinal == true</c> and a counter of <c>2 * BlockSize</c>.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsExactlyTwoBlocks_ShouldInvokeProcessBlockTwiceWithCorrectCountersAndFlags()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+
+        _ = sut.ComputeHash(SequentialBytes(2 * BlockSize));
+
+        Assert.AreEqual(2, sut.ProcessBlockInvocations.Count);
+
+        Assert.IsFalse(sut.ProcessBlockInvocations[0].IsFinal);
+        Assert.AreEqual((ulong)BlockSize, sut.ProcessBlockInvocations[0].Counter);
+
+        Assert.IsTrue(sut.ProcessBlockInvocations[1].IsFinal);
+        Assert.AreEqual((ulong)(2 * BlockSize), sut.ProcessBlockInvocations[1].Counter);
+    }
+
+    /// <summary>
+    /// Verifies that <c>2 * BlockSize + 1</c> bytes produce three compression calls with the expected counter
+    /// progression: <c>(false, BlockSize)</c>, <c>(false, 2 * BlockSize)</c>, <c>(true, 2 * BlockSize + 1)</c>.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsTwoBlocksPlusOne_ShouldInvokeProcessBlockThreeTimesWithCorrectCountersAndFlags()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+
+        _ = sut.ComputeHash(SequentialBytes((2 * BlockSize) + 1));
+
+        Assert.AreEqual(3, sut.ProcessBlockInvocations.Count);
+
+        Assert.IsFalse(sut.ProcessBlockInvocations[0].IsFinal);
+        Assert.AreEqual((ulong)BlockSize, sut.ProcessBlockInvocations[0].Counter);
+
+        Assert.IsFalse(sut.ProcessBlockInvocations[1].IsFinal);
+        Assert.AreEqual((ulong)(2 * BlockSize), sut.ProcessBlockInvocations[1].Counter);
+
+        Assert.IsTrue(sut.ProcessBlockInvocations[2].IsFinal);
+        Assert.AreEqual((ulong)((2 * BlockSize) + 1), sut.ProcessBlockInvocations[2].Counter);
+    }
+
+    /// <summary>
+    /// Verifies that the residual buffer is zero-padded for inputs whose length is not a multiple of the block size,
+    /// so the final compression observes a well-defined block (data bytes followed by zeros).
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInputIsSubBlock_ShouldZeroPadFinalBlockAndReportActualByteCounter()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+        byte[] input = new byte[] { 0xAA, 0xBB, 0xCC };
+
+        _ = sut.ComputeHash(input);
+
+        Assert.AreEqual(1, sut.ProcessBlockInvocations.Count);
+
+        var (block, counter, isFinal) = sut.ProcessBlockInvocations[0];
+        Assert.IsTrue(isFinal);
+        Assert.AreEqual(3UL, counter);
+
+        byte[] expected = new byte[BlockSize];
+        input.CopyTo(expected, 0);
+        CollectionAssert.AreEqual(expected, block);
+    }
+
+    /// <summary>
+    /// Verifies that recomputing the same input after the algorithm has been re-initialised produces an identical
+    /// invocation sequence (same block payloads, counters, and finalisation flags), confirming that
+    /// <c>Initialize</c> resets the inherited residual buffer and counter via the grandparent.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedTwiceWithIdenticalInput_ShouldProduceIdenticalInvocationSequence()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+        byte[] input = SequentialBytes((2 * BlockSize) + 3);
+
+        _ = sut.ComputeHash(input);
+        var firstRun = sut.ProcessBlockInvocations
+            .Select(invocation => (Block: (byte[])invocation.Block.Clone(), invocation.Counter, invocation.IsFinal))
+            .ToArray();
+
+        sut.ResetCapture();
+        _ = sut.ComputeHash(input);
+        var secondRun = sut.ProcessBlockInvocations.ToArray();
+
+        Assert.AreEqual(firstRun.Length, secondRun.Length);
+        for (int i = 0; i < firstRun.Length; i++)
+        {
+            Assert.AreEqual(firstRun[i].Counter, secondRun[i].Counter, $"Counter mismatch at invocation {i}.");
+            Assert.AreEqual(firstRun[i].IsFinal, secondRun[i].IsFinal, $"IsFinal mismatch at invocation {i}.");
+            CollectionAssert.AreEqual(firstRun[i].Block, secondRun[i].Block, $"Block payload mismatch at invocation {i}.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <c>Initialize</c> propagates through to the <see cref="DeferredFinalBlockHashAlgorithm{T}.OnInitialize" />
+    /// hook, ensuring derived algorithm-specific state is reset on every <c>ComputeHash</c> call.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalled_ShouldInvokeOnInitialize()
+    {
+        using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
+        int baseline = sut.OnInitializeCallCount;
+
+        sut.Initialize();
+
+        Assert.AreEqual(baseline + 1, sut.OnInitializeCallCount);
+    }
+
+    private static byte[] SequentialBytes(int length)
+    {
+        byte[] result = new byte[length];
+        for (int i = 0; i < length; i++)
+            result[i] = unchecked((byte)i);
+        return result;
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MonitoringBufferedBlockHashAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Test-oriented derivation of <see cref="BufferedBlockHashAlgorithm{T}" /> that records each call to the
+/// hooks defined by the base class and exposes the protected residual-buffer state for assertion. Used to
+/// verify the buffered-block contract in isolation without depending on any concrete cryptographic algorithm.
+/// </summary>
+public sealed class MonitoringBufferedBlockHashAlgorithm
+    : BufferedBlockHashAlgorithm<MonitoringBufferedBlockHashAlgorithm>
+{
+    /// <summary>
+    /// Lengths of every span passed to <see cref="HashCore(ReadOnlySpan{byte})" />, in invocation order. Lets tests
+    /// verify that the byte-array overload forwarded to the span overload with the expected slice length.
+    /// </summary>
+    public List<int> CapturedSpanLengths { get; } = new();
+
+    /// <summary>
+    /// Number of times <see cref="OnInitialize" /> has been invoked across the lifetime of the instance.
+    /// </summary>
+    public int OnInitializeCallCount { get; private set; }
+
+    /// <summary>
+    /// Number of times <see cref="OnDispose(bool)" /> has been invoked across the lifetime of the instance.
+    /// </summary>
+    public int OnDisposeCallCount { get; private set; }
+
+    /// <summary>
+    /// Captures the <c>disposing</c> argument from the most recent invocation of <see cref="OnDispose(bool)" />, or
+    /// <see langword="null" /> if it has never been invoked.
+    /// </summary>
+    public bool? LastDisposeFlag { get; private set; }
+
+    /// <summary>
+    /// Initialises a new instance with the default 8-byte block size.
+    /// </summary>
+    public MonitoringBufferedBlockHashAlgorithm()
+        : this(8)
+    {
+    }
+
+    /// <summary>
+    /// Initialises a new instance with the specified block size.
+    /// </summary>
+    /// <param name="blockSize">The block size, in bytes, to forward to the base constructor.</param>
+    public MonitoringBufferedBlockHashAlgorithm(int blockSize)
+        : base(blockSize)
+    {
+    }
+
+    /// <summary>
+    /// Gets a snapshot of the current residual byte count owned by the base class.
+    /// </summary>
+    /// <returns>The number of bytes currently held in the residual buffer.</returns>
+    public int ResidualBytesSnapshot => this._residualBytes;
+
+    /// <summary>
+    /// Gets a snapshot of the running byte total owned by the base class.
+    /// </summary>
+    /// <returns>The total number of bytes consumed so far, as tracked by the base class.</returns>
+    public ulong TotalBytesSnapshot => this._totalBytes;
+
+    /// <summary>
+    /// Gets the block size that was supplied to the base constructor.
+    /// </summary>
+    /// <returns>The configured block size, in bytes.</returns>
+    public int ConfiguredBlockSize => this.BlockSizeBytes;
+
+    /// <summary>
+    /// Gets a defensive copy of the residual buffer for test assertion purposes.
+    /// </summary>
+    /// <returns>A new byte array of length <see cref="ConfiguredBlockSize" /> containing the current residual bytes.</returns>
+    public byte[] ResidualBufferSnapshot => this._residualBlock.ToArray();
+
+    /// <summary>
+    /// Public test seam exposing the protected
+    /// <see cref="System.Security.Cryptography.HashAlgorithm.HashCore(byte[], int, int)" /> overload so tests may
+    /// drive it directly without going through <c>ComputeHash</c> (which performs its own validation before reaching
+    /// the override).
+    /// </summary>
+    /// <param name="array">The input byte array.</param>
+    /// <param name="ibStart">The start index in <paramref name="array" />.</param>
+    /// <param name="cbSize">The number of bytes to read from <paramref name="array" />.</param>
+    public void InvokeHashCore(byte[] array, int ibStart, int cbSize) =>
+        this.HashCore(array, ibStart, cbSize);
+
+    /// <summary>
+    /// Seeds the residual buffer to a known state so tests may verify that <see cref="BufferedBlockHashAlgorithm{T}.Initialize" />
+    /// and <see cref="BufferedBlockHashAlgorithm{T}.Dispose(bool)" /> clear it.
+    /// </summary>
+    /// <param name="data">The bytes to copy into the residual buffer. Must not exceed the configured block size.</param>
+    /// <param name="residualBytes">The residual byte count to record.</param>
+    /// <param name="totalBytes">The total byte count to record.</param>
+    public void SeedResidualState(byte[] data, int residualBytes, ulong totalBytes)
+    {
+        data.AsSpan().CopyTo(this._residualBlock.Span);
+        this._residualBytes = residualBytes;
+        this._totalBytes = totalBytes;
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        this.OnInitializeCallCount++;
+    }
+
+    /// <inheritdoc />
+    protected override void OnDispose(bool disposing)
+    {
+        this.OnDisposeCallCount++;
+        this.LastDisposeFlag = disposing;
+    }
+
+    /// <inheritdoc />
+    protected override void HashCore(ReadOnlySpan<byte> source)
+    {
+        this.CapturedSpanLengths.Add(source.Length);
+    }
+
+    /// <inheritdoc />
+    protected override byte[] HashFinal() =>
+        Array.Empty<byte>();
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MonitoringDeferredFinalBlockHashAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Test-oriented derivation of <see cref="DeferredFinalBlockHashAlgorithm{T}" /> that captures a copy of every
+/// <see cref="ProcessBlock(ReadOnlySpan{byte}, ulong, bool)" /> invocation along with its counter and finalisation
+/// flag. Used to verify the deferred-final-block buffering contract in isolation.
+/// </summary>
+public sealed class MonitoringDeferredFinalBlockHashAlgorithm
+    : DeferredFinalBlockHashAlgorithm<MonitoringDeferredFinalBlockHashAlgorithm>
+{
+    /// <summary>
+    /// Recorded <see cref="ProcessBlock(ReadOnlySpan{byte}, ulong, bool)" /> invocations in invocation order. Each
+    /// entry holds a defensive copy of the block bytes (the underlying span lives in the inherited residual buffer
+    /// and is overwritten by subsequent input).
+    /// </summary>
+    public List<(byte[] Block, ulong Counter, bool IsFinal)> ProcessBlockInvocations { get; } = new();
+
+    /// <summary>
+    /// Number of times <see cref="OnInitialize" /> has been invoked across the lifetime of the instance.
+    /// </summary>
+    public int OnInitializeCallCount { get; private set; }
+
+    /// <summary>
+    /// Initialises a new instance with the default 8-byte block size and an 8-bit digest.
+    /// </summary>
+    public MonitoringDeferredFinalBlockHashAlgorithm()
+        : this(8)
+    {
+    }
+
+    /// <summary>
+    /// Initialises a new instance with the specified block size and an 8-bit digest size (so that the
+    /// <see cref="System.Security.Cryptography.HashAlgorithm" /> infrastructure has a non-zero
+    /// <c>HashSize</c> when <c>ComputeHash</c> is invoked).
+    /// </summary>
+    /// <param name="blockSize">The block size, in bytes, to forward to the base constructor.</param>
+    public MonitoringDeferredFinalBlockHashAlgorithm(int blockSize)
+        : base(blockSize)
+    {
+        this.HashSizeValue = 8;
+    }
+
+    /// <summary>
+    /// Clears the recorded invocation log so that subsequent calls capture only fresh activity. Does not affect
+    /// algorithm state &#8212; use <see cref="System.Security.Cryptography.HashAlgorithm.Initialize" /> for that.
+    /// </summary>
+    public void ResetCapture()
+    {
+        this.ProcessBlockInvocations.Clear();
+    }
+
+    /// <inheritdoc />
+    protected override void OnInitialize()
+    {
+        this.OnInitializeCallCount++;
+    }
+
+    /// <inheritdoc />
+    protected override void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
+    {
+        this.ProcessBlockInvocations.Add((block.ToArray(), totalBytesIncludingThisBlock, isFinal));
+    }
+
+    /// <inheritdoc />
+    protected override byte[] ProcessFinalBlock() =>
+        new byte[] { (byte)this.ProcessBlockInvocations.Count };
+}


### PR DESCRIPTION
## Context

`Blake2b` and `Blake2s` previously inherited `HashAlgorithm` directly and duplicated ~80 lines each of residual buffering, total-byte tracking, "defer the last full block" rule, and finalisation-flag plumbing. The existing `BlockHashAlgorithm<T>` could not host them: its compression hook has no `isFinal` flag and its `HashCore` compresses every full block immediately, which breaks Blake's invariant that the last compression must carry the finalisation flag.

This PR introduces a sibling base for the Blake-family pattern, lifts the shared plumbing into a common grandparent, and migrates Blake2b/Blake2s onto the new base — with no public API change to any concrete algorithm.

## Final inheritance shape

```
HashAlgorithm
└── BufferedBlockHashAlgorithm<T>                 [NEW]   residual buffer, totals, dispose, HashCore delegation
    ├── BlockHashAlgorithm<T>                     [REPARENTED]   Merkle–Damgård + PadBlock + ProcessFinalBlock
    │   └── KeyedBlockHashAlgorithm<T>            [unchanged]
    │       └── SipHash<T>, Poly1305, Skein<T>    [unchanged]
    └── DeferredFinalBlockHashAlgorithm<T>        [NEW]   defer-last-full-block + (block, counter, isFinal) hook
        ├── Blake2b                               [REPARENTED, ~95 LoC deleted]
        └── Blake2s                               [REPARENTED, ~94 LoC deleted]
```

## Commits in order

1. **`introduce BufferedBlockHashAlgorithm<T> grandparent`** — new abstract grandparent owning `_residualBlock`, `_residualBytes`, `_totalBytes`, the disposal latch, the .NET-Standard `_finalized` flag, and the `HashCore(byte[], int, int) → HashCore(ReadOnlySpan<byte>)` forwarding override. Re-marks `HashCore(ReadOnlySpan<byte>)` as `abstract` so the type system blocks the infinite-recursion trap that would otherwise occur if a derived class only overrode the byte-array overload. Self-contained MSTest fixture driven by a `MonitoringBufferedBlockHashAlgorithm` stub verifies constructor validation, `Initialize`/`Dispose` hook invocation, residual-buffer clearing, and byte-array→span forwarding.

2. **`reparent BlockHashAlgorithm<T> onto BufferedBlockHashAlgorithm<T>`** — migrates the residual buffer (renamed `_residualByteBuffer → _residualBlock`), running counter (renamed `_totalLength → _totalBytes`), disposal latch, helpers, and byte-array `HashCore` override into the grandparent. `BlockHashAlgorithm<T>` retains the Merkle–Damgård-specific contract (`PadBlock`, `ProcessBlock`, `ProcessFinalBlock`, `ShouldPadFinalBlock`, `AllowUnalignedFinalBlock`, the immediate-fire-on-full-block buffering loop, and the pad-then-process orchestration). Empty `OnInitialize()` override satisfies the grandparent's abstract contract — the Merkle–Damgård base owns no algorithm-side state of its own.

3. **`add DeferredFinalBlockHashAlgorithm<T> sibling base`** — sibling to `BlockHashAlgorithm<T>` for the Blake-family pattern. Implements the defer-on-full-block buffering loop matching `Blake2b.cs:240-263` line-for-line, and the zero-pad-then-finalise step in `HashFinal`. Abstract `ProcessBlock(ReadOnlySpan<byte>, ulong totalBytesIncludingThisBlock, bool isFinal)` exposes the per-block counter and finalisation flag. Stub-driven MSTest fixture verifies the counter progression for empty / sub-block / exact-block / `BlockSize+1` / exactly-2-blocks / 2-blocks-plus-1 inputs, plus reuse-after-`Initialize` and zero-padding of partial final blocks.

4. **`port Blake2b to DeferredFinalBlockHashAlgorithm<T>`** — switches inheritance, deletes ~95 lines of duplicated plumbing, renames `Compress(byte[], ulong, bool) → ProcessBlock(ReadOnlySpan<byte>, ulong, bool)`. Compression body (sigma table, IV, working vector, 12 rounds of G mixing, finalisation-flag inversion via `v[14]`) is byte-for-byte identical. `OnInitialize` calls existing private `InitializeState`; `OnDispose` clears the chaining state `_h`, releases `HashValue`, and zeros `HashSizeValue`. **Existing Blake2b vector and streaming tests are the regression gate.**

5. **`port Blake2s to DeferredFinalBlockHashAlgorithm<T>`** — identical refactor shape to Blake2b, block size 64, 32-bit state words, 10-round G mixing, counter split into low/high 32-bit halves XOR'd into `v[12]`/`v[13]`. Same regression gate.

## What's deliberately deferred

- `KeyedDeferredFinalBlockHashAlgorithm<T>` — Blake2b's keyed-MAC mode is not currently exposed (`Blake2b.cs:30-31`: *"Keyed and tree-hashing modes are not currently exposed; this implementation targets the sequential, unkeyed digest profile."*), so a keyed variant of the new base would have zero consumers today. Per `CLAUDE.md`'s "don't introduce abstractions beyond what the task requires", deferred until either keyed mode is enabled or a second keyed Blake-family algorithm (Blake3 keyed mode, KangarooTwelve) lands.
- `IncrementalCoverageBytes` on `HashAlgorithmSpecification` and the consolidated incremental-input test harness — separate work item that builds on top of this refactor.
- Reparenting `Sha3`, `Shake`, `Blake3`, `CubeHash` — sponge / tree shapes are different state machines; out of scope for this PR.

## Verification

`dotnet build Bodu.sln` should be clean (no analyser warnings — `bld/Bodu.props` escalates CS1591/CS1574/etc. to errors).
`dotnet test Bodu.sln --settings test.runsettings` should be green:
- All existing Tiger / Whirlpool / AsconHash / Snefru / SipHash (64+128) / Poly1305 / Skein / Blake2b / Blake2s vector and streaming tests pass unchanged (the reparent regression gate).
- New stub-driven `BufferedBlockHashAlgorithmTests` and `DeferredFinalBlockHashAlgorithmTests` pass (the new-base contract gate).

The plan that drove this refactor is in `/root/.claude/plans/okay-prepare-a-plan-radiant-puppy.md` (local sandbox path).

## Risks worth flagging in review

- **Counter off-by-one** is the highest-risk regression. Mitigation: the `DeferredFinalBlockHashAlgorithm` stub test pins `(false, BlockSize)`, `(true, BlockSize)`, `(false, BlockSize) + (true, BlockSize+1)`, `(false, BlockSize) + (true, 2·BlockSize)`, and `(false, BlockSize) + (false, 2·BlockSize) + (true, 2·BlockSize+1)` before any Blake porting happens; Blake2 vector tests confirm end-to-end.
- **`byte[] → ReadOnlySpan<byte>` parameter switch** in the renamed `Compress → ProcessBlock`. Audited the body — the only `block`-typed reference inside is the loop reading 16 little-endian words, which uses `block.Slice(i * N, N)` (works identically on span vs array-as-span). No `Array.Clear`, indexer assignment, or `byte[]`-only API call inside.

---
_Generated by [Claude Code](https://claude.ai/code/session_011aJZxmGyRmWbvfR52SPDwh)_