### PR TITLE
Consolidate Blake2 sigma table and align MerkleTree factory API

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2Constants.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2Constants.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake2Constants.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Provides constants shared across BLAKE2 algorithm variants.
+/// </summary>
+internal static class Blake2Constants
+{
+    /// <summary>
+    /// The BLAKE2 sigma permutation schedule: 10 rows of 16 message-word indices used to select
+    /// the two message words fed into each <c>G</c> mixing call per round. Both BLAKE2b (12 rounds)
+    /// and BLAKE2s (10 rounds) use the same table, wrapping modulo 10 when the round count exceeds
+    /// the row count.
+    /// </summary>
+    internal static readonly byte[][] Sigma = new byte[10][]
+    {
+        new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
+        new byte[] { 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 },
+        new byte[] { 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 },
+        new byte[] { 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 },
+        new byte[] { 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 },
+        new byte[] { 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 },
+        new byte[] { 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 },
+        new byte[] { 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 },
+        new byte[] { 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 },
+        new byte[] { 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 },
+    };
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -62,23 +62,6 @@ public sealed class Blake2b : DeferredFinalBlockHashAlgorithm<Blake2b>
     };
 
     /// <summary>
-    /// The BLAKE2 sigma permutation table (10 rows; rounds 10 and 11 wrap back to rows 0 and 1).
-    /// </summary>
-    private static readonly byte[][] s_sigma = new byte[10][]
-    {
-        new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
-        new byte[] { 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 },
-        new byte[] { 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 },
-        new byte[] { 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 },
-        new byte[] { 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 },
-        new byte[] { 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 },
-        new byte[] { 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 },
-        new byte[] { 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 },
-        new byte[] { 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 },
-        new byte[] { 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 },
-    };
-
-    /// <summary>
     /// The eight 64-bit internal hash state words.
     /// </summary>
     private readonly ulong[] _h = new ulong[8];
@@ -240,7 +223,7 @@ public sealed class Blake2b : DeferredFinalBlockHashAlgorithm<Blake2b>
         // 12 rounds of G mixing.
         for (int r = 0; r < 12; r++)
         {
-            byte[] s = s_sigma[r % 10];
+            byte[] s = Blake2Constants.Sigma[r % 10];
 
             G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
             G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -62,23 +62,6 @@ public sealed class Blake2s : DeferredFinalBlockHashAlgorithm<Blake2s>
     };
 
     /// <summary>
-    /// The BLAKE2 sigma permutation table (10 rows; rounds are taken modulo 10).
-    /// </summary>
-    private static readonly byte[][] s_sigma = new byte[10][]
-    {
-        new byte[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15 },
-        new byte[] { 14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3 },
-        new byte[] { 11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4 },
-        new byte[] { 7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8 },
-        new byte[] { 9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13 },
-        new byte[] { 2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9 },
-        new byte[] { 12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11 },
-        new byte[] { 13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10 },
-        new byte[] { 6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5 },
-        new byte[] { 10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0 },
-    };
-
-    /// <summary>
     /// The eight 32-bit internal hash state words.
     /// </summary>
     private readonly uint[] _h = new uint[8];
@@ -240,7 +223,7 @@ public sealed class Blake2s : DeferredFinalBlockHashAlgorithm<Blake2s>
         // 10 rounds of G mixing.
         for (int r = 0; r < 10; r++)
         {
-            byte[] s = s_sigma[r % 10];
+            byte[] s = Blake2Constants.Sigma[r % 10];
 
             G(v, 0, 4, 8, 12, m[s[0]], m[s[1]]);
             G(v, 1, 5, 9, 13, m[s[2]], m[s[3]]);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -62,7 +62,35 @@ public sealed class MerkleTreeHash : IDisposable
     /// factory, block size, and fan-out.
     /// </summary>
     /// <param name="algorithmFactory">
-    ///   Factory that returns a fresh <see cref="HashAlgorithm"/> per hash operation.
+    ///   A typed factory whose <see cref="IHashAlgorithmFactory{T}.Create"/> method is invoked once
+    ///   per hash operation to obtain a fresh, independent <see cref="HashAlgorithm"/> instance.
+    ///   Must not be <see langword="null"/>. A distinct instance is created for each leaf and
+    ///   internal node so that no algorithm state is shared across operations.
+    /// </param>
+    /// <param name="blockSize">
+    ///   The size in bytes of each leaf block. Must be greater than zero. Defaults to 1024.
+    /// </param>
+    /// <param name="fanOut">
+    ///   The number of child nodes combined into each parent node during tree reduction.
+    ///   Must be at least 2. Defaults to 3. Larger values produce shallower trees.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///   <paramref name="algorithmFactory"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///   <paramref name="blockSize"/> is less than or equal to zero, or
+    ///   <paramref name="fanOut"/> is less than 2.
+    /// </exception>
+    public MerkleTreeHash(IHashAlgorithmFactory<HashAlgorithm> algorithmFactory, int blockSize = 1024, int fanOut = 3)
+        : this((algorithmFactory ?? throw new ArgumentNullException(nameof(algorithmFactory))).Create, blockSize, fanOut)
+    { }
+
+    /// <summary>
+    /// Initialises a new <see cref="MerkleTreeHash"/> instance with the specified hash algorithm
+    /// factory delegate, block size, and fan-out.
+    /// </summary>
+    /// <param name="algorithmFactory">
+    ///   Factory delegate that returns a fresh <see cref="HashAlgorithm"/> per hash operation.
     ///   Must not be <see langword="null"/>. A distinct instance is created for each leaf and
     ///   internal node so that no algorithm state is shared across operations.
     /// </param>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -136,7 +136,39 @@ public sealed class ParallelMerkleTreeHash : IDisposable
     /// algorithm factory, block size, and fan-out.
     /// </summary>
     /// <param name="algorithmFactory">
-    ///   Factory that returns a fresh, independent <see cref="HashAlgorithm"/> on each call.
+    ///   A typed factory whose <see cref="IHashAlgorithmFactory{T}.Create"/> method is invoked once
+    ///   per hash operation to obtain a fresh, independent <see cref="HashAlgorithm"/> instance.
+    ///   Must not be <see langword="null"/>. A distinct instance is created per hash operation so
+    ///   that concurrent level workers never share algorithm state.
+    /// </param>
+    /// <param name="blockSize">
+    ///   The size in bytes of each leaf block. Must be greater than zero. Defaults to 4096.
+    /// </param>
+    /// <param name="fanOut">
+    ///   The number of child nodes combined into each parent node during tree reduction.
+    ///   Must be at least 2. Defaults to 2. Larger values produce shallower trees but wider
+    ///   internal nodes.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    ///   <paramref name="algorithmFactory"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    ///   <paramref name="blockSize"/> is less than or equal to zero, or
+    ///   <paramref name="fanOut"/> is less than 2.
+    /// </exception>
+    public ParallelMerkleTreeHash(
+        IHashAlgorithmFactory<HashAlgorithm> algorithmFactory,
+        int blockSize = 4096,
+        int fanOut = 2)
+        : this((algorithmFactory ?? throw new ArgumentNullException(nameof(algorithmFactory))).Create, blockSize, fanOut)
+    { }
+
+    /// <summary>
+    /// Initialises a new <see cref="ParallelMerkleTreeHash"/> instance with the specified hash
+    /// algorithm factory delegate, block size, and fan-out.
+    /// </summary>
+    /// <param name="algorithmFactory">
+    ///   Factory delegate that returns a fresh, independent <see cref="HashAlgorithm"/> on each call.
     ///   Must not be <see langword="null"/>. A distinct instance is created per hash operation so
     ///   that concurrent level workers never share algorithm state.
     /// </param>


### PR DESCRIPTION
## Summary

- Extract the identical BLAKE2 sigma permutation schedule (10×16 byte rows) shared between `Blake2b` and `Blake2s` into a single `Blake2Constants.Sigma` static field, eliminating byte-for-byte duplication across the two files.
- Add `IHashAlgorithmFactory<HashAlgorithm>` constructor overloads to both `MerkleTreeHash` and `ParallelMerkleTreeHash`, aligning them with the existing `IHashAlgorithmFactory<T>` interface used by `HashAlgorithmHelper`. The `Func<HashAlgorithm>` convenience constructors are preserved for backward compatibility; the new overloads chain to them via the `Create` method group so no internal storage changes.

## Changes

| File | Change |
|---|---|
| `Blake2Constants.cs` | New `internal static class` holding the shared `Sigma` table |
| `Blake2b.cs` | Remove local `s_sigma`; reference `Blake2Constants.Sigma` |
| `Blake2s.cs` | Remove local `s_sigma`; reference `Blake2Constants.Sigma` |
| `MerkleTreeHash.cs` | Add `IHashAlgorithmFactory<HashAlgorithm>` constructor overload |
| `ParallelMerkleTreeHash.cs` | Add `IHashAlgorithmFactory<HashAlgorithm>` constructor overload |

## Test plan

- [ ] `Build and Test` CI workflow passes on this PR
- [ ] No regressions in Blake2b or Blake2s hashing (same sigma values, same round access pattern)
- [ ] Existing `Func<HashAlgorithm>` call sites for both Merkle tree types compile without change
- [ ] New `IHashAlgorithmFactory<HashAlgorithm>` overloads are callable with any typed factory (e.g. `IHashAlgorithmFactory<Blake2b>`) via covariance

https://claude.ai/code/session_017tME9PmdBMy9TRr8FxAbge

---
_Generated by [Claude Code](https://claude.ai/code/session_017tME9PmdBMy9TRr8FxAbge)_