### PR TITLE
Fix Adler checksum SIMD path to match scalar per-byte recurrence

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
@@ -21,7 +21,8 @@ namespace Bodu.IO.Hashing.Checksums;
 /// Adler checksums maintain two accumulators (A and B) and combine them to form the final checksum. Derived
 /// classes supply the modulus appropriate to the desired bit width (for example 65521 for Adler-32, or
 /// 4294967291 for Adler-64). The core hashing loop provides both a SIMD-accelerated path and a scalar
-/// fallback.
+/// fallback; the SIMD path applies the canonical positionally weighted block recurrence so that both paths
+/// produce identical digests for any input.
 /// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
@@ -67,27 +68,48 @@ public abstract class Adler<T>
 
         if (Vector.IsHardwareAccelerated && length >= 512)
         {
+            int width = Vector<byte>.Count;
+            int half = Vector<ushort>.Count;
+            T widthT = T.CreateTruncating((uint)width);
+
             while (index < length)
             {
                 int remaining = Math.Min(length - index, NMAX);
                 int chunkEnd = index + remaining;
 
-                while (index + Vector<byte>.Count <= chunkEnd)
+                // Per width-byte block [b_1 .. b_V] starting from accumulators (A, B), the
+                // canonical Adler recurrence yields:
+                //     A_new = A + Σ b_i
+                //     B_new = B + V · A + Σ (V - i + 1) · b_i
+                // The positional weighting and the V·A carry term are essential — omitting
+                // either produces a digest that does not match the per-byte definition.
+                while (index + width <= chunkEnd)
                 {
-                    var vec = new Vector<byte>(source.Slice(index, Vector<byte>.Count));
+                    Vector<byte> vec = new Vector<byte>(source.Slice(index, width));
                     Vector.Widen(vec, out Vector<ushort> lo, out Vector<ushort> hi);
 
-                    T sum = T.Zero;
-                    for (int i = 0; i < Vector<ushort>.Count; i++)
-                        sum += T.CreateTruncating(lo[i]) + T.CreateTruncating(hi[i]);
+                    T sumBytes = T.Zero;
+                    T sumWeighted = T.Zero;
+                    for (int i = 0; i < half; i++)
+                    {
+                        T loByte = T.CreateTruncating(lo[i]);
+                        T hiByte = T.CreateTruncating(hi[i]);
+                        sumBytes += loByte + hiByte;
+                        sumWeighted += (T.CreateTruncating((uint)(width - i)) * loByte)
+                                     + (T.CreateTruncating((uint)(half - i)) * hiByte);
+                    }
 
-                    pA += sum;
-                    pB += pA;
+                    pB += (pA * widthT) + sumWeighted;
+                    pA += sumBytes;
 
-                    index += Vector<byte>.Count;
+                    index += width;
                 }
 
-                index = chunkEnd;
+                while (index < chunkEnd)
+                {
+                    pA += T.CreateTruncating(source[index++]);
+                    pB += pA;
+                }
 
                 pA %= this._modulo;
                 pB %= this._modulo;

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32.cs
@@ -23,6 +23,25 @@ public sealed partial class Adler32Tests
             Abc = "018D00C7",
             QuickBrownFox = "5BCD0FDA",
             Zeros16 = "00100001",
+
+            // Long-input regression vectors for issue #127 — the buggy SIMD branch was not
+            // exercised by any pre-existing KAT (all < 512 bytes). Expected digests are the
+            // canonical zlib Adler-32 values for the (byte)(i & 0xFF) sequence at each length.
+            Additional = new[]
+            {
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte1K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte1K,
+                    ExpectedHex = "E4C9FE10",
+                },
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte8K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte8K,
+                    ExpectedHex = "3A54F0E2",
+                },
+            },
         },
     };
 

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32C.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32C.cs
@@ -23,6 +23,25 @@ public sealed partial class Adler32CTests
             Abc = "018D00C7",
             QuickBrownFox = "5BCD0FDA",
             Zeros16 = "00100001",
+
+            // Long-input regression vectors for issue #127 — Adler-32C uses modulus 65536, so
+            // expected digests are computed by the per-byte canonical recurrence (and verified
+            // against the scalar reference implementation) for the (byte)(i & 0xFF) sequence.
+            Additional = new[]
+            {
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte1K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte1K,
+                    ExpectedHex = "AE00FE01",
+                },
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte8K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte8K,
+                    ExpectedHex = "7000F001",
+                },
+            },
         },
     };
 

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler64Tests.64.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler64Tests.64.cs
@@ -23,6 +23,25 @@ public sealed partial class Adler64Tests
             Abc = "0000018D000000C7",
             QuickBrownFox = "00015BCD00000FDA",
             Zeros16 = "0000001000000001",
+
+            // Long-input regression vectors for issue #127 — expected digests are the canonical
+            // Adler-64 values (modulus 4294967291) for the (byte)(i & 0xFF) sequence at each
+            // length, derived from the per-byte spec.
+            Additional = new[]
+            {
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte1K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte1K,
+                    ExpectedHex = "03A7AE000001FE01",
+                },
+                new NonCryptographicHashKnownAnswer
+                {
+                    Name = "ModuloByte8K",
+                    Input = AdlerSimdRegressionInputs.ModuloByte8K,
+                    ExpectedHex = "FC5D7000000FF001",
+                },
+            },
         },
     };
 

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AdlerTests.SimdParity.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO.Hashing;
+
+namespace Bodu.IO.Hashing.Checksums;
+
+public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
+{
+    /// <summary>
+    /// Verifies that hashing an input long enough to engage the SIMD-accelerated branch
+    /// (≥ 512 bytes and crossing the internal NMAX reduction window) produces the same digest
+    /// as appending the same bytes one at a time, which always exercises the canonical scalar
+    /// per-byte recurrence.
+    /// </summary>
+    /// <param name="variant">The algorithm variant under test.</param>
+    /// <remarks>
+    /// Earlier known-answer vectors (<c>Empty</c>, <c>Abc</c>, <c>QuickBrownFox</c>, <c>Zeros16</c>,
+    /// <c>Sequential0To255</c>) are all under 512 bytes and never trigger the SIMD branch, so a
+    /// divergence between the two paths could previously go undetected. This vector is sized to
+    /// straddle the 5552-byte NMAX boundary and exercise multiple full vector chunks plus a
+    /// scalar tail.
+    /// </remarks>
+    [TestMethod]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    public void Append_WhenInputEngagesSimdBranch_ShouldMatchPerByteScalarPath(SingleTestVariant variant)
+    {
+        byte[] data = new byte[8192];
+        for (int i = 0; i < data.Length; i++)
+            data[i] = (byte)i;
+
+        NonCryptographicHashAlgorithm whole = CreateAlgorithm(variant);
+        whole.Append(data);
+
+        NonCryptographicHashAlgorithm perByte = CreateAlgorithm(variant);
+        for (int i = 0; i < data.Length; i++)
+            perByte.Append(data.AsSpan(i, 1));
+
+        CollectionAssert.AreEqual(whole.GetCurrentHash(), perByte.GetCurrentHash());
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
@@ -28,9 +28,7 @@ public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
     [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
     public void Append_WhenInputEngagesSimdBranch_ShouldMatchPerByteScalarPath(SingleTestVariant variant)
     {
-        byte[] data = new byte[8192];
-        for (int i = 0; i < data.Length; i++)
-            data[i] = (byte)i;
+        byte[] data = AdlerSimdRegressionInputs.ModuloByte8K;
 
         NonCryptographicHashAlgorithm whole = CreateAlgorithm(variant);
         whole.Append(data);
@@ -40,5 +38,32 @@ public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
             perByte.Append(data.AsSpan(i, 1));
 
         CollectionAssert.AreEqual(whole.GetCurrentHash(), perByte.GetCurrentHash());
+    }
+}
+
+/// <summary>
+/// Provides shared regression inputs used to pin Adler-style checksum behaviour against known canonical
+/// (zlib-cross-checked) digests on the SIMD-accelerated path.
+/// </summary>
+/// <remarks>
+/// Inputs are <c>(byte)(i &amp; 0xFF)</c> sequences sized to engage the SIMD branch (≥ 512 bytes). The
+/// 1 KiB vector matches the reproduction in issue #127 — it crosses the SIMD threshold but stays inside a
+/// single NMAX block. The 8 KiB vector additionally crosses the 5552-byte NMAX boundary so accumulator
+/// reduction at the chunk join is exercised.
+/// </remarks>
+internal static class AdlerSimdRegressionInputs
+{
+    /// <summary>The 1024-byte input <c>0x00, 0x01, …, 0xFF, 0x00, …</c> (four repetitions of 0..255).</summary>
+    public static readonly byte[] ModuloByte1K = Build(1024);
+
+    /// <summary>The 8192-byte input <c>0x00, 0x01, …, 0xFF, 0x00, …</c> (thirty-two repetitions of 0..255).</summary>
+    public static readonly byte[] ModuloByte8K = Build(8192);
+
+    private static byte[] Build(int length)
+    {
+        byte[] data = new byte[length];
+        for (int i = 0; i < length; i++)
+            data[i] = (byte)i;
+        return data;
     }
 }


### PR DESCRIPTION
## Summary
Fixes a critical bug in the SIMD-accelerated path of Adler checksum algorithms (Adler-32, Adler-32C, Adler-64) where the vectorized implementation was not applying the canonical positionally weighted block recurrence, causing digest mismatches when inputs were large enough to engage the SIMD branch (≥512 bytes).

## Key Changes
- **Corrected SIMD recurrence formula**: Updated the vectorized loop to properly compute both the sum of bytes and the positionally weighted sum required by the canonical Adler specification:
  - `A_new = A + Σ b_i`
  - `B_new = B + V·A + Σ (V - i + 1)·b_i`
  
  The previous implementation was missing the positional weighting `(V - i + 1)` and the `V·A` carry term, which are essential for correctness.

- **Separated SIMD and scalar paths**: Restructured the loop to clearly distinguish between the vectorized block processing (which now applies proper weighting) and the scalar tail handling for remaining bytes.

- **Added regression test coverage**: 
  - New test method `Append_WhenInputEngagesSimdBranch_ShouldMatchPerByteScalarPath` that verifies SIMD and per-byte scalar paths produce identical digests
  - Added `AdlerSimdRegressionInputs` helper class with 1 KiB and 8 KiB test vectors that cross SIMD thresholds and NMAX reduction boundaries
  - Extended known-answer test vectors for all three Adler variants with long-input regression cases (ModuloByte1K and ModuloByte8K)

- **Updated documentation**: Clarified in the class-level remarks that the SIMD path applies the canonical positionally weighted recurrence to ensure digest parity.

## Implementation Details
The fix ensures that both the SIMD and scalar paths implement the identical mathematical recurrence. The SIMD path now:
1. Processes `width`-byte blocks with proper positional weighting
2. Applies the `V·A` carry term before accumulating weighted bytes
3. Falls back to scalar per-byte processing for the tail
4. Performs modulo reduction at NMAX boundaries to prevent overflow

This resolves issue #127 where inputs ≥512 bytes would produce incorrect digests due to the buggy SIMD implementation.

https://claude.ai/code/session_01GcDSpsrBHKfzm7vSLoWCsb