### PR TITLE
test(Security.Cryptography): introduce data-driven KAT primitives for block ciphers; pilot Skipjack

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherKnownAnswer.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherKnownAnswer.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherKnownAnswer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Represents a single known-answer test vector for a symmetric block cipher — a named plaintext / ciphertext
+/// pair together with the per-row key (and, for tweakable ciphers, the per-row tweak) that produced the
+/// expected output. Mirrors the role of <see cref="KeyedHashAlgorithmKnownAnswer" /> on the keyed-hash side
+/// so cipher and hash families share the same data-driven KAT idiom.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Vectors are typically stored as named static fields in a per-cipher static class (for example
+/// <c>SkipjackKnownAnswers</c>) and exposed via a <c>For(variant)</c> accessor. The cipher test base class
+/// adapts each entry into a runnable test row, supplying a factory that constructs the cipher under test
+/// from <see cref="Key" /> and (when applicable) <see cref="Tweak" />.
+/// </para>
+/// <para>
+/// When <see cref="Key" /> is <see langword="null" /> the harness falls back to the variant's default
+/// <c>TestKey</c> from <see cref="BlockCipherSpecification" />. <see cref="Tweak" /> is ignored by
+/// non-tweakable cipher families and should be left <see langword="null" /> for them.
+/// </para>
+/// </remarks>
+public sealed record BlockCipherKnownAnswer
+{
+    /// <summary>Gets the semantic name of this test vector used in diagnostic messages.</summary>
+    public required string Name { get; init; }
+
+    /// <summary>Gets the plaintext input bytes — the value fed to <c>Encrypt</c> and the value
+    /// expected from <c>Decrypt</c> when applied to <see cref="Ciphertext" />.</summary>
+    public required byte[] Plaintext { get; init; }
+
+    /// <summary>Gets the ciphertext expected from <c>Encrypt</c>(<see cref="Plaintext" />), which is
+    /// also the value fed to <c>Decrypt</c> during the round-trip assertion.</summary>
+    public required byte[] Ciphertext { get; init; }
+
+    /// <summary>
+    /// Gets the per-row key applied to the cipher before encrypting <see cref="Plaintext" />, or
+    /// <see langword="null" /> when the variant's default <c>TestKey</c> from
+    /// <see cref="BlockCipherSpecification" /> should be used.
+    /// </summary>
+    /// <value>The key bytes, or <see langword="null" /> to defer to the variant default.</value>
+    public byte[]? Key { get; init; }
+
+    /// <summary>
+    /// Gets the per-row tweak applied to the cipher before encrypting <see cref="Plaintext" />, or
+    /// <see langword="null" /> for non-tweakable ciphers and for tweakable ciphers that should fall
+    /// back to the variant's default <c>TestTweak</c>.
+    /// </summary>
+    public byte[]? Tweak { get; init; }
+
+    /// <summary>
+    /// Gets an optional free-form profile tag describing the source or category of this vector — for
+    /// example <c>"RFC 3713 Appendix A"</c>, <c>"NIST AES KAT"</c>, or <c>"Bouncy Castle reference"</c>.
+    /// Surfaced in failure diagnostics so a test report makes the provenance obvious.
+    /// </summary>
+    public string? Profile { get; init; }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.cs
@@ -97,9 +97,34 @@ public abstract partial class BlockCipherTests<TTest, TCipher, TVariant>
     /// </summary>
     /// <param name="variant">The variant to generate test vectors for.</param>
     /// <returns>
-    /// A sequence of <see cref="CiperTextTestVector" /> instances representing named test inputs and their expected ciper text results.
+    /// A sequence of <see cref="KnownAnswerTest" /> instances representing named test inputs and their expected
+    /// ciphertext results.
     /// </returns>
     protected abstract IEnumerable<KnownAnswerTest> GetKnownAnswerTests(TVariant variant);
+
+    /// <summary>
+    /// Adapts a sequence of <see cref="BlockCipherKnownAnswer" /> vectors into the legacy
+    /// <see cref="KnownAnswerTest" /> shape consumed by the existing encrypt/decrypt KAT harness.
+    /// </summary>
+    /// <param name="answers">The data-driven vectors sourced from a per-cipher <c>&lt;Cipher&gt;KnownAnswers</c> static class.</param>
+    /// <param name="cipherFactory">A factory that constructs an <see cref="IBlockCipher" /> instance for a given vector,
+    /// applying its <see cref="BlockCipherKnownAnswer.Key" /> and (where applicable) <see cref="BlockCipherKnownAnswer.Tweak" />.</param>
+    /// <returns>A lazily-evaluated sequence of <see cref="KnownAnswerTest" /> rows wrapping each supplied vector.</returns>
+    /// <remarks>
+    /// Acts as the bridge between the externalised KAT data files (modelled on the Skein hash refactor) and the
+    /// existing <c>EncryptTestData</c> / <c>DecryptTestData</c> pipelines. Each emitted row carries a per-vector
+    /// <see cref="KnownAnswerTest.CipherFactory" /> that defers cipher construction until the test executes.
+    /// </remarks>
+    protected static IEnumerable<KnownAnswerTest> AdaptKnownAnswers(
+        IEnumerable<BlockCipherKnownAnswer> answers,
+        Func<BlockCipherKnownAnswer, IBlockCipher> cipherFactory) =>
+        answers.Select(answer => new KnownAnswerTest
+        {
+            Name = answer.Name,
+            Input = answer.Plaintext,
+            ExpectedOutput = answer.Ciphertext,
+            CipherFactory = () => cipherFactory(answer),
+        });
 
     ///// <summary>
     ///// Returns a fixed, deterministic key for use in tests that require stable output across runs.

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackBlockCipherTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackBlockCipherTests.cs
@@ -32,30 +32,8 @@ internal sealed partial class SkipjackBlockCipherTests
     }
 
     /// <inheritdocs/>
-    protected override IEnumerable<KnownAnswerTest> GetKnownAnswerTests(SingleTestVariant variant)
-    {
-        yield return new KnownAnswerTest
-        {
-            Name = "All-zero plaintext / key bit 0 set",
-            Input = Convert.FromHexString("0000000000000000"),
-            ExpectedOutput = Convert.FromHexString("E378FE4157A66452"),
-            CipherFactory = () => new SkipjackBlockCipher(Convert.FromHexString("80000000000000000000")),
-        };
-
-        yield return new KnownAnswerTest
-        {
-            Name = "All-zero plaintext / key bit 1 set",
-            Input = Convert.FromHexString("0000000000000000"),
-            ExpectedOutput = Convert.FromHexString("61CE4785762E8980"),
-            CipherFactory = () => new SkipjackBlockCipher(Convert.FromHexString("40000000000000000000")),
-        };
-
-        yield return new KnownAnswerTest
-        {
-            Name = "All-zero plaintext / key byte 1 high bit set",
-            Input = Convert.FromHexString("0000000000000000"),
-            ExpectedOutput = Convert.FromHexString("F76307829359FC11"),
-            CipherFactory = () => new SkipjackBlockCipher(Convert.FromHexString("00800000000000000000")),
-        };
-    }
+    protected override IEnumerable<KnownAnswerTest> GetKnownAnswerTests(SingleTestVariant variant) =>
+        AdaptKnownAnswers(
+            SkipjackKnownAnswers.For(variant),
+            answer => new SkipjackBlockCipher(answer.Key!));
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackKnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackKnownAnswers.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkipjackKnownAnswers.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Holds the curated <see cref="SkipjackBlockCipher" /> known-answer test vectors used by
+/// <see cref="SkipjackBlockCipherTests" />. Each vector encrypts an all-zero 64-bit plaintext under a
+/// single-bit-set 80-bit key; the expected ciphertexts are reproduced from the Bouncy Castle
+/// <c>SkipjackTest</c> reference, which itself derives from the original NSA Skipjack specification.
+/// </summary>
+/// <remarks>
+/// Skipjack pre-dates the published NIST KAT corpora, so the canonical published vectors are the
+/// single-bit-key avalanche cases used as a key-schedule sanity check by every reference implementation.
+/// They are sufficient to detect any divergence in the round-key byte ordering or the Rule&#160;A / Rule&#160;B
+/// alternation against the published cipher description.
+/// </remarks>
+internal static class SkipjackKnownAnswers
+{
+    /// <summary>
+    /// Returns the curated KAT vectors for <paramref name="variant" />. Skipjack exposes a single
+    /// configuration (80-bit key, 64-bit block) so the variant parameter is reserved for parity with
+    /// other cipher families and currently always yields the same set.
+    /// </summary>
+    public static IReadOnlyList<BlockCipherKnownAnswer> For(SingleTestVariant variant) => Default;
+
+    private const string AllZeroPlaintext = "0000000000000000";
+
+    private const string ProfileNsaReference = "NSA Skipjack reference / Bouncy Castle";
+
+    private static readonly BlockCipherKnownAnswer[] Default =
+    [
+        new BlockCipherKnownAnswer
+        {
+            Name = "AllZeroPlaintext_KeyBit0Set",
+            Profile = ProfileNsaReference,
+            Plaintext = Convert.FromHexString(AllZeroPlaintext),
+            Ciphertext = Convert.FromHexString("E378FE4157A66452"),
+            Key = Convert.FromHexString("80000000000000000000"),
+        },
+        new BlockCipherKnownAnswer
+        {
+            Name = "AllZeroPlaintext_KeyBit1Set",
+            Profile = ProfileNsaReference,
+            Plaintext = Convert.FromHexString(AllZeroPlaintext),
+            Ciphertext = Convert.FromHexString("61CE4785762E8980"),
+            Key = Convert.FromHexString("40000000000000000000"),
+        },
+        new BlockCipherKnownAnswer
+        {
+            Name = "AllZeroPlaintext_KeyByte1HighBitSet",
+            Profile = ProfileNsaReference,
+            Plaintext = Convert.FromHexString(AllZeroPlaintext),
+            Ciphertext = Convert.FromHexString("F76307829359FC11"),
+            Key = Convert.FromHexString("00800000000000000000"),
+        },
+    ];
+}


### PR DESCRIPTION
Mirrors the Skein hash KAT refactor (commit 0d60f96) on the cipher side. Adds
BlockCipherKnownAnswer as the shared per-vector record (Name / Plaintext /
Ciphertext / Key / Tweak / Profile) and an AdaptKnownAnswers helper on the
BlockCipherTests<> base that bridges the new data shape into the existing
EncryptTestData / DecryptTestData pipelines.

Migrates Skipjack as the pilot cipher: vectors move out of inline hex literals
in SkipjackBlockCipherTests.GetKnownAnswerTests and into a dedicated
SkipjackKnownAnswers static class, leaving the test class as a thin wrapper
that delegates via AdaptKnownAnswers. Other cipher families remain on the
existing path until migrated in follow-up commits.