### PR TITLE
Fix NotableDateCategory enum to match XSD schema and reclassify Easter providers

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
@@ -26,7 +26,7 @@ public sealed class GregorianEasterSundayNotableDateProvider
     protected override string Name => "Easter Sunday";
 
     /// <inheritdoc />
-    protected override NotableDateCategory Category => NotableDateCategory.Cultural;
+    protected override NotableDateCategory Category => NotableDateCategory.Religious;
 
     /// <inheritdoc />
     protected override Type? DefaultCalendarType => typeof(SysGlobal.GregorianCalendar);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
@@ -31,7 +31,7 @@ public sealed class OrthodoxEasterSundayNotableDateProvider
     protected override string Name => "Orthodox Easter Sunday";
 
     /// <inheritdoc />
-    protected override NotableDateCategory Category => NotableDateCategory.Cultural;
+    protected override NotableDateCategory Category => NotableDateCategory.Religious;
 
     /// <inheritdoc />
     protected override Type? DefaultCalendarType => typeof(SysGlobal.JulianCalendar);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
@@ -27,12 +27,12 @@ public enum AdjustmentAction
 	AddDays,
 
 	/// <summary>
-	/// Moves the date forward to the next weekday as defined by the configured <see cref="CalendarWeekendDefinition" />.
+	/// Moves the date forward to the next weekday as defined by the configured <see cref="Bodu.Extensions.CalendarWeekendDefinition" />.
 	/// </summary>
 	MoveToNextWeekday,
 
 	/// <summary>
-	/// Moves the date backward to the previous weekday as defined by the configured <see cref="CalendarWeekendDefinition" />.
+	/// Moves the date backward to the previous weekday as defined by the configured <see cref="Bodu.Extensions.CalendarWeekendDefinition" />.
 	/// </summary>
 	MoveToPreviousWeekday,
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
@@ -26,7 +26,7 @@ public enum AdjustmentTrigger
 	IfDayOfWeek,
 
 	/// <summary>
-	/// Activates when the calculated date falls on a weekend, as determined by the configured <see cref="CalendarWeekendDefinition" />.
+	/// Activates when the calculated date falls on a weekend, as determined by the configured <see cref="Bodu.Extensions.CalendarWeekendDefinition" />.
 	/// </summary>
 	IfWeekend,
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
@@ -36,7 +36,7 @@ internal sealed class NotableDateAdjuster
 	/// <summary>The configured weekend definition, forwarded to shift actions that move dates to a weekday.</summary>
 	private readonly CalendarWeekendDefinition _weekendDefinition;
 
-	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</summary>
+	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="Bodu.Extensions.CalendarWeekendDefinition.Custom" />.</summary>
 	private readonly IWeekendDefinitionProvider? _weekendProvider;
 
 	/// <summary>An optional registry of custom <see cref="IAdjustmentHandler" /> instances looked up by key.</summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateCategory.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateCategory.cs
@@ -30,7 +30,7 @@ public enum NotableDateCategory
 	Holiday,
 
 	/// <summary>
-	/// A religious, cultural, or secular observance that may or may not involve public closure.
+	/// A secular or cultural observance that may or may not involve public closure, and does not belong to a more specific category.
 	/// </summary>
 	Observance,
 
@@ -45,9 +45,34 @@ public enum NotableDateCategory
 	Cultural,
 
 	/// <summary>
+	/// A religious observance, ceremony, or holy day significant within a specific faith or denomination.
+	/// </summary>
+	Religious,
+
+	/// <summary>
 	/// A seasonal marker such as a solstice, equinox, or daylight-saving transition.
 	/// </summary>
 	Seasonal,
+
+	/// <summary>
+	/// A civic or national commemoration, such as a constitution day or independence memorial, that may not carry a statutory day off.
+	/// </summary>
+	Civic,
+
+	/// <summary>
+	/// A bank or financial-institution holiday on which banks and financial markets are closed, which may differ from the public holiday schedule.
+	/// </summary>
+	Bank,
+
+	/// <summary>
+	/// A school holiday or term boundary observed by educational institutions, which may not coincide with public holidays.
+	/// </summary>
+	School,
+
+	/// <summary>
+	/// An observance specific to a subnational region, state, or province that does not apply nationally.
+	/// </summary>
+	Regional,
 
 	/// <summary>
 	/// A notable date that does not fit any other primary category.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -88,7 +88,7 @@ public sealed class NotableDateService : INotableDateService
 	/// <summary>The configured weekend definition used for weekend and non-working-day evaluation.</summary>
 	private readonly CalendarWeekendDefinition _weekendDefinition;
 
-	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</summary>
+	/// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="Bodu.Extensions.CalendarWeekendDefinition.Custom" />.</summary>
 	private readonly IWeekendDefinitionProvider? _weekendProvider;
 
 	/// <summary>The resolver used to locate embedded XML resource files.</summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProviderTests.cs
@@ -85,7 +85,7 @@ public sealed class GregorianEasterSundayNotableDateProviderTests
 		Assert.AreEqual(1, result.Count);
 		NotableDate notable = result[0];
 		Assert.AreEqual("Easter Sunday", notable.Name);
-		Assert.AreEqual(NotableDateCategory.Cultural, notable.Category);
+		Assert.AreEqual(NotableDateCategory.Religious, notable.Category);
 		Assert.AreEqual(typeof(SysGlob.GregorianCalendar), notable.CalendarType);
 		Assert.AreEqual(1, notable.DurationDays);
 		Assert.IsFalse(notable.IsNonWorkingDay);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProviderTests.cs
@@ -83,7 +83,7 @@ public sealed class OrthodoxEasterSundayNotableDateProviderTests
 		Assert.AreEqual(1, result.Count);
 		NotableDate notable = result[0];
 		Assert.AreEqual("Orthodox Easter Sunday", notable.Name);
-		Assert.AreEqual(NotableDateCategory.Cultural, notable.Category);
+		Assert.AreEqual(NotableDateCategory.Religious, notable.Category);
 		Assert.AreEqual(typeof(SysGlob.JulianCalendar), notable.CalendarType);
 		Assert.AreEqual(1, notable.DurationDays);
 		Assert.IsFalse(notable.IsNonWorkingDay);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.TestData.cs
@@ -105,4 +105,22 @@ public partial class NotableDateRuleParserTests
 				<UseAll />
 			</UseFrom>
 		</NotableDates>";
+
+	public const string ReligiousRuleXml = @"
+		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
+			<NotableDate name=""Eid al-Fitr"">
+				<Rule name=""Eid al-Fitr Rule"" category=""Religious"">
+					<Algorithm key=""islamic-eid-al-fitr"" />
+				</Rule>
+			</NotableDate>
+		</NotableDates>";
+
+	public const string CivicRuleXml = @"
+		<NotableDates xmlns=""urn:bodu:globalization:calendar"">
+			<NotableDate name=""Constitution Day"">
+				<Rule name=""Constitution Day Rule"" category=""Civic"">
+					<Fixed month=""July"" day=""17"" />
+				</Rule>
+			</NotableDate>
+		</NotableDates>";
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.cs
@@ -51,6 +51,30 @@ public partial class NotableDateRuleParserTests
 	}
 
 	/// <summary>
+	/// Verifies that a rule whose <c>category</c> attribute is <c>"Religious"</c> is parsed as
+	/// <see cref="NotableDateCategory.Religious" /> rather than silently falling back to <see cref="NotableDateCategory.None" />.
+	/// </summary>
+	[TestMethod]
+	public void ParseXml_WhenCategoryIsReligious_ShouldReturnReligiousCategory()
+	{
+		var rule = NotableDateRuleParser.ParseXml(ReligiousRuleXml).Single();
+
+		Assert.AreEqual(NotableDateCategory.Religious, rule.Category);
+	}
+
+	/// <summary>
+	/// Verifies that a rule whose <c>category</c> attribute is <c>"Civic"</c> is parsed as
+	/// <see cref="NotableDateCategory.Civic" /> rather than silently falling back to <see cref="NotableDateCategory.None" />.
+	/// </summary>
+	[TestMethod]
+	public void ParseXml_WhenCategoryIsCivic_ShouldReturnCivicCategory()
+	{
+		var rule = NotableDateRuleParser.ParseXml(CivicRuleXml).Single();
+
+		Assert.AreEqual(NotableDateCategory.Civic, rule.Category);
+	}
+
+	/// <summary>
 	/// Verifies that parsing a Fixed rule populates the inclusive year window.
 	/// </summary>
 	[TestMethod]


### PR DESCRIPTION
Religious and Civic were valid notableDateCategory XSD values actively used in
41 XML resource rules, but were absent from the C# enum. ParseOptionalEnum used
Enum.TryParse which silently mapped both to None, mislabelling those dates at
runtime. Adding all five missing values (Religious, Civic, Bank, School, Regional)
brings the enum into full sync with the schema.

Observance summary updated to remove the word "religious" now that Religious is
its own category. Gregorian and Orthodox Easter Sunday providers recategorised
from Cultural to Religious for consistency with the XML-based rules. Parser
round-trip tests added to prevent a recurrence of the silent-None regression.

https://claude.ai/code/session_018DNu2mRnzWp5Yr9KCeyaoZ