### PR TITLE
Add comprehensive test suite for NonCryptographicHashAlgorithmExtensions

### DIFF
--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
@@ -1,0 +1,495 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using Bodu.Test.IO;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for the synchronous <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHash(NonCryptographicHashAlgorithm, byte[])" />,
+/// <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHash(NonCryptographicHashAlgorithm, byte[], int, int)" />,
+/// <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHash(NonCryptographicHashAlgorithm, ReadOnlySpan{byte})" />, and
+/// <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHash(NonCryptographicHashAlgorithm, Stream, int)" /> overloads.
+/// </summary>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    /// <summary>Hash bytes corresponding to a sum of zero (i.e. the digest of empty input).</summary>
+    private static readonly byte[] EmptyHash = BitConverter.GetBytes((uint)0);
+
+    // ─── byte[] overload — argument validation ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the byte-array overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmIsNull_ForByteArrayOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm!.ComputeHash(SampleData);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload throws <see cref="ArgumentNullException" /> when the buffer is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferIsNull_ForByteArrayOverload_ShouldThrowArgumentNullException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.ComputeHash((byte[])null!);
+        });
+    }
+
+    // ─── byte[] overload — correctness ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty buffer produces the digest corresponding to a zero accumulator.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferIsEmpty_ForByteArrayOverload_ShouldReturnEmptyHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(Array.Empty<byte>());
+
+        CollectionAssert.AreEqual(EmptyHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload returns the digest of all supplied bytes.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferContainsData_ForByteArrayOverload_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(SampleData);
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload incorporates any state previously accumulated on the algorithm
+    /// before computing the digest.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForByteArrayOverload_ShouldIncludePriorBytesInHash()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 100 }));
+        byte[] expected = BitConverter.GetBytes((uint)(100 + 1 + 2 + 3 + 4));
+
+        byte[] result = algorithm.ComputeHash(SampleData);
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload resets the underlying algorithm state, so two successive computations
+    /// over different inputs return independent digests.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledTwice_ForByteArrayOverload_ShouldResetStateBetweenCalls()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] first = algorithm.ComputeHash(SampleData);
+        byte[] second = algorithm.ComputeHash(new byte[] { 5, 6 });
+        byte[] expectedSecond = BitConverter.GetBytes((uint)(5 + 6));
+
+        CollectionAssert.AreEqual(SampleHash, first);
+        CollectionAssert.AreEqual(expectedSecond, second);
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array overload increments
+    /// <see cref="MonitoringNonCryptographicHashAlgorithm.ResetCallCount" />, confirming the underlying
+    /// <c>GetHashAndReset</c> path is exercised.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalled_ForByteArrayOverload_ShouldResetAlgorithm()
+    {
+        var algorithm = CreateAlgorithm();
+        int before = algorithm.ResetCallCount;
+
+        _ = algorithm.ComputeHash(SampleData);
+
+        Assert.AreEqual(before + 1, algorithm.ResetCallCount);
+    }
+
+    // ─── byte[] + offset + count overload — argument validation ───────────────────────────────
+
+    /// <summary>
+    /// Verifies that the byte-array range overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmIsNull_ForByteArrayRangeOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm!.ComputeHash(SampleData, 0, SampleData.Length);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the byte-array range overload throws <see cref="ArgumentNullException" /> when the buffer is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferIsNull_ForByteArrayRangeOverload_ShouldThrowArgumentNullException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.ComputeHash((byte[])null!, 0, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="offset" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenOffsetIsNegative_ForByteArrayRangeOverload_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = algorithm.ComputeHash(SampleData, -1, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="count" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCountIsNegative_ForByteArrayRangeOverload_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = algorithm.ComputeHash(SampleData, 0, -1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an <paramref name="offset" /> exceeding the buffer length throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenOffsetExceedsBuffer_ForByteArrayRangeOverload_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = algorithm.ComputeHash(SampleData, SampleData.Length + 1, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an <paramref name="offset" /> and <paramref name="count" /> combination extending past the end
+    /// of the buffer throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenOffsetPlusCountExceedsBuffer_ForByteArrayRangeOverload_ShouldThrowArgumentException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = algorithm.ComputeHash(SampleData, 2, SampleData.Length);
+        });
+    }
+
+    // ─── byte[] + offset + count overload — correctness ───────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a zero <paramref name="count" /> returns the digest of empty input.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCountIsZero_ForByteArrayRangeOverload_ShouldReturnEmptyHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(SampleData, 0, 0);
+
+        CollectionAssert.AreEqual(EmptyHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the range overload hashes only the bytes within the requested window.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenRangeIsSubset_ForByteArrayRangeOverload_ShouldReturnHashOfSubset()
+    {
+        var algorithm = CreateAlgorithm();
+        byte[] expected = BitConverter.GetBytes((uint)(2 + 3));
+
+        byte[] result = algorithm.ComputeHash(SampleData, 1, 2);
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that hashing the full buffer via the range overload is equivalent to the byte-array overload.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenRangeIsFullBuffer_ForByteArrayRangeOverload_ShouldMatchByteArrayOverload()
+    {
+        MonitoringNonCryptographicHashAlgorithm rangeAlgorithm = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm fullAlgorithm = CreateAlgorithm();
+
+        byte[] viaRange = rangeAlgorithm.ComputeHash(SampleData, 0, SampleData.Length);
+        byte[] viaFull = fullAlgorithm.ComputeHash(SampleData);
+
+        CollectionAssert.AreEqual(viaFull, viaRange);
+    }
+
+    // ─── ReadOnlySpan<byte> overload — argument validation ────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the span overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmIsNull_ForSpanOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm!.ComputeHash(new ReadOnlySpan<byte>(SampleData));
+        });
+    }
+
+    // ─── ReadOnlySpan<byte> overload — correctness ────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty span produces the digest corresponding to a zero accumulator.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenSpanIsEmpty_ForSpanOverload_ShouldReturnEmptyHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(ReadOnlySpan<byte>.Empty);
+
+        CollectionAssert.AreEqual(EmptyHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the span overload returns the digest of all supplied bytes.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenSpanContainsData_ForSpanOverload_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(new ReadOnlySpan<byte>(SampleData));
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the span overload resets the algorithm so a subsequent call begins from a clean state.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledTwice_ForSpanOverload_ShouldResetStateBetweenCalls()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] first = algorithm.ComputeHash(new ReadOnlySpan<byte>(SampleData));
+        byte[] second = algorithm.ComputeHash(new ReadOnlySpan<byte>(new byte[] { 7, 8 }));
+        byte[] expectedSecond = BitConverter.GetBytes((uint)(7 + 8));
+
+        CollectionAssert.AreEqual(SampleHash, first);
+        CollectionAssert.AreEqual(expectedSecond, second);
+    }
+
+    // ─── Stream overload — argument validation ────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the stream overload throws <see cref="ArgumentNullException" /> when the algorithm is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmIsNull_ForStreamOverload_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm!.ComputeHash(stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenStreamIsNull_ForStreamOverload_ShouldThrowArgumentNullException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.ComputeHash((Stream)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a zero <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferSizeIsZero_ForStreamOverload_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = algorithm.ComputeHash(stream, bufferSize: 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferSizeIsNegative_ForStreamOverload_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = algorithm.ComputeHash(stream, bufferSize: -1);
+        });
+    }
+
+    // ─── Stream overload — correctness ────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty stream produces the digest corresponding to a zero accumulator.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenStreamIsEmpty_ForStreamOverload_ShouldReturnEmptyHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(new MemoryStream(Array.Empty<byte>()));
+
+        CollectionAssert.AreEqual(EmptyHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload returns the digest of all bytes read from the source.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenStreamHasData_ForStreamOverload_ShouldMatchSpanOverload()
+    {
+        MonitoringNonCryptographicHashAlgorithm fromStream = CreateAlgorithm();
+        MonitoringNonCryptographicHashAlgorithm fromSpan = CreateAlgorithm();
+
+        byte[] viaStream = fromStream.ComputeHash(new MemoryStream(SampleData));
+        byte[] viaSpan = fromSpan.ComputeHash(new ReadOnlySpan<byte>(SampleData));
+
+        CollectionAssert.AreEqual(viaSpan, viaStream);
+    }
+
+    /// <summary>
+    /// Verifies that a small <paramref name="bufferSize" /> — forcing multiple read iterations — produces the same
+    /// digest as the default buffer size.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenBufferSizeSmallerThanInput_ForStreamOverload_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(new MemoryStream(SampleData), bufferSize: 1);
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="FixedChunkStream" /> delivering data 1 byte at a time produces the expected
+    /// digest.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenSourceIsFixedChunkStream_ForStreamOverload_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = algorithm.ComputeHash(new FixedChunkStream(SampleData, chunkSize: 1));
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="IOException" /> thrown by a <see cref="FaultingStream" /> mid-read propagates
+    /// cleanly out of the stream overload.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenSourceFaultsMidRead_ForStreamOverload_ShouldPropagateIOException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<IOException>(() =>
+        {
+            _ = algorithm.ComputeHash(new FaultingStream(SampleData, throwAfterBytes: 2));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload incorporates any state previously accumulated on the algorithm before
+    /// reading from the stream.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForStreamOverload_ShouldIncludePriorBytesInHash()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 50 }));
+        byte[] expected = BitConverter.GetBytes((uint)(50 + 1 + 2 + 3 + 4));
+
+        byte[] result = algorithm.ComputeHash(new MemoryStream(SampleData));
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload resets the algorithm so a subsequent call begins from a clean state.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledTwice_ForStreamOverload_ShouldResetStateBetweenCalls()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] first = algorithm.ComputeHash(new MemoryStream(SampleData));
+        byte[] second = algorithm.ComputeHash(new MemoryStream(new byte[] { 9, 10 }));
+        byte[] expectedSecond = BitConverter.GetBytes((uint)(9 + 10));
+
+        CollectionAssert.AreEqual(SampleHash, first);
+        CollectionAssert.AreEqual(expectedSecond, second);
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHashAsync.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHashAsync.cs
@@ -1,0 +1,249 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmExtensionsTests.ComputeHashAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.IO.Hashing;
+using System.Threading;
+using Bodu.Test.IO;
+
+namespace Bodu.IO.Hashing.Extensions;
+
+/// <summary>
+/// Tests for <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync(NonCryptographicHashAlgorithm, Stream, int, CancellationToken)" />.
+/// </summary>
+public partial class NonCryptographicHashAlgorithmExtensionsTests
+{
+    // ─── Argument validation ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> throws
+    /// <see cref="ArgumentNullException" /> when the algorithm is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenAlgorithmIsNull_ShouldThrowArgumentNullException()
+    {
+        NonCryptographicHashAlgorithm? algorithm = null;
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            _ = await algorithm!.ComputeHashAsync(stream));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> throws
+    /// <see cref="ArgumentNullException" /> when the source stream is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+            _ = await algorithm.ComputeHashAsync(null!));
+    }
+
+    /// <summary>
+    /// Verifies that a zero <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenBufferSizeIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            _ = await algorithm.ComputeHashAsync(stream, bufferSize: 0));
+    }
+
+    /// <summary>
+    /// Verifies that a negative <paramref name="bufferSize" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenBufferSizeIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        var algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+
+        await Assert.ThrowsExactlyAsync<ArgumentOutOfRangeException>(async () =>
+            _ = await algorithm.ComputeHashAsync(stream, bufferSize: -1));
+    }
+
+    // ─── Correctness ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that an empty stream produces the digest corresponding to a zero accumulator.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenStreamIsEmpty_ShouldReturnEmptyHash()
+    {
+        var algorithm = CreateAlgorithm();
+        byte[] expected = BitConverter.GetBytes((uint)0);
+
+        byte[] result = await algorithm.ComputeHashAsync(new MemoryStream(Array.Empty<byte>()));
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> returns the same
+    /// digest as the synchronous stream overload for identical input.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenCalled_ShouldMatchSynchronousComputeHash()
+    {
+        MonitoringNonCryptographicHashAlgorithm syncAlgorithm = CreateAlgorithm();
+        byte[] expected = syncAlgorithm.ComputeHash(new MemoryStream(SampleData));
+
+        var algorithm = CreateAlgorithm();
+        byte[] result = await algorithm.ComputeHashAsync(new MemoryStream(SampleData));
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that a small <paramref name="bufferSize" /> — forcing multiple read iterations — produces the
+    /// expected digest.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenBufferSizeSmallerThanInput_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = await algorithm.ComputeHashAsync(new MemoryStream(SampleData), bufferSize: 1);
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> incorporates any
+    /// state previously accumulated on the algorithm before reading from the stream.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenAlgorithmHasPriorState_ShouldIncludePriorBytesInHash()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.AppendData(new ReadOnlySpan<byte>(new byte[] { 25 }));
+        byte[] expected = BitConverter.GetBytes((uint)(25 + 1 + 2 + 3 + 4));
+
+        byte[] result = await algorithm.ComputeHashAsync(new MemoryStream(SampleData));
+
+        CollectionAssert.AreEqual(expected, result);
+    }
+
+    /// <summary>
+    /// Verifies that successive calls reset the algorithm so each computation begins from a clean state.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenCalledTwice_ShouldResetStateBetweenCalls()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] first = await algorithm.ComputeHashAsync(new MemoryStream(SampleData));
+        byte[] second = await algorithm.ComputeHashAsync(new MemoryStream(new byte[] { 11, 12 }));
+        byte[] expectedSecond = BitConverter.GetBytes((uint)(11 + 12));
+
+        CollectionAssert.AreEqual(SampleHash, first);
+        CollectionAssert.AreEqual(expectedSecond, second);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> increments
+    /// <see cref="MonitoringNonCryptographicHashAlgorithm.ResetCallCount" />, confirming the underlying
+    /// <c>GetHashAndReset</c> path is exercised.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenCalled_ShouldResetAlgorithm()
+    {
+        var algorithm = CreateAlgorithm();
+        int before = algorithm.ResetCallCount;
+
+        _ = await algorithm.ComputeHashAsync(new MemoryStream(SampleData));
+
+        Assert.AreEqual(before + 1, algorithm.ResetCallCount);
+    }
+
+    // ─── Stream variants ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that a <see cref="FixedChunkStream" /> delivering data 1 byte at a time produces the expected
+    /// digest.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenSourceIsFixedChunkStream_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = await algorithm.ComputeHashAsync(new FixedChunkStream(SampleData, chunkSize: 1));
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that a non-seekable stream is correctly hashed without invoking seek operations.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenSourceIsNonSeekable_ShouldReturnExpectedHash()
+    {
+        var algorithm = CreateAlgorithm();
+
+        byte[] result = await algorithm.ComputeHashAsync(new NonSeekableStream(SampleData));
+
+        CollectionAssert.AreEqual(SampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="IOException" /> thrown by a <see cref="FaultingStream" /> mid-read propagates
+    /// cleanly out of <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenSourceFaultsMidRead_ShouldPropagateIOException()
+    {
+        var algorithm = CreateAlgorithm();
+
+        await Assert.ThrowsExactlyAsync<IOException>(async () =>
+            _ = await algorithm.ComputeHashAsync(new FaultingStream(SampleData, throwAfterBytes: 2)));
+    }
+
+    // ─── Cancellation ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> throws
+    /// <see cref="OperationCanceledException" /> when the token is already cancelled before the call.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenTokenAlreadyCancelled_ShouldThrowOperationCanceledException()
+    {
+        var algorithm = CreateAlgorithm();
+        using MemoryStream stream = new(SampleData);
+        using CancellationTokenSource cts = new();
+        cts.Cancel();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            _ = await algorithm.ComputeHashAsync(stream, cancellationToken: cts.Token));
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="CancellationTriggerStream" /> cancelling the token mid-read causes
+    /// <see cref="NonCryptographicHashAlgorithmExtensions.ComputeHashAsync" /> to throw
+    /// <see cref="OperationCanceledException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task ComputeHashAsync_WhenCancellationTriggeredMidStream_ShouldThrowOperationCanceledException()
+    {
+        var algorithm = CreateAlgorithm();
+        using CancellationTokenSource cts = new();
+
+        // cancelAfterRead: 1 cancels the token after the first successful read; the next ReadAsync sees a
+        // cancelled token and throws OperationCanceledException before reading any further bytes.
+        using CancellationTriggerStream stream = new(
+            new MemoryStream(SampleData),
+            cts,
+            cancelAfterRead: 1);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+            _ = await algorithm.ComputeHashAsync(stream, bufferSize: 1, cancellationToken: cts.Token));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive test suite for the `NonCryptographicHashAlgorithmExtensions` class, covering both synchronous and asynchronous hash computation methods with extensive argument validation and correctness testing.

## Key Changes
- **ComputeHash synchronous tests** (`NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs`):
  - 495 lines of tests covering four overloads: `byte[]`, `byte[] + offset + count`, `ReadOnlySpan<byte>`, and `Stream`
  - Argument validation tests for null checks and range validation
  - Correctness tests verifying hash computation, state management, and algorithm reset behavior
  - Edge case handling (empty buffers, zero counts, small buffer sizes)
  - Stream variant testing with `FixedChunkStream` and `FaultingStream`

- **ComputeHashAsync tests** (`NonCryptographicHashAlgorithmExtensionsTests.ComputeHashAsync.cs`):
  - 249 lines of tests for the async stream overload
  - Argument validation for null checks and buffer size constraints
  - Correctness verification matching synchronous behavior
  - Stream variant testing including non-seekable streams
  - Cancellation token handling with pre-cancelled and mid-stream cancellation scenarios

## Notable Implementation Details
- Tests use a `MonitoringNonCryptographicHashAlgorithm` test double to verify algorithm reset behavior via `ResetCallCount`
- Sample data is a simple byte array `[1, 2, 3, 4]` with expected hash computed as sum of bytes
- Comprehensive coverage of state management: prior state inclusion, state reset between calls, and independent digest computation
- Stream tests use custom test utilities (`FixedChunkStream`, `FaultingStream`, `NonSeekableStream`, `CancellationTriggerStream`) to exercise edge cases
- All tests follow consistent naming convention: `ComputeHash[Async]_When[Condition]_For[Overload]_Should[Expected]`

https://claude.ai/code/session_01NYHNBHFkUZ4fqWgFoiWdWe