### PR TITLE
Add NotableDateFilter with primary/secondary gate and service overloads

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -45,6 +45,25 @@ public interface INotableDateService
 	IReadOnlyList<NotableDate> GetNotableDates(int year, string? territoryCode = null, Type? calendarType = null);
 
 	/// <summary>
+	/// Retrieves notable dates occurring within the supplied year that satisfy the supplied <paramref name="filter" />.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The filter is applied in two stages. The primary gate is evaluated against each <see cref="NotableDateRule" /> before its date
+	/// is resolved; rules that fail the primary gate are skipped entirely. The secondary gate is then evaluated against each
+	/// materialised <see cref="NotableDate" />, discarding dates that do not satisfy the full filter criteria. Filtered queries
+	/// bypass the per-year cache so that unfiltered queries continue to return complete, cached results.
+	/// </para>
+	/// </remarks>
+	/// <param name="year">The year to query.</param>
+	/// <param name="filter">The filter to apply. Must not be <see langword="null" />.</param>
+	/// <param name="territoryCode">Optional territory scope.</param>
+	/// <param name="calendarType">Optional calendar scope.</param>
+	/// <returns>The matching notable dates ordered by anchor date.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="filter" /> is <see langword="null" />.</exception>
+	IReadOnlyList<NotableDate> GetNotableDates(int year, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null);
+
+	/// <summary>
 	/// Retrieves every notable date intersecting the supplied inclusive range. Multi-day spans whose anchor falls outside the range
 	/// are still included if any day of the span lies within it.
 	/// </summary>
@@ -56,6 +75,27 @@ public interface INotableDateService
 	IReadOnlyList<NotableDate> GetNotableDates(DateTime startDate, DateTime endDate, string? territoryCode = null, Type? calendarType = null);
 
 	/// <summary>
+	/// Retrieves notable dates intersecting the supplied inclusive range that satisfy the supplied <paramref name="filter" />. Multi-day
+	/// spans are included when any day of the span lies within the range.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The filter is applied in two stages. The primary gate is evaluated against each <see cref="NotableDateRule" /> before its date
+	/// is resolved; rules that fail the primary gate are skipped entirely. The secondary gate is then evaluated against each
+	/// materialised <see cref="NotableDate" />, discarding dates that do not satisfy the full filter criteria. Filtered queries
+	/// bypass the per-year cache so that unfiltered queries continue to return complete, cached results.
+	/// </para>
+	/// </remarks>
+	/// <param name="startDate">The inclusive start of the range.</param>
+	/// <param name="endDate">The inclusive end of the range.</param>
+	/// <param name="filter">The filter to apply. Must not be <see langword="null" />.</param>
+	/// <param name="territoryCode">Optional territory scope.</param>
+	/// <param name="calendarType">Optional calendar scope.</param>
+	/// <returns>The matching notable dates ordered by anchor date.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="filter" /> is <see langword="null" />.</exception>
+	IReadOnlyList<NotableDate> GetNotableDates(DateTime startDate, DateTime endDate, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null);
+
+	/// <summary>
 	/// Retrieves every notable date that contains the supplied day, including multi-day spans whose anchor lies on a previous day.
 	/// </summary>
 	/// <param name="date">The day to query.</param>
@@ -63,6 +103,26 @@ public interface INotableDateService
 	/// <param name="calendarType">Optional calendar scope.</param>
 	/// <returns>The notable dates ordered by anchor date.</returns>
 	IReadOnlyList<NotableDate> GetNotableDates(DateTime date, string? territoryCode = null, Type? calendarType = null);
+
+	/// <summary>
+	/// Retrieves notable dates that contain the supplied day and satisfy the supplied <paramref name="filter" />, including multi-day
+	/// spans whose anchor lies on a previous day.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// The filter is applied in two stages. The primary gate is evaluated against each <see cref="NotableDateRule" /> before its date
+	/// is resolved; rules that fail the primary gate are skipped entirely. The secondary gate is then evaluated against each
+	/// materialised <see cref="NotableDate" />, discarding dates that do not satisfy the full filter criteria. Filtered queries
+	/// bypass the per-year cache so that unfiltered queries continue to return complete, cached results.
+	/// </para>
+	/// </remarks>
+	/// <param name="date">The day to query.</param>
+	/// <param name="filter">The filter to apply. Must not be <see langword="null" />.</param>
+	/// <param name="territoryCode">Optional territory scope.</param>
+	/// <param name="calendarType">Optional calendar scope.</param>
+	/// <returns>The matching notable dates ordered by anchor date.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="filter" /> is <see langword="null" />.</exception>
+	IReadOnlyList<NotableDate> GetNotableDates(DateTime date, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null);
 
 	/// <summary>
 	/// Discards all cached notable dates so that subsequent queries regenerate them from the underlying providers.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -1,0 +1,366 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFilter.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Represents a composable predicate applied in two stages when querying <see cref="NotableDate" /> instances from an
+/// <see cref="INotableDateService" />: a primary gate evaluated against the originating <see cref="NotableDateRule" /> before the date
+/// is resolved, and a secondary gate evaluated against the materialised <see cref="NotableDate" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Filters are created via the static factory methods on this class — for example <see cref="ForCategory" />, <see cref="WithTag" />,
+/// <see cref="InDateRange" /> — and combined through <see cref="And" />, <see cref="Or" />, <see cref="AllOf" />, and
+/// <see cref="AnyOf" />. Every instance is immutable; composition always returns a new <see cref="NotableDateFilter" />.
+/// </para>
+/// <para>
+/// <b>Primary gate (rule-level)</b>: Predicates backed by <see cref="NotableDateRule" /> metadata that the service evaluates before
+/// resolving the date. When a rule fails the primary gate the service skips the date-resolution step entirely, avoiding the cost of
+/// algorithm invocation, calendar conversion, and observance-adjustment evaluation for rules that cannot produce matching dates.
+/// Filters whose criteria are fully known from the rule — such as <see cref="ForCategory" />, <see cref="WithTag" />,
+/// <see cref="WithName" />, and <see cref="IsNonWorkingDay" /> — are deterministic at this stage and maximise the optimisation.
+/// </para>
+/// <para>
+/// <b>Secondary gate (date-level)</b>: Predicates that require the materialised <see cref="NotableDate" /> — such as
+/// <see cref="InDateRange" /> and <see cref="WasAdjusted" /> — are evaluated after the date is resolved. These predicates always
+/// allow the rule to pass the primary gate; all filtering occurs on the resolved date.
+/// </para>
+/// <para>
+/// <b>Composition behaviour</b>: When filters are combined with <see cref="And" />, a rule is skipped as soon as any primary-capable
+/// clause evaluates to <see langword="false" />. When combined with <see cref="Or" />, a rule is skipped only if every branch's
+/// primary gate returns <see langword="false" />.
+/// </para>
+/// <para>
+/// <b>Caching</b>: Filtered queries bypass the per-year cache maintained by <see cref="NotableDateService" /> so that unfiltered
+/// queries continue to receive complete, correctly cached results. The primary gate optimisation therefore applies on every filtered
+/// call rather than only on the first (cold) access.
+/// </para>
+/// </remarks>
+public sealed class NotableDateFilter
+{
+	private readonly Func<NotableDateRule, bool> _ruleGate;
+	private readonly Func<NotableDate, bool> _dateGate;
+
+	private NotableDateFilter(Func<NotableDateRule, bool> ruleGate, Func<NotableDate, bool> dateGate)
+	{
+		_ruleGate = ruleGate;
+		_dateGate = dateGate;
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Rule-level (primary) factories
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Category" /> equals <paramref name="category" />.
+	/// </summary>
+	/// <param name="category">The required category.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches the specified category.</returns>
+	public static NotableDateFilter ForCategory(NotableDateCategory category) =>
+		new(
+			rule => rule.Category == category,
+			date => date.Category == category);
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Category" /> is one of the supplied
+	/// <paramref name="categories" />.
+	/// </summary>
+	/// <param name="categories">The accepted categories. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches any of the specified categories.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="categories" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="categories" /> contains no elements.</exception>
+	public static NotableDateFilter ForAnyCategory(params NotableDateCategory[] categories)
+	{
+		ThrowHelper.ThrowIfNull(categories);
+		if (categories.Length == 0) throw new ArgumentException("At least one category must be supplied.", nameof(categories));
+
+		HashSet<NotableDateCategory> set = new(categories);
+		return new(
+			rule => set.Contains(rule.Category),
+			date => set.Contains(date.Category));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Tags" /> collection contains
+	/// <paramref name="tag" /> (case-insensitive).
+	/// </summary>
+	/// <param name="tag">The required tag. Must not be <see langword="null" />, empty, or whitespace.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches the specified tag.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="tag" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="tag" /> is empty or whitespace.</exception>
+	public static NotableDateFilter WithTag(string tag)
+	{
+		ThrowHelper.ThrowIfNullOrEmpty(tag);
+
+		return new(
+			rule => rule.Tags.Any(t => string.Equals(t, tag, StringComparison.OrdinalIgnoreCase)),
+			date => date.Tags.Any(t => string.Equals(t, tag, StringComparison.OrdinalIgnoreCase)));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Tags" /> collection contains at least one of the
+	/// supplied <paramref name="tags" /> (case-insensitive).
+	/// </summary>
+	/// <param name="tags">The accepted tags. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches any of the specified tags.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="tags" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="tags" /> contains no elements.</exception>
+	public static NotableDateFilter WithAnyTag(params string[] tags)
+	{
+		ThrowHelper.ThrowIfNull(tags);
+		if (tags.Length == 0) throw new ArgumentException("At least one tag must be supplied.", nameof(tags));
+
+		HashSet<string> set = new(tags, StringComparer.OrdinalIgnoreCase);
+		return new(
+			rule => rule.Tags.Any(t => set.Contains(t)),
+			date => date.Tags.Any(t => set.Contains(t)));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Tags" /> collection contains every one of the supplied
+	/// <paramref name="tags" /> (case-insensitive).
+	/// </summary>
+	/// <param name="tags">The required tags. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches all of the specified tags.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="tags" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="tags" /> contains no elements.</exception>
+	public static NotableDateFilter WithAllTags(params string[] tags)
+	{
+		ThrowHelper.ThrowIfNull(tags);
+		if (tags.Length == 0) throw new ArgumentException("At least one tag must be supplied.", nameof(tags));
+
+		HashSet<string> required = new(tags, StringComparer.OrdinalIgnoreCase);
+		return new(
+			rule => required.All(t => rule.Tags.Any(rt => string.Equals(rt, t, StringComparison.OrdinalIgnoreCase))),
+			date => required.All(t => date.Tags.Any(dt => string.Equals(dt, t, StringComparison.OrdinalIgnoreCase))));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Name" /> equals <paramref name="name" />
+	/// (case-insensitive).
+	/// </summary>
+	/// <param name="name">The required name. Must not be <see langword="null" />, empty, or whitespace.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches the specified name.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="name" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="name" /> is empty or whitespace.</exception>
+	public static NotableDateFilter WithName(string name)
+	{
+		ThrowHelper.ThrowIfNullOrEmpty(name);
+
+		return new(
+			rule => string.Equals(rule.Name, name, StringComparison.OrdinalIgnoreCase),
+			date => string.Equals(date.Name, name, StringComparison.OrdinalIgnoreCase));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.Name" /> is one of the supplied
+	/// <paramref name="names" /> (case-insensitive).
+	/// </summary>
+	/// <param name="names">The accepted names. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches any of the specified names.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="names" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="names" /> contains no elements.</exception>
+	public static NotableDateFilter WithAnyName(params string[] names)
+	{
+		ThrowHelper.ThrowIfNull(names);
+		if (names.Length == 0) throw new ArgumentException("At least one name must be supplied.", nameof(names));
+
+		HashSet<string> set = new(names, StringComparer.OrdinalIgnoreCase);
+		return new(
+			rule => set.Contains(rule.Name),
+			date => set.Contains(date.Name));
+	}
+
+	/// <summary>
+	/// Returns a filter that matches notable dates flagged as non-working days (<see cref="NotableDate.IsNonWorkingDay" /> is
+	/// <see langword="true" />).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// At the rule level the primary gate passes rules whose <see cref="NotableDateRule.IsNonWorkingDay" /> is <see langword="true" />
+	/// or whose <see cref="NotableDateRule.Adjustments" /> include at least one entry that explicitly sets the non-working flag or
+	/// delegates to a custom handler. Rules with no mechanism for producing a non-working date are skipped before resolution.
+	/// </para>
+	/// </remarks>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches only non-working dates.</returns>
+	public static NotableDateFilter IsNonWorkingDay() =>
+		new(
+			rule => rule.IsNonWorkingDay == true
+				|| rule.Adjustments.Any(a => a.IsNonWorkingDay == true
+					|| a.Action == AdjustmentAction.Custom
+					|| a.Trigger == AdjustmentTrigger.Custom),
+			date => date.IsNonWorkingDay);
+
+	// --------------------------------------------------------------------------------------
+	// Date-level (secondary) factories
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose span intersects the inclusive date range
+	/// [<paramref name="startDate" />, <paramref name="endDate" />].
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This filter operates only at the date level; every rule passes the primary gate. A multi-day notable date is included when any
+	/// day of its span falls within the supplied range.
+	/// </para>
+	/// </remarks>
+	/// <param name="startDate">The inclusive start of the range.</param>
+	/// <param name="endDate">The inclusive end of the range. Must not be earlier than <paramref name="startDate" />.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches dates intersecting the range.</returns>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="endDate" /> is earlier than <paramref name="startDate" />.</exception>
+	public static NotableDateFilter InDateRange(DateTime startDate, DateTime endDate)
+	{
+		if (endDate < startDate)
+			throw new ArgumentException(
+				$"endDate ({endDate:d}) must not be earlier than startDate ({startDate:d}).", nameof(endDate));
+
+		DateTime start = startDate.Date;
+		DateTime end = endDate.Date;
+
+		return new(
+			_ => true,
+			date => date.Date.Date <= end && date.EndDate.Date >= start);
+	}
+
+	/// <summary>
+	/// Returns a filter that matches only notable dates that were shifted from their originally calculated position by a triggered
+	/// <see cref="ObservanceAdjustment" /> (<see cref="NotableDate.WasAdjusted" /> is <see langword="true" />).
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This filter operates only at the date level; every rule passes the primary gate because the outcome of adjustment evaluation
+	/// is not known until after the date is resolved.
+	/// </para>
+	/// </remarks>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches only adjusted dates.</returns>
+	public static NotableDateFilter WasAdjusted() =>
+		new(
+			_ => true,
+			date => date.WasAdjusted);
+
+	/// <summary>
+	/// Returns a filter that matches notable dates whose <see cref="NotableDate.DurationDays" /> is at least
+	/// <paramref name="minimumDays" />.
+	/// </summary>
+	/// <param name="minimumDays">The minimum duration in days. Must be at least one.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> that matches dates spanning at least the minimum duration.</returns>
+	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="minimumDays" /> is less than one.</exception>
+	public static NotableDateFilter WithMinDuration(int minimumDays)
+	{
+		ThrowHelper.ThrowIfLessThan(minimumDays, 1);
+
+		return new(
+			rule => rule.DurationDays >= minimumDays,
+			date => date.DurationDays >= minimumDays);
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Composition
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Returns a new filter that passes only when both this filter and <paramref name="other" /> pass.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// At the rule level both primary gates are evaluated with short-circuit semantics: if this filter's gate returns
+	/// <see langword="false" /> the other filter's gate is not evaluated and the rule is skipped immediately.
+	/// </para>
+	/// </remarks>
+	/// <param name="other">The filter to combine with this filter. Must not be <see langword="null" />.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> representing the logical AND of the two filters.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="other" /> is <see langword="null" />.</exception>
+	public NotableDateFilter And(NotableDateFilter other)
+	{
+		ThrowHelper.ThrowIfNull(other);
+
+		return new(
+			rule => _ruleGate(rule) && other._ruleGate(rule),
+			date => _dateGate(date) && other._dateGate(date));
+	}
+
+	/// <summary>
+	/// Returns a new filter that passes when at least one of this filter or <paramref name="other" /> passes.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// At the rule level the combined primary gate returns <see langword="true" /> as soon as either branch's primary gate returns
+	/// <see langword="true" />. A rule is only skipped when every branch's gate returns <see langword="false" />.
+	/// </para>
+	/// </remarks>
+	/// <param name="other">The filter to combine with this filter. Must not be <see langword="null" />.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> representing the logical OR of the two filters.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="other" /> is <see langword="null" />.</exception>
+	public NotableDateFilter Or(NotableDateFilter other)
+	{
+		ThrowHelper.ThrowIfNull(other);
+
+		return new(
+			rule => _ruleGate(rule) || other._ruleGate(rule),
+			date => _dateGate(date) || other._dateGate(date));
+	}
+
+	/// <summary>
+	/// Returns a new filter that passes only when every filter in <paramref name="filters" /> passes.
+	/// </summary>
+	/// <remarks>
+	/// <para>Equivalent to chaining <see cref="And" /> across all supplied filters.</para>
+	/// </remarks>
+	/// <param name="filters">The filters to combine. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> representing the logical AND of all supplied filters.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="filters" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="filters" /> contains no elements.</exception>
+	public static NotableDateFilter AllOf(params NotableDateFilter[] filters)
+	{
+		ThrowHelper.ThrowIfNull(filters);
+		if (filters.Length == 0) throw new ArgumentException("At least one filter must be supplied.", nameof(filters));
+
+		return filters.Aggregate((acc, next) => acc.And(next));
+	}
+
+	/// <summary>
+	/// Returns a new filter that passes when at least one filter in <paramref name="filters" /> passes.
+	/// </summary>
+	/// <remarks>
+	/// <para>Equivalent to chaining <see cref="Or" /> across all supplied filters.</para>
+	/// </remarks>
+	/// <param name="filters">The filters to combine. Must not be <see langword="null" /> or empty.</param>
+	/// <returns>A new <see cref="NotableDateFilter" /> representing the logical OR of all supplied filters.</returns>
+	/// <exception cref="ArgumentNullException">Thrown when <paramref name="filters" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentException">Thrown when <paramref name="filters" /> contains no elements.</exception>
+	public static NotableDateFilter AnyOf(params NotableDateFilter[] filters)
+	{
+		ThrowHelper.ThrowIfNull(filters);
+		if (filters.Length == 0) throw new ArgumentException("At least one filter must be supplied.", nameof(filters));
+
+		return filters.Aggregate((acc, next) => acc.Or(next));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Internal evaluation
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Evaluates the primary gate against <paramref name="rule" />.
+	/// </summary>
+	/// <param name="rule">The rule to evaluate.</param>
+	/// <returns>
+	/// <see langword="false" /> if the rule is definitively excluded and date resolution can be skipped entirely;
+	/// <see langword="true" /> if the rule may produce dates that pass the secondary gate.
+	/// </returns>
+	internal bool IsRuleEligible(NotableDateRule rule) =>
+		_ruleGate(rule);
+
+	/// <summary>
+	/// Evaluates the secondary gate against the materialised <paramref name="date" />.
+	/// </summary>
+	/// <param name="date">The resolved notable date to evaluate.</param>
+	/// <returns><see langword="true" /> if the date satisfies all filter criteria; otherwise <see langword="false" />.</returns>
+	internal bool IsMatch(NotableDate date) =>
+		_dateGate(date);
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -177,7 +177,16 @@ public sealed class NotableDateService : INotableDateService
 	/// <inheritdoc />
 	public IReadOnlyList<NotableDate> GetNotableDates(int year, string? territoryCode = null, Type? calendarType = null)
 	{
-		var perYear = GetOrGenerateYear(year);
+		IReadOnlyList<NotableDate> perYear = GetOrGenerateYear(year);
+		return ProjectAndOrder(perYear, territoryCode, calendarType);
+	}
+
+	/// <inheritdoc />
+	public IReadOnlyList<NotableDate> GetNotableDates(int year, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null)
+	{
+		ThrowHelper.ThrowIfNull(filter);
+
+		IReadOnlyList<NotableDate> perYear = GenerateYearFiltered(year, filter);
 		return ProjectAndOrder(perYear, territoryCode, calendarType);
 	}
 
@@ -186,11 +195,11 @@ public sealed class NotableDateService : INotableDateService
 	{
 		if (endDate < startDate) (startDate, endDate) = (endDate, startDate);
 
-		var results = new List<NotableDate>();
+		List<NotableDate> results = new();
 		for (int year = startDate.Year; year <= endDate.Year; year++)
 		{
-			var perYear = GetOrGenerateYear(year);
-			foreach (var notable in perYear)
+			IReadOnlyList<NotableDate> perYear = GetOrGenerateYear(year);
+			foreach (NotableDate notable in perYear)
 			{
 				if (notable.EndDate < startDate.Date || notable.Date > endDate.Date) continue;
 				if (!MatchesContext(notable, territoryCode, calendarType)) continue;
@@ -208,17 +217,69 @@ public sealed class NotableDateService : INotableDateService
 	}
 
 	/// <inheritdoc />
+	public IReadOnlyList<NotableDate> GetNotableDates(DateTime startDate, DateTime endDate, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null)
+	{
+		ThrowHelper.ThrowIfNull(filter);
+
+		if (endDate < startDate) (startDate, endDate) = (endDate, startDate);
+
+		List<NotableDate> results = new();
+		for (int year = startDate.Year; year <= endDate.Year; year++)
+		{
+			IReadOnlyList<NotableDate> perYear = GenerateYearFiltered(year, filter);
+			foreach (NotableDate notable in perYear)
+			{
+				if (notable.EndDate < startDate.Date || notable.Date > endDate.Date) continue;
+				if (!MatchesContext(notable, territoryCode, calendarType)) continue;
+
+				results.Add(LocaliseIfNeeded(notable));
+			}
+		}
+
+		return results
+			.GroupBy(n => n.Date.Date)
+			.OrderBy(g => g.Key)
+			.SelectMany(g => _collisionResolver.Resolve(g.Key, g.ToList()))
+			.ToList();
+	}
+
+	/// <inheritdoc />
 	public IReadOnlyList<NotableDate> GetNotableDates(DateTime date, string? territoryCode = null, Type? calendarType = null)
 	{
-		var results = new List<NotableDate>();
+		List<NotableDate> results = new();
 
 		// Multi-day spans may have started in the previous year; check both years to cover wrap-around.
-		foreach (var year in new[] { date.Year - 1, date.Year })
+		foreach (int year in new[] { date.Year - 1, date.Year })
 		{
 			if (year < 1) continue;
 
-			var perYear = GetOrGenerateYear(year);
-			foreach (var notable in perYear)
+			IReadOnlyList<NotableDate> perYear = GetOrGenerateYear(year);
+			foreach (NotableDate notable in perYear)
+			{
+				if (!ContainsDay(notable, date.Date)) continue;
+				if (!MatchesContext(notable, territoryCode, calendarType)) continue;
+
+				results.Add(LocaliseIfNeeded(notable));
+			}
+		}
+
+		return _collisionResolver.Resolve(date.Date, results);
+	}
+
+	/// <inheritdoc />
+	public IReadOnlyList<NotableDate> GetNotableDates(DateTime date, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null)
+	{
+		ThrowHelper.ThrowIfNull(filter);
+
+		List<NotableDate> results = new();
+
+		// Multi-day spans may have started in the previous year; check both years to cover wrap-around.
+		foreach (int year in new[] { date.Year - 1, date.Year })
+		{
+			if (year < 1) continue;
+
+			IReadOnlyList<NotableDate> perYear = GenerateYearFiltered(year, filter);
+			foreach (NotableDate notable in perYear)
 			{
 				if (!ContainsDay(notable, date.Date)) continue;
 				if (!MatchesContext(notable, territoryCode, calendarType)) continue;
@@ -344,6 +405,74 @@ public sealed class NotableDateService : INotableDateService
 					bool isNonWorking = result.IsNonWorkingOverride ?? rule.IsNonWorkingDay ?? false;
 					var reason = new AdjustmentReason(anchor.Value, result.Trigger, result.Action, result.HandlerKey);
 					output.Add(BuildNotableDate(rule, result.AdjustedDate, emittedTerritory, reason, isNonWorking));
+				}
+			}
+		}
+
+		return output;
+	}
+
+    /// <summary>
+    /// Materialises the notable dates for <paramref name="year" /> by invoking every rule that passes the primary gate of
+    /// <paramref name="filter" />, applying observance adjustments, and retaining only those dates that pass the secondary gate.
+    /// Results are never written to the per-year cache so that unfiltered queries continue to receive complete cached results.
+    /// </summary>
+    /// <param name="year">The civil year to generate.</param>
+    /// <param name="filter">The filter whose primary gate is applied before date resolution and whose secondary gate is applied to
+    /// each materialised date.</param>
+    /// <returns>The filtered notable dates for <paramref name="year" />, in unspecified order.</returns>
+	private IReadOnlyList<NotableDate> GenerateYearFiltered(int year, NotableDateFilter filter)
+	{
+		List<NotableDate> output = new();
+
+		foreach (NotableDateRule rule in _effectiveRules)
+		{
+			if (!NotableDateRuleResolver.IsApplicable(rule, year))
+				continue;
+
+			if (!filter.IsRuleEligible(rule))
+				continue;
+
+			DateTime? anchor;
+			try
+			{
+				anchor = _resolver.ResolveAnchorDate(rule, year);
+			}
+			catch (InvalidOperationException)
+			{
+				continue;
+			}
+
+			if (anchor is null)
+				continue;
+
+			foreach (string? territory in ExpandTerritories(rule.TerritoryCode))
+			{
+				if (IsRemovedByOverride(rule, year, territory))
+					continue;
+
+				NotableDate baseDate = BuildNotableDate(rule, anchor.Value, territory, adjustmentReason: null);
+				if (filter.IsMatch(baseDate))
+					output.Add(baseDate);
+
+				foreach (ObservanceAdjustment adjustment in rule.Adjustments.OrderBy(a => a.Priority))
+				{
+					if (!NotableDateAdjuster.IsInScope(adjustment, year, territory, rule.CalendarType))
+						continue;
+
+					AdjustmentApplyResult result = _adjuster.Apply(adjustment, rule, anchor.Value, territory, rule.CalendarType);
+					if (!result.Activated || result.AdjustedDate.Date == anchor.Value.Date)
+						continue;
+
+					string? emittedTerritory = !string.IsNullOrEmpty(adjustment.TerritoryCode)
+						? adjustment.TerritoryCode
+						: territory;
+
+					bool isNonWorking = result.IsNonWorkingOverride ?? rule.IsNonWorkingDay ?? false;
+					AdjustmentReason reason = new(anchor.Value, result.Trigger, result.Action, result.HandlerKey);
+					NotableDate adjustedDate = BuildNotableDate(rule, result.AdjustedDate, emittedTerritory, reason, isNonWorking);
+					if (filter.IsMatch(adjustedDate))
+						output.Add(adjustedDate);
 				}
 			}
 		}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateFilterTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateFilterTests.cs
@@ -1,0 +1,860 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFilterTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the behaviour of <see cref="NotableDateFilter" /> factory methods, argument validation, primary-gate rule eligibility,
+/// secondary-gate date matching, and And/Or composition.
+/// </summary>
+[TestClass]
+public sealed class NotableDateFilterTests
+{
+	// --------------------------------------------------------------------------------------
+	// Helpers
+	// --------------------------------------------------------------------------------------
+
+	private static NotableDateRule MakeRule(
+		string name = "Test",
+		NotableDateCategory category = NotableDateCategory.Holiday,
+		bool? isNonWorkingDay = null,
+		ImmutableHashSet<string>? tags = null,
+		int durationDays = 1) =>
+		new()
+		{
+			Name = name,
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = category,
+			Month = 1,
+			Day = 1,
+			IsNonWorkingDay = isNonWorkingDay,
+			Tags = tags ?? ImmutableHashSet<string>.Empty,
+			DurationDays = durationDays,
+		};
+
+	private static NotableDate MakeDate(
+		string name = "Test",
+		NotableDateCategory category = NotableDateCategory.Holiday,
+		bool isNonWorkingDay = false,
+		ImmutableHashSet<string>? tags = null,
+		DateTime? date = null,
+		int durationDays = 1,
+		AdjustmentReason? adjustmentReason = null) =>
+		new()
+		{
+			Name = name,
+			Date = date ?? new DateTime(2024, 1, 1),
+			Category = category,
+			IsNonWorkingDay = isNonWorkingDay,
+			Tags = tags ?? ImmutableHashSet<string>.Empty,
+			DurationDays = durationDays,
+			AdjustmentReason = adjustmentReason,
+		};
+
+	// --------------------------------------------------------------------------------------
+	// ForCategory
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForCategory" /> passes the primary gate when the rule category matches.
+	/// </summary>
+	[TestMethod]
+	public void ForCategory_WhenRuleCategoryMatches_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Holiday);
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForCategory" /> fails the primary gate when the rule category does not match.
+	/// </summary>
+	[TestMethod]
+	public void ForCategory_WhenRuleCategoryDoesNotMatch_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Observance);
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForCategory" /> passes the secondary gate when the date category matches.
+	/// </summary>
+	[TestMethod]
+	public void ForCategory_WhenDateCategoryMatches_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Cultural);
+		NotableDate date = MakeDate(category: NotableDateCategory.Cultural);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForCategory" /> fails the secondary gate when the date category does not match.
+	/// </summary>
+	[TestMethod]
+	public void ForCategory_WhenDateCategoryDoesNotMatch_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Cultural);
+		NotableDate date = MakeDate(category: NotableDateCategory.Holiday);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// ForAnyCategory
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForAnyCategory" /> passes the primary gate when the rule category is one of the
+	/// accepted values.
+	/// </summary>
+	[TestMethod]
+	public void ForAnyCategory_WhenRuleCategoryIsOneOfAccepted_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForAnyCategory(NotableDateCategory.Holiday, NotableDateCategory.Observance);
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Observance);
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForAnyCategory" /> fails the primary gate when the rule category is not one of
+	/// the accepted values.
+	/// </summary>
+	[TestMethod]
+	public void ForAnyCategory_WhenRuleCategoryIsNotAccepted_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForAnyCategory(NotableDateCategory.Holiday, NotableDateCategory.Observance);
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Cultural);
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForAnyCategory" /> throws <see cref="ArgumentNullException" /> when the
+	/// categories array is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void ForAnyCategory_WhenCategoriesIsNull_ShouldThrowArgumentNullException()
+	{
+		NotableDateCategory[] categories = null!;
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = NotableDateFilter.ForAnyCategory(categories);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.ForAnyCategory" /> throws <see cref="ArgumentException" /> when the categories
+	/// array is empty.
+	/// </summary>
+	[TestMethod]
+	public void ForAnyCategory_WhenCategoriesIsEmpty_ShouldThrowArgumentException()
+	{
+		Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = NotableDateFilter.ForAnyCategory();
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithTag
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> passes the primary gate when the rule contains the tag
+	/// (case-insensitive).
+	/// </summary>
+	[TestMethod]
+	public void WithTag_WhenRuleHasMatchingTag_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithTag("Public");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("public", "Federal"));
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> fails the primary gate when the rule does not contain the tag.
+	/// </summary>
+	[TestMethod]
+	public void WithTag_WhenRuleDoesNotHaveTag_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithTag("Public");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("Christian"));
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> passes the secondary gate when the date contains the tag
+	/// (case-insensitive).
+	/// </summary>
+	[TestMethod]
+	public void WithTag_WhenDateHasMatchingTag_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithTag("Federal");
+		NotableDate date = MakeDate(tags: ImmutableHashSet.Create("FEDERAL"));
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> throws <see cref="ArgumentNullException" /> when <paramref name="tag" />
+	/// is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void WithTag_WhenTagIsNull_ShouldThrowArgumentNullException()
+	{
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = NotableDateFilter.WithTag(null!);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> throws <see cref="ArgumentException" /> when <paramref name="tag" />
+	/// is empty.
+	/// </summary>
+	[TestMethod]
+	public void WithTag_WhenTagIsEmpty_ShouldThrowArgumentException()
+	{
+		Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = NotableDateFilter.WithTag(string.Empty);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithAnyTag
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAnyTag" /> passes the primary gate when the rule contains at least one of the
+	/// accepted tags.
+	/// </summary>
+	[TestMethod]
+	public void WithAnyTag_WhenRuleHasAtLeastOneMatchingTag_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAnyTag("Public", "Federal");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("Christian", "Public"));
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAnyTag" /> fails the primary gate when the rule contains none of the accepted
+	/// tags.
+	/// </summary>
+	[TestMethod]
+	public void WithAnyTag_WhenRuleHasNoMatchingTag_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAnyTag("Public", "Federal");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("Christian"));
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithAllTags
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAllTags" /> passes the primary gate only when the rule contains every required
+	/// tag.
+	/// </summary>
+	[TestMethod]
+	public void WithAllTags_WhenRuleHasAllRequiredTags_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAllTags("Public", "Christian");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("Christian", "Public", "Federal"));
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAllTags" /> fails the primary gate when at least one required tag is absent.
+	/// </summary>
+	[TestMethod]
+	public void WithAllTags_WhenRuleIsMissingARequiredTag_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAllTags("Public", "Federal");
+		NotableDateRule rule = MakeRule(tags: ImmutableHashSet.Create("Public"));
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithName
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithName" /> passes the primary gate when the rule name matches
+	/// case-insensitively.
+	/// </summary>
+	[TestMethod]
+	public void WithName_WhenRuleNameMatchesCaseInsensitively_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithName("christmas day");
+		NotableDateRule rule = MakeRule(name: "Christmas Day");
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithName" /> fails the primary gate when the rule name does not match.
+	/// </summary>
+	[TestMethod]
+	public void WithName_WhenRuleNameDoesNotMatch_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithName("Christmas Day");
+		NotableDateRule rule = MakeRule(name: "Easter Sunday");
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithAnyName
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAnyName" /> passes the primary gate when the rule name is one of the accepted
+	/// names.
+	/// </summary>
+	[TestMethod]
+	public void WithAnyName_WhenRuleNameIsOneOfAccepted_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAnyName("Christmas Day", "Easter Sunday");
+		NotableDateRule rule = MakeRule(name: "Easter Sunday");
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAnyName" /> fails the primary gate when the rule name is not one of the
+	/// accepted names.
+	/// </summary>
+	[TestMethod]
+	public void WithAnyName_WhenRuleNameIsNotAccepted_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithAnyName("Christmas Day", "Easter Sunday");
+		NotableDateRule rule = MakeRule(name: "Anzac Day");
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// IsNonWorkingDay
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.IsNonWorkingDay" /> passes the primary gate when the rule is explicitly flagged as
+	/// a non-working day.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenRuleIsExplicitlyNonWorking_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.IsNonWorkingDay();
+		NotableDateRule rule = MakeRule(isNonWorkingDay: true);
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.IsNonWorkingDay" /> fails the primary gate when the rule has no non-working
+	/// mechanism.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenRuleHasNoNonWorkingMechanism_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.IsNonWorkingDay();
+		NotableDateRule rule = MakeRule(isNonWorkingDay: false);
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.IsNonWorkingDay" /> passes the secondary gate when the date is a non-working day.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenDateIsNonWorkingDay_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.IsNonWorkingDay();
+		NotableDate date = MakeDate(isNonWorkingDay: true);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.IsNonWorkingDay" /> fails the secondary gate when the date is not a non-working
+	/// day.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenDateIsWorkingDay_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.IsNonWorkingDay();
+		NotableDate date = MakeDate(isNonWorkingDay: false);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// InDateRange
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.InDateRange" /> always passes the primary gate because date ranges cannot be
+	/// determined from rule metadata alone.
+	/// </summary>
+	[TestMethod]
+	public void InDateRange_IsRuleEligibleAlwaysReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.InDateRange(new DateTime(2024, 6, 1), new DateTime(2024, 6, 30));
+		NotableDateRule rule = MakeRule();
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.InDateRange" /> passes the secondary gate when the date falls within the range.
+	/// </summary>
+	[TestMethod]
+	public void InDateRange_WhenDateIsWithinRange_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.InDateRange(new DateTime(2024, 6, 1), new DateTime(2024, 6, 30));
+		NotableDate date = MakeDate(date: new DateTime(2024, 6, 15));
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.InDateRange" /> fails the secondary gate when the date falls outside the range.
+	/// </summary>
+	[TestMethod]
+	public void InDateRange_WhenDateIsOutsideRange_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.InDateRange(new DateTime(2024, 6, 1), new DateTime(2024, 6, 30));
+		NotableDate date = MakeDate(date: new DateTime(2024, 7, 1));
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.InDateRange" /> passes the secondary gate when a multi-day span's end date
+	/// reaches into the range even though the anchor falls before it.
+	/// </summary>
+	[TestMethod]
+	public void InDateRange_WhenMultiDaySpanOverlapsRange_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.InDateRange(new DateTime(2024, 6, 1), new DateTime(2024, 6, 30));
+		NotableDate date = MakeDate(date: new DateTime(2024, 5, 30), durationDays: 5);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.InDateRange" /> throws <see cref="ArgumentException" /> when
+	/// <paramref name="endDate" /> is earlier than <paramref name="startDate" />.
+	/// </summary>
+	[TestMethod]
+	public void InDateRange_WhenEndDateIsBeforeStartDate_ShouldThrowArgumentException()
+	{
+		Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = NotableDateFilter.InDateRange(new DateTime(2024, 6, 30), new DateTime(2024, 6, 1));
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WasAdjusted
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WasAdjusted" /> always passes the primary gate because adjustment outcome is not
+	/// known at the rule level.
+	/// </summary>
+	[TestMethod]
+	public void WasAdjusted_IsRuleEligibleAlwaysReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WasAdjusted();
+		NotableDateRule rule = MakeRule();
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WasAdjusted" /> passes the secondary gate when the date has been adjusted.
+	/// </summary>
+	[TestMethod]
+	public void WasAdjusted_WhenDateWasAdjusted_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WasAdjusted();
+		AdjustmentReason reason = new(new DateTime(2024, 1, 1), AdjustmentTrigger.IfWeekend, AdjustmentAction.MoveToNextWeekday, null);
+		NotableDate date = MakeDate(adjustmentReason: reason);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WasAdjusted" /> fails the secondary gate when the date has not been adjusted.
+	/// </summary>
+	[TestMethod]
+	public void WasAdjusted_WhenDateWasNotAdjusted_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WasAdjusted();
+		NotableDate date = MakeDate(adjustmentReason: null);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	// --------------------------------------------------------------------------------------
+	// WithMinDuration
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithMinDuration" /> passes the primary gate when the rule duration meets the
+	/// minimum.
+	/// </summary>
+	[TestMethod]
+	public void WithMinDuration_WhenRuleDurationMeetsMinimum_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithMinDuration(3);
+		NotableDateRule rule = MakeRule(durationDays: 5);
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithMinDuration" /> fails the primary gate when the rule duration is below the
+	/// minimum.
+	/// </summary>
+	[TestMethod]
+	public void WithMinDuration_WhenRuleDurationIsBelowMinimum_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.WithMinDuration(3);
+		NotableDateRule rule = MakeRule(durationDays: 2);
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithMinDuration" /> throws <see cref="ArgumentOutOfRangeException" /> when
+	/// <paramref name="minimumDays" /> is less than one.
+	/// </summary>
+	[TestMethod]
+	public void WithMinDuration_WhenMinimumDaysIsZero_ShouldThrowArgumentOutOfRangeException()
+	{
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+		{
+			_ = NotableDateFilter.WithMinDuration(0);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// And
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> passes the primary gate only when both component gates pass.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenBothPrimaryGatesPass_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.WithTag("Public"));
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Holiday, tags: ImmutableHashSet.Create("Public"));
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> fails the primary gate when the first component gate fails.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenFirstPrimaryGateFails_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.WithTag("Public"));
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Observance, tags: ImmutableHashSet.Create("Public"));
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> fails the primary gate when the second component gate fails.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenSecondPrimaryGateFails_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.WithTag("Public"));
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Holiday, tags: ImmutableHashSet.Create("Christian"));
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> passes the secondary gate only when both component gates match the date.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenBothSecondaryGatesPass_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.IsNonWorkingDay());
+		NotableDate date = MakeDate(category: NotableDateCategory.Holiday, isNonWorkingDay: true);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> fails the secondary gate when the second component gate does not match.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenOneSecondaryGateFails_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.IsNonWorkingDay());
+		NotableDate date = MakeDate(category: NotableDateCategory.Holiday, isNonWorkingDay: false);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.And" /> throws <see cref="ArgumentNullException" /> when <paramref name="other" />
+	/// is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void And_WhenOtherIsNull_ShouldThrowArgumentNullException()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = filter.And(null!);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Or
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.Or" /> passes the primary gate when at least one component gate passes.
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenOnePrimaryGatePasses_IsRuleEligibleReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.Or(NotableDateFilter.ForCategory(NotableDateCategory.Observance));
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Observance);
+
+		Assert.IsTrue(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.Or" /> fails the primary gate when neither component gate passes.
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenNoPrimaryGatePasses_IsRuleEligibleReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.Or(NotableDateFilter.ForCategory(NotableDateCategory.Observance));
+		NotableDateRule rule = MakeRule(category: NotableDateCategory.Cultural);
+
+		Assert.IsFalse(filter.IsRuleEligible(rule));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.Or" /> passes the secondary gate when the second component matches the date.
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenSecondSecondaryGatePasses_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.Or(NotableDateFilter.IsNonWorkingDay());
+		NotableDate date = MakeDate(category: NotableDateCategory.Observance, isNonWorkingDay: true);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.Or" /> fails the secondary gate when neither component matches the date.
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenNoSecondaryGatePasses_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.Or(NotableDateFilter.IsNonWorkingDay());
+		NotableDate date = MakeDate(category: NotableDateCategory.Observance, isNonWorkingDay: false);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.Or" /> throws <see cref="ArgumentNullException" /> when <paramref name="other" />
+	/// is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenOtherIsNull_ShouldThrowArgumentNullException()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = filter.Or(null!);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// AllOf
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AllOf" /> passes the secondary gate when every supplied filter matches the date.
+	/// </summary>
+	[TestMethod]
+	public void AllOf_WhenAllFiltersMatch_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.AllOf(
+			NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+			NotableDateFilter.IsNonWorkingDay(),
+			NotableDateFilter.WithTag("Public"));
+		NotableDate date = MakeDate(
+			category: NotableDateCategory.Holiday,
+			isNonWorkingDay: true,
+			tags: ImmutableHashSet.Create("Public"));
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AllOf" /> fails the secondary gate when any supplied filter does not match.
+	/// </summary>
+	[TestMethod]
+	public void AllOf_WhenOneFilterFails_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.AllOf(
+			NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+			NotableDateFilter.IsNonWorkingDay());
+		NotableDate date = MakeDate(category: NotableDateCategory.Holiday, isNonWorkingDay: false);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AllOf" /> throws <see cref="ArgumentException" /> when the array is empty.
+	/// </summary>
+	[TestMethod]
+	public void AllOf_WhenFiltersIsEmpty_ShouldThrowArgumentException()
+	{
+		Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = NotableDateFilter.AllOf();
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// AnyOf
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AnyOf" /> passes the secondary gate when at least one supplied filter matches.
+	/// </summary>
+	[TestMethod]
+	public void AnyOf_WhenOneFilterMatches_IsMatchReturnsTrue()
+	{
+		NotableDateFilter filter = NotableDateFilter.AnyOf(
+			NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+			NotableDateFilter.ForCategory(NotableDateCategory.Observance));
+		NotableDate date = MakeDate(category: NotableDateCategory.Observance);
+
+		Assert.IsTrue(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AnyOf" /> fails the secondary gate when no supplied filter matches.
+	/// </summary>
+	[TestMethod]
+	public void AnyOf_WhenNoFilterMatches_IsMatchReturnsFalse()
+	{
+		NotableDateFilter filter = NotableDateFilter.AnyOf(
+			NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+			NotableDateFilter.ForCategory(NotableDateCategory.Observance));
+		NotableDate date = MakeDate(category: NotableDateCategory.Cultural);
+
+		Assert.IsFalse(filter.IsMatch(date));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.AnyOf" /> throws <see cref="ArgumentException" /> when the array is empty.
+	/// </summary>
+	[TestMethod]
+	public void AnyOf_WhenFiltersIsEmpty_ShouldThrowArgumentException()
+	{
+		Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = NotableDateFilter.AnyOf();
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Complex composition
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that a complex And/Or composition evaluates correctly — (Holiday OR Observance) AND NonWorking AND has "Public" tag.
+	/// </summary>
+	[TestMethod]
+	public void ComplexComposition_HolidayOrObservanceAndNonWorkingPublic_MatchesCorrectly()
+	{
+		NotableDateFilter filter = NotableDateFilter.AnyOf(
+				NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+				NotableDateFilter.ForCategory(NotableDateCategory.Observance))
+			.And(NotableDateFilter.IsNonWorkingDay())
+			.And(NotableDateFilter.WithTag("Public"));
+
+		NotableDate matching = MakeDate(
+			category: NotableDateCategory.Observance,
+			isNonWorkingDay: true,
+			tags: ImmutableHashSet.Create("Public", "Religious"));
+
+		NotableDate wrongCategory = MakeDate(
+			category: NotableDateCategory.Cultural,
+			isNonWorkingDay: true,
+			tags: ImmutableHashSet.Create("Public"));
+
+		NotableDate notNonWorking = MakeDate(
+			category: NotableDateCategory.Holiday,
+			isNonWorkingDay: false,
+			tags: ImmutableHashSet.Create("Public"));
+
+		Assert.IsTrue(filter.IsMatch(matching));
+		Assert.IsFalse(filter.IsMatch(wrongCategory));
+		Assert.IsFalse(filter.IsMatch(notNonWorking));
+	}
+
+	/// <summary>
+	/// Verifies that combining a primary-capable filter with a date-level filter via Or always passes the primary gate (since one
+	/// branch is always true at the rule level).
+	/// </summary>
+	[TestMethod]
+	public void Or_WhenOneBranchIsDateLevelOnly_PrimaryGateAlwaysPassesForAnyRule()
+	{
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Cultural)
+			.Or(NotableDateFilter.WasAdjusted());
+
+		NotableDateRule holidayRule = MakeRule(category: NotableDateCategory.Holiday);
+
+		// The WasAdjusted branch always returns true at rule level, so the OR must also return true.
+		Assert.IsTrue(filter.IsRuleEligible(holidayRule));
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Filter.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Filter.cs
@@ -1,0 +1,297 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.Filter.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+
+namespace Bodu.Globalization.Calendar;
+
+public sealed partial class NotableDateServiceTests
+{
+	private static NotableDateRule FixedWithTags(string name, int month, int day, NotableDateCategory category, bool nonWorking, ImmutableHashSet<string> tags) =>
+		new()
+		{
+			Name = name,
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = category,
+			Month = month,
+			Day = day,
+			IsNonWorkingDay = nonWorking,
+			Tags = tags,
+		};
+
+	// --------------------------------------------------------------------------------------
+	// GetNotableDates(year, filter)
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> returns only dates
+	/// matching the category filter and excludes all others.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndCategoryFilter_ShouldReturnOnlyMatchingCategory()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Observance B", 3, 15, NotableDateCategory.Observance),
+			Fixed("Holiday C", 12, 25, NotableDateCategory.Holiday));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(2, results.Count);
+		Assert.IsTrue(results.All(d => d.Category == NotableDateCategory.Holiday));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> returns no dates
+	/// when the filter matches no rules.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndFilterMatchingNoRules_ShouldReturnEmptyList()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Holiday B", 12, 25, NotableDateCategory.Holiday));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Cultural);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> returns dates
+	/// matching any of the supplied categories when an Or filter is used.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndOrCategoryFilter_ShouldReturnBothMatchingCategories()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Observance B", 3, 15, NotableDateCategory.Observance),
+			Fixed("Cultural C", 6, 1, NotableDateCategory.Cultural));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.Or(NotableDateFilter.ForCategory(NotableDateCategory.Observance));
+
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(2, results.Count);
+		Assert.IsTrue(results.All(d => d.Category == NotableDateCategory.Holiday || d.Category == NotableDateCategory.Observance));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> returns only dates
+	/// matching all criteria when an And filter is used.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndAndFilter_ShouldReturnIntersection()
+	{
+		NotableDateService service = BuildService(
+			FixedWithTags("Holiday Public", 1, 1, NotableDateCategory.Holiday, nonWorking: true, ImmutableHashSet.Create("Public")),
+			FixedWithTags("Holiday Private", 3, 15, NotableDateCategory.Holiday, nonWorking: false, ImmutableHashSet.Create("Regional")),
+			Fixed("Observance", 6, 1, NotableDateCategory.Observance, nonWorking: true));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday)
+			.And(NotableDateFilter.IsNonWorkingDay());
+
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Holiday Public", results[0].Name);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> returns results
+	/// ordered by anchor date.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndFilter_ShouldReturnResultsOrderedByDate()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday C", 12, 25, NotableDateCategory.Holiday),
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Holiday B", 7, 4, NotableDateCategory.Holiday));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(3, results.Count);
+		Assert.IsTrue(results[0].Date <= results[1].Date && results[1].Date <= results[2].Date);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(int, NotableDateFilter, string?, Type?)" /> throws
+	/// <see cref="ArgumentNullException" /> when the filter is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndNullFilter_ShouldThrowArgumentNullException()
+	{
+		NotableDateService service = BuildService(Fixed("Holiday A", 1, 1));
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = service.GetNotableDates(2024, null!);
+		});
+	}
+
+	/// <summary>
+	/// Verifies that a filtered query does not affect subsequent unfiltered queries, confirming that the per-year cache remains
+	/// intact and returns complete results after a filtered call.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithYearAndFilter_ShouldNotPolluteCacheForUnfilteredQuery()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Observance B", 6, 1, NotableDateCategory.Observance));
+
+		// Filtered call — should only return holidays.
+		IReadOnlyList<NotableDate> filtered = service.GetNotableDates(2024, NotableDateFilter.ForCategory(NotableDateCategory.Holiday));
+
+		// Unfiltered call — should return all dates including observances.
+		IReadOnlyList<NotableDate> unfiltered = service.GetNotableDates(2024);
+
+		Assert.AreEqual(1, filtered.Count);
+		Assert.AreEqual(2, unfiltered.Count);
+	}
+
+	// --------------------------------------------------------------------------------------
+	// GetNotableDates(startDate, endDate, filter)
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(DateTime, DateTime, NotableDateFilter, string?, Type?)" />
+	/// returns only dates within the range that also match the filter.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithDateRangeAndCategoryFilter_ShouldReturnMatchingDatesInRange()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday Jan", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Observance Mar", 3, 15, NotableDateCategory.Observance),
+			Fixed("Holiday Dec", 12, 25, NotableDateCategory.Holiday));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(
+			new DateTime(2024, 1, 1), new DateTime(2024, 6, 30), filter);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Holiday Jan", results[0].Name);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(DateTime, DateTime, NotableDateFilter, string?, Type?)" />
+	/// throws <see cref="ArgumentNullException" /> when the filter is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithDateRangeAndNullFilter_ShouldThrowArgumentNullException()
+	{
+		NotableDateService service = BuildService(Fixed("Holiday A", 1, 1));
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = service.GetNotableDates(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31), null!);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// GetNotableDates(date, filter)
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(DateTime, NotableDateFilter, string?, Type?)" /> returns the
+	/// notable date on that day when the filter matches.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithSingleDateAndMatchingFilter_ShouldReturnDate()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Holiday A", 1, 1, NotableDateCategory.Holiday),
+			Fixed("Observance B", 1, 1, NotableDateCategory.Observance));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(new DateTime(2024, 1, 1), filter);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Holiday A", results[0].Name);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(DateTime, NotableDateFilter, string?, Type?)" /> returns an
+	/// empty list when the filter excludes all dates on that day.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithSingleDateAndNonMatchingFilter_ShouldReturnEmptyList()
+	{
+		NotableDateService service = BuildService(
+			Fixed("Observance B", 1, 1, NotableDateCategory.Observance));
+
+		NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(new DateTime(2024, 1, 1), filter);
+
+		Assert.AreEqual(0, results.Count);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.GetNotableDates(DateTime, NotableDateFilter, string?, Type?)" /> throws
+	/// <see cref="ArgumentNullException" /> when the filter is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithSingleDateAndNullFilter_ShouldThrowArgumentNullException()
+	{
+		NotableDateService service = BuildService(Fixed("Holiday A", 1, 1));
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = service.GetNotableDates(new DateTime(2024, 1, 1), null!);
+		});
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Tag filter integration
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithTag" /> filters service results correctly, returning only dates whose rule
+	/// carries the specified tag.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithTagFilter_ShouldReturnOnlyTaggedDates()
+	{
+		NotableDateService service = BuildService(
+			FixedWithTags("Public Holiday", 1, 1, NotableDateCategory.Holiday, nonWorking: true, ImmutableHashSet.Create("Public")),
+			FixedWithTags("Regional Holiday", 6, 1, NotableDateCategory.Holiday, nonWorking: true, ImmutableHashSet.Create("Regional")));
+
+		NotableDateFilter filter = NotableDateFilter.WithTag("Public");
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(1, results.Count);
+		Assert.AreEqual("Public Holiday", results[0].Name);
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Name filter integration
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFilter.WithAnyName" /> returns only the named dates from the service.
+	/// </summary>
+	[TestMethod]
+	public void GetNotableDates_WithAnyNameFilter_ShouldReturnOnlyNamedDates()
+	{
+		NotableDateService service = BuildService(
+			Fixed("New Year's Day", 1, 1),
+			Fixed("Easter Sunday", 4, 1),
+			Fixed("Christmas Day", 12, 25));
+
+		NotableDateFilter filter = NotableDateFilter.WithAnyName("New Year's Day", "Christmas Day");
+		IReadOnlyList<NotableDate> results = service.GetNotableDates(2024, filter);
+
+		Assert.AreEqual(2, results.Count);
+		Assert.IsTrue(results.All(d => d.Name == "New Year's Day" || d.Name == "Christmas Day"));
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Filter.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Filter.cs
@@ -134,7 +134,7 @@ public sealed partial class NotableDateServiceTests
 
 		Assert.ThrowsExactly<ArgumentNullException>(() =>
 		{
-			_ = service.GetNotableDates(2024, null!);
+			_ = service.GetNotableDates(2024, (NotableDateFilter)null!);
 		});
 	}
 
@@ -194,7 +194,7 @@ public sealed partial class NotableDateServiceTests
 
 		Assert.ThrowsExactly<ArgumentNullException>(() =>
 		{
-			_ = service.GetNotableDates(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31), null!);
+			_ = service.GetNotableDates(new DateTime(2024, 1, 1), new DateTime(2024, 12, 31), (NotableDateFilter)null!);
 		});
 	}
 
@@ -247,7 +247,7 @@ public sealed partial class NotableDateServiceTests
 
 		Assert.ThrowsExactly<ArgumentNullException>(() =>
 		{
-			_ = service.GetNotableDates(new DateTime(2024, 1, 1), null!);
+			_ = service.GetNotableDates(new DateTime(2024, 1, 1), (NotableDateFilter)null!);
 		});
 	}
 


### PR DESCRIPTION
## Summary

- Introduces `NotableDateFilter` — a composable, immutable predicate evaluated in two stages against `INotableDateService` query results.
- **Primary gate**: evaluated against `NotableDateRule` metadata *before* date resolution; rules that fail are skipped entirely (no algorithm invocation, no calendar conversion).
- **Secondary gate**: evaluated against the materialised `NotableDate` for criteria that require a resolved date (`InDateRange`, `WasAdjusted`).
- And/Or composition via `And`, `Or`, `AllOf`, `AnyOf` with short-circuit primary-gate semantics.
- Three new `INotableDateService` overloads (year, date-range, single-day) each accepting a `NotableDateFilter` as the second parameter. Filtered queries bypass the per-year cache so unfiltered callers continue to receive complete cached results.
- Full MSTest coverage: `NotableDateFilterTests` (factory, validation, primary/secondary gate, composition) and `NotableDateServiceTests.Filter` (end-to-end service integration).

## Factory methods

| Factory | Primary gate | Secondary gate |
|---|---|---|
| `ForCategory` / `ForAnyCategory` | `rule.Category` | `date.Category` |
| `WithTag` / `WithAnyTag` / `WithAllTags` | `rule.Tags` | `date.Tags` |
| `WithName` / `WithAnyName` | `rule.Name` | `date.Name` |
| `IsNonWorkingDay` | `rule.IsNonWorkingDay` or adjustment flags | `date.IsNonWorkingDay` |
| `WithMinDuration` | `rule.DurationDays` | `date.DurationDays` |
| `InDateRange` | always `true` | span intersection |
| `WasAdjusted` | always `true` | `date.WasAdjusted` |

## Test plan

- [ ] Build passes with no warnings (`-warnaserror`)
- [ ] All existing tests pass (no regressions)
- [ ] `NotableDateFilterTests` — factory validation, primary gate eligibility, secondary gate matching, And/Or composition, complex nested predicates
- [ ] `NotableDateServiceTests.Filter` — category filter, Or filter, And filter, name filter, tag filter, null-filter validation, cache isolation

https://claude.ai/code/session_011FfmBgk1QsLFwb9x3cxmku

---
_Generated by [Claude Code](https://claude.ai/code/session_011FfmBgk1QsLFwb9x3cxmku)_