### PR TITLE
fix(Calendar): un-ignore AU notable-date tests

### DIFF
--- a/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
+++ b/Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj
@@ -41,6 +41,7 @@
 
   <ItemGroup>
     <None Remove="Globalization.Calendar.Resources\christian-gregorian.xml" />
+    <None Remove="Globalization.Calendar.Resources\christian-orthodox.xml" />
     <None Remove="Globalization.Calendar.Resources\global-all.xml" />
     <None Remove="Globalization.Calendar.Resources\global-core.xml" />
     <None Remove="Globalization.Calendar.Resources\global-cultural.xml" />
@@ -83,6 +84,7 @@
 
   <ItemGroup>
     <EmbeddedResource Include="Globalization.Calendar.Resources\christian-gregorian.xml" />
+    <EmbeddedResource Include="Globalization.Calendar.Resources\christian-orthodox.xml" />
     <EmbeddedResource Include="Globalization.Calendar.Resources\global-all.xml" />
     <EmbeddedResource Include="Globalization.Calendar.Resources\global-core.xml" />
     <EmbeddedResource Include="Globalization.Calendar.Resources\global-cultural.xml" />

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustralianNotableDatesTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustralianNotableDatesTests.cs
@@ -36,7 +36,6 @@ namespace Bodu.Globalization.Calendar
 		/// year 2026, when none of them collide with a weekend.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAu_ShouldIncludeNationalRules_ForYear2026()
 		{
 			var service = BuildAuService();
@@ -54,7 +53,6 @@ namespace Bodu.Globalization.Calendar
 		/// non-working Monday observance, with the adjusted occurrence carrying an <see cref="NotableDate.AdjustmentReason" />.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenAustraliaDayFallsOnSunday_ShouldEmitMondaySubstitute()
 		{
 			var service = BuildAuService();
@@ -77,7 +75,6 @@ namespace Bodu.Globalization.Calendar
 		/// returning the New South Wales Labour Day, demonstrating that subdivision-scoped rules survive the composite-key flatten.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAuVic_ShouldIncludeVictoriaLabourDay_AndExcludeNswLabourDay()
 		{
 			var service = BuildAuService();
@@ -95,7 +92,6 @@ namespace Bodu.Globalization.Calendar
 		/// and not the Victorian variant.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAuNsw_ShouldIncludeNswLabourDay_AndExcludeVictoriaLabourDay()
 		{
 			var service = BuildAuService();
@@ -114,7 +110,6 @@ namespace Bodu.Globalization.Calendar
 		/// contract that lets callers delineate national entries from subdivision-specific ones in the produced list.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAu_ShouldPreserveTerritoryCodeOnEveryEntry_ForDelineation()
 		{
 			var service = BuildAuService();
@@ -139,7 +134,6 @@ namespace Bodu.Globalization.Calendar
 		/// the statutory change that moved the holiday out of June.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAuQld_ShouldResolveKingsBirthdayToOctober_ForYear2026()
 		{
 			var service = BuildAuService();
@@ -156,7 +150,6 @@ namespace Bodu.Globalization.Calendar
 		/// <c>firstYear</c> bound.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAuAct_ForYear2017_ShouldNotIncludeReconciliationDay()
 		{
 			var service = BuildAuService();
@@ -170,7 +163,6 @@ namespace Bodu.Globalization.Calendar
 		/// Verifies that Reconciliation Day appears for the ACT from 2018 onwards and resolves to a Monday in late May.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAuAct_ForYear2018_ShouldIncludeReconciliationDay()
 		{
 			var service = BuildAuService();
@@ -188,7 +180,6 @@ namespace Bodu.Globalization.Calendar
 		/// statutory definition "the Tuesday in the week in which the first Tuesday in November occurs".
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenMelbourneCupDay_ForYear2026_ShouldResolveToFirstTuesdayOfNovember()
 		{
 			var service = BuildAuService();
@@ -206,7 +197,6 @@ namespace Bodu.Globalization.Calendar
 		/// 2026 falls on a Saturday and the national Boxing Day rule rolls weekend occurrences forward.
 		/// </summary>
 		[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void IsNonWorkingDay_WhenBoxingDayOnSaturday_ShouldReturnTrueForSubstituteMonday_ForAuNsw()
 		{
 			var service = BuildAuService();
@@ -228,7 +218,6 @@ namespace Bodu.Globalization.Calendar
 		[DataRow("AU-TAS")]
 		[DataRow("AU-NT")]
 		[DataRow("AU-ACT")]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenQueryingAnySubdivision_ShouldIncludeNationalAnzacDay_ForYear2026(string subdivision)
 		{
 			var service = BuildAuService();
@@ -248,8 +237,6 @@ namespace Bodu.Globalization.Calendar
 	/// both the original Saturday observance and the adjusted Monday substitute scoped to <c>AU-WA</c>.
 	/// </summary>
 	[TestMethod]
-	[Ignore("TODO: Need to investigate and fix the failure in this test, which is currently emitting the substitute Monday but without the expected AU-WA territory code or WasAdjusted flag.")]
-
         public void GetNotableDates_WhenAnzacDayOnSaturday_ShouldEmitMondaySubstitute_ForAuWa()
 	{
 		var service = BuildAuService();
@@ -274,7 +261,6 @@ namespace Bodu.Globalization.Calendar
 	/// only the original observance is emitted, reflecting the per-state divergence in Anzac Day weekend treatment.
 	/// </summary>
 	[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenAnzacDayOnSaturday_ShouldNotEmitSubstitute_ForAuNsw()
 	{
 		var service = BuildAuService();
@@ -292,7 +278,6 @@ namespace Bodu.Globalization.Calendar
 	/// Verifies that the Northern Territory observes a substitute Monday when Anzac Day falls on a Sunday (25 April 2021).
 	/// </summary>
 	[TestMethod]
-        [Ignore("TODO: Need to investigate and fix the failure in this test")]
         public void GetNotableDates_WhenAnzacDayOnSunday_ShouldEmitMondaySubstitute_ForAuNt()
 	{
 		var service = BuildAuService();

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
@@ -277,7 +277,6 @@ public sealed partial class NotableDateServiceTests
 	/// successfully and yields at least one notable date for a common year.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void Constructor_WhenParameterless_ShouldLoadEmbeddedResourceWithoutThrowing()
 	{
 		var service = new NotableDateService();

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceNotableDateRuleProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/XmlResourceNotableDateRuleProviderTests.cs
@@ -27,7 +27,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
     /// Verifies that loading the standalone Common resource exposes its rules without errors.
     /// </summary>
     [TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingCommonResource_ShouldExposeUniversalRules()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(CommonResource, new ResourcePathResolver());
@@ -44,7 +43,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// include any rule that the US file did not opt in to (for example, Easter Monday or Whit Monday).
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingUsResource_ShouldOnlyIncludeCherryPickedRules()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(UsResource, new ResourcePathResolver());
@@ -77,7 +75,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// and tags the territory.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenUseDirectiveAppliesOverrides_ShouldRetagInheritedRule()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(UsResource, new ResourcePathResolver());
@@ -93,7 +90,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// independent of what other country files do.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingGbResource_ShouldIncludeEasterMonday()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(GbResource, new ResourcePathResolver());
@@ -109,7 +105,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// Verifies that locally declared rules in a country file override the inherited rule with the same (name, territory) key.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLocalRuleOverridesInheritedRule_ShouldUseLocalRule()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(GbResource, new ResourcePathResolver());
@@ -126,7 +121,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// absent (because France did not cherry-pick it).
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenFrResource_ShouldExposeLocalNamesOnly()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(FrResource, new ResourcePathResolver());
@@ -143,7 +137,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// but no country-specific rules.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingDefaultComposite_ShouldExposeUniversalRulesViaUseAll()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(DefaultResource, new ResourcePathResolver());
@@ -164,7 +157,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// national and state-specific rules, and excludes any rule the AU file did not opt in to.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingAuResource_ShouldIncludeCherryPickedAndLocalRules()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(AuResource, new ResourcePathResolver());
@@ -210,7 +202,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// Birthday") when they are scoped to different subdivisions, since the override pipeline keys by composite (name, territory).
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingAuResource_ShouldYieldDistinctLabourDayAndKingsBirthdayRulesPerSubdivision()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(AuResource, new ResourcePathResolver());
@@ -243,7 +234,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// day, so that all subdivisions inherit it via the subdivision-aware containment match in <see cref="NotableDateService" />.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenLoadingAuResource_ShouldTagAnzacDayAsNationalNonWorkingDay()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(AuResource, new ResourcePathResolver());
@@ -286,7 +276,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// the supplied assembly rather than the currently-executing one.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void Constructor_WhenAssemblyOverrideSupplied_ShouldUseSuppliedAssembly()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(
@@ -306,7 +295,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// materialised the list.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenCalledTwice_ShouldReturnCachedResult()
 	{
 		var provider = new XmlResourceNotableDateRuleProvider(CommonResource, new ResourcePathResolver());
@@ -323,7 +311,6 @@ public sealed class XmlResourceNotableDateRuleProviderTests
 	/// for it. This test confirms the contract by verifying that the US set is a strict subset of Common's universal rules.
 	/// </summary>
 	[TestMethod]
-    [Ignore("TODO: Need to investigate and fix the failure in this test")]
     public void LoadRules_WhenSourceContainsRulesNotCherryPicked_ShouldNotInheritThem()
 	{
 		var common = new XmlResourceNotableDateRuleProvider(CommonResource, new ResourcePathResolver()).LoadRules().Select(r => r.Name).ToHashSet();


### PR DESCRIPTION
## Summary

- Removes `[Ignore]` from all 14 tests in `AustralianNotableDatesTests` (AU national, subdivision, weekend-substitute, and `firstYear` scenarios)
- Removes `[Ignore]` from all 15 tests in `XmlResourceNotableDateRuleProviderTests` (resource loading, cherry-pick, override, and AU-specific rule-set checks)
- Removes `[Ignore]` from the parameterless-constructor smoke test in `NotableDateServiceTests`

These tests were silenced in commit `6ee61f7` / `8b6c39d` to get to a passing baseline. This PR re-enables them so CI can identify which (if any) still fail and publish the results as comments.

## Test plan

- [ ] CI runs the calendar test project and reports pass/fail per test
- [ ] Any remaining failures are posted as PR comments for investigation
- [ ] The Orthodox Easter `[Ignore]` (tracked by #53) is intentionally left in place

https://claude.ai/code/session_01PDcgH8r2wE5sywM7drpVDh

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDcgH8r2wE5sywM7drpVDh)_