### PR TITLE
Refactor ConcurrentCircularBuffer snapshot protocol to use seqlock pattern

### DIFF
--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.IProducerConsumerCollection.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.IProducerConsumerCollection.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBuffer.IProducerConsumerCollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBuffer<T> :
+    IProducerConsumerCollection<T>
+{
+    /// <summary>
+    /// Attempts to add <paramref name="item"/> to the buffer using the producer-side path.
+    /// </summary>
+    /// <param name="item">The element to add. May be <see langword="null"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if the element was enqueued; <see langword="false"/> if the buffer is full and
+    /// <see cref="AllowOverwrite"/> is <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// Forwards to <see cref="TryEnqueue(T)"/>. Provided to satisfy
+    /// <see cref="IProducerConsumerCollection{T}"/> so the buffer can be wrapped by
+    /// <see cref="BlockingCollection{T}"/> for blocking-consumer scenarios.
+    /// </remarks>
+    bool IProducerConsumerCollection<T>.TryAdd(T item) => TryEnqueue(item);
+
+    /// <summary>
+    /// Attempts to remove and return the oldest element from the buffer.
+    /// </summary>
+    /// <param name="item">
+    /// When this method returns <see langword="true"/>, contains the removed element; when it returns
+    /// <see langword="false"/>, contains the default value of <typeparamref name="T"/>.
+    /// </param>
+    /// <returns><see langword="true"/> if an element was removed; otherwise <see langword="false"/>.</returns>
+    /// <remarks>
+    /// Forwards to <see cref="TryDequeue(out T?)"/>. Because <typeparamref name="T"/> is constrained to a
+    /// reference type, the <see cref="MaybeNullWhenAttribute"/> on the interface signature is honoured: the
+    /// out parameter is <see langword="null"/> when the method returns <see langword="false"/>.
+    /// </remarks>
+    bool IProducerConsumerCollection<T>.TryTake([MaybeNullWhen(false)] out T item)
+    {
+        bool taken = TryDequeue(out T? value);
+        item = value!;
+        return taken;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -36,7 +36,13 @@ namespace Bodu.Collections.Generic.Concurrent;
 /// </para>
 /// <para>
 /// When <see cref="AllowOverwrite"/> is <see langword="true"/>, enqueuing into a full buffer evicts the oldest
-/// element and raises the <see cref="ItemEvicted"/> event (after removal). Handler exceptions are swallowed.
+/// element and raises the <see cref="ItemEvicted"/> event (after removal). Handler exceptions are caught and
+/// suppressed; this differs intentionally from the non-concurrent <see cref="CircularBuffer{T}"/>, which
+/// propagates handler exceptions. Under MPMC the eviction has already been committed by the time the event
+/// fires (the head counter has advanced and the slot has been freed by another consumer or producer running in
+/// parallel), so propagating a handler exception cannot abort the eviction and would only obscure the cause of
+/// failure for unrelated callers. Subscribers that need to react to a throwing handler should perform their own
+/// catch/log in the handler body.
 /// </para>
 /// <para>
 /// The <see cref="Count"/> property is approximate under concurrency. For a stable point-in-time view of
@@ -45,6 +51,17 @@ namespace Bodu.Collections.Generic.Concurrent;
 /// <para>
 /// Enumeration iterates over a true snapshot captured at the moment the enumerator is created and does not
 /// reflect subsequent changes.
+/// </para>
+/// <para>
+/// Slots are padded to 64 bytes — the standard cache-line size on x86/x64 hardware — to prevent false sharing
+/// between adjacent producer- and consumer-touched slots. Targets with larger cache lines (notably Apple Silicon
+/// and some ARM SoCs at 128 bytes) remain correct; the padding is conservative on those platforms but does not
+/// degrade throughput.
+/// </para>
+/// <para>
+/// The generic type parameter is constrained to <c>class?</c> because the slot value is published and cleared
+/// through <see cref="System.Threading.Volatile"/> overloads that target reference types. Value-type element
+/// support would require a different publication mechanism and is intentionally out of scope for this type.
 /// </para>
 /// </remarks>
 /// <example>
@@ -181,12 +198,34 @@ public sealed partial class ConcurrentCircularBuffer<T>
     /// Occurs immediately <b>after</b> an item has been evicted because a new item was enqueued into a full buffer while
     /// <see cref="AllowOverwrite"/> is <see langword="true"/>.
     /// </summary>
-    /// <remarks>Exceptions thrown by handlers are caught and ignored.</remarks>
+    /// <remarks>
+    /// <para>
+    /// Exceptions thrown by handlers are caught and suppressed. Each subscriber's invocation is guarded
+    /// independently so that a throwing handler cannot prevent later handlers from receiving the notification.
+    /// </para>
+    /// <para>
+    /// This differs from the non-concurrent <see cref="CircularBuffer{T}.ItemEvicted"/>, which propagates
+    /// handler exceptions to the caller of <see cref="Enqueue"/>. Under MPMC the eviction has already been
+    /// committed by the time this event fires, so propagating the exception would block the caller for a
+    /// failure unrelated to their own write and could not undo the eviction.
+    /// </para>
+    /// </remarks>
     public event Action<T>? ItemEvicted;
 
     /// <summary>
     /// Gets or sets a value indicating whether enqueuing into a full buffer evicts the oldest element.
     /// </summary>
+    /// <value>
+    /// <see langword="true"/> to evict the oldest element when full; <see langword="false"/> to throw or return
+    /// <see langword="false"/> from the producer-side methods.
+    /// </value>
+    /// <returns>The current overwrite policy.</returns>
+    /// <remarks>
+    /// Toggling this property concurrently with an in-flight <see cref="Enqueue"/> or <see cref="TryEnqueue"/>
+    /// is safe but may have a benign window where a producer that observed the previous value commits its
+    /// behaviour (eviction or rejection) before the new value takes effect. The window does not corrupt buffer
+    /// state.
+    /// </remarks>
     public bool AllowOverwrite
     {
         get => Volatile.Read(ref _allowOverwrite);

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -62,7 +62,7 @@ namespace Bodu.Collections.Generic.Concurrent;
 ///]]>
 /// </example>
 [DebuggerDisplay("Count ≈ {Count}, Capacity = {Capacity}")]
-[DebuggerTypeProxy(typeof(CircularBufferDebugView<>))]
+[DebuggerTypeProxy(typeof(ConcurrentCircularBufferDebugView<>))]
 [Serializable]
 public sealed partial class ConcurrentCircularBuffer<T>
     where T : class?

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -87,6 +87,19 @@ public sealed partial class ConcurrentCircularBuffer<T>
     private const int DefaultCapacity = 16;
     private const int MinCapacity = 2;
 
+    /// <summary>
+    /// Maximum number of complete snapshot/index/contains attempts before falling back to a best-effort or
+    /// failing read. Sized for sustained-contention scenarios; under typical load a snapshot stabilises on
+    /// the first attempt.
+    /// </summary>
+    private const int SnapshotOuterRetryBudget = 64;
+
+    /// <summary>
+    /// Maximum number of seqlock pre/post sequence-read retries on a single slot before treating the slot
+    /// as unstable and aborting the surrounding snapshot or index read.
+    /// </summary>
+    private const int SlotReadRetryBudget = 8;
+
     // Immutable after construction
     private readonly Slot[] _buffer;
 
@@ -265,21 +278,58 @@ public sealed partial class ConcurrentCircularBuffer<T>
     public int Capacity => _capacity;
 
     /// <summary>
-    /// Gets the element at the specified zero-based logical index relative to the oldest element (snapshot-based).
+    /// Gets the element at the specified zero-based logical index relative to the oldest element.
     /// </summary>
-    /// <param name="index">The zero-based index of the element to retrieve. Must be non-negative and less than <see cref="Count"/>.</param>
-    /// <returns>The element at the specified logical index within the snapshot.</returns>
+    /// <param name="index">
+    /// The zero-based index of the element to retrieve. Must be non-negative and less than <see cref="Count"/>
+    /// observed at the moment of the call.
+    /// </param>
+    /// <returns>The element that was at the specified logical position during the call.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// <paramref name="index"/> is less than zero, or greater than or equal to the number of elements in the buffer at the time of the call.
+    /// <paramref name="index"/> is negative, or is greater than or equal to the number of elements in the
+    /// buffer observed at the time of the call.
     /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The buffer is under sustained concurrent modification and a stable single-slot read could not be
+    /// obtained within the retry budget.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The accessor performs a sequence-validated single-slot read; it does not allocate a snapshot. Two
+    /// consecutive index reads (for example, <c>buffer[i]</c> followed by <c>buffer[i + 1]</c>) are not
+    /// jointly atomic — concurrent producers or consumers may modify the buffer between the two reads.
+    /// Callers that require joint atomicity across multiple positions should call <see cref="ToArray"/> once
+    /// and index the resulting array.
+    /// </para>
+    /// </remarks>
     public T this[int index]
     {
         get
         {
             ThrowHelper.ThrowIfLessThan(index, 0);
-            var snapshot = ToArray();
-            ThrowHelper.ThrowIfGreaterThanOrEqual(index, snapshot.Length);
-            return snapshot[index];
+
+            SpinWait spinner = default;
+            for (int outerAttempt = 0; outerAttempt < SnapshotOuterRetryBudget; outerAttempt++)
+            {
+                int head = Volatile.Read(ref _head);
+                int tail = Volatile.Read(ref _tail);
+                int count = tail - head;
+                if (count < 0) count = 0;
+                if (count > _capacity) count = _capacity;
+
+                ThrowHelper.ThrowIfGreaterThanOrEqual(index, count);
+
+                int position = head + index;
+                if (TryReadStableSlot(SlotIndex(position), position + 1, out T? value)
+                    && Volatile.Read(ref _head) == head)
+                {
+                    return value!;
+                }
+
+                spinner.SpinOnce();
+            }
+
+            throw new InvalidOperationException(ResourceStrings.Concurrent_SnapshotUnstable);
         }
     }
 
@@ -309,18 +359,63 @@ public sealed partial class ConcurrentCircularBuffer<T>
     }
 
     /// <summary>
-    /// Determines whether a snapshot of the buffer contains the specified element.
+    /// Determines whether the buffer contains the specified element using
+    /// <see cref="EqualityComparer{T}.Default"/>.
     /// </summary>
     /// <param name="item">The element to locate. May be <see langword="null"/>.</param>
-    /// <returns><see langword="true"/> if the element was found in the snapshot; otherwise, <see langword="false"/>.</returns>
+    /// <returns>
+    /// <see langword="true"/> if a sequence-stable read found a match within the live region during the call;
+    /// otherwise <see langword="false"/>.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Walks the live region using a sequence-validated direct slot scan; no array allocation occurs in the
+    /// common case. Under sustained concurrent modification the scan restarts; if the retry budget is
+    /// exhausted, a single coherent <see cref="ToArray"/> snapshot is used as a fallback.
+    /// </para>
+    /// </remarks>
     public bool Contains(T? item)
     {
-        var comparer = EqualityComparer<T?>.Default;
-        foreach (var x in ToArray())
+        EqualityComparer<T?> comparer = EqualityComparer<T?>.Default;
+        SpinWait spinner = default;
+
+        for (int outerAttempt = 0; outerAttempt < SnapshotOuterRetryBudget; outerAttempt++)
+        {
+            int head = Volatile.Read(ref _head);
+            int tail = Volatile.Read(ref _tail);
+            int count = tail - head;
+            if (count <= 0) return false;
+            if (count > _capacity) count = _capacity;
+
+            bool slotFailure = false;
+            for (int i = 0; i < count; i++)
+            {
+                int position = head + i;
+                if (!TryReadStableSlot(SlotIndex(position), position + 1, out T? value))
+                {
+                    slotFailure = true;
+                    break;
+                }
+
+                if (comparer.Equals(value, item))
+                    return true;
+            }
+
+            // No match in this pass: only conclude false if the head has not advanced (otherwise our window
+            // shifted under us and the missing element may have been retroactively reclaimed before we read it).
+            if (!slotFailure && Volatile.Read(ref _head) == head)
+                return false;
+
+            spinner.SpinOnce();
+        }
+
+        // Fallback after exhausting the retry budget: a single coherent snapshot pass.
+        foreach (T? x in ToArray())
         {
             if (comparer.Equals(x, item))
                 return true;
         }
+
         return false;
     }
 
@@ -379,52 +474,140 @@ public sealed partial class ConcurrentCircularBuffer<T>
     /// Returns a snapshot of the buffer's contents in FIFO order.
     /// </summary>
     /// <returns>
-    /// An array containing the elements observed in the buffer, ordered from oldest to newest. Returns an empty array if the buffer
-    /// is empty.
+    /// An array containing the elements observed in the buffer, ordered from oldest to newest. Returns an empty
+    /// array if the buffer is empty.
     /// </returns>
     /// <remarks>
     /// <para>
-    /// This method uses a versioned retry loop to obtain a consistent snapshot. Up to 64 attempts are made to read a stable slice.
-    /// If the buffer is under sustained write pressure and a stable snapshot cannot be obtained, a best-effort read is returned.
+    /// Each slot in the snapshot is read using a sequence-validated seqlock pattern: the slot's coordination
+    /// sequence is read both before and after the value, and the read is committed only when both sequence
+    /// observations match the expected published mark. This guarantees the value, when committed, was the
+    /// element published at that logical position — never a value from an earlier or later generation.
+    /// </para>
+    /// <para>
+    /// If a slot cannot be stabilised within its retry budget, the entire snapshot is restarted. After the
+    /// outer retry budget is exhausted under sustained churn, a best-effort snapshot is returned in which
+    /// individual slots that still cannot be stabilised contribute the default value of <typeparamref name="T"/>;
+    /// every committed slot in that fallback path is still sequence-validated, so a torn or stale-generation
+    /// reference is never returned.
     /// </para>
     /// </remarks>
     public T[] ToArray()
     {
-        var spinner = default(SpinWait);
+        SpinWait spinner = default;
 
-        for (int attempt = 0; attempt < 64; attempt++)
+        for (int outerAttempt = 0; outerAttempt < SnapshotOuterRetryBudget; outerAttempt++)
         {
-            int v1 = Volatile.Read(ref _version);
             int head = Volatile.Read(ref _head);
             int tail = Volatile.Read(ref _tail);
 
             int count = tail - head;
             if (count <= 0) return Array.Empty<T>();
-            if (count > _capacity) count = _capacity; // defensive clamp
+            if (count > _capacity) count = _capacity;
 
-            var result = new T[count];
+            T[] result = new T[count];
+            bool slotFailure = false;
+
             for (int i = 0; i < count; i++)
             {
-                T? slotValue = Volatile.Read(ref _buffer[SlotIndex(head + i)].Value);
-                result[i] = slotValue!;
+                int position = head + i;
+                if (!TryReadStableSlot(SlotIndex(position), position + 1, out T? value))
+                {
+                    slotFailure = true;
+                    break;
+                }
+
+                result[i] = value!;
             }
 
-            int v2 = Volatile.Read(ref _version);
-            if (v1 == v2) return result;
+            // Final coherence check: confirm the head has not advanced past the position we used to lay the
+            // window out, otherwise our slots may have been retroactively reclaimed and re-published into a
+            // different generation that we just happened to read consistently.
+            if (!slotFailure && Volatile.Read(ref _head) == head)
+                return result;
+
             spinner.SpinOnce();
         }
 
-        // Fallback best-effort snapshot after exhausting retry budget
-        int h = Volatile.Read(ref _head);
-        int t = Volatile.Read(ref _tail);
-        int c = Math.Clamp(t - h, 0, _capacity);
-        var res = new T[c];
-        for (int i = 0; i < c; i++)
+        return BestEffortSnapshot();
+    }
+
+    /// <summary>
+    /// Produces a best-effort snapshot when the standard <see cref="ToArray"/> retry budget is exhausted.
+    /// Each slot is still sequence-validated; slots that cannot be stabilised are written as
+    /// <see langword="default"/> rather than as a torn or stale-generation value.
+    /// </summary>
+    /// <returns>The best-effort snapshot array.</returns>
+    private T[] BestEffortSnapshot()
+    {
+        int head = Volatile.Read(ref _head);
+        int tail = Volatile.Read(ref _tail);
+        int count = Math.Clamp(tail - head, 0, _capacity);
+        if (count == 0) return Array.Empty<T>();
+
+        T[] result = new T[count];
+        for (int i = 0; i < count; i++)
         {
-            T? slotValue = Volatile.Read(ref _buffer[SlotIndex(h + i)].Value);
-            res[i] = slotValue!;
+            int position = head + i;
+            if (TryReadStableSlot(SlotIndex(position), position + 1, out T? value))
+                result[i] = value!;
+
+            // Otherwise leave result[i] at default(T): null for the class? constraint on this type.
         }
-        return res;
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts a sequence-validated read of the slot at the given physical index, expecting the slot to be
+    /// in the published state for the supplied logical position.
+    /// </summary>
+    /// <param name="slotIndex">The physical slot index; must be in the range <c>[0, _capacity)</c>.</param>
+    /// <param name="expectedSequence">
+    /// The publication sequence the slot is expected to carry (<c>position + 1</c> for the slot's logical
+    /// head-relative position).
+    /// </param>
+    /// <param name="value">
+    /// On <see langword="true"/>, contains the committed value read from the slot. On <see langword="false"/>,
+    /// contains <see langword="default"/>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the slot was observed in the expected published state both before and
+    /// after the value read; <see langword="false"/> when the slot has been reclaimed, has not yet been
+    /// published, or could not be stabilised within the inner retry budget.
+    /// </returns>
+    /// <remarks>
+    /// Implements the seqlock read protocol: read sequence, read value, re-read sequence; commit when both
+    /// sequence reads equal <paramref name="expectedSequence"/>. A divergence between the two sequence reads
+    /// indicates the slot has been touched by a concurrent producer or consumer between the value read and
+    /// the post-check.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private bool TryReadStableSlot(int slotIndex, int expectedSequence, out T? value)
+    {
+        SpinWait spinner = default;
+        for (int attempt = 0; attempt < SlotReadRetryBudget; attempt++)
+        {
+            int seqPre = Volatile.Read(ref _buffer[slotIndex].Sequence);
+            if (seqPre - expectedSequence != 0)
+            {
+                value = default;
+                return false;
+            }
+
+            T? candidate = Volatile.Read(ref _buffer[slotIndex].Value);
+            int seqPost = Volatile.Read(ref _buffer[slotIndex].Sequence);
+            if (seqPost == seqPre)
+            {
+                value = candidate;
+                return true;
+            }
+
+            spinner.SpinOnce();
+        }
+
+        value = default;
+        return false;
     }
 
     /// <summary>

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -184,14 +184,41 @@ public sealed partial class ConcurrentCircularBuffer<T>
         : this(capacity, allowOverwrite)
     {
         ThrowHelper.ThrowIfNull(collection);
-        var items = collection as T[] ?? collection.ToArray();
+        T[] items = collection as T[] ?? collection.ToArray();
 
         if (!allowOverwrite && items.Length > capacity)
             throw new InvalidOperationException(ResourceStrings.Arg_Invalid_ArrayLengthExceedsCapacity);
 
-        // Enqueue in order using the lock-free path (no concurrency during construction).
-        foreach (var item in items.Skip(Math.Max(0, items.Length - capacity)))
-            InternalEnqueue(item, throwIfFull: !allowOverwrite);
+        InitialFill(items);
+    }
+
+    /// <summary>
+    /// Populates the freshly-constructed buffer directly from <paramref name="items"/>, retaining the trailing
+    /// <see cref="Capacity"/> elements when the source is larger. The instance is not yet observable by other
+    /// threads at this point, so the lock-free producer protocol is bypassed.
+    /// </summary>
+    /// <param name="items">The materialised source elements.</param>
+    /// <remarks>
+    /// <para>
+    /// Writes occur in published-state form: each populated slot's <c>Sequence</c> is set to its publication
+    /// mark (<c>tail + 1</c>) and <see cref="_tail"/> is advanced once at the end. <see cref="_head"/> remains
+    /// zero, so the live region is <c>[0, tail)</c>.
+    /// </para>
+    /// </remarks>
+    private void InitialFill(T[] items)
+    {
+        int capacity = _capacity;
+        int sourceLength = items.Length;
+        int copyLength = sourceLength <= capacity ? sourceLength : capacity;
+        int sourceOffset = sourceLength - copyLength;
+
+        for (int i = 0; i < copyLength; i++)
+        {
+            _buffer[i].Value = items[sourceOffset + i];
+            _buffer[i].Sequence = i + 1;
+        }
+
+        _tail = copyLength;
     }
 
     /// <summary>

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -116,9 +116,6 @@ public sealed partial class ConcurrentCircularBuffer<T>
 
     private int _tail;
 
-    // Version for snapshot readers
-    private int _version;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="ConcurrentCircularBuffer{T}"/> class with default capacity and overwriting enabled.
     /// </summary>
@@ -166,7 +163,6 @@ public sealed partial class ConcurrentCircularBuffer<T>
 
         _head = 0;
         _tail = 0;
-        _version = 0;
     }
 
     /// <summary>
@@ -717,7 +713,6 @@ public sealed partial class ConcurrentCircularBuffer<T>
                 T? value = Volatile.Read(ref slot.Value);
                 Volatile.Write(ref slot.Value, default!);
                 Volatile.Write(ref slot.Sequence, head + _capacity);
-                Interlocked.Increment(ref _version);
 
                 // AFTER removal: fire event; each handler is guarded independently so a throwing
                 // subscriber cannot prevent subsequent subscribers from receiving the notification.
@@ -781,8 +776,6 @@ public sealed partial class ConcurrentCircularBuffer<T>
                 item = Volatile.Read(ref slot.Value);
                 Volatile.Write(ref slot.Value, default!);
                 Volatile.Write(ref slot.Sequence, head + _capacity);
-
-                Interlocked.Increment(ref _version);
                 return true;
             }
             else if (diff < 0)
@@ -836,7 +829,6 @@ public sealed partial class ConcurrentCircularBuffer<T>
                 // write and publish
                 Volatile.Write(ref slot.Value, item);
                 Volatile.Write(ref slot.Sequence, tail + 1);
-                Interlocked.Increment(ref _version);
                 return true;
             }
             else if (diff < 0)

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBuffer.cs
@@ -640,11 +640,17 @@ public sealed partial class ConcurrentCircularBuffer<T>
         /// <summary>The Vyukov sequence number used to coordinate producers and consumers for this slot.</summary>
         public int Sequence;
 
-        // Aligns Value to an 8-byte boundary on all supported platforms.
+#pragma warning disable CS0649 // Padding fields are deliberately unassigned; they exist only to enforce layout.
+
+        /// <summary>Aligns <see cref="Value"/> to an 8-byte boundary on all supported platforms.</summary>
         private readonly int _sequencePadding;
+
+#pragma warning restore CS0649
 
         /// <summary>The stored element. Written by the producer, cleared by the consumer.</summary>
         public T? Value;
+
+#pragma warning disable CS0649 // Padding fields are deliberately unassigned; they exist only to enforce layout.
 
         // Pads the struct to 64 bytes: 4 (Sequence) + 4 (pad) + 8 (Value ref) + 6×8 (pad) = 64.
         private readonly long _pad0;
@@ -653,5 +659,7 @@ public sealed partial class ConcurrentCircularBuffer<T>
         private readonly long _pad3;
         private readonly long _pad4;
         private readonly long _pad5;
+
+#pragma warning restore CS0649
     }
 }

--- a/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBufferDebugView.cs
+++ b/Bodu.Core/src/Collections.Generic.Concurrent/ConcurrentCircularBufferDebugView.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferDebugView.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+/// <summary>
+/// Provides a debugger-friendly view of the <see cref="ConcurrentCircularBuffer{T}"/> contents.
+/// </summary>
+/// <typeparam name="T">Specifies the reference type stored in the buffer.</typeparam>
+/// <remarks>
+/// This proxy renders the buffer's contents as a flat array in the debugger by capturing a snapshot via
+/// <see cref="ConcurrentCircularBuffer{T}.ToArray"/> each time the debugger expands the items. The snapshot is
+/// stable for inspection but is not synchronised with concurrent producers or consumers.
+/// </remarks>
+internal sealed class ConcurrentCircularBufferDebugView<T>
+    where T : class?
+{
+    /// <summary>
+    /// The buffer instance being inspected.
+    /// </summary>
+    private readonly ConcurrentCircularBuffer<T> _buffer;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="ConcurrentCircularBufferDebugView{T}"/> class.
+    /// </summary>
+    /// <param name="buffer">The buffer instance to expose to the debugger. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="buffer"/> is <see langword="null"/>.</exception>
+    public ConcurrentCircularBufferDebugView(ConcurrentCircularBuffer<T> buffer) =>
+        _buffer = buffer ?? throw new ArgumentNullException(nameof(buffer));
+
+    /// <summary>
+    /// Gets the items currently observable in the <see cref="ConcurrentCircularBuffer{T}"/> as an array.
+    /// </summary>
+    /// <returns>A snapshot array of buffer contents in head-to-tail logical order.</returns>
+    /// <remarks>The display root is hidden so the debugger expands directly into the item list.</remarks>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public T[] Items => _buffer.ToArray();
+}

--- a/Bodu.Core/src/ResourceStrings.Designer.cs
+++ b/Bodu.Core/src/ResourceStrings.Designer.cs
@@ -635,7 +635,16 @@ internal class ResourceStrings {
             return ResourceManager.GetString("Arg_Required_ProviderInterface", resourceCulture);
         }
     }
-    
+
+    /// <summary>
+    ///   Looks up a localized string similar to The collection could not produce a stable snapshot under sustained concurrent modification..
+    /// </summary>
+    internal static string Concurrent_SnapshotUnstable {
+        get {
+            return ResourceManager.GetString("Concurrent_SnapshotUnstable", resourceCulture);
+        }
+    }
+
     /// <summary>
     ///   Looks up a localized string similar to Unrecognized file size format..
     /// </summary>

--- a/Bodu.Core/src/ResourceStrings.resx
+++ b/Bodu.Core/src/ResourceStrings.resx
@@ -219,6 +219,9 @@
   <data name="Arg_Invalid_Conversion" xml:space="preserve">
     <value>The value cannot be converted to type {0}.</value>
   </data>
+  <data name="Concurrent_SnapshotUnstable" xml:space="preserve">
+    <value>The collection could not produce a stable snapshot under sustained concurrent modification.</value>
+  </data>
   <data name="Format_FileSize_Unrecognized" xml:space="preserve">
     <value>Unrecognized file size format.</value>
   </data>

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Ctor.cs
@@ -304,4 +304,42 @@ public partial class ConcurrentCircularBufferTests
         Assert.AreEqual(0, buffer.Count);
         Assert.AreEqual(5, buffer.Capacity);
     }
+
+    /// <summary>
+    /// Verifies that a buffer constructed exactly at capacity from a source collection accepts subsequent
+    /// producer-side eviction (when overwrite is enabled), confirming the per-slot publication state recorded
+    /// by the construction-time fill is observable by the lock-free producer protocol.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenSourceFillsCapacity_ShouldRemainConsistentWithSubsequentEnqueue()
+    {
+        TestItem[] source = Enumerable.Range(1, 4).Select(i => new TestItem(i)).ToArray();
+        var buffer = new ConcurrentCircularBuffer<TestItem>(source, capacity: 4, allowOverwrite: true);
+
+        Assert.AreEqual(4, buffer.Count);
+        Assert.AreEqual(4, buffer.Capacity);
+
+        buffer.Enqueue(new TestItem(5));
+
+        int[] values = buffer.ToArray().Select(x => x.Value).ToArray();
+        CollectionAssert.AreEqual(new[] { 2, 3, 4, 5 }, values);
+    }
+
+    /// <summary>
+    /// Verifies that a buffer constructed from a source larger than its capacity retains only the trailing
+    /// window and that subsequent <c>Dequeue</c> operations return elements in the correct FIFO order from that
+    /// window.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenSourceLargerThanCapacityAndAllowOverwriteTrue_ShouldKeepTrailingWindowAndDequeueInOrder()
+    {
+        TestItem[] source = Enumerable.Range(1, 7).Select(i => new TestItem(i)).ToArray();
+        var buffer = new ConcurrentCircularBuffer<TestItem>(source, capacity: 3, allowOverwrite: true);
+
+        Assert.AreEqual(3, buffer.Count);
+        Assert.AreEqual(5, buffer.Dequeue().Value);
+        Assert.AreEqual(6, buffer.Dequeue().Value);
+        Assert.AreEqual(7, buffer.Dequeue().Value);
+        Assert.AreEqual(0, buffer.Count);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.DebugView.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.DebugView.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.DebugView.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that the <see cref="DebuggerTypeProxyAttribute"/> attached to <see cref="ConcurrentCircularBuffer{T}"/>
+    /// references a proxy whose constructor accepts a <see cref="ConcurrentCircularBuffer{T}"/> and that the proxy
+    /// can be instantiated without throwing.
+    /// </summary>
+    /// <remarks>
+    /// Guards against the latent defect where the attribute previously pointed to <c>CircularBufferDebugView&lt;&gt;</c>,
+    /// whose constructor accepts only the non-concurrent <c>CircularBuffer&lt;T&gt;</c>. Inspection in a debugger would
+    /// have thrown <see cref="ArgumentException"/> at construction time.
+    /// </remarks>
+    [TestMethod]
+    public void DebugView_WhenAttachedAttributeResolved_ShouldAcceptConcurrentBuffer()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(MinCapacity);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+
+        DebuggerTypeProxyAttribute? proxy = typeof(ConcurrentCircularBuffer<TestItem>)
+            .GetCustomAttributes<DebuggerTypeProxyAttribute>(inherit: false)
+            .SingleOrDefault();
+
+        Assert.IsNotNull(proxy, "ConcurrentCircularBuffer<T> is missing its DebuggerTypeProxy attribute.");
+
+        Type proxyType = Type.GetType(proxy!.ProxyTypeName!, throwOnError: true)!
+            .MakeGenericType(typeof(TestItem));
+
+        object instance = Activator.CreateInstance(proxyType, buffer)!;
+        Assert.IsNotNull(instance);
+    }
+
+    /// <summary>
+    /// Verifies that the debug view's <c>Items</c> property returns a snapshot whose contents match the buffer.
+    /// </summary>
+    [TestMethod]
+    public void DebugView_WhenItemsRead_ShouldReturnFifoSnapshot()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(capacity: 4);
+        buffer.Enqueue(new TestItem(10));
+        buffer.Enqueue(new TestItem(20));
+        buffer.Enqueue(new TestItem(30));
+
+        var view = new ConcurrentCircularBufferDebugView<TestItem>(buffer);
+        TestItem[] items = view.Items;
+
+        Assert.AreEqual(3, items.Length);
+        Assert.AreEqual(10, items[0].Value);
+        Assert.AreEqual(20, items[1].Value);
+        Assert.AreEqual(30, items[2].Value);
+    }
+
+    /// <summary>
+    /// Verifies that constructing the debug view with a <see langword="null"/> buffer throws
+    /// <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void DebugView_WhenBufferIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new ConcurrentCircularBufferDebugView<TestItem>(null!);
+        });
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.IProducerConsumerCollection.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.IProducerConsumerCollection.cs
@@ -1,0 +1,154 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.IProducerConsumerCollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IProducerConsumerCollection{T}.TryAdd"/> forwards to <c>TryEnqueue</c> and
+    /// returns <see langword="true"/> when space is available.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenSpaceAvailable_ShouldReturnTrue()
+    {
+        IProducerConsumerCollection<TestItem> sut =
+            new ConcurrentCircularBuffer<TestItem>(capacity: 4, allowOverwrite: false);
+
+        Assert.IsTrue(sut.TryAdd(new TestItem(1)));
+        Assert.IsTrue(sut.TryAdd(new TestItem(2)));
+        Assert.AreEqual(2, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IProducerConsumerCollection{T}.TryAdd"/> returns <see langword="false"/> when
+    /// the buffer is full and overwriting is disabled.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenFullAndAllowOverwriteFalse_ShouldReturnFalse()
+    {
+        IProducerConsumerCollection<TestItem> sut =
+            new ConcurrentCircularBuffer<TestItem>(capacity: 2, allowOverwrite: false);
+
+        Assert.IsTrue(sut.TryAdd(new TestItem(1)));
+        Assert.IsTrue(sut.TryAdd(new TestItem(2)));
+        Assert.IsFalse(sut.TryAdd(new TestItem(3)));
+        Assert.AreEqual(2, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IProducerConsumerCollection{T}.TryAdd"/> succeeds when overwriting is enabled
+    /// even on a full buffer.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenFullAndAllowOverwriteTrue_ShouldReturnTrueAndEvict()
+    {
+        var concrete = new ConcurrentCircularBuffer<TestItem>(capacity: 2, allowOverwrite: true);
+        IProducerConsumerCollection<TestItem> sut = concrete;
+
+        Assert.IsTrue(sut.TryAdd(new TestItem(1)));
+        Assert.IsTrue(sut.TryAdd(new TestItem(2)));
+        Assert.IsTrue(sut.TryAdd(new TestItem(3)));
+
+        TestItem[] snapshot = concrete.ToArray();
+        Assert.AreEqual(2, snapshot.Length);
+        Assert.AreEqual(2, snapshot[0].Value);
+        Assert.AreEqual(3, snapshot[1].Value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IProducerConsumerCollection{T}.TryTake"/> returns <see langword="false"/> on an
+    /// empty buffer and yields a <see langword="null"/> out value.
+    /// </summary>
+    [TestMethod]
+    public void TryTake_WhenEmpty_ShouldReturnFalseAndNullOut()
+    {
+        IProducerConsumerCollection<TestItem> sut =
+            new ConcurrentCircularBuffer<TestItem>(capacity: 4);
+
+        bool taken = sut.TryTake(out TestItem? item);
+
+        Assert.IsFalse(taken);
+        Assert.IsNull(item);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IProducerConsumerCollection{T}.TryTake"/> returns the oldest element in FIFO
+    /// order when items are present.
+    /// </summary>
+    [TestMethod]
+    public void TryTake_WhenItemPresent_ShouldReturnTrueAndOldestItem()
+    {
+        var concrete = new ConcurrentCircularBuffer<TestItem>(capacity: 4);
+        concrete.Enqueue(new TestItem(11));
+        concrete.Enqueue(new TestItem(22));
+        IProducerConsumerCollection<TestItem> sut = concrete;
+
+        Assert.IsTrue(sut.TryTake(out TestItem? first));
+        Assert.IsNotNull(first);
+        Assert.AreEqual(11, first!.Value);
+
+        Assert.IsTrue(sut.TryTake(out TestItem? second));
+        Assert.IsNotNull(second);
+        Assert.AreEqual(22, second!.Value);
+
+        Assert.IsFalse(sut.TryTake(out _));
+    }
+
+    /// <summary>
+    /// Verifies that the explicit <c>ToArray</c> and <c>CopyTo</c> members of
+    /// <see cref="IProducerConsumerCollection{T}"/> agree with the public surface and reflect the buffer's
+    /// FIFO order.
+    /// </summary>
+    [TestMethod]
+    public void IProducerConsumerCollection_ToArrayAndCopyTo_ShouldMatchPublicSurface()
+    {
+        var concrete = new ConcurrentCircularBuffer<TestItem>(capacity: 4);
+        concrete.Enqueue(new TestItem(1));
+        concrete.Enqueue(new TestItem(2));
+        concrete.Enqueue(new TestItem(3));
+        IProducerConsumerCollection<TestItem> sut = concrete;
+
+        TestItem[] viaInterface = sut.ToArray();
+        TestItem[] viaConcrete = concrete.ToArray();
+
+        Assert.AreEqual(viaConcrete.Length, viaInterface.Length);
+        for (int i = 0; i < viaConcrete.Length; i++)
+            Assert.AreEqual(viaConcrete[i].Value, viaInterface[i].Value);
+
+        TestItem[] copyTarget = new TestItem[5];
+        sut.CopyTo(copyTarget, index: 1);
+        Assert.IsNull(copyTarget[0]);
+        Assert.AreEqual(1, copyTarget[1].Value);
+        Assert.AreEqual(2, copyTarget[2].Value);
+        Assert.AreEqual(3, copyTarget[3].Value);
+        Assert.IsNull(copyTarget[4]);
+    }
+
+    /// <summary>
+    /// Verifies that the buffer can be wrapped by <see cref="BlockingCollection{T}"/> and that round-trip
+    /// <c>Add</c>/<c>Take</c> operations work as expected.
+    /// </summary>
+    [TestMethod]
+    public void BlockingCollection_WhenWrappingBuffer_ShouldRoundTrip()
+    {
+        var underlying = new ConcurrentCircularBuffer<TestItem>(capacity: 4, allowOverwrite: false);
+        using var blocking = new BlockingCollection<TestItem>(underlying, boundedCapacity: 4);
+
+        blocking.Add(new TestItem(7));
+        blocking.Add(new TestItem(8));
+        blocking.CompleteAdding();
+
+        TestItem first = blocking.Take();
+        TestItem second = blocking.Take();
+
+        Assert.AreEqual(7, first.Value);
+        Assert.AreEqual(8, second.Value);
+        Assert.IsTrue(blocking.IsCompleted);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Indexer.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Indexer.cs
@@ -138,4 +138,29 @@ public partial class ConcurrentCircularBufferTests
         Task.WaitAll(reader, writer);
         Assert.AreEqual(0, errors.Count, "Indexer threw during concurrent enqueue.");
     }
+
+    /// <summary>
+    /// Documents the indexer contract: two consecutive index reads are not jointly atomic. A producer or
+    /// consumer running between the two calls may shift the live window, so callers needing joint atomicity
+    /// across multiple positions must take a single <c>ToArray</c> snapshot and index the resulting array.
+    /// </summary>
+    /// <remarks>
+    /// In the absence of concurrent mutation each call is well-defined and consecutive reads observe the
+    /// expected adjacent values. This test records the contract rather than asserting non-atomicity directly,
+    /// which would require a deterministic interleaving harness.
+    /// </remarks>
+    [TestMethod]
+    public void Indexer_WhenCalledTwiceConsecutivelyOnQuiescentBuffer_ShouldReturnAdjacentValues()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(4);
+        buffer.Enqueue(new TestItem(100));
+        buffer.Enqueue(new TestItem(200));
+        buffer.Enqueue(new TestItem(300));
+
+        TestItem first = buffer[0];
+        TestItem second = buffer[1];
+
+        Assert.AreEqual(100, first.Value);
+        Assert.AreEqual(200, second.Value);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
@@ -852,4 +852,206 @@ public partial class ConcurrentCircularBufferTests
         Assert.IsTrue(buffer.Count >= 0 && buffer.Count <= buffer.Capacity,
             "Count must remain within [0, Capacity] after high-concurrency stress.");
     }
+
+    // -----------------------------------------------------------------------------------------
+    // New: ToArray must produce a coherent generation window under sustained eviction pressure.
+    //
+    // Each producer enqueues items tagged with a globally monotonic generation. Every snapshot
+    // returned by ToArray must satisfy two invariants:
+    //   - generations are strictly increasing within the snapshot (no torn cross-generation mix);
+    //   - max - min generation < capacity (the entire snapshot must fit inside the buffer's
+    //     active window at some moment in time).
+    // A violation indicates the per-slot snapshot protocol returned a stale slot from a
+    // previous generation alongside a slot from a more recent generation.
+    // -----------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ConcurrentCircularBuffer{T}.ToArray" /> never returns a snapshot whose tagged
+    /// generations span more than the buffer capacity or break strict monotonicity, even under sustained
+    /// concurrent eviction.
+    /// </summary>
+    [TestMethod]
+    [DataRow(true)]
+    [DataRow(false)]
+    public void ToArray_WhenUnderConcurrentEvictionPressure_ShouldNeverReturnTornGenerationMix(
+        bool allowOverwrite)
+    {
+        const int capacity = 32;
+        var buffer = new ConcurrentCircularBuffer<TestItem>(capacity, allowOverwrite);
+        using var cts = new CancellationTokenSource();
+        using var startGate = new ManualResetEventSlim(false);
+
+        int generation = 0;
+        int monotonicityViolations = 0;
+        int windowViolations = 0;
+        int snapshotFaults = 0;
+        int snapshotsTaken = 0;
+
+        int writerThreads = Math.Max(2, Environment.ProcessorCount);
+        int readerThreads = 2;
+        const int durationMs = 2000;
+        const int deadlockTimeoutMs = durationMs + 5000;
+
+        var writers = Enumerable.Range(0, writerThreads).Select(_ =>
+            Task.Run(() =>
+            {
+                startGate.Wait();
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    int gen = Interlocked.Increment(ref generation);
+                    buffer.TryEnqueue(new TestItem(gen));
+                }
+            }));
+
+        var readers = Enumerable.Range(0, readerThreads).Select(_ =>
+            Task.Run(() =>
+            {
+                startGate.Wait();
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    TestItem[] snap;
+                    try
+                    {
+                        snap = buffer.ToArray();
+                    }
+                    catch
+                    {
+                        Interlocked.Increment(ref snapshotFaults);
+                        continue;
+                    }
+
+                    Interlocked.Increment(ref snapshotsTaken);
+                    if (snap.Length == 0) continue;
+
+                    int min = snap[0].Value;
+                    int max = snap[0].Value;
+                    bool monotonic = true;
+                    for (int i = 1; i < snap.Length; i++)
+                    {
+                        int v = snap[i].Value;
+                        if (v <= snap[i - 1].Value) monotonic = false;
+                        if (v < min) min = v;
+                        if (v > max) max = v;
+                    }
+
+                    if (!monotonic)
+                        Interlocked.Increment(ref monotonicityViolations);
+                    if (max - min >= capacity)
+                        Interlocked.Increment(ref windowViolations);
+                }
+            }));
+
+        Task[] allTasks = writers.Concat(readers).ToArray();
+        startGate.Set();
+        Thread.Sleep(durationMs);
+        cts.Cancel();
+        bool completed = Task.WaitAll(allTasks, deadlockTimeoutMs);
+
+        TestContext.WriteLine(
+            $"AllowOverwrite={allowOverwrite}, SnapshotsTaken={snapshotsTaken}, " +
+            $"MonotonicityViolations={monotonicityViolations}, WindowViolations={windowViolations}, " +
+            $"SnapshotFaults={snapshotFaults}");
+
+        Assert.IsTrue(completed, $"Tasks did not complete within {deadlockTimeoutMs} ms.");
+        Assert.AreEqual(0, snapshotFaults, "ToArray must not throw under concurrent eviction pressure.");
+        Assert.AreEqual(0, monotonicityViolations,
+            "ToArray returned a snapshot whose generations were not strictly increasing — torn read.");
+        Assert.AreEqual(0, windowViolations,
+            "ToArray returned a snapshot spanning more generations than the buffer capacity — torn read.");
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // New: indexer must always return a value that was in the live window during the call.
+    //
+    // The reader loops `buffer[i]` over the observed Count and asserts each returned generation
+    // is no greater than the latest enqueued generation at the time of the call. A returned
+    // generation greater than `latestSeen` would mean the indexer surfaced a value from a
+    // future generation that did not exist in the buffer at any point during the read.
+    // -----------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the indexer returns only values that were genuinely in the live window during the call,
+    /// never a future or torn-generation value, while concurrent producers and consumers churn the buffer.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenContendedWithEnqueueAndDequeue_ShouldReturnAValueThatExisted()
+    {
+        const int capacity = 32;
+        var buffer = new ConcurrentCircularBuffer<TestItem>(capacity, allowOverwrite: true);
+        using var cts = new CancellationTokenSource();
+        using var startGate = new ManualResetEventSlim(false);
+
+        int generation = 0;
+        int futureValueViolations = 0;
+        int indexerFaults = 0;
+        int reads = 0;
+
+        int writerThreads = Math.Max(2, Environment.ProcessorCount);
+        int readerThreads = 2;
+        const int durationMs = 2000;
+        const int deadlockTimeoutMs = durationMs + 5000;
+
+        var writers = Enumerable.Range(0, writerThreads).Select(_ =>
+            Task.Run(() =>
+            {
+                startGate.Wait();
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    int gen = Interlocked.Increment(ref generation);
+                    buffer.TryEnqueue(new TestItem(gen));
+                }
+            }));
+
+        var consumers = Enumerable.Range(0, 1).Select(_ =>
+            Task.Run(() =>
+            {
+                startGate.Wait();
+                while (!cts.Token.IsCancellationRequested)
+                    buffer.TryDequeue(out _);
+            }));
+
+        var indexers = Enumerable.Range(0, readerThreads).Select(_ =>
+            Task.Run(() =>
+            {
+                startGate.Wait();
+                while (!cts.Token.IsCancellationRequested)
+                {
+                    int latest = Volatile.Read(ref generation);
+                    int count = buffer.Count;
+                    for (int i = 0; i < count; i++)
+                    {
+                        try
+                        {
+                            TestItem item = buffer[i];
+                            Interlocked.Increment(ref reads);
+                            if (item is not null && item.Value > latest)
+                                Interlocked.Increment(ref futureValueViolations);
+                        }
+                        catch (ArgumentOutOfRangeException)
+                        {
+                            // Count shrank between observation and access — expected race.
+                        }
+                        catch
+                        {
+                            Interlocked.Increment(ref indexerFaults);
+                        }
+                    }
+                }
+            }));
+
+        Task[] allTasks = writers.Concat(consumers).Concat(indexers).ToArray();
+        startGate.Set();
+        Thread.Sleep(durationMs);
+        cts.Cancel();
+        bool completed = Task.WaitAll(allTasks, deadlockTimeoutMs);
+
+        TestContext.WriteLine(
+            $"Reads={reads}, FutureValueViolations={futureValueViolations}, IndexerFaults={indexerFaults}");
+
+        Assert.IsTrue(completed, $"Tasks did not complete within {deadlockTimeoutMs} ms.");
+        Assert.AreEqual(0, indexerFaults, "Indexer must not throw apart from documented races.");
+        Assert.AreEqual(0, futureValueViolations,
+            "Indexer surfaced a value from a future generation that did not exist when the call started.");
+        Assert.IsTrue(reads > 0, "Indexer must have completed at least some successful reads.");
+    }
 }


### PR DESCRIPTION
## Summary

This PR refactors the `ConcurrentCircularBuffer<T>` snapshot and indexing protocol from a simple versioned retry loop to a per-slot seqlock pattern. The new approach provides stronger consistency guarantees under sustained concurrent modification while maintaining lock-free semantics.

## Key Changes

- **Seqlock-based slot reads**: Replaced the coarse-grained `_version` field with per-slot sequence coordination. Each slot's `Sequence` field is read before and after the value to detect concurrent modifications, ensuring values are never torn or from stale generations.

- **Improved snapshot stability**: `ToArray()` now validates that each slot read is sequence-stable and that the head pointer hasn't advanced during the snapshot window. If the retry budget is exhausted, a best-effort fallback snapshot is returned where unstable slots contribute default values rather than torn reads.

- **Enhanced indexer robustness**: The `this[int index]` accessor now performs sequence-validated single-slot reads with retry logic instead of allocating a full snapshot. Includes explicit documentation that consecutive index reads are not jointly atomic.

- **Refined Contains() method**: Updated to use the new per-slot validation pattern with retry budgets and fallback to `ToArray()` under sustained contention.

- **Optimized construction**: Introduced `InitialFill()` method that directly populates slots in published state during construction, bypassing the lock-free producer protocol since the instance is not yet observable.

- **Better documentation**: Expanded XML remarks throughout to clarify:
  - Why handler exceptions in `ItemEvicted` are suppressed (eviction is already committed in MPMC)
  - Cache-line padding strategy (64 bytes for x86/x64, conservative on larger cache lines)
  - Generic constraint to `class?` due to `Volatile` API limitations with value types
  - Snapshot protocol details and consistency guarantees

- **New test coverage**: Added comprehensive stress tests validating:
  - `ToArray()` never returns torn generation mixes under concurrent eviction
  - Indexer never surfaces future-generation values
  - Constructor behavior with oversized source collections
  - `IProducerConsumerCollection<T>` implementation
  - Debug view proxy correctness

- **Interface implementation**: Added explicit `IProducerConsumerCollection<T>` implementation to support wrapping with `BlockingCollection<T>`.

- **Debug view**: Created dedicated `ConcurrentCircularBufferDebugView<T>` class (replacing incorrect reference to non-concurrent `CircularBufferDebugView<T>`).

## Implementation Details

- Introduced `SnapshotOuterRetryBudget` (64 attempts) and `SlotReadRetryBudget` (8 attempts) constants to bound retry loops under sustained contention.
- The seqlock pattern ensures that committed values in snapshots were genuinely published at their logical positions, never mixing generations or returning stale references.
- Fallback best-effort snapshot path still validates each slot individually, so default values are only used for truly unstable slots—never torn or cross-generation reads.
- All changes maintain the lock-free producer/consumer protocol; only the reader-side snapshot mechanism is enhanced.

https://claude.ai/code/session_017Ww4yfsPPbfsSpWpmvD4Tq