### PR TITLE
docs(calendar): audit and fix XML documentation consistency across project

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
@@ -10,7 +10,7 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar.Algorithms;
 
 /// <summary>
-/// Provides a algorithm for determining the Gregorian date of Asalha Puja (Dharma Day) for a given year.
+/// Provides an algorithm for determining the Gregorian date of Asalha Puja (Dharma Day) for a given year.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
@@ -18,6 +18,7 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 public sealed class EasterSundayNotableDateAlgorithm
 	: INotableDateAlgorithm
 {
+	/// <summary>Shared per-process cache of computed Easter dates, keyed by year and calendar identity string.</summary>
 	private static readonly ConcurrentDictionary<(int year, string calendarId), DateTime> _easterCache = new();
 
 	/// <inheritdoc />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase .cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase .cs
@@ -1,16 +1,11 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
-// <copyright file="EasterSundayNotableDateProviderBase .cs" company="PlaceholderCompany">
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EasterSundayNotableDateProviderBase.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using SysGlobal = System.Globalization;
 
 namespace Bodu.Globalization.Calendar.Algorithms;
@@ -18,85 +13,101 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// <summary>
 /// Provides a base implementation for Easter Sunday notable date providers.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Derived classes supply the Easter Sunday calculation algorithm via <see cref="CalculateDate" /> and declare the
+/// <see cref="Name" />, <see cref="Category" />, and optional <see cref="Comment" /> and <see cref="DefaultCalendarType" />
+/// properties. Results are cached per year in a thread-safe <see cref="ConcurrentDictionary{TKey,TValue}" />.
+/// </para>
+/// </remarks>
 public abstract class EasterSundayNotableDateProviderBase : INotableDateProvider
 {
-    private readonly ConcurrentDictionary<int, DateTime> _dateCache = new();
+	/// <summary>Thread-safe per-year cache of computed Easter Sunday dates for this provider.</summary>
+	private readonly ConcurrentDictionary<int, DateTime> _dateCache = new();
 
-    /// <summary>
-    /// Gets the canonical notable date name produced by the provider.
-    /// </summary>
-    protected abstract string Name { get; }
+	/// <summary>
+	/// Gets the canonical notable date name produced by this provider (e.g. <c>"Easter Sunday"</c>).
+	/// </summary>
+	/// <returns>The name assigned to the produced <see cref="NotableDate" />.</returns>
+	protected abstract string Name { get; }
 
-    /// <summary>
-    /// Gets the category assigned to the produced notable date.
-    /// </summary>
-    protected abstract NotableDateCategory Category { get; }
+	/// <summary>
+	/// Gets the primary category assigned to the produced <see cref="NotableDate" />.
+	/// </summary>
+	/// <returns>The <see cref="NotableDateCategory" /> for the produced date.</returns>
+	protected abstract NotableDateCategory Category { get; }
 
-    /// <inheritdoc />
-    public abstract int MinSupportedYear { get; }
+	/// <inheritdoc />
+	public abstract int MinSupportedYear { get; }
 
-    /// <inheritdoc />
-    public virtual int MaxSupportedYear => 9999;
+	/// <inheritdoc />
+	public virtual int MaxSupportedYear => 9999;
 
-    /// <summary>
-    /// Gets the comment to attach to the produced notable date, if any.
-    /// </summary>
-    protected virtual string? Comment => null;
+	/// <summary>
+	/// Gets the optional comment attached to the produced <see cref="NotableDate" />.
+	/// </summary>
+	/// <returns>A human-readable comment, or <see langword="null" /> when none is applicable.</returns>
+	protected virtual string? Comment => null;
 
-    /// <inheritdoc />
-    public bool SupportsYear(int year) => year >= MinSupportedYear && year <= MaxSupportedYear;
+	/// <inheritdoc />
+	public bool SupportsYear(int year) => year >= MinSupportedYear && year <= MaxSupportedYear;
 
-    /// <summary>
-    /// Gets the tags to attach to the produced notable date.
-    /// </summary>
-    protected virtual ImmutableHashSet<string> Tags =>
-        ImmutableHashSet.Create<string>(
-            StringComparer.OrdinalIgnoreCase,
-            "Christianity",
-            "Easter");
+	/// <summary>
+	/// Gets the non-exclusive tags attached to the produced <see cref="NotableDate" />.
+	/// </summary>
+	/// <returns>
+	/// An <see cref="ImmutableHashSet{T}" /> containing at least <c>"Christianity"</c> and <c>"Easter"</c>.
+	/// Derived classes may override to add or replace tags.
+	/// </returns>
+	protected virtual ImmutableHashSet<string> Tags =>
+		ImmutableHashSet.Create<string>(
+			StringComparer.OrdinalIgnoreCase,
+			"Christianity",
+			"Easter");
 
-    /// <summary>
-    /// Gets the default calendar type associated with the provider, or <see langword="null" /> when no explicit calendar should be
-    /// attached unless supplied by the caller.
-    /// </summary>
-    protected virtual Type? DefaultCalendarType => null;
+	/// <summary>
+	/// Gets the default calendar type associated with this provider, attached to each produced <see cref="NotableDate" />
+	/// when the caller does not supply an explicit calendar.
+	/// </summary>
+	/// <returns>The <see cref="Type" /> of the default calendar, or <see langword="null" /> when no explicit calendar should be attached.</returns>
+	protected virtual Type? DefaultCalendarType => null;
 
-    /// <inheritdoc />
-    public IReadOnlyList<NotableDate> GetDates(int year, SysGlobal.Calendar? calendar = null)
-    {
-        ThrowHelper.ThrowIfLessThan(year, 1);
+	/// <inheritdoc />
+	public IReadOnlyList<NotableDate> GetDates(int year, SysGlobal.Calendar? calendar = null)
+	{
+		ThrowHelper.ThrowIfLessThan(year, 1);
 
-        ValidateCalendar(calendar);
+		ValidateCalendar(calendar);
 
-        DateTime date = _dateCache.GetOrAdd(year, CalculateDate);
+		DateTime date = _dateCache.GetOrAdd(year, CalculateDate);
 
-        return
-        [
-            new NotableDate
-                {
-                    Date = date,
-                    Name = Name,
-                    Category = Category,
-                    CalendarType = calendar?.GetType() ?? DefaultCalendarType,
-                    Tags = Tags,
-                    Comment = Comment,
-                    DurationDays = 1,
-                    IsNonWorkingDay = false,
-                },
-            ];
-    }
+		return
+		[
+			new NotableDate
+				{
+					Date = date,
+					Name = Name,
+					Category = Category,
+					CalendarType = calendar?.GetType() ?? DefaultCalendarType,
+					Tags = Tags,
+					Comment = Comment,
+					DurationDays = 1,
+					IsNonWorkingDay = false,
+				},
+			];
+	}
 
-    /// <summary>
-    /// Validates the optional calendar supplied to the provider.
-    /// </summary>
-    /// <param name="calendar">The calendar to validate.</param>
-    /// <exception cref="NotSupportedException">Thrown when the calendar is not supported by the provider.</exception>
-    protected abstract void ValidateCalendar(SysGlobal.Calendar? calendar);
+	/// <summary>
+	/// Validates the optional calendar supplied to <see cref="GetDates" />.
+	/// </summary>
+	/// <param name="calendar">The calendar to validate, or <see langword="null" /> for the default.</param>
+	/// <exception cref="NotSupportedException">Thrown when <paramref name="calendar" /> is not supported by this provider.</exception>
+	protected abstract void ValidateCalendar(SysGlobal.Calendar? calendar);
 
-    /// <summary>
-    /// Calculates the Easter Sunday date for the specified year.
-    /// </summary>
-    /// <param name="year">The target year.</param>
-    /// <returns>The resolved Easter Sunday date.</returns>
-    protected abstract DateTime CalculateDate(int year);
+	/// <summary>
+	/// Calculates the Easter Sunday date for the specified year.
+	/// </summary>
+	/// <param name="year">The target year.</param>
+	/// <returns>The resolved Easter Sunday date.</returns>
+	protected abstract DateTime CalculateDate(int year);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
@@ -17,7 +17,7 @@ namespace Bodu.Globalization.Calendar.Providers;
 /// This provider always uses the Gregorian computus. The optional <see cref="SysGlobal.Calendar" /> parameter is accepted only when it
 /// is <see langword="null" /> or a <see cref="SysGlobal.GregorianCalendar" />.
 /// </remarks>
-public sealed class GregorianEasterSundayNotableDateProvider 
+public sealed class GregorianEasterSundayNotableDateProvider
     : EasterSundayNotableDateProviderBase
 {
     /// <inheritdoc />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
@@ -10,7 +10,7 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar.Algorithms;
 
 /// <summary>
-/// Provides a algorithm for determining the approximate Gregorian date of a Hindu festival defined by a lunar month, paksha
+/// Provides an algorithm for determining the approximate Gregorian date of a Hindu festival defined by a lunar month, paksha
 /// (fortnight), and tithi (lunar day).
 /// </summary>
 /// <remarks>
@@ -58,11 +58,16 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 public sealed class HinduLunarNotableDateAlgorithm
 	: INotableDateAlgorithm
 {
-	// Length of a single tithi in days (synodic month / 30 tithis).
+	/// <summary>The duration of a single tithi in days, computed as the mean synodic month divided by 30 tithis.</summary>
 	private const double TithiDays = 29.530588861 / 30.0;
 
+	/// <summary>The Hindu lunar month in which the festival falls.</summary>
 	private readonly HinduLunarMonth _month;
+
+	/// <summary>The fortnight (bright or dark) within the month in which the tithi falls.</summary>
 	private readonly HinduPaksha _paksha;
+
+	/// <summary>The tithi number (1–15) within the paksha.</summary>
 	private readonly int _tithi;
 
 	/// <summary>
@@ -160,6 +165,8 @@ public sealed class HinduLunarNotableDateAlgorithm
 	/// Returns the approximate Gregorian month in which the new moon starting the given Hindu lunar month typically falls.
 	/// Used to seed the new moon search with a sensible start date.
 	/// </summary>
+	/// <param name="month">The Hindu lunar month whose approximate Gregorian start month is required.</param>
+	/// <returns>The Gregorian month number (1–12) that is the best search-start approximation for the given lunar month.</returns>
 	private static int GetSearchMonth(HinduLunarMonth month) =>
 		month switch
 		{

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
@@ -10,7 +10,7 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar.Algorithms;
 
 /// <summary>
-/// Provides a algorithm for determining the approximate Gregorian date of Losar (Tibetan New Year) for a given year.
+/// Provides an algorithm for determining the approximate Gregorian date of Losar (Tibetan New Year) for a given year.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LunarPhaseAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LunarPhaseAlgorithm.cs
@@ -22,10 +22,10 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// </remarks>
 internal static class LunarPhaseAlgorithm
 {
-	// J2000 epoch: January 1.5, 2000 = JDE 2451545.0 = 2000-01-01 12:00 UTC.
+	/// <summary>The J2000.0 epoch expressed as a <see cref="DateTime" /> (2000-01-01T12:00:00, kind unspecified), equal to JDE 2451545.0.</summary>
 	private static readonly DateTime J2000Epoch = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
 
-	// Mean synodic month in days (IAU value).
+	/// <summary>The mean synodic month length in days (IAU value), used to advance the lunation index between search attempts.</summary>
 	private const double SynodicMonth = 29.530588861;
 
 	/// <summary>
@@ -75,6 +75,10 @@ internal static class LunarPhaseAlgorithm
 	/// Estimates the lunation index k near the given year and month.
 	/// For full moons k is a half-integer (e.g. 0.5, 1.5); for new moons k is an integer.
 	/// </summary>
+	/// <param name="year">The Gregorian year used to anchor the estimate.</param>
+	/// <param name="month">The Gregorian month (1–12) used to refine the estimate within the year.</param>
+	/// <param name="fullMoon"><see langword="true" /> to bias toward a full-moon lunation index; <see langword="false" /> for a new-moon index.</param>
+	/// <returns>The estimated lunation index k.</returns>
 	private static double EstimateK(int year, int month, bool fullMoon)
 	{
 		double approxYear = year + (month - 1) / 12.0;
@@ -89,6 +93,7 @@ internal static class LunarPhaseAlgorithm
 	/// <param name="k">
 	/// Integer k for a new moon; k + 0.5 for a full moon; k + 0.25 / k + 0.75 for quarter moons.
 	/// </param>
+	/// <returns>The Julian Day Ephemeris (JDE) in Terrestrial Dynamical Time.</returns>
 	private static double ComputeLunarPhaseJde(double k)
 	{
 		double T = k / 1236.85;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
@@ -18,13 +18,13 @@ namespace Bodu.Globalization.Calendar.Providers;
 /// date. The optional <see cref="SysGlobal.Calendar" /> parameter is accepted only when it is <see langword="null" /> or a
 /// <see cref="SysGlobal.JulianCalendar" />.
 /// </remarks>
-public sealed class OrthodoxEasterSundayNotableDateProvider 
+public sealed class OrthodoxEasterSundayNotableDateProvider
     : EasterSundayNotableDateProviderBase
 {
-
     /// <inheritdoc />
     public override int MinSupportedYear => 1;
-    
+
+    /// <summary>A shared <see cref="SysGlobal.JulianCalendar" /> instance used to project Julian Easter dates to Gregorian equivalents.</summary>
     private static readonly SysGlobal.JulianCalendar JulianCalendar = new();
 
     /// <inheritdoc />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
@@ -10,7 +10,7 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar.Algorithms;
 
 /// <summary>
-/// Provides a algorithm for determining the Gregorian date of the Qingming solar term (清明節) for a given year.
+/// Provides an algorithm for determining the Gregorian date of the Qingming solar term (清明節) for a given year.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -32,11 +32,13 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 public sealed class QingmingNotableDateAlgorithm
 	: INotableDateAlgorithm
 {
-	// Fraction of the tropical year corresponding to 15 degrees of solar longitude.
-	// Tropical year ≈ 365.2422 days; 1° = 365.2422/360 days; 15° = 15.2184 days.
+	/// <summary>
+	/// The number of days corresponding to 15° of solar longitude (one solar term), computed as the tropical year length
+	/// (365.2422 days) multiplied by 15/360.
+	/// </summary>
 	private const double DegreesToDays15 = 15.0 * 365.2422 / 360.0;
 
-	// J2000 epoch expressed as a DateTime. This is January 1, 2000 at 12:00:00 UT (noon).
+	/// <summary>The J2000.0 epoch expressed as a <see cref="DateTime" /> (2000-01-01T12:00:00 UT, kind unspecified), equal to JDE 2451545.0.</summary>
 	private static readonly DateTime J2000Epoch = new DateTime(2000, 1, 1, 12, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
@@ -85,6 +87,8 @@ public sealed class QingmingNotableDateAlgorithm
 	/// Computes the Julian Day Ephemeris (JDE) of the vernal equinox for the given Gregorian year using the Meeus polynomial
 	/// (Table 27.a) and the 24-term correction (Table 27.c).
 	/// </summary>
+	/// <param name="year">The Gregorian year for which the vernal equinox JDE is computed.</param>
+	/// <returns>The Julian Day Ephemeris of the vernal equinox in Terrestrial Dynamical Time.</returns>
 	private static double ComputeVernalEquinoxJde(int year)
 	{
 		double Y = (year - 2000) / 1000.0;
@@ -116,8 +120,10 @@ public sealed class QingmingNotableDateAlgorithm
 	private static double DegToRad(double degrees) =>
 		degrees * (Math.PI / 180.0);
 
-	// Meeus Table 27.c — periodic correction terms for the March equinox.
-	// Each row is (amplitude, phase [°], rate [°/Julian century]).
+	/// <summary>
+	/// Periodic correction terms from Meeus Table 27.c for the March equinox. Each entry is
+	/// (amplitude, phase [°], rate [°/Julian century]).
+	/// </summary>
 	private static readonly (double A, double B, double C)[] s_correctionTerms =
 	[
 		(485,  324.96, 1934.136),

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
@@ -10,7 +10,7 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar.Algorithms;
 
 /// <summary>
-/// Provides a algorithm for determining the Gregorian date of Vesak (Buddha Day) for a given year.
+/// Provides an algorithm for determining the Gregorian date of Vesak (Buddha Day) for a given year.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -57,6 +57,13 @@ public sealed class VesakNotableDateAlgorithm
 		return ProjectToCalendar(fullMoon.Value, calendar);
 	}
 
+	/// <summary>
+	/// Projects <paramref name="date" /> into the specified calendar system, or returns the Gregorian date unchanged when
+	/// <paramref name="calendar" /> is <see langword="null" /> or a <see cref="SysGlobal.GregorianCalendar" />.
+	/// </summary>
+	/// <param name="date">The Gregorian date to project.</param>
+	/// <param name="calendar">The target calendar system, or <see langword="null" /> for Gregorian.</param>
+	/// <returns>The date expressed in <paramref name="calendar" />, with <see cref="DateTimeKind.Unspecified" /> kind.</returns>
 	private static DateTime? ProjectToCalendar(DateTime date, SysGlobal.Calendar? calendar)
 	{
 		SysGlobal.Calendar targetCalendar = calendar ?? new SysGlobal.GregorianCalendar();

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/CompositePluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/CompositePluginTrustPolicy.cs
@@ -18,6 +18,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </remarks>
 public sealed class CompositePluginTrustPolicy : IPluginTrustPolicy
 {
+	/// <summary>The ordered list of child policies evaluated in sequence; the first rejection short-circuits the rest.</summary>
 	private readonly ImmutableArray<IPluginTrustPolicy> _policies;
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/DelegatingPluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/DelegatingPluginTrustPolicy.cs
@@ -12,6 +12,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </summary>
 public sealed class DelegatingPluginTrustPolicy : IPluginTrustPolicy
 {
+	/// <summary>The delegate invoked to evaluate each candidate plugin context.</summary>
 	private readonly Func<PluginTrustContext, PluginTrustResult> _evaluator;
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/ExternalPluginLoader.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/ExternalPluginLoader.cs
@@ -31,6 +31,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </remarks>
 public sealed class ExternalPluginLoader
 {
+	/// <summary>The trust policy consulted before any assembly code is loaded into the process.</summary>
 	private readonly IPluginTrustPolicy _trustPolicy;
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/FileHashPluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/FileHashPluginTrustPolicy.cs
@@ -23,6 +23,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </remarks>
 public sealed class FileHashPluginTrustPolicy : IPluginTrustPolicy
 {
+	/// <summary>A normalised, case-insensitive map from assembly name to the pinned SHA-256 digest.</summary>
 	private readonly IReadOnlyDictionary<string, byte[]> _allowedHashesByAssemblyName;
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/StrongNamePluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/StrongNamePluginTrustPolicy.cs
@@ -23,6 +23,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </remarks>
 public sealed class StrongNamePluginTrustPolicy : IPluginTrustPolicy
 {
+	/// <summary>The set of normalised, lowercase-hex public-key tokens that are permitted to load.</summary>
 	private readonly HashSet<string> _allowedTokens;
 
 	/// <summary>
@@ -49,9 +50,15 @@ public sealed class StrongNamePluginTrustPolicy : IPluginTrustPolicy
 			: new PluginTrustResult(Trusted: false, Reason: $"Public-key token '{token}' is not in the allowlist.");
 	}
 
+	/// <summary>Normalises a public-key token string to trimmed lowercase, returning an empty string for <see langword="null" /> input.</summary>
+	/// <param name="token">The raw token string.</param>
+	/// <returns>The normalised lowercase token.</returns>
 	private static string NormaliseToken(string token) =>
 		(token ?? string.Empty).Trim().ToLowerInvariant();
 
+	/// <summary>Converts a byte array to its lowercase hexadecimal string representation.</summary>
+	/// <param name="bytes">The bytes to convert.</param>
+	/// <returns>A lowercase hex string of length <c>bytes.Length * 2</c>.</returns>
 	private static string ToHexString(byte[] bytes)
 	{
 		var chars = new char[bytes.Length * 2];
@@ -65,5 +72,8 @@ public sealed class StrongNamePluginTrustPolicy : IPluginTrustPolicy
 		return new string(chars);
 	}
 
+	/// <summary>Returns the lowercase hex character for a nibble value in the range 0–15.</summary>
+	/// <param name="nibble">The nibble value (0–15).</param>
+	/// <returns>The corresponding lowercase hexadecimal character.</returns>
 	private static char GetHexChar(int nibble) => (char)(nibble < 10 ? '0' + nibble : 'a' + (nibble - 10));
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
@@ -22,17 +22,17 @@ public enum AdjustmentAction
 	None = 0,
 
 	/// <summary>
-	/// Adds <c>ObservanceAdjustment.OffsetDays</c> to the calculated date. Negative values move backwards.
+	/// Adds <see cref="ObservanceAdjustment.OffsetDays" /> to the calculated date. Negative values move backwards.
 	/// </summary>
 	AddDays,
 
 	/// <summary>
-	/// Moves the date forward to the next weekday as defined by the configured <c>CalendarWeekendDefinition</c>.
+	/// Moves the date forward to the next weekday as defined by the configured <see cref="CalendarWeekendDefinition" />.
 	/// </summary>
 	MoveToNextWeekday,
 
 	/// <summary>
-	/// Moves the date backward to the previous weekday as defined by the configured <c>CalendarWeekendDefinition</c>.
+	/// Moves the date backward to the previous weekday as defined by the configured <see cref="CalendarWeekendDefinition" />.
 	/// </summary>
 	MoveToPreviousWeekday,
 
@@ -43,13 +43,13 @@ public enum AdjustmentAction
 	MoveToNextNonWorkingDay,
 
 	/// <summary>
-	/// Replaces the date with the resolved date of another notable date rule named by <c>ObservanceAdjustment.TargetRuleName</c>.
+	/// Replaces the date with the resolved date of another notable date rule named by <see cref="ObservanceAdjustment.TargetRuleName" />.
 	/// </summary>
 	ReplaceWithNamedDate,
 
 	/// <summary>
 	/// Delegates the adjustment to a registered <see cref="IAdjustmentHandler" /> looked up by
-	/// <c>ObservanceAdjustment.HandlerKey</c>.
+	/// <see cref="ObservanceAdjustment.HandlerKey" />.
 	/// </summary>
 	Custom,
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerContext.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerContext.cs
@@ -6,7 +6,6 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Captures the inputs delivered to an <see cref="IAdjustmentHandler" />.
 /// </summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
@@ -12,7 +12,10 @@ namespace Bodu.Globalization.Calendar;
 /// </summary>
 public sealed class AdjustmentHandlerRegistry : IAdjustmentHandlerRegistry
 {
+	/// <summary>The case-insensitive key-to-handler mapping maintained by this registry.</summary>
 	private readonly Dictionary<string, IAdjustmentHandler> _handlers = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>Lock protecting read-modify-write access to <see cref="_handlers" />.</summary>
 	private readonly object _gate = new();
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerResult.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerResult.cs
@@ -6,7 +6,6 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Captures the output produced by an <see cref="IAdjustmentHandler" />.
 /// </summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
@@ -21,12 +21,12 @@ public enum AdjustmentTrigger
 	Always = 0,
 
 	/// <summary>
-	/// Activates when the calculated date falls on the day of week specified by <c>ObservanceAdjustment.DayOfWeek</c>.
+	/// Activates when the calculated date falls on the day of week specified by <see cref="ObservanceAdjustment.DayOfWeek" />.
 	/// </summary>
 	IfDayOfWeek,
 
 	/// <summary>
-	/// Activates when the calculated date falls on a weekend, as determined by the configured <c>CalendarWeekendDefinition</c>.
+	/// Activates when the calculated date falls on a weekend, as determined by the configured <see cref="CalendarWeekendDefinition" />.
 	/// </summary>
 	IfWeekend,
 
@@ -41,12 +41,12 @@ public enum AdjustmentTrigger
 	IfNonWorkingDay,
 
 	/// <summary>
-	/// Activates when the calculated date occurs strictly before <c>ObservanceAdjustment.ComparisonDate</c>.
+	/// Activates when the calculated date occurs strictly before <see cref="ObservanceAdjustment.ComparisonDate" />.
 	/// </summary>
 	IfBeforeFixedDate,
 
 	/// <summary>
-	/// Activates when the calculated date occurs strictly after <c>ObservanceAdjustment.ComparisonDate</c>.
+	/// Activates when the calculated date occurs strictly after <see cref="ObservanceAdjustment.ComparisonDate" />.
 	/// </summary>
 	IfAfterFixedDate,
 
@@ -57,12 +57,12 @@ public enum AdjustmentTrigger
 
 	/// <summary>
 	/// Activates when the calculated date is the n-th occurrence of its weekday within its month, as specified by
-	/// <c>ObservanceAdjustment.WeekOrdinal</c>.
+	/// <see cref="ObservanceAdjustment.WeekOrdinal" />.
 	/// </summary>
 	IfNthOccurrenceInMonth,
 
 	/// <summary>
-	/// Activation is delegated to a registered <see cref="IAdjustmentHandler" /> looked up by <c>ObservanceAdjustment.HandlerKey</c>.
+	/// Activation is delegated to a registered <see cref="IAdjustmentHandler" /> looked up by <see cref="ObservanceAdjustment.HandlerKey" />.
 	/// </summary>
 	Custom,
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
@@ -6,11 +6,18 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Provides the default <see cref="INotableDateCollisionResolver" /> implementation. Sorts overlapping dates by category, falls back to
 /// alphabetic name, and removes exact duplicates.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This resolver removes structurally equal <see cref="NotableDate" /> entries first, then orders the remaining dates ascending by
+/// <see cref="NotableDateCategory" /> integer value (lower values indicate higher significance) and then alphabetically by
+/// <see cref="NotableDate.Name" />. It is used automatically when no custom <see cref="INotableDateCollisionResolver" /> is supplied
+/// to <see cref="NotableDateService" />.
+/// </para>
+/// </remarks>
 public sealed class DefaultNotableDateCollisionResolver : INotableDateCollisionResolver
 {
 	/// <inheritdoc />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
@@ -6,7 +6,6 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Implements custom evaluation and modification logic for an <see cref="ObservanceAdjustment" /> whose
 /// <see cref="ObservanceAdjustment.Trigger" /> or <see cref="ObservanceAdjustment.Action" /> is set to

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
@@ -16,7 +16,35 @@ namespace Bodu.Globalization.Calendar;
 /// Custom handlers are looked up by <see cref="ObservanceAdjustment.HandlerKey" /> from an <see cref="IAdjustmentHandlerRegistry" />.
 /// They receive the resolved date plus the surrounding context and return whether the adjustment activates and, if so, the new date.
 /// </para>
+/// <para>
+/// Register handlers via <see cref="AdjustmentHandlerRegistry" /> and supply the registry to the <see cref="NotableDateService" />
+/// constructor via the <c>adjustmentHandlers</c> parameter.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>A custom handler that shifts the observed date when it coincides with another named notable date:</para>
+/// <code>
+/// public sealed class ConflictAvoidanceHandler : IAdjustmentHandler
+/// {
+///     private readonly string _conflictingRuleName;
+///
+///     public ConflictAvoidanceHandler(string conflictingRuleName)
+///         => _conflictingRuleName = conflictingRuleName;
+///
+///     public AdjustmentHandlerResult Apply(AdjustmentHandlerContext context)
+///     {
+///         // Access parameters supplied on the ObservanceAdjustment:
+///         bool checkEnabled = context.Adjustment.HandlerParameters?.ContainsKey("enabled") == true;
+///         if (!checkEnabled)
+///             return new AdjustmentHandlerResult(Activated: false, AdjustedDate: context.Date);
+///
+///         // Shift by one day to avoid the conflict:
+///         DateTime shifted = context.Date.AddDays(1);
+///         return new AdjustmentHandlerResult(Activated: true, AdjustedDate: shifted, IsNonWorkingOverride: true);
+///     }
+/// }
+/// </code>
+/// </example>
 public interface IAdjustmentHandler
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandlerRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandlerRegistry.cs
@@ -6,10 +6,21 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Provides lookup of registered <see cref="IAdjustmentHandler" /> instances by stable key.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The registry is consulted during observance-adjustment evaluation when an <see cref="ObservanceAdjustment" /> declares
+/// <see cref="AdjustmentTrigger.Custom" /> or <see cref="AdjustmentAction.Custom" />. The adjuster resolves the handler by
+/// looking up <see cref="ObservanceAdjustment.HandlerKey" /> in the supplied registry. Custom handlers receive the full
+/// <see cref="AdjustmentHandlerContext" /> and may produce arbitrary date shifts or non-working-day overrides.
+/// </para>
+/// <para>
+/// Supply a populated <see cref="AdjustmentHandlerRegistry" /> to the <see cref="NotableDateService" /> constructor to enable
+/// custom trigger and action logic.
+/// </para>
+/// </remarks>
 public interface IAdjustmentHandlerRegistry
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
@@ -23,12 +23,12 @@ public interface INotableDateAlgorithm
 	/// </summary>
 	/// <param name="year">The target year for the calculation. Must be greater than or equal to 1.</param>
 	/// <param name="calendar">
-	/// Optional. A <see cref="SysGlobal.Calendar" /> instance representing the calendar system to use. If <c>null</c>, the default
+	/// An optional <see cref="SysGlobal.Calendar" /> instance representing the calendar system to use. When <see langword="null" />,
 	/// <see cref="SysGlobal.GregorianCalendar" /> is assumed.
 	/// </param>
 	/// <returns>
-	/// The computed <see cref="DateTime" /> representing the notable event in the given year and calendar system, or <c>null</c> if the
-	/// date cannot be determined.
+	/// The computed <see cref="DateTime" /> representing the notable event in the given year and calendar system, or
+	/// <see langword="null" /> if the date cannot be determined.
 	/// </returns>
 	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
 	/// <exception cref="NotSupportedException">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithmRegistry.cs
@@ -16,7 +16,26 @@ namespace Bodu.Globalization.Calendar;
 /// supplied by dependency injection or test code. This makes definitions resilient to assembly renames and allows algorithms to
 /// declare constructor dependencies.
 /// </para>
+/// <para>
+/// The built-in implementation is <see cref="NotableDateAlgorithmRegistry" />, which accepts pre-constructed algorithm instances
+/// and looks them up case-insensitively by key.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>Register algorithms and pass the registry to <see cref="NotableDateService" />:</para>
+/// <code>
+/// NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+///     .Register("easter-sunday", new GregorianEasterSundayNotableDateProvider())
+///     .Register("orthodox-easter", new OrthodoxEasterSundayNotableDateProvider());
+///
+/// NotableDateService service = new NotableDateService(
+///     ruleProviders: new[] { new XmlResourceNotableDateRuleProvider(
+///         "MyApp/Calendar/Resources/rules.xml",
+///         new ResourcePathResolver()) },
+///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+///     algorithmRegistry: registry);
+/// </code>
+/// </example>
 public interface INotableDateAlgorithmRegistry
 {
 	/// <summary>
@@ -24,13 +43,13 @@ public interface INotableDateAlgorithmRegistry
 	/// </summary>
 	/// <param name="key">The registry key. Must not be <see langword="null" /> or whitespace.</param>
 	/// <param name="algorithm">When this method returns <see langword="true" />, contains the resolved algorithm.</param>
-	/// <returns><see langword="true" /> if a algorithm is registered for <paramref name="key" />; otherwise <see langword="false" />.</returns>
+	/// <returns><see langword="true" /> if an algorithm is registered for <paramref name="key" />; otherwise <see langword="false" />.</returns>
 	bool TryGet(string key, out INotableDateAlgorithm algorithm);
 
 	/// <summary>
-	/// Indicates whether a algorithm is registered against the specified key.
+	/// Indicates whether an algorithm is registered against the specified key.
 	/// </summary>
 	/// <param name="key">The registry key.</param>
-	/// <returns><see langword="true" /> if a algorithm is registered; otherwise <see langword="false" />.</returns>
+	/// <returns><see langword="true" /> if an algorithm is registered; otherwise <see langword="false" />.</returns>
 	bool Contains(string key);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateCollisionResolver.cs
@@ -6,19 +6,40 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Resolves the canonical ordering, deduplication, or suppression of multiple <see cref="NotableDate" /> instances that fall on the
 /// same day.
 /// </summary>
 /// <remarks>
 /// <para>
-/// When two or more rules resolve to the same date for a given territory (for example a fixed bank holiday and a substitute observance,
-/// or Easter Monday landing on Anzac Day), the service consults its registered <see cref="INotableDateCollisionResolver" /> to decide
-/// how the overlapping dates should be presented. The default implementation simply orders by
-/// <see cref="NotableDate.Category" /> and <see cref="NotableDate.Name" />.
+/// When two or more rules resolve to the same date for a given territory — for example a fixed bank holiday and a substitute
+/// observance, or Easter Monday landing on Anzac Day — the service consults its registered
+/// <see cref="INotableDateCollisionResolver" /> to decide how the overlapping dates should be presented. The default implementation
+/// is <see cref="DefaultNotableDateCollisionResolver" />, which removes exact duplicates and orders results by
+/// <see cref="NotableDate.Category" /> then <see cref="NotableDate.Name" />.
+/// </para>
+/// <para>
+/// Supply a custom implementation via the <c>collisionResolver</c> parameter of the <see cref="NotableDateService" /> constructor
+/// to apply application-specific de-duplication, suppression, or ordering logic.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>An implementation that retains only the date with the lowest-valued <see cref="NotableDateCategory" />:</para>
+/// <code>
+/// public sealed class HighestPriorityCollisionResolver : INotableDateCollisionResolver
+/// {
+///     public IReadOnlyList&lt;NotableDate&gt; Resolve(DateTime date, IReadOnlyList&lt;NotableDate&gt; overlapping)
+///     {
+///         NotableDate winner = overlapping
+///             .OrderBy(d => (int)d.Category)
+///             .ThenBy(d => d.Name, StringComparer.OrdinalIgnoreCase)
+///             .First();
+///
+///         return new[] { winner };
+///     }
+/// }
+/// </code>
+/// </example>
 public interface INotableDateCollisionResolver
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateNameLocalizer.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateNameLocalizer.cs
@@ -16,7 +16,26 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="NotableDateRule.Name" /> is authored in invariant English. Implementations of <see cref="INotableDateNameLocalizer" />
 /// resolve that key to a culture-specific string — typically by looking it up in a <c>.resx</c> file or external translation catalogue.
 /// </para>
+/// <para>
+/// Supply an implementation via the <c>nameLocalizer</c> parameter of the <see cref="NotableDateService" /> constructor. When
+/// supplied, the service replaces each resolved <see cref="NotableDate.Name" /> with the localised form before returning results.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>A <c>.resx</c>-backed implementation that falls back to the canonical English name:</para>
+/// <code>
+/// public sealed class ResxNameLocalizer : INotableDateNameLocalizer
+/// {
+///     public string GetDisplayName(NotableDate notableDate, CultureInfo? culture = null)
+///     {
+///         string? translation = HolidayNames.ResourceManager
+///             .GetString(notableDate.Name, culture ?? CultureInfo.CurrentCulture);
+///
+///         return translation ?? notableDate.Name;
+///     }
+/// }
+/// </code>
+/// </example>
 public interface INotableDateNameLocalizer
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleOverrideProvider.cs
@@ -6,7 +6,6 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Supplies runtime modifications to the notable date rules loaded by base <see cref="INotableDateRuleProvider" /> sources.
 /// </summary>
@@ -18,6 +17,32 @@ namespace Bodu.Globalization.Calendar;
 /// ones.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Suppress Boxing Day for 2026 and inject a company-specific observance:</para>
+/// <code>
+/// public sealed class CompanyCalendarOverrides : INotableDateRuleOverrideProvider
+/// {
+///     public IEnumerable&lt;RuleRemoval&gt; GetRemovals()
+///     {
+///         // Remove Boxing Day for 2026 only:
+///         yield return new RuleRemoval("Boxing Day", FromYear: 2026, ToYear: 2026);
+///     }
+///
+///     public IEnumerable&lt;NotableDateRule&gt; GetAdditions()
+///     {
+///         yield return new NotableDateRule
+///         {
+///             Name = "Company Founding Day",
+///             Strategy = DateResolutionStrategy.Fixed,
+///             Category = NotableDateCategory.Observance,
+///             Month = 6,
+///             Day = 15,
+///             IsNonWorkingDay = true,
+///         };
+///     }
+/// }
+/// </code>
+/// </example>
 public interface INotableDateRuleOverrideProvider
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleProvider.cs
@@ -11,10 +11,29 @@ namespace Bodu.Globalization.Calendar;
 /// an embedded XML resource, JSON document, database, or external configuration system.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Rule providers are loaded once per <see cref="NotableDateService" /> instance. To express runtime-only modifications such as
 /// disabling a holiday or adding a one-off observance, use an <see cref="INotableDateRuleOverrideProvider" /> alongside the base
 /// providers.
+/// </para>
+/// <para>
+/// The built-in implementation is <see cref="XmlResourceNotableDateRuleProvider" />, which loads rules from an embedded XML resource
+/// and recursively resolves cherry-pick directives across linked resource files.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>A minimal in-memory implementation for testing or dynamic rule sets:</para>
+/// <code>
+/// public sealed class InMemoryRuleProvider : INotableDateRuleProvider
+/// {
+///     private readonly IReadOnlyList&lt;NotableDateRule&gt; _rules;
+///
+///     public InMemoryRuleProvider(IReadOnlyList&lt;NotableDateRule&gt; rules) =&gt; _rules = rules;
+///
+///     public IEnumerable&lt;NotableDateRule&gt; LoadRules() =&gt; _rules;
+/// }
+/// </code>
+/// </example>
 public interface INotableDateRuleProvider
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -13,10 +13,35 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="NotableDateRule" /> sources.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Implementations are responsible for combining base <see cref="INotableDateRuleProvider" /> sources with optional
 /// <see cref="INotableDateRuleOverrideProvider" /> layers, dispatching to the resolver and adjuster, caching results, and applying any
 /// registered <see cref="INotableDateCollisionResolver" /> and <see cref="INotableDateNameLocalizer" /> services to the output.
+/// </para>
+/// <para>
+/// The canonical implementation is <see cref="NotableDateService" />, which supports lazy per-year caching, thread-safe concurrent
+/// access, multi-day event spans, and composable <see cref="NotableDateFilter" /> predicates.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>Construct the service using the built-in global rule set, then query notable dates for Australia:</para>
+/// <code>
+/// INotableDateService service = new NotableDateService();
+///
+/// // All notable dates for Australia in 2026, ordered by date:
+/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU");
+///
+/// // Only non-working public holidays in Australia:
+/// NotableDateFilter filter = NotableDateFilter
+///     .ForCategory(NotableDateCategory.Public)
+///     .And(NotableDateFilter.IsNonWorkingDay());
+///
+/// IReadOnlyList&lt;NotableDate&gt; holidays = service.GetNotableDates(2026, filter, "AU");
+///
+/// // Test whether Christmas Day 2026 is a non-working day for New South Wales:
+/// bool isNonWorking = service.IsNonWorkingDay(new DateTime(2026, 12, 25), "AU-NSW");
+/// </code>
+/// </example>
 public interface INotableDateService
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IResourcePathResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IResourcePathResolver.cs
@@ -1,15 +1,32 @@
-﻿namespace Bodu.Globalization.Calendar;
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IResourcePathResolver.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
 
 /// <summary>
 /// Resolves resource paths declared inside notable-date XML resources.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Implementations translate the logical path syntax used in <c>&lt;UseFrom&gt;</c> directives — which may be absolute (for example
+/// <c>/Bodu/Globalization/Calendar/Resources/uk-all.xml</c>) or relative (for example <c>../regions/uk-england.xml</c>) — into the
+/// fully qualified resource name that the provider uses when loading the file.
+/// </para>
+/// <para>
+/// The built-in implementation is <see cref="ResourcePathResolver" />, which resolves paths using a logical <c>/</c>-delimited
+/// hierarchy and supports absolute and relative references including <c>.</c> and <c>..</c> segments.
+/// </para>
+/// </remarks>
 public interface IResourcePathResolver
 {
-    /// <summary>
-    /// Resolves a child resource path relative to the specified document resource path.
-    /// </summary>
-    /// <param name="documentPath">The fully qualified resource path of the document declaring the reference.</param>
-    /// <param name="childPath">The referenced child resource path.</param>
-    /// <returns>The fully qualified resolved resource path.</returns>
-    string Resolve(string documentPath, string childPath);
+	/// <summary>
+	/// Resolves a child resource path relative to the specified document resource path.
+	/// </summary>
+	/// <param name="documentPath">The fully qualified resource path of the document declaring the reference.</param>
+	/// <param name="childPath">The referenced child resource path.</param>
+	/// <returns>The fully qualified resolved resource path.</returns>
+	string Resolve(string documentPath, string childPath);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
@@ -25,6 +25,27 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="EndDate" /> inclusively.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Iterate notable dates for a territory and display their details:</para>
+/// <code>
+/// INotableDateService service = new NotableDateService();
+/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU");
+///
+/// foreach (NotableDate date in dates)
+/// {
+///     Console.WriteLine($"{date.Date:d}  {date.DisplayName}");
+///
+///     if (date.DurationDays > 1)
+///         Console.WriteLine($"  Spans through {date.EndDate:d} ({date.DurationDays} days)");
+///
+///     if (date.WasAdjusted)
+///         Console.WriteLine($"  Adjusted from {date.AdjustmentReason!.OriginalDate:d}");
+///
+///     if (date.IsNonWorkingDay)
+///         Console.WriteLine("  Non-working day");
+/// }
+/// </code>
+/// </example>
 public sealed record NotableDate
 {
 #if NET7_0_OR_GREATER

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
@@ -27,11 +27,22 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 internal sealed class NotableDateAdjuster
 {
+	/// <summary>Predicate for determining whether a given date falls on a weekend.</summary>
 	private readonly Func<DateTime, bool> _isWeekend;
+
+	/// <summary>Predicate for determining whether a given date is a non-working day in the specified territory and calendar context.</summary>
 	private readonly Func<DateTime, string?, Type?, bool> _isNonWorkingDay;
+
+	/// <summary>The configured weekend definition, forwarded to shift actions that move dates to a weekday.</summary>
 	private readonly CalendarWeekendDefinition _weekendDefinition;
+
+	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</summary>
 	private readonly IWeekendDefinitionProvider? _weekendProvider;
+
+	/// <summary>An optional registry of custom <see cref="IAdjustmentHandler" /> instances looked up by key.</summary>
 	private readonly IAdjustmentHandlerRegistry? _handlerRegistry;
+
+	/// <summary>An optional callback that resolves another rule's observed date by name, used by <see cref="AdjustmentAction.ReplaceWithNamedDate" />.</summary>
 	private readonly Func<string, int, string?, Type?, DateTime?>? _resolveByName;
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
@@ -18,7 +18,10 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry
 {
+	/// <summary>The case-insensitive key-to-algorithm mapping maintained by this registry.</summary>
 	private readonly Dictionary<string, INotableDateAlgorithm> _algorithms = new(StringComparer.OrdinalIgnoreCase);
+
+	/// <summary>Lock protecting read-modify-write access to <see cref="_algorithms" />.</summary>
 	private readonly object _gate = new();
 
 	/// <summary>
@@ -40,7 +43,7 @@ public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry
 	}
 
 	/// <summary>
-	/// Registers a algorithm against the specified key. Existing entries with the same key are replaced.
+	/// Registers an algorithm against the specified key. Existing entries with the same key are replaced.
 	/// </summary>
 	/// <param name="key">A short stable identifier, for example <c>"easter-sunday"</c>. Must not be <see langword="null" /> or whitespace.</param>
 	/// <param name="algorithm">The algorithm instance. Must not be <see langword="null" />.</param>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -42,9 +42,17 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 public sealed class NotableDateFilter
 {
+	/// <summary>The primary gate predicate evaluated against each <see cref="NotableDateRule" /> before date resolution.</summary>
 	private readonly Func<NotableDateRule, bool> _ruleGate;
+
+	/// <summary>The secondary gate predicate evaluated against each materialised <see cref="NotableDate" />.</summary>
 	private readonly Func<NotableDate, bool> _dateGate;
 
+	/// <summary>
+	/// Initialises a new <see cref="NotableDateFilter" /> with explicit primary and secondary gate delegates.
+	/// </summary>
+	/// <param name="ruleGate">The primary gate predicate evaluated against each rule before date resolution.</param>
+	/// <param name="dateGate">The secondary gate predicate evaluated against each materialised date.</param>
 	private NotableDateFilter(Func<NotableDateRule, bool> ruleGate, Func<NotableDate, bool> dateGate)
 	{
 		_ruleGate = ruleGate;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -15,7 +15,7 @@ namespace Bodu.Globalization.Calendar;
 /// <para>
 /// Filters are created via the static factory methods on this class — for example <see cref="ForCategory" />, <see cref="WithTag" />,
 /// <see cref="InDateRange" /> — and combined through <see cref="And" />, <see cref="Or" />, <see cref="AllOf" />, and
-/// <see cref="AnyOf" />. Every instance is immutable; composition always returns a new <see cref="NotableDateFilter" />.
+/// <see cref="AnyOf" />. Every instance is immutable; composition always produces a new <see cref="NotableDateFilter" />.
 /// </para>
 /// <para>
 /// <b>Primary gate (rule-level)</b>: Predicates backed by <see cref="NotableDateRule" /> metadata that the service evaluates before
@@ -40,6 +40,35 @@ namespace Bodu.Globalization.Calendar;
 /// call rather than only on the first (cold) access.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Compose filters and query notable dates from a service:</para>
+/// <code>
+/// INotableDateService service = new NotableDateService();
+///
+/// // Non-working public holidays for New South Wales in 2026:
+/// NotableDateFilter filter = NotableDateFilter
+///     .ForCategory(NotableDateCategory.Public)
+///     .And(NotableDateFilter.IsNonWorkingDay());
+///
+/// IReadOnlyList&lt;NotableDate&gt; holidays = service.GetNotableDates(2026, filter, "AU-NSW");
+///
+/// // Public or cultural dates tagged "Christian":
+/// NotableDateFilter christian = NotableDateFilter
+///     .ForAnyCategory(NotableDateCategory.Public, NotableDateCategory.Cultural)
+///     .And(NotableDateFilter.WithTag("Christian"));
+///
+/// // Dates whose span intersects Easter week 2026:
+/// NotableDateFilter easterWeek = NotableDateFilter.InDateRange(
+///     new DateTime(2026, 4, 5),
+///     new DateTime(2026, 4, 12));
+///
+/// // Combine multiple constraints using AllOf:
+/// NotableDateFilter combined = NotableDateFilter.AllOf(
+///     NotableDateFilter.ForCategory(NotableDateCategory.Public),
+///     NotableDateFilter.IsNonWorkingDay(),
+///     NotableDateFilter.WithName("Christmas Day"));
+/// </code>
+/// </example>
 public sealed class NotableDateFilter
 {
 	/// <summary>The primary gate predicate evaluated against each <see cref="NotableDateRule" /> before date resolution.</summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
@@ -22,10 +22,53 @@ namespace Bodu.Globalization.Calendar;
 /// rules.
 /// </para>
 /// <para>
+/// The <see cref="Strategy" /> property selects one of four resolution strategies:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="DateResolutionStrategy.Fixed" /> — resolves to an explicit month and day each year.</description></item>
+/// <item><description><see cref="DateResolutionStrategy.DayOfWeekInMonth" /> — resolves to the <em>n</em>th occurrence of a weekday within a month (for example, the second Monday of October).</description></item>
+/// <item><description><see cref="DateResolutionStrategy.Algorithm" /> — delegates to a registered <see cref="INotableDateAlgorithm" /> identified by <see cref="AlgorithmKey" /> (for example, Easter or Lunar New Year).</description></item>
+/// <item><description><see cref="DateResolutionStrategy.OffsetFromAnchor" /> — resolves by adding <see cref="OffsetDays" /> to the date produced by another named rule.</description></item>
+/// </list>
+/// <para>
 /// This type replaces the earlier <c>NotableDateDefinition</c>. The new name reads more naturally alongside <see cref="NotableDate" />:
 /// a <em>rule</em> produces <em>dates</em>.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>A fixed public holiday for Australia with a weekend roll-forward adjustment:</para>
+/// <code>
+/// NotableDateRule australiaDay = new NotableDateRule
+/// {
+///     Name = "Australia Day",
+///     Strategy = DateResolutionStrategy.Fixed,
+///     Category = NotableDateCategory.Public,
+///     Month = 1,
+///     Day = 26,
+///     TerritoryCode = "AU",
+///     IsNonWorkingDay = true,
+///     Tags = ImmutableArray.Create("Federal"),
+///     Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+///     {
+///         Key = "weekend-roll",
+///         Trigger = AdjustmentTrigger.IfWeekend,
+///         Action = AdjustmentAction.MoveToNextMonday,
+///         IsNonWorkingDay = true,
+///     }),
+/// };
+///
+/// // Algorithm-based rule (Easter Monday — offset from Easter Sunday):
+/// NotableDateRule easterMonday = new NotableDateRule
+/// {
+///     Name = "Easter Monday",
+///     Strategy = DateResolutionStrategy.OffsetFromAnchor,
+///     Category = NotableDateCategory.Public,
+///     AnchorRuleName = "Easter Sunday",
+///     OffsetDays = 1,
+///     IsNonWorkingDay = true,
+/// };
+/// </code>
+/// </example>
 public sealed record NotableDateRule
 {
 #if NET7_0_OR_GREATER

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleMerger.cs
@@ -64,6 +64,13 @@ internal static class NotableDateRuleMerger
 		return merged;
 	}
 
+	/// <summary>
+	/// Resolves the effective name for the merged rule, applying body name → flat local name → source name precedence.
+	/// </summary>
+	/// <param name="sourceName">The inherited rule name.</param>
+	/// <param name="flatLocalName">The <c>as</c> attribute on the <c>&lt;Use&gt;</c> directive, if any.</param>
+	/// <param name="bodyName">The name declared inside the override body, if any.</param>
+	/// <returns>The resolved name.</returns>
 	private static string ResolveName(string sourceName, string? flatLocalName, string? bodyName)
 	{
 		if (!string.IsNullOrWhiteSpace(bodyName))
@@ -73,6 +80,13 @@ internal static class NotableDateRuleMerger
 		return sourceName;
 	}
 
+	/// <summary>
+	/// Merges the override tag list into the inherited tag set, optionally clearing the inherited baseline first.
+	/// </summary>
+	/// <param name="inherited">The tag set from the source rule.</param>
+	/// <param name="overrideTags">Additional tags declared in the override body.</param>
+	/// <param name="clearTags">When <see langword="true" />, the inherited tags are discarded before adding override tags.</param>
+	/// <returns>The merged tag set.</returns>
 	private static ImmutableHashSet<string> MergeTags(
 		ImmutableHashSet<string> inherited,
 		ImmutableArray<string> overrideTags,
@@ -95,6 +109,15 @@ internal static class NotableDateRuleMerger
 		return builder.ToImmutable();
 	}
 
+	/// <summary>
+	/// Merges the override adjustments into the inherited adjustment list. Matching keys replace their inherited counterpart
+	/// in place; non-matching keys are appended. The inherited baseline may be cleared first when <paramref name="clearAdjustments" />
+	/// is <see langword="true" />.
+	/// </summary>
+	/// <param name="inherited">The adjustment list from the source rule.</param>
+	/// <param name="overrideAdjustments">Adjustments declared in the override body.</param>
+	/// <param name="clearAdjustments">When <see langword="true" />, the inherited adjustments are discarded before merging.</param>
+	/// <returns>The merged adjustment list.</returns>
 	private static ImmutableArray<ObservanceAdjustment> MergeAdjustments(
 		ImmutableArray<ObservanceAdjustment> inherited,
 		ImmutableArray<ObservanceAdjustment> overrideAdjustments,
@@ -125,6 +148,13 @@ internal static class NotableDateRuleMerger
 		return builder.ToImmutable();
 	}
 
+	/// <summary>
+	/// Finds the index of the adjustment whose <see cref="ObservanceAdjustment.Key" /> matches <paramref name="key" />
+	/// (case-insensitive), or returns <c>-1</c> if not found.
+	/// </summary>
+	/// <param name="builder">The mutable adjustment list being searched.</param>
+	/// <param name="key">The key to locate.</param>
+	/// <returns>The zero-based index, or <c>-1</c> when no match is found.</returns>
 	private static int IndexOfKey(ImmutableArray<ObservanceAdjustment>.Builder builder, string key)
 	{
 		for (int i = 0; i < builder.Count; i++)
@@ -136,6 +166,14 @@ internal static class NotableDateRuleMerger
 		return -1;
 	}
 
+	/// <summary>
+	/// Replaces all strategy-specific fields on <paramref name="rule" /> with the values from <paramref name="body" />,
+	/// clearing fields that are irrelevant to the new strategy.
+	/// </summary>
+	/// <param name="rule">The rule whose strategy fields are being replaced.</param>
+	/// <param name="strategy">The new resolution strategy.</param>
+	/// <param name="body">The override body supplying the replacement field values.</param>
+	/// <returns>A new rule with the strategy and its associated fields replaced.</returns>
 	private static NotableDateRule ApplyStrategyOverride(NotableDateRule rule, DateResolutionStrategy strategy, NotableDateRuleOverrideBody body) =>
 		strategy switch
 		{

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResolver.cs
@@ -24,7 +24,10 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 internal sealed class NotableDateRuleResolver
 {
+	/// <summary>A case-insensitive name-keyed lookup of every rule available for resolution, built once at construction.</summary>
 	private readonly IReadOnlyDictionary<string, NotableDateRule> _rulesByName;
+
+	/// <summary>An optional algorithm registry consulted for <see cref="DateResolutionStrategy.Algorithm" /> rules.</summary>
 	private readonly INotableDateAlgorithmRegistry? _algorithms;
 
 	/// <summary>
@@ -171,7 +174,7 @@ internal sealed class NotableDateRuleResolver
     /// Resolves a rule whose strategy is a registered <see cref="INotableDateAlgorithm" />,
     /// delegating to the configured algorithm registry.
     /// </summary>
-    /// <param name="rule">The rule bound to a algorithm strategy.</param>
+    /// <param name="rule">The rule bound to an algorithm strategy.</param>
     /// <param name="year">The civil year.</param>
     /// <returns>The calculated date, or <see langword="null" /> if the configured algorithm
     /// returns no date for the year.</returns>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -26,7 +26,36 @@ namespace Bodu.Globalization.Calendar;
 /// produces a single <see cref="NotableDate" /> whose <see cref="NotableDate.EndDate" /> is the inclusive last day of the span. Range
 /// and single-day queries return the span when any day within it intersects the query.
 /// </para>
+/// <para>
+/// The default no-argument constructor loads the embedded global rule set. The full constructor accepts base rule providers,
+/// weekend definitions, override providers, algorithm registries, custom adjustment handlers, collision resolvers, and name
+/// localisers, enabling complete control over the resolution pipeline.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>Construct with the built-in global rule set and query Australian public holidays:</para>
+/// <code>
+/// // Simplest construction — loads the embedded global rule set:
+/// NotableDateService service = new NotableDateService();
+///
+/// // All notable dates for New South Wales in 2026:
+/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU-NSW");
+///
+/// // Full construction with a custom XML rule file and algorithm registry:
+/// var registry = new NotableDateAlgorithmRegistry()
+///     .Register("easter-sunday", new GregorianEasterSundayNotableDateProvider());
+///
+/// NotableDateService fullService = new NotableDateService(
+///     ruleProviders: new[] { new XmlResourceNotableDateRuleProvider(
+///         "MyApp/Calendar/Resources/custom-rules.xml",
+///         new ResourcePathResolver()) },
+///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+///     algorithmRegistry: registry);
+///
+/// // Invalidate the cache when runtime overrides change:
+/// service.Invalidate();
+/// </code>
+/// </example>
 public sealed class NotableDateService : INotableDateService
 {
 	/// <summary>The embedded resource path for the default global rule set.</summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -29,21 +29,46 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 public sealed class NotableDateService : INotableDateService
 {
+	/// <summary>The embedded resource path for the default global rule set.</summary>
 	private const string DefaultResourceName = "Bodu/Globalization/Calendar/Resources/global-all.xml";
 
+	/// <summary>The immutable snapshot of base rules loaded at construction from all rule providers.</summary>
 	private readonly ImmutableArray<NotableDateRule> _baseRules;
+
+	/// <summary>The ordered list of override providers applied on top of the base rule set.</summary>
 	private readonly IReadOnlyList<INotableDateRuleOverrideProvider> _overrideProviders;
+
+	/// <summary>Snapshot of all override removals, materialised once at construction to avoid re-querying providers per year.</summary>
 	private readonly IReadOnlyList<RuleRemoval> _overrideRemovals;
+
+	/// <summary>The merged rule set after all overrides have been applied; drives every resolution pass.</summary>
 	private readonly IReadOnlyList<NotableDateRule> _effectiveRules;
+
+	/// <summary>The resolver that turns each rule into an anchor date for a given year.</summary>
 	private readonly NotableDateRuleResolver _resolver;
+
+	/// <summary>The adjuster that evaluates observance adjustments against a resolved anchor date.</summary>
 	private readonly NotableDateAdjuster _adjuster;
+
+	/// <summary>The resolver that arbitrates when multiple rules produce a date on the same day.</summary>
 	private readonly INotableDateCollisionResolver _collisionResolver;
+
+	/// <summary>The optional localizer used to translate notable date names into the active culture.</summary>
 	private readonly INotableDateNameLocalizer? _nameLocalizer;
+
+	/// <summary>The configured weekend definition used for weekend and non-working-day evaluation.</summary>
 	private readonly CalendarWeekendDefinition _weekendDefinition;
+
+	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</summary>
 	private readonly IWeekendDefinitionProvider? _weekendProvider;
+
+	/// <summary>The resolver used to locate embedded XML resource files.</summary>
 	private readonly IResourcePathResolver _resourcePathResolver;
 
+	/// <summary>Thread-safe per-year cache of fully resolved notable dates.</summary>
 	private readonly ConcurrentDictionary<int, IReadOnlyList<NotableDate>> _yearCache = new();
+
+	/// <summary>Lock protecting write access to <see cref="_yearCache" /> during first-time year generation.</summary>
 	private readonly object _gate = new();
 
 	// Per-thread set of years currently being generated on this thread. Used by GetOrGenerateYear to short-circuit recursive
@@ -64,7 +89,7 @@ public sealed class NotableDateService : INotableDateService
     /// </summary>
     /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
     /// <param name="weekendDefinition">The weekend definition to apply when evaluating weekends.</param>
-    /// <param name="resourcePathResolver">An optional custom weekend provider.</param>
+    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
     /// <param name="weekendProvider">An optional custom weekend provider.</param>
     /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
     /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
@@ -717,17 +742,27 @@ public sealed class NotableDateService : INotableDateService
 	/// </summary>
 	private sealed class CompositeAlgorithmRegistry : INotableDateAlgorithmRegistry
 	{
+		/// <summary>The host-supplied registry consulted first; its registrations take precedence on key collisions.</summary>
 		private readonly INotableDateAlgorithmRegistry _primary;
+
+		/// <summary>The plugin-supplied registry consulted when <see cref="_primary" /> does not contain the requested key.</summary>
 		private readonly INotableDateAlgorithmRegistry _fallback;
 
+		/// <summary>
+		/// Initialises a new instance of <see cref="CompositeAlgorithmRegistry" />.
+		/// </summary>
+		/// <param name="primary">The primary (host) registry, consulted first.</param>
+		/// <param name="fallback">The fallback (plugin) registry, consulted on primary misses.</param>
 		public CompositeAlgorithmRegistry(INotableDateAlgorithmRegistry primary, INotableDateAlgorithmRegistry fallback)
 		{
 			_primary = primary;
 			_fallback = fallback;
 		}
 
+		/// <inheritdoc />
 		public bool Contains(string key) => _primary.Contains(key) || _fallback.Contains(key);
 
+		/// <inheritdoc />
 		public bool TryGet(string key, out INotableDateAlgorithm algorithm)
 		{
 			if (_primary.TryGet(key, out algorithm!))

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
@@ -19,10 +19,40 @@ namespace Bodu.Globalization.Calendar;
 /// generation and may be scoped to a single territory, calendar, or year range.
 /// </para>
 /// <para>
+/// Multiple adjustments on a single rule allow layered logic — for example, one entry rolls a Saturday observance to Friday and a
+/// second entry rolls a Sunday observance to Monday — while <see cref="Key" /> identifiers allow individual entries to be
+/// targeted and overridden by <c>&lt;Use&gt;</c> directives when the rule is inherited by another resource.
+/// </para>
+/// <para>
 /// This type replaces the earlier <c>NotableDateAdjustmentRule</c>. The new name distinguishes the adjustment <em>specification</em>
 /// from the resolution <em>rule</em> that owns it.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Roll a public holiday to Monday when it falls on a weekend, scoped to all Australian territories:</para>
+/// <code>
+/// ObservanceAdjustment rollToMonday = new ObservanceAdjustment
+/// {
+///     Key = "weekend-to-monday",
+///     Trigger = AdjustmentTrigger.IfWeekend,
+///     Action = AdjustmentAction.MoveToNextMonday,
+///     TerritoryCode = "AU",
+///     IsNonWorkingDay = true,
+/// };
+///
+/// // In Western Australia only, move ANZAC Day observance from Sunday to Monday:
+/// ObservanceAdjustment waSubstitute = new ObservanceAdjustment
+/// {
+///     Key = "anzac-day-wa-sub",
+///     Trigger = AdjustmentTrigger.IfDayOfWeek,
+///     DayOfWeek = DayOfWeek.Sunday,
+///     Action = AdjustmentAction.MoveToNextMonday,
+///     TerritoryCode = "AU-WA",
+///     IsNonWorkingDay = true,
+///     Priority = 10,
+/// };
+/// </code>
+/// </example>
 public sealed record ObservanceAdjustment
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ResourcePathResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ResourcePathResolver.cs
@@ -14,13 +14,32 @@ namespace Bodu.Globalization.Calendar;
 /// <remarks>
 /// <para>
 /// Paths are resolved using a logical path model where <c>/</c> is the canonical separator.
-/// Backslashes are accepted as input and normalized to <c>/</c>.
+/// Backslash characters are accepted as input and normalised to <c>/</c>.
 /// </para>
 /// <para>
 /// The resolver does not convert paths to embedded-resource names or file-system paths. Provider-specific mapping should
-/// happen after resolution.
+/// happen after resolution — <see cref="XmlResourceNotableDateRuleProvider" /> handles the final translation to a manifest
+/// resource name by replacing <c>/</c> with <c>.</c>.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Resolve relative and absolute child paths:</para>
+/// <code>
+/// IResourcePathResolver resolver = new ResourcePathResolver();
+///
+/// // Relative resolution — sibling document:
+/// string result = resolver.Resolve(
+///     "/Bodu/Globalization/Calendar/Resources/au-all.xml",
+///     "../regions/au-nsw.xml");
+/// // result: "/Bodu/Globalization/Calendar/regions/au-nsw.xml"
+///
+/// // Absolute child path (leading slash) — resolved as-is:
+/// string abs = resolver.Resolve(
+///     "/Bodu/Globalization/Calendar/Resources/au-all.xml",
+///     "/Bodu/Globalization/Calendar/Resources/global-public.xml");
+/// // abs: "/Bodu/Globalization/Calendar/Resources/global-public.xml"
+/// </code>
+/// </example>
 public sealed class ResourcePathResolver : IResourcePathResolver
 {
     /// <inheritdoc />
@@ -40,16 +59,32 @@ public sealed class ResourcePathResolver : IResourcePathResolver
         return NormalizeAbsolute(Combine(parentDirectory, childPath));
     }
 
+    /// <summary>
+    /// Replaces all backslash characters in <paramref name="path" /> with forward slashes.
+    /// </summary>
+    /// <param name="path">The path to normalise.</param>
+    /// <returns>The path with backslashes replaced by forward slashes.</returns>
     private static string Normalize(string path)
     {
         return path.Replace('\\', '/');
     }
 
+    /// <summary>
+    /// Returns <see langword="true" /> if <paramref name="path" /> begins with a forward slash and is therefore an absolute path.
+    /// </summary>
+    /// <param name="path">The path to test.</param>
+    /// <returns><see langword="true" /> if the path is rooted; otherwise <see langword="false" />.</returns>
     private static bool IsRooted(string path)
     {
         return path.StartsWith("/", StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Collapses <c>.</c> and <c>..</c> segments from an absolute path and returns the canonical form.
+    /// </summary>
+    /// <param name="path">The absolute path to normalise. Need not already begin with <c>/</c>.</param>
+    /// <returns>The normalised absolute path, always starting with <c>/</c>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when <c>..</c> traversal escapes the root.</exception>
     private static string NormalizeAbsolute(string path)
     {
         var segments = new List<string>();
@@ -75,6 +110,11 @@ public sealed class ResourcePathResolver : IResourcePathResolver
         return "/" + string.Join('/', segments);
     }
 
+    /// <summary>
+    /// Returns the parent directory segment of <paramref name="documentPath" /> after normalising it to an absolute path.
+    /// </summary>
+    /// <param name="documentPath">The fully qualified resource path of a document.</param>
+    /// <returns>The parent directory path, or <c>/</c> when the document is at the root.</returns>
     private static string GetParentDirectory(string documentPath)
     {
         documentPath = NormalizeAbsolute(documentPath);
@@ -86,6 +126,12 @@ public sealed class ResourcePathResolver : IResourcePathResolver
             : documentPath[..lastSlash];
     }
 
+    /// <summary>
+    /// Joins <paramref name="parentDirectory" /> and <paramref name="childPath" /> with a single forward slash separator.
+    /// </summary>
+    /// <param name="parentDirectory">The parent directory path.</param>
+    /// <param name="childPath">The relative child path to append.</param>
+    /// <returns>The combined path.</returns>
     private static string Combine(string parentDirectory, string childPath)
     {
         if (string.IsNullOrWhiteSpace(parentDirectory) || parentDirectory == "/")

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
@@ -6,7 +6,6 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Specifies that a notable date rule should be suppressed by an <see cref="INotableDateRuleOverrideProvider" />.
 /// </summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
@@ -22,6 +22,27 @@ namespace Bodu.Globalization.Calendar;
 /// when the two are identical. Comparisons are performed case-insensitively against the canonical upper-case form.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Parse and compare territory codes:</para>
+/// <code>
+/// // Parse a country-level territory:
+/// if (TerritoryCode.TryParse("AU", out TerritoryCode australia))
+///     Console.WriteLine(australia.Country);        // "AU"
+///
+/// // Parse a subdivision:
+/// TerritoryCode nsw = TerritoryCode.Parse("AU-NSW");
+/// Console.WriteLine(nsw.HasSubdivision);           // true
+/// Console.WriteLine(nsw.Subdivision);              // "NSW"
+/// Console.WriteLine(nsw);                          // "AU-NSW"
+///
+/// // Containment: AU contains AU-NSW but not NZ:
+/// Console.WriteLine(australia.Contains(nsw));      // true
+/// Console.WriteLine(nsw.Contains(australia));      // false
+///
+/// // Parse a comma-separated list (invalid entries are silently skipped):
+/// IReadOnlyList&lt;TerritoryCode&gt; codes = TerritoryCode.ParseList("AU, AU-NSW, AU-VIC");
+/// </code>
+/// </example>
 public readonly record struct TerritoryCode
 {
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
@@ -20,7 +20,7 @@ namespace Bodu.Globalization.Calendar;
 /// <list type="number">
 /// <item><description>The supplied root resource is parsed.</description></item>
 /// <item><description>Each referenced source resource is loaded and recursively flattened, with cycle detection.</description></item>
-/// <item><description>For every <c>&lt;UseFrom&gt;</c> directive, the provider pulls the named rules (or every rule, when <c>&lt;UseAll&gt;</c> is present) from the source's flattened set, applies any per-directive scalar overrides, and adds the resulting rules to the local set.</description></item>
+/// <item><description>For every <c>&lt;UseFrom&gt;</c> directive, the provider pulls the named rules (or every rule when <c>&lt;UseAll&gt;</c> is present) from the source's flattened set, applies any per-directive scalar overrides, and adds the resulting rules to the local set.</description></item>
 /// <item><description>Locally declared <c>&lt;NotableDate&gt;</c> entries are added last and override any inherited rules with the same name.</description></item>
 /// </list>
 /// <para>
@@ -28,20 +28,47 @@ namespace Bodu.Globalization.Calendar;
 /// <c>&lt;Use&gt;</c> directive (or opt in via <c>&lt;UseAll /&gt;</c>) for that rule to appear in the consumer's flattened set.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Load rules from an embedded XML resource in the entry assembly and construct a service:</para>
+/// <code>
+/// // The resource is stored as "MyApp/Calendar/Resources/custom-rules.xml" in the assembly manifest:
+/// var provider = new XmlResourceNotableDateRuleProvider(
+///     "MyApp/Calendar/Resources/custom-rules.xml",
+///     new ResourcePathResolver());
+///
+/// INotableDateService service = new NotableDateService(
+///     ruleProviders: new[] { provider },
+///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+///
+/// // Load from a specific assembly (for example, a satellite resource assembly):
+/// Assembly resourceAssembly = Assembly.Load("MyApp.Resources");
+/// var crossAssemblyProvider = new XmlResourceNotableDateRuleProvider(
+///     "MyApp/Calendar/Resources/custom-rules.xml",
+///     new ResourcePathResolver(),
+///     assembly: resourceAssembly);
+/// </code>
+/// </example>
 public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvider
 {
-    private readonly string _rootResourceName;
-    private readonly IResourcePathResolver _resourcePathResolver;
-    private readonly Assembly _assembly;
+	/// <summary>The logical path of the root XML resource file that seeds the flatten pipeline.</summary>
+	private readonly string _rootResourceName;
+
+	/// <summary>The path resolver used to translate relative <c>&lt;UseFrom&gt;</c> paths into fully qualified resource names.</summary>
+	private readonly IResourcePathResolver _resourcePathResolver;
+
+	/// <summary>The assembly searched for embedded manifest resources during flattening.</summary>
+	private readonly Assembly _assembly;
+
+	/// <summary>Thread-safe lazy backing store for the fully flattened rule list; populated on first call to <see cref="LoadRules" />.</summary>
 	private readonly Lazy<List<NotableDateRule>> _flattenedRules;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="XmlResourceNotableDateRuleProvider" /> class.
     /// </summary>
-    /// <param name="xmlResourceName">The full manifest resource name of the root XML payload. Must not be <see langword="null" />.</param>
-    /// <param name="resourcePathResolver">The full manifest resource name of the root XML payload. Must not be <see langword="null" />.</param>
-    /// <param name="assembly">The assembly containing the embedded resource(s). Defaults to the currently executing assembly.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="xmlResourceName" /> is <see langword="null" />.</exception>
+    /// <param name="xmlResourceName">The logical resource path of the root XML payload (e.g. <c>Bodu/Globalization/Calendar/Resources/global-all.xml</c>). Must not be <see langword="null" />.</param>
+    /// <param name="resourcePathResolver">The resolver used to translate relative <c>&lt;UseFrom&gt;</c> paths into fully qualified resource names. Must not be <see langword="null" />.</param>
+    /// <param name="assembly">The assembly containing the embedded resource(s). Defaults to the currently executing assembly when <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="xmlResourceName" /> or <paramref name="resourcePathResolver" /> is <see langword="null" />.</exception>
     public XmlResourceNotableDateRuleProvider(string xmlResourceName, IResourcePathResolver resourcePathResolver, Assembly? assembly = null)
 	{
 		_rootResourceName = xmlResourceName ?? throw new ArgumentNullException(nameof(xmlResourceName));
@@ -71,8 +98,6 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
 		var byKey = FlattenResource(_rootResourceName, _resourcePathResolver, documentCache, flattenedCache, inProgress);
 		return byKey.Values.ToList();
 	}
-
-
 
     /// <summary>
     /// Flattens a single parsed resource document into a rule dictionary keyed by
@@ -178,6 +203,12 @@ public sealed class XmlResourceNotableDateRuleProvider : INotableDateRuleProvide
 		}
 	}
 
+    /// <summary>
+    /// Converts a logical slash-delimited path into the dot-delimited manifest resource name used by
+    /// <see cref="System.Reflection.Assembly.GetManifestResourceStream(string)" />.
+    /// </summary>
+    /// <param name="logicalPath">The logical resource path to convert. Must not be <see langword="null" />, empty, or whitespace.</param>
+    /// <returns>The manifest resource name with slashes replaced by dots and leading/trailing separators stripped.</returns>
     private static string ToProviderPath(string logicalPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(logicalPath);

--- a/docs/guides/calendar/algorithms.md
+++ b/docs/guides/calendar/algorithms.md
@@ -8,107 +8,149 @@ Several notable dates cannot be expressed as a fixed month/day or an *n*th weekd
 
 ## Built-in algorithms
 
-| Algorithm class | Date it computes | Standard / basis |
+The following classes implement `INotableDateAlgorithm` and can be registered in a `NotableDateAlgorithmRegistry` for use by rules with `Strategy = DateResolutionStrategy.Algorithm`:
+
+| Class | Date it computes | Notes |
 |---|---|---|
-| `GregorianEasterSundayNotableDateProvider` | Easter Sunday (Western) | Anonymous Gregorian algorithm (Computus) |
-| `OrthodoxEasterSundayNotableDateProvider` | Easter Sunday (Eastern Orthodox) | Julian calendar Computus, projected to Gregorian |
-| `HinduLunarNotableDateAlgorithm` | Hindu lunar calendar dates (Diwali, Holi, …) | Astronomical Hindu calendar |
-| `LosarNotableDateAlgorithm` | Losar (Tibetan New Year) | Tibetan lunisolar calendar |
-| `VesakNotableDateAlgorithm` | Vesak (Buddha's birthday) | Sri Lanka / Theravāda full-moon calculation |
-| `AsalhaPujaNotableDateAlgorithm` | Asalha Puja (Dhamma Day) | Full moon of the 8th lunar month |
-| `QingmingNotableDateAlgorithm` | Qingming (Tomb-Sweeping Day) | Solar term — 15° after Spring Equinox |
+| `EasterSundayNotableDateAlgorithm` | Easter Sunday | Gregorian computus for years ≥ 1583; Julian computus otherwise. |
+| `HinduLunarNotableDateAlgorithm` | Hindu lunar festivals (Diwali, Holi, …) | Approximate Gregorian projection of a Hindu panchanga date. |
+| `LosarNotableDateAlgorithm` | Losar (Tibetan New Year) | Tibetan lunisolar calculation. |
+| `VesakNotableDateAlgorithm` | Vesak (Buddha's birthday) | Full-moon calculation per Theravāda tradition. |
+| `AsalhaPujaNotableDateAlgorithm` | Asalha Puja (Dhamma Day) | Full moon of the 8th lunar month. |
+| `QingmingNotableDateAlgorithm` | Qingming (Tomb-Sweeping Day) | Solar term 15° after the Spring Equinox (typically 4–5 April). |
 
-## Using an algorithm in a rule
+The algorithm namespace also contains two `INotableDateProvider` implementations — `GregorianEasterSundayNotableDateProvider` and `OrthodoxEasterSundayNotableDateProvider` — which can be used directly when you want to compute Easter dates outside the rule-resolution pipeline.
 
-Rules that depend on a calculation algorithm set `DateResolutionStrategy.Algorithm`:
+## Registering an algorithm
+
+Rules reference algorithms by string key via `NotableDateRule.AlgorithmKey`. Register the corresponding instance in a `NotableDateAlgorithmRegistry` and supply it to `NotableDateService`:
 
 ```csharp
 using Bodu.Globalization.Calendar;
 using Bodu.Globalization.Calendar.Algorithms;
 
-// Register the Easter algorithm explicitly.
-var registry = new NotableDateAlgorithmRegistry();
-registry.Register<EasterSundayNotableDateAlgorithm>("EasterSunday");
+// Build a registry with fluent chaining:
+NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+    .Register("easter-sunday", new EasterSundayNotableDateAlgorithm())
+    .Register("qingming",      new QingmingNotableDateAlgorithm());
 
-// Build a rule that uses it.
-var goodFriday = new NotableDateRule
+var service = new NotableDateService(
+    ruleProviders:     new[] { new XmlResourceNotableDateRuleProvider(
+                           "MyApp/Calendar/Resources/rules.xml",
+                           new ResourcePathResolver()) },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    algorithmRegistry: registry);
+```
+
+Most built-in algorithm rules are already defined in the embedded global XML rule set and do not need to be registered manually when using the default `NotableDateService()` constructor.
+
+## Using an algorithm in a rule
+
+Rules that require an algorithm set `Strategy = DateResolutionStrategy.Algorithm` and identify the algorithm via `AlgorithmKey`:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+// Easter Sunday — resolved via the registered "easter-sunday" algorithm.
+NotableDateRule easterSunday = new NotableDateRule
 {
-    Name     = "Good Friday",
-    Category = NotableDateCategory.PublicHoliday,
-    Strategy = new DateResolutionStrategy
-    {
-        Kind           = DateResolutionKind.OffsetFromAnchor,
-        AnchorRuleName = "Easter Sunday",
-        DayOffset      = -2,                // 2 days before Easter
-    },
+    Name         = "Easter Sunday",
+    Strategy     = DateResolutionStrategy.Algorithm,
+    Category     = NotableDateCategory.Holiday,
+    AlgorithmKey = "easter-sunday",
+    IsNonWorkingDay = true,
+};
+
+// Easter Monday — offset 1 day from Easter Sunday.
+NotableDateRule easterMonday = new NotableDateRule
+{
+    Name           = "Easter Monday",
+    Strategy       = DateResolutionStrategy.OffsetFromAnchor,
+    Category       = NotableDateCategory.Holiday,
+    AnchorRuleName = "Easter Sunday",
+    OffsetDays     = 1,
+    IsNonWorkingDay = true,
+};
+
+// Good Friday — 2 days before Easter Sunday.
+NotableDateRule goodFriday = new NotableDateRule
+{
+    Name           = "Good Friday",
+    Strategy       = DateResolutionStrategy.OffsetFromAnchor,
+    Category       = NotableDateCategory.Holiday,
+    AnchorRuleName = "Easter Sunday",
+    OffsetDays     = -2,
+    IsNonWorkingDay = true,
 };
 ```
 
-Most built-in algorithm rules are already defined in the embedded global XML rule set and do not need to be registered manually.
+## Computing Easter directly
 
-## Easter Sunday
-
-Gregorian Easter (Western):
+Use the provider classes when you want Easter dates without setting up a full `NotableDateService`:
 
 ```csharp
-using Bodu.Globalization.Calendar.Algorithms;
+using Bodu.Globalization.Calendar.Providers;
 
-var easter = new GregorianEasterSundayNotableDateProvider();
-DateOnly easterDate = easter.ComputeEasterSunday(2025);
-Console.WriteLine(easterDate); // 2025-04-20
-```
+// Gregorian (Western) Easter:
+var gregorian = new GregorianEasterSundayNotableDateProvider();
+IReadOnlyList<NotableDate> easterDates = gregorian.GetDates(2026);
+Console.WriteLine(easterDates[0].Date); // 2026-04-05
 
-Orthodox Easter (Julian projection):
-
-```csharp
-using Bodu.Globalization.Calendar.Algorithms;
-
+// Orthodox Easter (Julian projection to Gregorian):
 var orthodox = new OrthodoxEasterSundayNotableDateProvider();
-DateOnly orthDate = orthodox.ComputeEasterSunday(2025);
-Console.WriteLine(orthDate); // 2025-04-20 (coincides in 2025)
+IReadOnlyList<NotableDate> orthDates = orthodox.GetDates(2026);
+Console.WriteLine(orthDates[0].Date); // 2026-04-12
 ```
 
 ## Qingming (solar term)
 
-Qingming falls on the solar term 15° after the Spring Equinox — typically 4 or 5 April:
+`QingmingNotableDateAlgorithm` implements `INotableDateAlgorithm` and can be called directly:
 
 ```csharp
 using Bodu.Globalization.Calendar.Algorithms;
 
 var qingming = new QingmingNotableDateAlgorithm();
-DateOnly date = qingming.Compute(2025);
-Console.WriteLine(date); // 2025-04-04
+DateTime? date = qingming.GetDate(2026);
+Console.WriteLine(date); // 2026-04-04
 ```
 
 ## Implementing a custom algorithm
 
-Implement `INotableDateAlgorithm` to add a calculation not covered by the built-in set:
+Implement `INotableDateAlgorithm` to add a calculation not covered by the built-in set. The single method `GetDate` receives the target year and an optional calendar system, and returns a `DateTime?` (`null` when the date cannot be determined for that year):
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
-public sealed class MothersDay : INotableDateAlgorithm
+// Mother's Day: second Sunday in May.
+public sealed class MothersDayAlgorithm : INotableDateAlgorithm
 {
-    // Second Sunday in May.
-    public DateOnly Compute(int year)
+    public DateTime? GetDate(int year, System.Globalization.Calendar? calendar = null)
     {
-        DateOnly firstOfMay = new DateOnly(year, 5, 1);
+        DateTime firstOfMay = new DateTime(year, 5, 1);
         int daysToFirstSunday = ((int)DayOfWeek.Sunday - (int)firstOfMay.DayOfWeek + 7) % 7;
         return firstOfMay.AddDays(daysToFirstSunday + 7);
     }
 }
 ```
 
-Register it with the service:
+Register it and wire up a rule:
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
-var registry = new NotableDateAlgorithmRegistry();
-registry.Register<MothersDay>("MothersDay");
+NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+    .Register("mothers-day", new MothersDayAlgorithm());
+
+NotableDateRule mothersDay = new NotableDateRule
+{
+    Name         = "Mother's Day",
+    Strategy     = DateResolutionStrategy.Algorithm,
+    Category     = NotableDateCategory.Observance,
+    AlgorithmKey = "mothers-day",
+};
 
 var service = new NotableDateService(
-    ruleProviders:     [myProvider],
+    ruleProviders:     new[] { new InMemoryRuleProvider(new[] { mothersDay }) },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
     algorithmRegistry: registry);
 ```

--- a/docs/guides/calendar/algorithms.md
+++ b/docs/guides/calendar/algorithms.md
@@ -158,4 +158,5 @@ var service = new NotableDateService(
 ## Where to go next
 
 - [Using NotableDateService](notable-dates.md) — loading rules, override layers, and caching.
+- [Authoring notable date rules](rule-authoring.md) — in-code objects, XML resource files, satellite assemblies, and runtime overrides.
 - [Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md) — full type reference.

--- a/docs/guides/calendar/index.md
+++ b/docs/guides/calendar/index.md
@@ -22,6 +22,11 @@ If you're looking for the generated API reference, see the [Bodu.Globalization.C
   <p>The built-in algorithm types — Easter, Hindu Lunar, Losar, Vesak, Asalha Puja, and Qingming — with registration guidance and a custom-algorithm walk-through.</p>
 </div>
 
+<div class="bodu-card">
+  <h3><a href="rule-authoring.html">Authoring notable date rules</a></h3>
+  <p>How to add your own rules — as in-code objects, embedded XML resource files, or satellite assemblies — and how to layer runtime overrides on top of the base rule set.</p>
+</div>
+
 </div>
 
 ## How the library works
@@ -60,4 +65,5 @@ Every notable date starts as a **`NotableDateRule`** — an authored recipe that
 
 - [Using NotableDateService](notable-dates.md) — patterns for querying, filtering, and overriding.
 - [Date calculation algorithms](algorithms.md) — selecting the right built-in algorithm and implementing your own.
+- [Authoring notable date rules](rule-authoring.md) — in-code objects, XML resource files, satellite assemblies, and runtime overrides.
 - [Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md) — full namespace overview.

--- a/docs/guides/calendar/index.md
+++ b/docs/guides/calendar/index.md
@@ -19,42 +19,42 @@ If you're looking for the generated API reference, see the [Bodu.Globalization.C
 
 <div class="bodu-card">
   <h3><a href="algorithms.html">Date calculation algorithms</a></h3>
-  <p>The built-in algorithm types — Gregorian Easter, Orthodox Easter, Hindu Lunar, Losar, Vesak, Asalha Puja, and Qingming — with algorithm selection guidance.</p>
+  <p>The built-in algorithm types — Easter, Hindu Lunar, Losar, Vesak, Asalha Puja, and Qingming — with registration guidance and a custom-algorithm walk-through.</p>
 </div>
 
 </div>
 
 ## How the library works
 
-```
-Rule (NotableDateRule)
-  └─► NotableDateRuleResolver.ResolveAnchorDate(rule, year)
-        └─► NotableDate  { Date, Name, Category, EndDate, … }
-```
+![NotableDateService resolution pipeline](../../images/diagrams/calendar-resolution-pipeline.svg)
 
-Every notable date starts as a **`NotableDateRule`** — an authored description that captures:
+Every notable date starts as a **`NotableDateRule`** — an authored recipe that the resolver turns into a concrete `NotableDate` instance per year. The rule captures:
 
-- **Strategy** (`DateResolutionStrategy`) — how to find the anchor date: a fixed month/day, an *n*th weekday-of-month, an offset from another rule's date, or a pluggable algorithm.
-- **Category** (`NotableDateCategory`) — `PublicHoliday`, `Observance`, `ReligiousFestival`, `CulturalEvent`, or `Other`.
-- **Territory** (`TerritoryCode`) — the ISO 3166-1 alpha-2 or sub-region code the rule applies to.
-- **Adjustments** (`ObservanceAdjustment`) — how the anchor moves when it falls on a weekend.
-- **Duration** (`DurationDays`) — multi-day spans such as Easter weekend.
+- **Strategy** (`DateResolutionStrategy`) — how to locate the anchor date each year: a fixed month/day, an *n*th weekday-of-month, an offset from another rule's date, or a pluggable algorithm.
+- **Category** (`NotableDateCategory`) — `Holiday`, `Observance`, `Remembrance`, `Cultural`, `Seasonal`, or `Other`.
+- **Territory** (`TerritoryCode`) — the ISO 3166-1 alpha-2 country or subdivision code the rule applies to (for example `AU`, `AU-NSW`).
+- **Adjustments** (`ObservanceAdjustment`) — how the anchor shifts when it falls on a weekend or other trigger condition.
+- **Duration** (`DurationDays`) — multi-day spans such as Easter weekend or Hanukkah.
 
-**`NotableDateService`** loads rules from one or more providers, layers override providers on top, resolves each rule for the requested year using `NotableDateRuleResolver`, and caches the results per year.
+**`NotableDateService`** loads rules from one or more providers, merges optional override providers on top, resolves each rule for the requested year, and caches results per year in a thread-safe `ConcurrentDictionary`.
 
 ## Key types
 
 | Type | Responsibility |
 |---|---|
 | `NotableDateService` | Main entry point — resolves, caches, and queries notable dates. |
-| `INotableDateService` | Interface for DI registration. |
-| `NotableDateRule` | Authored description of a notable date (strategy, category, territory, adjustments). |
-| `NotableDate` | Resolved result — the concrete date, name, category, and optional end date. |
-| `DateResolutionStrategy` | Describes how to locate the anchor date for a rule. |
-| `NotableDateRuleResolver` | Dispatches a rule to the correct resolution logic. |
-| `NotableDateFilter` | Builder for territory- and category-scoped queries. |
-| `TerritoryCode` | Strongly-typed ISO 3166-1 alpha-2 or sub-region code. |
+| `INotableDateService` | Interface for dependency-injection registration. |
+| `NotableDateRule` | Authored recipe describing a notable date (strategy, category, territory, adjustments). |
+| `NotableDate` | Resolved output — the concrete date, name, category, territory, and optional multi-day span. |
+| `DateResolutionStrategy` | Enum selecting how the anchor date is calculated (`Fixed`, `DayOfWeekInMonth`, `Algorithm`, `OffsetFromAnchor`). |
+| `NotableDateCategory` | Coarse-grained classification (`Holiday`, `Observance`, `Remembrance`, `Cultural`, `Seasonal`, `Other`). |
+| `NotableDateFilter` | Composable two-stage predicate for territory- and category-scoped queries. |
+| `ObservanceAdjustment` | Conditional date-shift specification (trigger + action + optional territory/year scope). |
+| `TerritoryCode` | Strongly-typed ISO 3166-1 alpha-2 country or subdivision code with containment semantics. |
 | `INotableDateAlgorithm` | Extension point for custom astronomical or calendar calculations. |
+| `NotableDateAlgorithmRegistry` | Key-based registry wiring named algorithms into the resolver. |
+| `INotableDateRuleProvider` | Contract for rule authoring sources (XML, database, in-memory). |
+| `INotableDateRuleOverrideProvider` | Contract for runtime rule additions and removals. |
 
 ## Related concepts
 

--- a/docs/guides/calendar/notable-dates.md
+++ b/docs/guides/calendar/notable-dates.md
@@ -250,4 +250,5 @@ INotableDateRuleProvider(s)              → base rules
 ## Where to go next
 
 - [Date calculation algorithms](algorithms.md) — the built-in algorithm types and how to implement a custom one.
+- [Authoring notable date rules](rule-authoring.md) — in-code objects, XML resource files, satellite assemblies, and runtime overrides.
 - [Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md) — full type reference.

--- a/docs/guides/calendar/notable-dates.md
+++ b/docs/guides/calendar/notable-dates.md
@@ -4,7 +4,7 @@ title: Using NotableDateService
 
 # Using NotableDateService
 
-`NotableDateService` is the main entry point for resolving notable dates (public holidays, observances, religious festivals) for a given year and territory. It loads rules from one or more `INotableDateRuleProvider` sources, layers optional override providers on top, and caches resolved `NotableDate` instances per year.
+`NotableDateService` is the main entry point for resolving notable dates (public holidays, observances, religious festivals) for a given year and territory. It loads rules from one or more `INotableDateRuleProvider` sources, merges optional override providers on top, and caches resolved `NotableDate` instances per year in a thread-safe `ConcurrentDictionary`.
 
 ## Pattern 1 — resolve the default global rule set
 
@@ -15,8 +15,8 @@ using Bodu.Globalization.Calendar;
 
 var service = new NotableDateService();
 
-// Resolve all notable dates for the current year.
-IReadOnlyList<NotableDate> dates = service.GetDates(DateTime.Today.Year);
+// All notable dates for the current year, globally.
+IReadOnlyList<NotableDate> dates = service.GetNotableDates(DateTime.Today.Year);
 
 foreach (NotableDate date in dates)
     Console.WriteLine($"{date.Date:d MMM yyyy}  [{date.TerritoryCode}]  {date.Name}");
@@ -24,36 +24,49 @@ foreach (NotableDate date in dates)
 
 ## Pattern 2 — filter by territory
 
-Pass a `TerritoryCode` to restrict results to a specific country or sub-region:
+Pass a territory code string to restrict results to a specific country or sub-region:
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
 var service = new NotableDateService();
 
-TerritoryCode au = TerritoryCode.From("AU");
-IReadOnlyList<NotableDate> auDates = service.GetDates(2025, au);
+// All notable dates for Australia in 2026.
+IReadOnlyList<NotableDate> auDates = service.GetNotableDates(2026, territoryCode: "AU");
 
-foreach (NotableDate date in auDates)
+// New South Wales only.
+IReadOnlyList<NotableDate> nswDates = service.GetNotableDates(2026, territoryCode: "AU-NSW");
+
+foreach (NotableDate date in nswDates)
     Console.WriteLine($"{date.Date:d MMM yyyy}  {date.Name}");
 ```
 
+`TerritoryCode` containment applies: a query for `"AU"` returns both country-level dates and all `"AU-XXX"` subdivision dates. A query for `"AU-NSW"` returns dates scoped to `AU-NSW` and unscoped (global) dates, but not other states.
+
 ## Pattern 3 — filter by category
 
-`NotableDateFilter` lets you combine territory and category criteria in one call:
+`NotableDateFilter` is a composable predicate built from static factory methods. Pass it to the filtered overload of `GetNotableDates`:
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
 var service = new NotableDateService();
 
-var filter = new NotableDateFilter
-{
-    TerritoryCode = TerritoryCode.From("GB"),
-    Category      = NotableDateCategory.PublicHoliday,
-};
+// Only public holidays for Great Britain.
+NotableDateFilter publicFilter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+IReadOnlyList<NotableDate> holidays = service.GetNotableDates(2026, publicFilter, "GB");
 
-IReadOnlyList<NotableDate> holidays = service.GetDates(2025, filter);
+// Non-working public holidays — combine predicates with And:
+NotableDateFilter nonWorkingFilter = NotableDateFilter
+    .ForCategory(NotableDateCategory.Holiday)
+    .And(NotableDateFilter.IsNonWorkingDay());
+
+IReadOnlyList<NotableDate> nonWorking = service.GetNotableDates(2026, nonWorkingFilter, "AU");
+
+// Multiple categories with Or:
+NotableDateFilter culturalOrObservance = NotableDateFilter
+    .ForCategory(NotableDateCategory.Cultural)
+    .Or(NotableDateFilter.ForCategory(NotableDateCategory.Observance));
 ```
 
 ## Pattern 4 — query a date range
@@ -63,75 +76,176 @@ using Bodu.Globalization.Calendar;
 
 var service = new NotableDateService();
 
-DateOnly from = new DateOnly(2025, 3, 1);
-DateOnly to   = new DateOnly(2025, 4, 30);
+DateTime from = new DateTime(2026, 3, 1);
+DateTime to   = new DateTime(2026, 4, 30);
 
-IReadOnlyList<NotableDate> spring = service.GetDates(from, to);
+IReadOnlyList<NotableDate> spring = service.GetNotableDates(from, to, "AU");
 ```
 
-Multi-day events (e.g. Easter — `DurationDays > 1`) are returned when *any* day of their span intersects the query window.
+Multi-day events (e.g. Easter — `DurationDays > 1`) are included when *any* day of their span intersects the query window.
 
-## Pattern 5 — check whether a date is a public holiday
+## Pattern 5 — query a single day
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
 var service = new NotableDateService();
 
-DateOnly anzac = new DateOnly(2025, 4, 25);
-TerritoryCode au = TerritoryCode.From("AU");
-
-bool isHoliday = service.IsPublicHoliday(anzac, au);
-Console.WriteLine(isHoliday); // True
+DateTime anzacDay = new DateTime(2026, 4, 25);
+IReadOnlyList<NotableDate> onDay = service.GetNotableDates(anzacDay, "AU");
 ```
 
-## Pattern 6 — layer custom override rules
+This overload also returns multi-day spans whose anchor lies on a preceding day but whose span covers the queried date.
 
-Override providers let you add, remove, or modify rules on top of the base rule set without touching the source XML. This is useful for organisation-specific closures or territory-specific corrections.
+## Pattern 6 — check non-working days and weekends
 
 ```csharp
 using Bodu.Globalization.Calendar;
 
-INotableDateRuleProvider baseProvider = new XmlResourceNotableDateRuleProvider(
-    "MyApp.Resources.holidays-base.xml",
-    new ResourcePathResolver());
+var service = new NotableDateService();
 
-INotableDateRuleOverrideProvider orgOverrides = new XmlResourceNotableDateRuleProvider(
-    "MyApp.Resources.holidays-org.xml",
+DateTime christmas = new DateTime(2026, 12, 25);
+
+// True when the date is Saturday or Sunday under the configured weekend definition.
+bool isWeekend = service.IsWeekend(christmas);
+
+// True when the date is a weekend or a notable date flagged IsNonWorkingDay for the territory.
+bool isNonWorking = service.IsNonWorkingDay(christmas, "AU");
+bool isNonWorkingNSW = service.IsNonWorkingDay(christmas, "AU-NSW");
+```
+
+## Pattern 7 — layer custom override rules
+
+Override providers add, remove, or patch rules on top of the base rule set without modifying the source XML. Implement `INotableDateRuleOverrideProvider` and pass instances via the `overrideProviders` constructor parameter:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+// Suppress Boxing Day for 2026 and inject a company event.
+public sealed class CompanyCalendarOverrides : INotableDateRuleOverrideProvider
+{
+    public IEnumerable<RuleRemoval> GetRemovals()
+    {
+        yield return new RuleRemoval("Boxing Day", FromYear: 2026, ToYear: 2026);
+    }
+
+    public IEnumerable<NotableDateRule> GetAdditions()
+    {
+        yield return new NotableDateRule
+        {
+            Name = "Company Founding Day",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Observance,
+            Month = 6,
+            Day = 15,
+            IsNonWorkingDay = true,
+        };
+    }
+}
+
+// Wire it up:
+var provider = new XmlResourceNotableDateRuleProvider(
+    "MyApp/Calendar/Resources/holidays-base.xml",
     new ResourcePathResolver());
 
 var service = new NotableDateService(
-    ruleProviders:     [baseProvider],
+    ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: [orgOverrides]);
+    overrideProviders: new[] { new CompanyCalendarOverrides() });
 ```
 
-## Pattern 7 — cache invalidation
+## Pattern 8 — cache invalidation
 
 The service caches resolved dates per year. Call `Invalidate` when override providers change:
 
 ```csharp
-// Clear the cached result for 2025 only.
-service.Invalidate(2025);
+// Clear the cached result for 2026 only.
+service.Invalidate(2026);
 
 // Clear the entire cache.
 service.Invalidate();
 ```
 
+## Working with NotableDate results
+
+`NotableDate` is an immutable record. Key properties:
+
+| Property | Description |
+|---|---|
+| `Date` | The resolved anchor date. |
+| `EndDate` | The inclusive last day (`Date + DurationDays - 1`). |
+| `DurationDays` | Span in days (1 for single-day events). |
+| `Name` | Canonical English name. |
+| `DisplayName` | Name qualified with territory and calendar suffix when scoped. |
+| `Category` | `NotableDateCategory` value. |
+| `TerritoryCode` | Territory the date applies to, or `null` for global. |
+| `IsNonWorkingDay` | Whether the date is flagged as a non-working day. |
+| `WasAdjusted` | Whether the date was shifted by an `ObservanceAdjustment`. |
+| `AdjustmentReason` | Original date and adjustment details when `WasAdjusted` is `true`. |
+| `Tags` | Optional non-exclusive classification tags (e.g. `"Christian"`, `"Federal"`). |
+
+```csharp
+foreach (NotableDate date in service.GetNotableDates(2026, "AU"))
+{
+    Console.WriteLine($"{date.Date:d}  {date.DisplayName}");
+
+    if (date.DurationDays > 1)
+        Console.WriteLine($"  Multi-day: ends {date.EndDate:d}");
+
+    if (date.WasAdjusted)
+        Console.WriteLine($"  Shifted from {date.AdjustmentReason!.OriginalDate:d}");
+}
+```
+
+## How the filter works
+
+![NotableDateFilter two-stage gate evaluation](../../images/diagrams/calendar-filter-gates.svg)
+
+Filtered queries apply the predicate in two stages:
+
+1. **Primary gate (rule-level)** — evaluated against each `NotableDateRule` *before* the date is resolved. Rules that fail are skipped entirely, avoiding the cost of algorithm invocation and adjustment evaluation. Factory methods such as `ForCategory`, `WithTag`, `WithName`, and `IsNonWorkingDay` operate at this stage.
+
+2. **Secondary gate (date-level)** — evaluated against the materialised `NotableDate` *after* resolution. Factory methods such as `InDateRange`, `WasAdjusted`, and `WithMinDuration` operate here because their result is not known until the date is computed.
+
+Filtered queries bypass the per-year cache so that unfiltered queries continue to return complete cached results.
+
+```csharp
+// Efficient: ForCategory is rule-level, so non-matching rules are never resolved.
+NotableDateFilter filter = NotableDateFilter
+    .ForCategory(NotableDateCategory.Holiday)
+    .And(NotableDateFilter.IsNonWorkingDay());
+
+// Date-level: every rule is resolved; the gate acts after resolution.
+NotableDateFilter adjusted = NotableDateFilter.WasAdjusted();
+
+// Combined: category pre-screens rules, date-range post-screens resolved dates.
+NotableDateFilter easterWeek = NotableDateFilter
+    .ForCategory(NotableDateCategory.Holiday)
+    .And(NotableDateFilter.InDateRange(
+        new DateTime(2026, 4, 1),
+        new DateTime(2026, 4, 14)));
+
+// AllOf / AnyOf for multi-filter composition:
+NotableDateFilter combined = NotableDateFilter.AllOf(
+    NotableDateFilter.ForCategory(NotableDateCategory.Holiday),
+    NotableDateFilter.IsNonWorkingDay(),
+    NotableDateFilter.WithTag("Federal"));
+```
+
 ## Understanding the resolution pipeline
 
 ```
-INotableDateRuleProvider(s)         → base rules
-  + INotableDateRuleOverrideProvider(s) → merged effective rules
+INotableDateRuleProvider(s)              → base rules
+  + INotableDateRuleOverrideProvider(s)  → merged effective rules
       → NotableDateRuleResolver.ResolveAnchorDate(rule, year)
-          → NotableDateAdjuster (weekday adjustments)
-              → NotableDate(s) for the year  [cached]
+          → NotableDateAdjuster (ObservanceAdjustment rules)
+              → NotableDate(s) for the year  [cached per year]
 ```
 
-1. **Rule loading** — base providers supply the initial rule list; override providers add, remove, or patch rules.
-2. **Anchor resolution** — `NotableDateRuleResolver` dispatches each rule's `DateResolutionStrategy` to the correct logic (fixed date, *n*th weekday, offset, or algorithm).
-3. **Adjustment** — `NotableDateAdjuster` shifts the anchor when it falls on a weekend, applying the `ObservanceAdjustment` policy on the rule.
-4. **Caching** — the resolved list for a year is stored in a thread-safe `ConcurrentDictionary` and reused on subsequent calls.
+1. **Rule loading** — base providers supply the initial rule list; override providers add, remove, or patch rules on top.
+2. **Anchor resolution** — `NotableDateRuleResolver` dispatches each rule's `DateResolutionStrategy` to the correct logic: fixed date, *n*th weekday-of-month, algorithm, or offset from another rule.
+3. **Adjustment** — `NotableDateAdjuster` applies `ObservanceAdjustment` specs to the anchor, shifting it when the trigger condition is met (e.g. falls on a weekend).
+4. **Caching** — the resolved list for each year is stored in a thread-safe `ConcurrentDictionary` and reused on subsequent unfiltered calls. `Invalidate()` clears the cache.
 
 ## Where to go next
 

--- a/docs/guides/calendar/rule-authoring.md
+++ b/docs/guides/calendar/rule-authoring.md
@@ -1,0 +1,462 @@
+---
+title: Authoring notable date rules
+---
+
+# Authoring notable date rules
+
+`NotableDateService` resolves dates from one or more `INotableDateRuleProvider` sources. There are three ways to supply rules, and they can be combined freely in a single service instance:
+
+| Approach | Best for |
+|---|---|
+| **In-code objects** | Tests, dynamic rules, generated rule sets. |
+| **XML resource files** | Large or versioned rule sets shared across assemblies. |
+| **Satellite assemblies** | Distributing rule sets as an independent NuGet package or selectively loading market-specific rules at runtime. |
+
+![Rule authoring — three provider approaches](../../images/diagrams/calendar-rule-authoring.svg)
+
+---
+
+## Approach 1 — In-code rule objects
+
+### Implementing INotableDateRuleProvider
+
+Implement the single-method `INotableDateRuleProvider` interface and return `NotableDateRule` instances from `LoadRules`:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+public sealed class InMemoryRuleProvider : INotableDateRuleProvider
+{
+    private readonly IReadOnlyList<NotableDateRule> _rules;
+
+    public InMemoryRuleProvider(params NotableDateRule[] rules) =>
+        _rules = rules;
+
+    public IEnumerable<NotableDateRule> LoadRules() => _rules;
+}
+```
+
+### Authoring rules — Fixed date
+
+A fixed-date rule specifies a month and day. Add an `ObservanceAdjustment` to shift the date when it falls on a weekend:
+
+```csharp
+using System.Collections.Immutable;
+using Bodu.Globalization.Calendar;
+
+NotableDateRule australiaDay = new NotableDateRule
+{
+    Name            = "Australia Day",
+    Strategy        = DateResolutionStrategy.Fixed,
+    Category        = NotableDateCategory.Holiday,
+    Month           = 1,
+    Day             = 26,
+    TerritoryCode   = "AU",
+    IsNonWorkingDay = true,
+    Tags            = ImmutableHashSet.Create("NationalHoliday"),
+    Adjustments     = ImmutableArray.Create(new ObservanceAdjustment
+    {
+        Key    = "weekend-roll",
+        Trigger = AdjustmentTrigger.IfWeekend,
+        Action  = AdjustmentAction.MoveToNextWeekday,
+    }),
+};
+```
+
+### Authoring rules — Nth weekday of month
+
+Specify `DayOfWeek` and `WeekOrdinal` (from `Bodu.Extensions.WeekOfMonthOrdinal`):
+
+```csharp
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+
+// Third Monday in January (US Martin Luther King Jr. Day).
+NotableDateRule mlkDay = new NotableDateRule
+{
+    Name            = "Martin Luther King Jr. Day",
+    Strategy        = DateResolutionStrategy.DayOfWeekInMonth,
+    Category        = NotableDateCategory.Holiday,
+    Month           = 1,
+    DayOfWeek       = DayOfWeek.Monday,
+    WeekOrdinal     = WeekOfMonthOrdinal.Third,
+    TerritoryCode   = "US",
+    IsNonWorkingDay = true,
+    FirstYear       = 1986,
+};
+```
+
+### Authoring rules — Offset from an anchor
+
+An `OffsetFromAnchor` rule is resolved relative to another rule's date. The anchor must appear in the same provider or in a provider registered earlier in the list:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+// Good Friday — 2 days before Easter Sunday.
+NotableDateRule goodFriday = new NotableDateRule
+{
+    Name            = "Good Friday",
+    Strategy        = DateResolutionStrategy.OffsetFromAnchor,
+    Category        = NotableDateCategory.Holiday,
+    AnchorRuleName  = "Easter Sunday",
+    OffsetDays      = -2,
+    IsNonWorkingDay = true,
+};
+
+// Easter Monday — 1 day after Easter Sunday.
+NotableDateRule easterMonday = new NotableDateRule
+{
+    Name            = "Easter Monday",
+    Strategy        = DateResolutionStrategy.OffsetFromAnchor,
+    Category        = NotableDateCategory.Holiday,
+    AnchorRuleName  = "Easter Sunday",
+    OffsetDays      = 1,
+    IsNonWorkingDay = true,
+};
+```
+
+### Authoring rules — Algorithm
+
+Algorithm rules delegate date calculation to a registered `INotableDateAlgorithm`. Supply the registry key and register the implementation when building `NotableDateService`:
+
+```csharp
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Algorithms;
+
+NotableDateRule easterSunday = new NotableDateRule
+{
+    Name            = "Easter Sunday",
+    Strategy        = DateResolutionStrategy.Algorithm,
+    Category        = NotableDateCategory.Holiday,
+    AlgorithmKey    = "easter-sunday",
+    IsNonWorkingDay = true,
+};
+```
+
+### Wiring up a provider
+
+Pass the provider to `NotableDateService` via `ruleProviders`. Multiple providers can be combined; their rule sets are merged in order:
+
+```csharp
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Algorithms;
+
+NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+    .Register("easter-sunday", new EasterSundayNotableDateAlgorithm());
+
+var provider = new InMemoryRuleProvider(easterSunday, goodFriday, easterMonday, australiaDay);
+
+var service = new NotableDateService(
+    ruleProviders:     new[] { provider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    algorithmRegistry: registry);
+```
+
+---
+
+## Approach 2 — XML resource files
+
+XML resources are the recommended format for large or shared rule sets. The file is schema-validated, supports composition via `<UseFrom>` directives, and can be updated independently of code.
+
+### Document structure
+
+Every rule file must declare the `urn:bodu:globalization:calendar` namespace:
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<NotableDates xmlns="urn:bodu:globalization:calendar"
+              xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+
+  <!-- UseFrom directives and NotableDate elements go here. -->
+
+</NotableDates>
+```
+
+### Declaring a rule — Fixed date
+
+Each `<NotableDate>` element groups one or more `<Rule>` variants under a canonical name. Rules apply globally unless `territory` restricts them:
+
+```xml
+<NotableDate name="Australia Day">
+  <Rule name="Fixed Australia Day With Weekend Roll"
+        category="Holiday"
+        territory="AU"
+        nonWorking="true"
+        comment="Substitute Monday observed when 26 January falls on a weekend.">
+    <Fixed month="January" day="26" />
+    <Tag>NationalHoliday</Tag>
+    <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
+  </Rule>
+</NotableDate>
+```
+
+**`<Rule>` attributes**
+
+| Attribute | Required | Description |
+|---|---|---|
+| `name` | Yes | Variant identifier within the notable date. Required when a notable date has multiple `<Rule>` elements. |
+| `category` | Yes | `Holiday`, `Observance`, `Remembrance`, `Cultural`, `Seasonal`, or `Other`. |
+| `territory` | No | ISO 3166-1 alpha-2 code or subdivision (e.g. `AU`, `AU-NSW`). Omit for global scope. |
+| `nonWorking` | No | `true` if this date is a non-working day. |
+| `firstYear` | No | Inclusive first year the rule applies. |
+| `lastYear` | No | Inclusive last year the rule applies. |
+| `durationDays` | No | Multi-day span (default: `1`). |
+| `priority` | No | Tie-break priority when multiple rules resolve to the same date (default: `100`). |
+| `comment` | No | Authoring annotation — not surfaced to consumers. |
+
+### Strategy elements
+
+Each `<Rule>` contains exactly one strategy element:
+
+**`<Fixed>`** — fixed month and day:
+
+```xml
+<Fixed month="December" day="25" />
+```
+
+**`<DayOfWeekInMonth>`** — nth occurrence of a weekday in a month:
+
+```xml
+<!-- Third Monday in January -->
+<DayOfWeekInMonth month="January" dayOfWeek="Monday" weekOrdinal="Third" />
+```
+
+`weekOrdinal` accepts: `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`.
+
+**`<OffsetFromAnchor>`** — days relative to another rule's resolved date:
+
+```xml
+<!-- Good Friday: 2 days before Easter Sunday -->
+<OffsetFromAnchor name="Easter Sunday" offset="-2" />
+```
+
+**`<Algorithm>`** — delegated to a registered algorithm; identified by key or assembly-qualified type name:
+
+```xml
+<Algorithm key="easter-sunday"
+           type="Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateAlgorithm, Bodu.Globalization.Calendar" />
+```
+
+### Adjustments and tags
+
+`<Adjustment>` elements shift the anchor date when a trigger condition fires. Multiple adjustments are evaluated in `priority` order (ascending):
+
+```xml
+<NotableDate name="Christmas Day">
+  <Rule name="Christmas Day With Substitute" category="Holiday" nonWorking="true">
+    <Fixed month="December" day="25" />
+    <Tag>Christian</Tag>
+    <!-- Move to the next non-working day when Christmas falls on a Saturday or Sunday. -->
+    <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
+  </Rule>
+</NotableDate>
+```
+
+**Common `when` / `action` values**
+
+| `when` | Fires when… |
+|---|---|
+| `IfWeekend` | The date falls on a weekend (per the configured `CalendarWeekendDefinition`). |
+| `IfWeekday` | The date falls on a weekday. |
+| `IfNonWorkingDay` | The date is already a non-working day (weekend or another notable date). |
+| `IfDayOfWeek` | The date falls on the weekday specified by an additional `dayOfWeek` attribute. |
+| `Always` | Unconditionally. |
+
+| `action` | Effect |
+|---|---|
+| `MoveToNextWeekday` | Advance to the next weekday. |
+| `MoveToPreviousWeekday` | Retreat to the previous weekday. |
+| `MoveToNextNonWorkingDay` | Advance past all non-working days. |
+| `AddDays` | Add a fixed `offset` in days (negative moves backwards). |
+
+### Composing rule sets with UseFrom
+
+`<UseFrom>` imports rules from another resource file. Imported rules must be explicitly opted in via `<UseAll>` (import everything) or individual `<Use>` directives (cherry-pick by name). This keeps composition intentional — adding a rule to a shared library does not cascade into consumers automatically.
+
+**`<UseAll>`** — opt in to every rule in the referenced file:
+
+```xml
+<UseFrom resource="./global-core.xml">
+  <UseAll />
+</UseFrom>
+```
+
+**`<Use>`** — cherry-pick a named rule and optionally apply overrides:
+
+```xml
+<UseFrom resource="./christian-gregorian.xml">
+  <!-- Adopt Easter Sunday as-is, scoped to AU. -->
+  <Use name="Easter Sunday" territory="AU" />
+
+  <!-- Adopt Good Friday as a non-working holiday for AU. -->
+  <Use name="Good Friday" territory="AU" nonWorking="true" />
+
+  <!-- Rename "Holy Saturday" to "Easter Saturday" for AU and add an adjustment. -->
+  <Use name="Holy Saturday" as="Easter Saturday" territory="AU" nonWorking="true">
+    <Rule name="Australian Christmas Day With Non-Working-Day Roll"
+          category="Holiday" nonWorking="true">
+      <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
+    </Rule>
+  </Use>
+</UseFrom>
+```
+
+**`clearInherited="true"`** — drop all inherited rule variants and replace with the rule declared in the directive body:
+
+```xml
+<UseFrom resource="./christian-gregorian.xml">
+  <Use name="Christmas Day" territory="AU-NT" clearInherited="true">
+    <Rule name="NT Christmas Day" category="Holiday" nonWorking="true">
+      <Fixed month="December" day="25" />
+      <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
+    </Rule>
+  </Use>
+</UseFrom>
+```
+
+`resource` paths use forward slashes. Relative paths resolve from the directory of the declaring file; absolute paths (starting with `/`) resolve from the root of the manifest resource namespace.
+
+### Embedding as a resource
+
+Add the XML file as an `<EmbeddedResource>` item in the project file. The manifest resource name is derived by replacing path separators with dots:
+
+```xml
+<ItemGroup>
+  <EmbeddedResource Include="Calendar\Resources\my-rules.xml" />
+</ItemGroup>
+```
+
+### Loading the provider
+
+Construct `XmlResourceNotableDateRuleProvider` with the logical path (forward-slash delimited) and a `ResourcePathResolver` to handle `<UseFrom>` path resolution:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+var provider = new XmlResourceNotableDateRuleProvider(
+    "MyApp/Calendar/Resources/my-rules.xml",
+    new ResourcePathResolver());
+
+var service = new NotableDateService(
+    ruleProviders:     new[] { provider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+```
+
+The logical path `"MyApp/Calendar/Resources/my-rules.xml"` is mapped to the manifest resource name `MyApp.Calendar.Resources.my-rules.xml`. Ensure the embedded resource path in the `.csproj` produces that manifest name (typically by placing the file under `MyApp/Calendar/Resources/` relative to the project root).
+
+---
+
+## Approach 3 — Satellite assemblies
+
+Embedding rule XML in a separate assembly keeps rules and application code independently versioned. This is useful for distributing a rule library, loading market-specific calendars on demand, or shrinking the main assembly.
+
+### Setting up the satellite project
+
+Create a class library that contains only the embedded XML resources:
+
+```xml
+<!-- MyApp.CalendarRules.csproj -->
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <AssemblyName>MyApp.CalendarRules</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\my-rules.xml" />
+    <EmbeddedResource Include="Resources\region-apac.xml" />
+  </ItemGroup>
+</Project>
+```
+
+### Loading from the satellite
+
+Pass the satellite assembly as the third constructor argument. The logical path resolves relative to that assembly's manifest resource namespace:
+
+```csharp
+using System.Reflection;
+using Bodu.Globalization.Calendar;
+
+Assembly rulesAssembly = Assembly.Load("MyApp.CalendarRules");
+
+var provider = new XmlResourceNotableDateRuleProvider(
+    "MyApp/CalendarRules/Resources/my-rules.xml",
+    new ResourcePathResolver(),
+    assembly: rulesAssembly);
+
+var service = new NotableDateService(
+    ruleProviders:     new[] { provider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+```
+
+Relative `<UseFrom>` paths in the satellite's XML files resolve against the satellite assembly. Cross-assembly references are not supported within a single provider; use multiple providers if rules span assemblies.
+
+---
+
+## Runtime overrides
+
+`INotableDateRuleOverrideProvider` layers additions and removals on top of the base rule set at runtime, without modifying the source XML or in-code providers. Override providers are evaluated after all base providers:
+
+```csharp
+using Bodu.Globalization.Calendar;
+
+public sealed class CompanyCalendarOverrides : INotableDateRuleOverrideProvider
+{
+    public IEnumerable<RuleRemoval> GetRemovals()
+    {
+        // Suppress Boxing Day for 2026 only.
+        yield return new RuleRemoval("Boxing Day", FromYear: 2026, ToYear: 2026);
+    }
+
+    public IEnumerable<NotableDateRule> GetAdditions()
+    {
+        yield return new NotableDateRule
+        {
+            Name            = "Company Founding Day",
+            Strategy        = DateResolutionStrategy.Fixed,
+            Category        = NotableDateCategory.Observance,
+            Month           = 6,
+            Day             = 15,
+            IsNonWorkingDay = true,
+        };
+    }
+}
+```
+
+Register override providers via the `overrideProviders` constructor parameter:
+
+```csharp
+var service = new NotableDateService(
+    ruleProviders:     new[] { provider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    overrideProviders: new[] { new CompanyCalendarOverrides() });
+```
+
+After changing override state, call `Invalidate()` to clear the resolved cache:
+
+```csharp
+service.Invalidate();       // Clear all years.
+service.Invalidate(2026);   // Clear 2026 only.
+```
+
+---
+
+## Choosing an approach
+
+| | In-Code | XML Files | Satellite Assembly |
+|---|---|---|---|
+| Schema validation | Manual | Yes (XSD) | Yes (XSD) |
+| Versioning | With code | Independent | Independent |
+| Cherry-pick composition | Manual | `<UseFrom>` / `<Use>` | `<UseFrom>` / `<Use>` |
+| Runtime overhead | Minimal | Parse + cache on first use | Parse + cache on first use |
+| Suitable for large rule sets | Impractical | Yes | Yes |
+| Independent deployment | No | No | Yes |
+
+Use in-code objects for unit tests or small dynamic rule sets. Use XML resource files when authoring dozens or more rules within the same project. Use satellite assemblies to distribute rule sets as a separate package or to load regional calendars on demand.
+
+## Where to go next
+
+- [Using NotableDateService](notable-dates.md) — filtering, territory queries, overrides, and caching.
+- [Date calculation algorithms](algorithms.md) — registering built-in algorithms and implementing custom ones.
+- [Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md) — full type reference.

--- a/docs/images/diagrams/calendar-filter-gates.svg
+++ b/docs/images/diagrams/calendar-filter-gates.svg
@@ -1,0 +1,134 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 250" role="img" aria-labelledby="fg-t fg-d">
+  <title id="fg-t">NotableDateFilter — two-stage gate evaluation</title>
+  <desc id="fg-d">A filtered GetNotableDates call passes each rule through a primary gate before resolving its date, then passes each resolved NotableDate through a secondary gate. Rules that fail the primary gate are skipped entirely, avoiding the cost of date resolution. Dates that fail the secondary gate are discarded from the result.</desc>
+
+  <defs>
+    <style>
+      .bg  { fill: #0F172A; }
+      .pan { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl { fill: #F8FAFC; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub { fill: #CBD5E1; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut { fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .err { fill: #EF4444; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ok  { fill: #4ADE80; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .rul { fill: #1E293B; stroke: #475569; stroke-width: 1; }
+      .gt1 { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .rsv { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .nd  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .gt2 { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out { fill: #431407; stroke: #FBBF24; stroke-width: 1; }
+      .skp { fill: #1A0808; stroke: #7F1D1D; stroke-width: 1; stroke-dasharray: 3 2; }
+      .w   { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+      .wt  { stroke: #2DD4BF; stroke-width: 1.5; fill: none; }
+      .wp  { stroke: #A78BFA; stroke-width: 1.5; fill: none; }
+      .we  { stroke: #EF4444; stroke-width: 1.3; fill: none; stroke-dasharray: 3 2; }
+    </style>
+    <marker id="a"  viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="at" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="ap" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+    <marker id="ae" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#EF4444"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="250"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="230" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">NotableDateFilter — two-stage gate evaluation</text>
+
+    <!-- ROW: main flow at y=78–116 (h=38, center y=97) -->
+
+    <!-- NotableDateRule input -->
+    <g transform="translate(16 78)">
+      <rect class="rul" width="90" height="38" rx="5"/>
+      <text class="lbl" x="45" y="15">Notable</text>
+      <text class="lbl" x="45" y="28">DateRule</text>
+    </g>
+    <line class="w" x1="106" y1="97" x2="132" y2="97" marker-end="url(#a)"/>
+
+    <!-- PRIMARY gate -->
+    <g transform="translate(132 78)">
+      <rect class="gt1" width="96" height="38" rx="5"/>
+      <text class="lbl" fill="#2DD4BF" x="48" y="14">Primary gate</text>
+      <text class="sub" x="48" y="27">(rule-level)</text>
+    </g>
+
+    <!-- pass arrow -->
+    <line class="wt" x1="228" y1="97" x2="254" y2="97" marker-end="url(#at)"/>
+    <text class="ok" x="241" y="90">pass</text>
+
+    <!-- RESOLVE -->
+    <g transform="translate(254 78)">
+      <rect class="rsv" width="100" height="38" rx="5"/>
+      <text class="lbl" x="50" y="15">Resolve</text>
+      <text class="sub" x="50" y="28">anchor date</text>
+    </g>
+    <line class="w" x1="354" y1="97" x2="380" y2="97" marker-end="url(#a)"/>
+
+    <!-- NotableDate -->
+    <g transform="translate(380 78)">
+      <rect class="nd" width="100" height="38" rx="5"/>
+      <text class="lbl" x="50" y="15">Notable</text>
+      <text class="lbl" x="50" y="28">Date</text>
+    </g>
+    <line class="w" x1="480" y1="97" x2="506" y2="97" marker-end="url(#a)"/>
+
+    <!-- SECONDARY gate -->
+    <g transform="translate(506 78)">
+      <rect class="gt2" width="100" height="38" rx="5"/>
+      <text class="lbl" fill="#C4B5FD" x="50" y="14">Secondary gate</text>
+      <text class="sub" x="50" y="27">(date-level)</text>
+    </g>
+
+    <!-- pass arrow -->
+    <line class="wp" x1="606" y1="97" x2="632" y2="97" marker-end="url(#ap)"/>
+    <text class="ok" x="619" y="90">pass</text>
+
+    <!-- RESULT -->
+    <g transform="translate(632 78)">
+      <rect class="out" width="150" height="38" rx="5"/>
+      <text class="lbl" fill="#FBBF24" x="75" y="15">Result</text>
+      <text class="sub" x="75" y="28">included in output</text>
+    </g>
+
+    <!-- FAIL: primary gate → skip -->
+    <path class="we" d="M 180 116 L 180 150" marker-end="url(#ae)"/>
+    <g transform="translate(136 150)">
+      <rect class="skp" width="88" height="30" rx="4"/>
+      <text class="err" x="44" y="12">skip</text>
+      <text class="mut" x="44" y="25">no resolution</text>
+    </g>
+    <text class="err" x="176" y="143">fail</text>
+
+    <!-- FAIL: secondary gate → discard -->
+    <path class="we" d="M 556 116 L 556 150" marker-end="url(#ae)"/>
+    <g transform="translate(516 150)">
+      <rect class="skp" width="80" height="30" rx="4"/>
+      <text class="err" x="40" y="12">discard</text>
+      <text class="mut" x="40" y="25">not returned</text>
+    </g>
+    <text class="err" x="552" y="143">fail</text>
+
+    <!-- FOOTER: examples of each gate -->
+    <text class="mut" x="180" y="200" text-anchor="middle">ForCategory · WithTag · WithName</text>
+    <text class="mut" x="180" y="213" text-anchor="middle">WithAnyTag · IsNonWorkingDay</text>
+    <text class="sub" x="180" y="200" text-anchor="middle" opacity="0"/>
+    <text class="mut" x="556" y="200" text-anchor="middle">InDateRange · WasAdjusted</text>
+    <text class="mut" x="556" y="213" text-anchor="middle">WithMinDuration</text>
+
+    <!-- Footer labels -->
+    <text class="sub" x="180" y="188" text-anchor="middle" fill="#2DD4BF">rule-level predicates</text>
+    <text class="sub" x="556" y="188" text-anchor="middle" fill="#A78BFA">date-level predicates</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/calendar-resolution-pipeline.svg
+++ b/docs/images/diagrams/calendar-resolution-pipeline.svg
@@ -1,0 +1,105 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 300" role="img" aria-labelledby="cp-t cp-d">
+  <title id="cp-t">NotableDateService — resolution pipeline</title>
+  <desc id="cp-d">Rule providers and optional override providers are merged into an effective rule set. The resolver dispatches each rule by strategy — Fixed, DayOfWeekInMonth, Algorithm, or OffsetFromAnchor — producing an anchor date. The adjuster evaluates ObservanceAdjustment rules. Resolved dates are stored in a thread-safe per-year cache and returned by GetNotableDates.</desc>
+
+  <defs>
+    <style>
+      .bg   { fill: #0F172A; }
+      .pan  { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr  { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl  { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl  { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub  { fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut  { fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .inp  { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1; }
+      .inp-d{ fill: #1A2335; stroke: #475569; stroke-width: 1; stroke-dasharray: 4 3; }
+      .rsv  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .adj  { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1; }
+      .cch  { fill: #431407; stroke: #FBBF24; stroke-width: 1; }
+      .bdg  { fill: #0F172A; stroke: #334155; stroke-width: 1; }
+      .bdg-t{ fill: #93C5FD; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .w    { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+      .wt   { stroke: #2DD4BF; stroke-width: 1.5; fill: none; }
+      .wm   { stroke: #475569; stroke-width: 1.4; fill: none; stroke-dasharray: 4 3; }
+    </style>
+    <marker id="a"  viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="at" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="300"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="280" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">NotableDateService — resolution pipeline</text>
+
+    <!-- INPUT: INotableDateRuleProvider -->
+    <g transform="translate(20 52)">
+      <rect class="inp" width="176" height="40" rx="5"/>
+      <text class="lbl" fill="#2DD4BF" x="88" y="16">INotableDateRuleProvider(s)</text>
+      <text class="mut" x="88" y="30">base rules (XML, database, …)</text>
+    </g>
+
+    <!-- INPUT: INotableDateRuleOverrideProvider -->
+    <g transform="translate(20 108)">
+      <rect class="inp-d" width="176" height="40" rx="5"/>
+      <text class="lbl" fill="#94A3B8" x="88" y="15">INotableDateRule</text>
+      <text class="lbl" fill="#94A3B8" x="88" y="29">OverrideProvider(s)</text>
+    </g>
+    <text class="mut" x="108" y="162">optional</text>
+
+    <!-- Arrows: providers → resolver -->
+    <path class="wt" d="M 196 72 L 240 72" marker-end="url(#at)"/>
+    <path class="wm" d="M 196 128 L 222 128 L 222 88 L 240 88"/>
+
+    <!-- RESOLVER box -->
+    <g transform="translate(240 52)">
+      <rect class="rsv" width="320" height="72" rx="5"/>
+      <text class="lbl" x="160" y="18">NotableDateRuleResolver</text>
+      <rect class="bdg" x="8"   y="27" width="52"  height="18" rx="3"/>
+      <text class="bdg-t" x="34"  y="39">Fixed</text>
+      <rect class="bdg" x="66"  y="27" width="72"  height="18" rx="3"/>
+      <text class="bdg-t" x="102" y="39">DayOfWeek</text>
+      <rect class="bdg" x="144" y="27" width="68"  height="18" rx="3"/>
+      <text class="bdg-t" x="178" y="39">Algorithm</text>
+      <rect class="bdg" x="218" y="27" width="94"  height="18" rx="3"/>
+      <text class="bdg-t" x="265" y="39">OffsetFromAnchor</text>
+    </g>
+
+    <!-- Arrow: resolver → adjuster -->
+    <line class="w" x1="400" y1="124" x2="400" y2="144" marker-end="url(#a)"/>
+
+    <!-- ADJUSTER box -->
+    <g transform="translate(240 144)">
+      <rect class="adj" width="320" height="48" rx="5"/>
+      <text class="lbl" x="160" y="19">NotableDateAdjuster</text>
+      <text class="sub" x="160" y="36">ObservanceAdjustment rules (weekend roll, territory scope, …)</text>
+    </g>
+
+    <!-- Arrow: adjuster → cache -->
+    <line class="w" x1="400" y1="192" x2="400" y2="210" marker-end="url(#a)"/>
+
+    <!-- CACHE bar -->
+    <g transform="translate(240 210)">
+      <rect class="cch" width="320" height="22" rx="3"/>
+      <text class="lbl" fill="#FBBF24" x="160" y="15">per-year cache  (thread-safe ConcurrentDictionary)</text>
+    </g>
+
+    <!-- Arrow: cache → output -->
+    <line class="w" x1="560" y1="221" x2="590" y2="221" marker-end="url(#a)"/>
+
+    <!-- OUTPUT -->
+    <g transform="translate(590 208)">
+      <rect class="cch" width="190" height="36" rx="5"/>
+      <text class="lbl" fill="#FBBF24" x="95" y="15">GetNotableDates(…)</text>
+      <text class="mut" x="95" y="28">IReadOnlyList&lt;NotableDate&gt;</text>
+    </g>
+
+    <text class="mut" x="400" y="252" text-anchor="middle">Invalidate() / Invalidate(year) — clears one year or the entire cache</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/calendar-rule-authoring.svg
+++ b/docs/images/diagrams/calendar-rule-authoring.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 260" role="img" aria-labelledby="ra-t ra-d">
+  <title id="ra-t">Rule authoring — three provider approaches</title>
+  <desc id="ra-d">Three approaches supply rules to NotableDateService. In-Code Objects implement INotableDateRuleProvider directly. XML Resource Files use XmlResourceNotableDateRuleProvider with an embedded .xml file. Satellite Assemblies use the same provider but pass a separate assembly. All three are passed via the ruleProviders constructor parameter. Optional runtime overrides implement INotableDateRuleOverrideProvider and are passed via overrideProviders.</desc>
+
+  <defs>
+    <style>
+      .bg  { fill: #0F172A; }
+      .pan { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl { fill: #F8FAFC; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub { fill: #CBD5E1; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut { fill: #94A3B8; font: 400 9px/1  "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ic  { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .xf  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .sa  { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .ov  { fill: #1A2335; stroke: #475569; stroke-width: 1; stroke-dasharray: 4 3; }
+      .svc { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .out { fill: #431407; stroke: #FBBF24; stroke-width: 1; }
+      .wt  { stroke: #2DD4BF; stroke-width: 1.5; fill: none; }
+      .wb  { stroke: #60A5FA; stroke-width: 1.5; fill: none; }
+      .wp  { stroke: #A78BFA; stroke-width: 1.5; fill: none; }
+      .wd  { stroke: #475569; stroke-width: 1.3; fill: none; stroke-dasharray: 4 3; }
+      .w   { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+    </style>
+    <marker id="a"  viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="at" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60A5FA"/>
+    </marker>
+    <marker id="ap" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+    <marker id="ad" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#475569"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="260"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="240" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Rule authoring — three provider approaches</text>
+
+    <!-- In-Code Objects -->
+    <g transform="translate(16 50)">
+      <rect class="ic" width="214" height="40" rx="5"/>
+      <text class="lbl" fill="#2DD4BF" x="107" y="14">In-Code Objects</text>
+      <text class="sub" x="107" y="27">INotableDateRuleProvider</text>
+      <text class="mut" x="107" y="39">custom C# implementation</text>
+    </g>
+
+    <!-- XML Resource Files -->
+    <g transform="translate(16 102)">
+      <rect class="xf" width="214" height="40" rx="5"/>
+      <text class="lbl" fill="#93C5FD" x="107" y="14">XML Resource Files</text>
+      <text class="sub" x="107" y="27">XmlResourceNotableDateRuleProvider</text>
+      <text class="mut" x="107" y="39">embedded .xml — same assembly</text>
+    </g>
+
+    <!-- Satellite Assembly -->
+    <g transform="translate(16 154)">
+      <rect class="sa" width="214" height="40" rx="5"/>
+      <text class="lbl" fill="#C4B5FD" x="107" y="14">Satellite Assembly</text>
+      <text class="sub" x="107" y="27">XmlResourceNotableDateRuleProvider</text>
+      <text class="mut" x="107" y="39">assembly: separate project</text>
+    </g>
+
+    <!-- Runtime Overrides (dashed, optional) -->
+    <g transform="translate(16 207)">
+      <rect class="ov" width="214" height="32" rx="5"/>
+      <text class="lbl" fill="#94A3B8" x="107" y="13">Runtime Overrides</text>
+      <text class="sub" x="107" y="26">INotableDateRuleOverrideProvider</text>
+    </g>
+    <text class="mut" x="123" y="248" text-anchor="middle">optional</text>
+
+    <!-- Arrows: sources → service (bend at x=248) -->
+    <path class="wt" d="M 230 70  L 248 70  L 248 105 L 270 105" marker-end="url(#at)"/>
+    <line class="wb" x1="230" y1="122" x2="270" y2="122"         marker-end="url(#ab)"/>
+    <path class="wp" d="M 230 174 L 248 174 L 248 141 L 270 141" marker-end="url(#ap)"/>
+    <path class="wd" d="M 230 223 L 248 223 L 248 162 L 270 162" marker-end="url(#ad)"/>
+
+    <!-- NotableDateService box -->
+    <g transform="translate(270 78)">
+      <rect class="svc" width="288" height="100" rx="5"/>
+      <text class="lbl" x="144" y="18">NotableDateService</text>
+      <text class="sub" x="144" y="36">ruleProviders: INotableDateRuleProvider[]</text>
+      <text class="sub" x="144" y="51">weekendDefinition: CalendarWeekendDefinition</text>
+      <text class="sub" x="144" y="66">overrideProviders: INotableDateRuleOverrideProvider[]</text>
+      <text class="mut" x="144" y="82">algorithmRegistry · adjustmentHandlers · …</text>
+      <text class="mut" x="144" y="95">per-year cache (ConcurrentDictionary)</text>
+    </g>
+
+    <!-- Arrow: service → output -->
+    <line class="w" x1="558" y1="128" x2="594" y2="128" marker-end="url(#a)"/>
+
+    <!-- Output box -->
+    <g transform="translate(594 108)">
+      <rect class="out" width="180" height="40" rx="5"/>
+      <text class="lbl" fill="#FBBF24" x="90" y="15">GetNotableDates(…)</text>
+      <text class="sub" x="90" y="29">IReadOnlyList&lt;NotableDate&gt;</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
- Grammar: correct 'a algorithm' → 'an algorithm' in 7 algorithm class and method summaries
- NotableDateService: fix incorrect resourcePathResolver param description (was 'custom weekend provider')
- INotableDateAlgorithm: replace <c>null</c> with <see langword="null"/> and tighten <param>/<returns> wording
- AdjustmentAction/AdjustmentTrigger enums: replace bare <c> code references with <see cref> for all ObservanceAdjustment members and CalendarWeekendDefinition
- Private members: add XML <summary> docs to all undocumented private fields across NotableDateService, NotableDateAdjuster, NotableDateRuleResolver, NotableDateFilter, algorithm classes, and plugin trust policies
- Private methods: add full XML docs (including <param>/<returns>) to NotableDateRuleMerger helpers, VesakNotableDateAlgorithm.ProjectToCalendar, and StrongNamePluginTrustPolicy helpers
- LunarPhaseAlgorithm: add missing <param name="fullMoon"> to EstimateK and <returns> to ComputeLunarPhaseJde; replace inline comments on J2000Epoch/SynodicMonth with XML docs
- QingmingNotableDateAlgorithm: add <param>/<returns> to ComputeVernalEquinoxJde; convert inline comments on constants and s_correctionTerms to XML docs
- HinduLunarNotableDateAlgorithm: add <param>/<returns> to GetSearchMonth; convert TithiDays inline comment and private field comments to XML docs
- NotableDateService.CompositeAlgorithmRegistry: add <summary>, <param> on constructor, <inheritdoc/> on Contains/TryGet, and field docs
- EasterSundayNotableDateProviderBase: remove unused System.Text and System.Threading.Tasks usings; fix copyright header filename (trailing space); add <returns> to all abstract/virtual properties; document _dateCache field; add <para> context to class remarks
- OrthodoxEasterSundayNotableDateProvider: remove spurious blank line after opening brace; document static JulianCalendar field; fix trailing whitespace on class declaration
- GregorianEasterSundayNotableDateProvider: fix trailing whitespace on class declaration
- AdjustmentHandlerContext/IAdjustmentHandler/AdjustmentHandlerResult: remove spurious double blank lines after namespace declaration
- NotableDateFilter: add XML docs to private constructor

https://claude.ai/code/session_019EfEiLaqmr61vGkraa89WX