### PR TITLE
test(Security.Cryptography): refactor Skein tests to data-driven KAT model

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.Ubi.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.Ubi.cs
@@ -13,6 +13,24 @@ namespace Bodu.Security.Cryptography;
 public abstract partial class Skein<T>
 {
     /// <summary>
+    /// Returns the cached initial chaining value derived from the configuration block (and the optional KEY UBI phase
+    /// when a key is set). Exposed for Skein 1.3 Appendix B verification — the published IVs for the canonical unkeyed
+    /// hash configurations must equal the words returned here when the algorithm is constructed with no key and the
+    /// matching output size.
+    /// </summary>
+    /// <returns>A defensive copy of the chaining-value words that <see cref="Initialize" /> would seed the state with.</returns>
+    /// <remarks>
+    /// The first call computes and caches the IV; subsequent calls return clones of the cached value. Mutating the
+    /// returned array does not affect the algorithm's internal state.
+    /// </remarks>
+    internal ulong[] GetInitialChainingValueWords()
+    {
+        this.ThrowIfDisposed();
+        this.EnsureChainingValueInitialized();
+        return (ulong[])this._initialChainingValue.Clone();
+    }
+
+    /// <summary>
     /// Applies a single Skein <c>UBI</c> (Unique Block Iteration) compression step that folds <paramref name="block" />
     /// into the chaining state using the supplied tweak fields.
     /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmKnownAnswer.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmKnownAnswer.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="KeyedHashAlgorithmKnownAnswer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Represents a single known-answer test vector for a keyed hash family — a named input payload paired with an
+/// optional per-row key, an optional descriptive profile tag, and the expected hex-encoded digest produced by the
+/// algorithm under test for the specification's selected variant.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Instances populate <see cref="KeyedHashAlgorithmKnownAnswers.Vectors" /> on the keyed-hash specification. The
+/// per-row <see cref="Key" /> lets a single algorithm variant span multiple keyed test cases — for example, the
+/// Skein 1.3 / NIST CD <c>random+MAC</c> KAT entries, where every vector carries its own randomly chosen MAC key
+/// of varying length.
+/// </para>
+/// <para>
+/// When <see cref="Key" /> is <see langword="null" /> the harness uses the variant's default key from
+/// <see cref="KeyedAlgorithmSpecification.TestKey" />. When <see cref="Key" /> is an empty array the harness
+/// assigns the empty-key sentinel that variable-length-optional-key algorithms (Skein, BLAKE2) treat as the
+/// canonical unkeyed mode.
+/// </para>
+/// </remarks>
+public sealed record KeyedHashAlgorithmKnownAnswer
+{
+    /// <summary>Gets the semantic name of this test vector used in diagnostic messages.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the raw input bytes to feed to the algorithm.</summary>
+    public required byte[] Input { get; init; }
+
+    /// <summary>Gets the hex-encoded expected digest produced by hashing <see cref="Input" /> with this row's key.</summary>
+    public required string ExpectedHex { get; init; }
+
+    /// <summary>
+    /// Gets the per-row key applied to the algorithm before computing the digest, or <see langword="null" /> when the
+    /// variant's default <see cref="KeyedAlgorithmSpecification.TestKey" /> should be used.
+    /// </summary>
+    /// <value>The key bytes, an empty array for the unkeyed sentinel, or <see langword="null" /> to defer to the variant default.</value>
+    public byte[]? Key { get; init; }
+
+    /// <summary>
+    /// Gets an optional free-form profile tag describing the source or category of this vector — for example
+    /// <c>"Spec Appendix C"</c>, <c>"NIST CD KAT"</c>, or <c>"BouncyCastle reference"</c>. Surfaced in failure
+    /// diagnostics so a test report makes the provenance obvious.
+    /// </summary>
+    public string? Profile { get; init; }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmKnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmKnownAnswers.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="KeyedHashAlgorithmKnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Declares the keyed known-answer test vectors associated with a keyed-hash specification variant. Sits alongside
+/// <see cref="HashAlgorithmKnownAnswers" /> on <see cref="KeyedAlgorithmSpecification" /> so unkeyed shared inputs
+/// and keyed per-row vectors stay clearly separated in the spec record.
+/// </summary>
+/// <remarks>
+/// The keyed harness flattens every entry in <see cref="Vectors" /> into a data-driven test row, applying the
+/// row's <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> (or the variant default) to the algorithm before
+/// computing the digest and comparing against the expected hex.
+/// </remarks>
+public sealed record KeyedHashAlgorithmKnownAnswers
+{
+    /// <summary>
+    /// Gets the keyed known-answer vectors for this variant. Defaults to an empty list, in which case the keyed
+    /// harness emits no per-row assertions for the variant.
+    /// </summary>
+    public IReadOnlyList<KeyedHashAlgorithmKnownAnswer> Vectors { get; init; } =
+        Array.Empty<KeyedHashAlgorithmKnownAnswer>();
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmSpecification .cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedHashAlgorithmSpecification .cs
@@ -28,6 +28,17 @@ public record KeyedAlgorithmSpecification
     public required byte[] TestKey { get; init; }
 
     /// <summary>
+    /// Gets the keyed known-answer test vectors associated with this variant. Each entry may carry its own per-row
+    /// key, or fall back to <see cref="TestKey" /> when <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> is
+    /// <see langword="null" />.
+    /// </summary>
+    /// <value>
+    /// A <see cref="KeyedHashAlgorithmKnownAnswers" /> record carrying per-row keyed vectors. Defaults to an empty
+    /// record, in which case the keyed harness emits no per-row assertions for this variant.
+    /// </value>
+    public KeyedHashAlgorithmKnownAnswers KeyedAnswers { get; init; } = new();
+
+    /// <summary>
     /// Gets a value indicating whether the algorithm requires an exact key length. <see langword="true" /> when
     /// <see cref="MinKeyLength" /> equals <see cref="MaxKeyLength" />.
     /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024AppendixBIVs.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024AppendixBIVs.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein1024AppendixBIVs.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the Skein 1.3 Appendix B precomputed initial chaining values for the three <see cref="Skein1024" /> output
+/// sizes. The constants are reproduced verbatim from the Skein 1.3 / NIST CD reference distribution so the test
+/// suite can verify the production CFG-UBI derivation against the published values.
+/// </summary>
+internal static class Skein1024AppendixBIVs
+{
+    /// <summary>Skein-1024-384 initial chaining value (state size 1024 bits, output 384 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein1024_384 = new ulong[]
+    {
+        0x5102B6B8C1894A35UL,
+        0xFEEBC9E3FE8AF11AUL,
+        0x0C807F06E32BED71UL,
+        0x60C13A52B41A91F6UL,
+        0x9716D35DD4917C38UL,
+        0xE780DF126FD31D3AUL,
+        0x797846B6C898303AUL,
+        0xB172C2A8B3572A3BUL,
+        0xC9BC8203A6104A6CUL,
+        0x65909338D75624F4UL,
+        0x94BCC5684B3F81A0UL,
+        0x3EBBF51E10ECFD46UL,
+        0x2DF50F0BEEB08542UL,
+        0x3B5A65300DBC6516UL,
+        0x484B9CD2167BBCE1UL,
+        0x2D136947D4CBAFEAUL,
+    };
+
+    /// <summary>Skein-1024-512 initial chaining value (state size 1024 bits, output 512 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein1024_512 = new ulong[]
+    {
+        0xCAEC0E5D7C1B1B18UL,
+        0xA01B0E045F03E802UL,
+        0x33840451ED912885UL,
+        0x374AFB04EAEC2E1CUL,
+        0xDF25A0E2813581F7UL,
+        0xE40040938B12F9D2UL,
+        0xA662D539C2ED39B6UL,
+        0xFA8B85CF45D8C75AUL,
+        0x8316ED8E29EDE796UL,
+        0x053289C02E9F91B8UL,
+        0xC3F8EF1D6D518B73UL,
+        0xBDCEC3C4D5EF332EUL,
+        0x549A7E5222974487UL,
+        0x670708725B749816UL,
+        0xB9CD28FBF0581BD1UL,
+        0x0E2940B815804974UL,
+    };
+
+    /// <summary>Skein-1024-1024 initial chaining value (state size 1024 bits, output 1024 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein1024_1024 = new ulong[]
+    {
+        0xD593DA0741E72355UL,
+        0x15B5E511AC73E00CUL,
+        0x5180E5AEBAF2C4F0UL,
+        0x03BD41D3FCBCAFAFUL,
+        0x1CAEC6FD1983A898UL,
+        0x6E510B8BCDD0589FUL,
+        0x77E2BDFDC6394ADAUL,
+        0xC11E1DB524DCB0A3UL,
+        0xD6D14AF9C6329AB5UL,
+        0x6A9B0BFC6EB67E0DUL,
+        0x9243C60DCCFF1332UL,
+        0x1A1F1DDE743F02D4UL,
+        0x0996753C10ED0BB8UL,
+        0x6572DD22F2B4969AUL,
+        0x61FD3062D00A579AUL,
+        0x1DE0536E8682E539UL,
+    };
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024KnownAnswers.cs
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein1024KnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the curated <see cref="Skein1024" /> known-answer test vectors, transcribed verbatim from the Skein 1.3 /
+/// NIST CD <c>skein_golden_kat.txt</c> reference distribution.
+/// </summary>
+/// <remarks>
+/// Skein-1024-1024 ships with a richer message-length set covering empty, one-byte, one-block, and two-block
+/// messages. The 384- and 512-bit truncations carry one 1024-bit incrementing-message vector each.
+/// </remarks>
+internal static class Skein1024KnownAnswers
+{
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Empty = Array.Empty<KeyedHashAlgorithmKnownAnswer>();
+
+    /// <summary>
+    /// Returns the curated KAT vectors for <paramref name="variant" />, or an empty array when the NIST CD KAT
+    /// publishes no vectors for that (output, mode) combination.
+    /// </summary>
+    public static IReadOnlyList<KeyedHashAlgorithmKnownAnswer> For(Skein1024TestVariant variant) => variant switch
+    {
+        Skein1024TestVariant.Hash_384 => Hash384,
+        Skein1024TestVariant.Mac_384 => Mac384,
+        Skein1024TestVariant.Hash_512 => Hash512,
+        Skein1024TestVariant.Mac_512 => Mac512,
+        Skein1024TestVariant.Hash_1024 => Hash1024,
+        Skein1024TestVariant.Mac_1024 => Mac1024,
+        _ => Empty,
+    };
+
+    private const string IncrementingOneBlockSkein1024 =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0" +
+        "DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0" +
+        "BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A0" +
+        "9F9E9D9C9B9A999897969594939291908F8E8D8C8B8A89888786858483828180";
+
+    private const string IncrementingTwoBlocksSkein1024 =
+        IncrementingOneBlockSkein1024 +
+        "7F7E7D7C7B7A797877767574737271706F6E6D6C6B6A696867666564636261605F5E5D5C5B5A595857565554535251504F4E4D4C4B4A49484746454443424140" +
+        "3F3E3D3C3B3A393837363534333231302F2E2D2C2B2A292827262524232221201F1E1D1C1B1A191817161514131211100F0E0D0C0B0A09080706050403020100";
+
+    // 1024-bit truncation messages reuse the one-block sequence.
+    private const string Incrementing1024Bits = IncrementingOneBlockSkein1024;
+
+    private const string MacOneBlockSkein1024 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135" +
+        "BA26FEDE2EE187417F816048D00FC23512737A2113709A77E4170C49A94B7FDF" +
+        "F45FF579A72287743102E7766C35CA5ABC5DFE2F63A1E726CE5FBD2926DB03A2" +
+        "DD18B03FC1508A9AAC45EB362440203A323E09EDEE6324EE2E37B4432C1867ED";
+
+    private const string MacTwoBlocksSkein1024 =
+        MacOneBlockSkein1024 +
+        "696E6C9DB1E6ABEA026288954A9C2D5758D7C5DB7C9E48AA3D21CAE3D977A7C3926066AA393DBD538DD0C30DA8916C8757F24C18488014668A2627163A37B261" +
+        "833DC2F8C3C56B1B2E0BE21FD3FBDB507B2950B77A6CC02EFB393E57419383A920767BCA2C972107AA61384542D47CBFB82CFE5C415389D1B0A2D74E2C5DA851";
+
+    private const string Mac1024BitsSkein1024 = MacOneBlockSkein1024;
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash384 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex =
+                "A550F3071A8826044FF5F14E88AA86938087A10C155102C09D3B3E3BBF5C96B0" +
+                "FE9C1C705E5D0BACCDC98FED102542E5",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac384 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein1024),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1" +
+                "935DF3061FF06E9F204192BA11E5BB2CAC0430C1C370CB3D113FEA5EC1021EB8" +
+                "75E5946D7A96AC69A1626C6206B7252736F24253C9EE9B85EB852DFC814631346C" +
+                "042EB4187AA1C015A4767032C0BB28F076B66485F51531C12E948F47DBC2CB90" +
+                "4A4B75D1E8A6D931DAB4A07E0A54D1BB5B55E602141746BD09FB15E8F01A8D74" +
+                "E9E63959CB37336BC1B896EC78DA734C15E362DB04368FBBA280F20A043E0D09" +
+                "41E9F5193E1B360A33C43B266524880125222E648F05F28BE34BA3CABFC9C544"),
+            ExpectedHex =
+                "98AF454D7FA3706DFAAFBF58C3F9944868B57F68F493987347A69FCE19865FEB" +
+                "BA0407A16B4E82065035651F0B1E0327",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash512 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex =
+                "57E3DE8CA38A69C9405ABF2A4063B4855C775B6D6C464725D325FAF27EB6F15F" +
+                "086B11DA99E252ACFCF3BBE62E08BC10252850C40BB4766C32C10D998DB27B10",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac512 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein1024),
+            Key = Array.Empty<byte>(),
+            ExpectedHex =
+                "0B50658B7F45ECC7CF211D5E2D16A8AE5764B28271C136C8B03C1CC308ABACE9" +
+                "EECAFF8584CCE97A9AB75804B1250A30A76D69139B47A433E9FAEBE6A4B7DD10",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash1024 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_Empty",
+            Profile = "NIST CD KAT",
+            Input = Array.Empty<byte>(),
+            ExpectedHex =
+                "0FFF9563BB3279289227AC77D319B6FFF8D7E9F09DA1247B72A0A265CD6D2A62" +
+                "645AD547ED8193DB48CFF847C06494A03F55666D3B47EB4C20456C9373C86297" +
+                "D630D5578EBD34CB40991578F9F52B18003EFA35D3DA6553FF35DB91B81AB890" +
+                "BEC1B189B7F52CB2A783EBB7D823D725B0B4A71F6824E88F68F982EEFC6D19C6",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneByte",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString("FF"),
+            ExpectedHex =
+                "E62C05802EA0152407CDD8787FDA9E35703DE862A4FBC119CFF8590AFE79250B" +
+                "CCC8B3FAF1BD2422AB5C0D263FB2F8AFB3F796F048000381531B6F00D85161BC" +
+                "0FFF4BEF2486B1EBCD3773FABF50AD4AD5639AF9040E3F29C6C931301BF79832" +
+                "E9DA09857E831E82EF8B4691C235656515D437D2BDA33BCEC001C67FFDE15BA8",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingOneBlockSkein1024),
+            ExpectedHex =
+                "1F3E02C46FB80A3FCD2DFBBC7C173800B40C60C2354AF551189EBF433C3D85F9" +
+                "FF1803E6D920493179ED7AE7FCE69C3581A5A2F82D3E0C7A295574D0CD7D217C" +
+                "484D2F6313D59A7718EAD07D0729C24851D7E7D2491B902D489194E6B7D369DB" +
+                "0AB7AA106F0EE0A39A42EFC54F18D93776080985F907574F995EC6A37153A578",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingTwoBlocksSkein1024),
+            ExpectedHex =
+                "842A53C99C12B0CF80CF69491BE5E2F7515DE8733B6EA9422DFD676665B5FA42" +
+                "FFB3A9C48C217777950848CECDB48F640F81FB92BEF6F88F7A85C1F7CD1446C9" +
+                "161C0AFE8F25AE444F40D3680081C35AA43F640FD5FA3C3C030BCC06ABAC01D0" +
+                "98BCC984EBD8322712921E00B1BA07D6D01F26907050255EF2C8E24F716C52A5",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac1024 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacOneBlockSkein1024),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1"),
+            ExpectedHex =
+                "211AC479E9961141DA3AAC19D320A1DBBBFAD55D2DCE87E6A345FCD58E368275" +
+                "97378432B482D89BAD44DDDB13E6AD86E0EE1E0882B4EB0CD6A181E9685E18DD" +
+                "302EBB3AA74502C06254DCADFB2BD45D288F82366B7AFC3BC0F6B1A3C2E8F84D" +
+                "37FBEDD07A3F8FCFF84FAF24C53C11DA600AAA118E76CFDCB366D0B3F7729DCE",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacTwoBlocksSkein1024),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1" +
+                "935DF3061FF06E9F204192BA11E5BB2CAC0430C1C370CB3D113FEA5EC1021EB8" +
+                "75E5946D7A96AC69A1626C6206B7252736F24253C9EE9B85EB852DFC814631346C"),
+            ExpectedHex =
+                "46A42B0D7B8679F8FCEA156C072CF9833C468A7D59AC5E5D326957D60DFE1CDF" +
+                "B27EB54C760B9E049FDA47F0B847AC68D6B340C02C39D4A18C1BDFECE3F405FA" +
+                "E8AA848BDBEFE3A4C277A095E921228618D3BE8BD1999A071682810DE748440A" +
+                "D416A97742CC9E8A9B85455B1D76472CF562F525116698D5CD0A35DDF86E7F8A",
+        },
+    ];
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024TestVariant.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024TestVariant.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein1024TestVariant.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Enumerates the (output size, operating mode) configurations exercised by <see cref="Skein1024Tests" />, mirroring
+/// the output sizes permitted by <see cref="Skein1024" /> (384, 512, 1024 bits) across both the canonical plain hash
+/// profile and the keyed Skein-MAC-1024 profile.
+/// </summary>
+/// <remarks>
+/// The <c>Hash</c> entries select the unkeyed plain hash; the <c>Mac</c> entries select Skein-MAC by assigning the
+/// specification's <see cref="KeyedAlgorithmSpecification.TestKey" /> on construction. Per-row keys carried by
+/// <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> override the variant default during keyed known-answer runs.
+/// </remarks>
+public enum Skein1024TestVariant
+{
+    /// <summary>Skein-1024-384, plain hash profile (no key).</summary>
+    Hash_384,
+
+    /// <summary>Skein-MAC-1024-384, keyed profile.</summary>
+    Mac_384,
+
+    /// <summary>Skein-1024-512, plain hash profile (no key).</summary>
+    Hash_512,
+
+    /// <summary>Skein-MAC-1024-512, keyed profile.</summary>
+    Mac_512,
+
+    /// <summary>Skein-1024-1024, plain hash profile (no key).</summary>
+    Hash_1024,
+
+    /// <summary>Skein-MAC-1024-1024, keyed profile.</summary>
+    Mac_1024,
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.KnownAnswers.cs
@@ -9,44 +9,6 @@ namespace Bodu.Security.Cryptography;
 public partial class Skein1024Tests
 {
     /// <summary>
-    /// Verifies that Skein-1024-1024 reproduces the canonical empty-message digest published with the Skein 1.3
-    /// specification.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsEmpty_ForSkein1024_ShouldMatchSpecificationVector()
-    {
-        using var skein = new Skein1024();
-
-        byte[] actual = skein.ComputeHash(Array.Empty<byte>());
-
-        Assert.AreEqual(
-            "0FFF9563BB3279289227AC77D319B6FFF8D7E9F09DA1247B72A0A265CD6D2A62" +
-            "645AD547ED8193DB48CFF847C06494A03F55666D3B47EB4C20456C9373C86297" +
-            "D630D5578EBD34CB40991578F9F52B18003EFA35D3DA6553FF35DB91B81AB890" +
-            "BEC1B189B7F52CB2A783EBB7D823D725B0B4A71F6824E88F68F982EEFC6D19C6",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
-    /// Verifies that Skein-1024-1024 reproduces the BouncyCastle reference vector for a single-byte <c>0xFB</c>
-    /// message, exercising the sub-block final-block padding path at the widest state size.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsSingleByte_ForSkein1024_ShouldMatchReferenceVector()
-    {
-        using var skein = new Skein1024();
-
-        byte[] actual = skein.ComputeHash(new byte[] { 0xFB });
-
-        Assert.AreEqual(
-            "6426BDC57B2771A6EF1B0DD39F8096A9A07554565743AC3DE851D28258FCFF22" +
-            "9993E11C4E6BEBC8B6ECB0AD1B140276081AA390EC3875960336119427827473" +
-            "4770671B79F076771E2CFDAAF5ADC9B10CBAE43D8E6CD2B1C1F5D6C82DC96618" +
-            "00DDC476F25865B8748253173187D81DA971C027D91D32FB390301C2110D2DB2",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
     /// Verifies that <see cref="Skein1024.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.cs
@@ -42,7 +42,7 @@ public partial class Skein1024Tests
             MinKeyLength = 16,
             MaxKeyLength = Skein<Skein1024>.MaxKeySizeBytes,
             ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein1024>.MaxKeySizeBytes],
-            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            TestKey = SkeinTestKey,
             KnownAnswers = new HashAlgorithmKnownAnswers
             {
                 Empty = variant == Skein1024TestVariant.Hash_1024 ? Skein1024_1024_EmptyHash : null,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.cs
@@ -7,45 +7,88 @@
 namespace Bodu.Security.Cryptography;
 
 /// <summary>
-/// Contains unit tests for the <see cref="Skein1024" /> hash algorithm.
+/// Contains unit tests for the <see cref="Skein1024" /> hash algorithm across every supported
+/// (output size, operating mode) combination — the three <see cref="Skein1024TestVariant" /> hash variants and the
+/// matching Skein-MAC-1024 variants — driven from the Skein 1.3 / NIST CD known-answer test vectors and the
+/// Appendix B initial chaining values.
 /// </summary>
 [TestClass]
 public partial class Skein1024Tests
-    : Security.Cryptography.SkeinTests<Skein1024Tests, Skein1024>
+    : Security.Cryptography.SkeinTests<Skein1024Tests, Skein1024, Skein1024TestVariant>
 {
-    private const string Skein1024EmptyHash =
+    private const string Skein1024_1024_EmptyHash =
         "0FFF9563BB3279289227AC77D319B6FFF8D7E9F09DA1247B72A0A265CD6D2A62" +
         "645AD547ED8193DB48CFF847C06494A03F55666D3B47EB4C20456C9373C86297" +
         "D630D5578EBD34CB40991578F9F52B18003EFA35D3DA6553FF35DB91B81AB890" +
         "BEC1B189B7F52CB2A783EBB7D823D725B0B4A71F6824E88F68F982EEFC6D19C6";
 
     /// <inheritdoc />
-    protected override HashAlgorithmSpecification GetSpecification(SingleTestVariant variant) => new KeyedAlgorithmSpecification
-    {
-        HashSize = 1024,
-        InputBlockSize = 128,
-        OutputBlockSize = 128,
-        IsStateless = false,
-        LongInputLength = 512,
-        BoundaryLengths = [1, 16, 128, 256, 512],
-        MinKeyLength = 16,
-        MaxKeyLength = Skein<Skein1024>.MaxKeySizeBytes,
-        ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein1024>.MaxKeySizeBytes],
-        TestKey = SkeinTestKey,
-        KnownAnswers = new()
-        {
-            Empty = Skein1024EmptyHash,
-        },
-    };
+    protected override Skein1024TestVariant DefaultVariant => Skein1024TestVariant.Hash_1024;
 
     /// <inheritdoc />
-    protected override Skein1024 CreateAlgorithm(SingleTestVariant variant) => new Skein1024();
+    public override IEnumerable<Skein1024TestVariant> GetHashAlgorithmVariants() =>
+        Enum.GetValues<Skein1024TestVariant>();
+
+    /// <inheritdoc />
+    protected override HashAlgorithmSpecification GetSpecification(Skein1024TestVariant variant) =>
+        new KeyedAlgorithmSpecification
+        {
+            HashSize = OutputBitsFor(variant),
+            InputBlockSize = Skein1024.BlockSizeBytes,
+            OutputBlockSize = Skein1024.BlockSizeBytes,
+            IsStateless = false,
+            LongInputLength = 512,
+            BoundaryLengths = [1, 16, 128, 256, 512],
+            MinKeyLength = 16,
+            MaxKeyLength = Skein<Skein1024>.MaxKeySizeBytes,
+            ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein1024>.MaxKeySizeBytes],
+            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            KnownAnswers = new HashAlgorithmKnownAnswers
+            {
+                Empty = variant == Skein1024TestVariant.Hash_1024 ? Skein1024_1024_EmptyHash : null,
+            },
+            KeyedAnswers = new KeyedHashAlgorithmKnownAnswers
+            {
+                Vectors = Skein1024KnownAnswers.For(variant),
+            },
+        };
+
+    /// <inheritdoc />
+    protected override Skein1024 CreateAlgorithm(Skein1024TestVariant variant)
+    {
+        var algorithm = new Skein1024(OutputBitsFor(variant));
+        if (IsMacVariant(variant))
+            algorithm.Key = SkeinTestKey;
+        return algorithm;
+    }
 
     /// <inheritdoc />
     /// <remarks>
-    /// See <see cref="Skein256Tests.GetExpectedHashesForIncrementalInput" /> — authoritative incremental vectors
-    /// are still pending for the Skein family; until they land the incremental test remains inconclusive.
+    /// See <see cref="Skein256Tests.GetExpectedHashesForIncrementalInput" /> — the Skein 1.3 KAT files do not
+    /// publish a dense byte-by-byte sequence; the data-driven keyed KAT path supplies the reference coverage.
     /// </remarks>
-    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(SingleTestVariant variant) =>
+    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(Skein1024TestVariant variant) =>
         Array.Empty<string>();
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<ulong>? GetExpectedAppendixBChainingValue(Skein1024TestVariant variant) =>
+        variant switch
+        {
+            Skein1024TestVariant.Hash_384 => Skein1024AppendixBIVs.Skein1024_384,
+            Skein1024TestVariant.Hash_512 => Skein1024AppendixBIVs.Skein1024_512,
+            Skein1024TestVariant.Hash_1024 => Skein1024AppendixBIVs.Skein1024_1024,
+            _ => null,
+        };
+
+    /// <summary>
+    /// Translates a <see cref="Skein1024TestVariant" /> into the digest size in bits embedded in the variant name.
+    /// </summary>
+    private static int OutputBitsFor(Skein1024TestVariant variant) =>
+        variant switch
+        {
+            Skein1024TestVariant.Hash_384 or Skein1024TestVariant.Mac_384 => 384,
+            Skein1024TestVariant.Hash_512 or Skein1024TestVariant.Mac_512 => 512,
+            Skein1024TestVariant.Hash_1024 or Skein1024TestVariant.Mac_1024 => 1024,
+            _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown Skein1024 variant."),
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256AppendixBIVs.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256AppendixBIVs.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein256AppendixBIVs.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the Skein 1.3 Appendix B precomputed initial chaining values for the four <see cref="Skein256" /> output
+/// sizes. The constants are reproduced verbatim from the Skein 1.3 / NIST CD reference distribution so the test
+/// suite can verify the production CFG-UBI derivation against the published values.
+/// </summary>
+internal static class Skein256AppendixBIVs
+{
+    /// <summary>Skein-256-128 initial chaining value (state size 256 bits, output 128 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein256_128 = new ulong[]
+    {
+        0xE1111906964D7260UL,
+        0x883DAAA77C8D811CUL,
+        0x10080DF491960F7AUL,
+        0xCCF7DDE5B45BC1C2UL,
+    };
+
+    /// <summary>Skein-256-160 initial chaining value (state size 256 bits, output 160 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein256_160 = new ulong[]
+    {
+        0x1420231472825E98UL,
+        0x2AC4E9A25A77E590UL,
+        0xD47A58568838D63EUL,
+        0x2DD2E4968586AB7DUL,
+    };
+
+    /// <summary>Skein-256-224 initial chaining value (state size 256 bits, output 224 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein256_224 = new ulong[]
+    {
+        0xC6098A8C9AE5EA0BUL,
+        0x876D568608C5191CUL,
+        0x99CB88D7D7F53884UL,
+        0x384BDDB1AEDDB5DEUL,
+    };
+
+    /// <summary>Skein-256-256 initial chaining value (state size 256 bits, output 256 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein256_256 = new ulong[]
+    {
+        0xFC9DA860D048B449UL,
+        0x2FCA66479FA7D833UL,
+        0xB33BC3896656840FUL,
+        0x6A54E920FDE8DA69UL,
+    };
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256KnownAnswers.cs
@@ -1,0 +1,164 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein256KnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the curated <see cref="Skein256" /> known-answer test vectors, transcribed verbatim from the Skein 1.3 /
+/// NIST CD <c>skein_golden_kat.txt</c> reference distribution. Each per-variant collection is keyed on a
+/// <see cref="Skein256TestVariant" /> value so the test fixture can attach the correct rows to that variant's
+/// specification.
+/// </summary>
+/// <remarks>
+/// The non-canonical truncations (Skein-256-160, -224) ship with a single 1024-bit message in the reference KAT;
+/// Skein-256-256 ships with a richer set spanning empty, single-byte, one-block and two-block messages. Skein-256
+/// with a 128-bit output has no published KAT vectors in the NIST CD distribution and so contributes no rows.
+/// </remarks>
+internal static class Skein256KnownAnswers
+{
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Empty = Array.Empty<KeyedHashAlgorithmKnownAnswer>();
+
+    /// <summary>
+    /// Returns the curated KAT vectors for <paramref name="variant" />, or an empty array when the NIST CD KAT
+    /// publishes no vectors for that (output, mode) combination.
+    /// </summary>
+    public static IReadOnlyList<KeyedHashAlgorithmKnownAnswer> For(Skein256TestVariant variant) => variant switch
+    {
+        Skein256TestVariant.Hash_160 => Hash160,
+        Skein256TestVariant.Mac_160 => Mac160,
+        Skein256TestVariant.Hash_224 => Hash224,
+        Skein256TestVariant.Mac_224 => Mac224,
+        Skein256TestVariant.Hash_256 => Hash256,
+        Skein256TestVariant.Mac_256 => Mac256,
+        _ => Empty,
+    };
+
+    private const string IncrementingOneBlockSkein256 =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0";
+
+    private const string IncrementingTwoBlocksSkein256 =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0" +
+        "DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0";
+
+    private const string Incrementing1024Bits =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0" +
+        "DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0" +
+        "BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A0" +
+        "9F9E9D9C9B9A999897969594939291908F8E8D8C8B8A89888786858483828180";
+
+    private const string MacOneBlockSkein256 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135";
+
+    private const string MacTwoBlocksSkein256 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135" +
+        "BA26FEDE2EE187417F816048D00FC23512737A2113709A77E4170C49A94B7FDF";
+
+    // 1024-bit MAC payload for Skein-256 = 128 bytes = four Skein-256 blocks. Same byte sequence shape as the
+    // canonical Skein-256 random+MAC corpus, just longer than the two-block Mac vectors above.
+    private const string Mac1024BitsSkein256 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135" +
+        "BA26FEDE2EE187417F816048D00FC23512737A2113709A77E4170C49A94B7FDF" +
+        "F45FF579A72287743102E7766C35CA5ABC5DFE2F63A1E726CE5FBD2926DB03A2" +
+        "DD18B03FC1508A9AAC45EB362440203A323E09EDEE6324EE2E37B4432C1867ED";
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash160 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex = "1FD30886A2C315DE86F67FFE66EDDDCF73BE4FE4",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac160 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein256),
+            Key = Array.Empty<byte>(),
+            ExpectedHex = "4982E9E281C13F1117134816A7B858E8F12FB729",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash224 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex = "FAE243AB76B414FC4883EE73102FDCF51C2D74B98DF185A0BE9045F6",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac224 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein256),
+            Key = Convert.FromHexString("CB41F1706CDE09651203C2D0EFBADDF8"),
+            ExpectedHex = "A097340709B443ED2C0A921F5DCEFEF3EAD65C4F0BCD5F13DA54D7ED",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash256 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_Empty",
+            Profile = "NIST CD KAT",
+            Input = Array.Empty<byte>(),
+            ExpectedHex = "C8877087DA56E072870DAA843F176E9453115929094C3A40C463A196C29BF7BA",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneByte",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString("FF"),
+            ExpectedHex = "0B98DCD198EA0E50A7A244C444E25C23DA30C10FC9A1F270A6637F1F34E67ED2",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingOneBlockSkein256),
+            ExpectedHex = "8D0FA4EF777FD759DFD4044E6F6A5AC3C774AEC943DCFC07927B723B5DBF408B",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingTwoBlocksSkein256),
+            ExpectedHex = "DF28E916630D0B44C4A849DC9A02F07A07CB30F732318256B15D865AC4AE162F",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac256 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacOneBlockSkein256),
+            Key = Convert.FromHexString("CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E"),
+            ExpectedHex = "9E9980FCC16EE082CF164A5147D0E0692AEFFE3DCB8D620E2BB542091162E2E9",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacTwoBlocksSkein256),
+            Key = Convert.FromHexString("CB41F1706CDE09651203C2D0EFBADDF8"),
+            ExpectedHex = "B1B8C18188E69A6ECAE0B6018E6B638C6A91E6DE6881E32A60858468C17B520D",
+        },
+    ];
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256TestVariant.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256TestVariant.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein256TestVariant.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Enumerates the (output size, operating mode) configurations exercised by <see cref="Skein256Tests" />, mirroring
+/// the output sizes permitted by <see cref="Skein256" /> (128, 160, 224, 256 bits) across both the canonical plain
+/// hash profile and the keyed Skein-MAC-256 profile.
+/// </summary>
+/// <remarks>
+/// The <c>Hash</c> entries select the unkeyed plain hash; the <c>Mac</c> entries select Skein-MAC by assigning the
+/// specification's <see cref="KeyedAlgorithmSpecification.TestKey" /> on construction. Per-row keys carried by
+/// <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> override the variant default during keyed known-answer runs.
+/// </remarks>
+public enum Skein256TestVariant
+{
+    /// <summary>Skein-256-128, plain hash profile (no key).</summary>
+    Hash_128,
+
+    /// <summary>Skein-MAC-256-128, keyed profile.</summary>
+    Mac_128,
+
+    /// <summary>Skein-256-160, plain hash profile (no key).</summary>
+    Hash_160,
+
+    /// <summary>Skein-MAC-256-160, keyed profile.</summary>
+    Mac_160,
+
+    /// <summary>Skein-256-224, plain hash profile (no key).</summary>
+    Hash_224,
+
+    /// <summary>Skein-MAC-256-224, keyed profile.</summary>
+    Mac_224,
+
+    /// <summary>Skein-256-256, plain hash profile (no key).</summary>
+    Hash_256,
+
+    /// <summary>Skein-MAC-256-256, keyed profile.</summary>
+    Mac_256,
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.KnownAnswers.cs
@@ -9,38 +9,6 @@ namespace Bodu.Security.Cryptography;
 public partial class Skein256Tests
 {
     /// <summary>
-    /// Verifies that Skein-256-256 reproduces the canonical empty-message digest published with the Skein 1.3
-    /// specification and carried by every mainstream reference implementation.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsEmpty_ForSkein256_ShouldMatchSpecificationVector()
-    {
-        using var skein = new Skein256();
-
-        byte[] actual = skein.ComputeHash(Array.Empty<byte>());
-
-        Assert.AreEqual(
-            "C8877087DA56E072870DAA843F176E9453115929094C3A40C463A196C29BF7BA",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
-    /// Verifies that Skein-256-256 reproduces the BouncyCastle reference vector for a single-byte <c>0xFB</c>
-    /// message, exercising the sub-block final-block padding path at the smallest state size.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsSingleByte_ForSkein256_ShouldMatchReferenceVector()
-    {
-        using var skein = new Skein256();
-
-        byte[] actual = skein.ComputeHash(new byte[] { 0xFB });
-
-        Assert.AreEqual(
-            "088EB23CC2BCCFB8171AA64E966D4AF937325167DFCD170700FFD21F8A4CBDAC",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
     /// Verifies that <see cref="Skein256.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.cs
@@ -7,43 +7,89 @@
 namespace Bodu.Security.Cryptography;
 
 /// <summary>
-/// Contains unit tests for the <see cref="Skein256" /> hash algorithm.
+/// Contains unit tests for the <see cref="Skein256" /> hash algorithm across every supported
+/// (output size, operating mode) combination — the four <see cref="Skein256TestVariant" /> hash variants and the
+/// matching Skein-MAC-256 variants — driven from the Skein 1.3 / NIST CD known-answer test vectors and the
+/// Appendix B initial chaining values.
 /// </summary>
 [TestClass]
 public partial class Skein256Tests
-    : Security.Cryptography.SkeinTests<Skein256Tests, Skein256>
+    : Security.Cryptography.SkeinTests<Skein256Tests, Skein256, Skein256TestVariant>
 {
-    private const string Skein256EmptyHash = "C8877087DA56E072870DAA843F176E9453115929094C3A40C463A196C29BF7BA";
+    private const string Skein256_256_EmptyHash =
+        "C8877087DA56E072870DAA843F176E9453115929094C3A40C463A196C29BF7BA";
 
     /// <inheritdoc />
-    protected override HashAlgorithmSpecification GetSpecification(SingleTestVariant variant) => new KeyedAlgorithmSpecification
-    {
-        HashSize = 256,
-        InputBlockSize = 32,
-        OutputBlockSize = 32,
-        IsStateless = false,
-        LongInputLength = 200,
-        BoundaryLengths = [1, 8, 16, 32, 64, 128],
-        MinKeyLength = 16,
-        MaxKeyLength = Skein<Skein256>.MaxKeySizeBytes,
-        ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein256>.MaxKeySizeBytes],
-        TestKey = SkeinTestKey,
-        KnownAnswers = new()
+    protected override Skein256TestVariant DefaultVariant => Skein256TestVariant.Hash_256;
+
+    /// <inheritdoc />
+    public override IEnumerable<Skein256TestVariant> GetHashAlgorithmVariants() =>
+        Enum.GetValues<Skein256TestVariant>();
+
+    /// <inheritdoc />
+    protected override HashAlgorithmSpecification GetSpecification(Skein256TestVariant variant) =>
+        new KeyedAlgorithmSpecification
         {
-            Empty = Skein256EmptyHash,
-        },
-    };
+            HashSize = OutputBitsFor(variant),
+            InputBlockSize = Skein256.BlockSizeBytes,
+            OutputBlockSize = Skein256.BlockSizeBytes,
+            IsStateless = false,
+            LongInputLength = 200,
+            BoundaryLengths = [1, 8, 16, 32, 64, 128],
+            MinKeyLength = 16,
+            MaxKeyLength = Skein<Skein256>.MaxKeySizeBytes,
+            ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein256>.MaxKeySizeBytes],
+            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            KnownAnswers = new HashAlgorithmKnownAnswers
+            {
+                Empty = variant == Skein256TestVariant.Hash_256 ? Skein256_256_EmptyHash : null,
+            },
+            KeyedAnswers = new KeyedHashAlgorithmKnownAnswers
+            {
+                Vectors = Skein256KnownAnswers.For(variant),
+            },
+        };
 
     /// <inheritdoc />
-    protected override Skein256 CreateAlgorithm(SingleTestVariant variant) => new Skein256();
+    protected override Skein256 CreateAlgorithm(Skein256TestVariant variant)
+    {
+        var algorithm = new Skein256(OutputBitsFor(variant));
+        if (IsMacVariant(variant))
+            algorithm.Key = SkeinTestKey;
+        return algorithm;
+    }
 
     /// <inheritdoc />
     /// <remarks>
-    /// The framework iterates this set to exercise every incremental input length. Skein does not yet ship
-    /// authoritative reference vectors across the full <c>InputBlockSize * 8</c> range; returning an empty list
-    /// marks the incremental-input test as <see cref="MSTest.TestAdapter.TestOutcome.Inconclusive" /> until a
-    /// vetted reference set is wired in.
+    /// The framework iterates this set to exercise every incremental input length. The Skein 1.3 KAT files do not
+    /// publish a dense byte-by-byte sequence, so this returns an empty list and the incremental test reports
+    /// inconclusive. The Skein KAT coverage instead arrives via
+    /// <see cref="SkeinTests{TTest, TAlgorithm, TVariant}.ComputeHash_WhenUsingKeyedKnownAnswer_ShouldMatchExpected" />.
     /// </remarks>
-    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(SingleTestVariant variant) =>
+    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(Skein256TestVariant variant) =>
         Array.Empty<string>();
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<ulong>? GetExpectedAppendixBChainingValue(Skein256TestVariant variant) =>
+        variant switch
+        {
+            Skein256TestVariant.Hash_128 => Skein256AppendixBIVs.Skein256_128,
+            Skein256TestVariant.Hash_160 => Skein256AppendixBIVs.Skein256_160,
+            Skein256TestVariant.Hash_224 => Skein256AppendixBIVs.Skein256_224,
+            Skein256TestVariant.Hash_256 => Skein256AppendixBIVs.Skein256_256,
+            _ => null,
+        };
+
+    /// <summary>
+    /// Translates a <see cref="Skein256TestVariant" /> into the digest size in bits embedded in the variant name.
+    /// </summary>
+    private static int OutputBitsFor(Skein256TestVariant variant) =>
+        variant switch
+        {
+            Skein256TestVariant.Hash_128 or Skein256TestVariant.Mac_128 => 128,
+            Skein256TestVariant.Hash_160 or Skein256TestVariant.Mac_160 => 160,
+            Skein256TestVariant.Hash_224 or Skein256TestVariant.Mac_224 => 224,
+            Skein256TestVariant.Hash_256 or Skein256TestVariant.Mac_256 => 256,
+            _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown Skein256 variant."),
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.cs
@@ -39,7 +39,7 @@ public partial class Skein256Tests
             MinKeyLength = 16,
             MaxKeyLength = Skein<Skein256>.MaxKeySizeBytes,
             ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein256>.MaxKeySizeBytes],
-            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            TestKey = SkeinTestKey,
             KnownAnswers = new HashAlgorithmKnownAnswers
             {
                 Empty = variant == Skein256TestVariant.Hash_256 ? Skein256_256_EmptyHash : null,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512AppendixBIVs.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512AppendixBIVs.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein512AppendixBIVs.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the Skein 1.3 Appendix B precomputed initial chaining values for the six <see cref="Skein512" /> output
+/// sizes. The constants are reproduced verbatim from the Skein 1.3 / NIST CD reference distribution so the test
+/// suite can verify the production CFG-UBI derivation against the published values.
+/// </summary>
+internal static class Skein512AppendixBIVs
+{
+    /// <summary>Skein-512-128 initial chaining value (state size 512 bits, output 128 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_128 = new ulong[]
+    {
+        0xA8BC7BF36FBF9F52UL,
+        0x1E9872CEBD1AF0AAUL,
+        0x309B1790B32190D3UL,
+        0xBCFBB8543F94805CUL,
+        0x0DA61BCD6E31B11BUL,
+        0x1A18EBEAD46A32E3UL,
+        0xA2CC5B18CE84AA82UL,
+        0x6982AB289D46982DUL,
+    };
+
+    /// <summary>Skein-512-160 initial chaining value (state size 512 bits, output 160 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_160 = new ulong[]
+    {
+        0x28B81A2AE013BD91UL,
+        0xC2F11668B5BDF78FUL,
+        0x1760D8F3F6A56F12UL,
+        0x4FB747588239904FUL,
+        0x21EDE07F7EAF5056UL,
+        0xD908922E63ED70B8UL,
+        0xB8EC76FFECCB52FAUL,
+        0x01A47BB8A3F27A6EUL,
+    };
+
+    /// <summary>Skein-512-224 initial chaining value (state size 512 bits, output 224 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_224 = new ulong[]
+    {
+        0xCCD0616248677224UL,
+        0xCBA65CF3A92339EFUL,
+        0x8CCD69D652FF4B64UL,
+        0x398AED7B3AB890B4UL,
+        0x0F59D1B1457D2BD0UL,
+        0x6776FE6575D4EB3DUL,
+        0x99FBC70E997413E9UL,
+        0x9E2CFCCFE1C41EF7UL,
+    };
+
+    /// <summary>Skein-512-256 initial chaining value (state size 512 bits, output 256 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_256 = new ulong[]
+    {
+        0xCCD044A12FDB3E13UL,
+        0xE83590301A79A9EBUL,
+        0x55AEA0614F816E6FUL,
+        0x2A2767A4AE9B94DBUL,
+        0xEC06025E74DD7683UL,
+        0xE7A436CDC4746251UL,
+        0xC36FBAF9393AD185UL,
+        0x3EEDBA1833EDFC13UL,
+    };
+
+    /// <summary>Skein-512-384 initial chaining value (state size 512 bits, output 384 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_384 = new ulong[]
+    {
+        0xA3F6C6BF3A75EF5FUL,
+        0xB0FEF9CCFD84FAA4UL,
+        0x9D77DD663D770CFEUL,
+        0xD798CBF3B468FDDAUL,
+        0x1BC4A6668A0E4465UL,
+        0x7ED7D434E5807407UL,
+        0x548FC1ACD4EC44D6UL,
+        0x266E17546AA18FF8UL,
+    };
+
+    /// <summary>Skein-512-512 initial chaining value (state size 512 bits, output 512 bits).</summary>
+    public static readonly IReadOnlyList<ulong> Skein512_512 = new ulong[]
+    {
+        0x4903ADFF749C51CEUL,
+        0x0D95DE399746DF03UL,
+        0x8FD1934127C79BCEUL,
+        0x9A255629FF352CB1UL,
+        0x5DB62599DF6CA7B0UL,
+        0xEABE394CA9D5C3F4UL,
+        0x991112C71A75B523UL,
+        0xAE18A40B660FCC33UL,
+    };
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512KnownAnswers.cs
@@ -1,0 +1,238 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein512KnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the curated <see cref="Skein512" /> known-answer test vectors, transcribed verbatim from the Skein 1.3 /
+/// NIST CD <c>skein_golden_kat.txt</c> reference distribution.
+/// </summary>
+/// <remarks>
+/// Skein-512-512 ships with a richer message-length set covering empty, one-byte, one-block, and two-block messages.
+/// The non-canonical truncations (160, 224, 256, 384) carry a single 1024-bit incrementing-message vector each.
+/// Skein-512 with a 128-bit output has no published KAT vectors in the NIST CD distribution.
+/// </remarks>
+internal static class Skein512KnownAnswers
+{
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Empty = Array.Empty<KeyedHashAlgorithmKnownAnswer>();
+
+    /// <summary>
+    /// Returns the curated KAT vectors for <paramref name="variant" />, or an empty array when the NIST CD KAT
+    /// publishes no vectors for that (output, mode) combination.
+    /// </summary>
+    public static IReadOnlyList<KeyedHashAlgorithmKnownAnswer> For(Skein512TestVariant variant) => variant switch
+    {
+        Skein512TestVariant.Hash_160 => Hash160,
+        Skein512TestVariant.Mac_160 => Mac160,
+        Skein512TestVariant.Hash_224 => Hash224,
+        Skein512TestVariant.Mac_224 => Mac224,
+        Skein512TestVariant.Hash_256 => Hash256,
+        Skein512TestVariant.Mac_256 => Mac256,
+        Skein512TestVariant.Hash_384 => Hash384,
+        Skein512TestVariant.Mac_384 => Mac384,
+        Skein512TestVariant.Hash_512 => Hash512,
+        Skein512TestVariant.Mac_512 => Mac512,
+        _ => Empty,
+    };
+
+    private const string IncrementingOneBlockSkein512 =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0" +
+        "DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0";
+
+    private const string IncrementingTwoBlocksSkein512 =
+        "FFFEFDFCFBFAF9F8F7F6F5F4F3F2F1F0EFEEEDECEBEAE9E8E7E6E5E4E3E2E1E0" +
+        "DFDEDDDCDBDAD9D8D7D6D5D4D3D2D1D0CFCECDCCCBCAC9C8C7C6C5C4C3C2C1C0" +
+        "BFBEBDBCBBBAB9B8B7B6B5B4B3B2B1B0AFAEADACABAAA9A8A7A6A5A4A3A2A1A0" +
+        "9F9E9D9C9B9A999897969594939291908F8E8D8C8B8A89888786858483828180";
+
+    // Same byte sequence as IncrementingTwoBlocksSkein512 — the 1024-bit truncation vectors reuse this message.
+    private const string Incrementing1024Bits = IncrementingTwoBlocksSkein512;
+
+    private const string MacOneBlockSkein512 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135" +
+        "BA26FEDE2EE187417F816048D00FC23512737A2113709A77E4170C49A94B7FDF";
+
+    private const string MacTwoBlocksSkein512 =
+        "D3090C72167517F7C7AD82A70C2FD3F6443F608301591E598EADB195E8357135" +
+        "BA26FEDE2EE187417F816048D00FC23512737A2113709A77E4170C49A94B7FDF" +
+        "F45FF579A72287743102E7766C35CA5ABC5DFE2F63A1E726CE5FBD2926DB03A2" +
+        "DD18B03FC1508A9AAC45EB362440203A323E09EDEE6324EE2E37B4432C1867ED";
+
+    // 1024-bit MAC payload reused by the truncation vectors.
+    private const string Mac1024BitsSkein512 = MacTwoBlocksSkein512;
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash160 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex = "7D59D23FCF38FF54710F0D38D3A0ACCE7B8D64F6",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac160 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein512),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C193"),
+            ExpectedHex = "5670B226156570DFF3EFE16661AB86EB24982CDF",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash224 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex = "21521B15C8A9F05D5958F997008E95C50C4EEE35FB30BA81D5831856",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac224 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein512),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1" +
+                "935DF3061FF06E9F204192BA11E5BB2CAC0430C1C370CB3D113FEA5EC1021EB8" +
+                "75E5946D7A96AC69A1626C6206B7252736F24253C9EE9B85EB852DFC814631346C"),
+            ExpectedHex = "C41B9FF9753E6C0F8ED88866E320535E927FE4DA552C289841A920DB",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash256 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex = "1A6A5BA08E74A864B5CB052CFB9B2FA128203230A4D9923A329F5427C477A4DB",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac256 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein512),
+            Key = Array.Empty<byte>(),
+            ExpectedHex = "AA703B798B6F472BAA9D1E1689FA0F70F8DCA25A6046BB2C8FB7F34407934AE4",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash384 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Incrementing1024Bits),
+            ExpectedHex =
+                "EEAF4DC9B668C2A270B90CBD2E986C857E464B08903E5B6DDA1F15736F50D1BF" +
+                "2B6C40A398B79C67533592EFD96BD8DC",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac384 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_NistKat1024",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(Mac1024BitsSkein512),
+            Key = Convert.FromHexString("CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E"),
+            ExpectedHex =
+                "DFBF5C1319A1D9D70EFB2F1600FBCF694F935907F31D24A16D6CD2FB2D7855A7" +
+                "69681766C0A29DA778EED346CD1D740F",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Hash512 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_Empty",
+            Profile = "NIST CD KAT",
+            Input = Array.Empty<byte>(),
+            ExpectedHex =
+                "BC5B4C50925519C290CC634277AE3D6257212395CBA733BBAD37A4AF0FA06AF4" +
+                "1FCA7903D06564FEA7A2D3730DBDB80C1F85562DFCC070334EA4D1D9E72CBA7A",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneByte",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString("FF"),
+            ExpectedHex =
+                "71B7BCE6FE6452227B9CED6014249E5BF9A9754C3AD618CCC4E0AAE16B316CC8" +
+                "CA698D864307ED3E80B6EF1570812AC5272DC409B5A012DF2A579102F340617A",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingOneBlockSkein512),
+            ExpectedHex =
+                "45863BA3BE0C4DFC27E75D358496F4AC9A736A505D9313B42B2F5EADA79FC17F" +
+                "63861E947AFB1D056AA199575AD3F8C9A3CC1780B5E5FA4CAE050E989876625B",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Hash_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(IncrementingTwoBlocksSkein512),
+            ExpectedHex =
+                "91CCA510C263C4DDD010530A33073309628631F308747E1BCBAA90E451CAB92E" +
+                "5188087AF4188773A332303E6667A7A210856F742139000071F48E8BA2A5ADB7",
+        },
+    ];
+
+    private static readonly KeyedHashAlgorithmKnownAnswer[] Mac512 =
+    [
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_OneBlock",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacOneBlockSkein512),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1" +
+                "935DF3061FF06E9F204192BA11E5BB2CAC0430C1C370CB3D113FEA5EC1021EB8" +
+                "75E5946D7A96AC69A1626C6206B7252736F24253C9EE9B85EB852DFC814631346C"),
+            ExpectedHex =
+                "7690BA61F10E0BBA312980B0212E6A9A51B0E9AADFDE7CA535754A706E042335" +
+                "B29172AAE29D8BAD18EFAF92D43E6406F3098E253F41F2931EDA5911DC740352",
+        },
+        new KeyedHashAlgorithmKnownAnswer
+        {
+            Name = "Mac_TwoBlocks",
+            Profile = "NIST CD KAT",
+            Input = Convert.FromHexString(MacTwoBlocksSkein512),
+            Key = Convert.FromHexString(
+                "CB41F1706CDE09651203C2D0EFBADDF847A0D315CB2E53FF8BAC41DA0002672E" +
+                "920244C66E02D5F0DAD3E94C42BB65F0D14157DECF4105EF5609D5B0984457C1"),
+            ExpectedHex =
+                "04D8CDDB0AD931D54D195899A094684344E902286037272890BCE98A41813EDC" +
+                "37A3CEE190A693FCCA613EE30049CE7EC2BDFF9613F56778A13F8C28A21D167A",
+        },
+    ];
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512TestVariant.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512TestVariant.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Skein512TestVariant.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Enumerates the (output size, operating mode) configurations exercised by <see cref="Skein512Tests" />, mirroring
+/// the output sizes permitted by <see cref="Skein512" /> (128, 160, 224, 256, 384, 512 bits) across both the
+/// canonical plain hash profile and the keyed Skein-MAC-512 profile.
+/// </summary>
+/// <remarks>
+/// The <c>Hash</c> entries select the unkeyed plain hash; the <c>Mac</c> entries select Skein-MAC by assigning the
+/// specification's <see cref="KeyedAlgorithmSpecification.TestKey" /> on construction. Per-row keys carried by
+/// <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> override the variant default during keyed known-answer runs.
+/// </remarks>
+public enum Skein512TestVariant
+{
+    /// <summary>Skein-512-128, plain hash profile (no key).</summary>
+    Hash_128,
+
+    /// <summary>Skein-MAC-512-128, keyed profile.</summary>
+    Mac_128,
+
+    /// <summary>Skein-512-160, plain hash profile (no key).</summary>
+    Hash_160,
+
+    /// <summary>Skein-MAC-512-160, keyed profile.</summary>
+    Mac_160,
+
+    /// <summary>Skein-512-224, plain hash profile (no key).</summary>
+    Hash_224,
+
+    /// <summary>Skein-MAC-512-224, keyed profile.</summary>
+    Mac_224,
+
+    /// <summary>Skein-512-256, plain hash profile (no key).</summary>
+    Hash_256,
+
+    /// <summary>Skein-MAC-512-256, keyed profile.</summary>
+    Mac_256,
+
+    /// <summary>Skein-512-384, plain hash profile (no key).</summary>
+    Hash_384,
+
+    /// <summary>Skein-MAC-512-384, keyed profile.</summary>
+    Mac_384,
+
+    /// <summary>Skein-512-512, plain hash profile (no key).</summary>
+    Hash_512,
+
+    /// <summary>Skein-MAC-512-512, keyed profile.</summary>
+    Mac_512,
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.KnownAnswers.cs
@@ -9,40 +9,6 @@ namespace Bodu.Security.Cryptography;
 public partial class Skein512Tests
 {
     /// <summary>
-    /// Verifies that Skein-512-512 reproduces the canonical empty-message digest published with the Skein 1.3
-    /// specification.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsEmpty_ForSkein512_ShouldMatchSpecificationVector()
-    {
-        using var skein = new Skein512();
-
-        byte[] actual = skein.ComputeHash(Array.Empty<byte>());
-
-        Assert.AreEqual(
-            "BC5B4C50925519C290CC634277AE3D6257212395CBA733BBAD37A4AF0FA06AF4" +
-            "1FCA7903D06564FEA7A2D3730DBDB80C1F85562DFCC070334EA4D1D9E72CBA7A",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
-    /// Verifies that Skein-512-512 reproduces the BouncyCastle reference vector for a single-byte <c>0xFB</c>
-    /// message, exercising the sub-block final-block padding path at the primary state size.
-    /// </summary>
-    [TestMethod]
-    public void ComputeHash_WhenInputIsSingleByte_ForSkein512_ShouldMatchReferenceVector()
-    {
-        using var skein = new Skein512();
-
-        byte[] actual = skein.ComputeHash(new byte[] { 0xFB });
-
-        Assert.AreEqual(
-            "C49E03D50B4B2CC46BD3B7EF7014C8A45B016399FD1714467B7596C86DE98240" +
-            "E35BF7F9772B7D65465CD4CFFAB14E6BC154C54FC67B8BC340ABF08EFF572B9E",
-            Convert.ToHexString(actual));
-    }
-
-    /// <summary>
     /// Verifies that <see cref="Skein512.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.cs
@@ -7,43 +7,92 @@
 namespace Bodu.Security.Cryptography;
 
 /// <summary>
-/// Contains unit tests for the <see cref="Skein512" /> hash algorithm.
+/// Contains unit tests for the <see cref="Skein512" /> hash algorithm across every supported
+/// (output size, operating mode) combination — the six <see cref="Skein512TestVariant" /> hash variants and the
+/// matching Skein-MAC-512 variants — driven from the Skein 1.3 / NIST CD known-answer test vectors and the
+/// Appendix B initial chaining values.
 /// </summary>
 [TestClass]
 public partial class Skein512Tests
-    : Security.Cryptography.SkeinTests<Skein512Tests, Skein512>
+    : Security.Cryptography.SkeinTests<Skein512Tests, Skein512, Skein512TestVariant>
 {
-    private const string Skein512EmptyHash =
+    private const string Skein512_512_EmptyHash =
         "BC5B4C50925519C290CC634277AE3D6257212395CBA733BBAD37A4AF0FA06AF4" +
         "1FCA7903D06564FEA7A2D3730DBDB80C1F85562DFCC070334EA4D1D9E72CBA7A";
 
     /// <inheritdoc />
-    protected override HashAlgorithmSpecification GetSpecification(SingleTestVariant variant) => new KeyedAlgorithmSpecification
-    {
-        HashSize = 512,
-        InputBlockSize = 64,
-        OutputBlockSize = 64,
-        IsStateless = false,
-        LongInputLength = 256,
-        BoundaryLengths = [1, 16, 64, 128, 256],
-        MinKeyLength = 16,
-        MaxKeyLength = Skein<Skein512>.MaxKeySizeBytes,
-        ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein512>.MaxKeySizeBytes],
-        TestKey = SkeinTestKey,
-        KnownAnswers = new()
-        {
-            Empty = Skein512EmptyHash,
-        },
-    };
+    protected override Skein512TestVariant DefaultVariant => Skein512TestVariant.Hash_512;
 
     /// <inheritdoc />
-    protected override Skein512 CreateAlgorithm(SingleTestVariant variant) => new Skein512();
+    public override IEnumerable<Skein512TestVariant> GetHashAlgorithmVariants() =>
+        Enum.GetValues<Skein512TestVariant>();
+
+    /// <inheritdoc />
+    protected override HashAlgorithmSpecification GetSpecification(Skein512TestVariant variant) =>
+        new KeyedAlgorithmSpecification
+        {
+            HashSize = OutputBitsFor(variant),
+            InputBlockSize = Skein512.BlockSizeBytes,
+            OutputBlockSize = Skein512.BlockSizeBytes,
+            IsStateless = false,
+            LongInputLength = 256,
+            BoundaryLengths = [1, 16, 64, 128, 256],
+            MinKeyLength = 16,
+            MaxKeyLength = Skein<Skein512>.MaxKeySizeBytes,
+            ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein512>.MaxKeySizeBytes],
+            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            KnownAnswers = new HashAlgorithmKnownAnswers
+            {
+                Empty = variant == Skein512TestVariant.Hash_512 ? Skein512_512_EmptyHash : null,
+            },
+            KeyedAnswers = new KeyedHashAlgorithmKnownAnswers
+            {
+                Vectors = Skein512KnownAnswers.For(variant),
+            },
+        };
+
+    /// <inheritdoc />
+    protected override Skein512 CreateAlgorithm(Skein512TestVariant variant)
+    {
+        var algorithm = new Skein512(OutputBitsFor(variant));
+        if (IsMacVariant(variant))
+            algorithm.Key = SkeinTestKey;
+        return algorithm;
+    }
 
     /// <inheritdoc />
     /// <remarks>
-    /// See <see cref="Skein256Tests.GetExpectedHashesForIncrementalInput" /> — authoritative incremental vectors
-    /// are still pending for the Skein family; until they land the incremental test remains inconclusive.
+    /// See <see cref="Skein256Tests.GetExpectedHashesForIncrementalInput" /> — the Skein 1.3 KAT files do not
+    /// publish a dense byte-by-byte sequence; the data-driven keyed KAT path supplies the reference coverage.
     /// </remarks>
-    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(SingleTestVariant variant) =>
+    protected override IReadOnlyList<string> GetExpectedHashesForIncrementalInput(Skein512TestVariant variant) =>
         Array.Empty<string>();
+
+    /// <inheritdoc />
+    protected override IReadOnlyList<ulong>? GetExpectedAppendixBChainingValue(Skein512TestVariant variant) =>
+        variant switch
+        {
+            Skein512TestVariant.Hash_128 => Skein512AppendixBIVs.Skein512_128,
+            Skein512TestVariant.Hash_160 => Skein512AppendixBIVs.Skein512_160,
+            Skein512TestVariant.Hash_224 => Skein512AppendixBIVs.Skein512_224,
+            Skein512TestVariant.Hash_256 => Skein512AppendixBIVs.Skein512_256,
+            Skein512TestVariant.Hash_384 => Skein512AppendixBIVs.Skein512_384,
+            Skein512TestVariant.Hash_512 => Skein512AppendixBIVs.Skein512_512,
+            _ => null,
+        };
+
+    /// <summary>
+    /// Translates a <see cref="Skein512TestVariant" /> into the digest size in bits embedded in the variant name.
+    /// </summary>
+    private static int OutputBitsFor(Skein512TestVariant variant) =>
+        variant switch
+        {
+            Skein512TestVariant.Hash_128 or Skein512TestVariant.Mac_128 => 128,
+            Skein512TestVariant.Hash_160 or Skein512TestVariant.Mac_160 => 160,
+            Skein512TestVariant.Hash_224 or Skein512TestVariant.Mac_224 => 224,
+            Skein512TestVariant.Hash_256 or Skein512TestVariant.Mac_256 => 256,
+            Skein512TestVariant.Hash_384 or Skein512TestVariant.Mac_384 => 384,
+            Skein512TestVariant.Hash_512 or Skein512TestVariant.Mac_512 => 512,
+            _ => throw new ArgumentOutOfRangeException(nameof(variant), variant, "Unknown Skein512 variant."),
+        };
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.cs
@@ -40,7 +40,7 @@ public partial class Skein512Tests
             MinKeyLength = 16,
             MaxKeyLength = Skein<Skein512>.MaxKeySizeBytes,
             ValidKeyLengths = [0, 16, 32, 64, 128, 256, Skein<Skein512>.MaxKeySizeBytes],
-            TestKey = IsMacVariant(variant) ? SkeinTestKey : Array.Empty<byte>(),
+            TestKey = SkeinTestKey,
             KnownAnswers = new HashAlgorithmKnownAnswers
             {
                 Empty = variant == Skein512TestVariant.Hash_512 ? Skein512_512_EmptyHash : null,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.InitialChainingValues.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.InitialChainingValues.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkeinTests.InitialChainingValues.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
+{
+    /// <summary>
+    /// Returns the Skein 1.3 Appendix B initial chaining value words for the unkeyed plain-hash configuration
+    /// associated with <paramref name="variant" />, or <see langword="null" /> when the concrete test class does
+    /// not publish an Appendix B IV for that variant (for example, the <c>Mac_</c> variants where the IV depends
+    /// on the per-row key and there is no published constant).
+    /// </summary>
+    /// <param name="variant">The variant under test.</param>
+    /// <returns>
+    /// The IV as a sequence of 64-bit little-endian words exactly as published in Appendix B of the Skein 1.3
+    /// specification, or <see langword="null" /> when no published IV applies to the variant.
+    /// </returns>
+    protected abstract IReadOnlyList<ulong>? GetExpectedAppendixBChainingValue(TVariant variant);
+
+    /// <summary>
+    /// Verifies that the cached initial chaining value computed by <see cref="Skein{T}" /> matches the constant
+    /// published in Skein 1.3 Appendix B for every variant whose concrete test class declares one. Variants
+    /// without a published IV (typically the <c>Mac_</c> profiles) are reported as inconclusive.
+    /// </summary>
+    /// <param name="variant">The variant under test.</param>
+    [TestMethod]
+    [DynamicData(nameof(HashAlgorithmVariants))]
+    public void InitialChainingValue_WhenComputed_ShouldMatchAppendixB(TVariant variant)
+    {
+        IReadOnlyList<ulong>? expected = GetExpectedAppendixBChainingValue(variant);
+        if (expected is null)
+        {
+            Assert.Inconclusive($"[{variant}] No Appendix B initial chaining value published for this variant.");
+            return;
+        }
+
+        using TAlgorithm algorithm = CreateAlgorithm(variant);
+
+        // For the canonical Appendix B IV we compare against the unkeyed configuration: the published constant
+        // assumes no preliminary KEY UBI phase, so reset the key to the empty sentinel before reading the IV.
+        algorithm.Key = Array.Empty<byte>();
+
+        ulong[] actual = algorithm.GetInitialChainingValueWords();
+
+        Assert.AreEqual(
+            expected.Count,
+            actual.Length,
+            $"[{variant}] IV word count mismatch (expected {expected.Count}, got {actual.Length}).");
+
+        for (int i = 0; i < expected.Count; i++)
+        {
+            Assert.AreEqual(
+                expected[i],
+                actual[i],
+                $"[{variant}] IV word {i}: expected 0x{expected[i]:X16}, got 0x{actual[i]:X16}.");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.KnownAnswers.cs
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkeinTests.KnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
+{
+    /// <summary>
+    /// Yields a data row for every keyed known-answer vector declared by every Skein variant. Each row is shaped as
+    /// <c>(variant, vector name, profile-or-empty, key-or-null, input bytes, expected bytes)</c> and feeds the
+    /// <see cref="ComputeHash_WhenUsingKeyedKnownAnswer_ShouldMatchExpected" /> data-driven test.
+    /// </summary>
+    /// <returns>A sequence of test-case argument arrays for MSTest's <see cref="DynamicDataAttribute" />.</returns>
+    /// <remarks>
+    /// The Skein-MAC <c>random+MAC</c> entries published with the Skein 1.3 / NIST CD KAT carry a different MAC key
+    /// for every vector (and frequently a key length that differs from the spec's nominal MAC size), which the
+    /// shared <c>HashAlgorithmKnownAnswers</c> slot cannot represent. Skein declares its keyed corpus through this
+    /// dedicated path so each per-row key reaches the algorithm before <see cref="HashAlgorithm.ComputeHash(byte[])" />.
+    /// </remarks>
+    public static IEnumerable<object[]> KeyedKnownAnswerTestData()
+    {
+        var instance = new TTest();
+        foreach (var variant in instance.GetHashAlgorithmVariants())
+        {
+            if (instance.GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
+                continue;
+
+            foreach (KeyedHashAlgorithmKnownAnswer vector in specification.KeyedAnswers.Vectors)
+            {
+                yield return new object[]
+                {
+                    variant,
+                    vector.Name,
+                    vector.Profile ?? string.Empty,
+                    (object?)vector.Key ?? string.Empty,
+                    vector.Input,
+                    Convert.FromHexString(vector.ExpectedHex),
+                };
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that hashing <paramref name="input" /> under the variant configured by <paramref name="variant" />
+    /// (with <paramref name="key" /> overriding the variant default when supplied as a non-string array) reproduces
+    /// <paramref name="expected" /> — the published Skein 1.3 / NIST CD known-answer digest for this row.
+    /// </summary>
+    /// <param name="variant">The (output size, mode) configuration to instantiate.</param>
+    /// <param name="vectorName">A semantic name printed in the failure message to identify the row.</param>
+    /// <param name="profile">A free-form provenance tag printed alongside the name (for example <c>"NIST CD KAT"</c>).</param>
+    /// <param name="keyOrSentinel">
+    /// The per-row key as a <c>byte[]</c> when supplied; an empty string sentinel signals "use the variant default".
+    /// MSTest <c>[DynamicData]</c> cannot round-trip a real <see langword="null" /> through the row tuple, so the
+    /// empty-string sentinel substitutes for the absence of a per-row key.
+    /// </param>
+    /// <param name="input">The message bytes to hash.</param>
+    /// <param name="expected">The expected digest bytes.</param>
+    [TestMethod]
+    [DynamicData(nameof(KeyedKnownAnswerTestData))]
+    public void ComputeHash_WhenUsingKeyedKnownAnswer_ShouldMatchExpected(
+        TVariant variant,
+        string vectorName,
+        string profile,
+        object keyOrSentinel,
+        byte[] input,
+        byte[] expected)
+    {
+        using TAlgorithm algorithm = CreateAlgorithm(variant);
+
+        if (keyOrSentinel is byte[] perRowKey)
+            algorithm.Key = perRowKey;
+
+        byte[] actual = algorithm.ComputeHash(input);
+
+        string label = string.IsNullOrEmpty(profile) ? vectorName : $"{vectorName} [{profile}]";
+        CollectionAssert.AreEqual(
+            expected,
+            actual,
+            $"Skein KAT mismatch for variant '{variant}', vector '{label}'.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.cs
@@ -7,19 +7,28 @@
 namespace Bodu.Security.Cryptography;
 
 /// <summary>
-/// Shared test fixture for the <see cref="Skein{T}" /> family of hash algorithms, providing the keyed-hash test
-/// harness with the Skein-specific relaxations required by the variable-length optional-key contract.
+/// Shared test fixture for the <see cref="Skein{T}" /> family of hash algorithms, parameterised by a Skein-specific
+/// variant enum that encodes both the requested output size and the operating mode (plain hash vs Skein-MAC) so a
+/// single test class can drive every (state, output, mode) combination supported by its variant.
 /// </summary>
 /// <typeparam name="TTest">The concrete test class inheriting this fixture.</typeparam>
 /// <typeparam name="TAlgorithm">The specific Skein variant under test (<see cref="Skein256" />, <see cref="Skein512" />, or <see cref="Skein1024" />).</typeparam>
+/// <typeparam name="TVariant">
+/// The per-class variant enum encoding (output size, mode) — for example <see cref="Skein256TestVariant" />. The
+/// enum's name convention is <c>Hash_<i>n</i></c> for the plain-hash profile and <c>Mac_<i>n</i></c> for the keyed
+/// Skein-MAC profile, where <i>n</i> is the digest size in bits.
+/// </typeparam>
 [TestClass]
-public abstract partial class SkeinTests<TTest, TAlgorithm>
-    : Security.Cryptography.KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, SingleTestVariant>
-    where TTest : SkeinTests<TTest, TAlgorithm>, new()
+public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
+    : Security.Cryptography.KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TVariant>
+    where TTest : SkeinTests<TTest, TAlgorithm, TVariant>, new()
     where TAlgorithm : Skein<TAlgorithm>, new()
+    where TVariant : struct, Enum
 {
     /// <summary>
-    /// A deterministic 32-byte key used for all Skein-MAC round-trip tests across every variant.
+    /// A deterministic 32-byte key used as the variant default for every Skein-MAC profile across every Skein
+    /// variant. Per-row keys carried by <see cref="KeyedHashAlgorithmKnownAnswer.Key" /> override this default for
+    /// keyed known-answer runs.
     /// </summary>
     protected static readonly byte[] SkeinTestKey =
     [
@@ -47,18 +56,23 @@ public abstract partial class SkeinTests<TTest, TAlgorithm>
     protected override bool EnforcesMinimumKeyLength => false;
 
     /// <inheritdoc />
-    public override IEnumerable<SingleTestVariant> GetHashAlgorithmVariants() => new[]
-    {
-        SingleTestVariant.Default,
-    };
-
-    /// <inheritdoc />
     /// <remarks>
     /// The base default-construction helper assigns the specification's <see cref="KeyedAlgorithmSpecification.TestKey" />
-    /// to <see cref="Skein{T}.Key" />. Skein's specifications publish an empty <c>TestKey</c> so that baseline fixtures
-    /// exercise the canonical plain-hash profile; derived tests that need a keyed fixture supply their own key.
+    /// to <see cref="Skein{T}.Key" />. For the unkeyed default variant Skein's specifications publish an empty
+    /// <c>TestKey</c> so baseline fixtures exercise the canonical plain-hash profile; keyed variants supply the
+    /// shared <see cref="SkeinTestKey" />.
     /// </remarks>
-    protected override TAlgorithm CreateAlgorithm() => new TAlgorithm();
+    protected override TAlgorithm CreateAlgorithm() => CreateAlgorithm(DefaultVariant);
+
+    /// <summary>
+    /// Returns <see langword="true" /> when <paramref name="variant" />'s name begins with <c>"Mac_"</c>, indicating
+    /// the keyed Skein-MAC profile. Concrete test classes follow the <c>Hash_<i>n</i></c> / <c>Mac_<i>n</i></c>
+    /// naming convention so this single helper covers every Skein variant enum.
+    /// </summary>
+    /// <param name="variant">The variant under test.</param>
+    /// <returns><see langword="true" /> if the variant selects the keyed MAC profile; otherwise <see langword="false" />.</returns>
+    protected static bool IsMacVariant(TVariant variant) =>
+        variant.ToString().StartsWith("Mac_", StringComparison.Ordinal);
 
     /// <summary>
     /// Verifies that supplying a non-empty <see cref="Skein{T}.Key" /> causes the digest to differ from the plain,


### PR DESCRIPTION
Promote SkeinTests<TTest, TAlgorithm> to a 3-arg generic
SkeinTests<TTest, TAlgorithm, TVariant> so each Skein concrete test
class drives every supported (output size, operating mode) combination
through a per-class enum (Skein256TestVariant / Skein512TestVariant /
Skein1024TestVariant) instead of the single-variant placeholder.

Add a parallel KeyedHashAlgorithmKnownAnswer / KeyedHashAlgorithmKnownAnswers
record pair, hung off KeyedAlgorithmSpecification.KeyedAnswers, that lets
keyed families declare per-row vectors carrying their own optional Key,
optional Profile tag, and expected hex without disturbing the existing
HashAlgorithmKnownAnswers slot used by unkeyed hashes. The Skein test
fixture flattens these rows through a dedicated [DynamicData] dispatch
that applies the per-row key (overriding the variant default) before
ComputeHash, so every NIST CD random+MAC vector reaches the algorithm
under its own published key.

Populate the Skein-256 / -512 / -1024 known-answer tables verbatim from
the Skein 1.3 / NIST CD skein_golden_kat.txt corpus across the four
canonical hash and MAC profiles per state size, and verify the Skein 1.3
Appendix B precomputed initial chaining values against an internal
GetInitialChainingValueWords accessor on Skein<T> for every published
(state, output) pair.

https://claude.ai/code/session_01DJdgW7AxqSYVTWzeg6FZWW