### PR TITLE
Suppress obsolete serialization warnings and remove redundant assertion

### DIFF
--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.Enumerator.cs
@@ -106,7 +106,6 @@ public partial class ConcurrentCircularBufferTests
         {
             var snapshot = buffer.ToArray();
             Assert.IsTrue(snapshot.Length <= buffer.Capacity);
-            Assert.IsTrue(snapshot.All(x => x is TestItem or null));
         });
 
         var mutateTask = Task.Run(() =>

--- a/Bodu.Core/test/WeekPatternTests.Serializable.cs
+++ b/Bodu.Core/test/WeekPatternTests.Serializable.cs
@@ -9,6 +9,8 @@ using System.Runtime.Serialization;
 
 namespace Bodu;
 
+#pragma warning disable SYSLIB0050 // Type or member is obsolete (formatter-based serialization)
+
 public partial class WeekPatternTests
 {
     /// <summary>
@@ -82,3 +84,5 @@ public partial class WeekPatternTests
         Assert.IsInstanceOfType<SerializationException>(ex.InnerException);
     }
 }
+
+#pragma warning restore SYSLIB0050


### PR DESCRIPTION
## Summary
This PR addresses compiler warnings related to obsolete formatter-based serialization and removes a redundant assertion from concurrent buffer tests.

## Key Changes
- Added pragma directives to suppress SYSLIB0050 warnings in `WeekPatternTests.Serializable.cs` around the formatter-based serialization test code
- Removed redundant assertion `Assert.IsTrue(snapshot.All(x => x is TestItem or null))` from `ConcurrentCircularBufferTests.Enumerator.cs` that was checking an obvious condition

## Implementation Details
The serialization tests in `WeekPatternTests` use the obsolete `BinaryFormatter`-based serialization APIs. Rather than refactoring the tests, the pragma directives suppress the compiler warnings for this specific file section where the obsolete APIs are intentionally used for testing purposes.

The assertion removed from the enumerator test was checking that all items in the snapshot are either `TestItem` or `null`, which is guaranteed by the buffer's type system and the snapshot operation itself, making the check redundant.

https://claude.ai/code/session_01BHTw23ffwYsrXcDnE1VsMu