### PR TITLE
fix(Security.Cryptography): switch TryFillWithRandomNonZeroBytes to per-byte rejection

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.RandomNumberGenerator.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.RandomNumberGenerator.cs
@@ -39,54 +39,80 @@ public static partial class CryptoHelpers
     }
 
     /// <summary>
-    /// Attempts to fill the provided span with cryptographically secure random bytes that do not include <c>0x00</c>, retrying
-    /// a bounded number of times.
+    /// Attempts to fill the provided span with cryptographically secure random bytes that do not include <c>0x00</c>, redrawing
+    /// each individual zero byte up to a bounded number of times.
     /// </summary>
     /// <param name="buffer">The span to fill.</param>
     /// <returns>
     /// <see langword="true" /> if the buffer was filled successfully without any zero bytes; otherwise, <see langword="false" />
-    /// once the retry limit has been reached.
+    /// once the per-byte redraw limit has been reached for any position.
     /// </returns>
-    /// <remarks>Intended for performance-sensitive scenarios where indefinite retry is undesirable.</remarks>
+    /// <remarks>
+    /// Uses per-byte rejection sampling: the buffer is filled once, and only positions that came up zero are individually
+    /// redrawn. This scales linearly with buffer length rather than exponentially, so the failure probability stays
+    /// negligible (≈ 256<sup>-8</sup> per byte) regardless of how large the buffer is. Intended for performance-sensitive
+    /// scenarios where indefinite retry is undesirable.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool TryFillWithRandomNonZeroBytes(Span<byte> buffer)
     {
-        const int maxAttempts = 5;
+        const int maxRedrawsPerByte = 8;
 
 #if NETSTANDARD2_0
-using (var rng = RandomNumberGenerator.Create())
-{
-    byte[] temp = new byte[buffer.Length];
-
-    try
-    {
-        for (int i = 0; i < maxAttempts; i++)
+        using (var rng = RandomNumberGenerator.Create())
         {
-            rng.GetBytes(temp);
-            if (Array.IndexOf(temp, (byte)0) < 0)
+            byte[] temp = new byte[buffer.Length];
+            try
             {
+                rng.GetBytes(temp);
+
+                // Per-byte rejection: only redraw the positions that came up zero.
+                byte[] single = new byte[1];
+                for (int i = 0; i < temp.Length; i++)
+                {
+                    int redraws = 0;
+                    while (temp[i] == 0)
+                    {
+                        if (redraws == maxRedrawsPerByte)
+                            return false;
+
+                        rng.GetBytes(single);
+                        temp[i] = single[0];
+                        redraws++;
+                    }
+                }
+
+                single[0] = 0;
                 temp.CopyTo(buffer);
                 return true;
             }
+            finally
+            {
+                // Wipe temp so any random bytes drawn (success or failure path) do not linger on the managed heap.
+                Array.Clear(temp, 0, temp.Length);
+            }
         }
-    }
-    finally
-    {
-        // Wipe temp so any random bytes that were drawn (on the successful copy
-        // path as well as the retry-exhaustion path) do not linger on the managed heap.
-        Array.Clear(temp, 0, temp.Length);
-    }
-}
 #else
-        for (int i = 0; i < maxAttempts; i++)
-        {
-            RandomNumberGenerator.Fill(buffer);
-            if (buffer.IndexOf((byte)0) < 0)
-                return true;
-        }
-#endif
+        RandomNumberGenerator.Fill(buffer);
 
-        return false;
+        // Per-byte rejection: only redraw the positions that came up zero.
+        Span<byte> single = stackalloc byte[1];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            int redraws = 0;
+            while (buffer[i] == 0)
+            {
+                if (redraws == maxRedrawsPerByte)
+                    return false;
+
+                RandomNumberGenerator.Fill(single);
+                buffer[i] = single[0];
+                redraws++;
+            }
+        }
+
+        return true;
+#endif
     }
 
     /// <summary>


### PR DESCRIPTION
The previous implementation used whole-buffer rejection: refill the entire
span and retry up to 5 times if any byte was zero. This scales exponentially
badly with buffer length — at 32 bytes the per-call false-return rate is
≈ 2.3×10⁻⁵, at 256 bytes ≈ 9.7%, at 1024 bytes ≈ 91%. The existing test
TryFillWithRandomNonZeroBytes_WhenSuccessful_ShouldReturnTrueAndFillBuffer
flakes on CI roughly once per few hundred runs as a result.

Switch to the same per-byte rejection algorithm already used by the sibling
FillWithRandomBytesExcluding helper: fill the buffer once, then redraw only
the positions that came up zero, capped at maxRedrawsPerByte = 8 redraws per
position. The bound preserves the documented "performance-sensitive bounded
effort" contract while pushing the per-byte failure probability to ≈ 256⁻⁸
(~2.9×10⁻²⁰), so the function now scales linearly with buffer length and is
deterministic in practice for any realistic input.

Both the NETSTANDARD2_0 and net8.0 branches are updated. Test file is
untouched; the existing 100-iteration loop in
TryFillWithRandomNonZeroBytes_WhenSuccessful_ShouldReturnTrueAndFillBuffer
will now pass deterministically.

https://claude.ai/code/session_014R89DiyQ55zryjCSgt9kUt