### PR TITLE
feat(IO.Hashing): add NonCryptographicHashAlgorithmExtensions with full test coverage

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.AppendData.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.AppendData.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.AppendData.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Hashing;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Feeds a span of bytes into the ongoing hash computation of the specified <see cref="NonCryptographicHashAlgorithm" />
+    /// without finalising it.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance receiving the data. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="data">The span of bytes to feed into the hash computation.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method is a null-guarded wrapper around <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" />,
+    /// intended for use in incremental hashing scenarios where data is supplied in multiple segments. Retrieve the current
+    /// digest at any point by calling <see cref="NonCryptographicHashAlgorithm.GetCurrentHash()" /> or
+    /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
+    /// </para>
+    /// <para>
+    /// If <paramref name="data" /> is empty, this method returns without performing any work.
+    /// </para>
+    /// </remarks>
+    public static void AppendData(this NonCryptographicHashAlgorithm algorithm, ReadOnlySpan<byte> data)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        if (data.IsEmpty)
+            return;
+
+        algorithm.Append(data);
+    }
+
+    /// <summary>
+    /// Reads all bytes from <paramref name="source" /> and feeds them into the hash accumulator via
+    /// <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" />, without finalising the computation.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance receiving the data. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="source">
+    /// The stream whose bytes are appended to the current hash state. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="bufferSize">
+    /// The number of bytes read per iteration. Must be greater than zero. Defaults to 4096.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="bufferSize" /> is less than or equal to zero.
+    /// </exception>
+    /// <exception cref="IOException">
+    /// <paramref name="source" /> threw an <see cref="IOException" /> during a read.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method allows large or streaming sources to be incorporated into an incremental hash computation. Because only
+    /// <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" /> is called, the hash state is not finalised after
+    /// this method returns.
+    /// </para>
+    /// <para>
+    /// The read buffer is rented from <see cref="ArrayPool{T}.Shared" /> and returned in all exit paths, including exception
+    /// propagation.
+    /// </para>
+    /// </remarks>
+    public static void AppendData(this NonCryptographicHashAlgorithm algorithm, Stream source, int bufferSize = 4096)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(source);
+
+        if (bufferSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(bufferSize), bufferSize, "Buffer size must be greater than zero.");
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = source.Read(buffer, 0, bufferSize)) > 0)
+                algorithm.Append(buffer.AsSpan(0, bytesRead));
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.AppendDataAsync.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.AppendDataAsync.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.AppendDataAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.Buffers;
+using System.IO;
+using System.IO.Hashing;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Asynchronously reads all bytes from <paramref name="source" /> and feeds them into the hash accumulator via
+    /// <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" />, without finalising the computation.
+    /// </summary>
+    /// <param name="algorithm">The hash algorithm to use. Must not be <see langword="null" />.</param>
+    /// <param name="source">
+    /// The stream whose bytes are appended to the current hash state. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="bufferSize">
+    /// The number of bytes read per iteration. Must be greater than zero. Defaults to 4096.
+    /// </param>
+    /// <param name="cancellationToken">
+    /// Token used to cancel the read loop. When signalled, the current
+    /// <see cref="Stream.ReadAsync(Memory{byte}, CancellationToken)" /> is cancelled and
+    /// <see cref="OperationCanceledException" /> is propagated to the caller.
+    /// </param>
+    /// <returns>A <see cref="Task" /> that completes when all bytes have been fed into the accumulator.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="bufferSize" /> is less than or equal to zero.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken" /> was signalled before or during the read loop.
+    /// </exception>
+    /// <exception cref="IOException">
+    /// <paramref name="source" /> threw an <see cref="IOException" /> during a read.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This method is the asynchronous counterpart to
+    /// <see cref="AppendData(NonCryptographicHashAlgorithm, Stream, int)" />. It allows large or streaming sources to be
+    /// incorporated into an incremental hash computation without blocking the calling thread.
+    /// </para>
+    /// <para>
+    /// Because only <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" /> is called, the hash state is
+    /// not finalised after this method returns. The caller retrieves the digest by calling
+    /// <see cref="NonCryptographicHashAlgorithm.GetCurrentHash()" /> or
+    /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" /> when all data has been supplied.
+    /// </para>
+    /// <para>
+    /// Multiple <see cref="AppendDataAsync" /> calls — and calls interleaved with the synchronous
+    /// <see cref="AppendData(NonCryptographicHashAlgorithm, Stream, int)" /> — accumulate correctly because both delegate to
+    /// <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" /> on the same instance.
+    /// </para>
+    /// <para>
+    /// The read buffer is rented from <see cref="ArrayPool{T}.Shared" /> and returned in all exit paths, including
+    /// cancellation and exception propagation.
+    /// </para>
+    /// </remarks>
+    public static async Task AppendDataAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream source,
+        int bufferSize = 4096,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(source);
+
+        if (bufferSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(bufferSize), bufferSize, "Buffer size must be greater than zero.");
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+        try
+        {
+            int bytesRead;
+            while ((bytesRead = await source
+                .ReadAsync(buffer.AsMemory(0, bufferSize), cancellationToken)
+                .ConfigureAwait(false)) > 0)
+            {
+                algorithm.Append(buffer.AsSpan(0, bytesRead));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.TryVerifyHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.TryVerifyHash.cs
@@ -1,0 +1,337 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.TryVerifyHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Attempts to compute and verify the hash of a byte array, reporting both whether the operation succeeded and whether
+    /// the hash matched.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">
+    /// The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHash">
+    /// The expected hash value to compare against. A <see langword="null" /> value causes the method to return
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="result">
+    /// When this method returns <see langword="true" />, contains <see langword="true" /> if the computed hash matched
+    /// <paramref name="expectedHash" />; otherwise, <see langword="false" />. Always <see langword="false" /> when the
+    /// method itself returns <see langword="false" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the hash computation and comparison completed without error; <see langword="false" /> if
+    /// <paramref name="input" /> or <paramref name="expectedHash" /> is <see langword="null" />, or an internal exception
+    /// occurred.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// Unlike <see cref="VerifyHash(NonCryptographicHashAlgorithm, byte[], byte[])" />, this overload distinguishes
+    /// between a failed operation (return value <see langword="false" />) and a successful but non-matching comparison
+    /// (<paramref name="result" /> = <see langword="false" />). Both <see langword="null" /> inputs are treated as an
+    /// operation failure, making this overload suitable for defensive validation where inputs may be absent.
+    /// </remarks>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        byte[] input,
+        byte[] expectedHash,
+        out bool result)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        result = false;
+
+        if (input == null || expectedHash == null)
+            return false;
+
+        try
+        {
+            result = algorithm.VerifyHash(input, expectedHash);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a byte array against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">
+    /// The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value to compare against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        byte[] input,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        if (input == null)
+            return false;
+
+        try
+        {
+            return algorithm.VerifyHash(input, expectedHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a byte array against an expected hexadecimal hash string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">
+    /// The input data to hash. A <see langword="null" /> value causes the method to return <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHex">The expected hash as a hexadecimal string. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />; otherwise,
+    /// <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHex" /> is <see langword="null" />.
+    /// </exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        byte[] input,
+        string expectedHex)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        if (input == null)
+            return false;
+
+        try
+        {
+            return algorithm.VerifyHash(input, expectedHex);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of an encoded string against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The plain-text string to encode and hash. Must not be <see langword="null" />.</param>
+    /// <param name="encoding">
+    /// The encoding used to convert <paramref name="input" /> to bytes. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, <paramref name="encoding" />, or
+    /// <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        string input,
+        Encoding encoding,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(encoding);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        try
+        {
+            return algorithm.VerifyHash(input, encoding, expectedHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a span of bytes against the expected hash span.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The span of input bytes to hash.</param>
+    /// <param name="expectedHash">The expected hash as a read-only byte span.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        ReadOnlySpan<byte> input,
+        ReadOnlySpan<byte> expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        try
+        {
+            return algorithm.VerifyHash(input, expectedHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a memory buffer against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The memory buffer containing the input data to hash.</param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        ReadOnlyMemory<byte> input,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        try
+        {
+            return algorithm.VerifyHash(input, expectedHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a stream against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The input stream to read and hash. A <see langword="null" /> value causes the method to return
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHash">
+    /// The expected hash value as a byte array. A <see langword="null" /> value causes the method to return
+    /// <see langword="false" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the stream produces a matching hash; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        if (stream == null || expectedHash == null)
+            return false;
+
+        try
+        {
+            return algorithm.VerifyHash(stream, expectedHash);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to compute and verify the hash of a stream against the expected hexadecimal hash string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The input stream to read and hash. A <see langword="null" /> value causes the method to return
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHex">The expected hash value as a hexadecimal string. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the stream hash matches <paramref name="expectedHex" />; otherwise,
+    /// <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHex" /> is <see langword="null" />.
+    /// </exception>
+    public static bool TryVerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        string expectedHex)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        if (stream == null)
+            return false;
+
+        try
+        {
+            return algorithm.VerifyHash(stream, expectedHex);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.TryVerifyHashAsync.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.TryVerifyHashAsync.cs
@@ -1,0 +1,286 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.TryVerifyHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of a stream against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The stream to read and hash. A <see langword="null" /> value causes the task to resolve to
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHash">
+    /// The expected hash value as a byte array. A <see langword="null" /> value causes the task to resolve to
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        byte[] expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        if (stream == null || expectedHash == null)
+            return false;
+
+        try
+        {
+            return await algorithm.VerifyHashAsync(stream, expectedHash, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of a stream against the expected hexadecimal hash string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The readable stream to hash asynchronously. A <see langword="null" /> value causes the task to resolve to
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHex">
+    /// The expected hash as a hexadecimal string. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />;
+    /// otherwise, <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHex" /> is <see langword="null" />.
+    /// </exception>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        string expectedHex,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        if (stream == null)
+            return false;
+
+        try
+        {
+            return await algorithm.VerifyHashAsync(stream, expectedHex, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of a stream against the expected hash value held in a
+    /// memory buffer.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The stream to read and hash asynchronously. A <see langword="null" /> value causes the task to resolve to
+    /// <see langword="false" />.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value as a <see cref="ReadOnlyMemory{T}" /> of bytes.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="algorithm" /> is <see langword="null" />.</exception>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        ReadOnlyMemory<byte> expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        if (stream == null)
+            return false;
+
+        try
+        {
+            return await algorithm.VerifyHashAsync(stream, expectedHash, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of a byte array against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input data to hash. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, or <paramref name="expectedHash" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <paramref name="input" /> is wrapped in a non-allocating <see cref="MemoryStream" /> and passed to the
+    /// stream-based
+    /// <see cref="VerifyHashAsync(NonCryptographicHashAlgorithm, Stream, byte[], CancellationToken)" /> overload.
+    /// </remarks>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        byte[] input,
+        byte[] expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        try
+        {
+            using MemoryStream stream = new(input, writable: false);
+            return await algorithm.VerifyHashAsync(stream, expectedHash, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of a byte array against the expected hexadecimal hash
+    /// string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input data to hash. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHex">
+    /// The expected hash as a hexadecimal string. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />;
+    /// otherwise, <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, or <paramref name="expectedHex" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <paramref name="input" /> is wrapped in a non-allocating <see cref="MemoryStream" /> and passed to the
+    /// stream-based
+    /// <see cref="VerifyHashAsync(NonCryptographicHashAlgorithm, Stream, string, CancellationToken)" /> overload.
+    /// </remarks>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        byte[] input,
+        string expectedHex,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        try
+        {
+            using MemoryStream stream = new(input, writable: false);
+            return await algorithm.VerifyHashAsync(stream, expectedHex, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Attempts to asynchronously compute and verify the hash of an encoded string against the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input string to encode and hash. Must not be <see langword="null" />.</param>
+    /// <param name="encoding">
+    /// The character encoding used to convert <paramref name="input" /> to bytes. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, <paramref name="encoding" />, or
+    /// <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The encoded bytes are wrapped in a non-allocating <see cref="MemoryStream" /> and passed to the stream-based
+    /// <see cref="VerifyHashAsync(NonCryptographicHashAlgorithm, Stream, byte[], CancellationToken)" /> overload.
+    /// </remarks>
+    public static async Task<bool> TryVerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        string input,
+        Encoding encoding,
+        byte[] expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(encoding);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        try
+        {
+            byte[] inputBytes = encoding.GetBytes(input);
+            using MemoryStream stream = new(inputBytes, writable: false);
+            return await algorithm.VerifyHashAsync(stream, expectedHash, cancellationToken).ConfigureAwait(false);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.VerifyHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.VerifyHash.cs
@@ -1,0 +1,292 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.VerifyHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Verifies that the computed hash of the input data matches the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input byte array whose hash will be computed. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, or <paramref name="expectedHash" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The algorithm state is reset before computation and restored to a clean state after
+    /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" /> completes. Any prior incremental state is
+    /// discarded.
+    /// </remarks>
+    public static bool VerifyHash(this NonCryptographicHashAlgorithm algorithm, byte[] input, byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        algorithm.Reset();
+        algorithm.Append(input);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedHash);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the input data matches the expected hash value expressed as a hexadecimal string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input byte array whose hash will be computed. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHex">
+    /// The expected hash value as a hexadecimal string. Case-insensitive. Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />; otherwise,
+    /// <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="input" />, or <paramref name="expectedHex" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="expectedHex" /> is decoded to bytes before the hash is computed so that a malformed hex string
+    /// fails fast without performing unnecessary work.
+    /// </para>
+    /// <para>
+    /// A malformed <paramref name="expectedHex" /> string (one that cannot be decoded) is treated as a non-match and
+    /// returns <see langword="false" />.
+    /// </para>
+    /// </remarks>
+    public static bool VerifyHash(this NonCryptographicHashAlgorithm algorithm, byte[] input, string expectedHex)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(input);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        byte[] expectedBytes;
+        try
+        {
+            expectedBytes = Convert.FromHexString(expectedHex);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        algorithm.Reset();
+        algorithm.Append(input);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedBytes);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the stream matches the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The input stream to read and hash. Must not be <see langword="null" /> and must be readable.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the hash of the stream matches <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHash" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The algorithm state is reset before the stream is read. Any prior incremental state is discarded.
+    /// </remarks>
+    public static bool VerifyHash(this NonCryptographicHashAlgorithm algorithm, Stream stream, byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(stream);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        algorithm.Reset();
+        algorithm.AppendData(stream);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedHash);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the stream matches the expected hash value expressed as a hexadecimal string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The input stream to read and hash. Must not be <see langword="null" /> and must be readable.
+    /// </param>
+    /// <param name="expectedHex">
+    /// The expected hash value as a hexadecimal string. Case-insensitive. Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the hash of the stream matches <paramref name="expectedHex" />; otherwise,
+    /// <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHex" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="expectedHex" /> is decoded to bytes before the stream is read so that a malformed hex string
+    /// fails fast without consuming stream data or wasting the hash computation.
+    /// </para>
+    /// <para>
+    /// A malformed <paramref name="expectedHex" /> string is treated as a non-match and returns
+    /// <see langword="false" />.
+    /// </para>
+    /// </remarks>
+    public static bool VerifyHash(this NonCryptographicHashAlgorithm algorithm, Stream stream, string expectedHex)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(stream);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        byte[] expectedBytes;
+        try
+        {
+            expectedBytes = Convert.FromHexString(expectedHex);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        algorithm.Reset();
+        algorithm.AppendData(stream);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedBytes);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the input span matches the expected hash span.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> used to compute the hash. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="input">The input span of bytes to hash.</param>
+    /// <param name="expectedHash">The expected hash as a read-only span of bytes.</param>
+    /// <returns>
+    /// <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The algorithm state is reset before computation and restored to a clean state via
+    /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" /> after the digest is produced.
+    /// </remarks>
+    public static bool VerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        ReadOnlySpan<byte> input,
+        ReadOnlySpan<byte> expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+
+        algorithm.Reset();
+        algorithm.Append(input);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedHash);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the input memory block matches the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> used to compute the hash. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="input">The memory buffer containing the input data to hash.</param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the hash of <paramref name="input" /> equals <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Delegates to the
+    /// <see cref="VerifyHash(NonCryptographicHashAlgorithm, ReadOnlySpan{byte}, ReadOnlySpan{byte})" /> overload.
+    /// </remarks>
+    public static bool VerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        ReadOnlyMemory<byte> input,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        return algorithm.VerifyHash(input.Span, expectedHash);
+    }
+
+    /// <summary>
+    /// Verifies that the computed hash of the encoded string matches the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> used to compute the hash. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="text">The input string to encode and hash. Must not be <see langword="null" />.</param>
+    /// <param name="encoding">
+    /// The encoding used to convert <paramref name="text" /> to bytes. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="expectedHash">The expected hash as a byte array. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the hash of the encoded string equals <paramref name="expectedHash" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="text" />, <paramref name="encoding" />, or
+    /// <paramref name="expectedHash" /> is <see langword="null" />.
+    /// </exception>
+    public static bool VerifyHash(
+        this NonCryptographicHashAlgorithm algorithm,
+        string text,
+        Encoding encoding,
+        byte[] expectedHash)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(text);
+        ThrowHelper.ThrowIfNull(encoding);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        byte[] data = encoding.GetBytes(text);
+
+        return algorithm.VerifyHash(data, expectedHash);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.VerifyHashAsync.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.VerifyHashAsync.cs
@@ -1,0 +1,180 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.VerifyHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu;
+using System;
+using System.IO;
+using System.IO.Hashing;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+    /// <summary>
+    /// Asynchronously verifies that the computed hash of a stream matches the expected hash value.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">
+    /// The stream to read and hash asynchronously. Must not be <see langword="null" /> and must be readable.
+    /// </param>
+    /// <param name="expectedHash">The expected hash value as a byte array. Must not be <see langword="null" />.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHash" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken" /> was signalled before or during stream reading.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The algorithm state is reset before the stream is read. Any prior incremental state is discarded.
+    /// </para>
+    /// <para>
+    /// If <paramref name="cancellationToken" /> is already cancelled on entry, an
+    /// <see cref="OperationCanceledException" /> is thrown immediately before any I/O begins.
+    /// </para>
+    /// </remarks>
+    public static async Task<bool> VerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        byte[] expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(stream);
+        ThrowHelper.ThrowIfNull(expectedHash);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        algorithm.Reset();
+        await algorithm.AppendDataAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedHash);
+    }
+
+    /// <summary>
+    /// Asynchronously verifies that the computed hash of a stream matches the expected hexadecimal hash string.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">The readable stream to hash asynchronously. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHex">
+    /// The expected hash as a hexadecimal string. Case-insensitive. Must not be <see langword="null" />.
+    /// </param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash matches <paramref name="expectedHex" />;
+    /// otherwise, <see langword="false" />.
+    /// Returns <see langword="false" /> if <paramref name="expectedHex" /> is not a valid hexadecimal string.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" />, <paramref name="stream" />, or <paramref name="expectedHex" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken" /> was signalled before or during stream reading.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <paramref name="expectedHex" /> is decoded to bytes before the stream is read so that a malformed hex string
+    /// fails fast without consuming stream data. A malformed <paramref name="expectedHex" /> string is treated as a
+    /// non-match and returns <see langword="false" />.
+    /// </para>
+    /// <para>
+    /// If <paramref name="cancellationToken" /> is already cancelled on entry, an
+    /// <see cref="OperationCanceledException" /> is thrown immediately before any I/O begins.
+    /// </para>
+    /// </remarks>
+    public static async Task<bool> VerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        string expectedHex,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(stream);
+        ThrowHelper.ThrowIfNull(expectedHex);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        byte[] expectedBytes;
+        try
+        {
+            expectedBytes = Convert.FromHexString(expectedHex);
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+
+        algorithm.Reset();
+        await algorithm.AppendDataAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedBytes);
+    }
+
+    /// <summary>
+    /// Asynchronously verifies that the computed hash of a stream matches the expected hash value held in a memory buffer.
+    /// </summary>
+    /// <param name="algorithm">
+    /// The <see cref="NonCryptographicHashAlgorithm" /> instance used to compute the hash. Must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <param name="stream">The readable stream to hash asynchronously. Must not be <see langword="null" />.</param>
+    /// <param name="expectedHash">The expected hash value as a <see cref="ReadOnlyMemory{T}" /> of bytes.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that evaluates to <see langword="true" /> if the computed hash equals <paramref name="expectedHash" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="algorithm" /> or <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// <paramref name="cancellationToken" /> was signalled before or during stream reading.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This overload supports allocation-reduced verification when the expected hash is already held in a
+    /// <see cref="ReadOnlyMemory{T}" /> buffer.
+    /// </para>
+    /// <para>
+    /// If <paramref name="cancellationToken" /> is already cancelled on entry, an
+    /// <see cref="OperationCanceledException" /> is thrown immediately before any I/O begins.
+    /// </para>
+    /// </remarks>
+    public static async Task<bool> VerifyHashAsync(
+        this NonCryptographicHashAlgorithm algorithm,
+        Stream stream,
+        ReadOnlyMemory<byte> expectedHash,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(algorithm);
+        ThrowHelper.ThrowIfNull(stream);
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        algorithm.Reset();
+        await algorithm.AppendDataAsync(stream, cancellationToken: cancellationToken).ConfigureAwait(false);
+        byte[] actualHash = algorithm.GetHashAndReset();
+
+        return actualHash.AsSpan().SequenceEqual(expectedHash.Span);
+    }
+}

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO.Hashing;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Provides a set of <see langword="static" /> (<see langword="Shared" /> in Visual Basic) extension methods that extend the
+/// <see cref="NonCryptographicHashAlgorithm" /> class with verification, comparison, and incremental hashing capabilities.
+/// </summary>
+public static partial class NonCryptographicHashAlgorithmExtensions
+{
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/MonitoringNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/MonitoringNonCryptographicHashAlgorithm.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MonitoringNonCryptographicHashAlgorithm.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO.Hashing;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// A test-oriented non-cryptographic hash algorithm that computes the sum of all input bytes as a 32-bit unsigned
+/// integer, while monitoring usage. This implementation is designed for verifying calls to
+/// <see cref="NonCryptographicHashAlgorithm" /> extension methods during testing.
+/// </summary>
+/// <remarks>
+/// The hash output is <c>BitConverter.GetBytes((uint)sum)</c> in the platform byte order, making the expected hash
+/// of any input trivially computable without reference vectors.
+/// </remarks>
+public sealed class MonitoringNonCryptographicHashAlgorithm : NonCryptographicHashAlgorithm
+{
+    private uint _sum;
+
+    /// <summary>
+    /// Initialises a new instance of <see cref="MonitoringNonCryptographicHashAlgorithm" /> with a 4-byte output.
+    /// </summary>
+    public MonitoringNonCryptographicHashAlgorithm()
+        : base(hashLengthInBytes: sizeof(uint))
+    {
+    }
+
+    /// <summary>Gets the number of times <see cref="Append(ReadOnlySpan{byte})" /> has been called on this instance.</summary>
+    public int AppendCallCount { get; private set; }
+
+    /// <summary>Gets the number of times <see cref="GetCurrentHashCore" /> has been invoked.</summary>
+    public int GetCurrentHashCoreCallCount { get; private set; }
+
+    /// <summary>Gets the number of times <see cref="Reset()" /> has been called on this instance.</summary>
+    public int ResetCallCount { get; private set; }
+
+    /// <summary>Gets the total number of bytes fed into this instance across all <see cref="Append(ReadOnlySpan{byte})" /> calls.</summary>
+    public long BytesAppended { get; private set; }
+
+    /// <inheritdoc />
+    public override void Append(ReadOnlySpan<byte> source)
+    {
+        foreach (byte b in source)
+            _sum += b;
+
+        BytesAppended += source.Length;
+        AppendCallCount++;
+    }
+
+    /// <inheritdoc />
+    protected override void GetCurrentHashCore(Span<byte> destination)
+    {
+        BitConverter.TryWriteBytes(destination, _sum);
+        GetCurrentHashCoreCallCount++;
+    }
+
+    /// <inheritdoc />
+    public override void Reset()
+    {
+        _sum = 0;
+        BytesAppended = 0;
+        ResetCallCount++;
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.AppendData.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.AppendData.cs
@@ -1,0 +1,238 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.AppendData.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using Bodu.Test.IO;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the synchronous <see cref="NonCryptographicHashAlgorithmExtensions.AppendData" /> overloads covering
+/// span and stream inputs.
+/// </summary>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Span overload — argument validation ──────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the span overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenAlgorithmIsNull_ForSpanOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm!.AppendData(new ReadOnlySpan<byte>(new byte[] { 1, 2, 3 }));
+        });
+    }
+
+    // ─── Span overload — accumulation ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty span does not alter the current hash state.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenSpanIsEmpty_ShouldNotContributeToHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm baseline = CreateAlgorithm();
+
+        algorithm.AppendData(ReadOnlySpan<byte>.Empty);
+
+        CollectionAssert.AreEqual(baseline.GetCurrentHash(), algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that the supplied bytes contribute to the hash after retrieval.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenSpanContainsData_ShouldContributeToHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] expected = BitConverter.GetBytes((uint)(1 + 2 + 3 + 4));
+
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 1, 2, 3, 4 }));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that multiple calls accumulate all supplied bytes correctly.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenCalledMultipleTimes_ShouldAccumulateAllBytes()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] expected = BitConverter.GetBytes((uint)(10 + 20 + 30 + 40));
+
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 10, 20 }));
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 30, 40 }));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.AppendData(NonCryptographicHashAlgorithm, ReadOnlySpan{byte})" />
+    /// increments <see cref="MonitoringNonCryptographicHashAlgorithm.AppendCallCount" />, confirming the underlying
+    /// <see cref="NonCryptographicHashAlgorithm.Append" /> path is exercised exactly once per call.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenCalled_ShouldInvokeAppendOnce()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        int before = algorithm.AppendCallCount;
+
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 1, 2, 3 }));
+
+        Assert.AreEqual(before + 1, algorithm.AppendCallCount);
+    }
+
+    // ─── Stream overload — argument validation ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenAlgorithmIsNull_ForStreamOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm!.AppendData(stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.AppendData((Stream)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a zero <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenBufferSizeIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.AppendData(stream, bufferSize: 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenBufferSizeIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.AppendData(stream, bufferSize: -1);
+        });
+    }
+
+    // ─── Stream overload — correctness ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty stream does not alter the current hash state.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenStreamIsEmpty_ShouldNotContributeToHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm baseline = CreateAlgorithm();
+
+        algorithm.AppendData(new MemoryStream(Array.Empty<byte>()));
+
+        CollectionAssert.AreEqual(baseline.GetCurrentHash(), algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that stream bytes contribute to the hash identically to a direct span append.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenStreamHasData_ShouldMatchDirectSpanAppend()
+    {
+        MonitoringNonCryptographicHashAlgorithm fromStream = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm fromSpan = CreateAlgorithm();
+
+        fromStream.AppendData(new MemoryStream(SampleData));
+        fromSpan.AppendData(SampleData.AsSpan());
+
+        CollectionAssert.AreEqual(fromSpan.GetCurrentHash(), fromStream.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that a small <paramref name="bufferSize" /> — forcing multiple read iterations — produces the same
+    /// result as the default buffer size.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenBufferSizeSmallerThanInput_ShouldProduceCorrectHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.AppendData(new MemoryStream(SampleData), bufferSize: 1);
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="FixedChunkStream" /> delivering data 1 byte at a time is correctly accumulated.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenSourceIsFixedChunkStream_ShouldProduceCorrectHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.AppendData(new FixedChunkStream(SampleData, chunkSize: 1));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="IOException" /> thrown by a <see cref="FaultingStream" /> mid-read propagates
+    /// cleanly out of the stream overload.
+    /// </summary>
+    [TestMethod]
+    public void AppendData_WhenSourceFaultsMidRead_ShouldPropagateIOException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<IOException>(() =>
+        {
+            algorithm.AppendData(new FaultingStream(SampleData, throwAfterBytes: 2));
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.AppendDataAsync.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.AppendDataAsync.cs
@@ -1,0 +1,252 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.AppendDataAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Threading;
+using Bodu.Test.IO;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" />.
+/// </summary>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Argument validation ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> throws
+    /// <see cref="ArgumentNullException" /> when the algorithm is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm!.AppendDataAsync(stream));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> throws
+    /// <see cref="ArgumentNullException" /> when the source stream is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm.AppendDataAsync(null!));
+    }
+
+    /// <summary>
+    /// Verifies that a zero <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenBufferSizeIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            await algorithm.AppendDataAsync(stream, bufferSize: 0));
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenBufferSizeIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            await algorithm.AppendDataAsync(stream, bufferSize: -1));
+    }
+
+    // ─── Correctness ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty stream does not alter the current hash state.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenStreamIsEmpty_ShouldNotContributeToHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm baseline = CreateAlgorithm();
+
+        await algorithm.AppendDataAsync(new MemoryStream(Array.Empty<byte>()));
+
+        CollectionAssert.AreEqual(baseline.GetCurrentHash(), algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that stream bytes feed into the accumulator and produce the same digest as the synchronous span
+    /// overload on the same data.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenCalled_ShouldMatchSynchronousAppendData()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        await algorithm.AppendDataAsync(new MemoryStream(SampleData));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that multiple <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> calls accumulate
+    /// all bytes in order, producing the same result as hashing the concatenated data in a single operation.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenCalledMultipleTimes_ShouldAccumulateAllBytes()
+    {
+        byte[] part1 = new byte[] { 1, 2, 3, 4 };
+        byte[] part2 = new byte[] { 5, 6, 7, 8 };
+        byte[] combined = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(combined.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        await algorithm.AppendDataAsync(new MemoryStream(part1));
+        await algorithm.AppendDataAsync(new MemoryStream(part2));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> interleaved with
+    /// the synchronous <see cref="NonCryptographicHashAlgorithmExtensions.AppendData(NonCryptographicHashAlgorithm, ReadOnlySpan{byte})" />
+    /// accumulates all bytes correctly.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenMixedWithSyncAppendData_ShouldAccumulateAllBytes()
+    {
+        byte[] part1 = new byte[] { 10, 20 };
+        byte[] part2 = new byte[] { 30, 40 };
+        byte[] combined = new byte[] { 10, 20, 30, 40 };
+
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(combined.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.AppendData(part1.AsSpan());
+        await algorithm.AppendDataAsync(new MemoryStream(part2));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that a small <paramref name="bufferSize" /> — forcing multiple read iterations — produces the correct
+    /// hash.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenBufferSizeSmallerThanInput_ShouldProduceCorrectHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        await algorithm.AppendDataAsync(new MemoryStream(SampleData), bufferSize: 1);
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    // ─── Stream variants ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see cref="FixedChunkStream" /> delivering data 1 byte at a time is correctly accumulated.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenSourceIsFixedChunkStream_ShouldProduceCorrectHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        await algorithm.AppendDataAsync(new FixedChunkStream(SampleData, chunkSize: 1));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that a non-seekable stream is correctly accumulated without invoking seek operations.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenSourceIsNonSeekable_ShouldProduceCorrectHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm reference = CreateAlgorithm();
+        reference.AppendData(SampleData.AsSpan());
+        byte[] expected = reference.GetCurrentHash();
+
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        await algorithm.AppendDataAsync(new NonSeekableStream(SampleData));
+
+        CollectionAssert.AreEqual(expected, algorithm.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="IOException" /> thrown by a <see cref="FaultingStream" /> mid-read propagates
+    /// cleanly out of <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenSourceFaultsMidRead_ShouldPropagateIOException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        await Assert.ThrowsExactlyAsync<IOException>(async () =>
+            await algorithm.AppendDataAsync(new FaultingStream(SampleData, throwAfterBytes: 2)));
+    }
+
+    // ─── Cancellation ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> throws
+    /// <see cref="OperationCanceledException" /> when the token is already cancelled before the call.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenTokenAlreadyCancelled_ShouldThrowOperationCanceledException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await algorithm.AppendDataAsync(stream, cancellationToken: cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="CancellationTriggerStream" /> cancelling the token mid-read causes
+    /// <see cref="NonCryptographicHashAlgorithmExtensions.AppendDataAsync" /> to throw
+    /// <see cref="OperationCanceledException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task AppendDataAsync_WhenCancellationTriggeredMidStream_ShouldThrowOperationCanceledException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using CancellationTokenSource cts = new();
+
+        // cancelAfterRead: 1 cancels the token after the first successful read; the next ReadAsync sees a
+        // cancelled token and throws OperationCanceledException before reading any further bytes.
+        using CancellationTriggerStream stream = new(new MemoryStream(SampleData), cts, cancelAfterRead: 1);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await algorithm.AppendDataAsync(stream, cancellationToken: cts.Token));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHash.cs
@@ -1,0 +1,277 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the synchronous try-pattern <see cref="NonCryptographicHashAlgorithmExtensions.TryVerifyHash" />
+/// overloads.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Unlike <c>VerifyHash</c>, the try-pattern treats a <see langword="null" /> byte-array input and a malformed hex
+/// expected value as graceful non-matches (<see langword="false" />) rather than throwing.
+/// </para>
+/// <para>
+/// Nulls that still raise <see cref="ArgumentNullException" /> are those that represent programmer error: a null
+/// algorithm receiver (the extension method cannot dispatch without one) and the string-overload arguments
+/// (<c>input</c>, <c>encoding</c>, and expected hash).
+/// </para>
+/// </remarks>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Matching input → true ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching byte-array input returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        Assert.IsTrue(algorithm.TryVerifyHash(SampleData, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a matching byte-array input returns <see langword="true" /> when the expected hash is supplied
+    /// as a hex string.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        Assert.IsTrue(algorithm.TryVerifyHash(SampleData, SampleHex));
+    }
+
+    /// <summary>
+    /// Verifies that a matching <see cref="ReadOnlySpan{T}" /> input returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenSpanMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        ReadOnlySpan<byte> input = SampleData;
+        ReadOnlySpan<byte> expected = SampleHash;
+
+        Assert.IsTrue(algorithm.TryVerifyHash(input, expected));
+    }
+
+    /// <summary>
+    /// Verifies that a matching <see cref="ReadOnlyMemory{T}" /> input returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenMemoryMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        ReadOnlyMemory<byte> memory = SampleData;
+
+        Assert.IsTrue(algorithm.TryVerifyHash(memory, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a matching string + encoding input returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStringEncodedMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        Assert.IsTrue(algorithm.TryVerifyHash(SampleString, SampleEncoding, SampleStringHash));
+    }
+
+    /// <summary>
+    /// Verifies that a matching stream input returns <see langword="true" /> when the expected hash is a byte array.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStreamMatchesByteArray_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.IsTrue(algorithm.TryVerifyHash(stream, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a matching stream input returns <see langword="true" /> when the expected hash is a hex string.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStreamMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.IsTrue(algorithm.TryVerifyHash(stream, SampleHex));
+    }
+
+    // ─── Non-matching input → false ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a non-matching byte-array input returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        Assert.IsFalse(algorithm.TryVerifyHash(SampleData, wrong));
+    }
+
+    /// <summary>
+    /// Verifies that a malformed hex string is treated as a non-match and returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenHexStringIsMalformed_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.TryVerifyHash(SampleData, "ZZZZZZZZ"));
+    }
+
+    // ─── Null inputs handled gracefully ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a null byte-array input returns <see langword="false" /> rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayInputIsNull_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.TryVerifyHash((byte[])null!, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a null stream returns <see langword="false" /> rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStreamIsNull_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.TryVerifyHash((Stream)null!, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a null stream in the hex overload returns <see langword="false" /> rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStreamIsNull_ForHexOverload_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.TryVerifyHash((Stream)null!, SampleHex));
+    }
+
+    // ─── Out-bool overload ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the out-bool overload returns <see langword="true" /> and sets <paramref name="result" /> to
+    /// <see langword="true" /> when the hash matches.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayMatchesWithOutBool_ShouldReturnTrueAndSetResult()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool succeeded = algorithm.TryVerifyHash(SampleData, SampleHash, out bool result);
+
+        Assert.IsTrue(succeeded);
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that the out-bool overload returns <see langword="true" /> and sets <paramref name="result" /> to
+    /// <see langword="false" /> when the hash does not match.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenByteArrayDoesNotMatchWithOutBool_ShouldReturnTrueAndSetResultFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        bool succeeded = algorithm.TryVerifyHash(SampleData, wrong, out bool result);
+
+        Assert.IsTrue(succeeded);
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that the out-bool overload returns <see langword="false" /> and sets <paramref name="result" /> to
+    /// <see langword="false" /> when the input is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenInputIsNullWithOutBool_ShouldReturnFalseAndSetResultFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool succeeded = algorithm.TryVerifyHash((byte[])null!, SampleHash, out bool result);
+
+        Assert.IsFalse(succeeded);
+        Assert.IsFalse(result);
+    }
+
+    // ─── Argument validation — exceptions still thrown ────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> algorithm receiver still raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            NonCryptographicHashAlgorithm? algorithm = null;
+            algorithm!.TryVerifyHash(SampleData, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash in the byte-array overload still raises
+    /// <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenExpectedHashIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.TryVerifyHash(SampleData, (byte[])null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hex string still raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.TryVerifyHash(SampleData, (string)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash in the stream overload still raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void TryVerifyHash_WhenStreamExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.TryVerifyHash(new MemoryStream(), (string)null!);
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHashAsync.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHashAsync.cs
@@ -1,0 +1,256 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.TryVerifyHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+using System.Threading;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the asynchronous try-pattern <see cref="NonCryptographicHashAlgorithmExtensions.TryVerifyHashAsync" />
+/// overloads.
+/// </summary>
+/// <remarks>
+/// The try-pattern async overloads catch all exceptions (including
+/// <see cref="OperationCanceledException" />) and return <see langword="false" /> rather than propagating them, with
+/// the sole exception of a <see langword="null" /> algorithm receiver which still throws
+/// <see cref="ArgumentNullException" />.
+/// </remarks>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Stream + byte-array ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching stream input returns <see langword="true" /> for the byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamMatchesByteArray_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, SampleHash);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a non-matching stream input returns <see langword="false" /> for the byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamDoesNotMatchByteArray_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, wrong);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a null stream returns <see langword="false" /> rather than throwing for the byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamIsNull_ForByteArrayOverload_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.TryVerifyHashAsync((Stream)null!, SampleHash);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash returns <see langword="false" /> rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenExpectedHashIsNull_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, (byte[])null!);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── Stream + hex string ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching stream input returns <see langword="true" /> for the hex overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, SampleHex);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a null stream returns <see langword="false" /> for the hex overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamIsNull_ForHexOverload_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.TryVerifyHashAsync((Stream)null!, SampleHex);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that a malformed hex string returns <see langword="false" /> rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenHexStringIsMalformed_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, "ZZZZZZZZ");
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── Stream + ReadOnlyMemory ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching stream input returns <see langword="true" /> for the memory overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamMatchesMemory_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        ReadOnlyMemory<byte> expected = SampleHash;
+
+        bool result = await algorithm.TryVerifyHashAsync(stream, expected);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a null stream returns <see langword="false" /> for the memory overload.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStreamIsNull_ForMemoryOverload_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        ReadOnlyMemory<byte> expected = SampleHash;
+
+        bool result = await algorithm.TryVerifyHashAsync((Stream)null!, expected);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── Byte-array input ─────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching byte-array input returns <see langword="true" /> when expected hash is a byte array.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenByteArrayMatchesByteArray_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.TryVerifyHashAsync(SampleData, SampleHash);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a matching byte-array input returns <see langword="true" /> when expected hash is a hex string.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenByteArrayMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.TryVerifyHashAsync(SampleData, SampleHex);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a non-matching byte-array input returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenByteArrayDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        bool result = await algorithm.TryVerifyHashAsync(SampleData, wrong);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── String + encoding ────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a matching encoded string input returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStringEncodedMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.TryVerifyHashAsync(SampleString, SampleEncoding, SampleStringHash);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a non-matching encoded string input returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenStringEncodedDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        bool result = await algorithm.TryVerifyHashAsync(SampleString, SampleEncoding, wrong);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── Argument validation ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> algorithm receiver still raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm!.TryVerifyHashAsync(stream, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hex string still raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task TryVerifyHashAsync_WhenExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm.TryVerifyHashAsync(stream, (string)null!));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.VerifyHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.VerifyHash.cs
@@ -1,0 +1,384 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.VerifyHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Text;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the synchronous <see cref="NonCryptographicHashAlgorithmExtensions.VerifyHash" /> overloads covering
+/// byte-array, span, memory, string-with-encoding, and stream inputs.
+/// </summary>
+/// <remarks>
+/// <c>VerifyHash</c> throws on any null argument (algorithm, input, expected hash, encoding) and returns a simple
+/// <see langword="true" />/<see langword="false" /> result for valid inputs. Exception-swallowing behaviour belongs
+/// to the <c>TryVerifyHash</c> family instead.
+/// </remarks>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Byte-array overload — matching input ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the byte-array overload returns <see langword="true" /> when the input matches the expected hash.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenByteArrayMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] input = { 1, 2, 3, 4 };
+        byte[] expected = BitConverter.GetBytes((uint)(1 + 2 + 3 + 4));
+
+        Assert.IsTrue(algorithm.VerifyHash(input, expected));
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload accepts an expected hash supplied as a hex string and returns
+    /// <see langword="true" /> when the hashes match.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenByteArrayMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] input = { 10, 10 };
+        string expectedHex = Convert.ToHexString(BitConverter.GetBytes((uint)20));
+
+        Assert.IsTrue(algorithm.VerifyHash(input, expectedHex));
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload returns <see langword="false" /> when the input produces a different hash.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenByteArrayDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        Assert.IsFalse(algorithm.VerifyHash(SampleData, wrong));
+    }
+
+    /// <summary>
+    /// Verifies that a malformed hex string is treated as a non-match and returns <see langword="false" /> rather than
+    /// throwing.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenHexStringIsMalformed_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.VerifyHash(SampleData, "ZZZZZZZZ"));
+    }
+
+    /// <summary>
+    /// Verifies that an empty input produces a hash of zero, which does not match <see cref="SampleHash" />.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenInputIsEmpty_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsFalse(algorithm.VerifyHash(Array.Empty<byte>(), SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that <c>VerifyHash</c> resets any prior accumulated state before computing, so successive calls
+    /// with different inputs produce independent results.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenCalledSuccessively_ShouldResetStateBeforeEachComputation()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.IsTrue(algorithm.VerifyHash(SampleData, SampleHash));
+        Assert.IsTrue(algorithm.VerifyHash(SampleData, SampleHash));
+    }
+
+    // ─── Span and memory overloads ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that both the <see cref="ReadOnlySpan{T}" /> and <see cref="ReadOnlyMemory{T}" /> overloads accept
+    /// the same input and produce the same verification result.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenSpanAndMemoryMatch_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] input = { 6, 6 };
+        ReadOnlyMemory<byte> memory = input;
+        byte[] expected = BitConverter.GetBytes((uint)12);
+
+        Assert.IsTrue(algorithm.VerifyHash(new ReadOnlySpan<byte>(input), new ReadOnlySpan<byte>(expected)));
+        Assert.IsTrue(algorithm.VerifyHash(memory, expected));
+    }
+
+    /// <summary>
+    /// Verifies that the span overload returns <see langword="false" /> when the hashes differ.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenSpanDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        ReadOnlySpan<byte> wrong = BitConverter.GetBytes((uint)999);
+
+        Assert.IsFalse(algorithm.VerifyHash(new ReadOnlySpan<byte>(SampleData), wrong));
+    }
+
+    // ─── String-with-encoding overload ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the string overload encodes the input with the supplied encoding before hashing and returns
+    /// <see langword="true" /> when the result matches.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenEncodedStringMatches_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        string input = "ABC"; // ASCII: 65 + 66 + 67 = 198
+        byte[] expected = BitConverter.GetBytes((uint)198);
+
+        Assert.IsTrue(algorithm.VerifyHash(input, Encoding.ASCII, expected));
+    }
+
+    /// <summary>
+    /// Verifies that the string overload returns <see langword="false" /> when the encoded hash does not match.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenEncodedStringDoesNotMatch_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        Assert.IsFalse(algorithm.VerifyHash(SampleString, SampleEncoding, wrong));
+    }
+
+    // ─── Stream overload ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream overload reads the entire stream and returns <see langword="true" /> when the
+    /// accumulated hash matches.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamMatchesHash_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(new byte[] { 5, 5, 5 });
+        byte[] expected = BitConverter.GetBytes((uint)15);
+
+        Assert.IsTrue(algorithm.VerifyHash(stream, expected));
+    }
+
+    /// <summary>
+    /// Verifies that the stream-with-hex overload returns <see langword="true" /> when the stream hash matches the
+    /// hex string.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.IsTrue(algorithm.VerifyHash(stream, SampleHex));
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload resets prior state before reading, so it hashes only the stream content.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamCalledAfterAppend_ShouldIgnorePriorState()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append(new byte[] { 100, 200 }); // prior state — must be discarded
+
+        using MemoryStream stream = new(SampleData);
+
+        Assert.IsTrue(algorithm.VerifyHash(stream, SampleHash));
+    }
+
+    // ─── Argument validation ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> algorithm receiver raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            NonCryptographicHashAlgorithm? algorithm = null;
+            algorithm!.VerifyHash(SampleData, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null input byte array raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenInputIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash((byte[])null!, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash byte array raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenExpectedHashIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(SampleData, (byte[])null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hex string raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(SampleData, (string)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null stream raises <see cref="ArgumentNullException" /> on the stream-with-byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash((Stream)null!, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash raises <see cref="ArgumentNullException" /> on the stream overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamExpectedHashIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(stream, (byte[])null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hex string raises <see cref="ArgumentNullException" /> on the stream overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStreamExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(stream, (string)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null string input raises <see cref="ArgumentNullException" /> on the string+encoding overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenStringInputIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(null!, Encoding.ASCII, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null encoding raises <see cref="ArgumentNullException" /> on the string+encoding overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenEncodingIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash("hello", null!, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash raises <see cref="ArgumentNullException" /> on the string+encoding overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenExpectedHashIsNullForString_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash("hello", Encoding.ASCII, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null algorithm raises <see cref="ArgumentNullException" /> on the span overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenAlgorithmIsNull_ForSpanOverload_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            NonCryptographicHashAlgorithm? algorithm = null;
+            algorithm!.VerifyHash(new ReadOnlySpan<byte>(SampleData), new ReadOnlySpan<byte>(SampleHash));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null algorithm raises <see cref="ArgumentNullException" /> on the memory overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenAlgorithmIsNull_ForMemoryOverload_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            NonCryptographicHashAlgorithm? algorithm = null;
+            algorithm!.VerifyHash(new ReadOnlyMemory<byte>(SampleData), SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null expected hash raises <see cref="ArgumentNullException" /> on the memory overload.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_WhenExpectedHashIsNull_ForMemoryOverload_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            algorithm.VerifyHash(new ReadOnlyMemory<byte>(SampleData), null!);
+        });
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.VerifyHashAsync.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.VerifyHashAsync.cs
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.VerifyHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Threading;
+using Bodu.Test.IO;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the asynchronous <see cref="NonCryptographicHashAlgorithmExtensions.VerifyHashAsync" /> overloads
+/// covering stream inputs, memory buffers, and hex strings.
+/// </summary>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Byte-array expected hash ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream-with-byte-array overload returns <see langword="true" /> when the hashes match.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamMatchesByteArray_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.VerifyHashAsync(stream, SampleHash);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that the stream-with-byte-array overload returns <see langword="false" /> when the hashes differ.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamDoesNotMatchByteArray_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        byte[] wrong = BitConverter.GetBytes((uint)999);
+
+        bool result = await algorithm.VerifyHashAsync(stream, wrong);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── Hex string expected hash ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream-with-hex overload returns <see langword="true" /> when the hashes match.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamMatchesHex_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.VerifyHashAsync(stream, SampleHex);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that a malformed hex string is treated as a non-match and returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenHexStringIsMalformed_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.VerifyHashAsync(stream, "ZZZZZZZZ");
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── ReadOnlyMemory expected hash ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream-with-memory overload returns <see langword="true" /> when the hashes match.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamMatchesMemory_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        ReadOnlyMemory<byte> expected = SampleHash;
+
+        bool result = await algorithm.VerifyHashAsync(stream, expected);
+
+        Assert.IsTrue(result);
+    }
+
+    /// <summary>
+    /// Verifies that the stream-with-memory overload returns <see langword="false" /> when the hashes differ.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamDoesNotMatchMemory_ShouldReturnFalse()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        ReadOnlyMemory<byte> wrong = BitConverter.GetBytes((uint)999);
+
+        bool result = await algorithm.VerifyHashAsync(stream, wrong);
+
+        Assert.IsFalse(result);
+    }
+
+    // ─── State reset behaviour ────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <c>VerifyHashAsync</c> resets prior accumulated state so it hashes only the stream content.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenCalledAfterAppend_ShouldIgnorePriorState()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.Append(new byte[] { 100, 200 }); // prior state — must be discarded
+
+        using MemoryStream stream = new(SampleData);
+
+        bool result = await algorithm.VerifyHashAsync(stream, SampleHash);
+
+        Assert.IsTrue(result);
+    }
+
+    // ─── Stream variants ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see cref="FixedChunkStream" /> delivering data 1 byte at a time is correctly hashed.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenSourceIsFixedChunkStream_ShouldReturnTrue()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        bool result = await algorithm.VerifyHashAsync(new FixedChunkStream(SampleData, chunkSize: 1), SampleHash);
+
+        Assert.IsTrue(result);
+    }
+
+    // ─── Cancellation ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an already-cancelled token causes <see cref="OperationCanceledException" /> before any I/O.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenTokenAlreadyCancelled_ShouldThrowOperationCanceledException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            await algorithm.VerifyHashAsync(stream, SampleHash, cts.Token));
+    }
+
+    // ─── Argument validation ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> algorithm raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm!.VerifyHashAsync(stream, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> stream raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm.VerifyHashAsync((Stream)null!, SampleHash));
+    }
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> expected hash raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenExpectedHashIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm.VerifyHashAsync(stream, (byte[])null!));
+    }
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> expected hex string raises <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task VerifyHashAsync_WhenExpectedHexIsNull_ShouldThrowArgumentNullException()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            await algorithm.VerifyHashAsync(stream, (string)null!));
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests covering the <see cref="NonCryptographicHashAlgorithmExtensions" /> surface — including
+/// <c>AppendData</c>, <c>AppendDataAsync</c>, <c>VerifyHash</c>, <c>VerifyHashAsync</c>,
+/// <c>TryVerifyHash</c>, and <c>TryVerifyHashAsync</c>. Tests for each method live in their own partial file.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tests use <see cref="MonitoringNonCryptographicHashAlgorithm" />, a deterministic test-infrastructure algorithm
+/// that accumulates input bytes as a 32-bit unsigned integer sum. This makes the expected hash of any input
+/// trivially computable — <c>BitConverter.GetBytes((uint)sum)</c> — which is why the fixtures below use small byte
+/// arrays rather than published test vectors.
+/// </para>
+/// <para>
+/// This file holds only shared fixtures and helpers. All test methods are declared in per-method partial files.
+/// </para>
+/// </remarks>
+[TestClass]
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    /// <summary>Deterministic sample input whose additive byte sum is 10.</summary>
+    private static readonly byte[] SampleData = { 1, 2, 3, 4 };
+
+    /// <summary>Expected hash of <see cref="SampleData" /> (byte sum = 10, platform byte order uint).</summary>
+    private static readonly byte[] SampleHash = BitConverter.GetBytes((uint)(1 + 2 + 3 + 4));
+
+    /// <summary>Uppercase hex representation of <see cref="SampleHash" />.</summary>
+    private static readonly string SampleHex = Convert.ToHexString(SampleHash);
+
+    /// <summary>Sample ASCII string whose encoded byte sum is 394 (<c>'a'</c>+<c>'b'</c>+<c>'c'</c>+<c>'d'</c>).</summary>
+    private static readonly string SampleString = "abcd";
+
+    /// <summary>Expected hash of <see cref="SampleString" /> encoded as ASCII.</summary>
+    private static readonly byte[] SampleStringHash = BitConverter.GetBytes((uint)(97 + 98 + 99 + 100));
+
+    /// <summary>The encoding paired with <see cref="SampleString" /> and <see cref="SampleStringHash" />.</summary>
+    private static readonly Encoding SampleEncoding = Encoding.ASCII;
+
+    /// <summary>
+    /// Creates a fresh <see cref="MonitoringNonCryptographicHashAlgorithm" /> instance for a single test.
+    /// </summary>
+    /// <returns>A new <see cref="MonitoringNonCryptographicHashAlgorithm" /> with no accumulated state.</returns>
+    private static MonitoringNonCryptographicHashAlgorithm CreateAlgorithm() => new();
+}


### PR DESCRIPTION
Introduces a complete set of extension methods for NonCryptographicHashAlgorithm
mirroring the HashAlgorithmExtensions API in Bodu.Security.Cryptography:
- AppendData (span and stream overloads with ArrayPool buffering)
- AppendDataAsync (async stream overload with cancellation support)
- VerifyHash (7 overloads: byte[], hex string, stream, span, memory, string+encoding)
- VerifyHashAsync (3 async stream overloads)
- TryVerifyHash (8 defensive overloads including out-bool variant)
- TryVerifyHashAsync (6 async defensive overloads)

Adds MonitoringNonCryptographicHashAlgorithm test double and comprehensive
MSTest coverage for all overloads including null guards, edge cases, stream
faulting, cancellation, and multi-call state accumulation.

https://claude.ai/code/session_01RJkLuYreYAfJKgJVp6cuNW