### PR TITLE
docs(core): add wireframe diagrams for circular buffer, deque, evicting dictionary

### DIFF
--- a/docs/guides/core/circular-buffer.md
+++ b/docs/guides/core/circular-buffer.md
@@ -8,6 +8,10 @@ title: Circular buffer
 
 For concurrent access, use `ConcurrentCircularBuffer<T>` — a thread-safe wrapper that uses a `ReaderWriterLockSlim` internally.
 
+![CircularBuffer ring with Head, Tail, and overwrite/reject behaviour](../../images/diagrams/circular-buffer.svg)
+
+The backing array is allocated once. `Head` marks the oldest entry (the next `Dequeue` / `Peek` target) and `Tail` marks the next free slot (the next `Enqueue` target). Both indices advance with `(idx + 1) % Capacity`, which is what makes the storage a ring rather than a shifting array.
+
 ## Pattern 1 — basic enqueue and dequeue
 
 ```csharp

--- a/docs/guides/core/deque.md
+++ b/docs/guides/core/deque.md
@@ -8,6 +8,10 @@ title: Deque
 
 For a single-ended FIFO buffer with eviction-on-full semantics, see [Circular buffer](circular-buffer.md). For thread-safe concurrent FIFO access, use `ConcurrentCircularBuffer<T>` (a separate, lock-free implementation).
 
+![Deque backing array with Head, Tail, wrap-around, and AllowGrow behaviour](../../images/diagrams/deque.svg)
+
+`Head` and `Tail` index into a contiguous backing array but advance modulo `Capacity`, so the logical sequence may wrap past the end of the array. `AddFirst` / `RemoveFirst` operate at the head end; `AddLast` / `RemoveLast` operate at the tail end. The indexer `this[i]` reads in logical order, hiding the wrap from callers.
+
 ## Pattern 1 — growable double-ended queue (default)
 
 `new Deque<T>()` and `new Deque<T>(capacity)` both produce a growable deque. The capacity argument is a hint — the backing array doubles automatically when filled.

--- a/docs/guides/core/evicting-dictionary.md
+++ b/docs/guides/core/evicting-dictionary.md
@@ -12,6 +12,10 @@ title: Evicting dictionary
 | `LeastRecentlyUsed` | The entry that was accessed furthest in the past. | General-purpose caches where recency predicts future use. |
 | `LeastFrequentlyUsed` | The entry with the lowest access count. | Long-lived caches where popularity predicts future use. |
 
+![EvictingDictionary entries with FIFO, LRU, and LFU eviction lanes](../../images/diagrams/evicting-dictionary.svg)
+
+Every entry carries three pieces of metadata — insertion timestamp, last-access timestamp, and access count. Each policy maintains its own ordering over those metadata, and the head of that ordering is the next victim. Reads via `this[key]` and `TryGetValue` update the recency and frequency metadata; `Touch` promotes a key without reading the value.
+
 ## Pattern 1 — LRU cache
 
 ```csharp

--- a/docs/images/diagrams/circular-buffer.svg
+++ b/docs/images/diagrams/circular-buffer.svg
@@ -1,0 +1,152 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" role="img" aria-labelledby="cb-t cb-d">
+  <title id="cb-t">CircularBuffer&lt;T&gt; — fixed-capacity FIFO ring</title>
+  <desc id="cb-d">A CircularBuffer is a contiguous array of slots arranged conceptually as a ring. A Head pointer marks the oldest element (read end) and a Tail pointer marks the next free slot (write end). Enqueue advances Tail, Dequeue advances Head, and both indices wrap modulo Capacity. When the buffer is full, AllowOverwrite=true overwrites the oldest entry and pushes Head forwards, while AllowOverwrite=false rejects the insert.</desc>
+
+  <defs>
+    <style>
+      .bg   { fill: #0F172A; }
+      .pan  { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr  { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl  { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl  { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .lbl-l{ fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; }
+      .sub  { fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub-l{ fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; }
+      .mut  { fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut-l{ fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; }
+      .slot      { fill: #1A2335; stroke: #475569; stroke-width: 1.2; }
+      .slot-full { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .slot-head { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.8; }
+      .slot-tail { fill: #431407; stroke: #FBBF24; stroke-width: 1.8; }
+      .slot-text { fill: #F8FAFC; font: 700 13px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .idx       { fill: #94A3B8; font: 400 9px/1  "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .pin-h     { fill: #60A5FA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .pin-t     { fill: #FBBF24; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .case-ovr  { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.2; }
+      .case-rej  { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.2; }
+      .ring      { fill: none; stroke: #334155; stroke-width: 1.2; stroke-dasharray: 3 3; }
+      .arc-cw    { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+      .w         { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+      .wt        { stroke: #2DD4BF; stroke-width: 1.5; fill: none; }
+      .wb        { stroke: #60A5FA; stroke-width: 1.5; fill: none; }
+      .wy        { stroke: #FBBF24; stroke-width: 1.5; fill: none; }
+    </style>
+    <marker id="cb-a"  viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="cb-ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60A5FA"/>
+    </marker>
+    <marker id="cb-ay" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#FBBF24"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="340"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="320" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">CircularBuffer&lt;T&gt; — fixed-capacity FIFO ring</text>
+
+    <!-- Ring of 8 slots (clockwise from 12 o'clock).
+         center (200, 185), radius 95, slot size 36x36 -->
+    <circle class="ring" cx="200" cy="185" r="95"/>
+
+    <!-- slot 0 (12) - filled, value A -->
+    <g transform="translate(200 90)">
+      <rect class="slot-full" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="slot-text" x="0" y="5">A</text>
+      <text class="idx" x="0" y="-26">[0]</text>
+    </g>
+    <!-- slot 1 (1:30) - filled, value B -->
+    <g transform="translate(267 117)">
+      <rect class="slot-full" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="slot-text" x="0" y="5">B</text>
+      <text class="idx" x="32" y="-16">[1]</text>
+    </g>
+    <!-- slot 2 (3) - filled, value C -->
+    <g transform="translate(295 185)">
+      <rect class="slot-full" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="slot-text" x="0" y="5">C</text>
+      <text class="idx" x="36" y="4">[2]</text>
+    </g>
+    <!-- slot 3 (4:30) - tail, next free -->
+    <g transform="translate(267 253)">
+      <rect class="slot-tail" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="idx" x="32" y="20">[3]</text>
+    </g>
+    <!-- slot 4 (6) - empty -->
+    <g transform="translate(200 280)">
+      <rect class="slot" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="idx" x="0" y="-24">[4]</text>
+    </g>
+    <!-- slot 5 (7:30) - empty -->
+    <g transform="translate(133 253)">
+      <rect class="slot" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="idx" x="-22" y="22">[5]</text>
+    </g>
+    <!-- slot 6 (9) - empty -->
+    <g transform="translate(105 185)">
+      <rect class="slot" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="idx" x="-36" y="4">[6]</text>
+    </g>
+    <!-- slot 7 (10:30) - head, oldest entry -->
+    <g transform="translate(133 117)">
+      <rect class="slot-head" x="-22" y="-18" width="44" height="36" rx="4"/>
+      <text class="slot-text" x="0" y="5">Z</text>
+      <text class="idx" x="-32" y="-16">[7]</text>
+    </g>
+
+    <!-- Head pointer label (anchored to slot 7) -->
+    <g transform="translate(60 110)">
+      <rect class="slot-head" x="-30" y="-12" width="60" height="22" rx="3"/>
+      <text class="pin-h" x="0" y="3" fill="#0F172A">Head</text>
+    </g>
+    <line class="wb" x1="92" y1="110" x2="113" y2="113" marker-end="url(#cb-ab)"/>
+    <text class="mut-l" x="20" y="138">oldest →</text>
+    <text class="mut-l" x="20" y="150">Dequeue / Peek</text>
+
+    <!-- Tail pointer label (anchored to slot 3) -->
+    <g transform="translate(360 240)">
+      <rect class="slot-tail" x="-30" y="-12" width="60" height="22" rx="3"/>
+      <text class="pin-t" x="0" y="3" fill="#0F172A">Tail</text>
+    </g>
+    <line class="wy" x1="328" y1="248" x2="293" y2="252" marker-end="url(#cb-ay)"/>
+    <text class="mut" x="267" y="285">next free →</text>
+    <text class="mut" x="267" y="296">Enqueue writes here</text>
+
+    <!-- direction-of-rotation arc -->
+    <path class="arc-cw" d="M 200 145 A 40 40 0 0 1 240 185" marker-end="url(#cb-a)"/>
+    <text class="mut" x="215" y="158">advance</text>
+    <text class="mut" x="215" y="170">(idx + 1) % Cap</text>
+
+    <!-- Vertical separator between ring and right column -->
+    <line x1="400" y1="50" x2="400" y2="305" stroke="#334155" stroke-width="1" stroke-dasharray="3 3"/>
+
+    <!-- Right column heading -->
+    <text class="lbl-l" x="416" y="64">Behaviour when Count == Capacity</text>
+
+    <!-- AllowOverwrite = true case -->
+    <g transform="translate(416 78)">
+      <rect class="case-ovr" width="368" height="92" rx="5"/>
+      <text class="lbl-l" x="14" y="20" fill="#2DD4BF">AllowOverwrite = true  (default)</text>
+      <text class="sub-l" x="14" y="38">Tail wraps over Head: the oldest slot is overwritten</text>
+      <text class="sub-l" x="14" y="54">and Head advances by one. Count stays at Capacity.</text>
+      <text class="mut-l" x="14" y="74">Use for sliding windows — keep the most-recent N values.</text>
+    </g>
+
+    <!-- AllowOverwrite = false case -->
+    <g transform="translate(416 180)">
+      <rect class="case-rej" width="368" height="92" rx="5"/>
+      <text class="lbl-l" x="14" y="20" fill="#C4B5FD">AllowOverwrite = false</text>
+      <text class="sub-l" x="14" y="38">Enqueue throws InvalidOperationException;</text>
+      <text class="sub-l" x="14" y="54">TryEnqueue returns false. Buffer is unchanged.</text>
+      <text class="mut-l" x="14" y="74">Use for bounded producer / consumer queues.</text>
+    </g>
+
+    <!-- Footer note -->
+    <text class="mut-l" x="20" y="305">Backing array allocated once. Count / Capacity / IsFull / IsEmpty are O(1). ConcurrentCircularBuffer&lt;T&gt; wraps the same logic with a ReaderWriterLockSlim.</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/deque.svg
+++ b/docs/images/diagrams/deque.svg
@@ -1,0 +1,158 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" role="img" aria-labelledby="dq-t dq-d">
+  <title id="dq-t">Deque&lt;T&gt; — double-ended queue over a circular array</title>
+  <desc id="dq-d">A Deque is a contiguous backing array indexed circularly. Head marks the first logical element, Tail marks the last. AddFirst and RemoveFirst operate on the head end; AddLast and RemoveLast operate on the tail end. Both ends are amortised O(1). When the deque is full, AllowGrow=true reallocates and doubles the backing array, while AllowGrow=false rejects further inserts.</desc>
+
+  <defs>
+    <style>
+      .bg   { fill: #0F172A; }
+      .pan  { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr  { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl  { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl-l{ fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; }
+      .sub-l{ fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; }
+      .mut-l{ fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; }
+      .slot      { fill: #1A2335; stroke: #475569; stroke-width: 1.2; }
+      .slot-full { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .slot-head { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.8; }
+      .slot-tail { fill: #431407; stroke: #FBBF24; stroke-width: 1.8; }
+      .slot-text { fill: #F8FAFC; font: 700 13px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .idx       { fill: #94A3B8; font: 400 9px/1  "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .pin-h     { fill: #60A5FA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .pin-t     { fill: #FBBF24; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .case-ok   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.2; }
+      .case-fix  { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.2; }
+      .wb        { stroke: #60A5FA; stroke-width: 1.5; fill: none; }
+      .wy        { stroke: #FBBF24; stroke-width: 1.5; fill: none; }
+      .wrap      { stroke: #94A3B8; stroke-width: 1.2; fill: none; stroke-dasharray: 4 3; }
+    </style>
+    <marker id="dq-ab" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#60A5FA"/>
+    </marker>
+    <marker id="dq-ay" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#FBBF24"/>
+    </marker>
+    <marker id="dq-aw" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#94A3B8"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="340"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="320" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Deque&lt;T&gt; — double-ended queue over a circular array</text>
+
+    <!-- Backing-array caption -->
+    <text class="mut-l" x="32" y="60">Backing array — length = Capacity (8). Indices wrap modulo Capacity.</text>
+
+    <!-- 8-cell row. Each cell 80x44, centred at x = 56 + i*92, y = 130. -->
+    <!-- Demonstrating wrap-around with Head=6, Tail=2, Count=5.
+         Logical order (head → tail) = arr[6], arr[7], arr[0], arr[1], arr[2] = D E F G H -->
+
+    <g transform="translate(0 130)">
+      <!-- [0] F -->
+      <g transform="translate(56 0)">
+        <rect class="slot-full" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="slot-text" x="0" y="6">F</text>
+        <text class="idx" x="0" y="-30">[0]</text>
+      </g>
+      <!-- [1] G -->
+      <g transform="translate(148 0)">
+        <rect class="slot-full" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="slot-text" x="0" y="6">G</text>
+        <text class="idx" x="0" y="-30">[1]</text>
+      </g>
+      <!-- [2] H — Tail -->
+      <g transform="translate(240 0)">
+        <rect class="slot-tail" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="slot-text" x="0" y="6">H</text>
+        <text class="idx" x="0" y="-30">[2]</text>
+      </g>
+      <!-- [3] empty -->
+      <g transform="translate(332 0)">
+        <rect class="slot" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="idx" x="0" y="-30">[3]</text>
+      </g>
+      <!-- [4] empty -->
+      <g transform="translate(424 0)">
+        <rect class="slot" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="idx" x="0" y="-30">[4]</text>
+      </g>
+      <!-- [5] empty -->
+      <g transform="translate(516 0)">
+        <rect class="slot" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="idx" x="0" y="-30">[5]</text>
+      </g>
+      <!-- [6] D — Head -->
+      <g transform="translate(608 0)">
+        <rect class="slot-head" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="slot-text" x="0" y="6">D</text>
+        <text class="idx" x="0" y="-30">[6]</text>
+      </g>
+      <!-- [7] E -->
+      <g transform="translate(700 0)">
+        <rect class="slot-full" x="-40" y="-22" width="80" height="44" rx="5"/>
+        <text class="slot-text" x="0" y="6">E</text>
+        <text class="idx" x="0" y="-30">[7]</text>
+      </g>
+    </g>
+
+    <!-- Wrap arc connecting [7] back to [0] -->
+    <path class="wrap" d="M 740 90 C 770 86, 770 162, 740 152"/>
+    <path class="wrap" d="M 56 152 C 26 162, 26 86, 56 90" marker-end="url(#dq-aw)"/>
+    <text class="mut-l" x="375" y="90" text-anchor="middle">indices wrap: arr[Capacity − 1] → arr[0]</text>
+
+    <!-- Logical-order caption directly under the cells -->
+    <text class="mut-l" x="400" y="178" text-anchor="middle">logical order (head → tail):  D · E · F · G · H</text>
+
+    <!-- Head pin label, anchored to slot [6] -->
+    <g transform="translate(608 208)">
+      <rect class="slot-head" x="-30" y="-12" width="60" height="22" rx="3"/>
+      <text class="pin-h" x="0" y="3" fill="#0F172A">Head</text>
+    </g>
+    <line class="wb" x1="608" y1="194" x2="608" y2="160" marker-end="url(#dq-ab)"/>
+
+    <!-- Tail pin label, anchored to slot [2] -->
+    <g transform="translate(240 208)">
+      <rect class="slot-tail" x="-30" y="-12" width="60" height="22" rx="3"/>
+      <text class="pin-t" x="0" y="3" fill="#0F172A">Tail</text>
+    </g>
+    <line class="wy" x1="240" y1="194" x2="240" y2="160" marker-end="url(#dq-ay)"/>
+
+    <!-- Head-end operations panel -->
+    <g transform="translate(20 240)">
+      <rect class="case-ok" width="160" height="60" rx="5" fill="none" stroke="#60A5FA"/>
+      <text class="lbl-l" x="80" y="18" text-anchor="middle" fill="#60A5FA">head end</text>
+      <text class="sub-l" x="80" y="34" text-anchor="middle">AddFirst → Head −−</text>
+      <text class="sub-l" x="80" y="50" text-anchor="middle">RemoveFirst → Head ++</text>
+    </g>
+
+    <!-- Centre AllowGrow comparison -->
+    <g transform="translate(192 240)">
+      <rect class="case-ok" width="220" height="60" rx="5"/>
+      <text class="lbl-l" x="14" y="18" fill="#2DD4BF">AllowGrow = true  (default)</text>
+      <text class="sub-l" x="14" y="34">Full → backing array doubles</text>
+      <text class="sub-l" x="14" y="50">in size; existing entries are rebased.</text>
+    </g>
+
+    <g transform="translate(420 240)">
+      <rect class="case-fix" width="220" height="60" rx="5"/>
+      <text class="lbl-l" x="14" y="18" fill="#C4B5FD">AllowGrow = false</text>
+      <text class="sub-l" x="14" y="34">Full → AddFirst / AddLast throw;</text>
+      <text class="sub-l" x="14" y="50">TryAdd* return false.</text>
+    </g>
+
+    <!-- Tail-end operations panel -->
+    <g transform="translate(652 240)">
+      <rect class="case-ok" width="128" height="60" rx="5" fill="none" stroke="#FBBF24"/>
+      <text class="lbl-l" x="64" y="18" text-anchor="middle" fill="#FBBF24">tail end</text>
+      <text class="sub-l" x="64" y="34" text-anchor="middle">AddLast → Tail ++</text>
+      <text class="sub-l" x="64" y="50" text-anchor="middle">RemoveLast → Tail −−</text>
+    </g>
+
+    <!-- Footer -->
+    <text class="mut-l" x="20" y="312">EnsureCapacity pre-allocates regardless of AllowGrow.  TrimExcess shrinks back to Count.  this[i] reads in logical (head-to-tail) order, not raw array order.</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/evicting-dictionary.svg
+++ b/docs/images/diagrams/evicting-dictionary.svg
@@ -1,0 +1,162 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 360" role="img" aria-labelledby="ed-t ed-d">
+  <title id="ed-t">EvictingDictionary&lt;TKey, TValue&gt; — fixed-capacity cache with three eviction policies</title>
+  <desc id="ed-d">An EvictingDictionary stores key-value entries up to a fixed Capacity. Each entry carries metadata: insertion timestamp, last-access timestamp, and access count. When a write would exceed Capacity, the configured policy selects a victim. FirstInFirstOut evicts the earliest inserted entry, LeastRecentlyUsed evicts the entry accessed furthest in the past, and LeastFrequentlyUsed evicts the entry with the smallest access count. Reads via the indexer or TryGetValue update the metadata; Touch promotes a key without reading its value.</desc>
+
+  <defs>
+    <style>
+      .bg   { fill: #0F172A; }
+      .pan  { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr  { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl  { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl  { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .lbl-l{ fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; }
+      .sub  { fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub-l{ fill: #CBD5E1; font: 400 11px/1 "Segoe UI",Arial,sans-serif; }
+      .mut  { fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut-l{ fill: #94A3B8; font: 400 10px/1 "Segoe UI",Arial,sans-serif; }
+      .entry      { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.4; }
+      .entry-key  { fill: #F8FAFC; font: 700 13px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .entry-meta { fill: #94A3B8; font: 400 9px/1  "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .lane-fifo  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.2; }
+      .lane-lru   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.2; }
+      .lane-lfu   { fill: #431407; stroke: #FBBF24; stroke-width: 1.2; }
+      .victim     { fill: #4B1414; stroke: #F87171; stroke-width: 1.6; }
+      .w          { stroke: #CBD5E1; stroke-width: 1.5; fill: none; }
+      .wr         { stroke: #F87171; stroke-width: 1.6; fill: none; }
+      .wt         { stroke: #2DD4BF; stroke-width: 1.5; fill: none; }
+    </style>
+    <marker id="ed-a"  viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#CBD5E1"/>
+    </marker>
+    <marker id="ed-ar" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#F87171"/>
+    </marker>
+    <marker id="ed-at" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="360"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="340" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">EvictingDictionary&lt;TKey, TValue&gt; — fixed-capacity cache with three eviction policies</text>
+
+    <!-- ─────────────────── Storage strip (top) ─────────────────── -->
+    <text class="mut-l" x="20" y="56">Storage — Capacity = 4 (Count == Capacity, next write triggers eviction)</text>
+
+    <!-- 4 entries side by side. Each cell 158x60, centred at x = 92 + i*168, y = 96 -->
+    <g transform="translate(0 96)">
+      <!-- A: oldest insert, recency=2, freq=4 -->
+      <g transform="translate(92 0)">
+        <rect class="entry" x="-79" y="-30" width="158" height="60" rx="6"/>
+        <text class="entry-key" x="0" y="-8">"A" → α</text>
+        <text class="entry-meta" x="0" y="10">inserted: t = 1</text>
+        <text class="entry-meta" x="0" y="22">last access: t = 6   freq: 4</text>
+      </g>
+      <!-- B: recency=4 (least recent), freq=1 (least frequent) -->
+      <g transform="translate(260 0)">
+        <rect class="entry" x="-79" y="-30" width="158" height="60" rx="6"/>
+        <text class="entry-key" x="0" y="-8">"B" → β</text>
+        <text class="entry-meta" x="0" y="10">inserted: t = 2</text>
+        <text class="entry-meta" x="0" y="22">last access: t = 4   freq: 1</text>
+      </g>
+      <!-- C: recency=3, freq=3 -->
+      <g transform="translate(428 0)">
+        <rect class="entry" x="-79" y="-30" width="158" height="60" rx="6"/>
+        <text class="entry-key" x="0" y="-8">"C" → γ</text>
+        <text class="entry-meta" x="0" y="10">inserted: t = 3</text>
+        <text class="entry-meta" x="0" y="22">last access: t = 5   freq: 3</text>
+      </g>
+      <!-- D: most recent insert, recency=1 (most recent), freq=2 -->
+      <g transform="translate(596 0)">
+        <rect class="entry" x="-79" y="-30" width="158" height="60" rx="6"/>
+        <text class="entry-key" x="0" y="-8">"D" → δ</text>
+        <text class="entry-meta" x="0" y="10">inserted: t = 5</text>
+        <text class="entry-meta" x="0" y="22">last access: t = 7   freq: 2</text>
+      </g>
+    </g>
+
+    <!-- New write arrow on the right -->
+    <g transform="translate(740 96)">
+      <rect class="entry" x="-22" y="-22" width="44" height="44" rx="5" fill="#0F172A" stroke="#2DD4BF" stroke-dasharray="3 3"/>
+      <text class="entry-key" x="0" y="6" fill="#2DD4BF">"E"</text>
+      <text class="entry-meta" x="0" y="-30">incoming</text>
+    </g>
+    <line class="wt" x1="708" y1="96" x2="685" y2="96" marker-end="url(#ed-at)"/>
+
+    <!-- ─────────────────── Three-policy lanes ─────────────────── -->
+    <text class="lbl-l" x="20" y="178">Eviction order tracked per policy — head of lane is the next victim:</text>
+
+    <!-- FIFO lane -->
+    <g transform="translate(20 196)">
+      <rect class="lane-fifo" width="760" height="38" rx="5"/>
+      <text class="lbl-l" x="14" y="23" fill="#93C5FD">FIFO</text>
+      <text class="mut-l" x="14" y="34" fill="#93C5FD">earliest insertion first</text>
+      <!-- order: A (oldest insert) → B → C → D -->
+      <g transform="translate(220 19)">
+        <rect class="victim" x="-22" y="-13" width="44" height="26" rx="3"/>
+        <text class="entry-key" x="0" y="4">A</text>
+      </g>
+      <text class="mut" x="262" y="23">→</text>
+      <rect x="284" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#60A5FA"/>
+      <text class="entry-key" x="306" y="23">B</text>
+      <text class="mut" x="346" y="23">→</text>
+      <rect x="368" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#60A5FA"/>
+      <text class="entry-key" x="390" y="23">C</text>
+      <text class="mut" x="430" y="23">→</text>
+      <rect x="452" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#60A5FA"/>
+      <text class="entry-key" x="474" y="23">D</text>
+      <text class="mut-l" x="520" y="23" fill="#94A3B8">victim = "A"  (inserted at t = 1)</text>
+    </g>
+
+    <!-- LRU lane -->
+    <g transform="translate(20 240)">
+      <rect class="lane-lru" width="760" height="38" rx="5"/>
+      <text class="lbl-l" x="14" y="23" fill="#C4B5FD">LRU</text>
+      <text class="mut-l" x="14" y="34" fill="#C4B5FD">least-recent access first</text>
+      <!-- order: B (last access t=4) → C → A → D -->
+      <g transform="translate(220 19)">
+        <rect class="victim" x="-22" y="-13" width="44" height="26" rx="3"/>
+        <text class="entry-key" x="0" y="4">B</text>
+      </g>
+      <text class="mut" x="262" y="23">→</text>
+      <rect x="284" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#A78BFA"/>
+      <text class="entry-key" x="306" y="23">C</text>
+      <text class="mut" x="346" y="23">→</text>
+      <rect x="368" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#A78BFA"/>
+      <text class="entry-key" x="390" y="23">A</text>
+      <text class="mut" x="430" y="23">→</text>
+      <rect x="452" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#A78BFA"/>
+      <text class="entry-key" x="474" y="23">D</text>
+      <text class="mut-l" x="520" y="23" fill="#94A3B8">victim = "B"  (last access at t = 4)</text>
+    </g>
+
+    <!-- LFU lane -->
+    <g transform="translate(20 284)">
+      <rect class="lane-lfu" width="760" height="38" rx="5"/>
+      <text class="lbl-l" x="14" y="23" fill="#FBBF24">LFU</text>
+      <text class="mut-l" x="14" y="34" fill="#FBBF24">least-frequent first</text>
+      <!-- order: B (freq=1) → D (2) → C (3) → A (4) -->
+      <g transform="translate(220 19)">
+        <rect class="victim" x="-22" y="-13" width="44" height="26" rx="3"/>
+        <text class="entry-key" x="0" y="4">B</text>
+      </g>
+      <text class="mut" x="262" y="23">→</text>
+      <rect x="284" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#FBBF24"/>
+      <text class="entry-key" x="306" y="23">D</text>
+      <text class="mut" x="346" y="23">→</text>
+      <rect x="368" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#FBBF24"/>
+      <text class="entry-key" x="390" y="23">C</text>
+      <text class="mut" x="430" y="23">→</text>
+      <rect x="452" y="6" width="44" height="26" rx="3" fill="#0F172A" stroke="#FBBF24"/>
+      <text class="entry-key" x="474" y="23">A</text>
+      <text class="mut-l" x="520" y="23" fill="#94A3B8">victim = "B"  (access count = 1)</text>
+    </g>
+
+    <!-- Footer notes -->
+    <text class="mut-l" x="20" y="338">Reads via this[key] / TryGetValue update last-access and increment freq.  Touch(key) promotes recency without reading the value.</text>
+  </g>
+</svg>


### PR DESCRIPTION
Each Bodu.Core collection guide now opens with an SVG wireframe matching the
existing Fletcher / CRC / calendar diagrams: a labelled ring with Head and
Tail pins for CircularBuffer<T>, a backing-array strip with wrap-around and
AllowGrow comparison for Deque<T>, and a storage strip plus FIFO / LRU / LFU
eviction-order lanes for EvictingDictionary<TKey, TValue>.