### PR TITLE
Add IndexedPriorityQueue<TElement, TPriority> implementation

### DIFF
--- a/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.Enumerator.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.Enumerator.cs
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueue.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class IndexedPriorityQueue<TElement, TPriority>
+    : IEnumerable<KeyValuePair<TElement, TPriority>>
+{
+    /// <inheritdoc />
+    IEnumerator<KeyValuePair<TElement, TPriority>> IEnumerable<KeyValuePair<TElement, TPriority>>.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <summary>
+    /// Enumerates the element-priority pairs of an <see cref="IndexedPriorityQueue{TElement, TPriority}"/>
+    /// in heap-storage order.
+    /// </summary>
+    /// <remarks>
+    /// <para>Use the <see langword="foreach"/> statement to enumerate the queue rather than using this struct directly.</para>
+    /// <para>
+    /// The enumerator captures the queue's modification version at construction. Any structural mutation —
+    /// <see cref="Enqueue"/>, <see cref="Dequeue"/>, <see cref="Update"/>, <see cref="Remove"/>,
+    /// <see cref="EnqueueOrUpdate"/>, or <see cref="Clear"/> — invalidates an in-flight enumerator and
+    /// causes <see cref="MoveNext"/> or <see cref="Reset"/> to throw <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator :
+        IEnumerator<KeyValuePair<TElement, TPriority>>
+    {
+        /// <summary>
+        /// The queue being enumerated.
+        /// </summary>
+        private readonly IndexedPriorityQueue<TElement, TPriority> _queue;
+
+        /// <summary>
+        /// The queue's <see cref="_version"/> captured at construction; used to detect concurrent modification.
+        /// </summary>
+        private readonly int _version;
+
+        /// <summary>
+        /// The slot index currently exposed by <see cref="Current"/>; <c>-1</c> indicates an unstarted or exhausted enumerator.
+        /// </summary>
+        private int _index;
+
+        /// <summary>
+        /// The element-priority pair returned by <see cref="Current"/> for the current position.
+        /// </summary>
+        private KeyValuePair<TElement, TPriority> _current;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Enumerator"/> struct.
+        /// </summary>
+        /// <param name="queue">The queue to enumerate.</param>
+        internal Enumerator(IndexedPriorityQueue<TElement, TPriority> queue)
+        {
+            _queue = queue;
+            _version = queue._version;
+            _index = -1;
+            _current = default!;
+        }
+
+        /// <inheritdoc />
+        public KeyValuePair<TElement, TPriority> Current =>
+            _index < 0
+                ? throw new InvalidOperationException(ResourceStrings.InvalidOperation_EnumeratorNotOnElement)
+                : _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            // No unmanaged resources; method provided for interface completeness.
+        }
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            if (_version != _queue._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            int next = _index + 1;
+            if (next >= _queue._size)
+            {
+                _index = -1;
+                _current = default!;
+                return false;
+            }
+
+            (TElement Element, TPriority Priority) node = _queue._nodes[next];
+            _current = new KeyValuePair<TElement, TPriority>(node.Element, node.Priority);
+            _index = next;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            if (_version != _queue._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _index = -1;
+            _current = default!;
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.ICollection.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.ICollection.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueue.ICollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Bodu.Collections.Generic;
+
+#pragma warning disable CA1010 // Generic interface should also be implemented
+#pragma warning disable CA1710 // Identifiers should have correct suffix
+
+public sealed partial class IndexedPriorityQueue<TElement, TPriority> :
+#pragma warning restore CA1710 // Identifiers should have correct suffix
+#pragma warning restore CA1010 // Generic interface should also be implemented
+    ICollection
+{
+    /// <summary>
+    /// Lazily-allocated synchronisation root returned by the explicit <see cref="ICollection.SyncRoot"/> implementation.
+    /// </summary>
+    [NonSerialized]
+    private object? _syncRoot;
+
+    /// <summary>
+    /// Gets a value indicating whether access to the queue is synchronized (thread-safe). Always returns
+    /// <see langword="false"/>; <see cref="IndexedPriorityQueue{TElement, TPriority}"/> is not thread-safe.
+    /// </summary>
+    /// <value>Always <see langword="false"/>.</value>
+    /// <returns>Always <see langword="false"/>.</returns>
+    bool ICollection.IsSynchronized => false;
+
+    /// <summary>
+    /// Gets a lazily-initialised object that can be used to synchronise access to the queue.
+    /// </summary>
+    /// <value>A non-null object suitable as a <see cref="Monitor"/> target.</value>
+    /// <returns>The synchronisation root.</returns>
+    object ICollection.SyncRoot =>
+        _syncRoot ?? Interlocked.CompareExchange(ref _syncRoot, new object(), null) ?? _syncRoot!;
+
+    /// <summary>
+    /// Copies the queue's element-priority pairs to the specified array, starting at the specified index,
+    /// in heap-storage order.
+    /// </summary>
+    /// <param name="array">The destination array. Must be single-dimensional, zero-based, and have an element type compatible with <see cref="KeyValuePair{TElement, TPriority}"/>.</param>
+    /// <param name="index">The zero-based starting index in <paramref name="array"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is negative.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="array"/> is multidimensional, not zero-based, has an incompatible element type, or has insufficient room from <paramref name="index"/> onward.
+    /// </exception>
+    void ICollection.CopyTo(Array array, int index)
+    {
+        ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfArrayMultidimensional(array);
+        ThrowHelper.ThrowIfArrayIsNotZeroBased(array);
+        ThrowHelper.ThrowIfNegative(index);
+        ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, index + _size);
+
+        try
+        {
+            if (array is KeyValuePair<TElement, TPriority>[] typedArray)
+            {
+                for (int i = 0; i < _size; i++)
+                {
+                    (TElement Element, TPriority Priority) node = _nodes[i];
+                    typedArray[index + i] = new KeyValuePair<TElement, TPriority>(node.Element, node.Priority);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < _size; i++)
+                {
+                    (TElement Element, TPriority Priority) node = _nodes[i];
+                    array.SetValue(new KeyValuePair<TElement, TPriority>(node.Element, node.Priority), index + i);
+                }
+            }
+        }
+        catch (ArrayTypeMismatchException ex)
+        {
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_ArrayType, nameof(array), ex);
+        }
+        catch (InvalidCastException ex)
+        {
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_ArrayType, nameof(array), ex);
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.cs
@@ -1,0 +1,720 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueue.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Represents a binary min-heap priority queue keyed by element identity, supporting O(log n) re-prioritisation
+/// (decrease- or increase-key) and removal of any element by value.
+/// </summary>
+/// <typeparam name="TElement">Specifies the element type used as the queue's identity. Must be non-null and unique within the queue.</typeparam>
+/// <typeparam name="TPriority">Specifies the priority type used for ordering.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="IndexedPriorityQueue{TElement, TPriority}"/> complements
+/// <see cref="System.Collections.Generic.PriorityQueue{TElement, TPriority}"/> by maintaining an auxiliary
+/// element-to-index map alongside the heap. This map turns <see cref="Contains(TElement)"/>,
+/// <see cref="TryGetPriority(TElement, out TPriority)"/>, and the slot lookup used by
+/// <see cref="Update(TElement, TPriority)"/>, <see cref="Remove(TElement)"/>, and
+/// <see cref="EnqueueOrUpdate(TElement, TPriority)"/> into O(1) operations and the subsequent heap
+/// repair into O(log n) — the operations Dijkstra's algorithm, Prim's algorithm, and A* require.
+/// </para>
+/// <para>
+/// The trade-off relative to the BCL <see cref="System.Collections.Generic.PriorityQueue{TElement, TPriority}"/>
+/// is that elements are unique. <see cref="Enqueue(TElement, TPriority)"/> throws
+/// <see cref="ArgumentException"/> if the element is already present; use
+/// <see cref="EnqueueOrUpdate(TElement, TPriority)"/> for set semantics.
+/// </para>
+/// <para>
+/// Ordering is determined by an <see cref="IComparer{TPriority}"/>; smaller priorities are dequeued first
+/// (min-heap). To obtain max-heap behaviour, supply a reversed comparer. Element identity uses an
+/// <see cref="IEqualityComparer{TElement}"/>; both default to the framework default comparer when not specified.
+/// </para>
+/// <para>
+/// Enumeration walks the underlying heap array in storage order, not priority order. Dequeue items in turn
+/// to obtain priority-ordered output.
+/// </para>
+/// <para>
+/// <see cref="IndexedPriorityQueue{TElement, TPriority}"/> is not thread-safe. Concurrent reads and writes
+/// require external synchronisation.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("Count = {Count}")]
+[DebuggerTypeProxy(typeof(IndexedPriorityQueueDebugView<,>))]
+[Serializable]
+public sealed partial class IndexedPriorityQueue<TElement, TPriority>
+    : IReadOnlyCollection<KeyValuePair<TElement, TPriority>>
+    where TElement : notnull
+{
+    /// <summary>
+    /// The default capacity used when the heap is grown from an empty backing array.
+    /// </summary>
+    private const int DefaultGrowCapacity = 4;
+
+    /// <summary>
+    /// Backing storage for the heap. Slots <c>[0.._size)</c> are valid heap nodes; the remainder is
+    /// uninitialised reserve capacity.
+    /// </summary>
+    private (TElement Element, TPriority Priority)[] _nodes;
+
+    /// <summary>
+    /// Maps each element currently in the heap to its position in <see cref="_nodes"/>. Kept in lock-step
+    /// with every swap, insert, and removal so that lookup-by-element remains O(1).
+    /// </summary>
+    private readonly Dictionary<TElement, int> _index;
+
+    /// <summary>
+    /// The priority comparer used for heap ordering. Smaller values (per this comparer) are dequeued first.
+    /// </summary>
+    private readonly IComparer<TPriority> _comparer;
+
+    /// <summary>
+    /// The number of nodes currently stored in the heap. Always satisfies <c>_size &lt;= _nodes.Length</c>.
+    /// </summary>
+    private int _size;
+
+    /// <summary>
+    /// Mutation counter used by <see cref="Enumerator"/> to detect concurrent modification. Incremented on
+    /// every operation that adds, removes, or re-prioritises an element, and on <see cref="Clear"/>.
+    /// </summary>
+    private int _version;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class with
+    /// zero initial capacity, the default priority comparer, and the default element comparer.
+    /// </summary>
+    public IndexedPriorityQueue()
+        : this(0, null, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class with
+    /// the specified initial capacity, using the default priority comparer and element comparer.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the heap. Must be non-negative.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
+    public IndexedPriorityQueue(int capacity)
+        : this(capacity, null, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class with
+    /// zero initial capacity and the specified priority comparer.
+    /// </summary>
+    /// <param name="priorityComparer">
+    /// The comparer used to order priorities, or <see langword="null"/> to use <see cref="Comparer{T}.Default"/>.
+    /// </param>
+    public IndexedPriorityQueue(IComparer<TPriority>? priorityComparer)
+        : this(0, priorityComparer, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class with
+    /// the specified initial capacity and priority comparer.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the heap. Must be non-negative.</param>
+    /// <param name="priorityComparer">
+    /// The comparer used to order priorities, or <see langword="null"/> to use <see cref="Comparer{T}.Default"/>.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
+    public IndexedPriorityQueue(int capacity, IComparer<TPriority>? priorityComparer)
+        : this(capacity, priorityComparer, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class with
+    /// the specified initial capacity, priority comparer, and element comparer.
+    /// </summary>
+    /// <param name="capacity">The initial capacity of the heap. Must be non-negative.</param>
+    /// <param name="priorityComparer">
+    /// The comparer used to order priorities, or <see langword="null"/> to use <see cref="Comparer{T}.Default"/>.
+    /// </param>
+    /// <param name="elementComparer">
+    /// The comparer used to test element equality, or <see langword="null"/> to use <see cref="EqualityComparer{T}.Default"/>.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
+    public IndexedPriorityQueue(int capacity, IComparer<TPriority>? priorityComparer, IEqualityComparer<TElement>? elementComparer)
+    {
+        ThrowHelper.ThrowIfNegative(capacity);
+
+        _nodes = capacity == 0
+            ? Array.Empty<(TElement, TPriority)>()
+            : new (TElement, TPriority)[capacity];
+        _comparer = priorityComparer ?? Comparer<TPriority>.Default;
+        _index = new Dictionary<TElement, int>(capacity, elementComparer ?? EqualityComparer<TElement>.Default);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class
+    /// containing the supplied element-priority pairs, heapified in O(n).
+    /// </summary>
+    /// <param name="items">
+    /// The element-priority pairs used to populate the queue. Element keys must be unique. Must not be <see langword="null"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="items"/> contains a duplicate element key.</exception>
+    public IndexedPriorityQueue(IEnumerable<KeyValuePair<TElement, TPriority>> items)
+        : this(items, null, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueue{TElement, TPriority}"/> class
+    /// containing the supplied element-priority pairs, with the specified priority and element comparers.
+    /// </summary>
+    /// <param name="items">
+    /// The element-priority pairs used to populate the queue. Element keys must be unique. Must not be <see langword="null"/>.
+    /// </param>
+    /// <param name="priorityComparer">
+    /// The comparer used to order priorities, or <see langword="null"/> to use <see cref="Comparer{T}.Default"/>.
+    /// </param>
+    /// <param name="elementComparer">
+    /// The comparer used to test element equality, or <see langword="null"/> to use <see cref="EqualityComparer{T}.Default"/>.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="items"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="items"/> contains a duplicate element key.</exception>
+    /// <remarks>
+    /// When <paramref name="items"/> implements <see cref="ICollection{T}"/> the backing array is allocated
+    /// up-front to its <see cref="ICollection{T}.Count"/> and the heap is built bottom-up in O(n);
+    /// otherwise the array grows on demand as items are appended.
+    /// </remarks>
+    public IndexedPriorityQueue(IEnumerable<KeyValuePair<TElement, TPriority>> items, IComparer<TPriority>? priorityComparer, IEqualityComparer<TElement>? elementComparer)
+    {
+        ThrowHelper.ThrowIfNull(items);
+
+        _comparer = priorityComparer ?? Comparer<TPriority>.Default;
+        IEqualityComparer<TElement> resolvedElementComparer = elementComparer ?? EqualityComparer<TElement>.Default;
+
+        if (items is ICollection<KeyValuePair<TElement, TPriority>> collection)
+        {
+            int initialCapacity = collection.Count;
+            _nodes = initialCapacity == 0
+                ? Array.Empty<(TElement, TPriority)>()
+                : new (TElement, TPriority)[initialCapacity];
+            _index = new Dictionary<TElement, int>(initialCapacity, resolvedElementComparer);
+        }
+        else
+        {
+            _nodes = Array.Empty<(TElement, TPriority)>();
+            _index = new Dictionary<TElement, int>(resolvedElementComparer);
+        }
+
+        foreach (KeyValuePair<TElement, TPriority> pair in items)
+        {
+            ThrowHelper.ThrowIfNull(pair.Key);
+            if (!_index.TryAdd(pair.Key, _size))
+                throw new ArgumentException(string.Format(DuplicateElementMessageFormat, pair.Key), nameof(items));
+
+            if (_size == _nodes.Length)
+                Grow(_size + 1);
+
+            _nodes[_size] = (pair.Key, pair.Value);
+            _size++;
+        }
+
+        Heapify();
+    }
+
+    /// <summary>
+    /// Gets the number of elements contained in the queue.
+    /// </summary>
+    /// <returns>The current element count.</returns>
+    public int Count => _size;
+
+    /// <summary>
+    /// Gets the total number of elements the internal data structure can hold without resizing.
+    /// </summary>
+    /// <returns>The length of the internal heap array.</returns>
+    public int Capacity => _nodes.Length;
+
+    /// <summary>
+    /// Gets the priority comparer used by the queue to order elements.
+    /// </summary>
+    /// <returns>The configured <see cref="IComparer{TPriority}"/>.</returns>
+    public IComparer<TPriority> Comparer => _comparer;
+
+    /// <summary>
+    /// Gets the element equality comparer used by the queue to identify elements.
+    /// </summary>
+    /// <returns>The configured <see cref="IEqualityComparer{TElement}"/>.</returns>
+    public IEqualityComparer<TElement> ElementComparer => _index.Comparer;
+
+    /// <summary>
+    /// Determines whether the queue contains the specified element.
+    /// </summary>
+    /// <param name="element">The element to locate. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the element is present; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    public bool Contains(TElement element)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        return _index.ContainsKey(element);
+    }
+
+    /// <summary>
+    /// Retrieves the priority associated with the specified element.
+    /// </summary>
+    /// <param name="element">The element whose priority is to be retrieved. Must not be <see langword="null"/>.</param>
+    /// <returns>The priority currently associated with <paramref name="element"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    /// <exception cref="KeyNotFoundException"><paramref name="element"/> is not present in the queue.</exception>
+    public TPriority GetPriority(TElement element)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (!_index.TryGetValue(element, out int slot))
+            throw new KeyNotFoundException(string.Format(ElementNotFoundMessageFormat, element));
+
+        return _nodes[slot].Priority;
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the priority associated with the specified element.
+    /// </summary>
+    /// <param name="element">The element whose priority is to be retrieved. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">
+    /// When this method returns, contains the priority associated with <paramref name="element"/> if found;
+    /// otherwise, the default value of <typeparamref name="TPriority"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if the element was found; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    public bool TryGetPriority(TElement element, out TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (_index.TryGetValue(element, out int slot))
+        {
+            priority = _nodes[slot].Priority;
+            return true;
+        }
+
+        priority = default!;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the element-priority pair at the head of the queue without removing it.
+    /// </summary>
+    /// <returns>The element-priority pair with the smallest priority per the configured comparer.</returns>
+    /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+    public KeyValuePair<TElement, TPriority> Peek()
+    {
+        if (_size == 0)
+            throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionEmpty);
+
+        (TElement Element, TPriority Priority) head = _nodes[0];
+        return new KeyValuePair<TElement, TPriority>(head.Element, head.Priority);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the element-priority pair at the head of the queue without removing it.
+    /// </summary>
+    /// <param name="element">When this method returns, contains the head element if the queue is non-empty; otherwise, the default value of <typeparamref name="TElement"/>.</param>
+    /// <param name="priority">When this method returns, contains the head priority if the queue is non-empty; otherwise, the default value of <typeparamref name="TPriority"/>.</param>
+    /// <returns><see langword="true"/> if a head element was retrieved; otherwise, <see langword="false"/>.</returns>
+    public bool TryPeek(out TElement element, out TPriority priority)
+    {
+        if (_size == 0)
+        {
+            element = default!;
+            priority = default!;
+            return false;
+        }
+
+        (TElement Element, TPriority Priority) head = _nodes[0];
+        element = head.Element;
+        priority = head.Priority;
+        return true;
+    }
+
+    /// <summary>
+    /// Adds the specified element with the specified priority. The element must not already be present.
+    /// </summary>
+    /// <param name="element">The element to add. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">The priority associated with the element.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException"><paramref name="element"/> is already present in the queue.</exception>
+    public void Enqueue(TElement element, TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (!TryEnqueueCore(element, priority))
+            throw new ArgumentException(string.Format(DuplicateElementMessageFormat, element), nameof(element));
+    }
+
+    /// <summary>
+    /// Attempts to add the specified element with the specified priority.
+    /// </summary>
+    /// <param name="element">The element to add. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">The priority associated with the element.</param>
+    /// <returns><see langword="true"/> if the element was added; <see langword="false"/> if it was already present.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    public bool TryEnqueue(TElement element, TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        return TryEnqueueCore(element, priority);
+    }
+
+    /// <summary>
+    /// Adds the specified element with the specified priority, or re-prioritises it if already present.
+    /// </summary>
+    /// <param name="element">The element to add or update. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">The priority to assign.</param>
+    /// <returns>
+    /// <see langword="true"/> if the element was added; <see langword="false"/> if an existing entry was updated.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    /// <remarks>This is the canonical primitive for Dijkstra-style relaxation steps.</remarks>
+    public bool EnqueueOrUpdate(TElement element, TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (_index.TryGetValue(element, out int slot))
+        {
+            UpdateAt(slot, priority);
+            return false;
+        }
+
+        EnqueueCore(element, priority);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes and returns the element-priority pair at the head of the queue.
+    /// </summary>
+    /// <returns>The dequeued element-priority pair.</returns>
+    /// <exception cref="InvalidOperationException">The queue is empty.</exception>
+    public KeyValuePair<TElement, TPriority> Dequeue()
+    {
+        if (_size == 0)
+            throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionEmpty);
+
+        (TElement Element, TPriority Priority) head = _nodes[0];
+        RemoveAt(0);
+        return new KeyValuePair<TElement, TPriority>(head.Element, head.Priority);
+    }
+
+    /// <summary>
+    /// Attempts to remove and return the element-priority pair at the head of the queue.
+    /// </summary>
+    /// <param name="element">When this method returns, contains the dequeued element if successful; otherwise, the default value of <typeparamref name="TElement"/>.</param>
+    /// <param name="priority">When this method returns, contains the dequeued priority if successful; otherwise, the default value of <typeparamref name="TPriority"/>.</param>
+    /// <returns><see langword="true"/> if an element was dequeued; otherwise, <see langword="false"/>.</returns>
+    public bool TryDequeue(out TElement element, out TPriority priority)
+    {
+        if (_size == 0)
+        {
+            element = default!;
+            priority = default!;
+            return false;
+        }
+
+        (TElement Element, TPriority Priority) head = _nodes[0];
+        element = head.Element;
+        priority = head.Priority;
+        RemoveAt(0);
+        return true;
+    }
+
+    /// <summary>
+    /// Re-prioritises the specified element. The element must already be present.
+    /// </summary>
+    /// <param name="element">The element to re-prioritise. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">The new priority to assign.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    /// <exception cref="KeyNotFoundException"><paramref name="element"/> is not present in the queue.</exception>
+    /// <remarks>
+    /// Works for both decrease-key and increase-key. Cost is O(log n) and includes a single sift-up
+    /// or sift-down of the moved node; if the priority is unchanged the operation is a no-op.
+    /// </remarks>
+    public void Update(TElement element, TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (!_index.TryGetValue(element, out int slot))
+            throw new KeyNotFoundException(string.Format(ElementNotFoundMessageFormat, element));
+
+        UpdateAt(slot, priority);
+    }
+
+    /// <summary>
+    /// Attempts to re-prioritise the specified element.
+    /// </summary>
+    /// <param name="element">The element to re-prioritise. Must not be <see langword="null"/>.</param>
+    /// <param name="priority">The new priority to assign.</param>
+    /// <returns><see langword="true"/> if the element was found and updated; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    public bool TryUpdate(TElement element, TPriority priority)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (!_index.TryGetValue(element, out int slot))
+            return false;
+
+        UpdateAt(slot, priority);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the specified element from the queue if present.
+    /// </summary>
+    /// <param name="element">The element to remove. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if the element was found and removed; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="element"/> is <see langword="null"/>.</exception>
+    public bool Remove(TElement element)
+    {
+        ThrowHelper.ThrowIfNull(element);
+
+        if (!_index.TryGetValue(element, out int slot))
+            return false;
+
+        RemoveAt(slot);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes all elements from the queue.
+    /// </summary>
+    /// <remarks>
+    /// The backing capacity is preserved; call <see cref="TrimExcess"/> to release the unused storage.
+    /// </remarks>
+    public void Clear()
+    {
+        if (_size == 0)
+            return;
+
+        Array.Clear(_nodes, 0, _size);
+        _index.Clear();
+        _size = 0;
+        _version++;
+    }
+
+    /// <summary>
+    /// Ensures that the internal storage can hold at least <paramref name="capacity"/> elements without reallocating.
+    /// </summary>
+    /// <param name="capacity">The minimum capacity to ensure. Must be non-negative.</param>
+    /// <returns>The new capacity of the internal storage.</returns>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="capacity"/> is negative.</exception>
+    public int EnsureCapacity(int capacity)
+    {
+        ThrowHelper.ThrowIfNegative(capacity);
+
+        if (_nodes.Length < capacity)
+            Grow(capacity);
+
+        return _nodes.Length;
+    }
+
+    /// <summary>
+    /// Reduces the internal storage to match the current element count.
+    /// </summary>
+    /// <remarks>This method does not bump the modification version: enumerators remain valid.</remarks>
+    public void TrimExcess()
+    {
+        if (_size == _nodes.Length)
+            return;
+
+        if (_size == 0)
+        {
+            _nodes = Array.Empty<(TElement, TPriority)>();
+            return;
+        }
+
+        var trimmed = new (TElement, TPriority)[_size];
+        Array.Copy(_nodes, trimmed, _size);
+        _nodes = trimmed;
+    }
+
+    /// <summary>
+    /// Returns a struct enumerator that walks the heap storage in array order.
+    /// </summary>
+    /// <returns>A new <see cref="Enumerator"/> bound to this queue.</returns>
+    /// <remarks>
+    /// Enumeration is in heap-storage order, not priority order. To enumerate in priority order, drain the
+    /// queue with successive <see cref="Dequeue"/> calls.
+    /// </remarks>
+    public Enumerator GetEnumerator() => new(this);
+
+    /// <summary>
+    /// Inserts an element-priority pair without performing input validation. The element must not be present.
+    /// </summary>
+    /// <param name="element">The element to insert.</param>
+    /// <param name="priority">The associated priority.</param>
+    private void EnqueueCore(TElement element, TPriority priority)
+    {
+        if (_size == _nodes.Length)
+            Grow(_size + 1);
+
+        int slot = _size;
+        _nodes[slot] = (element, priority);
+        _index[element] = slot;
+        _size++;
+        _version++;
+
+        SiftUp(slot);
+    }
+
+    /// <summary>
+    /// Attempts to insert an element-priority pair, returning <see langword="false"/> if the element is already present.
+    /// </summary>
+    /// <param name="element">The element to insert.</param>
+    /// <param name="priority">The associated priority.</param>
+    /// <returns><see langword="true"/> if the element was inserted; otherwise, <see langword="false"/>.</returns>
+    private bool TryEnqueueCore(TElement element, TPriority priority)
+    {
+        if (_index.ContainsKey(element))
+            return false;
+
+        EnqueueCore(element, priority);
+        return true;
+    }
+
+    /// <summary>
+    /// Re-prioritises the node at the specified slot, performing the appropriate sift-up or sift-down.
+    /// </summary>
+    /// <param name="slot">The slot in <see cref="_nodes"/> whose priority is being changed.</param>
+    /// <param name="newPriority">The replacement priority.</param>
+    private void UpdateAt(int slot, TPriority newPriority)
+    {
+        TPriority oldPriority = _nodes[slot].Priority;
+        int direction = _comparer.Compare(newPriority, oldPriority);
+        if (direction == 0)
+            return;
+
+        _nodes[slot] = (_nodes[slot].Element, newPriority);
+        _version++;
+
+        if (direction < 0)
+            SiftUp(slot);
+        else
+            SiftDown(slot);
+    }
+
+    /// <summary>
+    /// Removes the node at the specified slot, repairing the heap by moving the trailing node into the gap
+    /// and sifting it up or down as required.
+    /// </summary>
+    /// <param name="slot">The slot in <see cref="_nodes"/> to remove.</param>
+    private void RemoveAt(int slot)
+    {
+        int lastIndex = _size - 1;
+        (TElement Element, TPriority Priority) removed = _nodes[slot];
+        _index.Remove(removed.Element);
+
+        if (slot < lastIndex)
+        {
+            (TElement Element, TPriority Priority) moved = _nodes[lastIndex];
+            _nodes[slot] = moved;
+            _index[moved.Element] = slot;
+
+            int direction = _comparer.Compare(moved.Priority, removed.Priority);
+            if (direction < 0)
+                SiftUp(slot);
+            else if (direction > 0)
+                SiftDown(slot);
+        }
+
+        _nodes[lastIndex] = default!;
+        _size = lastIndex;
+        _version++;
+    }
+
+    /// <summary>
+    /// Bubbles the node at <paramref name="slot"/> toward the root while it has a smaller priority than its parent.
+    /// </summary>
+    /// <param name="slot">The starting slot to sift upward.</param>
+    private void SiftUp(int slot)
+    {
+        while (slot > 0)
+        {
+            int parent = (slot - 1) >> 1;
+            if (_comparer.Compare(_nodes[slot].Priority, _nodes[parent].Priority) >= 0)
+                break;
+
+            Swap(slot, parent);
+            slot = parent;
+        }
+    }
+
+    /// <summary>
+    /// Bubbles the node at <paramref name="slot"/> toward the leaves while a child has a smaller priority.
+    /// </summary>
+    /// <param name="slot">The starting slot to sift downward.</param>
+    private void SiftDown(int slot)
+    {
+        int half = _size >> 1;
+        while (slot < half)
+        {
+            int left = (slot << 1) + 1;
+            int right = left + 1;
+            int target = (right < _size && _comparer.Compare(_nodes[right].Priority, _nodes[left].Priority) < 0)
+                ? right
+                : left;
+
+            if (_comparer.Compare(_nodes[target].Priority, _nodes[slot].Priority) >= 0)
+                break;
+
+            Swap(slot, target);
+            slot = target;
+        }
+    }
+
+    /// <summary>
+    /// Swaps the two specified slots in <see cref="_nodes"/> and updates <see cref="_index"/> accordingly.
+    /// </summary>
+    /// <param name="a">The first slot to swap.</param>
+    /// <param name="b">The second slot to swap.</param>
+    private void Swap(int a, int b)
+    {
+        (TElement Element, TPriority Priority) temp = _nodes[a];
+        _nodes[a] = _nodes[b];
+        _nodes[b] = temp;
+
+        _index[_nodes[a].Element] = a;
+        _index[_nodes[b].Element] = b;
+    }
+
+    /// <summary>
+    /// Builds the heap invariant from the bottom up in O(n).
+    /// </summary>
+    /// <remarks>Used only by the <see cref="IEnumerable{T}"/> constructor before the queue is observable.</remarks>
+    private void Heapify()
+    {
+        for (int i = (_size - 2) >> 1; i >= 0; i--)
+            SiftDown(i);
+    }
+
+    /// <summary>
+    /// Expands the backing array to at least <paramref name="minCapacity"/> elements, doubling the existing
+    /// length where possible.
+    /// </summary>
+    /// <param name="minCapacity">The minimum capacity required after the resize.</param>
+    private void Grow(int minCapacity)
+    {
+        int newCapacity = _nodes.Length == 0 ? DefaultGrowCapacity : _nodes.Length * 2;
+        if ((uint)newCapacity > Array.MaxLength)
+            newCapacity = Array.MaxLength;
+        if (newCapacity < minCapacity)
+            newCapacity = minCapacity;
+
+        var resized = new (TElement, TPriority)[newCapacity];
+        if (_size > 0)
+            Array.Copy(_nodes, resized, _size);
+        _nodes = resized;
+    }
+
+    /// <summary>
+    /// The composite-format string used when reporting a duplicate element key. The single placeholder
+    /// receives the offending element's <see cref="object.ToString"/> representation.
+    /// </summary>
+    private const string DuplicateElementMessageFormat = "An element with the key '{0}' already exists in the queue.";
+
+    /// <summary>
+    /// The composite-format string used when reporting a missing element key. The single placeholder
+    /// receives the requested element's <see cref="object.ToString"/> representation.
+    /// </summary>
+    private const string ElementNotFoundMessageFormat = "The element '{0}' was not found in the queue.";
+}

--- a/Bodu.Core/src/Collections.Generic/IndexedPriorityQueueDebugView.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedPriorityQueueDebugView.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueDebugView.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Provides a debugger-friendly view of the contents of an
+/// <see cref="IndexedPriorityQueue{TElement, TPriority}"/>.
+/// </summary>
+/// <typeparam name="TElement">Specifies the element type of the underlying queue.</typeparam>
+/// <typeparam name="TPriority">Specifies the priority type of the underlying queue.</typeparam>
+/// <remarks>
+/// The view materialises the queue's element-priority pairs into an array sorted by priority so that the
+/// debugger surfaces the dequeue order rather than the heap-storage order. The underlying queue is not
+/// mutated by this view.
+/// </remarks>
+internal sealed class IndexedPriorityQueueDebugView<TElement, TPriority>
+    where TElement : notnull
+{
+    /// <summary>
+    /// The queue instance being inspected.
+    /// </summary>
+    private readonly IndexedPriorityQueue<TElement, TPriority> _queue;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="IndexedPriorityQueueDebugView{TElement, TPriority}"/> class.
+    /// </summary>
+    /// <param name="queue">The queue instance to debug. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="queue"/> is <see langword="null"/>.</exception>
+    public IndexedPriorityQueueDebugView(IndexedPriorityQueue<TElement, TPriority> queue) =>
+        _queue = queue ?? throw new ArgumentNullException(nameof(queue));
+
+    /// <summary>
+    /// Gets the queue's element-priority pairs sorted in dequeue (priority) order for display in the debugger.
+    /// </summary>
+    /// <returns>An array of pairs ordered ascending by the queue's configured comparer.</returns>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public KeyValuePair<TElement, TPriority>[] Items =>
+        _queue.OrderBy(pair => pair.Value, _queue.Comparer).ToArray();
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueDebugViewTests.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueDebugViewTests.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueDebugViewTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+[TestClass]
+public class IndexedPriorityQueueDebugViewTests
+{
+    /// <summary>
+    /// Verifies that the debug view constructor throws <see cref="ArgumentNullException" /> when given a null queue.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenQueueIsNull_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new IndexedPriorityQueueDebugView<string, int>(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the debug view exposes items sorted ascending by priority.
+    /// </summary>
+    [TestMethod]
+    public void Items_WhenQueueHasMultipleEntries_ShouldReturnPriorityOrderedArray()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 30);
+        queue.Enqueue("b", 10);
+        queue.Enqueue("c", 20);
+
+        var view = new IndexedPriorityQueueDebugView<string, int>(queue);
+        var items = view.Items;
+
+        Assert.AreEqual(3, items.Length);
+        Assert.AreEqual("b", items[0].Key);
+        Assert.AreEqual("c", items[1].Key);
+        Assert.AreEqual("a", items[2].Key);
+    }
+
+    /// <summary>
+    /// Verifies that the debug view returns an empty array when the queue is empty.
+    /// </summary>
+    [TestMethod]
+    public void Items_WhenQueueIsEmpty_ShouldReturnEmptyArray()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        var view = new IndexedPriorityQueueDebugView<string, int>(queue);
+
+        Assert.AreEqual(0, view.Items.Length);
+    }
+
+    /// <summary>
+    /// Verifies that the debug view does not mutate the queue.
+    /// </summary>
+    [TestMethod]
+    public void Items_WhenAccessed_ShouldNotMutateQueue()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+
+        var view = new IndexedPriorityQueueDebugView<string, int>(queue);
+        _ = view.Items;
+
+        Assert.AreEqual(2, queue.Count);
+        Assert.IsTrue(queue.Contains("a"));
+        Assert.IsTrue(queue.Contains("b"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Capacity.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Capacity.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Capacity.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.EnsureCapacity" /> grows the backing array.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenLargerThanCurrent_ShouldGrowBacking()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(2);
+
+        int newCapacity = queue.EnsureCapacity(64);
+
+        Assert.IsTrue(newCapacity >= 64);
+        Assert.IsTrue(queue.Capacity >= 64);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.EnsureCapacity" /> does not shrink existing capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenSmallerThanCurrent_ShouldPreserveCapacity()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(64);
+
+        int newCapacity = queue.EnsureCapacity(8);
+
+        Assert.AreEqual(64, newCapacity);
+        Assert.AreEqual(64, queue.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that a negative argument to <see cref="IndexedPriorityQueue{TElement, TPriority}.EnsureCapacity" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenNegative_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = queue.EnsureCapacity(-1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TrimExcess" /> shrinks the backing array to <c>Count</c>.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCapacityExceedsCount_ShouldShrinkToCount()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(64);
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+        queue.Enqueue("c", 3);
+
+        queue.TrimExcess();
+
+        Assert.AreEqual(3, queue.Capacity);
+        Assert.AreEqual(3, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TrimExcess" /> on an empty queue resets capacity to zero.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenQueueIsEmpty_ShouldResetCapacityToZero()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(64);
+
+        queue.TrimExcess();
+
+        Assert.AreEqual(0, queue.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TrimExcess" /> preserves heap order.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenInvoked_ShouldPreserveDequeueOrder()
+    {
+        var queue = new IndexedPriorityQueue<int, int>(64);
+        for (int i = 0; i < 10; i++)
+            queue.Enqueue(i, 100 - i);
+
+        queue.TrimExcess();
+
+        var drained = DrainAll(queue);
+        AssertNonDecreasing(drained);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Clear.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Clear.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Clear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Clear" /> empties the queue and resets <c>Count</c>.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenQueueIsNonEmpty_ShouldRemoveAllElements()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+
+        queue.Clear();
+
+        Assert.AreEqual(0, queue.Count);
+        Assert.IsFalse(queue.Contains("a"));
+        Assert.IsFalse(queue.Contains("b"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Clear" /> on an empty queue is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenQueueIsEmpty_ShouldRemainEmpty()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Clear();
+
+        Assert.AreEqual(0, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the queue can be reused after <see cref="IndexedPriorityQueue{TElement, TPriority}.Clear" />.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenFollowedByEnqueue_ShouldAcceptNewElements()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Clear();
+        queue.Enqueue("a", 99);
+
+        Assert.AreEqual(1, queue.Count);
+        Assert.AreEqual(99, queue.GetPriority("a"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Clear" /> preserves the backing capacity.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenInvoked_ShouldPreserveCapacity()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(64);
+        queue.Enqueue("a", 1);
+
+        int capacityBefore = queue.Capacity;
+        queue.Clear();
+
+        Assert.AreEqual(capacityBefore, queue.Capacity);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Contains.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Contains.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Contains.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Contains" /> returns <see langword="true" /> for a present element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementPresent_ShouldReturnTrue()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.IsTrue(queue.Contains("a"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Contains" /> returns <see langword="false" /> for a missing element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementMissing_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.IsFalse(queue.Contains("b"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Contains" /> with a <see langword="null" /> element throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementIsNull_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = queue.Contains(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.GetPriority" /> returns the stored priority.
+    /// </summary>
+    [TestMethod]
+    public void GetPriority_WhenElementPresent_ShouldReturnPriority()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 42);
+
+        Assert.AreEqual(42, queue.GetPriority("a"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.GetPriority" /> on a missing element throws <see cref="KeyNotFoundException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetPriority_WhenElementMissing_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<KeyNotFoundException>(() =>
+        {
+            _ = queue.GetPriority("missing");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryGetPriority" /> returns <see langword="true" /> and the priority for a present element.
+    /// </summary>
+    [TestMethod]
+    public void TryGetPriority_WhenElementPresent_ShouldReturnTrue()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 42);
+
+        Assert.IsTrue(queue.TryGetPriority("a", out int priority));
+        Assert.AreEqual(42, priority);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryGetPriority" /> returns <see langword="false" /> for a missing element.
+    /// </summary>
+    [TestMethod]
+    public void TryGetPriority_WhenElementMissing_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsFalse(queue.TryGetPriority("missing", out int priority));
+        Assert.AreEqual(0, priority);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Ctor.cs
@@ -1,0 +1,185 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Ctor.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that the parameterless constructor produces an empty queue with zero capacity.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenDefaultUsed_ShouldCreateEmptyQueue()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.AreEqual(0, queue.Count);
+        Assert.AreEqual(0, queue.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a positive capacity allocates the backing array up-front.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(8)]
+    [DataRow(1024)]
+    public void Ctor_WhenCapacityProvided_ShouldSetCapacity(int capacity)
+    {
+        var queue = new IndexedPriorityQueue<string, int>(capacity);
+
+        Assert.AreEqual(capacity, queue.Capacity);
+        Assert.AreEqual(0, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a negative capacity throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void Ctor_WhenCapacityIsNegative_ShouldThrowExactly(int capacity)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new IndexedPriorityQueue<string, int>(capacity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null priority comparer falls back to <see cref="Comparer{T}.Default" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenPriorityComparerIsNull_ShouldUseDefaultComparer()
+    {
+        var queue = new IndexedPriorityQueue<string, int>((IComparer<int>?)null);
+
+        Assert.AreSame(Comparer<int>.Default, queue.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that a custom priority comparer is exposed via <see cref="IndexedPriorityQueue{TElement, TPriority}.Comparer" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenPriorityComparerProvided_ShouldExposeComparer()
+    {
+        IComparer<int> reverse = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        var queue = new IndexedPriorityQueue<string, int>(0, reverse);
+
+        Assert.AreSame(reverse, queue.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that a null element comparer falls back to <see cref="EqualityComparer{T}.Default" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenElementComparerIsNull_ShouldUseDefaultElementComparer()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(0, null, null);
+
+        Assert.AreSame(EqualityComparer<string>.Default, queue.ElementComparer);
+    }
+
+    /// <summary>
+    /// Verifies that a custom element comparer is exposed via <see cref="IndexedPriorityQueue{TElement, TPriority}.ElementComparer" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenElementComparerProvided_ShouldExposeElementComparer()
+    {
+        IEqualityComparer<string> ignoreCase = StringComparer.OrdinalIgnoreCase;
+        var queue = new IndexedPriorityQueue<string, int>(0, null, ignoreCase);
+
+        Assert.AreSame(ignoreCase, queue.ElementComparer);
+    }
+
+    /// <summary>
+    /// Verifies that a null source enumerable throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenItemsCollectionIsNull_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new IndexedPriorityQueue<string, int>((IEnumerable<KeyValuePair<string, int>>)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the items constructor populates the queue with all supplied pairs.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenItemsProvided_ShouldPopulateQueue()
+    {
+        var items = new[]
+        {
+            new KeyValuePair<string, int>("c", 30),
+            new KeyValuePair<string, int>("a", 10),
+            new KeyValuePair<string, int>("b", 20),
+        };
+
+        var queue = new IndexedPriorityQueue<string, int>(items);
+
+        Assert.AreEqual(3, queue.Count);
+        Assert.IsTrue(queue.Contains("a"));
+        Assert.IsTrue(queue.Contains("b"));
+        Assert.IsTrue(queue.Contains("c"));
+    }
+
+    /// <summary>
+    /// Verifies that the items constructor heapifies its input so that <see cref="IndexedPriorityQueue{TElement, TPriority}.Dequeue" /> yields ascending priorities.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenItemsProvided_ShouldDequeueInPriorityOrder()
+    {
+        var items = new[]
+        {
+            new KeyValuePair<int, int>(1, 50),
+            new KeyValuePair<int, int>(2, 10),
+            new KeyValuePair<int, int>(3, 40),
+            new KeyValuePair<int, int>(4, 20),
+            new KeyValuePair<int, int>(5, 30),
+        };
+
+        var queue = new IndexedPriorityQueue<int, int>(items);
+        var drained = DrainAll(queue);
+
+        AssertNonDecreasing(drained);
+        CollectionAssert.AreEqual(new[] { 2, 4, 5, 3, 1 }, drained.Select(p => p.Key).ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate element key in the source enumerable throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenItemsContainDuplicateKey_ShouldThrowExactly()
+    {
+        var items = new[]
+        {
+            new KeyValuePair<string, int>("a", 1),
+            new KeyValuePair<string, int>("a", 2),
+        };
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = new IndexedPriorityQueue<string, int>(items);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a non-collection enumerable source is consumed correctly.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenItemsProvidedAsEnumerable_ShouldPopulateQueue()
+    {
+        IEnumerable<KeyValuePair<int, int>> source =
+            Enumerable.Range(1, 5).Select(i => new KeyValuePair<int, int>(i, 100 - i));
+
+        var queue = new IndexedPriorityQueue<int, int>(source);
+
+        Assert.AreEqual(5, queue.Count);
+        Assert.AreEqual(5, queue.Peek().Key); // smallest priority is element 5 with priority 95
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Dequeue.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Dequeue.cs
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Dequeue.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Dequeue" /> removes the element with the smallest priority.
+    /// </summary>
+    [TestMethod]
+    public void Dequeue_WhenQueueIsNonEmpty_ShouldReturnSmallestPriorityElement()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 30);
+        queue.Enqueue("b", 10);
+        queue.Enqueue("c", 20);
+
+        var head = queue.Dequeue();
+
+        Assert.AreEqual("b", head.Key);
+        Assert.AreEqual(10, head.Value);
+        Assert.AreEqual(2, queue.Count);
+        Assert.IsFalse(queue.Contains("b"));
+    }
+
+    /// <summary>
+    /// Verifies that draining the queue yields elements in non-decreasing priority order.
+    /// </summary>
+    [TestMethod]
+    public void Dequeue_WhenDrainingMultipleElements_ShouldYieldPriorityOrder()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        int[] priorities = { 50, 10, 40, 20, 30, 5, 70, 60 };
+        for (int i = 0; i < priorities.Length; i++)
+            queue.Enqueue(i, priorities[i]);
+
+        var drained = DrainAll(queue);
+
+        AssertNonDecreasing(drained);
+        Assert.AreEqual(priorities.Length, drained.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Dequeue" /> on an empty queue throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Dequeue_WhenQueueIsEmpty_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = queue.Dequeue();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryDequeue" /> returns <see langword="false" /> on an empty queue and leaves outputs at default.
+    /// </summary>
+    [TestMethod]
+    public void TryDequeue_WhenQueueIsEmpty_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsFalse(queue.TryDequeue(out string? element, out int priority));
+        Assert.IsNull(element);
+        Assert.AreEqual(0, priority);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryDequeue" /> returns the head pair when the queue is non-empty.
+    /// </summary>
+    [TestMethod]
+    public void TryDequeue_WhenQueueIsNonEmpty_ShouldReturnHeadPair()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 5);
+        queue.Enqueue("b", 1);
+
+        Assert.IsTrue(queue.TryDequeue(out string? element, out int priority));
+        Assert.AreEqual("b", element);
+        Assert.AreEqual(1, priority);
+        Assert.AreEqual(1, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that with a reverse priority comparer the queue behaves as a max-heap.
+    /// </summary>
+    [TestMethod]
+    public void Dequeue_WhenComparerIsReversed_ShouldBehaveAsMaxHeap()
+    {
+        IComparer<int> reverse = Comparer<int>.Create((a, b) => b.CompareTo(a));
+        var queue = new IndexedPriorityQueue<string, int>(0, reverse);
+        queue.Enqueue("a", 10);
+        queue.Enqueue("b", 30);
+        queue.Enqueue("c", 20);
+
+        Assert.AreEqual("b", queue.Dequeue().Key);
+        Assert.AreEqual("c", queue.Dequeue().Key);
+        Assert.AreEqual("a", queue.Dequeue().Key);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Enqueue.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Enqueue.cs
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Enqueue.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Enqueue" /> adds an element and increments <c>Count</c>.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenElementIsNew_ShouldAddAndIncrementCount()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.AreEqual(1, queue.Count);
+        Assert.IsTrue(queue.Contains("a"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Enqueue" /> with a duplicate element throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenElementIsDuplicate_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            queue.Enqueue("a", 2);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that enqueuing a <see langword="null" /> element throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenElementIsNull_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            queue.Enqueue(null!, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryEnqueue" /> returns <see langword="true" /> for a new element.
+    /// </summary>
+    [TestMethod]
+    public void TryEnqueue_WhenElementIsNew_ShouldReturnTrue()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsTrue(queue.TryEnqueue("a", 1));
+        Assert.AreEqual(1, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryEnqueue" /> returns <see langword="false" /> for a duplicate element and leaves the queue unchanged.
+    /// </summary>
+    [TestMethod]
+    public void TryEnqueue_WhenElementIsDuplicate_ShouldReturnFalseAndPreserveCount()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.IsFalse(queue.TryEnqueue("a", 99));
+        Assert.AreEqual(1, queue.Count);
+        Assert.AreEqual(1, queue.GetPriority("a"));
+    }
+
+    /// <summary>
+    /// Verifies that the element comparer (e.g., case-insensitive) drives duplicate detection.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenElementComparerIsCaseInsensitive_ShouldRejectCaseVariantAsDuplicate()
+    {
+        var queue = new IndexedPriorityQueue<string, int>(0, null, StringComparer.OrdinalIgnoreCase);
+        queue.Enqueue("a", 1);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            queue.Enqueue("A", 2);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that successive enqueues grow the backing array beyond the initial capacity.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenExceedingInitialCapacity_ShouldGrowBacking()
+    {
+        var queue = new IndexedPriorityQueue<int, int>(2);
+
+        for (int i = 0; i < 100; i++)
+            queue.Enqueue(i, i);
+
+        Assert.AreEqual(100, queue.Count);
+        Assert.IsTrue(queue.Capacity >= 100);
+    }
+
+    /// <summary>
+    /// Verifies that an enqueue that becomes the new minimum is the next dequeued.
+    /// </summary>
+    [TestMethod]
+    public void Enqueue_WhenNewElementHasSmallestPriority_ShouldBecomeHead()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 50);
+        queue.Enqueue("b", 100);
+        queue.Enqueue("c", 1);
+
+        Assert.AreEqual("c", queue.Peek().Key);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Enumerator.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Enumerator.cs
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that the struct enumerator yields exactly <c>Count</c> pairs covering all elements.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenWalkingHeap_ShouldYieldAllElementsExactlyOnce()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        for (int i = 0; i < 20; i++)
+            queue.Enqueue(i, 100 - i);
+
+        var seen = new HashSet<int>();
+        foreach (var pair in queue)
+            Assert.IsTrue(seen.Add(pair.Key), $"duplicate element {pair.Key}");
+
+        Assert.AreEqual(20, seen.Count);
+    }
+
+    /// <summary>
+    /// Verifies that calling <c>Current</c> before the first <c>MoveNext</c> throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenAccessingCurrentBeforeMoveNext_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        var enumerator = queue.GetEnumerator();
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.Current;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that mutating the queue invalidates an in-flight enumerator on the next <c>MoveNext</c>.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenQueueMutatedDuringEnumeration_ShouldInvalidateEnumerator()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        for (int i = 0; i < 5; i++)
+            queue.Enqueue(i, i);
+
+        var enumerator = queue.GetEnumerator();
+        Assert.IsTrue(enumerator.MoveNext());
+
+        queue.Enqueue(99, 99);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.MoveNext();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>Reset</c> rewinds the enumerator and that subsequent enumeration yields the same set.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenReset_ShouldRestartEnumeration()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        for (int i = 0; i < 5; i++)
+            queue.Enqueue(i, i);
+
+        var enumerator = queue.GetEnumerator();
+        while (enumerator.MoveNext())
+        {
+        }
+
+        enumerator.Reset();
+        int count = 0;
+        while (enumerator.MoveNext())
+            count++;
+
+        Assert.AreEqual(5, count);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Reset</c> on an invalidated enumerator throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetAfterMutation_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        var enumerator = queue.GetEnumerator();
+        queue.Enqueue("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            enumerator.Reset();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>Dispose</c> on the struct enumerator does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenDisposed_ShouldNotThrow()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        var enumerator = queue.GetEnumerator();
+        enumerator.Dispose();
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.ICollection.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.ICollection.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.ICollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <c>ICollection.IsSynchronized</c> is always <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_IsSynchronized_ShouldReturnFalse()
+    {
+        ICollection collection = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsFalse(collection.IsSynchronized);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ICollection.SyncRoot</c> returns a stable, non-null object across calls.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_SyncRoot_ShouldReturnStableNonNullObject()
+    {
+        ICollection collection = new IndexedPriorityQueue<string, int>();
+
+        object first = collection.SyncRoot;
+        object second = collection.SyncRoot;
+
+        Assert.IsNotNull(first);
+        Assert.AreSame(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that <c>CopyTo</c> writes element-priority pairs into a typed destination array.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_CopyTo_WhenDestinationIsTypedArray_ShouldCopyAllPairs()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+        ICollection collection = queue;
+
+        var destination = new KeyValuePair<string, int>[3];
+        collection.CopyTo(destination, 1);
+
+        Assert.AreEqual(default(KeyValuePair<string, int>), destination[0]);
+        Assert.IsTrue(destination[1].Key is "a" or "b");
+        Assert.IsTrue(destination[2].Key is "a" or "b");
+    }
+
+    /// <summary>
+    /// Verifies that <c>CopyTo</c> with a <see langword="null" /> destination throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_CopyTo_WhenArrayIsNull_ShouldThrowExactly()
+    {
+        ICollection collection = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            collection.CopyTo(null!, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>CopyTo</c> with a multidimensional destination throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_CopyTo_WhenArrayIsMultidimensional_ShouldThrowExactly()
+    {
+        ICollection collection = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            collection.CopyTo(new KeyValuePair<string, int>[2, 2], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>CopyTo</c> with a negative starting index throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_CopyTo_WhenIndexIsNegative_ShouldThrowExactly()
+    {
+        ICollection collection = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            collection.CopyTo(new KeyValuePair<string, int>[1], -1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>CopyTo</c> into an array that is too small throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_CopyTo_WhenDestinationTooSmall_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+        ICollection collection = queue;
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            collection.CopyTo(new KeyValuePair<string, int>[1], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>Count</c> on the <see cref="ICollection" /> facet matches the queue's count.
+    /// </summary>
+    [TestMethod]
+    public void ICollection_Count_ShouldMatchQueueCount()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+        ICollection collection = queue;
+
+        Assert.AreEqual(2, collection.Count);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Peek.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Peek.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Peek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Peek" /> returns the smallest-priority pair without removing it.
+    /// </summary>
+    [TestMethod]
+    public void Peek_WhenQueueIsNonEmpty_ShouldReturnHeadWithoutRemoving()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 30);
+        queue.Enqueue("b", 10);
+
+        var head = queue.Peek();
+
+        Assert.AreEqual("b", head.Key);
+        Assert.AreEqual(10, head.Value);
+        Assert.AreEqual(2, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Peek" /> on an empty queue throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Peek_WhenQueueIsEmpty_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = queue.Peek();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryPeek" /> returns <see langword="false" /> on an empty queue.
+    /// </summary>
+    [TestMethod]
+    public void TryPeek_WhenQueueIsEmpty_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsFalse(queue.TryPeek(out string? element, out int priority));
+        Assert.IsNull(element);
+        Assert.AreEqual(0, priority);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryPeek" /> returns the head pair when the queue is non-empty.
+    /// </summary>
+    [TestMethod]
+    public void TryPeek_WhenQueueIsNonEmpty_ShouldReturnHead()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 50);
+        queue.Enqueue("b", 5);
+
+        Assert.IsTrue(queue.TryPeek(out string? element, out int priority));
+        Assert.AreEqual("b", element);
+        Assert.AreEqual(5, priority);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Remove.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that removing the head element preserves the heap invariant for the remainder.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementIsHead_ShouldDropHeadAndPreserveInvariant()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 2);
+        queue.Enqueue("c", 3);
+        queue.Enqueue("d", 4);
+
+        Assert.IsTrue(queue.Remove("a"));
+        Assert.AreEqual(3, queue.Count);
+        Assert.AreEqual("b", queue.Peek().Key);
+    }
+
+    /// <summary>
+    /// Verifies that removing the last (trailing) heap-storage element does not corrupt the queue.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementIsLastInStorage_ShouldRemoveCleanly()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        for (int i = 0; i < 10; i++)
+            queue.Enqueue(i, i);
+
+        // The last storage slot's element is implementation-defined; remove every element by
+        // dequeue order to confirm no corruption.
+        Assert.IsTrue(queue.Remove(9));
+        Assert.IsFalse(queue.Contains(9));
+
+        var drained = DrainAll(queue);
+        AssertNonDecreasing(drained);
+        Assert.AreEqual(9, drained.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Remove" /> returns <see langword="false" /> for a missing element.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementMissing_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+
+        Assert.IsFalse(queue.Remove("missing"));
+        Assert.AreEqual(1, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Remove" /> with a <see langword="null" /> element throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementIsNull_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = queue.Remove(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the heap invariant survives a sequence of removals that triggers both sift-up and sift-down repairs.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenManyMixedElements_ShouldMaintainHeapInvariant()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        for (int i = 0; i < 50; i++)
+            queue.Enqueue(i, (i * 13) % 97);
+
+        // Remove a scattered subset.
+        foreach (int key in new[] { 0, 5, 10, 15, 25, 35, 49 })
+            Assert.IsTrue(queue.Remove(key));
+
+        var drained = DrainAll(queue);
+        AssertNonDecreasing(drained);
+        Assert.AreEqual(50 - 7, drained.Length);
+    }
+
+    /// <summary>
+    /// Verifies that an element re-enqueued after removal is treated as new.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenFollowedByEnqueue_ShouldAcceptElementAsNew()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Remove("a");
+        queue.Enqueue("a", 99);
+
+        Assert.AreEqual(99, queue.GetPriority("a"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Update.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.Update.cs
@@ -1,0 +1,148 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.Update.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Verifies that decreasing an element's priority via <see cref="IndexedPriorityQueue{TElement, TPriority}.Update" /> moves it toward the head.
+    /// </summary>
+    [TestMethod]
+    public void Update_WhenPriorityDecreased_ShouldMoveElementToHead()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 100);
+        queue.Enqueue("b", 50);
+        queue.Enqueue("c", 75);
+
+        queue.Update("a", 1);
+
+        Assert.AreEqual("a", queue.Peek().Key);
+        Assert.AreEqual(1, queue.GetPriority("a"));
+    }
+
+    /// <summary>
+    /// Verifies that increasing an element's priority via <see cref="IndexedPriorityQueue{TElement, TPriority}.Update" /> demotes it.
+    /// </summary>
+    [TestMethod]
+    public void Update_WhenPriorityIncreased_ShouldMoveElementAwayFromHead()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 1);
+        queue.Enqueue("b", 50);
+        queue.Enqueue("c", 75);
+
+        queue.Update("a", 1000);
+
+        Assert.AreNotEqual("a", queue.Peek().Key);
+        Assert.AreEqual(1000, queue.GetPriority("a"));
+    }
+
+    /// <summary>
+    /// Verifies that an update that leaves the priority unchanged is a no-op and does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void Update_WhenPriorityIsUnchanged_ShouldNotInvalidateEnumerator()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 5);
+        queue.Enqueue("b", 10);
+
+        using var enumerator = ((IEnumerable<KeyValuePair<string, int>>)queue).GetEnumerator();
+        queue.Update("a", 5);
+        bool moved = enumerator.MoveNext();
+
+        Assert.IsTrue(moved);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.Update" /> on a missing element throws <see cref="KeyNotFoundException" />.
+    /// </summary>
+    [TestMethod]
+    public void Update_WhenElementMissing_ShouldThrowExactly()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.ThrowsExactly<KeyNotFoundException>(() =>
+        {
+            queue.Update("missing", 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryUpdate" /> returns <see langword="false" /> for a missing element without throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryUpdate_WhenElementMissing_ShouldReturnFalse()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsFalse(queue.TryUpdate("missing", 1));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.TryUpdate" /> returns <see langword="true" /> and re-prioritises an existing element.
+    /// </summary>
+    [TestMethod]
+    public void TryUpdate_WhenElementExists_ShouldReturnTrueAndUpdate()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 100);
+        queue.Enqueue("b", 50);
+
+        Assert.IsTrue(queue.TryUpdate("a", 1));
+        Assert.AreEqual("a", queue.Peek().Key);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.EnqueueOrUpdate" /> adds a new element and returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void EnqueueOrUpdate_WhenElementIsNew_ShouldReturnTrueAndAdd()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+
+        Assert.IsTrue(queue.EnqueueOrUpdate("a", 1));
+        Assert.AreEqual(1, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedPriorityQueue{TElement, TPriority}.EnqueueOrUpdate" /> updates an existing element and returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void EnqueueOrUpdate_WhenElementExists_ShouldReturnFalseAndUpdate()
+    {
+        var queue = new IndexedPriorityQueue<string, int>();
+        queue.Enqueue("a", 100);
+
+        Assert.IsFalse(queue.EnqueueOrUpdate("a", 5));
+        Assert.AreEqual(5, queue.GetPriority("a"));
+        Assert.AreEqual(1, queue.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the heap remains valid after a long mixed sequence of Enqueue, Update, and Remove operations.
+    /// </summary>
+    [TestMethod]
+    public void Update_WhenMixedWithEnqueueAndRemove_ShouldMaintainHeapInvariant()
+    {
+        var queue = new IndexedPriorityQueue<int, int>();
+        var rng = new Random(seed: 12345);
+
+        for (int i = 0; i < 200; i++)
+            queue.Enqueue(i, rng.Next(0, 1_000_000));
+
+        for (int i = 0; i < 200; i += 3)
+            queue.Update(i, rng.Next(0, 1_000_000));
+
+        for (int i = 0; i < 200; i += 7)
+            queue.Remove(i);
+
+        var drained = DrainAll(queue);
+        AssertNonDecreasing(drained);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedPriorityQueueTests.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedPriorityQueueTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic;
+
+[TestClass]
+public partial class IndexedPriorityQueueTests
+{
+    /// <summary>
+    /// Drains the queue and returns every element-priority pair in dequeue order.
+    /// </summary>
+    /// <param name="queue">The queue to drain.</param>
+    /// <returns>An array of pairs ordered by ascending priority.</returns>
+    private static KeyValuePair<TElement, TPriority>[] DrainAll<TElement, TPriority>(
+        IndexedPriorityQueue<TElement, TPriority> queue)
+        where TElement : notnull
+    {
+        var list = new List<KeyValuePair<TElement, TPriority>>(queue.Count);
+        while (queue.Count > 0)
+            list.Add(queue.Dequeue());
+        return list.ToArray();
+    }
+
+    /// <summary>
+    /// Asserts that the priorities of <paramref name="pairs"/> are non-decreasing under
+    /// <see cref="Comparer{T}.Default"/>.
+    /// </summary>
+    /// <param name="pairs">The drained pairs to validate.</param>
+    private static void AssertNonDecreasing<TElement, TPriority>(KeyValuePair<TElement, TPriority>[] pairs)
+        where TElement : notnull
+    {
+        var comparer = Comparer<TPriority>.Default;
+        for (int i = 1; i < pairs.Length; i++)
+            Assert.IsTrue(
+                comparer.Compare(pairs[i - 1].Value, pairs[i].Value) <= 0,
+                $"Priorities not non-decreasing at index {i}: {pairs[i - 1].Value} > {pairs[i].Value}");
+    }
+}


### PR DESCRIPTION
## Summary
Introduces a new `IndexedPriorityQueue<TElement, TPriority>` generic collection that implements a binary min-heap priority queue with O(log n) re-prioritization support. This complements the BCL's `PriorityQueue<TElement, TPriority>` by maintaining an auxiliary element-to-index map, enabling efficient lookup and modification of any element by identity.

## Key Changes

- **Core Implementation** (`IndexedPriorityQueue.cs`): 
  - Binary min-heap data structure with O(1) element lookup via internal dictionary
  - O(log n) operations for enqueue, dequeue, update (decrease/increase key), and remove
  - Support for custom priority and element comparers
  - Bulk initialization from enumerable with O(n) heapification
  - Capacity management with `EnsureCapacity()` and automatic growth

- **Enumerator Support** (`IndexedPriorityQueue.Enumerator.cs`):
  - Struct-based enumerator for heap-storage-order traversal
  - Concurrent modification detection via version tracking
  - Implements `IEnumerable<KeyValuePair<TElement, TPriority>>`

- **ICollection Support** (`IndexedPriorityQueue.ICollection.cs`):
  - Explicit `ICollection` implementation with `CopyTo()` and `SyncRoot`
  - Thread-safety properties (not thread-safe, but provides standard interface)

- **Debug Support** (`IndexedPriorityQueueDebugView.cs`):
  - Debugger-friendly view showing elements in priority order
  - Decorated with `[DebuggerDisplay]` and `[DebuggerTypeProxy]` attributes

- **Comprehensive Test Suite**:
  - Constructor tests covering capacity, comparers, and bulk initialization
  - Operation tests for enqueue, dequeue, peek, update, remove, and clear
  - Enumerator tests including concurrent modification detection
  - ICollection interface compliance tests
  - Capacity management tests
  - Debug view tests

## Notable Implementation Details

- Elements must be non-null and unique within the queue; `Enqueue()` throws `ArgumentException` on duplicates
- Use `EnqueueOrUpdate()` for set semantics (insert-or-update behavior)
- Ordering determined by `IComparer<TPriority>`; smaller priorities dequeued first (min-heap)
- Enumeration walks heap storage order, not priority order; dequeue items sequentially for sorted output
- Not thread-safe; requires external synchronization for concurrent access
- Supports both throwing and non-throwing variants of operations (e.g., `Enqueue` vs `TryEnqueue`)

https://claude.ai/code/session_012WswcqDwTCWJRAxLxiWfNT