### PR TITLE
docs(extensions): align period-bound DateTime/DateOnly XML docs

### DIFF
--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.Add.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.Add.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.Add.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,22 +11,30 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Adds the specified number of years, months, and fractional days to the given <see cref="DateOnly"/>.
+    /// Returns a new <see cref="DateOnly"/> obtained by adding the specified number of years, months, and days to the supplied <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> value to which the offsets will be applied.</param>
+    /// <param name="date">The date value to which the offsets are applied.</param>
     /// <param name="years">The number of calendar years to add. A negative value subtracts years.</param>
     /// <param name="months">The number of calendar months to add. A negative value subtracts months.</param>
-    /// <param name="days">The number of days to add, including fractional values. A negative value subtracts days.</param>
-    /// <returns>A new <see cref="DateOnly"/> adjusted by the specified number of years, months, and days.</returns>
+    /// <param name="days">The number of days to add. A negative value subtracts days.</param>
+    /// <returns>A <see cref="DateOnly"/> value adjusted by the specified number of years, months, and days.</returns>
     /// <remarks>
-    /// <para>Applies adjustments in the following order: <b>years</b>, then <b>months</b>, then <b>days</b>.</para>
-    /// <para>Clamps the resulting day to the last valid day of the calculated month if overflow occurs.</para>
-    /// <para>Only full days are supported. Any fractional <paramref name="days"/> is rounded to the nearest whole number.</para>
-    /// <para>Internally uses <see cref="DateOnly.DayNumber"/> for efficient tick-free date math.</para>
+    /// <para>Adjustments are applied in the order years, then months, then days. When the resulting day does not exist in the target month (e.g. February 30), the date is clamped to the last valid day of that month, accounting for leap years and varying month lengths.</para>
+    /// <para><b>Examples:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var d1 = new DateOnly(2023, 1, 31);
+    /// var result1 = d1.Add(0, 1, 0); // → 2023-02-28 (non-leap year)
+    ///
+    /// var d2 = new DateOnly(2020, 1, 31);
+    /// var result2 = d2.Add(0, 1, 0); // → 2020-02-29 (leap year)
+    ///
+    /// var d3 = new DateOnly(2024, 2, 29);
+    /// var result3 = d3.Add(1, 0, 0); // → 2025-02-28 (2025 is not a leap year)
+    ///]]>
+    /// </code>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the resulting date is before <see cref="DateOnly.MinValue"/> or after <see cref="DateOnly.MaxValue"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.</exception>
     public static DateOnly Add(this DateOnly date, int years, int months, int days)
     {
         date.GetDateParts(out int year, out int month, out int day);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.Age.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.Age.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.Age.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,37 +11,27 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Calculates the age in full calendar years as at today’s date ( <see cref="DateTime.Today"/>).
+    /// Returns the age in full calendar years between the specified <paramref name="date"/> and today's date.
     /// </summary>
-    /// <param name="date">The earlier date to calculate from, typically representing a birth date or historical reference.</param>
-    /// <returns>
-    /// The number of full calendar years that have elapsed between <paramref name="date"/> and today. Returns 0 if
-    /// <paramref name="date"/> occurs after today.
-    /// </returns>
+    /// <param name="date">The earlier date to calculate from, typically representing a birth date or other reference point.</param>
+    /// <returns>The number of full calendar years that have elapsed between <paramref name="date"/> and today. Returns <c>0</c> if <paramref name="date"/> occurs after today.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> is February 29 in a leap year and today is not a leap year, the age is calculated as if the birthday
-    /// were on February 28.
-    /// </para>
-    /// <para>The result is clamped to 0 to avoid returning negative values for future dates.</para>
+    /// <para>This overload determines the number of full years that have passed by comparing the year, month, and day components. If the month and day of <paramref name="date"/> have not yet occurred in the current year, the result is decremented by one.</para>
+    /// <para>If <paramref name="date"/> is February 29 in a leap year and today is not a leap year, the comparison is performed as if the date were February 28.</para>
+    /// <para>The result is clamped to <c>0</c> to avoid returning negative values when <paramref name="date"/> is in the future.</para>
     /// </remarks>
     public static int Age(this DateOnly date) => date.Age(DateTime.Today.ToDateOnly());
 
     /// <summary>
-    /// Calculates the age in full calendar years as at a specified reference date.
+    /// Returns the age in full calendar years between the specified <paramref name="date"/> and a supplied reference date.
     /// </summary>
-    /// <param name="date">The earlier date to calculate from, typically representing a birth date or historical reference.</param>
+    /// <param name="date">The earlier date to calculate from, typically representing a birth date or other reference point.</param>
     /// <param name="asAtDate">The later date to calculate to, representing the point in time at which the age is evaluated.</param>
-    /// <returns>
-    /// The number of full calendar years that have elapsed between <paramref name="date"/> and <paramref name="asAtDate"/>. Returns 0
-    /// if <paramref name="asAtDate"/> occurs before <paramref name="date"/>.
-    /// </returns>
+    /// <returns>The number of full calendar years that have elapsed between <paramref name="date"/> and <paramref name="asAtDate"/>. Returns <c>0</c> if <paramref name="asAtDate"/> occurs before <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> is February 29 in a leap year and <paramref name="asAtDate"/> occurs in a non-leap year, the age is
-    /// calculated as if the birthday were on February 28.
-    /// </para>
-    /// <para>The result is clamped to 0 to avoid returning negative values for future dates.</para>
+    /// <para>This overload determines the number of full years that have passed by comparing the year, month, and day components. If the month and day of <paramref name="date"/> have not yet occurred in the year of <paramref name="asAtDate"/>, the result is decremented by one.</para>
+    /// <para>If <paramref name="date"/> is February 29 in a leap year and <paramref name="asAtDate"/> is in a non-leap year, the comparison is performed as if the date were February 28.</para>
+    /// <para>The result is clamped to <c>0</c> to avoid returning negative values when <paramref name="date"/> is after <paramref name="asAtDate"/>.</para>
     /// </remarks>
     public static int Age(this DateOnly date, DateOnly asAtDate)
     {

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.DayName.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.DayName.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.DayName.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,25 +13,23 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the full name of the day of the week for the specified <see cref="DateOnly"/>, using the formatting rules of the
-    /// current culture.
+    /// Returns the full name of the day of the week for the specified <see cref="DateOnly"/>, using the formatting rules of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose day of the week is used to determine the name.</param>
-    /// <returns>A <see cref="string"/> representing the localized full day name based on <see cref="CultureInfo.CurrentCulture"/>.</returns>
-    /// <remarks>This method retrieves the day name from <see cref="DateTimeFormatInfo.DayNames"/> using the current culture's formatting.</remarks>
+    /// <param name="date">The date value whose <see cref="DateOnly.DayOfWeek"/> is used to determine the name.</param>
+    /// <returns>A <see cref="string"/> containing the localised full day name, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetDayName(DayOfWeek)"/> method of the current culture to retrieve the day name. For culture-specific results, use the <see cref="DayName(DateOnly, CultureInfo?)"/> overload.</para>
+    /// </remarks>
     public static string DayName(this DateOnly date) => date.DayName(null!);
 
     /// <summary>
-    /// Returns the full name of the day of the week for the specified <see cref="DateOnly"/>, using the formatting rules of the
-    /// specified <see cref="CultureInfo"/>.
+    /// Returns the full name of the day of the week for the specified <see cref="DateOnly"/>, using the formatting rules of the supplied or current culture.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose day of the week is used to determine the name.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to format the result. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>A <see cref="string"/> representing the localized full day name for the day of <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose <see cref="DateOnly.DayOfWeek"/> is used to determine the name.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to format the result. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="string"/> containing the localised full day name for <paramref name="date"/>, formatted using the supplied or current culture.</returns>
     /// <remarks>
-    /// This method retrieves the day name from the <see cref="DateTimeFormatInfo.DayNames"/> collection of the specified or current culture.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetDayName(DayOfWeek)"/> method of the supplied or current culture to retrieve the day name.</para>
     /// </remarks>
     public static string DayName(this DateOnly date, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.GetDayName(date.DayOfWeek);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.DaysInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,13 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the number of days in the month of the specified <see cref="DateOnly"/>, using the Gregorian calendar.
+    /// Returns the number of days in the calendar month of the specified <see cref="DateOnly"/>, using the proleptic Gregorian calendar.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose month and year are used to determine the number of days.</param>
-    /// <returns>The total number of days in the month for the given <paramref name="date"/>, based on the <see cref="System.Globalization.GregorianCalendar"/>.</returns>
+    /// <param name="date">The date value whose year and month are used to determine the result.</param>
+    /// <returns>The total number of days in the specified month and year of <paramref name="date"/>, based on the <see cref="System.Globalization.GregorianCalendar"/>.</returns>
     /// <remarks>
-    /// This method always evaluates the number of days using the proleptic Gregorian calendar, regardless of the current culture or
-    /// calendar settings.
+    /// <para>This overload always evaluates the result using the proleptic Gregorian calendar, regardless of the current culture or calendar settings.</para>
     /// </remarks>
     public static int DaysInMonth(this DateOnly date) => DateTime.DaysInMonth(date.Year, date.Month);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.DaysInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,30 +13,23 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the number of days in the calendar year of the specified <see cref="DateOnly"/>, using the current culture's calendar.
+    /// Returns the number of days in the calendar year of the specified <see cref="DateOnly"/>, using the calendar of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> for which to calculate the number of days in its calendar year.</param>
-    /// <returns>
-    /// The total number of days in the year corresponding to <paramref name="date"/>, as defined by the current culture's <see cref="Calendar"/>.
-    /// </returns>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <returns>The total number of days in the year of <paramref name="date"/>, as defined by the calendar of <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// This method uses the calendar defined by <see cref="CultureInfo.CurrentCulture"/>. The result may vary depending on the
-    /// calendar system (e.g., Gregorian, Hebrew, Hijri).
+    /// <para>This overload uses the calendar defined by <see cref="CultureInfo.CurrentCulture"/>. The result may vary depending on the calendar system (e.g. Gregorian, Hebrew, Hijri).</para>
     /// </remarks>
     public static int DaysInYear(this DateOnly date) => date.DaysInYear((Calendar?)null);
 
     /// <summary>
-    /// Returns the number of days in the calendar year of the specified <see cref="DateOnly"/>, using the specified <see cref="Calendar"/>.
+    /// Returns the number of days in the calendar year of the specified <see cref="DateOnly"/>, using the supplied or current calendar.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose year is evaluated.</param>
-    /// <param name="calendar">
-    /// The <see cref="Calendar"/> used to determine the number of days in the year. If <c>null</c>, the current culture's calendar is used.
-    /// </param>
-    /// <returns>The number of days in the year of <paramref name="date"/>, based on the provided or fallback calendar.</returns>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <param name="calendar">An optional <see cref="Calendar"/> used to evaluate the result. If <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The number of days in the year of <paramref name="date"/>, based on the supplied or fallback calendar.</returns>
     /// <remarks>
-    /// Use this method when you want to explicitly calculate based on a specific calendar system (e.g.,
-    /// <see cref="GregorianCalendar"/>, <see cref="HebrewCalendar"/>). If <paramref name="calendar"/> is <see langword="null"/>, the calendar
-    /// from <see cref="CultureInfo.CurrentCulture"/> is used.
+    /// <para>Use this overload when you want to explicitly calculate based on a specific calendar system (e.g. <see cref="GregorianCalendar"/>, <see cref="HebrewCalendar"/>). If <paramref name="calendar"/> is <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</para>
     /// </remarks>
     public static int DaysInYear(this DateOnly date, Calendar? calendar) => (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInYear(date.Year);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,20 +11,34 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the first day of the same month and year as the specified date.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the same calendar month and year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose month and year are used.</param>
-    /// <returns>A <see cref="DateOnly"/> value set to the first day of the same month and year as <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose year and month are used to determine the result.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the same calendar month and year as <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This method calculates the first day of the month using Gregorian calendar rules.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var date = new DateOnly(2025, 7, 15);
+    /// var result = date.FirstDayOfMonth(); // → 2025-07-01
+    ///]]>
+    /// </code>
+    /// </remarks>
     public static DateOnly FirstDayOfMonth(this DateOnly date) => DateOnly.FromDayNumber(DateTimeExtensions.GetDayNumber(date.Year, date.Month, 1));
 
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the first day of the specified year and month.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the specified calendar month and year.
     /// </summary>
-    /// <param name="year">The year component of the date. Must be between 1 and 9999 inclusive.</param>
-    /// <param name="month">The month component of the date. Must be between 1 and 12 inclusive.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
     /// <returns>A <see cref="DateOnly"/> value set to the first day of the specified month and year.</returns>
+    /// <remarks>
+    /// <para>This method uses Gregorian calendar rules to determine the resulting date.</para>
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999, or if <paramref name="month"/> is not between 1 and 12.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12.
     /// </exception>
     public static DateOnly FirstDayOfMonth(int year, int month)
     {

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,99 +11,33 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the first day of the calendar quarter for the specified <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the calendar quarter that contains the specified <paramref name="date"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose quarter is evaluated.</param>
-    /// <returns>A <see cref="DateOnly"/> value representing the first day of the quarter that includes <paramref name="date"/>.</returns>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the standard calendar quarter definition:
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <term>Q1</term>
-    /// <description>January–March</description>
-    /// </item>
-    /// <item>
-    /// <term>Q2</term>
-    /// <description>April–June</description>
-    /// </item>
-    /// <item>
-    /// <term>Q3</term>
-    /// <description>July–September</description>
-    /// </item>
-    /// <item>
-    /// <term>Q4</term>
-    /// <description>October–December</description>
-    /// </item>
+    /// <item><term>Q1</term><description>January – March</description></item>
+    /// <item><term>Q2</term><description>April – June</description></item>
+    /// <item><term>Q3</term><description>July – September</description></item>
+    /// <item><term>Q4</term><description>October – December</description></item>
     /// </list>
     /// </remarks>
     public static DateOnly FirstDayOfQuarter(this DateOnly date) => FirstDayOfQuarter(date, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the first day of the specified <paramref name="quarter"/> in the given
-    /// <paramref name="year"/>, based on the standard calendar quarter definition.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the quarter that contains the specified <paramref name="date"/>, using the specified calendar quarter definition.
     /// </summary>
-    /// <param name="quarter">
-    /// The quarter number to evaluate (1 through 4), using the conventional calendar-based quarters: Q1 = Jan–Mar, Q2 = Apr–Jun, Q3 =
-    /// Jul–Sep, Q4 = Oct–Dec.
-    /// </param>
-    /// <param name="year">
-    /// The calendar year in which the quarter is to be evaluated. The returned date will represent the start of the quarter within this year.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the first day of the specified calendar quarter in the given year.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is not between 1 and 4 (inclusive).</exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the corresponding quarter.</returns>
     /// <remarks>
-    /// <para>This method uses the standard month-aligned calendar quarter system defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>:</para>
-    /// <list type="bullet">
-    /// <item>
-    /// <term>Q1</term>
-    /// <description>January – March</description>
-    /// </item>
-    /// <item>
-    /// <term>Q2</term>
-    /// <description>April – June</description>
-    /// </item>
-    /// <item>
-    /// <term>Q3</term>
-    /// <description>July – September</description>
-    /// </item>
-    /// <item>
-    /// <term>Q4</term>
-    /// <description>October – December</description>
-    /// </item>
-    /// </list>
-    /// <para>
-    /// For other fiscal or custom quarter definitions, use the <see cref="FirstDayOfQuarter(CalendarQuarterDefinition, int, int)"/> or
-    /// provider-based overloads.
-    /// </para>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month (e.g. January – March) or anchored to a custom day-of-month boundary.</para>
+    /// <para>For provider-driven (e.g. 4-4-5 fiscal) quarters, use the <see cref="FirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> overload instead.</para>
     /// </remarks>
-    public static DateOnly FirstDayOfQuarter(int quarter, int year) => FirstDayOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
-
-    /// <summary>
-    /// Returns the first day of the quarter that includes the specified <paramref name="date"/>, based on the provided <see cref="CalendarQuarterDefinition"/>.
-    /// </summary>
-    /// <param name="date">
-    /// The <see cref="DateOnly"/> to evaluate. The returned value will be the first calendar day of the quarter that contains this
-    /// date, according to the selected definition.
-    /// </param>
-    /// <param name="definition">Specifies the quarter definition used to determine the first date of the quarter.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the first day of the identified quarter.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid member of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>, which requires a provider-based
-    /// overload (see <see cref="FirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/>).
-    /// </exception>
-    /// <remarks>
-    /// <para>
-    /// This method supports both month-aligned and day-aligned quarter definitions. When the definition is not aligned to the first day
-    /// of a month, the result will reflect the exact starting day of the quarter as defined.
-    /// </para>
-    /// <para>
-    /// For custom or non-standard quarter systems, use the <see cref="FirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/>
-    /// overload with a custom implementation of <see cref="IQuarterDefinitionProvider"/>.
-    /// </para>
-    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly FirstDayOfQuarter(this DateOnly date, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -117,35 +51,49 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the first day of the specified <paramref name="quarter"/> in the given <paramref name="year"/>, based on the provided <see cref="CalendarQuarterDefinition"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the quarter that contains the specified <paramref name="date"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="definition">Specifies the quarter definition used to determine the first date of the quarter.</param>
-    /// <param name="quarter">
-    /// The quarter number to evaluate (1 through 4). Represents the Nth quarter following the definition’s anchor month and day.
-    /// </param>
-    /// <param name="year">
-    /// The reference calendar year. The result will represent the start date of the specified quarter relative to this year. If the
-    /// quarter begins in the next calendar year (based on modular month arithmetic), the year will be incremented accordingly.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the first day of the specified quarter in the applicable year.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is not between 1 and 4 (inclusive), or if <paramref name="definition"/> is not a defined
-    /// value of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>, which requires a provider-based
-    /// overload. Use the <see cref="FirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> method instead.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the quarter containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// For month-aligned definitions (e.g., <c>07</c> for July), each quarter starts on the 1st day of the corresponding month and
-    /// repeats every 3 months.
-    /// </para>
-    /// <para>
-    /// For day-aligned definitions (e.g., <c>0406</c> for April 6), each quarter starts on a specific day-of-month, and subsequent
-    /// quarters maintain the day anchor across three-month intervals.
-    /// </para>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating boundary logic to the supplied <paramref name="provider"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns a date outside the range of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>.</exception>
+    public static DateOnly FirstDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        return provider.GetQuarterStartDate(date);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the specified quarter and year.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is less than 1 or greater than 4.</exception>
+    public static DateOnly FirstDayOfQuarter(int quarter, int year) => FirstDayOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
+    /// </summary>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive. If the quarter begins in the next calendar year (based on the definition's anchor), the year will be incremented accordingly.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the specified quarter.</returns>
+    /// <remarks>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
     public static DateOnly FirstDayOfQuarter(CalendarQuarterDefinition definition, int quarter, int year)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
@@ -156,23 +104,5 @@ public static partial class DateOnlyExtensions
                 string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
 
         return DateOnly.FromDayNumber(ComputeQuarterStartDayNumber(year, quarter, GetQuarterDefinition(definition)));
-    }
-
-    /// <summary>
-    /// Returns the first day of the quarter based on a custom <see cref="IQuarterDefinitionProvider"/> implementation.
-    /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose quarter is being evaluated.</param>
-    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter logic.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the first calendar day of the applicable custom quarter.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns an invalid quarter boundary.</exception>
-    /// <remarks>
-    /// This method supports advanced or domain-specific definitions of quarters by delegating logic to the specified
-    /// <paramref name="provider"/>, such as 4-4-5 fiscal calendars or regional fiscal systems.
-    /// </remarks>
-    public static DateOnly FirstDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        return provider.GetQuarterStartDate(date);
     }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,27 +14,25 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the first day of the week that contains the specified <see cref="DateOnly"/>, using the current culture's settings.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the week that contains the specified <paramref name="date"/>, using the first day of the week defined by <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> for which to determine the start of the week.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the first day of the week that includes <paramref name="date"/>.</returns>
-    /// <remarks>This method uses <see cref="CultureInfo.CurrentCulture"/> to determine the first day of the week, based on <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</remarks>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the culturally defined first day of the week containing <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the first day of the week, based on <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
+    /// </remarks>
     public static DateOnly FirstDayOfWeek(this DateOnly date) => date.FirstDayOfWeek(null!);
 
     /// <summary>
-    /// Returns the first day of the week that contains the specified <see cref="DateOnly"/>, using the provided culture or the current culture.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the week that contains the specified <paramref name="date"/>, using the first day of the week defined by the supplied or current culture.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> for which to determine the start of the week.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> that defines the first day of the week via
-    /// <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the first day of the week that includes <paramref name="date"/>.</returns>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that defines the first day of the week via <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the culturally defined first day of the week containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// The method calculates the number of days to subtract from <paramref name="date"/> to reach the start of the week as defined by
-    /// the specified or current culture. The result is validated to ensure it falls within the valid range of <see cref="DateOnly"/>.
+    /// <para>This method computes the day offset between <paramref name="date"/> and the culture-specific first day of the week, and subtracts that offset.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the calculated date is outside the valid range supported by <see cref="DateOnly"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.</exception>
     public static DateOnly FirstDayOfWeek(this DateOnly date, CultureInfo culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
@@ -51,30 +49,18 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the first day of the week that contains the specified <see cref="DateOnly"/>, using the inferred start-of-week day from
-    /// the provided <see cref="CalendarWeekendDefinition"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the first day of the week that contains the specified <paramref name="date"/>, using a start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose week context is evaluated.</param>
-    /// <param name="weekend">
-    /// A <see cref="CalendarWeekendDefinition"/> value used to infer the start of the week and determine the week's structure.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> value representing the first day of the week that contains <paramref name="date"/>. The returned
-    /// value is normalised to midnight and preserves the date context without a time component.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value, or if the resulting date
-    /// exceeds the valid <see cref="DateOnly"/> range.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> used to infer the first day of the week. For example, <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first day of the week containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the specified <paramref name="weekend"/> to infer the first day of the week.
-    /// <para>
-    /// If <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.None"/>, the method defaults to using
-    /// <see cref="DayOfWeek.Monday"/> as the start of the week.
-    /// </para>
-    /// The result is offset backward from <paramref name="date"/> to the most recent occurrence of the inferred first day of the week,
-    /// and is returned with no time component (00:00:00).
+    /// <para>The method infers the start of the week based on the specified <paramref name="weekend"/> value. If <see cref="CalendarWeekendDefinition.None"/> is supplied, the method defaults to using <see cref="DayOfWeek.Monday"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value,
+    /// -or- the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.
+    /// </exception>
     public static DateOnly FirstDayOfWeek(this DateOnly date, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,22 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the first occurrence of the specified <see cref="DayOfWeek"/> within the same month and year as the provided <see cref="DateOnly"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose month and year define the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Friday"/> will return the first Friday in the month.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the first occurrence of <paramref name="dayOfWeek"/> in the same month and year as <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="System.ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="date">The date value whose month and year are used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>The result is calculated by evaluating the 1st day of the month and advancing forward to the first matching <paramref name="dayOfWeek"/>.</para>
-    /// <para>The returned date is guaranteed to fall within the same calendar month and year as <paramref name="date"/>.</para>
+    /// <para>The search begins on the first day of the month and proceeds forward to locate the first matching weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly FirstDayOfWeekInMonth(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfWeekInQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,28 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified
-    /// <see cref="DateOnly"/>, using the provided <see cref="CalendarQuarterDefinition"/> to determine the quarter boundaries.
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> used to identify the calendar quarter.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first
-    /// Monday in the quarter.
-    /// </param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are segmented.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> value representing the first occurrence of <paramref name="dayOfWeek"/> in the quarter that includes <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> or <paramref name="definition"/> is not a defined enumeration value.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The result is calculated by first determining the start day number of the quarter containing <paramref name="date"/> (as defined by
-    /// <paramref name="definition"/>), and then finding the first occurrence of <paramref name="dayOfWeek"/> on or after that day.
-    /// </para>
-    /// <para>The returned date is guaranteed to fall within the same quarter as <paramref name="date"/>.</para>
+    /// <para>The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
     public static DateOnly FirstDayOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -45,33 +36,21 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the first occurrence of the specified <see cref="DayOfWeek"/> within the given calendar quarter and year, using the
-    /// provided <see cref="CalendarQuarterDefinition"/> to determine quarter boundaries.
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year in which the specified quarter occurs.</param>
-    /// <param name="quarter">The 1-based quarter number (1 through 4).</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first
-    /// Monday in the quarter.
-    /// </param>
-    /// <param name="definition">
-    /// The <see cref="CalendarQuarterDefinition"/> that defines how quarters are segmented, such as calendar year or fiscal year.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the first occurrence of <paramref name="dayOfWeek"/> within the specified quarter and year,
-    /// as defined by <paramref name="definition"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is not between 1 and 4 inclusive, or if <paramref name="definition"/> or
-    /// <paramref name="dayOfWeek"/> is not a defined enumeration value.
-    /// </exception>
+    /// <param name="year">The calendar year of the result.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the specified quarter and year.</returns>
     /// <remarks>
-    /// <para>
-    /// The calculation begins from the first day number of the quarter (as defined by <paramref name="definition"/>) and advances forward
-    /// to find the first occurrence of the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The returned value is based on <see cref="DateOnly"/> and does not include any time or kind component.</para>
+    /// <para>The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
     public static DateOnly FirstDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfWeekInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfWeekInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,22 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the first occurrence of the specified <see cref="DayOfWeek"/> in the calendar year of the given <see cref="DateOnly"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the same calendar year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose year is used as the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday of the year.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the first occurrence of <paramref name="dayOfWeek"/> in the same year as <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the year. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the same calendar year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>The result is calculated by evaluating January 1 of the year and advancing forward to the first matching <paramref name="dayOfWeek"/>.</para>
-    /// <para>The returned value is guaranteed to fall within the same calendar year as <paramref name="date"/>.</para>
+    /// <para>The search begins on January 1 of the year and proceeds forward to locate the first matching weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly FirstDayOfWeekInYear(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDayOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FirstDayOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,12 +13,17 @@ public static partial class DateOnlyExtensions
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first day of the same calendar year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose year is used to calculate the result.</param>
-    /// <returns>A <see cref="DateOnly"/> set to January 1 of the same year as <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to January 1 of the same calendar year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method resets the date to January 1 of the year. The result always falls within the same calendar year as the original <paramref name="date"/>.
-    /// </para>
+    /// <para>This method calculates the first day of the year using Gregorian calendar rules.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var date = new DateOnly(2025, 7, 15);
+    /// var result = date.FirstDayOfYear(); // → 2025-01-01
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateOnly FirstDayOfYear(this DateOnly date) => new DateOnly(date.Year, 1, 1);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsFirstDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsFirstDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsFirstDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,10 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the first day of its month.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the first day of its calendar month.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> is the first day of its month; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>This method checks whether the day component of the <paramref name="date"/> is equal to 1.</remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the first day of its month; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>This method evaluates whether the <see cref="DateOnly.Day"/> component is equal to <c>1</c>.</para>
+    /// </remarks>
     public static bool IsFirstDayOfMonth(this DateOnly date) => date.Day == 1;
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsFirstDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsFirstDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsFirstDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,14 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the first day of its calendar quarter.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the first day of its calendar quarter, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> is the first day of its quarter; otherwise, <see langword="false"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the first day of its quarter; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// first day of the quarter based on the standard calendar year definition (January–March as Q1, etc.). The comparison is performed
-    /// using the <see cref="DateOnly"/> property to normalise the time to midnight before evaluating the boundary.
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
     /// </remarks>
     public static bool IsFirstDayOfQuarter(this DateOnly date)
     {
@@ -27,28 +25,13 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the first day of its calendar quarter based on a
-    /// specified <see cref="CalendarQuarterDefinition"/>.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the first day of its calendar quarter, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="definition">Specifies the quarter definition used to determine the first date of the quarter.</param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> is the first day of its quarter based on the specified
-    /// <paramref name="definition"/>; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid member of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the
-    /// <see cref="IsFirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> overload with a custom
-    /// <see cref="IQuarterDefinitionProvider"/> implementation in this case.
-    /// </exception>
-    /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// first day of the quarter based on the provided <paramref name="definition"/>. The comparison is performed using the
-    /// <see cref="DateOnly"/> property to normalise the time to midnight before evaluating the boundary.
-    /// </remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the first day of its quarter under <paramref name="definition"/>; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static bool IsFirstDayOfQuarter(this DateOnly date, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -62,23 +45,12 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the first day of its calendar quarter based on a
-    /// custom quarter definition provided by an <see cref="IQuarterDefinitionProvider"/>.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the first day of its calendar quarter, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="provider">
-    /// An implementation of <see cref="IQuarterDefinitionProvider"/> that defines how quarter boundaries are determined.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> is the first day of its quarter according to the rules of the specified
-    /// <paramref name="provider"/>; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the first day of its quarter as defined by <paramref name="provider"/>; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// first day of the quarter, using the logic defined by the specified <paramref name="provider"/>. The comparison is performed
-    /// using the <see cref="DateOnly"/> property to normalise the time to midnight before evaluating the boundary.
-    /// </remarks>
     public static bool IsFirstDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsInRange.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsInRange.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsInRange.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,36 +11,29 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the specified <see cref="DateOnly"/> value falls within the range defined by <paramref name="start"/> and
-    /// <paramref name="end"/>, inclusive.
+    /// Determines whether the specified <see cref="DateOnly"/> falls within the inclusive range defined by <paramref name="start"/> and <paramref name="end"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value to evaluate.</param>
-    /// <param name="start">The start of the range.</param>
-    /// <param name="end">The end of the range.</param>
-    /// <returns>
-    /// <c>true</c> if <paramref name="date"/> is greater than or equal to <paramref name="start"/> and less than or equal to
-    /// <paramref name="end"/>; otherwise, <c>false</c>.
-    /// </returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="start">The inclusive lower bound of the range.</param>
+    /// <param name="end">The inclusive upper bound of the range.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> is greater than or equal to <paramref name="start"/> and less than or equal to <paramref name="end"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// The range check is inclusive, meaning the result is <see langword="true"/> if <paramref name="date"/> equals either
-    /// <paramref name="start"/> or <paramref name="end"/>.
+    /// <para>The range check is inclusive: the result is <see langword="true"/> if <paramref name="date"/> equals either <paramref name="start"/> or <paramref name="end"/>.</para>
+    /// <para>If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values of <paramref name="date"/>.</para>
     /// </remarks>
     public static bool IsInRange(this DateOnly date, DateOnly start, DateOnly end) => date.CompareTo(start) >= 0 && date.CompareTo(end) <= 0;
 
     /// <summary>
-    /// Determines whether the specified nullable <see cref="DateOnly"/> value falls within the range defined by <paramref name="start"/>
-    /// and <paramref name="end"/>, inclusive.
+    /// Determines whether the specified nullable <see cref="DateOnly"/> falls within the inclusive range defined by <paramref name="start"/> and <paramref name="end"/>.
     /// </summary>
-    /// <param name="date">The nullable <see cref="DateOnly"/> value to evaluate.</param>
-    /// <param name="start">The start of the range.</param>
-    /// <param name="end">The end of the range.</param>
-    /// <returns>
-    /// <c>true</c> if <paramref name="date"/> has a value and that value is greater than or equal to <paramref name="start"/> and less
-    /// than or equal to <paramref name="end"/>; otherwise, <c>false</c>.
-    /// </returns>
+    /// <param name="date">The nullable date value to evaluate.</param>
+    /// <param name="start">The inclusive lower bound of the range.</param>
+    /// <param name="end">The inclusive upper bound of the range.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> has a value that is greater than or equal to <paramref name="start"/> and less than or equal to <paramref name="end"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
     /// <para>If <paramref name="date"/> is <see langword="null"/>, the result is <see langword="false"/>.</para>
-    /// <para>The range check is inclusive, meaning the result is <see langword="true"/> if the value equals either boundary.</para>
+    /// <para>The range check is inclusive: the result is <see langword="true"/> if the value equals either boundary.</para>
+    /// <para>If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values of <paramref name="date"/>.</para>
     /// </remarks>
     public static bool IsInRange(this DateOnly? date, DateOnly start, DateOnly end) => date.HasValue && date.Value.IsInRange(start, end);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLastDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLastDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsLastDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,13 +11,13 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the last day of its month.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the last day of its calendar month.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> is the last day of its month; otherwise, <see langword="false"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the last day of its month; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// This method compares the day component of the <paramref name="date"/> with the total number of days in its month, accounting
-    /// for variations such as leap years.
+    /// <para>This method compares the <see cref="DateOnly.Day"/> component to the total number of days in the same month and year, accounting for leap-year adjustments to February.</para>
+    /// <para>Equivalent to checking whether <c>date.Day == DateTime.DaysInMonth(date.Year, date.Month)</c>.</para>
     /// </remarks>
     public static bool IsLastDayOfMonth(this DateOnly date) => date.Day == DateTime.DaysInMonth(date.Year, date.Month);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLastDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLastDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsLastDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,16 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the last day of its calendar quarter based on the
-    /// standard January–December quarter definition.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the last day of its calendar quarter, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> is the last day of its quarter; otherwise, <see langword="false"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the last day of its quarter; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// last day of the quarter, assuming a standard calendar year definition where Q1 is January–March, Q2 is April–June, Q3 is
-    /// July–September, and Q4 is October–December. The comparison is performed using the <see cref="DateOnly"/> property to normalise
-    /// the time to midnight before evaluating the boundary.
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
     /// </remarks>
     public static bool IsLastDayOfQuarter(this DateOnly date)
     {
@@ -29,28 +25,13 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the last day of its calendar quarter based on a
-    /// specified <see cref="CalendarQuarterDefinition"/>.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the last day of its calendar quarter, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="definition">Specifies the quarter definition used to determine the last date of the quarter.</param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> is the last day of its quarter based on the specified
-    /// <paramref name="definition"/>; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid member of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the
-    /// <see cref="IsFirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> overload with a custom
-    /// <see cref="IQuarterDefinitionProvider"/> implementation in this case.
-    /// </exception>
-    /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// last day of the quarter based on the provided <paramref name="definition"/>. The comparison is performed using the
-    /// <see cref="DateOnly"/> property to normalise the time to midnight before evaluating the boundary.
-    /// </remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the last day of its quarter under <paramref name="definition"/>; otherwise, <see langword="false"/>.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static bool IsLastDayOfQuarter(this DateOnly date, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -64,23 +45,12 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines whether the current <see cref="DateOnly"/> instance represents the last day of its calendar quarter based on a
-    /// custom quarter definition provided by an <see cref="IQuarterDefinitionProvider"/>.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on the last day of its calendar quarter, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="provider">
-    /// An implementation of <see cref="IQuarterDefinitionProvider"/> that defines how quarter boundaries are determined.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> is the last day of its quarter according to the rules of the specified
-    /// <paramref name="provider"/>; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> represents the last day of its quarter as defined by <paramref name="provider"/>; otherwise, <see langword="false"/>.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <remarks>
-    /// This method evaluates whether the date component (ignoring the time of day) of the <paramref name="date"/> corresponds to the
-    /// last day of the quarter, using the logic defined by the specified <paramref name="provider"/>. The comparison is performed
-    /// using the <see cref="DateOnly"/> property to normalise the time to midnight before evaluating the boundary.
-    /// </remarks>
     public static bool IsLastDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLeapYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsLeapYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsLeapYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,13 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the year of the specified <see cref="DateOnly"/> is a leap year in the Gregorian calendar.
+    /// Determines whether the year of the specified <see cref="DateOnly"/> is a leap year, according to the proleptic Gregorian calendar.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose year is evaluated.</param>
-    /// <returns><see langword="true"/> if the year is a leap year (i.e., contains February 29); otherwise, <see langword="false"/>.</returns>
+    /// <param name="date">The date value whose <see cref="DateOnly.Year"/> is evaluated.</param>
+    /// <returns><see langword="true"/> if the year contains February 29; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// This method follows the rules of the Gregorian calendar, where a leap year occurs every 4 years, except for years that are
-    /// divisible by 100 but not by 400 (e.g., 2000 was a leap year, but 1900 was not).
+    /// <para>This method applies the Gregorian leap-year rules:</para>
+    /// <list type="bullet">
+    /// <item><description>Years divisible by 4 are leap years,</description></item>
+    /// <item><description>except years divisible by 100,</description></item>
+    /// <item><description>unless also divisible by 400.</description></item>
+    /// </list>
+    /// <para>For example, the years 2000 and 2024 are leap years, while 1900 and 2100 are not.</para>
+    /// <para>This method does not consider culture-specific calendars; it always evaluates leap years using the Gregorian calendar.</para>
     /// </remarks>
     public static bool IsLeapYear(this DateOnly date) => DateTime.IsLeapYear(date.Year);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,25 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekday using the default
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekday, using the default <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> is not Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>A weekday is defined as any day not considered a weekend by the default rule.</remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> does not fall on Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>A weekday is any day not considered a weekend under the <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule. This overload is equivalent to calling <see cref="IsWeekday(DateOnly, CalendarWeekendDefinition, IWeekendDefinitionProvider?)"/> with <see cref="CalendarWeekendDefinition.SaturdaySunday"/> and no custom provider.</para>
+    /// </remarks>
     public static bool IsWeekday(this DateOnly date) => !IsWeekend(date, CalendarWeekendDefinition.SaturdaySunday, null);
 
     /// <summary>
-    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekday, based on the provided
-    /// <see cref="CalendarWeekendDefinition"/> rule.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekday, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> value that defines which days are considered part of the weekend.</param>
-    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> used for custom weekend rules.</param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> is considered a weekday under the specified weekend rule; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> but <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> is not a weekend under the supplied rule or provider; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>The method evaluates whether the <see cref="DateOnly.DayOfWeek"/> of <paramref name="date"/> is excluded from the weekend definition supplied by <paramref name="weekend"/> and optionally refined by <paramref name="provider"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static bool IsWeekday(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekend(date, weekend, provider);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekday.cs
@@ -30,6 +30,9 @@ public static partial class DateOnlyExtensions
     /// <remarks>
     /// <para>The method evaluates whether the <see cref="DateOnly.DayOfWeek"/> of <paramref name="date"/> is excluded from the weekend definition supplied by <paramref name="weekend"/> and optionally refined by <paramref name="provider"/>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsWeekday(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekend(date, weekend, provider);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekend.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekend.cs
@@ -30,6 +30,9 @@ public static partial class DateOnlyExtensions
     /// <remarks>
     /// <para>This method supports alternative weekend definitions used in different cultures and regions, such as Friday/Saturday or Sunday-only.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsWeekend(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => DateTimeExtensions.IsWeekend(date.DayOfWeek, weekend, provider);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekend.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsWeekend.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.IsWeekend.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,35 +11,25 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekend using the default
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekend, using the default <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <returns><see langword="true"/> if the <paramref name="date"/> occurs on Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>This method assumes the standard Western weekend definition, where weekends are Saturday and Sunday.</remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> falls on Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard weekend definition where Saturday and Sunday are considered weekend days.</para>
+    /// </remarks>
     public static bool IsWeekend(this DateOnly date) => DateTimeExtensions.IsWeekend(date.DayOfWeek, CalendarWeekendDefinition.SaturdaySunday, null);
 
     /// <summary>
-    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekend, based on the provided
-    /// <see cref="CalendarWeekendDefinition"/> rule.
+    /// Determines whether the specified <see cref="DateOnly"/> falls on a weekend, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <param name="weekend">
-    /// The <see cref="CalendarWeekendDefinition"/> value that defines which days are considered part of the weekend.
-    /// </param>
-    /// <param name="provider">
-    /// An optional custom <see cref="IWeekendDefinitionProvider"/> used when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns>
-    /// <see langword="true"/> if the <paramref name="date"/> occurs on a weekend day according to the specified rule or custom
-    /// provider; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> but no <paramref name="provider"/> is supplied.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are treated as weekend days.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="date"/> falls on a weekend day as defined by the supplied rule or provider; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// Use this method to evaluate weekend status under different global or cultural definitions, such as Friday/Saturday in the Middle
-    /// East or Sunday-only in some business contexts.
+    /// <para>This method supports alternative weekend definitions used in different cultures and regions, such as Friday/Saturday or Sunday-only.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static bool IsWeekend(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => DateTimeExtensions.IsWeekend(date.DayOfWeek, weekend, provider);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,20 +11,34 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the last day of the same month and year as the specified date.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the same calendar month and year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose month and year are used.</param>
-    /// <returns>A <see cref="DateOnly"/> value set to the last day of the same month and year as <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose year and month are used to determine the result.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the same calendar month and year as <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This method calculates the last day of the month using Gregorian calendar rules. Leap years are correctly accounted for when determining the length of February.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var date = new DateOnly(2024, 2, 15);
+    /// var result = date.LastDayOfMonth(); // → 2024-02-29
+    ///]]>
+    /// </code>
+    /// </remarks>
     public static DateOnly LastDayOfMonth(this DateOnly date) => DateOnly.FromDayNumber(DateTimeExtensions.GetDayNumber(date.Year, date.Month, DateTime.DaysInMonth(date.Year, date.Month)));
 
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the last day of the specified year and month.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the specified calendar month and year.
     /// </summary>
-    /// <param name="year">The year component of the date. Must be between 1 and 9999 inclusive.</param>
-    /// <param name="month">The month component of the date. Must be between 1 and 12 inclusive.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
     /// <returns>A <see cref="DateOnly"/> value set to the last day of the specified month and year.</returns>
+    /// <remarks>
+    /// <para>This method uses Gregorian calendar rules to determine the number of days in the specified month, including leap-year adjustments for February.</para>
+    /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999, or if <paramref name="month"/> is not between 1 and 12.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12.
     /// </exception>
     public static DateOnly LastDayOfMonth(int year, int month)
     {

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,97 +11,33 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the last day of the calendar quarter for the specified <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the calendar quarter that contains the specified <paramref name="date"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose quarter is evaluated.</param>
-    /// <returns>A <see cref="DateOnly"/> value representing the last day of the quarter that includes <paramref name="date"/>.</returns>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the standard calendar quarter definition:
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <term>Q1</term>
-    /// <description>January–March</description>
-    /// </item>
-    /// <item>
-    /// <term>Q2</term>
-    /// <description>April–June</description>
-    /// </item>
-    /// <item>
-    /// <term>Q3</term>
-    /// <description>July–September</description>
-    /// </item>
-    /// <item>
-    /// <term>Q4</term>
-    /// <description>October–December</description>
-    /// </item>
+    /// <item><term>Q1</term><description>January – March</description></item>
+    /// <item><term>Q2</term><description>April – June</description></item>
+    /// <item><term>Q3</term><description>July – September</description></item>
+    /// <item><term>Q4</term><description>October – December</description></item>
     /// </list>
     /// </remarks>
     public static DateOnly LastDayOfQuarter(this DateOnly date) => LastDayOfQuarter(date, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the last day of the specified <paramref name="quarter"/> in the given
-    /// <paramref name="year"/>, using the standard month-aligned calendar quarter definition.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the quarter that contains the specified <paramref name="date"/>, using the specified calendar quarter definition.
     /// </summary>
-    /// <param name="quarter">
-    /// The quarter number to evaluate (1 through 4), based on the conventional calendar quarters: Q1 = January–March, Q2 = April–June,
-    /// Q3 = July–September, Q4 = October–December.
-    /// </param>
-    /// <param name="year">
-    /// The calendar year used to evaluate the quarter. The returned date will represent the last day of the quarter relative to this year.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the final day of the specified calendar quarter in the given year.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is not between 1 and 4 (inclusive).</exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the corresponding quarter.</returns>
     /// <remarks>
-    /// <para>This method uses the <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> structure as the default quarter system:</para>
-    /// <list type="bullet">
-    /// <item>
-    /// <term>Q1</term>
-    /// <description>January 1 – March 31</description>
-    /// </item>
-    /// <item>
-    /// <term>Q2</term>
-    /// <description>April 1 – June 30</description>
-    /// </item>
-    /// <item>
-    /// <term>Q3</term>
-    /// <description>July 1 – September 30</description>
-    /// </item>
-    /// <item>
-    /// <term>Q4</term>
-    /// <description>October 1 – December 31</description>
-    /// </item>
-    /// </list>
-    /// <para>
-    /// To evaluate alternate fiscal or day-aligned definitions, use the
-    /// <see cref="LastDayOfQuarter(CalendarQuarterDefinition, int, int)"/> or provider-based overloads.
-    /// </para>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month (e.g. January – March) or anchored to a custom day-of-month boundary.</para>
+    /// <para>For provider-driven (e.g. 4-4-5 fiscal) quarters, use the <see cref="LastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> overload instead.</para>
     /// </remarks>
-    public static DateOnly LastDayOfQuarter(int quarter, int year) => LastDayOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
-
-    /// <summary>
-    /// Returns the last day of the quarter that includes the specified <paramref name="date"/>, based on the provided <see cref="CalendarQuarterDefinition"/>.
-    /// </summary>
-    /// <param name="date">
-    /// The <see cref="DateOnly"/> to evaluate. The returned value will be the final calendar day of the quarter that contains this
-    /// date, as defined by the selected quarter structure.
-    /// </param>
-    /// <param name="definition">Specifies the quarter definition used to determine the last date of the quarter.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the last day of the determined quarter.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid member of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the
-    /// <see cref="LastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> overload with a custom
-    /// <see cref="IQuarterDefinitionProvider"/> implementation in this case.
-    /// </exception>
-    /// <remarks>
-    /// <para>
-    /// This method supports both month-aligned and day-aligned quarter structures. When the definition does not align to the first day
-    /// of a month, the result is computed based on the anchor day and adjusted accordingly.
-    /// </para>
-    /// <para>For non-standard quarter systems (e.g., 4-4-5 or 13-week models), use the provider-based overload <see cref="LastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/>.</para>
-    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly LastDayOfQuarter(this DateOnly date, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -115,31 +51,49 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the last day of the specified <paramref name="quarter"/> in the given <paramref name="year"/>, based on the provided <see cref="CalendarQuarterDefinition"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the quarter that contains the specified <paramref name="date"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="definition">Specifies the quarter definition used to determine the last date of the quarter.</param>
-    /// <param name="quarter">
-    /// The quarter number to evaluate (1 through 4). Represents the Nth quarter following the definition’s anchor month and day.
-    /// </param>
-    /// <param name="year">
-    /// The reference calendar year. The result will represent the end date of the specified quarter relative to this year. If the
-    /// quarter ends in the next calendar year (based on modular month arithmetic), the year will be incremented accordingly.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the last day of the specified quarter in the applicable year.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is not between 1 and 4 (inclusive), or if <paramref name="definition"/> is not a defined
-    /// value of the <see cref="CalendarQuarterDefinition"/> enumeration.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>, which requires a provider-based
-    /// overload. Use the <see cref="LastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> method instead.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the quarter containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>For month-aligned definitions (e.g., <c>07</c> for July), each quarter ends on the last day of the third month.</para>
-    /// <para>
-    /// For day-aligned definitions (e.g., <c>0406</c> for April 6), each quarter ends the day before the next quarter’s anchor day.
-    /// </para>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating boundary logic to the supplied <paramref name="provider"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns a date outside the range of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>.</exception>
+    public static DateOnly LastDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        return provider.GetQuarterEndDate(date);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the specified quarter and year.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is less than 1 or greater than 4.</exception>
+    public static DateOnly LastDayOfQuarter(int quarter, int year) => LastDayOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
+    /// </summary>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive. If the quarter ends in the next calendar year (based on the definition's anchor), the year will be incremented accordingly.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the specified quarter.</returns>
+    /// <remarks>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
     public static DateOnly LastDayOfQuarter(CalendarQuarterDefinition definition, int quarter, int year)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
@@ -150,23 +104,5 @@ public static partial class DateOnlyExtensions
                 string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
 
         return DateOnly.FromDayNumber(ComputeQuarterEndDayNumber(year, quarter, GetQuarterDefinition(definition)));
-    }
-
-    /// <summary>
-    /// Returns the last day of the quarter based on a custom <see cref="IQuarterDefinitionProvider"/> implementation.
-    /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose quarter is being evaluated.</param>
-    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter logic.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the last calendar day of the applicable custom quarter.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns an invalid quarter boundary.</exception>
-    /// <remarks>
-    /// This method supports advanced quarter systems such as 4-4-5 accounting or domain-specific fiscal quarters by delegating logic to
-    /// the specified <paramref name="provider"/>.
-    /// </remarks>
-    public static DateOnly LastDayOfQuarter(this DateOnly date, IQuarterDefinitionProvider provider)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        return provider.GetQuarterEndDate(date);
     }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,27 +14,25 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the last day of the week that contains the specified <see cref="DateOnly"/>, using the current culture's settings.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the week that contains the specified <paramref name="date"/>, using the last day of the week defined by <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> for which to determine the end of the week.</param>
-    /// <returns>A <see cref="DateOnly"/> representing the last day of the week that includes <paramref name="date"/>.</returns>
-    /// <remarks>This method uses <see cref="CultureInfo.CurrentCulture"/> to determine the last day of the week, inferred from <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</remarks>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the culturally defined last day of the week containing <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the last day of the week, inferred from <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
+    /// </remarks>
     public static DateOnly LastDayOfWeek(this DateOnly date) => date.LastDayOfWeek(null!);
 
     /// <summary>
-    /// Returns the last day of the week that contains the specified <see cref="DateOnly"/>, using the provided or current culture.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the week that contains the specified <paramref name="date"/>, using the last day of the week defined by the supplied or current culture.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> for which to determine the end of the week.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to determine the first day of the week via
-    /// <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the last day of the week that includes <paramref name="date"/>.</returns>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that defines the first day of the week via <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the culturally defined last day of the week containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method calculates the number of days to add to <paramref name="date"/> to reach the culturally defined last day of the week.
-    /// The result is validated to ensure it falls within the valid range of <see cref="DateOnly"/>.
+    /// <para>This method computes the day offset between <paramref name="date"/> and the culture-specific last day of the week, and adds that offset.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the calculated result exceeds the supported range for <see cref="DateOnly"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.</exception>
     public static DateOnly LastDayOfWeek(this DateOnly date, CultureInfo culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
@@ -51,31 +49,18 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the last day of the week that contains the specified <see cref="DateOnly"/>, using the inferred start-of-week day from the
-    /// provided <see cref="CalendarWeekendDefinition"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the last day of the week that contains the specified <paramref name="date"/>, using a start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose week context is evaluated.</param>
-    /// <param name="weekend">
-    /// A <see cref="CalendarWeekendDefinition"/> value used to infer the start of the week and determine the week's structure.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> value representing the last day of the week that contains <paramref name="date"/>. The returned value is
-    /// normalised to midnight and preserves the date context without a time component.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value, or if the resulting date
-    /// exceeds the valid <see cref="DateOnly"/> range.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing week.</param>
+    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> used to infer the last day of the week. For example, <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start (and therefore a Sunday end).</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last day of the week containing <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the specified <paramref name="weekend"/> to infer the first day of the week, then calculates the last day as 6
-    /// days after the inferred start.
-    /// <para>
-    /// If <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.None"/>, the method defaults to using
-    /// <see cref="DayOfWeek.Monday"/> as the start of the week.
-    /// </para>
-    /// The result is offset forward from <paramref name="date"/> to the next occurrence of the inferred last day of the week, and is
-    /// returned with no time component (00:00:00).
+    /// <para>The method infers the start of the week based on the specified <paramref name="weekend"/> value, then calculates the last day as six days after the inferred start. If <see cref="CalendarWeekendDefinition.None"/> is supplied, the method defaults to using <see cref="DayOfWeek.Monday"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value,
+    /// -or- the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.
+    /// </exception>
     public static DateOnly LastDayOfWeek(this DateOnly date, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the last occurrence of the specified <see cref="DayOfWeek"/> within the same month and year as the given <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose month and year define the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate. For example, <see cref="DayOfWeek.Friday"/> returns the last Friday of the month.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the last occurrence of <paramref name="dayOfWeek"/> in the same month and year as <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value in the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="date">The date value whose month and year are used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The search begins at the last day of the month and proceeds backward until a matching <paramref name="dayOfWeek"/> is found.
-    /// </para>
-    /// <para>The returned date always falls within the same calendar month and year as <paramref name="date"/>.</para>
+    /// <para>The search begins on the last day of the month and proceeds backward to locate the last matching weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly LastDayOfWeekInMonth(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfWeekInQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,28 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified
-    /// <see cref="DateOnly"/>, using the provided <see cref="CalendarQuarterDefinition"/> to determine the quarter boundaries.
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> used to identify the calendar quarter.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last
-    /// Monday in the quarter.
-    /// </param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are segmented.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> value representing the last occurrence of <paramref name="dayOfWeek"/> in the quarter that includes <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> or <paramref name="definition"/> is not a defined enumeration value.
-    /// </exception>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The result is calculated by first determining the end date of the quarter containing <paramref name="date"/> (as defined by
-    /// <paramref name="definition"/>), and then finding the last occurrence of <paramref name="dayOfWeek"/> on or before that date.
-    /// </para>
-    /// <para>The returned value is guaranteed to fall within the same quarter as <paramref name="date"/>.</para>
+    /// <para>The end of the quarter is computed using <paramref name="definition"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
     public static DateOnly LastDayOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -45,31 +36,21 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the last occurrence of the specified <see cref="DayOfWeek"/> within the given calendar quarter and year, using the
-    /// provided <see cref="CalendarQuarterDefinition"/> to determine quarter boundaries.
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year in which the quarter occurs.</param>
-    /// <param name="quarter">The 1-based quarter number (1 through 4).</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate within the quarter. For example, <see cref="DayOfWeek.Friday"/> returns the last
-    /// Friday in the quarter.
-    /// </param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are segmented.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> value representing the last occurrence of <paramref name="dayOfWeek"/> within the specified quarter
-    /// and year, as defined by <paramref name="definition"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is not between 1 and 4 inclusive, or if <paramref name="definition"/> or
-    /// <paramref name="dayOfWeek"/> is not a valid enumeration value.
-    /// </exception>
+    /// <param name="year">The calendar year of the result.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the specified quarter and year.</returns>
     /// <remarks>
-    /// <para>
-    /// The calculation begins from the last day of the quarter, as defined by <paramref name="definition"/>, and steps backward to
-    /// find the most recent occurrence of the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The returned value reflects a calendar date within the quarter and does not include any time or kind metadata.</para>
+    /// <para>The end of the quarter is computed using <paramref name="definition"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
     public static DateOnly LastDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfWeekInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfWeekInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,27 +11,20 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the last occurrence of the specified <see cref="DayOfWeek"/> within the same calendar year as the given <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the same calendar year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> whose year defines the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Sunday"/> returns the last Sunday in the year.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the last occurrence of the specified <paramref name="dayOfWeek"/> within the same
-    /// calendar year as <paramref name="date"/>.
-    /// </returns>
-    /// <exception cref="System.ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the year. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the same calendar year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// The search begins from December 31 of the year specified in <paramref name="date"/> and proceeds backward to find the specified <paramref name="dayOfWeek"/>.
+    /// <para>The search begins on December 31 of the year and proceeds backward to locate the last matching weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly LastDayOfWeekInYear(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-        int dayNumber = DateTimeExtensions.GetDayNumberUnchecked(date.Year, 12, 31);
 
+        int dayNumber = DateTimeExtensions.GetDayNumberUnchecked(date.Year, 12, 31);
         return DateOnly.FromDayNumber(dayNumber - (((int)GetDayOfWeekFromDayNumber(dayNumber) - (int)dayOfWeek + 7) % 7));
     }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDayOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.LastDayOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,13 +13,17 @@ public static partial class DateOnlyExtensions
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last day of the same calendar year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> whose year is used to determine the result.</param>
-    /// <returns>A <see cref="DateOnly"/> set to December 31 of the same year as <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose year is used to determine the result.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to December 31 of the same calendar year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method returns December 31 of the specified year using the Gregorian calendar. The result always falls within the same
-    /// calendar year as <paramref name="date"/>.
-    /// </para>
+    /// <para>This method calculates the last day of the year using Gregorian calendar rules.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var date = new DateOnly(2025, 7, 15);
+    /// var result = date.LastDayOfYear(); // → 2025-12-31
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateOnly LastDayOfYear(this DateOnly date) => new DateOnly(date.Year, 12, 31);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.Max.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.Max.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.Max.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -16,18 +16,19 @@ public static partial class DateOnlyExtensions
     /// <param name="first">The first <see cref="DateOnly"/> value to compare.</param>
     /// <param name="second">The second <see cref="DateOnly"/> value to compare.</param>
     /// <returns>The later of the two <see cref="DateOnly"/> values. If both values are equal, <paramref name="first"/> is returned.</returns>
-    /// <remarks>This method compares two non-null <see cref="DateOnly"/> values using <see cref="DateOnly.CompareTo(DateOnly)"/>.</remarks>
+    /// <remarks>
+    /// <para>This method compares the two values using the greater-than-or-equal-to (<c>&gt;=</c>) operator, which is equivalent to <see cref="DateOnly.CompareTo(DateOnly)"/>.</para>
+    /// </remarks>
     public static DateOnly Max(DateOnly first, DateOnly second) => first >= second ? first : second;
 
     /// <summary>
-    /// Returns the later of two nullable <see cref="DateOnly"/> values.
+    /// Returns the later of two specified nullable <see cref="DateOnly"/> values.
     /// </summary>
     /// <param name="first">The first nullable <see cref="DateOnly"/> value to compare.</param>
     /// <param name="second">The second nullable <see cref="DateOnly"/> value to compare.</param>
-    /// <returns>The later non-null <see cref="DateOnly"/> value, or <c>null</c> if both values are <c>null</c>.</returns>
+    /// <returns>The later non-null <see cref="DateOnly"/> value, or <see langword="null"/> if both values are <see langword="null"/>.</returns>
     /// <remarks>
-    /// If both values are non-null, they are compared using <see cref="DateOnly.CompareTo(DateOnly)"/>. If only one is non-null, that
-    /// value is returned.
+    /// <para>If both values are non-null, they are compared using the greater-than-or-equal-to (<c>&gt;=</c>) operator. If only one value is non-null, that value is returned. If both are <see langword="null"/>, the result is <see langword="null"/>.</para>
     /// </remarks>
     public static DateOnly? Max(DateOnly? first, DateOnly? second) => first.HasValue && second.HasValue ? (first.Value >= second.Value ? first : second) : first ?? second;
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.Min.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.Min.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.Min.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -16,18 +16,19 @@ public static partial class DateOnlyExtensions
     /// <param name="first">The first <see cref="DateOnly"/> value to compare.</param>
     /// <param name="second">The second <see cref="DateOnly"/> value to compare.</param>
     /// <returns>The earlier of the two <see cref="DateOnly"/> values. If both values are equal, <paramref name="first"/> is returned.</returns>
-    /// <remarks>This method compares two non-null <see cref="DateOnly"/> values using <see cref="DateOnly.CompareTo(DateOnly)"/>.</remarks>
+    /// <remarks>
+    /// <para>This method compares the two values using the less-than-or-equal-to (<c>&lt;=</c>) operator, which is equivalent to <see cref="DateOnly.CompareTo(DateOnly)"/>.</para>
+    /// </remarks>
     public static DateOnly Min(DateOnly first, DateOnly second) => first <= second ? first : second;
 
     /// <summary>
-    /// Returns the earlier of two nullable <see cref="DateOnly"/> values.
+    /// Returns the earlier of two specified nullable <see cref="DateOnly"/> values.
     /// </summary>
     /// <param name="first">The first nullable <see cref="DateOnly"/> value to compare.</param>
     /// <param name="second">The second nullable <see cref="DateOnly"/> value to compare.</param>
-    /// <returns>The earlier non-null <see cref="DateOnly"/> value, or <c>null</c> if both values are <c>null</c>.</returns>
+    /// <returns>The earlier non-null <see cref="DateOnly"/> value, or <see langword="null"/> if both values are <see langword="null"/>.</returns>
     /// <remarks>
-    /// If both values are non-null, they are compared using <see cref="DateOnly.CompareTo(DateOnly)"/>. If only one is non-null, that
-    /// value is returned.
+    /// <para>If both values are non-null, they are compared using the less-than-or-equal-to (<c>&lt;=</c>) operator. If only one value is non-null, that value is returned. If both are <see langword="null"/>, the result is <see langword="null"/>.</para>
     /// </remarks>
     public static DateOnly? Min(DateOnly? first, DateOnly? second) =>
         first.HasValue && second.HasValue

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.MonthName.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.MonthName.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.MonthName.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,26 +13,23 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the full name of the month for the specified <see cref="DateOnly"/>, using the formatting rules of the current culture.
+    /// Returns the full name of the month for the specified <see cref="DateOnly"/>, using the formatting rules of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose month is used to determine the name.</param>
-    /// <returns>A <see cref="string"/> representing the localized full month name based on <see cref="CultureInfo.CurrentCulture"/>.</returns>
+    /// <param name="date">The date value whose month component is used to determine the name.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// This method retrieves the month name from <see cref="DateTimeFormatInfo.MonthNames"/> using the current culture's formatting.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the current culture to retrieve the month name. For culture-specific results, use the <see cref="MonthName(DateOnly, CultureInfo?)"/> overload.</para>
     /// </remarks>
     public static string MonthName(this DateOnly date) => date.MonthName((CultureInfo?)null);
 
     /// <summary>
-    /// Returns the full name of the month for the specified <see cref="DateOnly"/>, using the formatting rules of the specified <see cref="CultureInfo"/>.
+    /// Returns the full name of the month for the specified <see cref="DateOnly"/>, using the formatting rules of the supplied or current culture.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value whose month is used to determine the name.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to format the result. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>A <see cref="string"/> representing the localized full month name for the month of <paramref name="date"/>.</returns>
+    /// <param name="date">The date value whose month component is used to determine the name.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to format the result. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name for <paramref name="date"/>, formatted using the supplied or current culture.</returns>
     /// <remarks>
-    /// This method retrieves the month name from the <see cref="DateTimeFormatInfo.MonthNames"/> collection of the specified or
-    /// current culture.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the supplied or current culture to retrieve the month name.</para>
     /// </remarks>
-    public static string MonthName(this DateOnly date, CultureInfo? culture) => (culture ?? System.Globalization.CultureInfo.CurrentCulture).DateTimeFormat.GetMonthName(date.Month);
+    public static string MonthName(this DateOnly date, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.GetMonthName(date.Month);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NearestDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NearestDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.NearestDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,15 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the nearest date to <paramref name="date"/> that falls on the specified <paramref name="dayOfWeek"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the nearest date (before or after) to the specified <paramref name="date"/> that falls on the given <see cref="DayOfWeek"/>.
     /// </summary>
-    /// <param name="date">The reference date.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to find.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the closest date (before or after) to <paramref name="date"/> that falls on the
-    /// specified <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when an enumeration argument is not a defined value of its declaring type.</exception>
+    /// <param name="date">The reference date value.</param>
+    /// <param name="dayOfWeek">The target <see cref="DayOfWeek"/> to locate.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the closest date (either before or after) to <paramref name="date"/> that falls on the specified <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned.</returns>
+    /// <remarks>
+    /// <para>The result is computed by evaluating the day-distance between <paramref name="date"/> and the nearest occurrence of <paramref name="dayOfWeek"/> in either direction.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly NearestDayOfWeek(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -28,19 +28,17 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the nearest date to the specified year/month/day that falls on the given <paramref name="dayOfWeek"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the nearest date (before or after) to the specified calendar <paramref name="year"/>, <paramref name="month"/>, and <paramref name="day"/> that falls on the given <see cref="DayOfWeek"/>.
     /// </summary>
-    /// <param name="year">The year component of the reference date.</param>
-    /// <param name="month">The month component of the reference date.</param>
-    /// <param name="day">The day component of the reference date.</param>
-    /// <param name="dayOfWeek">The target <see cref="DayOfWeek"/> to find.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the closest date (before or after) to the input date that falls on the specified
-    /// <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <param name="year">The calendar year of the reference date. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the reference date. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="day">The day component of the reference date. Must be valid for the specified <paramref name="year"/> and <paramref name="month"/>, including leap-year considerations for February.</param>
+    /// <param name="dayOfWeek">The target <see cref="DayOfWeek"/> to locate.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the closest date (either before or after) to the specified reference date that falls on the given <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned.</returns>
+    /// <remarks>
+    /// <para>The result is computed by evaluating the day-distance between the specified reference date and the nearest occurrence of <paramref name="dayOfWeek"/> in either direction.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly NearestDayOfWeek(int year, int month, int day, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NextDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NextDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.NextDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the next calendar occurrence of the specified <see cref="DayOfWeek"/> after
-    /// the given <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the next calendar occurrence of the specified <see cref="DayOfWeek"/> after the given <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search forward.</param>
-    /// <param name="dayOfWeek">
-    /// The desired <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> will return the next Monday.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the next occurrence of <paramref name="dayOfWeek"/> after <paramref name="date"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> enum value.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search forward.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> returns the next Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the next occurrence of <paramref name="dayOfWeek"/> following <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> already falls on the specified <paramref name="dayOfWeek"/>, the result will be exactly 7 days
-    /// later (i.e., the next calendar occurrence).
-    /// </para>
-    /// <para>The returned value is a pure calendar date with no time or kind metadata.</para>
+    /// <para>If <paramref name="date"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly seven days later. The method advances forward in time and never returns the original date.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly NextDayOfWeek(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NextOccurrence.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NextOccurrence.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.NextOccurrence.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,33 +11,24 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Calculates the next occurrence of a periodic event based on a given start date and recurrence interval, relative to a specified
-    /// point in time.
+    /// Returns a new <see cref="DateOnly"/> representing the next occurrence of a recurring event that starts at <paramref name="start"/> and repeats every <paramref name="intervalDays"/> days, occurring on or after the specified <paramref name="after"/> date.
     /// </summary>
-    /// <param name="start">The <see cref="DateOnly"/> representing the initial start date of the recurring event.</param>
-    /// <param name="intervalDays">The number of days between each recurrence. Must be greater than zero.</param>
-    /// <param name="after">A <see cref="DateOnly"/> after which the next occurrence should be found.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the next occurrence of the event after the specified <paramref name="after"/> date.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="intervalDays"/> is less than or equal to zero.</exception>
+    /// <param name="start">The date value representing the initial reference point of the recurring event.</param>
+    /// <param name="intervalDays">The fixed number of days between successive occurrences. Must be greater than zero.</param>
+    /// <param name="after">The date after which the next occurrence must fall.</param>
+    /// <returns>A <see cref="DateOnly"/> value representing the next occurrence of the event aligned with <paramref name="start"/> and recurring every <paramref name="intervalDays"/> days, on or after <paramref name="after"/>.</returns>
     /// <remarks>
-    /// The returned date is aligned with the <paramref name="start"/> date and repeats every <paramref name="intervalDays"/> days.
-    /// </remarks>
-    /// <example>
-    /// The following example finds the next occurrence of an event that starts on January 1, 2024 and repeats every 5 days, after a
-    /// given reference date:
+    /// <para>If <paramref name="after"/> is earlier than <paramref name="start"/>, the method returns <paramref name="start"/>. Otherwise, it computes the smallest multiple of <paramref name="intervalDays"/> added to <paramref name="start"/> that occurs after <paramref name="after"/>.</para>
+    /// <para><b>Example:</b></para>
     /// <code>
     ///<![CDATA[
     /// var start = new DateOnly(2024, 1, 1);
     /// var after = new DateOnly(2024, 1, 12);
-    /// int intervalDays = 5;
-    ///
-    /// var next = start.NextOccurrence(intervalDays, after);
-    /// // Output: 2024-01-16
+    /// var next = start.NextOccurrence(intervalDays: 5, after); // → 2024-01-16
     ///]]>
     /// </code>
-    /// </example>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="intervalDays"/> is less than or equal to zero.</exception>
     public static DateOnly NextOccurrence(this DateOnly start, int intervalDays, DateOnly after)
     {
         ThrowHelper.ThrowIfLessThanOrEqual(intervalDays, 0);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NextWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NextWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.NextWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the next calendar weekday after the given <paramref name="date"/>, based on
-    /// the specified <paramref name="weekend"/> definition.
+    /// Returns a new <see cref="DateOnly"/> representing the next calendar weekday after the specified <paramref name="date"/>, based on the supplied <paramref name="weekend"/> definition.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search forward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines which days are considered weekends.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the next weekday after <paramref name="date"/>, according to the specified
-    /// <paramref name="weekend"/> pattern.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid <see cref="CalendarWeekendDefinition"/> value.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search forward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first calendar day after <paramref name="date"/> that is not a weekend under the specified <paramref name="weekend"/> rule.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> is a weekday, the result will be the next calendar day that is also a weekday based on the weekend definition.
-    /// </para>
-    /// <para>The returned value is a pure calendar date and does not include any time-of-day or kind metadata.</para>
+    /// <para>The method evaluates each successive day until it finds one that is not designated as a weekend by the specified rule. The original <paramref name="date"/> is never returned, even if it already falls on a weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateOnly NextWeekday(this DateOnly date, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);
@@ -44,29 +35,16 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the next calendar weekday after the given <paramref name="date"/>, based on
-    /// the specified <paramref name="weekend"/> definition and optional <paramref name="provider"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the next calendar weekday after the specified <paramref name="date"/>, using the supplied <paramref name="weekend"/> definition and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search forward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines the default pattern of weekend days.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> that can override the weekend definition with custom logic. If
-    /// <c>null</c>, the behaviour falls back to the rules defined by <paramref name="weekend"/>.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the next weekday after <paramref name="date"/>, according to the specified
-    /// <paramref name="weekend"/> definition and optional <paramref name="provider"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid value of the <see cref="CalendarWeekendDefinition"/> enumeration.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search forward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>. If <see langword="null"/>, the default behaviour for the supplied <paramref name="weekend"/> applies.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first calendar day after <paramref name="date"/> that is not a weekend under the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> is a weekday, the result will be the next calendar day that is also a weekday, as determined by
-    /// either the default <paramref name="weekend"/> pattern or the logic provided by <paramref name="provider"/>.
-    /// </para>
-    /// <para>The returned value is a calendar-only result with no time or kind metadata.</para>
+    /// <para>The method evaluates each successive day following <paramref name="date"/> until it finds one that is not considered a weekend, either by the supplied <paramref name="weekend"/> pattern or by the custom logic of <paramref name="provider"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateOnly NextWeekday(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NthDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NthDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.NthDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,30 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a <see cref="DateOnly"/> representing the Nth occurrence of the specified <see cref="DayOfWeek"/> in the same month
-    /// and year as the given <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The input <see cref="DateOnly"/> providing the month and year context (the day component is ignored).</param>
-    /// <param name="dayOfWeek">The day of the week to locate within the month.</param>
-    /// <param name="ordinal">
-    /// The ordinal occurrence to locate, such as <see cref="WeekOfMonthOrdinal.First"/>, <see cref="WeekOfMonthOrdinal.Second"/>, or <see cref="WeekOfMonthOrdinal.Last"/>.
-    /// <para>
-    /// <b>Note:</b><see cref="WeekOfMonthOrdinal.Fifth"/> only applies when a fifth instance of the specified weekday exists in the month.
-    /// </para>
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the specified Nth occurrence of <paramref name="dayOfWeek"/> within the same month and
-    /// year as <paramref name="date"/>.
-    /// </returns>
+    /// <param name="date">The date value whose month and year are used to determine the result. The day component is ignored.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the nth Monday.</param>
+    /// <param name="ordinal">The ordinal occurrence to return. Valid values are <see cref="WeekOfMonthOrdinal.First"/>, <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>, <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>. <see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the requested occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="ordinal"/> is <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching weekday in the
-    /// month. For all other values, the result is calculated by counting from the first occurrence of the weekday in the month.
-    /// </para>
+    /// <para>For <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching <paramref name="dayOfWeek"/> in the month. For other ordinal values, the method locates the first matching weekday and offsets by a multiple of seven days to reach the desired ordinal.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> or <paramref name="ordinal"/> is not a defined enumeration value, or if the specified
-    /// occurrence does not exist within the month.
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="ordinal"/> is not a defined value of the <see cref="WeekOfMonthOrdinal"/> enumeration,
+    /// -or- the requested <paramref name="ordinal"/> does not occur within the month (for example, a fifth Thursday in February).
     /// </exception>
     public static DateOnly NthDayOfWeekInMonth(this DateOnly date, DayOfWeek dayOfWeek, WeekOfMonthOrdinal ordinal)
     {
@@ -64,29 +53,23 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Calculates the date of the Nth occurrence of a specified day of the week within a given month and year.
+    /// Returns a new <see cref="DateOnly"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the given calendar <paramref name="month"/> and <paramref name="year"/>.
     /// </summary>
-    /// <param name="year">The year for which to calculate the date. Must be between the <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>.</param>
-    /// <param name="month">The month (1–12) for which to calculate the date.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to find within the specified month.</param>
-    /// <param name="ordinal">
-    /// The ordinal occurrence of the specified day of the week to return (e.g. First, Second, Third, Fourth, Last). If the specified
-    /// ordinal does not occur in the given month (e.g., a fifth Monday in February), an <see cref="ArgumentOutOfRangeException"/> is thrown.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the Nth occurrence of the specified <paramref name="dayOfWeek"/> in the given
-    /// <paramref name="month"/> and <paramref name="year"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the specified <paramref name="ordinal"/> does not correspond to a valid date in the given month.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Thrown if the <paramref name="dayOfWeek"/> or <paramref name="ordinal"/> is not a defined enumeration value.
-    /// </exception>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Tuesday"/> returns the nth Tuesday.</param>
+    /// <param name="ordinal">The ordinal occurrence to return. Valid values are <see cref="WeekOfMonthOrdinal.First"/>, <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>, <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>. <see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the requested occurrence of <paramref name="dayOfWeek"/> within the specified <paramref name="year"/> and <paramref name="month"/>.</returns>
     /// <remarks>
-    /// For <see cref="WeekOfMonthOrdinal.Last"/>, the last matching day of the week in the month is returned. For other ordinal
-    /// values, the method starts from the first matching day and adds full weeks to locate the Nth occurrence.
+    /// <para>For <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching <paramref name="dayOfWeek"/> in the month. For other ordinal values, the method locates the first matching weekday and offsets by a multiple of seven days to reach the desired ordinal.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="ordinal"/> is not a defined value of the <see cref="WeekOfMonthOrdinal"/> enumeration,
+    /// -or- the requested <paramref name="ordinal"/> does not occur within the month (for example, a fifth Thursday in February).
+    /// </exception>
     public static DateOnly NthDayOfWeekInMonth(int year, int month, DayOfWeek dayOfWeek, WeekOfMonthOrdinal ordinal)
     {
         ThrowHelper.ThrowIfOutOfRange(year, DateOnly.MinValue.Year, DateOnly.MaxValue.Year);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.OrdinalWeekOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.OrdinalWeekOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.OrdinalWeekOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,20 +11,13 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the ordinal occurrence of the weekday (e.g., first, second, third) for the specified <see cref="DateOnly"/> within its month.
+    /// Returns the <see cref="WeekOfMonthOrdinal"/> represented by the specified <see cref="DateOnly"/>, indicating the ordinal occurrence of its <see cref="DateOnly.DayOfWeek"/> within the month.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <returns>
-    /// A <see cref="WeekOfMonthOrdinal"/> value representing which occurrence of the <see cref="DateOnly.DayOfWeek"/> the given date
-    /// is, within the same calendar month (e.g., the 2nd Tuesday).
-    /// </returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns>A <see cref="WeekOfMonthOrdinal"/> value indicating which occurrence of the weekday <paramref name="date"/> represents within its calendar month.</returns>
     /// <remarks>
-    /// The method calculates how many full weeks have passed since the first day of the month to determine the ordinal position of the
-    /// weekday for the given <paramref name="date"/>.
-    /// <para>
-    /// <b>Note:</b> The <see cref="WeekOfMonthOrdinal.Fifth"/> value is uncommon and only applies to months that contain five
-    /// occurrences of the specified <see cref="DayOfWeek"/>.
-    /// </para>
+    /// <para>The result is calculated by counting how many full seven-day intervals have passed since the start of the month, based on <see cref="DateOnly.Day"/>. For example, the 1st through 7th of the month yield <see cref="WeekOfMonthOrdinal.First"/>, while the 8th through 14th yield <see cref="WeekOfMonthOrdinal.Second"/>, and so on.</para>
+    /// <para><see cref="WeekOfMonthOrdinal.Fifth"/> is only returned when a month contains five occurrences of the given <see cref="DateOnly.DayOfWeek"/>.</para>
     /// </remarks>
     public static WeekOfMonthOrdinal OrdinalWeekOfMonth(this DateOnly date)
     {

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.PreviousDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the most recent occurrence of the specified <see cref="DayOfWeek"/> prior to the
-    /// given <paramref name="date"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the previous calendar occurrence of the specified <see cref="DayOfWeek"/> before the given <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search backward.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Friday"/> returns the previous Friday before the given date.
-    /// </param>
-    /// <returns>A <see cref="DateOnly"/> representing the most recent occurrence of <paramref name="dayOfWeek"/> prior to <paramref name="date"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search backward.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> returns the previous Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the previous occurrence of <paramref name="dayOfWeek"/> preceding <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> already falls on the specified <paramref name="dayOfWeek"/>, the result will be exactly 7 days earlier
-    /// (the previous calendar occurrence).
-    /// </para>
-    /// <para>The returned value is a calendar date and does not include any time or kind metadata.</para>
+    /// <para>If <paramref name="date"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly seven days earlier. The method moves backward in time and never returns the original date.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateOnly PreviousDayOfWeek(this DateOnly date, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.PreviousWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,25 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the previous calendar weekday before the given <paramref name="date"/>,
-    /// based on the specified <paramref name="weekend"/> definition.
+    /// Returns a new <see cref="DateOnly"/> representing the previous calendar weekday before the specified <paramref name="date"/>, based on the supplied <paramref name="weekend"/> definition.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search backward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines which days are considered weekends.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the previous weekday prior to <paramref name="date"/>, excluding days defined as
-    /// weekends by <paramref name="weekend"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid <see cref="CalendarWeekendDefinition"/> value.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search backward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first calendar day before <paramref name="date"/> that is not a weekend under the specified <paramref name="weekend"/> rule.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> falls on a weekday, the result will be the previous calendar day that is also a weekday according to
-    /// the specified <paramref name="weekend"/> pattern.
-    /// </para>
-    /// <para>The returned value does not include any time or kind metadata and is purely a calendar date.</para>
+    /// <para>The method evaluates each preceding day until it finds one that is not designated as a weekend by the specified rule. The original <paramref name="date"/> is never returned, even if it already falls on a weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateOnly PreviousWeekday(this DateOnly date, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);
@@ -45,29 +35,16 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the previous calendar weekday before the given <paramref name="date"/>,
-    /// based on the specified <paramref name="weekend"/> definition and optional <paramref name="provider"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the previous calendar weekday before the specified <paramref name="date"/>, using the supplied <paramref name="weekend"/> definition and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="date">The starting <see cref="DateOnly"/> from which to search backward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines the default pattern of weekend days.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> that can override the weekend definition with custom logic. If
-    /// <c>null</c>, the default behaviour based on <paramref name="weekend"/> is used.
-    /// </param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> representing the previous weekday according to the specified <paramref name="weekend"/> definition
-    /// and optional <paramref name="provider"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid <see cref="CalendarWeekendDefinition"/> value.
-    /// </exception>
+    /// <param name="date">The starting date value from which to search backward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>. If <see langword="null"/>, the default behaviour for the supplied <paramref name="weekend"/> applies.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first calendar day before <paramref name="date"/> that is not a weekend under the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="date"/> falls on a weekday, the result will be the previous calendar day that is also a weekday according to
-    /// the specified <paramref name="weekend"/> pattern or the custom rules provided by <paramref name="provider"/>.
-    /// </para>
-    /// <para>The returned value is a pure calendar date and does not include any time or kind metadata.</para>
+    /// <para>The method evaluates each preceding day prior to <paramref name="date"/> until it finds one that is not considered a weekend, either by the supplied <paramref name="weekend"/> pattern or by the custom logic of <paramref name="provider"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateOnly PreviousWeekday(this DateOnly date, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.Quarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.Quarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.Quarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,52 +12,26 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the quarter number (1–4) of the year for the specified <see cref="DateOnly"/>, using the standard calendar quarter
-    /// definition ( <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>).
+    /// Returns the quarter number (1 – 4) of the year for the specified <see cref="DateOnly"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value to evaluate.</param>
-    /// <returns>An integer between 1 and 4 representing the calendar quarter that includes <paramref name="date"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns>An integer between 1 and 4 representing the calendar quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the standard Gregorian calendar quarter structure aligned to the calendar year:
-    /// <list type="bullet">
-    /// <item>
-    /// <term>Q1</term>
-    /// <description>1 January – 31 March</description>
-    /// </item>
-    /// <item>
-    /// <term>Q2</term>
-    /// <description>1 April – 30 June</description>
-    /// </item>
-    /// <item>
-    /// <term>Q3</term>
-    /// <description>1 July – 30 September</description>
-    /// </item>
-    /// <item>
-    /// <term>Q4</term>
-    /// <description>1 October – 31 December</description>
-    /// </item>
-    /// </list>
-    /// The quarter number returned is based on the month of <paramref name="date"/>, regardless of the day or time.
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
     /// </remarks>
     public static int Quarter(this DateOnly date) => GetQuarterForDate(date, GetQuarterDefinition(CalendarQuarterDefinition.JanuaryToDecember));
 
     /// <summary>
-    /// Returns the quarter number (1–4) for the specified <see cref="DateOnly"/>, using the given <see cref="CalendarQuarterDefinition"/>
-    /// to determine the fiscal calendar structure.
+    /// Returns the quarter number (1 – 4) for the specified <see cref="DateOnly"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value to evaluate.</param>
-    /// <param name="definition">Specifies the quarter definition used to determine the quarter.</param>
-    /// <returns>An integer between 1 and 4 representing the quarter that includes the specified <paramref name="date"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid value of the <see cref="CalendarQuarterDefinition"/> enum, or if it is
-    /// <see cref="CalendarQuarterDefinition.Custom"/>. Use the <see cref="Quarter(DateOnly, IQuarterDefinitionProvider)"/> overload to
-    /// support custom definitions.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how the year is segmented into quarters.</param>
+    /// <returns>An integer between 1 and 4 representing the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method supports predefined quarter structures aligned to calendar or financial years. The result is based on adjusting the
-    /// input month by the definition offset and mapping the result to a 1-based quarter.
+    /// <para>This overload supports both month-aligned and day-aligned quarter definitions. For provider-driven custom calendars (e.g. 4-4-5 retail calendars), use the <see cref="Quarter(DateOnly, IQuarterDefinitionProvider)"/> overload.</para>
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown when the method preconditions are not met.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static int Quarter(this DateOnly date, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -70,26 +44,16 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the quarter number (1–4) for the specified <see cref="DateOnly"/>, using a custom <see cref="IQuarterDefinitionProvider"/> implementation.
+    /// Returns the quarter number (1 – 4) for the specified <see cref="DateOnly"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> value to evaluate.</param>
-    /// <param name="provider">
-    /// An implementation of <see cref="IQuarterDefinitionProvider"/> that determines the quarter based on custom logic.
-    /// </param>
-    /// <returns>An integer between 1 and 4 representing the quarter that includes the specified <paramref name="date"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the quarter value returned by the provider is outside the valid range of 1 through 4.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>An integer between 1 and 4 representing the quarter that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// Use this overload to support advanced or non-standard fiscal calendars, such as 4-4-5 financial periods, retail accounting
-    /// calendars, or region-specific quarter models not covered by <see cref="CalendarQuarterDefinition"/>.
-    /// <para>
-    /// This method delegates to <see cref="IQuarterDefinitionProvider.GetQuarter(DateOnly)"/> and can be used in conjunction with
-    /// <see cref="FirstDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> and
-    /// <see cref="LastDayOfQuarter(DateOnly, IQuarterDefinitionProvider)"/> for complete custom quarter boundary resolution.
-    /// </para>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating to <see cref="IQuarterDefinitionProvider.GetQuarter(DateOnly)"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value returned by <paramref name="provider"/> is not in the range 1 – 4.</exception>
     public static int Quarter(this DateOnly date, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);
@@ -103,16 +67,13 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Computes the tick value for the last day of the specified quarter based on a custom month-day anchor definition.
+    /// Computes the day number for the last day of the specified quarter, based on a month-day anchor definition.
     /// </summary>
     /// <param name="year">The fiscal or calendar year in which the quarter ends.</param>
-    /// <param name="quarter">The quarter number (1–4).</param>
-    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g., (4, 6) for April 6).</param>
-    /// <returns>The number of ticks representing midnight at the start of the day *after* the last day of the quarter.</returns>
-    /// <remarks>
-    /// The returned value subtracts one day from the start of the next quarter to yield the final calendar day of the current quarter. This
-    /// accounts for wrap-around years when the end of Q4 exceeds the anchor month.
-    /// </remarks>
+    /// <param name="quarter">The 1-based quarter number (1 – 4).</param>
+    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g. (4, 6) for April 6).</param>
+    /// <returns>The day number representing the last day of the specified quarter.</returns>
+    /// <remarks>The result is calculated by subtracting one day from the start of the next quarter, accounting for wrap-around years when the end of Q4 exceeds the anchor month.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ComputeQuarterEndDayNumber(
         int year,
@@ -126,16 +87,13 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Computes the tick value for the first day of the specified quarter based on a custom month-day anchor definition.
+    /// Computes the day number for the first day of the specified quarter, based on a month-day anchor definition.
     /// </summary>
     /// <param name="year">The fiscal or calendar year in which the quarter starts.</param>
-    /// <param name="quarter">The quarter number (1–4).</param>
-    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g., (4, 6) for April 6).</param>
-    /// <returns>The number of ticks representing midnight on the first day of the specified quarter.</returns>
-    /// <remarks>
-    /// The method accounts for non-standard quarter anchors that may wrap into the following calendar year. For example, a fiscal year
-    /// starting in October will have Q1 starting in October of the previous year.
-    /// </remarks>
+    /// <param name="quarter">The 1-based quarter number (1 – 4).</param>
+    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g. (4, 6) for April 6).</param>
+    /// <returns>The day number representing the first day of the specified quarter.</returns>
+    /// <remarks>Accounts for non-standard quarter anchors that may wrap into the following calendar year. For example, a fiscal year starting in October will have Q1 starting in October of the previous year.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int ComputeQuarterStartDayNumber(
         int year,
@@ -149,16 +107,12 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines the fiscal or calendar year and quarter number for a given <see cref="DateOnly"/> based on a custom quarter definition.
+    /// Determines the fiscal year and quarter that include the specified <paramref name="referenceDate"/>, using the supplied quarter definition.
     /// </summary>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are anchored.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines quarter anchor points.</param>
     /// <param name="referenceDate">The date to evaluate.</param>
-    /// <returns>A tuple containing the resolved <c>Year</c> and <c>Quarter</c> (1–4) that include the <paramref name="referenceDate"/>.</returns>
-    /// <remarks>
-    /// This method supports both standard and non-standard quarter definitions by calculating the appropriate year and quarter number for
-    /// the given <paramref name="referenceDate"/>. If the computed start date of the quarter is after the reference date, the year is
-    /// decremented to represent the previous fiscal year.
-    /// </remarks>
+    /// <returns>A tuple containing the resolved year and quarter number (1 – 4).</returns>
+    /// <remarks>If the calculated start of the resolved quarter is after <paramref name="referenceDate"/>, the year is decremented to reflect the prior fiscal year.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static (int Year, int Quarter) GetQuarterAndYearFromDate(CalendarQuarterDefinition definition, DateOnly referenceDate)
     {
@@ -179,9 +133,9 @@ public static partial class DateOnlyExtensions
     /// <summary>
     /// Extracts the anchor month and day components from a <see cref="CalendarQuarterDefinition"/> value.
     /// </summary>
-    /// <param name="definition">A <see cref="CalendarQuarterDefinition"/> enum value encoded as MMDD (e.g., 401 for 1 April).</param>
-    /// <returns>A tuple <c>(defMonth, defDay)</c> representing the anchor month and day of Q1.</returns>
-    /// <remarks>Used as a normalised form of the quarter definition for modular math calculations.</remarks>
+    /// <param name="definition">A <see cref="CalendarQuarterDefinition"/> value encoded as MMDD (e.g. 406 for April 6).</param>
+    /// <returns>A tuple <c>(defMonth, defDay)</c> representing the anchor month and day that define the start of Q1.</returns>
+    /// <remarks>This helper unpacks the encoded <see cref="CalendarQuarterDefinition"/> value for internal use in modular calculations.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static (uint defMonth, uint defDay) GetQuarterDefinition(CalendarQuarterDefinition definition)
     {
@@ -194,13 +148,12 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Determines the fiscal or calendar quarter number (1–4) that contains the specified <see cref="DateOnly"/>, based on the supplied
-    /// quarter definition anchor.
+    /// Determines the quarter number (1 – 4) that includes the specified <see cref="DateOnly"/>, based on a month-day anchor definition.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="definition">A tuple representing the anchor month and day (e.g., (4, 1) for April 1) that defines the start of Q1.</param>
-    /// <returns>An integer in the range [1, 4] representing the resolved quarter number.</returns>
-    /// <remarks>If the date falls on the first month of a quarter but before the anchor day, it is assigned to the previous quarter.</remarks>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="definition">A tuple representing the start of Q1, encoded as (month, day).</param>
+    /// <returns>An integer between 1 and 4 representing the resolved quarter number.</returns>
+    /// <remarks>If <paramref name="date"/> falls before the anchor day in the quarter's first month, it is considered part of the previous quarter.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetQuarterForDate(this DateOnly date, (uint defMonth, uint defDay) definition)
     {

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.UnixTime(Epoch).cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.UnixTime(Epoch).cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.UnixTime(Epoch).cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,13 +11,14 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Converts a Unix timestamp expressed in milliseconds since 1970-01-01T00:00:00Z to a <see cref="DateOnly"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the calendar date corresponding to the specified Unix timestamp, expressed in milliseconds since 1970-01-01T00:00:00Z.
     /// </summary>
-    /// <param name="timestamp">The number of milliseconds elapsed since the Unix epoch (1970-01-01T00:00:00Z).</param>
-    /// <returns>A <see cref="DateOnly"/> representing the calendar date in UTC.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="timestamp"/> falls outside the valid range for conversion to <see cref="DateOnly"/>.
-    /// </exception>
+    /// <param name="timestamp">The number of milliseconds that have elapsed since the Unix epoch.</param>
+    /// <returns>A <see cref="DateOnly"/> value representing the calendar date in UTC corresponding to <paramref name="timestamp"/>.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="ToUnixTimeMilliseconds(DateOnly)"/> to perform the inverse conversion.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="timestamp"/> is outside the range supported for conversion to <see cref="DateOnly"/>.</exception>
     /// <seealso cref="ToUnixTimeMilliseconds(DateOnly)"/>
     public static DateOnly FromUnixTimeMilliseconds(long timestamp)
     {
@@ -26,13 +27,14 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Converts a Unix timestamp expressed in seconds since 1970-01-01T00:00:00Z to a <see cref="DateOnly"/>.
+    /// Returns a new <see cref="DateOnly"/> representing the calendar date corresponding to the specified Unix timestamp, expressed in seconds since 1970-01-01T00:00:00Z.
     /// </summary>
-    /// <param name="timestamp">The number of seconds elapsed since the Unix epoch (1970-01-01T00:00:00Z).</param>
-    /// <returns>A <see cref="DateOnly"/> representing the calendar date in UTC.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="timestamp"/> falls outside the valid range for conversion to <see cref="DateOnly"/>.
-    /// </exception>
+    /// <param name="timestamp">The number of seconds that have elapsed since the Unix epoch.</param>
+    /// <returns>A <see cref="DateOnly"/> value representing the calendar date in UTC corresponding to <paramref name="timestamp"/>.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="ToUnixTimeSeconds(DateOnly)"/> to perform the inverse conversion.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="timestamp"/> is outside the range supported for conversion to <see cref="DateOnly"/>.</exception>
     /// <seealso cref="ToUnixTimeSeconds(DateOnly)"/>
     public static DateOnly FromUnixTimeSeconds(long timestamp)
     {
@@ -41,18 +43,24 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Converts the specified <see cref="DateOnly"/> to the number of milliseconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z).
+    /// Returns the number of milliseconds that have elapsed between the Unix epoch (1970-01-01T00:00:00Z) and the specified <see cref="DateOnly"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to convert. The date is interpreted as UTC.</param>
-    /// <returns>The number of milliseconds since the Unix epoch.</returns>
+    /// <param name="date">The date value to convert. The value is interpreted as UTC.</param>
+    /// <returns>The total number of milliseconds since the Unix epoch.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="FromUnixTimeMilliseconds(long)"/> to perform the inverse conversion.</para>
+    /// </remarks>
     /// <seealso cref="FromUnixTimeMilliseconds(long)"/>
     public static long ToUnixTimeMilliseconds(this DateOnly date) => ((date.DayNumber * DateTimeExtensions.TicksPerDay) - DateTimeExtensions.UnixEpochTicks) / DateTimeExtensions.TicksPerMillisecond;
 
     /// <summary>
-    /// Converts the specified <see cref="DateOnly"/> to the number of seconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z).
+    /// Returns the number of seconds that have elapsed between the Unix epoch (1970-01-01T00:00:00Z) and the specified <see cref="DateOnly"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to convert. The date is interpreted as UTC.</param>
-    /// <returns>The number of seconds since the Unix epoch.</returns>
+    /// <param name="date">The date value to convert. The value is interpreted as UTC.</param>
+    /// <returns>The total number of seconds since the Unix epoch.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="FromUnixTimeSeconds(long)"/> to perform the inverse conversion.</para>
+    /// </remarks>
     /// <seealso cref="FromUnixTimeSeconds(long)"/>
     public static long ToUnixTimeSeconds(this DateOnly date) => ((date.DayNumber * DateTimeExtensions.TicksPerDay) - DateTimeExtensions.UnixEpochTicks) / DateTimeExtensions.TicksPerSecond;
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.WeekOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.WeekOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.WeekOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,15 +14,13 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the current culture's calendar
-    /// week rule and first day of the week.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <returns>The 1-based week number of the month for the specified date.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="date"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// This method uses the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> defined by
-    /// <see cref="CultureInfo.CurrentCulture"/>. The result is based on the difference in week-of-year values between the input date
-    /// and the first day of its month, plus one.
+    /// <para>The result is calculated by comparing the week-of-year for <paramref name="date"/> against the week-of-year for the first day of its month, plus one.</para>
+    /// <para>Week numbering is determined by <see cref="CultureInfo.CurrentCulture"/>, specifically its <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
     /// </remarks>
     public static int WeekOfMonth(this DateOnly date)
     {
@@ -31,17 +29,13 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the week rule and first day of
-    /// week defined by the given <paramref name="culture"/>.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the calendar settings of the supplied or current culture.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="culture">
-    /// The culture providing the calendar rule and week start. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>The 1-based week number of the month for the specified date.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="date"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// The week number is determined by comparing the week of year for the input date and the first day of the same month, based on the
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> in the specified culture.
+    /// <para>This overload uses the supplied culture's <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> to compute the result.</para>
     /// </remarks>
     public static int WeekOfMonth(this DateOnly date, CultureInfo? culture)
     {
@@ -50,20 +44,19 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the specified
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> start day.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateOnly"/>, using the supplied <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> as the week-starting day.
     /// </summary>
-    /// <param name="date">The date to evaluate.</param>
-    /// <param name="weekRule">The calendar rule that defines how the first week of the year is determined.</param>
-    /// <param name="weekStart">The day considered the start of the week.</param>
-    /// <returns>The 1-based week number of the month for the specified date.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekRule"/> or <paramref name="weekStart"/> is not a defined enum value.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="weekRule">The <see cref="CalendarWeekRule"/> that defines how the first week of the year is identified.</param>
+    /// <param name="weekStart">The <see cref="DayOfWeek"/> on which each week begins.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="date"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// The method compares the week of year for the input date and the first day of its month to determine the week-of-month value. The
-    /// result is always 1-based and sensitive to the chosen calendar rule and week start.
+    /// <para>The result is calculated by comparing the week-of-year for <paramref name="date"/> against the week-of-year for the first day of its month, using the supplied rule and start day.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekRule"/> is not a defined value of the <see cref="CalendarWeekRule"/> enumeration,
+    /// -or- <paramref name="weekStart"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
     public static int WeekOfMonth(this DateOnly date, CalendarWeekRule weekRule, DayOfWeek weekStart)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekRule);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.WeekOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.WeekOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.WeekOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,29 +14,27 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
-    /// Returns the week number (1–53) of the year that contains the specified <see cref="DateOnly"/>, using the current culture's
-    /// calendar and week rule.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateOnly"/>, using the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <returns>The culture-specific week number of the year that contains <paramref name="date"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> defined in
-    /// <see cref="CultureInfo.CurrentCulture"/>. Week numbering may vary across cultures (e.g., U.S. vs ISO 8601).
+    /// <para>Week numbering is determined by <see cref="CultureInfo.CurrentCulture"/>, which may follow different conventions:</para>
+    /// <list type="bullet">
+    /// <item><description>U.S. system: week 1 starts on Sunday and includes January 1.</description></item>
+    /// <item><description>ISO 8601: week 1 starts on Monday and includes the first Thursday of the year.</description></item>
+    /// </list>
     /// </remarks>
     public static int WeekOfYear(this DateOnly date) => date.WeekOfYear(null);
 
     /// <summary>
-    /// Returns the week number (1–53) of the year that contains the specified <see cref="DateOnly"/>, using the given <paramref name="culture"/>.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateOnly"/>, using the calendar rules of the supplied or current culture.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <param name="culture">
-    /// The <see cref="CultureInfo"/> used to determine the calendar, week rule, and first day of the week. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>The culture-specific week number of the year that contains <paramref name="date"/>.</returns>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// This method uses <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> from
-    /// the specified culture to compute the result.
+    /// <para>This overload allows culture-specific calculation of week numbers (e.g. for Gregorian or ISO 8601 calendars).</para>
     /// </remarks>
     public static int WeekOfYear(this DateOnly date, CultureInfo? culture)
     {
@@ -45,19 +43,19 @@ public static partial class DateOnlyExtensions
     }
 
     /// <summary>
-    /// Returns the week number (1–53) of the year that contains the specified <see cref="DateOnly"/>, using the specified
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> start day.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateOnly"/>, using the supplied <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> as the week-starting day.
     /// </summary>
-    /// <param name="date">The <see cref="DateOnly"/> to evaluate.</param>
-    /// <param name="weekRule">The calendar rule that defines how the first week of the year is determined.</param>
-    /// <param name="weekStart">The day considered the start of the week.</param>
-    /// <returns>A 1-based integer representing the week number of the year that contains the specified date.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekRule"/> or <paramref name="weekStart"/> is not a defined enumeration value.
-    /// </exception>
+    /// <param name="date">The date value to evaluate.</param>
+    /// <param name="weekRule">The <see cref="CalendarWeekRule"/> that defines how the first week of the year is identified.</param>
+    /// <param name="weekStart">The <see cref="DayOfWeek"/> on which each week begins.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="date"/>.</returns>
     /// <remarks>
-    /// The result may vary depending on the rule and starting day. For example, ISO 8601 uses <c>FirstFourDayWeek</c> and <c>Monday</c>.
+    /// <para>This overload enables custom calendar logic such as ISO 8601 (<see cref="CalendarWeekRule.FirstFourDayWeek"/>, <see cref="DayOfWeek.Monday"/>) or localised U.S./European systems.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekRule"/> is not a defined value of the <see cref="CalendarWeekRule"/> enumeration,
+    /// -or- <paramref name="weekStart"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
     public static int WeekOfYear(this DateOnly date, CalendarWeekRule weekRule, DayOfWeek weekStart)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekRule);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Add.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Add.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Add.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,41 +11,18 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> that adds the specified number of years, months, and fractional days to the value of the specified instance.
+    /// Returns a new <see cref="DateTime"/> obtained by adding the specified number of years, months, and fractional days to the supplied <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value to add to.</param>
-    /// <param name="years">The number of years to add.</param>
-    /// <param name="months">The number of months to add.</param>
-    /// <param name="days">The number of days to add, including fractional values.</param>
-    /// <returns>
-    /// An object whose value is the sum of the date and time represented by <paramref name="dateTime"/> and the specified number of years, months, and days.
-    /// </returns>
+    /// <param name="dateTime">The date and time value to which the offsets are applied.</param>
+    /// <param name="years">The number of calendar years to add. A negative value subtracts years.</param>
+    /// <param name="months">The number of calendar months to add. A negative value subtracts months.</param>
+    /// <param name="days">The number of days to add, including fractional values. A negative value subtracts days.</param>
+    /// <returns>An object whose value is the result of adding the specified number of years, months, and days to <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method returns a new <see cref="DateTime"/> whose value is the result of adding the specified number of calendar years, calendar months,
-    /// and fractional days to <paramref name="dateTime"/>. The original instance is not modified.
-    /// </para>
-    /// <para>
-    /// Adjustments are performed in the following order: years, then months, then days.
-    /// Negative values for any parameter subtract from the date.
-    /// </para>
-    /// <para>
-    /// When the resulting day does not exist in the target month (e.g., February 30), the date is clamped to the last valid day of that month.
-    /// The method accounts for leap years and the varying number of days in each month.
-    /// </para>
-    /// <para>
-    /// The <paramref name="days"/> parameter supports fractional values, which are applied with tick-level precision. Values smaller than 1e-10 are ignored.
-    /// The original time-of-day is preserved unless <paramref name="days"/> includes a fractional component, in which case the time is adjusted accordingly.
-    /// </para>
-    /// <para>
-    /// This method performs all adjustments using tick arithmetic and does not rely on <see cref="DateTime.AddYears(int)"/>,
-    /// <see cref="DateTime.AddMonths(int)"/>, or <see cref="DateTime.AddDays(double)"/>, making it suitable for performance-critical paths.
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
-    /// <para>
-    /// <b>Examples:</b>
+    /// <para>Adjustments are applied in the order years, then months, then days. When the resulting day does not exist in the target month (e.g. February 30), the date is clamped to the last valid day of that month, accounting for leap years and varying month lengths.</para>
+    /// <para>The <paramref name="days"/> parameter supports fractional values, applied with tick-level precision. Values smaller than 1e-10 are ignored. The original time-of-day is preserved unless <paramref name="days"/> includes a fractional component, in which case the time is adjusted accordingly.</para>
+    /// <para>This method performs all adjustments using tick arithmetic and does not rely on <see cref="DateTime.AddYears(int)"/>, <see cref="DateTime.AddMonths(int)"/>, or <see cref="DateTime.AddDays(double)"/>, making it suitable for performance-critical paths.</para>
+    /// <para><b>Examples:</b></para>
     /// <code>
     ///<![CDATA[
     /// var dt1 = new DateTime(2023, 1, 31);
@@ -55,20 +32,17 @@ public static partial class DateTimeExtensions
     /// var result2 = dt2.Add(0, 1, 0); // → 2020-02-29 (leap year)
     ///
     /// var dt3 = new DateTime(2023, 3, 15, 10, 30, 0);
-    /// var result3 = dt3.Add(1, -2, 10.75); // → 2024-01-25 19:30:00 (adds 1 year, subtracts 2 months, adds 10.75 days)
+    /// var result3 = dt3.Add(1, -2, 10.75); // → 2024-01-25 19:30:00
     ///
     /// var dt4 = new DateTime(2022, 10, 5, 8, 0, 0);
-    /// var result4 = dt4.Add(0, 0, -2.5); // → 2022-10-02 20:00:00 (subtracts 2.5 days)
+    /// var result4 = dt4.Add(0, 0, -2.5); // → 2022-10-02 20:00:00
     ///
     /// var dt5 = new DateTime(2024, 2, 29);
     /// var result5 = dt5.Add(1, 0, 0); // → 2025-02-28 (2025 is not a leap year)
     ///]]>
     /// </code>
-    /// </para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// The resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.</exception>
     public static DateTime Add(this DateTime dateTime, int years, int months, double days)
     {
         // Extract parts from original date

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Age.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Age.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Age.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,50 +11,27 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Calculates the age in full calendar years as at today’s date ( <see cref="DateTime.Today"/>).
+    /// Returns the age in full calendar years between the specified <paramref name="dateTime"/> and <see cref="DateTime.Today"/>.
     /// </summary>
     /// <param name="dateTime">The earlier date to calculate from, typically representing a birth date or other reference point.</param>
-    /// <returns>
-    /// The number of full calendar years that have elapsed between <paramref name="dateTime"/> and <see cref="DateTime.Today"/>. Returns
-    /// 0 if <paramref name="dateTime"/> occurs after today.
-    /// </returns>
+    /// <returns>The number of full calendar years that have elapsed between <paramref name="dateTime"/> and <see cref="DateTime.Today"/>. Returns <c>0</c> if <paramref name="dateTime"/> occurs after today.</returns>
     /// <remarks>
-    /// <para>
-    /// This method determines the number of full years that have passed by comparing the year, month, and day components. If the month and
-    /// day of <paramref name="dateTime"/> have not yet occurred in the current year, the result is decremented by one.
-    /// </para>
-    /// <para>
-    /// If <paramref name="dateTime"/> is February 29 in a leap year and today is not a leap year, the comparison is performed as if the
-    /// date were February 28.
-    /// </para>
-    /// <para>The result is clamped to 0 to avoid returning negative values when <paramref name="dateTime"/> is in the future.</para>
-    /// <note>The <see cref="DateTime.Kind"/> property is ignored when calculating the result.</note>
+    /// <para>This overload determines the number of full years that have passed by comparing the year, month, and day components. If the month and day of <paramref name="dateTime"/> have not yet occurred in the current year, the result is decremented by one.</para>
+    /// <para>If <paramref name="dateTime"/> is February 29 in a leap year and today is not a leap year, the comparison is performed as if the date were February 28.</para>
+    /// <para>The result is clamped to <c>0</c> to avoid returning negative values when <paramref name="dateTime"/> is in the future. The <see cref="DateTime.Kind"/> property is ignored when calculating the result.</para>
     /// </remarks>
-    public static int Age(this DateTime dateTime)
-    {
-        return dateTime.Age(DateTime.Today);
-    }
+    public static int Age(this DateTime dateTime) => dateTime.Age(DateTime.Today);
 
     /// <summary>
-    /// Calculates the age in full calendar years as at a specified reference date.
+    /// Returns the age in full calendar years between the specified <paramref name="dateTime"/> and a supplied reference date.
     /// </summary>
     /// <param name="dateTime">The earlier date to calculate from, typically representing a birth date or other reference point.</param>
     /// <param name="atDate">The later date to calculate to, representing the point in time at which the age is evaluated.</param>
-    /// <returns>
-    /// The number of full calendar years that have elapsed between <paramref name="dateTime"/> and <paramref name="atDate"/>. Returns 0
-    /// if <paramref name="atDate"/> occurs before <paramref name="dateTime"/>.
-    /// </returns>
+    /// <returns>The number of full calendar years that have elapsed between <paramref name="dateTime"/> and <paramref name="atDate"/>. Returns <c>0</c> if <paramref name="atDate"/> occurs before <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method determines the number of full years that have passed by comparing the year, month, and day components. If the month and
-    /// day of <paramref name="dateTime"/> have not yet occurred in the <paramref name="atDate"/> year, the result is decremented by one.
-    /// </para>
-    /// <para>
-    /// If <paramref name="dateTime"/> is February 29 in a leap year and <paramref name="atDate"/> is in a non-leap year, the comparison
-    /// is performed as if the date were February 28.
-    /// </para>
-    /// <para>The result is clamped to 0 to avoid returning negative values when <paramref name="dateTime"/> is after <paramref name="atDate"/>.</para>
-    /// <note>The <see cref="DateTime.Kind"/> property is ignored when calculating the result.</note>
+    /// <para>This overload determines the number of full years that have passed by comparing the year, month, and day components. If the month and day of <paramref name="dateTime"/> have not yet occurred in the year of <paramref name="atDate"/>, the result is decremented by one.</para>
+    /// <para>If <paramref name="dateTime"/> is February 29 in a leap year and <paramref name="atDate"/> is in a non-leap year, the comparison is performed as if the date were February 28.</para>
+    /// <para>The result is clamped to <c>0</c> to avoid returning negative values when <paramref name="dateTime"/> is after <paramref name="atDate"/>. The <see cref="DateTime.Kind"/> property is ignored when calculating the result.</para>
     /// </remarks>
     public static int Age(this DateTime dateTime, DateTime atDate)
     {
@@ -69,6 +46,6 @@ public static partial class DateTimeExtensions
         if (atMonth < birthMonth || (atMonth == birthMonth && atDay < birthDay))
             age--;
 
-        return age < 0 ? 0 : age; // Clamp to 0
+        return age < 0 ? 0 : age;
     }
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.DayName.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.DayName.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.DayName.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,37 +13,23 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the full name of the day of the week for the specified <see cref="DateTime"/>, using the formatting rules of the current culture.
+    /// Returns the full name of the day of the week for the specified <see cref="DateTime"/>, using the formatting rules of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose <see cref="DateTime.DayOfWeek"/> value is used to determine the name.</param>
-    /// <returns>A <see cref="string"/> containing the localized full name of the day of the week, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
+    /// <param name="dateTime">The date and time value whose <see cref="DateTime.DayOfWeek"/> is used to determine the name.</param>
+    /// <returns>A <see cref="string"/> containing the localised full day name, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// <para>This method uses the <see cref="DateTimeFormatInfo.DayNames"/> method of the current culture to return the day name.</para>
-    /// <para>For culture-specific results, use the <see cref="DayName(DateTime, CultureInfo)"/> overload.</para>
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetDayName(DayOfWeek)"/> method of the current culture to retrieve the day name. For culture-specific results, use the <see cref="DayName(DateTime, CultureInfo)"/> overload.</para>
     /// </remarks>
-    public static string DayName(this DateTime dateTime)
-    {
-        return dateTime.DayName((CultureInfo?)null);
-    }
+    public static string DayName(this DateTime dateTime) => dateTime.DayName((CultureInfo?)null);
 
     /// <summary>
-    /// Returns the full name of the day of the week for the specified <see cref="DateTime"/>, using the formatting rules of the specified culture.
+    /// Returns the full name of the day of the week for the specified <see cref="DateTime"/>, using the formatting rules of the supplied or current culture.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose <see cref="DateTime.DayOfWeek"/> value is used to determine the name.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to format the result. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>
-    /// A <see cref="string"/> containing the localized full name of the day of the week for <paramref name="dateTime"/>, formatted using
-    /// the specified or current culture.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose <see cref="DateTime.DayOfWeek"/> is used to determine the name.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to format the result. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="string"/> containing the localised full day name for <paramref name="dateTime"/>, formatted using the supplied or current culture.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses the <see cref="DateTimeFormatInfo.DayNames"/> method of the specified or current culture to return the day name.
-    /// </para>
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetDayName(DayOfWeek)"/> method of the supplied or current culture to retrieve the day name.</para>
     /// </remarks>
-    public static string DayName(this DateTime dateTime, CultureInfo? culture)
-    {
-        return (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.GetDayName(dateTime.DayOfWeek);
-    }
+    public static string DayName(this DateTime dateTime, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.GetDayName(dateTime.DayOfWeek);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.DaysInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.DaysInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.DaysInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,74 +13,36 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the number of days in the month of the specified <see cref="DateTime"/>, using the proleptic Gregorian calendar.
+    /// Returns the number of days in the calendar month of the specified <see cref="DateTime"/>, using the proleptic Gregorian calendar.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose year and month are used to determine the number of days.</param>
+    /// <param name="dateTime">The date and time value whose year and month are used to determine the result.</param>
     /// <returns>The total number of days in the specified month and year of <paramref name="dateTime"/>, based on the <see cref="GregorianCalendar"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method always calculates the result using the proleptic Gregorian calendar (i.e., the calendar used internally by
-    /// <see cref="DateTime"/>), regardless of the current culture or calendar settings.
-    /// </para>
-    /// <para>
-    /// For culture-specific results, use the <see cref="DaysInMonth(DateTime, CultureInfo)"/> or
-    /// <see cref="DaysInMonth(DateTime, Calendar)"/> overloads.
-    /// </para>
+    /// <para>This overload always evaluates the result using the proleptic Gregorian calendar, regardless of the current culture or calendar settings. For culture-specific results, use the <see cref="DaysInMonth(DateTime, CultureInfo)"/> or <see cref="DaysInMonth(DateTime, Calendar)"/> overload.</para>
     /// </remarks>
-    public static int DaysInMonth(this DateTime dateTime)
-    {
-        return DateTime.DaysInMonth(dateTime.Year, dateTime.Month);
-    }
+    public static int DaysInMonth(this DateTime dateTime) => DateTime.DaysInMonth(dateTime.Year, dateTime.Month);
 
     /// <summary>
-    /// Returns the number of days in the month of the specified <see cref="DateTime"/>, using the calendar associated with the specified culture.
+    /// Returns the number of days in the calendar month of the specified <see cref="DateTime"/>, using the calendar associated with the supplied culture.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose year and month are used to determine the number of days.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to determine the calendar. If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>
-    /// The total number of days in the specified month and year of <paramref name="dateTime"/>, based on the calendar used by <paramref name="culture"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year and month are used to determine the result.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the calendar. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The total number of days in the specified month and year of <paramref name="dateTime"/>, based on the calendar of <paramref name="culture"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method retrieves the <see cref="Calendar"/> from the culture’s <see cref="DateTimeFormatInfo.Calendar"/> property and returns
-    /// the number of days for the month of the given <paramref name="dateTime"/>.
-    /// </para>
-    /// <para>This is useful when working with cultures that use non-Gregorian calendars such as <see cref="HebrewCalendar"/> or <see cref="HijriCalendar"/>.</para>
-    /// <note>If the calendar supports leap months or eras, this method does not account for them explicitly. For precise control, use the
-    /// overload that accepts a <see cref="Calendar"/> directly.</note>
+    /// <para>This overload retrieves the <see cref="Calendar"/> from the culture's <see cref="DateTimeFormatInfo.Calendar"/> property and returns the number of days for the month of the supplied <paramref name="dateTime"/>.</para>
+    /// <para>This is useful when working with cultures that use non-Gregorian calendars such as <see cref="HebrewCalendar"/> or <see cref="HijriCalendar"/>. If the calendar supports leap months or eras, this method does not account for them explicitly. For precise control, use the overload that accepts a <see cref="Calendar"/> directly.</para>
     /// </remarks>
-    public static int DaysInMonth(this DateTime dateTime, CultureInfo? culture)
-    {
-        return (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.Calendar.GetDaysInMonth(dateTime.Year, dateTime.Month);
-    }
+    public static int DaysInMonth(this DateTime dateTime, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.Calendar.GetDaysInMonth(dateTime.Year, dateTime.Month);
 
     /// <summary>
-    /// Returns the number of days in the month of the specified <see cref="DateTime"/>, using the specified or current culture’s calendar.
+    /// Returns the number of days in the calendar month of the specified <see cref="DateTime"/>, using the supplied or current culture's calendar.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose year and month are used to determine the number of days.</param>
-    /// <param name="calendar">
-    /// An optional <see cref="Calendar"/> instance used to evaluate the number of days. If <c>null</c>, the calendar of
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>
-    /// The total number of days in the specified month and year of <paramref name="dateTime"/>, based on the rules of the given or current calendar.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year and month are used to determine the result.</param>
+    /// <param name="calendar">An optional <see cref="Calendar"/> instance used to evaluate the result. If <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The total number of days in the specified month and year of <paramref name="dateTime"/>, based on the rules of the supplied or current calendar.</returns>
     /// <remarks>
-    /// <para>
-    /// This method supports calendar-aware computations for systems such as <see cref="HebrewCalendar"/>, <see cref="HijriCalendar"/>,
-    /// <see cref="JapaneseCalendar"/>, and others supported by .NET.
-    /// </para>
-    /// <para>
-    /// The result is equivalent to <c>calendar.GetDaysInMonth(dateTime.Year, dateTime.Month)</c>, or uses the current culture's calendar if
-    /// <paramref name="calendar"/> is <see langword="null"/>.
-    /// </para>
-    /// <note>This method does not account for leap months. For calendars that support leap months or multiple eras, consider using
-    /// <c>GetDaysInMonth(year, month, era)</c> instead.</note>
+    /// <para>This overload supports calendar-aware computations for systems such as <see cref="HebrewCalendar"/>, <see cref="HijriCalendar"/>, <see cref="JapaneseCalendar"/>, and others supported by .NET. The result is equivalent to <c>calendar.GetDaysInMonth(dateTime.Year, dateTime.Month)</c>, or uses the current culture's calendar if <paramref name="calendar"/> is <see langword="null"/>.</para>
+    /// <para>This method does not account for leap months. For calendars that support leap months or multiple eras, consider using <c>GetDaysInMonth(year, month, era)</c> instead.</para>
     /// </remarks>
-    public static int DaysInMonth(this DateTime dateTime, Calendar? calendar)
-    {
-        return (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInMonth(dateTime.Year, dateTime.Month);
-    }
+    public static int DaysInMonth(this DateTime dateTime, Calendar? calendar) => (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInMonth(dateTime.Year, dateTime.Month);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.DaysInYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.DaysInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.DaysInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,36 +13,23 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the number of days in the calendar year of the specified <see cref="DateTime"/>, using the current culture's calendar.
+    /// Returns the number of days in the calendar year of the specified <see cref="DateTime"/>, using the calendar of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> for which to calculate the number of days in its calendar year.</param>
-    /// <returns>
-    /// The total number of days in the year corresponding to <paramref name="dateTime"/>, as defined by the current culture's <see cref="Calendar"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
+    /// <returns>The total number of days in the year of <paramref name="dateTime"/>, as defined by the calendar of <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// This method uses the calendar defined by <see cref="CultureInfo.CurrentCulture"/>. The result may vary depending on the calendar
-    /// system (e.g., Gregorian, Hebrew, Hijri).
+    /// <para>This overload uses the calendar defined by <see cref="CultureInfo.CurrentCulture"/>. The result may vary depending on the calendar system (e.g. Gregorian, Hebrew, Hijri).</para>
     /// </remarks>
-    public static int DaysInYear(this DateTime dateTime)
-    {
-        return dateTime.DaysInYear((Calendar?)null);
-    }
+    public static int DaysInYear(this DateTime dateTime) => dateTime.DaysInYear((Calendar?)null);
 
     /// <summary>
-    /// Returns the number of days in the calendar year of the specified <see cref="DateTime"/>, using the specified <see cref="Calendar"/>.
+    /// Returns the number of days in the calendar year of the specified <see cref="DateTime"/>, using the supplied or current calendar.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose year is evaluated.</param>
-    /// <param name="calendar">
-    /// The <see cref="Calendar"/> used to determine the number of days in the year. If <c>null</c>, the current culture's calendar is used.
-    /// </param>
-    /// <returns>The number of days in the year of <paramref name="dateTime"/>, based on the provided or fallback calendar.</returns>
+    /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
+    /// <param name="calendar">An optional <see cref="Calendar"/> used to evaluate the result. If <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The number of days in the year of <paramref name="dateTime"/>, based on the supplied or fallback calendar.</returns>
     /// <remarks>
-    /// Use this method when you want to explicitly calculate based on a specific calendar system (e.g., <see cref="GregorianCalendar"/>,
-    /// <see cref="HebrewCalendar"/>). If <paramref name="calendar"/> is <see langword="null"/>, the calendar from
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
+    /// <para>Use this overload when you want to explicitly calculate based on a specific calendar system (e.g. <see cref="GregorianCalendar"/>, <see cref="HebrewCalendar"/>). If <paramref name="calendar"/> is <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</para>
     /// </remarks>
-    public static int DaysInYear(this DateTime dateTime, Calendar? calendar)
-    {
-        return (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInYear(dateTime.Year);
-    }
+    public static int DaysInYear(this DateTime dateTime, Calendar? calendar) => (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInYear(dateTime.Year);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.EndOfDay.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.EndOfDay.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.EndOfDay.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,33 +11,17 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the final possible tick of the same calendar day as the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the end of the calendar day (23:59:59.9999999) that contains the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value whose day is used to determine the end-of-day timestamp.</param>
-    /// <returns>
-    /// An object whose value is set to 23:59:59.9999999 on the same calendar day as <paramref name="dateTime"/>, with the original
-    /// <see cref="DateTime.Kind"/> preserved.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose date is preserved while the time is set to the final tick of the day.</param>
+    /// <returns>An object whose value is set to 23:59:59.9999999 on the same calendar day as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method returns a <see cref="DateTime"/> instance representing the last representable moment of the specified day,
-    /// with a time component of 23:59:59.9999999—one tick before midnight.
-    /// </para>
-    /// <para>
-    /// The result is calculated by extracting the date component from <paramref name="dateTime"/> and adding
-    /// <c>TicksPerDay - 1</c> to represent the end of that day.
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
-    /// <para><b>Examples:</b></para>
+    /// <para>The result is calculated by extracting the date component of <paramref name="dateTime"/> and adding <c>TicksPerDay - 1</c> to represent the last representable moment of the day — one tick before midnight of the next day.</para>
+    /// <para><b>Example:</b></para>
     /// <code>
     ///<![CDATA[
-    /// var input = new DateTime(2024, 7, 7, 10, 30, 0);
-    /// var end = input.EndOfDay(); // → 2024-07-07 23:59:59.9999999
-    ///
-    /// var utcInput = new DateTime(2024, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-    /// var utcEnd = utcInput.EndOfDay(); // → 2024-01-01 23:59:59.9999999 (UTC)
+    /// var dt = new DateTime(2024, 7, 7, 10, 30, 0);
+    /// var result = dt.EndOfDay(); // → 2024-07-07 23:59:59.9999999
     ///]]>
     /// </code>
     /// </remarks>

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,19 +11,13 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the same month and year as the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the same calendar month and year as the specified <paramref name="dateTime"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value whose year and month are used to determine the result.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first day of the same calendar month and year.
-    /// </returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the same calendar month and year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method returns a <see cref="DateTime"/> with the day component set to 1 and the time component set to midnight (00:00:00).
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
+    /// <para>This method calculates the first day of the month using Gregorian calendar rules.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// <para><b>Example:</b></para>
     /// <code>
     ///<![CDATA[
@@ -35,31 +29,18 @@ public static partial class DateTimeExtensions
     public static DateTime FirstDayOfMonth(this DateTime dateTime) => new DateTime(GetFirstDayOfMonthTicks(dateTime), dateTime.Kind);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the specified month and year.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the specified calendar month and year.
     /// </summary>
-    /// <param name="year">The calendar year of the result. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="month">The calendar month of the result, where 1 represents January and 12 represents December.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first day of the specified month and year.
-    /// </returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the specified month and year, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method constructs a <see cref="DateTime"/> from the specified <paramref name="year"/> and <paramref name="month"/> with the day
-    /// component set to 1 and the time component set to midnight (00:00:00).
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.
-    /// </para>
-    /// <para><b>Example:</b></para>
-    /// <code>
-    ///<![CDATA[
-    /// var result = DateTimeExtensions.GetFirstDayOfMonth(2024, 2); // → 2024-02-01 00:00:00
-    ///]]>
-    /// </code>
+    /// <para>This method uses Gregorian calendar rules to determine the resulting date.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
-    /// -or- if <paramref name="month"/> is less than 1 or greater than 12.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12.
     /// </exception>
     public static DateTime GetFirstDayOfMonth(int year, int month)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,34 +11,35 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the calendar quarter that contains the specified instance, using
-    /// the standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the calendar quarter that contains the specified <paramref name="dateTime"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the calendar quarter.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter containing <paramref name="dateTime"/>.</returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter that contains <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>This method uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>:</para>
+    /// <list type="bullet">
+    /// <item><term>Q1</term><description>January – March</description></item>
+    /// <item><term>Q2</term><description>April – June</description></item>
+    /// <item><term>Q3</term><description>July – September</description></item>
+    /// <item><term>Q4</term><description>October – December</description></item>
+    /// </list>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     public static DateTime FirstDayOfQuarter(this DateTime dateTime) => FirstDayOfQuarterInternal(dateTime, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the quarter that contains the specified instance, using the
-    /// specified calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the quarter that contains the specified <paramref name="dateTime"/>, using the specified calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to determine quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the corresponding quarter.</returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the corresponding quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// The <paramref name="definition"/> controls whether quarters are aligned by month (e.g., Jan–Mar) or anchored to custom day-based boundaries.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month (e.g. January – March) or anchored to a custom day-of-month boundary.</para>
+    /// <para>For provider-driven (e.g. 4-4-5 fiscal) quarters, use the <see cref="FirstDayOfQuarter(DateTime, IQuarterDefinitionProvider)"/> overload instead.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a valid enumeration value.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateTime FirstDayOfQuarter(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -51,18 +52,17 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the quarter that contains the specified instance, using a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the quarter that contains the specified <paramref name="dateTime"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="provider">An implementation of <see cref="IQuarterDefinitionProvider"/> defining custom quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter containing <paramref name="dateTime"/>.</returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating boundary logic to the supplied <paramref name="provider"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the provider returns a date outside the range of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns a date outside the range of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>.</exception>
     public static DateTime FirstDayOfQuarter(this DateTime dateTime, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);
@@ -71,40 +71,37 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the specified calendar quarter in the given year, using the
-    /// standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 (Jan–Mar) to 4 (Oct–Dec).</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the specified quarter and year.</returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the specified quarter and year, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>This method uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is outside the supported range,
-    /// -or- if <paramref name="quarter"/> is less than 1 or greater than 4.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4.
     /// </exception>
     public static DateTime GetFirstDayOfQuarter(int year, int quarter) => GetFirstDayOfQuarter(year, quarter, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the specified quarter and year, using the provided quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are aligned.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the specified quarter.</returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the specified quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is outside the supported range,
-    /// -or- if <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- if <paramref name="definition"/> is not a valid enumeration value.
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use a provider-based overload instead.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
     public static DateTime GetFirstDayOfQuarter(int year, int quarter, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
@@ -118,12 +115,12 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the first day of the quarter that contains the specified <see cref="DateTime"/>, using a prevalidated quarter definition.
+    /// Returns the first day of the quarter that contains the specified <paramref name="dateTime"/>, using a prevalidated calendar quarter <paramref name="definition"/>.
     /// </summary>
-    /// <param name="dateTime">The reference date.</param>
-    /// <param name="definition">A valid <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter.</returns>
-    /// <remarks>This method performs no validation and should be used only when the input definition is known to be valid.</remarks>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where the <paramref name="definition"/> is known to be valid.</remarks>
     private static DateTime FirstDayOfQuarterInternal(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         (int year, int quarter) = GetQuarterAndYearFromDate(definition, referenceDate: dateTime);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,37 +14,27 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified instance, using the first
-    /// day of the week defined by the current culture.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified <paramref name="dateTime"/>, using the first day of the week defined by <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined first day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined first day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
     /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the first day of the week, based on <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     public static DateTime FirstDayOfWeek(this DateTime dateTime) => dateTime.FirstDayOfWeek((CultureInfo?)null);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified instance, using the first
-    /// day of the week defined by the specified or current culture.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified <paramref name="dateTime"/>, using the first day of the week defined by the supplied or current culture.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to determine the first day of the week. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined first day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that defines the first day of the week via <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined first day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method computes the day offset between <paramref name="dateTime"/> and the culture-specific first day of the week, subtracts
-    /// that offset, and resets the time to midnight.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This method computes the day offset between <paramref name="dateTime"/> and the culture-specific first day of the week, subtracts that offset, and resets the time to midnight.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.</exception>
     public static DateTime FirstDayOfWeek(this DateTime dateTime, CultureInfo? culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
@@ -64,25 +54,18 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified instance, using a
-    /// start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the week that contains the specified <paramref name="dateTime"/>, using a start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <param name="weekend">
-    /// A <see cref="CalendarWeekendDefinition"/> used to infer the first day of the week. For example,
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start.
-    /// </param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> used to infer the first day of the week. For example, <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// The method infers the start of the week based on the specified <paramref name="weekend"/> value. If
-    /// <see cref="CalendarWeekendDefinition.None"/> is provided, the method defaults to using <see cref="DayOfWeek.Monday"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method infers the start of the week based on the specified <paramref name="weekend"/> value. If <see cref="CalendarWeekendDefinition.None"/> is supplied, the method defaults to using <see cref="DayOfWeek.Monday"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid <see cref="CalendarWeekendDefinition"/> value,
-    /// -or- if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
+    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value,
+    /// -or- the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
     /// </exception>
     public static DateTime FirstDayOfWeek(this DateTime dateTime, CalendarWeekendDefinition weekend)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,16 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the same
-    /// month and year as the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="dateTime"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value whose month and year are used to determine the result.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the same
-    /// calendar month and year as <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
     /// <para>The search begins on the first day of the month and proceeds forward to locate the first matching weekday.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime FirstDayOfWeekInMonth(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -37,26 +29,20 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the given
-    /// year and month.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the given calendar month and year.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="month">The calendar month to evaluate, from 1 (January) to 12 (December).</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the specified
-    /// <paramref name="year"/> and <paramref name="month"/>.
-    /// </returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the specified <paramref name="year"/> and <paramref name="month"/>, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>This method starts from the first day of the month and proceeds forward to find the first occurrence of the specified <paramref name="dayOfWeek"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The search begins on the first day of the month and proceeds forward to locate the first matching weekday.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="month"/> is less than 1 or greater than 12,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
     /// </exception>
     public static DateTime GetFirstDayOfWeekInMonth(int year, int month, DayOfWeek dayOfWeek)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfWeekInQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,16 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the
-    /// calendar quarter that contains the specified instance, using the standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the calendar quarter that contains the specified <paramref name="dateTime"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the quarter.
-    /// </returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> to determine quarter boundaries. The result is
-    /// calculated by starting at the first day of the quarter and searching forward to the first occurrence of the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>. The search begins on the first day of the quarter and proceeds forward to locate the first matching weekday.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime FirstDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -43,29 +35,21 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter
-    /// that contains the specified instance, using the given quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="dateTime"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to define quarter boundaries.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the quarter.
-    /// </returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// The result is calculated by identifying the first day of the quarter based on <paramref name="definition"/> and searching forward
-    /// to the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value,
-    /// -or- <paramref name="definition"/> is not a valid <see cref="CalendarQuarterDefinition"/> value.
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateTime FirstDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -85,26 +69,18 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter
-    /// that contains the specified instance, using a custom quarter definition provider.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="dateTime"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> implementation that defines quarter boundaries.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the quarter.
-    /// </returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// The result is determined by starting at the beginning of the quarter as defined by <paramref name="provider"/> and searching
-    /// forward to the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The start of the quarter is determined by the supplied <paramref name="provider"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime FirstDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);
@@ -115,26 +91,20 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the
-    /// specified quarter and year, using the standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the specified calendar <paramref name="quarter"/> and <paramref name="year"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the quarter.
-    /// </returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> to define quarter boundaries, and computes the first
-    /// date within the quarter that matches <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
     /// </exception>
     public static DateTime GetFirstDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek)
     {
@@ -151,32 +121,24 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the
-    /// specified quarter and year, using the specified quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to define quarter boundaries.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the quarter.
-    /// </returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that
-    /// matches the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value,
-    /// -or- <paramref name="definition"/> is not a valid <see cref="CalendarQuarterDefinition"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateTime GetFirstDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(year, DateTimeExtensions.MinYear, DateTimeExtensions.MaxYear);
@@ -197,24 +159,15 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Computes the first occurrence of the specified <see cref="DayOfWeek"/> within the given quarter and year, based on the provided
-    /// <see cref="CalendarQuarterDefinition"/>, and returns a <see cref="DateTime"/> value with the specified <see cref="DateTimeKind"/>.
+    /// Returns the first occurrence of the specified <paramref name="dayOfWeek"/> within the given <paramref name="quarter"/> and <paramref name="year"/>, using a prevalidated calendar quarter <paramref name="definition"/> and applying the supplied <paramref name="kind"/>.
     /// </summary>
-    /// <param name="year">The calendar year that contains the quarter. Must be within the valid range of <see cref="DateTime"/>.</param>
-    /// <param name="quarter">The quarter number (1 to 4) within the specified year.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. The method searches forward from the start of the quarter to find the first occurrence.
-    /// </param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how the year is divided into quarters.</param>
-    /// <param name="kind">The <see cref="DateTimeKind"/> to apply to the resulting <see cref="DateTime"/> value.</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> representing midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the
-    /// specified quarter, using the specified <paramref name="kind"/>.
-    /// </returns>
-    /// <remarks>
-    /// This method is used internally to calculate the first matching weekday in a quarter, with tick-level precision. It assumes that all
-    /// arguments have been validated by the caller.
-    /// </remarks>
+    /// <param name="year">The calendar year that contains the quarter.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. The method searches forward from the start of the quarter to find the first occurrence.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <param name="kind">The <see cref="DateTimeKind"/> applied to the resulting <see cref="DateTime"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the specified quarter, using <paramref name="kind"/>.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where all arguments are known to be valid.</remarks>
     private static DateTime GetFirstDayOfWeekInQuarterInternal(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition, DateTimeKind kind)
     {
         long ticks = ComputeQuarterStartTicks(year, quarter, GetQuarterDefinition(definition));

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfWeekInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfWeekInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,16 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> in the calendar
-    /// year of the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the same calendar year as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value whose <c>Year</c> property defines the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday in the year.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> in the calendar year of <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the year. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first occurrence of <paramref name="dayOfWeek"/> within the same calendar year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method starts from January 1 of the year specified by <paramref name="dateTime"/>, and proceeds forward to locate the first
-    /// date that falls on the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The search begins on January 1 of the year and proceeds forward to locate the first matching weekday.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime FirstDayOfWeekInYear(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FirstDayOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.FirstDayOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,16 +11,20 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the same calendar year as the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the same calendar year as the specified <paramref name="dateTime"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on January 1 of the same calendar year as <paramref name="dateTime"/>.</returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on January 1 of the same calendar year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method resets the date component to January 1 and the time component to midnight (00:00:00), preserving the original calendar
-    /// year from <paramref name="dateTime"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This method calculates the first day of the year using Gregorian calendar rules.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var dt = new DateTime(2025, 7, 15, 14, 45, 0);
+    /// var result = dt.FirstDayOfYear(); // → 2025-01-01 00:00:00
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateTime FirstDayOfYear(this DateTime dateTime) => new DateTime(GetDateTicks(dateTime.Year, 1, 1), dateTime.Kind);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetElapsedTimeSince.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetElapsedTimeSince.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetElapsedTimeSince.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,23 +11,14 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a <see cref="TimeSpan"/> representing the time elapsed between the specified <see cref="DateTime"/> and the current UTC time.
+    /// Returns a <see cref="TimeSpan"/> representing the time that has elapsed between the specified <paramref name="dateTime"/> and <see cref="DateTime.UtcNow"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value to compare against <see cref="DateTime.UtcNow"/>.</param>
-    /// <returns>
-    /// The time interval between <paramref name="dateTime"/> and the current UTC time; that is, <paramref name="dateTime"/> minus <see cref="DateTime.UtcNow"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value to compare against <see cref="DateTime.UtcNow"/>. Must have a <see cref="DateTime.Kind"/> of either <see cref="DateTimeKind.Utc"/> or <see cref="DateTimeKind.Local"/>.</param>
+    /// <returns>The signed time interval between <paramref name="dateTime"/> and the current UTC time; that is, <see cref="DateTime.UtcNow"/> minus <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="dateTime"/> is in local time ( <see cref="DateTimeKind.Local"/>), it is automatically converted to UTC using
-    /// <see cref="DateTime.ToUniversalTime"/> before comparison.
-    /// </para>
-    /// <para>
-    /// If the <paramref name="dateTime"/> has a <see cref="DateTimeKind"/> of <see cref="DateTimeKind.Unspecified"/>, an exception is
-    /// thrown to avoid ambiguity regarding the time zone context.
-    /// </para>
+    /// <para>If <paramref name="dateTime"/> is in local time (<see cref="DateTimeKind.Local"/>), it is converted to UTC using <see cref="DateTime.ToUniversalTime"/> before comparison. <see cref="DateTimeKind.Unspecified"/> values are rejected to avoid ambiguity regarding the time zone context.</para>
     /// </remarks>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="dateTime"/> has a <see cref="DateTimeKind"/> of <see cref="DateTimeKind.Unspecified"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="dateTime"/> has a <see cref="DateTime.Kind"/> of <see cref="DateTimeKind.Unspecified"/>.</exception>
     public static TimeSpan GetElapsedTimeSince(this DateTime dateTime)
     {
         DateTime utcInput = dateTime.Kind switch

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetFirstDateOfIsoWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetFirstDateOfIsoWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetFirstDateOfIsoWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,34 +14,22 @@ public static partial class DateTimeExtensions
     /// <summary>
     /// Returns a new <see cref="DateTime"/> representing the first day (Monday) of the specified ISO 8601 week and year.
     /// </summary>
-    /// <param name="isoYear">
-    /// The ISO 8601 year, defined as the year containing the Thursday of the first ISO week. This may differ from the calendar year for
-    /// dates near the beginning or end of the year.
-    /// </param>
-    /// <param name="isoWeek">The ISO 8601 week number to evaluate, ranging from 1 to 53 depending on the year.</param>
-    /// <returns>The date of the Monday that begins the specified ISO 8601 week, at midnight (00:00:00).</returns>
+    /// <param name="isoYear">The ISO 8601 year, defined as the year containing the Thursday of the first ISO week. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="isoWeek">The ISO 8601 week number to evaluate, ranging from 1 to the number of ISO weeks in the supplied year.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the Monday that begins the specified ISO 8601 week, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method computes the first day of a given ISO 8601 week by anchoring on January 4 (which always falls in ISO week 1), then
-    /// backtracking to the preceding Monday and advancing by the specified number of weeks.
-    /// </para>
+    /// <para>This method computes the first day of a given ISO 8601 week by anchoring on January 4 (which always falls in ISO week 1), then backtracking to the preceding Monday and advancing by the supplied number of weeks.</para>
     /// <para>The ISO 8601 calendar follows these rules:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>Weeks begin on Monday.</description>
-    /// </item>
-    /// <item>
-    /// <description>Week 1 is the first week that contains a Thursday.</description>
-    /// </item>
-    /// <item>
-    /// <description>Years may contain either 52 or 53 weeks.</description>
-    /// </item>
+    /// <item><description>weeks begin on Monday;</description></item>
+    /// <item><description>week 1 is the first week containing at least four days of the new year;</description></item>
+    /// <item><description>years contain either 52 or 53 weeks.</description></item>
     /// </list>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="isoYear"/> is less than 1 or greater than 9999,
-    /// -or- <paramref name="isoWeek"/> is less than 1 or greater than the number of ISO weeks in the given year.
+    /// Thrown if <paramref name="isoYear"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="isoWeek"/> is less than 1 or greater than the number of ISO weeks in <paramref name="isoYear"/>.
     /// </exception>
     public static DateTime GetFirstDateOfIsoWeek(int isoYear, int isoWeek)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoWeekOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoWeekOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetIsoWeekOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,24 +12,17 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the ISO 8601 week number for the specified <see cref="DateTime"/>.
+    /// Returns the ISO 8601 week number for the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <returns>The ISO 8601 week number of the year that contains <paramref name="dateTime"/>, ranging from 1 to 53.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns>An integer in the range 1 – 53 representing the ISO 8601 week number that contains <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>This method uses the ISO 8601 standard for week numbering, where:</para>
+    /// <para>This method follows the ISO 8601 standard for week numbering, where:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>Weeks begin on Monday.</description>
-    /// </item>
-    /// <item>
-    /// <description>Week 1 is the first week that contains at least four days in the new year.</description>
-    /// </item>
+    /// <item><description>weeks begin on Monday;</description></item>
+    /// <item><description>week 1 is the first week containing at least four days of the new year.</description></item>
     /// </list>
-    /// <para>
-    /// The result is computed using <see cref="CalendarWeekRule.FirstFourDayWeek"/> and <see cref="DayOfWeek.Monday"/> against the
-    /// date portion of <paramref name="dateTime"/>. Any time-of-day component is discarded before the calculation.
-    /// </para>
+    /// <para>The result is computed using <see cref="CalendarWeekRule.FirstFourDayWeek"/> and <see cref="DayOfWeek.Monday"/> against the date portion of <paramref name="dateTime"/>. Any time-of-day component is discarded before the calculation.</para>
     /// </remarks>
     public static int GetIsoWeekOfYear(this DateTime dateTime) =>
         GetWeekOfYear(TruncateToDateTicks(dateTime), CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoWeeksInYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoWeeksInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetIsoWeeksInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,27 +12,19 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the number of ISO 8601 weeks in the specified year (either 52 or 53).
+    /// Returns the number of ISO 8601 weeks in the specified <paramref name="year"/>.
     /// </summary>
-    /// <param name="year">The ISO 8601 year to evaluate.</param>
-    /// <returns>The number of ISO 8601 weeks in the specified year: either 52 or 53.</returns>
+    /// <param name="year">The ISO 8601 year to evaluate. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <returns>The number of ISO 8601 weeks in the supplied year — either 52 or 53.</returns>
     /// <remarks>
     /// <para>According to ISO 8601, a year contains 53 weeks if either of the following is true:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>January 1 of the specified year falls on a Thursday.</description>
-    /// </item>
-    /// <item>
-    /// <description>December 31 of the specified year falls on a Thursday (equivalent to January 1 of the following year falling on a Friday).</description>
-    /// </item>
+    /// <item><description>January 1 of the supplied year falls on a Thursday;</description></item>
+    /// <item><description>December 31 of the supplied year falls on a Thursday (equivalent to January 1 of the following year falling on a Friday).</description></item>
     /// </list>
-    /// <para>All other years contain exactly 52 weeks.</para>
-    /// <para>
-    /// The implementation determines these conditions by computing the weekday of January 1 for the specified year and for the following
-    /// year, using <see cref="GetDayOfWeekForJanuary1"/>.
-    /// </para>
+    /// <para>All other years contain exactly 52 weeks. The implementation evaluates these conditions by computing the weekday of January 1 for the supplied year and the following year, using <see cref="GetDayOfWeekForJanuary1(int)"/>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="year"/> is less than 1 or greater than 9999.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>.</exception>
     public static int GetIsoWeeksInYear(int year)
     {
         ThrowHelper.ThrowIfOutOfRange(year, DateTime.MinValue.Year, DateTime.MaxValue.Year);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetIsoYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetIsoYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,19 +14,12 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the ISO 8601 year associated with the specified <see cref="DateTime"/>.
+    /// Returns the ISO 8601 year associated with the specified <paramref name="date"/>.
     /// </summary>
-    /// <param name="date">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <returns>The ISO 8601 calendar year that contains the week of <paramref name="date"/>.</returns>
+    /// <param name="date">The date and time value to evaluate.</param>
+    /// <returns>The ISO 8601 calendar year that contains the ISO week of <paramref name="date"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The ISO 8601 year may differ from the calendar year of <paramref name="date"/>. A date near the start or end of a calendar year may
-    /// belong to the ISO year of the adjacent calendar year, depending on where its week falls.
-    /// </para>
-    /// <para>
-    /// For example, January 1 may belong to the last week of the previous ISO year, and December 31 may belong to week 1 of the following
-    /// ISO year.
-    /// </para>
+    /// <para>The ISO 8601 year may differ from the calendar year of <paramref name="date"/>. A date near the start or end of a calendar year may belong to the ISO year of the adjacent calendar year, depending on which ISO week it falls into. For example, January 1 may belong to the last week of the previous ISO year, and December 31 may belong to week 1 of the following ISO year.</para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static int GetIsoYear(this DateTime date)

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetStartDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetStartDateOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.GetStartDateOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,34 +12,20 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the first day of the specified week number in the given calendar year, based on
-    /// the week rule and first day of the week defined by the specified or current <see cref="CultureInfo"/>.
+    /// Returns a new <see cref="DateTime"/> representing the first day of the specified culture-defined week number in the given calendar year.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="week">
-    /// The culture-defined week number to evaluate, starting at 1. The maximum valid value depends on the <see cref="CalendarWeekRule"/>
-    /// and <see cref="DayOfWeek"/> used by the specified <paramref name="culture"/>.
-    /// </param>
+    /// <param name="year">The calendar year to evaluate. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="week">The culture-defined week number to evaluate, starting at 1. The maximum valid value depends on the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> used by the supplied <paramref name="culture"/>.</param>
     /// <param name="culture">An optional <see cref="CultureInfo"/> used to determine the <see cref="CalendarWeekRule"/> and starting <see cref="DayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the first date of the specified week in the specified year.</returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the first date of the specified week in the specified year, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses the culture-defined week numbering system. It begins by identifying the first occurrence of the culture's defined
-    /// <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> on or before January 1 of the specified year, then advances in 7-day intervals to
-    /// calculate the start of the specified week.
-    /// </para>
-    /// <para>
-    /// The result is validated by recalculating the week number for the computed date using the
-    /// internal week-of-year calculation and comparing it to <paramref name="week"/>. Dates that
-    /// fall in the previous calendar year (such as the start of ISO week 1 in late December) are
-    /// handled correctly.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>This method uses the culture-defined week numbering system. It begins by identifying the first occurrence of the culture's <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> on or before January 1 of the supplied year, then advances in 7-day intervals to calculate the start of the supplied week.</para>
+    /// <para>The result is validated by recalculating the week number for the computed date using the internal week-of-year calculation and comparing it to <paramref name="week"/>. Dates that fall in the previous calendar year (such as the start of ISO week 1 in late December) are handled correctly.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
-    /// -or- <paramref name="week"/> does not correspond to a valid week number for <paramref name="year"/> under the rules of the
-    /// specified or current <paramref name="culture"/>.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="week"/> does not correspond to a valid week number for <paramref name="year"/> under the rules of the supplied or current <paramref name="culture"/>.
     /// </exception>
     public static DateTime GetStartDateOfWeek(int year, int week, CultureInfo? culture = null)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.GetStartDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.GetStartDateOfWeek.cs
@@ -20,10 +20,7 @@ public static partial class DateTimeExtensions
     /// The culture-defined week number to evaluate, starting at 1. The maximum valid value depends on the <see cref="CalendarWeekRule"/>
     /// and <see cref="DayOfWeek"/> used by the specified <paramref name="culture"/>.
     /// </param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to determine the <see cref="CalendarWeekRule"/> and starting <see cref="DayOfWeek"/>.
-    /// If <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to determine the <see cref="CalendarWeekRule"/> and starting <see cref="DayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
     /// <returns>An object whose value is set to midnight (00:00:00) on the first date of the specified week in the specified year.</returns>
     /// <remarks>
     /// <para>

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsFirstDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsFirstDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsFirstDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,7 +11,7 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> falls on the first day of its month.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the first day of its calendar month.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
     /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the first day of its month; otherwise, <see langword="false"/>.</returns>

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsFirstDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsFirstDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsFirstDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,16 +11,13 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> is the first day of its calendar quarter, based on the standard
-    /// calendar quarter definition (Q1: January–March, Q2: April–June, etc.).
+    /// Determines whether the specified <see cref="DateTime"/> falls on the first day of its calendar quarter, using the standard calendar quarter definition.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
-    /// <returns><see langword="true"/> if <paramref name="dateTime"/> is the first day of its quarter; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the first day of its quarter; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> to determine quarter boundaries. The result is computed
-    /// by comparing the date component of <paramref name="dateTime"/> against the start of its containing quarter.
-    /// </para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
     public static bool IsFirstDayOfQuarter(this DateTime dateTime)
     {
@@ -29,25 +26,16 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> is the first day of its calendar quarter, based on the specified <see cref="CalendarQuarterDefinition"/>.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the first day of its calendar quarter, using the supplied calendar quarter definition.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
-    /// <param name="definition">The quarter definition used to determine the start of the quarter (e.g., <see cref="CalendarQuarterDefinition.AprilToMarch"/>).</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is the first day of its quarter based on the given definition; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the first day of its quarter under <paramref name="definition"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method compares the date component of <paramref name="dateTime"/> to the computed start of the quarter, using the provided <paramref name="definition"/>.
-    /// </para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="definition"/> is not a valid <see cref="CalendarQuarterDefinition"/> value.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use
-    /// <see cref="IsFirstDayOfQuarter(DateTime, IQuarterDefinitionProvider)"/> for custom quarter logic.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static bool IsFirstDayOfQuarter(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -61,18 +49,13 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> is the first day of its calendar quarter, based on a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the first day of its calendar quarter, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
-    /// <param name="provider">A custom quarter provider that defines the start of each quarter.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is the first day of its quarter as defined by the provider; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the first day of its quarter as defined by <paramref name="provider"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method compares the date component of <paramref name="dateTime"/> to the result returned by <paramref name="provider"/>.
-    /// Time-of-day is ignored in the comparison.
-    /// </para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
     public static bool IsFirstDayOfQuarter(this DateTime dateTime, IQuarterDefinitionProvider provider)

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsInRange.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsInRange.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsInRange.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,46 +11,29 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> value falls within the inclusive range defined by
-    /// <paramref name="start"/> and <paramref name="end"/>.
+    /// Determines whether the specified <see cref="DateTime"/> falls within the inclusive range defined by <paramref name="start"/> and <paramref name="end"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
-    /// <param name="start">The start of the range.</param>
-    /// <param name="end">The end of the range.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is greater than or equal to <paramref name="start"/> and less than or equal
-    /// to <paramref name="end"/>; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="start">The inclusive lower bound of the range.</param>
+    /// <param name="end">The inclusive upper bound of the range.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> is greater than or equal to <paramref name="start"/> and less than or equal to <paramref name="end"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The range check is inclusive, meaning the result is <see langword="true"/> if <paramref name="dateTime"/> equals either
-    /// <paramref name="start"/> or <paramref name="end"/>.
-    /// </para>
-    /// <para>
-    /// If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values
-    /// of <paramref name="dateTime"/>.
-    /// </para>
+    /// <para>The range check is inclusive: the result is <see langword="true"/> if <paramref name="dateTime"/> equals either <paramref name="start"/> or <paramref name="end"/>.</para>
+    /// <para>If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values of <paramref name="dateTime"/>.</para>
     /// </remarks>
     public static bool IsInRange(this DateTime dateTime, DateTime start, DateTime end) => dateTime.CompareTo(start) >= 0 && dateTime.CompareTo(end) <= 0;
 
     /// <summary>
-    /// Returns an indication whether the specified nullable <see cref="DateTime"/> value falls within the inclusive range defined by
-    /// <paramref name="start"/> and <paramref name="end"/>.
+    /// Determines whether the specified nullable <see cref="DateTime"/> falls within the inclusive range defined by <paramref name="start"/> and <paramref name="end"/>.
     /// </summary>
     /// <param name="dateTime">The nullable date and time value to evaluate.</param>
-    /// <param name="start">The start of the range.</param>
-    /// <param name="end">The end of the range.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is not <see langword="null"/> and its value is greater than or equal to
-    /// <paramref name="start"/> and less than or equal to <paramref name="end"/>; otherwise, <see langword="false"/>.
-    /// </returns>
+    /// <param name="start">The inclusive lower bound of the range.</param>
+    /// <param name="end">The inclusive upper bound of the range.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> has a value that is greater than or equal to <paramref name="start"/> and less than or equal to <paramref name="end"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
     /// <para>If <paramref name="dateTime"/> is <see langword="null"/>, the result is <see langword="false"/>.</para>
-    /// <para>The range check is inclusive, meaning the result is <see langword="true"/> if the value equals either boundary.</para>
-    /// <para>
-    /// If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values
-    /// of <paramref name="dateTime"/>.
-    /// </para>
+    /// <para>The range check is inclusive: the result is <see langword="true"/> if the value equals either boundary.</para>
+    /// <para>If <paramref name="end"/> is earlier than <paramref name="start"/>, the method returns <see langword="false"/> for all values of <paramref name="dateTime"/>.</para>
     /// </remarks>
     public static bool IsInRange(this DateTime? dateTime, DateTime start, DateTime end) => dateTime.HasValue && dateTime.Value.IsInRange(start, end);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsLastDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsLastDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsLastDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,15 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> instance represents the last day of its month.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the last day of its calendar month.
     /// </summary>
     /// <param name="dateTime">The date and time value to evaluate.</param>
-    /// <returns><see langword="true"/> if <paramref name="dateTime"/> is the last calendar day of its month; otherwise, <see langword="false"/>.</returns>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the last day of its month; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method compares the day component of <paramref name="dateTime"/> to the total number of days in the same month and year,
-    /// accounting for leap years and variable month lengths.
-    /// </para>
+    /// <para>This method compares the <see cref="DateTime.Day"/> component to the total number of days in the same month and year, accounting for leap-year adjustments to February.</para>
     /// <para>Equivalent to checking whether <c>dateTime.Day == DateTime.DaysInMonth(dateTime.Year, dateTime.Month)</c>.</para>
     /// </remarks>
     public static bool IsLastDayOfMonth(this DateTime dateTime) => dateTime.Day == DateTime.DaysInMonth(dateTime.Year, dateTime.Month);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsLastDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsLastDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsLastDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,17 +11,13 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> instance represents the last day of its calendar quarter, based
-    /// on the standard January–December quarter definition.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the last day of its calendar quarter, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
-    /// <returns><see langword="true"/> if <paramref name="dateTime"/> is the final calendar day of its quarter; otherwise, <see langword="false"/>.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the last day of its quarter; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses the <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> convention: Q1 = Jan–Mar, Q2 = Apr–Jun, Q3 =
-    /// Jul–Sep, Q4 = Oct–Dec.
-    /// </para>
-    /// <para>The comparison is performed on the date component only (time is normalised to 00:00:00).</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
     public static bool IsLastDayOfQuarter(this DateTime dateTime)
     {
@@ -30,26 +26,16 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> instance represents the last day of its calendar quarter, based
-    /// on a specified <see cref="CalendarQuarterDefinition"/>.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the last day of its calendar quarter, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to determine quarter boundaries. Must not be <see cref="CalendarQuarterDefinition.Custom"/>.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is the final calendar day of its quarter based on
-    /// <paramref name="definition"/>; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined member of <see cref="CalendarQuarterDefinition"/>.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the overload that accepts an
-    /// <see cref="IQuarterDefinitionProvider"/> instead.
-    /// </exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the last day of its quarter under <paramref name="definition"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The method evaluates whether the date portion of <paramref name="dateTime"/> (normalised to 00:00:00) is the final day of its
-    /// quarter according to the specified definition.
-    /// </para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static bool IsLastDayOfQuarter(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -63,22 +49,15 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> instance represents the last day of its calendar quarter, based
-    /// on a custom quarter definition provider.
+    /// Determines whether the specified <see cref="DateTime"/> falls on the last day of its calendar quarter, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
-    /// <param name="provider">An implementation of <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundary logic.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="dateTime"/> is the final calendar day of its quarter according to
-    /// <paramref name="provider"/>; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> represents the last day of its quarter as defined by <paramref name="provider"/>; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The method compares the date portion (normalised to 00:00:00) of <paramref name="dateTime"/> with the end of quarter date returned
-    /// by the specified <paramref name="provider"/>.
-    /// </para>
+    /// <para>The comparison is performed on the date component only; the time component of <paramref name="dateTime"/> is ignored.</para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
     public static bool IsLastDayOfQuarter(this DateTime dateTime, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsLeapYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsLeapYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsLeapYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the year component of the specified <see cref="DateTime"/> is a leap year, according to the proleptic
-    /// Gregorian calendar.
+    /// Determines whether the year of the specified <see cref="DateTime"/> is a leap year, according to the proleptic Gregorian calendar.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose <c>Year</c> value is evaluated.</param>
+    /// <param name="dateTime">The date and time value whose <see cref="DateTime.Year"/> is evaluated.</param>
     /// <returns><see langword="true"/> if the year contains February 29; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>This method applies the Gregorian leap year rules:</para>
+    /// <para>This method applies the Gregorian leap-year rules:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>Years divisible by 4 are leap years,</description>
-    /// </item>
-    /// <item>
-    /// <description>except years divisible by 100,</description>
-    /// </item>
-    /// <item>
-    /// <description>unless also divisible by 400.</description>
-    /// </item>
+    /// <item><description>Years divisible by 4 are leap years,</description></item>
+    /// <item><description>except years divisible by 100,</description></item>
+    /// <item><description>unless also divisible by 400.</description></item>
     /// </list>
     /// <para>For example, the years 2000 and 2024 are leap years, while 1900 and 2100 are not.</para>
-    /// <note type="note">This method does not consider culture-specific calendars. It always evaluates leap years based on the Gregorian calendar.</note>
+    /// <para>This method does not consider culture-specific calendars; it always evaluates leap years using the Gregorian calendar.</para>
     /// </remarks>
     public static bool IsLeapYear(this DateTime dateTime) => DateTime.IsLeapYear(dateTime.Year);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,62 +11,39 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> falls on a weekday using the default
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
+    /// Determines whether the specified <see cref="DateTime"/> falls on a weekday, using the default <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <returns><see langword="true"/> if the date is not a Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> does not fall on Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// A weekday is defined as any day not considered part of the weekend under the <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
-    /// </para>
-    /// <para>
-    /// This method is equivalent to calling <see cref="IsWeekday(DateTime, CalendarWeekendDefinition, IWeekendDefinitionProvider?)"/> with
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> and no custom provider.
-    /// </para>
+    /// <para>A weekday is any day not considered a weekend under the <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule. This overload is equivalent to calling <see cref="IsWeekday(DateTime, CalendarWeekendDefinition, IWeekendDefinitionProvider?)"/> with <see cref="CalendarWeekendDefinition.SaturdaySunday"/> and no custom provider.</para>
     /// </remarks>
     public static bool IsWeekday(this DateTime dateTime) => !IsWeekend(dateTime, CalendarWeekendDefinition.SaturdaySunday, null);
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> falls on a weekday, based on the provided
-    /// <see cref="CalendarWeekendDefinition"/> rule.
+    /// Determines whether the specified <see cref="DateTime"/> falls on a weekday, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> value that defines which days are considered weekends.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> used to resolve weekend days when <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns><see langword="true"/> if the date is not considered part of the weekend; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> is not a weekend under the supplied rule or provider; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method checks whether the day represented by <paramref name="dateTime"/> is excluded from the weekend definition provided by
-    /// <paramref name="weekend"/> and optionally refined by <paramref name="provider"/>.
-    /// </para>
-    /// <para>If the input falls outside the weekend range, it is considered a weekday.</para>
+    /// <para>The method evaluates whether the <see cref="DateTime.DayOfWeek"/> of <paramref name="dateTime"/> is excluded from the weekend definition supplied by <paramref name="weekend"/> and optionally refined by <paramref name="provider"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static bool IsWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekend(dateTime, weekend, provider);
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DayOfWeek"/> value is considered a weekday based on the given weekend rule
-    /// or provider.
+    /// Determines whether the specified <see cref="DayOfWeek"/> is considered a weekday, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
     /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to evaluate.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines which days are treated as part of the weekend.</param>
-    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> used when <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.</param>
-    /// <returns><see langword="true"/> if the day is not considered part of the weekend; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dayOfWeek"/> is not a weekend under the supplied rule or provider; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method evaluates whether <paramref name="dayOfWeek"/> is excluded from the weekend days as defined by
-    /// <paramref name="weekend"/>. If a custom weekend rule is specified, the evaluation is delegated to the given <paramref name="provider"/>.
-    /// </para>
     /// <para>This method is equivalent to <c>!IsWeekend(dayOfWeek, weekend, provider)</c>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
 #pragma warning disable S2190 // Loops and recursions should not be infinite
 
     public static bool IsWeekday(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekday(dayOfWeek, weekend, provider);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
@@ -30,7 +30,10 @@ public static partial class DateTimeExtensions
     /// <remarks>
     /// <para>The method evaluates whether the <see cref="DateTime.DayOfWeek"/> of <paramref name="dateTime"/> is excluded from the weekend definition supplied by <paramref name="weekend"/> and optionally refined by <paramref name="provider"/>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekend(dateTime, weekend, provider);
 
     /// <summary>
@@ -43,7 +46,10 @@ public static partial class DateTimeExtensions
     /// <remarks>
     /// <para>This method is equivalent to <c>!IsWeekend(dayOfWeek, weekend, provider)</c>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
 #pragma warning disable S2190 // Loops and recursions should not be infinite
 
     public static bool IsWeekday(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekday(dayOfWeek, weekend, provider);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
@@ -30,7 +30,10 @@ public static partial class DateTimeExtensions
     /// <remarks>
     /// <para>This method supports alternative weekend definitions used in different cultures and regions, such as Friday/Saturday or Sunday-only.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsWeekend(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => IsWeekend(dateTime.DayOfWeek, weekend, provider);
 
     /// <summary>
@@ -43,7 +46,11 @@ public static partial class DateTimeExtensions
     /// <remarks>
     /// <para>This overload supports custom weekend evaluation logic via <paramref name="provider"/> when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration, or if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
+    /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
+    /// </exception>
     public static bool IsWeekend(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekend.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.IsWeekend.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,48 +11,39 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> falls on a weekend using the default
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
+    /// Determines whether the specified <see cref="DateTime"/> falls on a weekend, using the default <see cref="CalendarWeekendDefinition.SaturdaySunday"/> rule.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <returns><see langword="true"/> if the date falls on a Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
-    /// <remarks>This method uses the standard weekend definition, where Saturday and Sunday are considered weekend days.</remarks>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> falls on Saturday or Sunday; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard weekend definition where Saturday and Sunday are considered weekend days.</para>
+    /// </remarks>
     public static bool IsWeekend(this DateTime dateTime) => IsWeekend(dateTime.DayOfWeek, CalendarWeekendDefinition.SaturdaySunday, null);
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DateTime"/> falls on a weekend using the provided
-    /// <see cref="CalendarWeekendDefinition"/> rule and optional custom provider.
+    /// Determines whether the specified <see cref="DateTime"/> falls on a weekend, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> value that defines which days are treated as weekend days.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> that provides custom logic for evaluating weekend days when
-    /// <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns><see langword="true"/> if the date falls on a weekend day as defined by the rule or provider; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are treated as weekend days.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dateTime"/> falls on a weekend day as defined by the supplied rule or provider; otherwise, <see langword="false"/>.</returns>
     /// <remarks>
-    /// This method supports alternative weekend definitions used in different cultures and regions, such as Friday/Saturday or Sunday-only.
+    /// <para>This method supports alternative weekend definitions used in different cultures and regions, such as Friday/Saturday or Sunday-only.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static bool IsWeekend(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => IsWeekend(dateTime.DayOfWeek, weekend, provider);
 
     /// <summary>
-    /// Returns an indication whether the specified <see cref="DayOfWeek"/> value is considered a weekend day based on the specified
-    /// <see cref="CalendarWeekendDefinition"/> and optional custom provider.
+    /// Determines whether the specified <see cref="DayOfWeek"/> is considered a weekend day, using the supplied <see cref="CalendarWeekendDefinition"/> and an optional custom <paramref name="provider"/>.
     /// </summary>
     /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to evaluate.</param>
-    /// <param name="weekend">The weekend rule that defines which days are considered part of the weekend.</param>
-    /// <param name="provider">
-    /// A custom <see cref="IWeekendDefinitionProvider"/> used only when <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns><see langword="true"/> if the day is considered part of the weekend; otherwise, <see langword="false"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is
-    /// <see langword="null"/>, or if <paramref name="weekend"/> is not a defined value.
-    /// </exception>
-    /// <remarks>This method supports custom weekend evaluation logic via <paramref name="provider"/> when using <see cref="CalendarWeekendDefinition.Custom"/>.</remarks>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekend days.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</param>
+    /// <returns><see langword="true"/> if <paramref name="dayOfWeek"/> is considered a weekend day; otherwise, <see langword="false"/>.</returns>
+    /// <remarks>
+    /// <para>This overload supports custom weekend evaluation logic via <paramref name="provider"/> when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration, or if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration, or if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.</exception>
     public static bool IsWeekend(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDateOfIsoWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDateOfIsoWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDateOfIsoWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,36 +12,24 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last date (Sunday) of the specified ISO 8601 week and year.
+    /// Returns a new <see cref="DateTime"/> representing the last day (Sunday) of the specified ISO 8601 week and year.
     /// </summary>
-    /// <param name="isoYear">
-    /// The ISO 8601 year, which corresponds to the calendar year containing the Thursday of the first ISO week (e.g., 2024).
-    /// </param>
-    /// <param name="isoWeek">The ISO 8601 week number within the specified year. Valid values range from 1 to 53, depending on the year.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the Sunday that ends the specified ISO 8601 week.</returns>
+    /// <param name="isoYear">The ISO 8601 year, defined as the year containing the Thursday of the first ISO week. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="isoWeek">The ISO 8601 week number to evaluate, ranging from 1 to the number of ISO weeks in the supplied year.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the Sunday that ends the specified ISO 8601 week, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>According to the ISO 8601 standard:</para>
+    /// <para>This method computes the last day of a given ISO 8601 week by anchoring on January 4 (which always falls in ISO week 1), backtracking to the preceding Monday, advancing by the supplied number of weeks, and adding six days to reach the Sunday of that week.</para>
+    /// <para>The ISO 8601 calendar follows these rules:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>Weeks begin on Monday and end on Sunday.</description>
-    /// </item>
-    /// <item>
-    /// <description>Week 1 is the first week with at least four days in the new year.</description>
-    /// </item>
-    /// <item>
-    /// <description>January 4th is always part of ISO week 1.</description>
-    /// </item>
+    /// <item><description>weeks begin on Monday and end on Sunday;</description></item>
+    /// <item><description>week 1 is the first week containing at least four days of the new year;</description></item>
+    /// <item><description>years contain either 52 or 53 weeks.</description></item>
     /// </list>
-    /// <para>
-    /// This method calculates the target Sunday by anchoring on January 4th, backtracking to the Monday of ISO week 1, advancing by the
-    /// specified number of weeks, and adding six days to reach the Sunday of that week.
-    /// </para>
-    /// <note type="tip">For the corresponding start of the week, use <see cref="GetFirstDateOfIsoWeek"/>.</note>
-    /// <para>The result has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>. For the corresponding start of the week, use <see cref="GetFirstDateOfIsoWeek(int, int)"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="isoYear"/> is outside the valid range, or if <paramref name="isoWeek"/> is less than 1 or greater than
-    /// the number of ISO weeks in the year.
+    /// Thrown if <paramref name="isoYear"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="isoWeek"/> is less than 1 or greater than the number of ISO weeks in <paramref name="isoYear"/>.
     /// </exception>
     public static DateTime LastDateOfIsoWeek(int isoYear, int isoWeek)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,42 +11,36 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the same month and year as the specified <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the same calendar month and year as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The input <see cref="DateTime"/> whose month and year are used to determine the last day.</param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the last day of the month, with the original <see cref="DateTime.Kind"/> preserved.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year and month are used to determine the result.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the same calendar month and year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method calculates the last day of the month using Gregorian calendar rules. Leap years are correctly accounted for when
-    /// determining the length of February.
-    /// </para>
-    /// <para>The result has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// <para>This method calculates the last day of the month using Gregorian calendar rules. Leap years are correctly accounted for when determining the length of February.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var dt = new DateTime(2024, 2, 15, 14, 45, 0);
+    /// var result = dt.LastDayOfMonth(); // → 2024-02-29 00:00:00
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateTime LastDayOfMonth(this DateTime dateTime) => new DateTime(GetLastDayOfMonthTicks(dateTime), dateTime.Kind);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the specified month and year.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the specified calendar month and year.
     /// </summary>
-    /// <param name="year">
-    /// The calendar year component of the date. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and
-    /// <see cref="DateTime.MaxValue"/>, inclusive.
-    /// </param>
-    /// <param name="month">
-    /// The month component of the date. Must be an integer between 1 and 12, inclusive, where 1 represents January and 12 represents December.
-    /// </param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
     /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the specified month and year, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses Gregorian calendar logic to determine the number of days in the specified month, including leap year adjustments
-    /// for February.
-    /// </para>
+    /// <para>This method uses Gregorian calendar rules to determine the number of days in the specified month, including leap-year adjustments for February.</para>
     /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of
-    /// <see cref="DateTime.MaxValue"/>, or if <paramref name="month"/> is outside the valid range of 1 to 12.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12.
     /// </exception>
     public static DateTime LastDayOfMonth(int year, int month)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,40 +11,96 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the specified calendar quarter in the given year, using the
-    /// standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the calendar quarter that contains the specified <paramref name="dateTime"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 (Jan–Mar) to 4 (Oct–Dec).</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the specified quarter and year.</returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the quarter that contains <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>This method uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>:</para>
+    /// <list type="bullet">
+    /// <item><term>Q1</term><description>January – March</description></item>
+    /// <item><term>Q2</term><description>April – June</description></item>
+    /// <item><term>Q3</term><description>July – September</description></item>
+    /// <item><term>Q4</term><description>October – December</description></item>
+    /// </list>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    public static DateTime LastDayOfQuarter(this DateTime dateTime) => LastDayOfQuarterInternal(dateTime, CalendarQuarterDefinition.JanuaryToDecember);
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last day of the quarter that contains the specified <paramref name="dateTime"/>, using the specified calendar quarter definition.
+    /// </summary>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the corresponding quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month (e.g. January – March) or anchored to a custom day-of-month boundary.</para>
+    /// <para>For provider-driven (e.g. 4-4-5 fiscal) quarters, use the <see cref="LastDayOfQuarter(DateTime, IQuarterDefinitionProvider)"/> overload instead.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
+    public static DateTime LastDayOfQuarter(this DateTime dateTime, CalendarQuarterDefinition definition)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
+
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
+        return LastDayOfQuarterInternal(dateTime, definition);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last day of the quarter that contains the specified <paramref name="dateTime"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// </summary>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the quarter containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating boundary logic to the supplied <paramref name="provider"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the <paramref name="provider"/> returns a date outside the range of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>.</exception>
+    public static DateTime LastDayOfQuarter(this DateTime dateTime, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        return provider.GetQuarterEnd(dateTime);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the specified quarter and year, using <see cref="DateTimeKind.Unspecified"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is outside the supported range,
-    /// -or- if <paramref name="quarter"/> is less than 1 or greater than 4.
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4.
     /// </exception>
     public static DateTime GetLastDayOfQuarter(int year, int quarter) => GetLastDayOfQuarter(year, quarter, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the specified quarter and year, using the provided quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how quarters are aligned.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the specified quarter.</returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the specified quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is outside the supported range,
-    /// -or- if <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- if <paramref name="definition"/> is not a valid enumeration value.
+    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use a provider-based overload instead.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
     public static DateTime GetLastDayOfQuarter(int year, int quarter, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
@@ -58,71 +114,12 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the calendar quarter that contains the specified instance, using
-    /// the standard calendar quarter definition.
+    /// Returns the last day of the quarter that contains the specified <paramref name="dateTime"/>, using a prevalidated calendar quarter <paramref name="definition"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the calendar quarter.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the quarter containing <paramref name="dateTime"/>.</returns>
-    /// <remarks>
-    /// <para>This method uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    public static DateTime LastDayOfQuarter(this DateTime dateTime) => LastDayOfQuarterInternal(dateTime, CalendarQuarterDefinition.JanuaryToDecember);
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the quarter that contains the specified instance, using the
-    /// specified calendar quarter definition.
-    /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to determine quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the corresponding quarter.</returns>
-    /// <remarks>
-    /// <para>
-    /// The <paramref name="definition"/> controls whether quarters are aligned by month (e.g., Jan–Mar) or anchored to custom day-based boundaries.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a valid enumeration value.</exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
-    public static DateTime LastDayOfQuarter(this DateTime dateTime, CalendarQuarterDefinition definition)
-    {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
-
-        if (definition == CalendarQuarterDefinition.Custom)
-            throw new InvalidOperationException(
-                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
-
-        return LastDayOfQuarterInternal(dateTime, definition);
-    }
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the quarter that contains the specified instance, using a custom <see cref="IQuarterDefinitionProvider"/>.
-    /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="provider">An implementation of <see cref="IQuarterDefinitionProvider"/> defining custom quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the quarter containing <paramref name="dateTime"/>.</returns>
-    /// <remarks>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the provider returns a date outside the range of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>.
-    /// </exception>
-    public static DateTime LastDayOfQuarter(this DateTime dateTime, IQuarterDefinitionProvider provider)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        return provider.GetQuarterEnd(dateTime);
-    }
-
-    /// <summary>
-    /// Returns the last day of the quarter that includes the specified <paramref name="dateTime"/>, using the provided quarter definition.
-    /// </summary>
-    /// <param name="dateTime">The date used to evaluate the quarter.</param>
-    /// <param name="definition">The quarter definition, assumed to be valid and non-custom.</param>
-    /// <returns>An object whose value is set to midnight on the last day of the applicable quarter, preserving the <see cref="DateTime.Kind"/>.</returns>
-    /// <remarks>This method skips validation and is intended for internal use in trusted contexts.</remarks>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where the <paramref name="definition"/> is known to be valid.</remarks>
     private static DateTime LastDayOfQuarterInternal(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         (int year, int quarter) = GetQuarterAndYearFromDate(definition, referenceDate: dateTime);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,37 +14,27 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified instance, using the last day
-    /// of the week defined by the current culture.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified <paramref name="dateTime"/>, using the last day of the week defined by <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined last day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined last day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the last day of the week, based on <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the last day of the week, inferred from <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     public static DateTime LastDayOfWeek(this DateTime dateTime) => dateTime.LastDayOfWeek((CultureInfo?)null);
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified instance, using the last day
-    /// of the week defined by the specified or current culture.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified <paramref name="dateTime"/>, using the last day of the week defined by the supplied or current culture.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> used to determine the last day of the week. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined last day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that defines the first day of the week via <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the culturally defined last day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method computes the day offset between <paramref name="dateTime"/> and the culture-specific last day of the week, subtracts
-    /// that offset, and resets the time to midnight.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This method computes the day offset between <paramref name="dateTime"/> and the culture-specific last day of the week, adds that offset, and resets the time to midnight.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.</exception>
     public static DateTime LastDayOfWeek(this DateTime dateTime, CultureInfo? culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
@@ -66,25 +56,18 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified instance, using a
-    /// start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the week that contains the specified <paramref name="dateTime"/>, using a start-of-week inferred from the specified <see cref="CalendarWeekendDefinition"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value used to determine the containing week.</param>
-    /// <param name="weekend">
-    /// A <see cref="CalendarWeekendDefinition"/> used to infer the last day of the week. For example,
-    /// <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start.
-    /// </param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the week containing <paramref name="dateTime"/>.</returns>
+    /// <param name="weekend">A <see cref="CalendarWeekendDefinition"/> used to infer the last day of the week. For example, <see cref="CalendarWeekendDefinition.SaturdaySunday"/> implies a Monday start (and therefore a Sunday end).</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last day of the week containing <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// The method infers the start of the week based on the specified <paramref name="weekend"/> value. If
-    /// <see cref="CalendarWeekendDefinition.None"/> is provided, the method defaults to using <see cref="DayOfWeek.Monday"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method infers the start of the week based on the specified <paramref name="weekend"/> value, then calculates the last day as six days after the inferred start. If <see cref="CalendarWeekendDefinition.None"/> is supplied, the method defaults to using <see cref="DayOfWeek.Monday"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid <see cref="CalendarWeekendDefinition"/> value,
-    /// -or- if the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
+    /// Thrown if <paramref name="weekend"/> is not a defined <see cref="CalendarWeekendDefinition"/> value,
+    /// -or- the resulting date is earlier than <see cref="DateTime.MinValue"/> or later than <see cref="DateTime.MaxValue"/>.
     /// </exception>
     public static DateTime LastDayOfWeek(this DateTime dateTime, CalendarWeekendDefinition weekend)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,39 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the given
-    /// year and month.
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="year">The calendar year to evaluate. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="month">The calendar month to evaluate, from 1 (January) to 12 (December).</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the specified
-    /// <paramref name="year"/> and <paramref name="month"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose month and year are used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>This method starts from the last day of the month and proceeds backwards to find the last occurrence of the specified <paramref name="dayOfWeek"/>.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The search begins on the last day of the month and proceeds backward to locate the last matching weekday.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateTime LastDayOfWeekInMonth(this DateTime dateTime, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        long ticks = GetLastDayOfWeekInMonthAsTicks(dateTime, dayOfWeek);
+        return new DateTime(ticks, dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the given calendar month and year.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the specified <paramref name="year"/> and <paramref name="month"/>, using <see cref="DateTimeKind.Unspecified"/>.</returns>
+    /// <remarks>
+    /// <para>The search begins on the last day of the month and proceeds backward to locate the last matching weekday.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="month"/> is less than 1 or greater than 12,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
     /// </exception>
     public static DateTime GetLastDayOfWeekInMonth(int year, int month, DayOfWeek dayOfWeek)
     {
@@ -40,32 +53,5 @@ public static partial class DateTimeExtensions
 
         long ticks = GetLastDayOfWeekInMonth(GetDateTicks(year, month, DateTime.DaysInMonth(year, month)), dayOfWeek);
         return new DateTime(ticks, DateTimeKind.Unspecified);
-    }
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the same
-    /// month and year as the specified instance.
-    /// </summary>
-    /// <param name="dateTime">The date and time value whose month and year are used to determine the result.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the same calendar
-    /// month and year as <paramref name="dateTime"/>.
-    /// </returns>
-    /// <remarks>
-    /// <para>The search begins on the last day of the month and proceeds backwards to locate the first matching weekday.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
-    public static DateTime LastDayOfWeekInMonth(this DateTime dateTime, DayOfWeek dayOfWeek)
-    {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-
-        long ticks = GetLastDayOfWeekInMonthAsTicks(dateTime, dayOfWeek);
-        return new DateTime(ticks, dateTime.Kind);
     }
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInQuarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfWeekInQuarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,100 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the
-    /// specified quarter and year, using the standard calendar quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the calendar quarter that contains the specified <paramref name="dateTime"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the quarter.</returns>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> to define quarter boundaries, and computes the last date
-    /// within the quarter that matches <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>. The search begins on the last day of the quarter and proceeds backward to locate the last matching weekday.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        (int year, int quarter) = DateTimeExtensions.GetQuarterAndYearFromDate(CalendarQuarterDefinition.JanuaryToDecember, dateTime);
+        return DateTimeExtensions.GetLastDayOfWeekInQuarterInternal(
+            year,
+            quarter,
+            dayOfWeek,
+            CalendarQuarterDefinition.JanuaryToDecember,
+            dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="dateTime"/>, using the supplied calendar quarter definition.
+    /// </summary>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>
+    /// <para>The end of the quarter is computed using <paramref name="definition"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
+    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
+
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
+        (int year, int quarter) = DateTimeExtensions.GetQuarterAndYearFromDate(definition, dateTime);
+        return DateTimeExtensions.GetLastDayOfWeekInQuarterInternal(
+            year,
+            quarter,
+            dayOfWeek,
+            definition,
+            dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="dateTime"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// </summary>
+    /// <param name="dateTime">The date and time value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the quarter, with the original <see cref="DateTime.Kind"/> preserved.</returns>
+    /// <remarks>
+    /// <para>The end of the quarter is determined by the supplied <paramref name="provider"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        DateTime dt = provider.GetQuarterEnd(dateTime);
+        return new DateTime(dt.Ticks + DateTimeExtensions.GetTicksToPreviousDayOfWeek(dt, dayOfWeek), dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the specified calendar <paramref name="quarter"/> and <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
     /// </exception>
     public static DateTime GetLastDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek)
     {
@@ -45,30 +121,24 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the
-    /// specified quarter and year, using the specified quarter definition.
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year. Must be between 1 and 9999, inclusive.</param>
-    /// <param name="quarter">The quarter number, from 1 to 4.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to define quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the quarter.</returns>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the quarter, using <see cref="DateTimeKind.Unspecified"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds backwards to the last date that
-    /// matches the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance is <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// <para>The end of the quarter is computed using <paramref name="definition"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="year"/> is less than 1 or greater than 9999,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
     /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
-    /// -or- <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value,
-    /// -or- <paramref name="definition"/> is not a valid <see cref="CalendarQuarterDefinition"/> value.
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateTime GetLastDayOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(year, DateTimeExtensions.MinYear, DateTimeExtensions.MaxYear);
@@ -89,122 +159,15 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the calendar
-    /// quarter that contains the specified instance, using the standard calendar quarter definition.
+    /// Returns the last occurrence of the specified <paramref name="dayOfWeek"/> within the given <paramref name="quarter"/> and <paramref name="year"/>, using a prevalidated calendar quarter <paramref name="definition"/> and applying the supplied <paramref name="kind"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the quarter.</returns>
-    /// <remarks>
-    /// <para>
-    /// This method uses <see cref="CalendarQuarterDefinition.JanuaryToDecember"/> to determine quarter boundaries. The result is
-    /// calculated by starting at the last day of the quarter and searching backwards to the last occurrence of the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
-    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek)
-    {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-
-        (int year, int quarter) = DateTimeExtensions.GetQuarterAndYearFromDate(CalendarQuarterDefinition.JanuaryToDecember, dateTime);
-        return DateTimeExtensions.GetLastDayOfWeekInQuarterInternal(
-            year,
-            quarter,
-            dayOfWeek,
-            CalendarQuarterDefinition.JanuaryToDecember,
-            dateTime.Kind);
-    }
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter
-    /// that contains the specified instance, using the given quarter definition.
-    /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> used to define quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the quarter.</returns>
-    /// <remarks>
-    /// <para>
-    /// The result is calculated by identifying the last day of the quarter based on <paramref name="definition"/> and searching backwards
-    /// to the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value,
-    /// -or- <paramref name="definition"/> is not a valid <see cref="CalendarQuarterDefinition"/> value.
-    /// </exception>
-    /// <exception cref="InvalidOperationException">
-    /// Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>. Use the provider-based overload instead.
-    /// </exception>
-    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
-    {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
-
-        if (definition == CalendarQuarterDefinition.Custom)
-            throw new InvalidOperationException(
-                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
-
-        (int year, int quarter) = DateTimeExtensions.GetQuarterAndYearFromDate(definition, dateTime);
-        return DateTimeExtensions.GetLastDayOfWeekInQuarterInternal(
-            year,
-            quarter,
-            dayOfWeek,
-            definition,
-            dateTime.Kind);
-    }
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter
-    /// that contains the specified instance, using a custom quarter definition provider.
-    /// </summary>
-    /// <param name="dateTime">The date and time value used to determine the quarter.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate within the quarter.</param>
-    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> implementation that defines quarter boundaries.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the quarter.</returns>
-    /// <remarks>
-    /// <para>
-    /// The result is determined by starting at the beginning of the quarter as defined by <paramref name="provider"/> and searching
-    /// backwards to the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
-    /// </remarks>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
-    public static DateTime LastDayOfWeekInQuarter(this DateTime dateTime, DayOfWeek dayOfWeek, IQuarterDefinitionProvider provider)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-
-        DateTime dt = provider.GetQuarterEnd(dateTime);
-        return new DateTime(dt.Ticks + DateTimeExtensions.GetTicksToPreviousDayOfWeek(dt, dayOfWeek), dateTime.Kind);
-    }
-
-    /// <summary>
-    /// Computes the last occurrence of the specified <see cref="DayOfWeek"/> within the given quarter and year, based on the provided
-    /// <see cref="CalendarQuarterDefinition"/>, and returns a <see cref="DateTime"/> with the specified <see cref="DateTimeKind"/>.
-    /// </summary>
-    /// <param name="year">The calendar year that contains the quarter. Must be within the valid range of <see cref="DateTime"/>.</param>
-    /// <param name="quarter">The quarter number (1 to 4) within the specified year.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate. The method searches backward from the end of the quarter to find the last occurrence.
-    /// </param>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines how the year is divided into quarters.</param>
-    /// <param name="kind">The <see cref="DateTimeKind"/> to apply to the resulting <see cref="DateTime"/>.</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> representing midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the
-    /// specified quarter, using the specified <paramref name="kind"/>.
-    /// </returns>
-    /// <remarks>
-    /// This method is used internally to calculate the final matching weekday in a quarter with tick-level precision. It assumes that all
-    /// arguments have been validated by the caller and does not perform any range or enum checks.
-    /// </remarks>
+    /// <param name="year">The calendar year that contains the quarter.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. The method searches backward from the end of the quarter to find the last occurrence.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <param name="kind">The <see cref="DateTimeKind"/> applied to the resulting <see cref="DateTime"/>.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the specified quarter, using <paramref name="kind"/>.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where all arguments are known to be valid.</remarks>
     private static DateTime GetLastDayOfWeekInQuarterInternal(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition, DateTimeKind kind)
     {
         long ticks = ComputeQuarterStartTicks(year, quarter, GetQuarterDefinition(definition));

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfWeekInYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfWeekInYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,16 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> in the calendar
-    /// year of the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the same calendar year as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The date and time value whose <c>Year</c> property defines the search range.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday in the year.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> in the calendar year of <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the year. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the last occurrence of <paramref name="dayOfWeek"/> within the same calendar year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method starts from December 31 of the year specified by <paramref name="dateTime"/>, and proceeds backwrds to locate the last
-    /// date that falls on the specified <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The search begins on December 31 of the year and proceeds backward to locate the last matching weekday.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime LastDayOfWeekInYear(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.LastDayOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.LastDayOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,16 +11,20 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the last day of the same calendar year as the specified instance.
+    /// Returns a new <see cref="DateTime"/> representing the last day of the same calendar year as the specified <paramref name="dateTime"/>.
     /// </summary>
     /// <param name="dateTime">The date and time value whose year is used to determine the result.</param>
-    /// <returns>An object whose value is set to midnight (00:00:00) on December 31 of the same calendar year as <paramref name="dateTime"/>.</returns>
+    /// <returns>An object whose value is set to midnight (00:00:00) on December 31 of the same calendar year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method resets the date component to January 1 and the time component to midnight (00:00:00), preserving the original calendar
-    /// year from <paramref name="dateTime"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>This method calculates the last day of the year using Gregorian calendar rules.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var dt = new DateTime(2025, 7, 15, 14, 45, 0);
+    /// var result = dt.LastDayOfYear(); // → 2025-12-31 00:00:00
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateTime LastDayOfYear(this DateTime dateTime) => new DateTime(GetDateTicks(dateTime.Year, 12, 31), dateTime.Kind);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Max.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Max.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Max.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,27 +11,24 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a <see cref="DateTime"/> whose value is the later of the two specified values.
+    /// Returns the later of two specified <see cref="DateTime"/> values.
     /// </summary>
     /// <param name="first">The first <see cref="DateTime"/> value to compare.</param>
     /// <param name="second">The second <see cref="DateTime"/> value to compare.</param>
-    /// <returns>The <see cref="DateTime"/> whose value is later. If both values are equal, <paramref name="first"/> is returned.</returns>
+    /// <returns>The later of the two <see cref="DateTime"/> values. If both values are equal, <paramref name="first"/> is returned.</returns>
     /// <remarks>
-    /// This method compares the two values using the greater-than-or-equal-to ( <c>&gt;=</c>) operator, which is equivalent to <see cref="DateTime.CompareTo(DateTime)"/>.
+    /// <para>This method compares the two values using the greater-than-or-equal-to (<c>&gt;=</c>) operator, which is equivalent to <see cref="DateTime.CompareTo(DateTime)"/>. The <see cref="DateTime.Kind"/> of the selected value is preserved.</para>
     /// </remarks>
     public static DateTime Max(DateTime first, DateTime second) => first >= second ? first : second;
 
     /// <summary>
-    /// Returns a nullable <see cref="DateTime"/> whose value is the later of the two specified values.
+    /// Returns the later of two specified nullable <see cref="DateTime"/> values.
     /// </summary>
     /// <param name="first">The first nullable <see cref="DateTime"/> value to compare.</param>
     /// <param name="second">The second nullable <see cref="DateTime"/> value to compare.</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> whose value is later, or <c>null</c> if both <paramref name="first"/> and <paramref name="second"/> are <c>null</c>.
-    /// </returns>
+    /// <returns>The later non-null <see cref="DateTime"/> value, or <see langword="null"/> if both values are <see langword="null"/>.</returns>
     /// <remarks>
-    /// <para>If both values are non-null, they are compared using the greater-than-or-equal-to ( <c>&gt;=</c>) operator.</para>
-    /// <para>If only one value is non-null, that value is returned. If both are <c>null</c>, the result is <see langword="null"/>.</para>
+    /// <para>If both values are non-null, they are compared using the greater-than-or-equal-to (<c>&gt;=</c>) operator. If only one value is non-null, that value is returned. If both are <see langword="null"/>, the result is <see langword="null"/>.</para>
     /// </remarks>
 #pragma warning disable S3358 // Ternary operators should not be nested
 

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Midday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Midday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Midday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,18 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing 12:00 PM (midday) on the same calendar day as the specified <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing midday (12:00:00) on the same calendar day as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The input <see cref="DateTime"/> whose date is used to compute the result.</param>
-    /// <returns>
-    /// An object whose value is set to exactly 12:00:00.000 (noon) on the same date as <paramref name="dateTime"/>, preserving its <see cref="DateTime.Kind"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose date is preserved while the time is set to midday.</param>
+    /// <returns>An object whose value is set to 12:00:00.000 on the same calendar day as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method replaces the time component of the input with exactly 12:00 PM (midday), while retaining the original year, month, day,
-    /// and <see cref="DateTime.Kind"/>.
-    /// </para>
-    /// <para>The returned value always represents the midpoint of the day and contains no fractional seconds or milliseconds.</para>
+    /// <para>This method replaces the time component of the input with exactly 12:00 PM (noon) while retaining the date and <see cref="DateTime.Kind"/> of the input. The returned value contains no fractional seconds or milliseconds.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var dt = new DateTime(2025, 7, 15, 14, 45, 0);
+    /// var result = dt.Midday(); // → 2025-07-15 12:00:00
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateTime Midday(this DateTime dateTime) => new DateTime(dateTime.Date.Ticks + (TicksPerHour * 12), dateTime.Kind);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Midnight.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Midnight.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Midnight.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,20 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing midnight (00:00:00) at the start of the same calendar day as the specified <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing midnight (00:00:00) on the same calendar day as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The input <see cref="DateTime"/> whose calendar date is preserved.</param>
-    /// <returns>
-    /// An object whose value is set to 00:00:00 (midnight) on the same date as <paramref name="dateTime"/>, preserving its <see cref="DateTime.Kind"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose date is preserved while the time is reset to midnight.</param>
+    /// <returns>An object whose value is set to 00:00:00 on the same calendar day as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method is functionally equivalent to accessing the <see cref="DateTime.Date"/> property. It normalises the time component to
-    /// midnight while retaining the date and <see cref="DateTime.Kind"/> of the input.
-    /// </para>
-    /// <para>
-    /// Use this method to explicitly express intent to retrieve the start of the day in scenarios where clarity and precision are preferred.
-    /// </para>
+    /// <para>This method is functionally equivalent to <see cref="StartOfDay(DateTime)"/> and to accessing <see cref="DateTime.Date"/>. It normalises the time component to midnight while retaining the date and <see cref="DateTime.Kind"/> of the input.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
+    ///<![CDATA[
+    /// var dt = new DateTime(2025, 7, 15, 14, 45, 0);
+    /// var result = dt.Midnight(); // → 2025-07-15 00:00:00
+    ///]]>
+    /// </code>
     /// </remarks>
     public static DateTime Midnight(this DateTime dateTime) => dateTime.Date;
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Min.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Min.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Min.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -15,13 +15,9 @@ public static partial class DateTimeExtensions
     /// </summary>
     /// <param name="first">The first <see cref="DateTime"/> value to compare.</param>
     /// <param name="second">The second <see cref="DateTime"/> value to compare.</param>
-    /// <returns>
-    /// An object whose value is set to the earlier of the two <see cref="DateTime"/> values. If both values are equal,
-    /// <paramref name="first"/> is returned.
-    /// </returns>
+    /// <returns>The earlier of the two <see cref="DateTime"/> values. If both values are equal, <paramref name="first"/> is returned.</returns>
     /// <remarks>
-    /// This method compares the values using <see cref="DateTime.CompareTo(DateTime)"/> and returns the earlier one. The result preserves
-    /// the original <see cref="DateTime.Kind"/> of the selected value.
+    /// <para>This method compares the two values using the less-than-or-equal-to (<c>&lt;=</c>) operator, which is equivalent to <see cref="DateTime.CompareTo(DateTime)"/>. The <see cref="DateTime.Kind"/> of the selected value is preserved.</para>
     /// </remarks>
     public static DateTime Min(DateTime first, DateTime second) => first <= second ? first : second;
 
@@ -30,12 +26,9 @@ public static partial class DateTimeExtensions
     /// </summary>
     /// <param name="first">The first nullable <see cref="DateTime"/> value to compare.</param>
     /// <param name="second">The second nullable <see cref="DateTime"/> value to compare.</param>
-    /// <returns>
-    /// An object whose value is set to the earlier of the two non-null <see cref="DateTime"/> values, or <c>null</c> if both are <c>null</c>.
-    /// </returns>
+    /// <returns>The earlier non-null <see cref="DateTime"/> value, or <see langword="null"/> if both values are <see langword="null"/>.</returns>
     /// <remarks>
-    /// <para>If both values are non-null, they are compared using <see cref="DateTime.CompareTo(DateTime)"/> and the earlier is returned.</para>
-    /// <para>If only one value is non-null, it is returned. If both are <c>null</c>, the result is <see langword="null"/>.</para>
+    /// <para>If both values are non-null, they are compared using the less-than-or-equal-to (<c>&lt;=</c>) operator. If only one value is non-null, that value is returned. If both are <see langword="null"/>, the result is <see langword="null"/>.</para>
     /// </remarks>
 #pragma warning disable S3358 // Ternary operators should not be nested
 

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.MonthName.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.MonthName.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.MonthName.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,37 +13,26 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the full name of the specified calendar month, using the formatting rules of the current culture.
+    /// Returns the full name of the specified calendar month, using the formatting rules of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="month">
-    /// The month number to evaluate. Must be an integer between 1 and 12, where 1 represents January and 12 represents December.
-    /// </param>
-    /// <returns>A <see cref="string"/> containing the localized full name of the specified month, based on <see cref="CultureInfo.CurrentCulture"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="month"/> is less than 1 or greater than 12.</exception>
+    /// <param name="month">The calendar month. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// This method uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the current culture to retrieve the full name of
-    /// the specified month.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the current culture to retrieve the month name.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="month"/> is less than 1 or greater than 12.</exception>
     public static string GetMonthName(int month) => GetMonthName(month, (CultureInfo?)null);
 
     /// <summary>
-    /// Returns the full name of the specified calendar month, using the formatting rules of the provided culture.
+    /// Returns the full name of the specified calendar month, using the formatting rules of the supplied or current culture.
     /// </summary>
-    /// <param name="month">
-    /// The month number to evaluate. Must be an integer between 1 and 12, where 1 represents January and 12 represents December.
-    /// </param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> that specifies the formatting rules. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>
-    /// A <see cref="string"/> containing the localized full name of the specified month, based on the specified or current culture.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="month"/> is less than 1 or greater than 12.</exception>
+    /// <param name="month">The calendar month. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to format the result. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name, formatted using the supplied or current culture.</returns>
     /// <remarks>
-    /// This method uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the specified or current culture to retrieve the
-    /// full name of the specified month.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the supplied or current culture to retrieve the month name.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="month"/> is less than 1 or greater than 12.</exception>
     public static string GetMonthName(int month, CultureInfo? culture)
     {
         ThrowHelper.ThrowIfOutOfRange(month, 1, 12);
@@ -51,30 +40,23 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the full name of the month for the specified <see cref="DateTime"/>, using the current culture's formatting rules.
+    /// Returns the full name of the month for the specified <see cref="DateTime"/>, using the formatting rules of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose month component is used to retrieve the name.</param>
-    /// <returns>A <see cref="string"/> containing the localized full name of the month, based on <see cref="CultureInfo.CurrentCulture"/>.</returns>
+    /// <param name="dateTime">The date and time value whose month component is used to determine the name.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name, formatted using <see cref="CultureInfo.CurrentCulture"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the current culture to return the full month name.
-    /// </para>
-    /// <para>For culture-specific results, use the <see cref="MonthName(DateTime, CultureInfo)"/> overload.</para>
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the current culture to retrieve the month name. For culture-specific results, use the <see cref="MonthName(DateTime, CultureInfo)"/> overload.</para>
     /// </remarks>
     public static string MonthName(this DateTime dateTime) => dateTime.MonthName((CultureInfo?)null);
 
     /// <summary>
-    /// Returns the full name of the month for the specified <see cref="DateTime"/>, using the formatting rules of the provided <see cref="CultureInfo"/>.
+    /// Returns the full name of the month for the specified <see cref="DateTime"/>, using the formatting rules of the supplied or current culture.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose month component is used to retrieve the name.</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> that specifies the formatting rules. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>A <see cref="string"/> containing the localized full name of the month, based on the specified or current culture.</returns>
+    /// <param name="dateTime">The date and time value whose month component is used to determine the name.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used to format the result. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>A <see cref="string"/> containing the localised full month name for <paramref name="dateTime"/>, formatted using the supplied or current culture.</returns>
     /// <remarks>
-    /// This method uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the specified or current culture to retrieve the
-    /// full name of the month represented by <paramref name="dateTime"/>.
+    /// <para>This overload uses the <see cref="DateTimeFormatInfo.GetMonthName(int)"/> method of the supplied or current culture to retrieve the month name.</para>
     /// </remarks>
     public static string MonthName(this DateTime dateTime, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.GetMonthName(dateTime.Month);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NearestDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NearestDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.NearestDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,19 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the closest date (before or after) to <paramref name="dateTime"/> that falls on
-    /// the specified <paramref name="dayOfWeek"/>.
+    /// Returns a new <see cref="DateTime"/> representing the nearest date (before or after) to the specified <paramref name="dateTime"/> that falls on the given <see cref="DayOfWeek"/>.
     /// </summary>
-    /// <param name="dateTime">The reference <see cref="DateTime"/> value.</param>
+    /// <param name="dateTime">The reference date and time value.</param>
     /// <param name="dayOfWeek">The target <see cref="DayOfWeek"/> to locate.</param>
-    /// <returns>
-    /// An object whose value is set to the closest date (either before or after) to <paramref name="dateTime"/> that falls on the
-    /// specified <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.
-    /// </exception>
-    /// <remarks>The result preserves the <see cref="DateTime.Kind"/> of the input.</remarks>
+    /// <returns>An object whose value is set to the closest date (either before or after) to <paramref name="dateTime"/> that falls on the specified <paramref name="dayOfWeek"/>, with the original time-of-day and <see cref="DateTime.Kind"/> preserved. If two dates are equally close, the earlier one is returned.</returns>
+    /// <remarks>
+    /// <para>The result is computed by evaluating the day-distance between <paramref name="dateTime"/> and the nearest occurrence of <paramref name="dayOfWeek"/> in either direction.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime NearestDayOfWeek(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
@@ -31,38 +27,20 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the closest date (before or after) to the specified year, month, and day that
-    /// falls on the given <paramref name="dayOfWeek"/>.
+    /// Returns a new <see cref="DateTime"/> representing the nearest date (before or after) to the specified calendar <paramref name="year"/>, <paramref name="month"/>, and <paramref name="day"/> that falls on the given <see cref="DayOfWeek"/>.
     /// </summary>
-    /// <param name="year">
-    /// The calendar year component of the reference date. Must be between the <c>Year</c> property values of
-    /// <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.
-    /// </param>
-    /// <param name="month">
-    /// The calendar month component of the reference date. Must be an integer between 1 and 12, inclusive, where 1 represents January and
-    /// 12 represents December.
-    /// </param>
-    /// <param name="day">
-    /// The day component of the reference date. Must be valid for the specified <paramref name="year"/> and <paramref name="month"/>,
-    /// including leap year considerations for February.
-    /// </param>
-    /// <param name="dayOfWeek">
-    /// The target <see cref="DayOfWeek"/> value to locate. For example, specifying <see cref="DayOfWeek.Monday"/> returns the date
-    /// closest to the reference date that falls on a Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to the closest date (either before or after) to the specified reference date that falls on the given
-    /// <paramref name="dayOfWeek"/>. If two dates are equally close, the earlier one is returned. The result is normalised to midnight
-    /// (00:00:00) and has <see cref="DateTimeKind.Unspecified"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration, or if
-    /// <paramref name="year"/>, <paramref name="month"/>, or <paramref name="day"/> is outside the valid range supported by <see cref="DateTime"/>.
-    /// </exception>
+    /// <param name="year">The calendar year of the reference date. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the reference date. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="day">The day component of the reference date. Must be valid for the specified <paramref name="year"/> and <paramref name="month"/>, including leap-year considerations for February.</param>
+    /// <param name="dayOfWeek">The target <see cref="DayOfWeek"/> to locate.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the closest date (either before or after) to the specified reference date that falls on the given <paramref name="dayOfWeek"/>, using <see cref="DateTimeKind.Unspecified"/>. If two dates are equally close, the earlier one is returned.</returns>
     /// <remarks>
-    /// The result is computed by evaluating the distance (in days) between the specified reference date and the nearest occurrence of the
-    /// specified <paramref name="dayOfWeek"/>. If both a forward and backward date are equally close, the earlier date is returned.
+    /// <para>The result is computed by evaluating the day-distance between the specified reference date and the nearest occurrence of <paramref name="dayOfWeek"/> in either direction.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/>, <paramref name="month"/>, or <paramref name="day"/> does not represent a valid date,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
     public static DateTime NearestDayOfWeek(int year, int month, int day, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NextDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NextDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.NextDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,28 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the next calendar occurrence of the specified <paramref name="dayOfWeek"/> after
-    /// the given <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing the next calendar occurrence of the specified <see cref="DayOfWeek"/> after the given <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">
-    /// The starting <see cref="DateTime"/> from which to search forward. The result preserves the original time-of-day and <see cref="DateTime.Kind"/>.
-    /// </param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> value to locate. For example, specifying <see cref="DayOfWeek.Monday"/> returns the next Monday.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to the next occurrence of <paramref name="dayOfWeek"/> following <paramref name="dateTime"/>. The
-    /// result maintains the original time-of-day and <see cref="DateTime.Kind"/> of <paramref name="dateTime"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid value of the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search forward.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> returns the next Monday.</param>
+    /// <returns>An object whose value is set to the next occurrence of <paramref name="dayOfWeek"/> following <paramref name="dateTime"/>, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="dateTime"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly 7 days later.
-    /// </para>
-    /// <para>This method advances forward in time and does not return the current date, even if it matches the requested day of the week.</para>
+    /// <para>If <paramref name="dateTime"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly seven days later. The method advances forward in time and never returns the original date.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime NextDayOfWeek(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NextOccurrence.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NextOccurrence.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.NextOccurrence.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,36 +11,25 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the next occurrence of a recurring event based on a specified
-    /// <paramref name="dateTime"/> time and fixed <paramref name="interval"/>, occurring strictly after the given
-    /// <paramref name="after"/> timestamp.
+    /// Returns a new <see cref="DateTime"/> representing the next occurrence of a recurring event that starts at <paramref name="dateTime"/> and repeats every <paramref name="interval"/>, occurring strictly after the specified <paramref name="after"/> timestamp.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> representing the initial reference point for the recurring event.</param>
-    /// <param name="interval">The fixed <see cref="TimeSpan"/> between occurrences. Must be greater than <see cref="TimeSpan.Zero"/>.</param>
-    /// <param name="after">A <see cref="DateTime"/> indicating the point in time after which the next occurrence should be determined.</param>
-    /// <returns>
-    /// An object whose value is set to the first occurrence of the event that falls strictly after <paramref name="after"/>, based on
-    /// the provided <paramref name="dateTime"/> and recurring <paramref name="interval"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</exception>
+    /// <param name="dateTime">The date and time value representing the initial reference point of the recurring event.</param>
+    /// <param name="interval">The fixed <see cref="TimeSpan"/> between successive occurrences. Must be greater than <see cref="TimeSpan.Zero"/>.</param>
+    /// <param name="after">The point in time after which the next occurrence must fall.</param>
+    /// <returns>An object whose value is the first occurrence of the event that falls strictly after <paramref name="after"/>, based on the supplied <paramref name="dateTime"/> and recurring <paramref name="interval"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>If <paramref name="after"/> is earlier than or equal to <paramref name="dateTime"/>, the method returns <paramref name="dateTime"/>.</para>
-    /// <para>
-    /// Otherwise, the method computes the smallest multiple of <paramref name="interval"/> added to <paramref name="dateTime"/> that
-    /// occurs after <paramref name="after"/>.
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
-    /// <code language="csharp">
+    /// <para>If <paramref name="after"/> is earlier than or equal to <paramref name="dateTime"/>, the method returns <paramref name="dateTime"/>. Otherwise, it computes the smallest multiple of <paramref name="interval"/> added to <paramref name="dateTime"/> that occurs after <paramref name="after"/>.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
     ///<![CDATA[
-    /// var start = new DateTime(2025, 7, 7, 9, 0, 0);           // 09:00
-    /// var interval = TimeSpan.FromHours(1);                    // Every hour
+    /// var start = new DateTime(2025, 7, 7, 9, 0, 0);          // 09:00
+    /// var interval = TimeSpan.FromHours(1);                    // every hour
     /// var after = new DateTime(2025, 7, 7, 10, 45, 0);         // 10:45
-    /// var next = start.NextOccurrence(interval, after);        // 11:00
+    /// var next = start.NextOccurrence(interval, after);        // → 11:00
     ///]]>
     /// </code>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</exception>
     public static DateTime NextOccurrence(this DateTime dateTime, TimeSpan interval, DateTime after)
     {
         ThrowHelper.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);
@@ -48,7 +37,6 @@ public static partial class DateTimeExtensions
         if (after <= dateTime)
             return dateTime;
 
-        // Calculate how many full intervals fit between start and after
         double intervalsPassed = (double)(after - dateTime).Ticks / interval.Ticks;
         long nextIntervalCount = (long)Math.Ceiling(intervalsPassed);
 

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NextWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NextWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.NextWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the next calendar weekday after the specified <paramref name="dateTime"/>, based
-    /// on the provided <paramref name="weekend"/> definition.
+    /// Returns a new <see cref="DateTime"/> representing the next calendar weekday after the specified <paramref name="dateTime"/>, based on the supplied <paramref name="weekend"/> definition.
     /// </summary>
-    /// <param name="dateTime">The starting <see cref="DateTime"/> from which to search forward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines which days are considered weekends.</param>
-    /// <returns>
-    /// An object whose value is set to the first calendar day after <paramref name="dateTime"/> that is not considered a weekend according
-    /// to the specified <paramref name="weekend"/> rule.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid member of the <see cref="CalendarWeekendDefinition"/> enumeration.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search forward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <returns>An object whose value is set to the first calendar day after <paramref name="dateTime"/> that is not a weekend under the specified <paramref name="weekend"/> rule, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="dateTime"/> already falls on a weekday, the result will be the next calendar day that is also a weekday under
-    /// the given <paramref name="weekend"/> pattern.
-    /// </para>
-    /// <para>This method evaluates each successive day until it finds one that is not designated as a weekend by the specified rule.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method evaluates each successive day until it finds one that is not designated as a weekend by the specified rule. The original <paramref name="dateTime"/> is never returned, even if it already falls on a weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateTime NextWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);
@@ -46,28 +35,16 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the next calendar weekday after the specified <paramref name="dateTime"/>, using
-    /// the given <paramref name="weekend"/> definition and optional custom <paramref name="provider"/> logic.
+    /// Returns a new <see cref="DateTime"/> representing the next calendar weekday after the specified <paramref name="dateTime"/>, using the supplied <paramref name="weekend"/> definition and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="dateTime">The starting <see cref="DateTime"/> from which to search forward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines the weekend pattern.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to the first calendar day after <paramref name="dateTime"/> that is considered a weekday according to
-    /// the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/> (if applicable).
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search forward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>. If <see langword="null"/>, the default behaviour for the supplied <paramref name="weekend"/> applies.</param>
+    /// <returns>An object whose value is set to the first calendar day after <paramref name="dateTime"/> that is not a weekend under the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/>, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method evaluates each successive day following <paramref name="dateTime"/> until it finds one that is not considered a weekend
-    /// under the specified <paramref name="weekend"/> pattern or the custom logic defined by <paramref name="provider"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method evaluates each successive day following <paramref name="dateTime"/> until it finds one that is not considered a weekend, either by the supplied <paramref name="weekend"/> pattern or by the custom logic of <paramref name="provider"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateTime NextWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NthDayOfWeekInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NthDayOfWeekInMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.NthDayOfWeekInMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,46 +11,65 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the given
-    /// <paramref name="month"/> and <paramref name="year"/>.
+    /// Returns a new <see cref="DateTime"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the same calendar month and year as the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="year">
-    /// The calendar year to evaluate. Must be between the year values of <see cref="DateTime.MinValue"/> and
-    /// <see cref="DateTime.MaxValue"/>, inclusive.
-    /// </param>
-    /// <param name="month">The calendar month to evaluate. Must be an integer from 1 (January) to 12 (December), inclusive.</param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the specified month. For example, <see cref="DayOfWeek.Tuesday"/> will return the nth
-    /// Tuesday as determined by <paramref name="ordinal"/>.
-    /// </param>
-    /// <param name="ordinal">
-    /// The ordinal occurrence to return. Valid values include <see cref="WeekOfMonthOrdinal.First"/>,
-    /// <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>,
-    /// <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>.
-    /// <para><b>Note:</b><see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</para>
-    /// </param>
-    /// <returns>
-    /// A new <see cref="DateTime"/> with the time set to midnight and <see cref="DateTimeKind.Unspecified"/>, representing the requested
-    /// occurrence of <paramref name="dayOfWeek"/> in the specified <paramref name="month"/> and <paramref name="year"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if:
-    /// <list type="bullet">
-    /// <item><paramref name="year"/> is outside the supported range for <see cref="DateTime"/> values.</item>
-    /// <item><paramref name="month"/> is not between 1 and 12.</item>
-    /// <item><paramref name="dayOfWeek"/> is not a valid <see cref="DayOfWeek"/> value.</item>
-    /// <item><paramref name="ordinal"/> is not a valid <see cref="WeekOfMonthOrdinal"/> value.</item>
-    /// <item><paramref name="ordinal"/> refers to a day that does not occur in the given month (e.g., fifth Thursday in February).</item>
-    /// </list>
-    /// </exception>
+    /// <param name="dateTime">The date and time value whose month and year are used to determine the result. The day component is ignored.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> returns the nth Monday.</param>
+    /// <param name="ordinal">The ordinal occurrence to return. Valid values are <see cref="WeekOfMonthOrdinal.First"/>, <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>, <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>. <see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the requested occurrence of <paramref name="dayOfWeek"/> within the same calendar month and year as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// For <see cref="WeekOfMonthOrdinal.Last"/>, the method searches backward from the end of the month for the final matching <paramref name="dayOfWeek"/>.
-    /// </para>
-    /// <para>
-    /// For other ordinal values, the method finds the first matching weekday and adds a multiple of 7 days to locate the requested occurrence.
-    /// </para>
+    /// <para>For <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching <paramref name="dayOfWeek"/> in the month. For other ordinal values, the method locates the first matching weekday and offsets by a multiple of seven days to reach the desired ordinal.</para>
+    /// <para>The returned value has its time component normalised to midnight (00:00:00), and the original <see cref="DateTime.Kind"/> is retained.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="ordinal"/> is not a defined value of the <see cref="WeekOfMonthOrdinal"/> enumeration,
+    /// -or- the requested <paramref name="ordinal"/> does not occur within the month (for example, a fifth Thursday in February).
+    /// </exception>
+    public static DateTime NthDayOfWeekInMonth(this DateTime dateTime, DayOfWeek dayOfWeek, WeekOfMonthOrdinal ordinal)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(ordinal);
+
+        switch (ordinal)
+        {
+            case Extensions.WeekOfMonthOrdinal.First:
+                return new DateTime(GetFirstDayOfWeekInMonthTicks(dateTime, dayOfWeek), dateTime.Kind);
+
+            case Extensions.WeekOfMonthOrdinal.Last:
+                return dateTime.LastDayOfWeekInMonth(dayOfWeek);
+
+            default:
+                var result = new DateTime(GetFirstDayOfWeekInMonthTicks(dateTime, dayOfWeek) + (((int)ordinal - 1) * TicksPerWeek), dateTime.Kind);
+
+                if (result.Month != dateTime.Month)
+                    throw new ArgumentOutOfRangeException(
+                        nameof(ordinal),
+                        string.Format(ResourceStrings.Arg_Invalid_OrdinalDoesNotExistForMonth, ordinal, dayOfWeek, dateTime.ToString("MMMM yyyy")));
+
+                return result;
+        }
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the given calendar <paramref name="month"/> and <paramref name="year"/>.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateTime.MinValue"/> and <see cref="DateTime.MaxValue"/>, inclusive.</param>
+    /// <param name="month">The calendar month of the result. Must be between 1 and 12, inclusive, where 1 represents January and 12 represents December.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Tuesday"/> returns the nth Tuesday.</param>
+    /// <param name="ordinal">The ordinal occurrence to return. Valid values are <see cref="WeekOfMonthOrdinal.First"/>, <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>, <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>. <see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</param>
+    /// <returns>An object whose value is set to midnight (00:00:00) on the requested occurrence of <paramref name="dayOfWeek"/> within the specified <paramref name="year"/> and <paramref name="month"/>, using <see cref="DateTimeKind.Unspecified"/>.</returns>
+    /// <remarks>
+    /// <para>For <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching <paramref name="dayOfWeek"/> in the month. For other ordinal values, the method locates the first matching weekday and offsets by a multiple of seven days to reach the desired ordinal.</para>
+    /// <para>The returned value is normalised to midnight (00:00:00) and uses <see cref="DateTimeKind.Unspecified"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateTime.MinValue"/> or greater than that of <see cref="DateTime.MaxValue"/>,
+    /// -or- <paramref name="month"/> is less than 1 or greater than 12,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
+    /// -or- <paramref name="ordinal"/> is not a defined value of the <see cref="WeekOfMonthOrdinal"/> enumeration,
+    /// -or- the requested <paramref name="ordinal"/> does not occur within the month (for example, a fifth Thursday in February).
+    /// </exception>
     public static DateTime GetNthDayOfWeekInMonth(int year, int month, DayOfWeek dayOfWeek, WeekOfMonthOrdinal ordinal)
     {
         ThrowHelper.ThrowIfOutOfRange(year, MinYear, MaxYear);
@@ -73,62 +92,6 @@ public static partial class DateTimeExtensions
                     throw new ArgumentOutOfRangeException(
                         nameof(ordinal),
                         string.Format(ResourceStrings.Arg_Invalid_OrdinalDoesNotExistForMonth, ordinal, dayOfWeek, $"{GetMonthName(month)} {year:0000}"));
-
-                return result;
-        }
-    }
-
-    /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the specified ordinal occurrence of a <see cref="DayOfWeek"/> within the same
-    /// calendar month and year as the given <paramref name="dateTime"/>.
-    /// </summary>
-    /// <param name="dateTime">
-    /// The reference <see cref="DateTime"/>. Only the month and year components are used; the day component is ignored.
-    /// </param>
-    /// <param name="dayOfWeek">
-    /// The <see cref="DayOfWeek"/> to locate within the month. For example, <see cref="DayOfWeek.Monday"/> will return the nth Monday as
-    /// defined by <paramref name="ordinal"/>.
-    /// </param>
-    /// <param name="ordinal">
-    /// The ordinal occurrence to return. Valid values include <see cref="WeekOfMonthOrdinal.First"/>,
-    /// <see cref="WeekOfMonthOrdinal.Second"/>, <see cref="WeekOfMonthOrdinal.Third"/>, <see cref="WeekOfMonthOrdinal.Fourth"/>,
-    /// <see cref="WeekOfMonthOrdinal.Fifth"/>, and <see cref="WeekOfMonthOrdinal.Last"/>.
-    /// <para><b>Note:</b><see cref="WeekOfMonthOrdinal.Fifth"/> is valid only in months where five matching weekdays occur.</para>
-    /// </param>
-    /// <returns>
-    /// A new <see cref="DateTime"/> set to midnight and having the same <see cref="DateTime.Kind"/> as <paramref name="dateTime"/>,
-    /// representing the requested occurrence of <paramref name="dayOfWeek"/> within the same month and year as <paramref name="dateTime"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> or <paramref name="ordinal"/> is not a defined enumeration value, or if the requested
-    /// <paramref name="ordinal"/> does not exist within the month.
-    /// </exception>
-    /// <remarks>
-    /// <para>
-    /// For <see cref="WeekOfMonthOrdinal.Last"/>, the method returns the final matching <paramref name="dayOfWeek"/> in the month. For
-    /// all other values, the method locates the first matching weekday and offsets by a multiple of 7 days to reach the desired ordinal.
-    /// </para>
-    /// </remarks>
-    public static DateTime NthDayOfWeekInMonth(this DateTime dateTime, DayOfWeek dayOfWeek, WeekOfMonthOrdinal ordinal)
-    {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
-        ThrowHelper.ThrowIfEnumValueIsUndefined(ordinal);
-
-        switch (ordinal)
-        {
-            case Extensions.WeekOfMonthOrdinal.First:
-                return new DateTime(GetFirstDayOfWeekInMonthTicks(dateTime, dayOfWeek), dateTime.Kind);
-
-            case Extensions.WeekOfMonthOrdinal.Last:
-                return dateTime.LastDayOfWeekInMonth(dayOfWeek);
-
-            default:
-                var result = new DateTime(GetFirstDayOfWeekInMonthTicks(dateTime, dayOfWeek) + (((int)ordinal - 1) * TicksPerWeek), dateTime.Kind);
-
-                if (result.Month != dateTime.Month)
-                    throw new ArgumentOutOfRangeException(
-                        nameof(ordinal),
-                        string.Format(ResourceStrings.Arg_Invalid_OrdinalDoesNotExistForMonth, ordinal, dayOfWeek, dateTime.ToString("MMMM yyyy")));
 
                 return result;
         }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.OrdinalWeekOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.OrdinalWeekOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.OrdinalWeekOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,25 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Gets the <see cref="WeekOfMonthOrdinal"/> represented by this <see cref="DateTime"/> instance, indicating the ordinal occurrence
-    /// of its <see cref="DateTime.DayOfWeek"/> within the month.
+    /// Returns the <see cref="WeekOfMonthOrdinal"/> represented by the specified <see cref="DateTime"/>, indicating the ordinal occurrence of its <see cref="DateTime.DayOfWeek"/> within the month.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> instance to evaluate.</param>
-    /// <returns>
-    /// A <see cref="WeekOfMonthOrdinal"/> value that indicates which occurrence of the weekday this <paramref name="dateTime"/>
-    /// represents within its calendar month.
-    /// </returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns>A <see cref="WeekOfMonthOrdinal"/> value indicating which occurrence of the weekday <paramref name="dateTime"/> represents within its calendar month.</returns>
     /// <remarks>
-    /// <para>
-    /// This method calculates how many full 7-day intervals have passed since the start of the month, based on <see cref="DateTime.Day"/>.
-    /// For example, the 1st through 7th of the month yield <see cref="WeekOfMonthOrdinal.First"/>, while the 8th through 14th yield
-    /// <see cref="WeekOfMonthOrdinal.Second"/>, and so on.
-    /// </para>
-    /// <para><b>Note:</b><see cref="WeekOfMonthOrdinal.Fifth"/> is only returned when a month contains five occurrences of the given <see cref="DateTime.DayOfWeek"/>.</para>
+    /// <para>The result is calculated by counting how many full seven-day intervals have passed since the start of the month, based on <see cref="DateTime.Day"/>. For example, the 1st through 7th of the month yield <see cref="WeekOfMonthOrdinal.First"/>, while the 8th through 14th yield <see cref="WeekOfMonthOrdinal.Second"/>, and so on.</para>
+    /// <para><see cref="WeekOfMonthOrdinal.Fifth"/> is only returned when a month contains five occurrences of the given <see cref="DateTime.DayOfWeek"/>.</para>
     /// </remarks>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if the calculated ordinal does not correspond to a defined <see cref="WeekOfMonthOrdinal"/> value.
-    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the calculated ordinal does not correspond to a defined value of the <see cref="WeekOfMonthOrdinal"/> enumeration.</exception>
     public static WeekOfMonthOrdinal OrdinalWeekOfMonth(this DateTime dateTime)
     {
         int ordinal = ((dateTime.Day - 1) / 7) + 1;

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousDayOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousDayOfWeek.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.PreviousDayOfWeek.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,24 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the previous calendar occurrence of the specified <paramref name="dayOfWeek"/>
-    /// before the given <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing the previous calendar occurrence of the specified <see cref="DayOfWeek"/> before the given <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The starting <see cref="DateTime"/> from which to search backwards.</param>
-    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> value to locate.</param>
-    /// <returns>
-    /// An object whose value is set to the previous occurrence of <paramref name="dayOfWeek"/> preceeding <paramref name="dateTime"/>.
-    /// The result maintains the original time-of-day and <see cref="DateTime.Kind"/> of <paramref name="dateTime"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="dayOfWeek"/> is not a valid value of the <see cref="DayOfWeek"/> enumeration.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search backward.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. For example, <see cref="DayOfWeek.Monday"/> returns the previous Monday.</param>
+    /// <returns>An object whose value is set to the previous occurrence of <paramref name="dayOfWeek"/> preceding <paramref name="dateTime"/>, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="dateTime"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly 7 days earlier.
-    /// </para>
-    /// <para>This method advances backwards in time and does not return the current date, even if it matches the requested day of the week.</para>
+    /// <para>If <paramref name="dateTime"/> already falls on the specified <paramref name="dayOfWeek"/>, the result is exactly seven days earlier. The method moves backward in time and never returns the original date.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
     public static DateTime PreviousDayOfWeek(this DateTime dateTime, DayOfWeek dayOfWeek)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousOccurrence.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousOccurrence.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.PreviousOccurrence.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,50 +11,31 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the previous occurrence of a recurring event based on a specified
-    /// <paramref name="dateTime"/> time and fixed <paramref name="interval"/>, occurring strictly before the given
-    /// <paramref name="before"/> timestamp.
+    /// Returns a new <see cref="DateTime"/> representing the previous occurrence of a recurring event that starts at <paramref name="dateTime"/> and repeats every <paramref name="interval"/>, occurring strictly before the specified <paramref name="before"/> timestamp.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> representing the initial reference point for the recurring event.</param>
-    /// <param name="interval">The fixed <see cref="TimeSpan"/> between occurrences. Must be greater than <see cref="TimeSpan.Zero"/>.</param>
-    /// <param name="before">
-    /// A <see cref="DateTime"/> indicating the point in time before which the previous occurrence should be determined.
-    /// </param>
-    /// <returns>
-    /// A new <see cref="DateTime"/> representing the last occurrence of the event that falls strictly before
-    /// <paramref name="before"/>, based on the specified <paramref name="dateTime"/> and recurring <paramref name="interval"/>.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="interval"/> is less than or equal to <see cref="TimeSpan.Zero"/>.
-    /// </exception>
+    /// <param name="dateTime">The date and time value representing the initial reference point of the recurring event.</param>
+    /// <param name="interval">The fixed <see cref="TimeSpan"/> between successive occurrences. Must be greater than <see cref="TimeSpan.Zero"/>.</param>
+    /// <param name="before">The point in time before which the previous occurrence must fall.</param>
+    /// <returns>An object whose value is the last occurrence of the event that falls strictly before <paramref name="before"/>, based on the supplied <paramref name="dateTime"/> and recurring <paramref name="interval"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="before"/> is earlier than or equal to <paramref name="dateTime"/>, the method returns the occurrence
-    /// immediately prior to <paramref name="dateTime"/>.
-    /// </para>
-    /// <para>
-    /// Otherwise, the method computes the largest multiple of <paramref name="interval"/> added to <paramref name="dateTime"/>
-    /// that remains strictly less than <paramref name="before"/>. When <paramref name="before"/> falls exactly on an occurrence
-    /// boundary, the occurrence at that boundary is excluded and the preceding one is returned.
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
-    /// <code language="csharp">
+    /// <para>If <paramref name="before"/> is earlier than or equal to <paramref name="dateTime"/>, the method returns the occurrence immediately prior to <paramref name="dateTime"/>. Otherwise, it computes the largest multiple of <paramref name="interval"/> added to <paramref name="dateTime"/> that remains strictly less than <paramref name="before"/>. When <paramref name="before"/> falls exactly on an occurrence boundary, the occurrence at that boundary is excluded and the preceding one is returned.</para>
+    /// <para><b>Example:</b></para>
+    /// <code>
     ///<![CDATA[
     /// var start    = new DateTime(2025, 7, 7, 9, 0, 0);             // 09:00
-    /// var interval = TimeSpan.FromHours(1);                         // Every hour
+    /// var interval = TimeSpan.FromHours(1);                          // every hour
     ///
     /// // before is between two occurrences — returns the occurrence at 10:00
-    /// var before1  = new DateTime(2025, 7, 7, 10, 45, 0);           // 10:45
-    /// var prev1    = start.PreviousOccurrence(interval, before1);   // 10:00
+    /// var before1  = new DateTime(2025, 7, 7, 10, 45, 0);            // 10:45
+    /// var prev1    = start.PreviousOccurrence(interval, before1);    // → 10:00
     ///
     /// // before falls exactly on an occurrence — returns the one before it
-    /// var before2  = new DateTime(2025, 7, 7, 11, 0, 0);            // 11:00 (on boundary)
-    /// var prev2    = start.PreviousOccurrence(interval, before2);   // 10:00
+    /// var before2  = new DateTime(2025, 7, 7, 11, 0, 0);             // 11:00 (on boundary)
+    /// var prev2    = start.PreviousOccurrence(interval, before2);    // → 10:00
     ///]]>
     /// </code>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="interval"/> is less than or equal to <see cref="TimeSpan.Zero"/>.</exception>
     public static DateTime PreviousOccurrence(this DateTime dateTime, TimeSpan interval, DateTime before)
     {
         ThrowHelper.ThrowIfLessThanOrEqual(interval, TimeSpan.Zero);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousWeekday.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.PreviousWeekday.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,26 +11,15 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the previous calendar weekday before the specified <paramref name="dateTime"/>,
-    /// based on the provided <paramref name="weekend"/> definition.
+    /// Returns a new <see cref="DateTime"/> representing the previous calendar weekday before the specified <paramref name="dateTime"/>, based on the supplied <paramref name="weekend"/> definition.
     /// </summary>
-    /// <param name="dateTime">The starting <see cref="DateTime"/> from which to search backward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines which days are considered weekends.</param>
-    /// <returns>
-    /// An object whose value is set to the first calendar day before <paramref name="dateTime"/> that is not considered a weekend
-    /// according to the specified <paramref name="weekend"/> rule.
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is not a valid member of the <see cref="CalendarWeekendDefinition"/> enumeration.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search backward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <returns>An object whose value is set to the first calendar day before <paramref name="dateTime"/> that is not a weekend under the specified <paramref name="weekend"/> rule, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// If <paramref name="dateTime"/> already falls on a weekday, the result will be the most recent calendar day that is also a weekday
-    /// under the given <paramref name="weekend"/> pattern.
-    /// </para>
-    /// <para>This method evaluates each preceding day until it finds one that is not designated as a weekend by the specified rule.</para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method evaluates each preceding day until it finds one that is not designated as a weekend by the specified rule. The original <paramref name="dateTime"/> is never returned, even if it already falls on a weekday.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateTime PreviousWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);
@@ -46,28 +35,16 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the previous calendar weekday before the specified <paramref name="dateTime"/>,
-    /// using the given <paramref name="weekend"/> definition and optional custom <paramref name="provider"/> logic.
+    /// Returns a new <see cref="DateTime"/> representing the previous calendar weekday before the specified <paramref name="dateTime"/>, using the supplied <paramref name="weekend"/> definition and an optional custom <paramref name="provider"/>.
     /// </summary>
-    /// <param name="dateTime">The starting <see cref="DateTime"/> from which to search backward.</param>
-    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that defines the weekend pattern.</param>
-    /// <param name="provider">
-    /// An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is set to <see cref="CalendarWeekendDefinition.Custom"/>.
-    /// </param>
-    /// <returns>
-    /// An object whose value is set to the first calendar day before <paramref name="dateTime"/> that is considered a weekday according to
-    /// the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/> (if applicable).
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
-    /// </exception>
+    /// <param name="dateTime">The starting date and time value from which to search backward.</param>
+    /// <param name="weekend">The <see cref="CalendarWeekendDefinition"/> that determines which days are considered weekends.</param>
+    /// <param name="provider">An optional <see cref="IWeekendDefinitionProvider"/> that supplies custom weekend logic when <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/>. If <see langword="null"/>, the default behaviour for the supplied <paramref name="weekend"/> applies.</param>
+    /// <returns>An object whose value is set to the first calendar day before <paramref name="dateTime"/> that is not a weekend under the specified <paramref name="weekend"/> rule and the logic of <paramref name="provider"/>, with the original time-of-day and <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method evaluates each preceding day prior to <paramref name="dateTime"/> until it finds one that is not considered a weekend
-    /// under the specified <paramref name="weekend"/> pattern or the custom logic defined by <paramref name="provider"/>.
-    /// </para>
-    /// <para>The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.</para>
+    /// <para>The method evaluates each preceding day prior to <paramref name="dateTime"/> until it finds one that is not considered a weekend, either by the supplied <paramref name="weekend"/> pattern or by the custom logic of <paramref name="provider"/>.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration.</exception>
     public static DateTime PreviousWeekday(this DateTime dateTime, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Quarter.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Quarter.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Quarter.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -12,30 +12,26 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Gets the quarter number (1–4) of the year for the specified <see cref="DateTime"/>, using the standard calendar quarter definition
-    /// ( <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>).
+    /// Returns the quarter number (1 – 4) of the year for the specified <see cref="DateTime"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
     /// <returns>An integer between 1 and 4 representing the calendar quarter that contains <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>This method uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>: Q1 = Jan – Mar, Q2 = Apr – Jun, Q3 = Jul – Sep, Q4 = Oct – Dec.</para>
     /// </remarks>
     public static int Quarter(this DateTime dateTime) => GetQuarterForDate(dateTime, GetQuarterDefinition(CalendarQuarterDefinition.JanuaryToDecember));
 
     /// <summary>
-    /// Gets the quarter number (1–4) for the specified <see cref="DateTime"/>, using a predefined <see cref="CalendarQuarterDefinition"/>.
+    /// Returns the quarter number (1 – 4) for the specified <see cref="DateTime"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
-    /// <param name="definition">The quarter definition that determines how the year is segmented into quarters.</param>
-    /// <returns>An integer between 1 and 4 representing the quarter that contains the given <paramref name="dateTime"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a valid enum value or is <see cref="CalendarQuarterDefinition.Custom"/>.</exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how the year is segmented into quarters.</param>
+    /// <returns>An integer between 1 and 4 representing the quarter that contains <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method supports various standard calendar and financial quarter alignments by unpacking the encoded anchor month and day.
-    /// </para>
-    /// <para>For custom models, use <see cref="Quarter(DateTime, IQuarterDefinitionProvider)"/> instead.</para>
+    /// <para>This overload supports both month-aligned and day-aligned quarter definitions. For provider-driven custom calendars (e.g. 4-4-5 retail calendars), use the <see cref="Quarter(DateTime, IQuarterDefinitionProvider)"/> overload.</para>
     /// </remarks>
-    /// <exception cref="InvalidOperationException">Thrown when the method preconditions are not met.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static int Quarter(this DateTime dateTime, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
@@ -48,17 +44,16 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Gets the quarter number (1–4) for the specified <see cref="DateTime"/>, using a custom quarter definition provider.
+    /// Returns the quarter number (1 – 4) for the specified <see cref="DateTime"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to evaluate.</param>
-    /// <param name="provider">An <see cref="IQuarterDefinitionProvider"/> that defines how quarters are structured.</param>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
     /// <returns>An integer between 1 and 4 representing the quarter that contains <paramref name="dateTime"/>.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the quarter returned by the provider is not in the range 1–4.</exception>
     /// <remarks>
-    /// <para>Use this overload to support complex fiscal models such as 4-4-5 retail calendars or non-month-aligned systems.</para>
-    /// <para>This method calls <see cref="IQuarterDefinitionProvider.GetQuarter(DateTime)"/> to resolve the quarter.</para>
+    /// <para>This overload supports advanced or domain-specific quarter systems by delegating to <see cref="IQuarterDefinitionProvider.GetQuarter(DateTime)"/> — for example, 4-4-5 retail calendars or regional fiscal quarters.</para>
     /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the value returned by <paramref name="provider"/> is not in the range 1 – 4.</exception>
     public static int Quarter(this DateTime dateTime, IQuarterDefinitionProvider provider)
     {
         ThrowHelper.ThrowIfNull(provider);
@@ -75,8 +70,8 @@ public static partial class DateTimeExtensions
     /// Computes the tick value for the end of the specified quarter, based on a month-day anchor definition.
     /// </summary>
     /// <param name="year">The year in which the quarter ends.</param>
-    /// <param name="quarter">The 1-based quarter number (1–4).</param>
-    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g., (4, 6) for April 6).</param>
+    /// <param name="quarter">The 1-based quarter number (1 – 4).</param>
+    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g. (4, 6) for April 6).</param>
     /// <returns>The number of ticks representing midnight on the last day of the quarter.</returns>
     /// <remarks>This is calculated by subtracting one day from the start of the next quarter.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -101,8 +96,8 @@ public static partial class DateTimeExtensions
     /// Computes the tick value for the start of the specified quarter, based on a month-day anchor definition.
     /// </summary>
     /// <param name="year">The year in which the quarter begins.</param>
-    /// <param name="quarter">The 1-based quarter number (1–4).</param>
-    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g., (4, 6) for April 6).</param>
+    /// <param name="quarter">The 1-based quarter number (1 – 4).</param>
+    /// <param name="definition">A tuple representing the anchor month and day that define the start of Q1 (e.g. (4, 6) for April 6).</param>
     /// <returns>The number of ticks representing midnight on the first day of the quarter.</returns>
     /// <remarks>Accounts for wrap-around years when the anchor month begins in the latter part of the year.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -124,15 +119,12 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Determines the fiscal year and quarter that include the specified <paramref name="referenceDate"/> using the given quarter definition.
+    /// Determines the fiscal year and quarter that include the specified <paramref name="referenceDate"/>, using the supplied quarter definition.
     /// </summary>
     /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that defines quarter anchor points.</param>
     /// <param name="referenceDate">The date to evaluate.</param>
-    /// <returns>A tuple containing the resolved year and quarter number (1–4).</returns>
-    /// <remarks>
-    /// If the calculated start of the resolved quarter is after <paramref name="referenceDate"/>, the year is decremented to reflect the
-    /// prior fiscal year.
-    /// </remarks>
+    /// <returns>A tuple containing the resolved year and quarter number (1 – 4).</returns>
+    /// <remarks>If the calculated start of the resolved quarter is after <paramref name="referenceDate"/>, the year is decremented to reflect the prior fiscal year.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static (int Year, int Quarter) GetQuarterAndYearFromDate(CalendarQuarterDefinition definition, DateTime referenceDate)
     {
@@ -161,9 +153,9 @@ public static partial class DateTimeExtensions
     /// <summary>
     /// Extracts the anchor month and day components from a <see cref="CalendarQuarterDefinition"/> value.
     /// </summary>
-    /// <param name="definition">A <see cref="CalendarQuarterDefinition"/> value encoded as MMDD (e.g., 406 for April 6).</param>
+    /// <param name="definition">A <see cref="CalendarQuarterDefinition"/> value encoded as MMDD (e.g. 406 for April 6).</param>
     /// <returns>A tuple <c>(defMonth, defDay)</c> representing the anchor month and day that define the start of Q1.</returns>
-    /// <remarks>This method unpacks the encoded <see cref="CalendarQuarterDefinition"/> value for internal use in modular calculations.</remarks>
+    /// <remarks>This helper unpacks the encoded <see cref="CalendarQuarterDefinition"/> value for internal use in modular calculations.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static (uint defMonth, uint defDay) GetQuarterDefinition(CalendarQuarterDefinition definition)
     {
@@ -176,14 +168,12 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Determines the quarter number (1–4) that includes the specified <see cref="DateTime"/>, based on a month-day anchor definition.
+    /// Determines the quarter number (1 – 4) that includes the specified <see cref="DateTime"/>, based on a month-day anchor definition.
     /// </summary>
-    /// <param name="dateTime">The date to evaluate.</param>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
     /// <param name="definition">A tuple representing the start of Q1, encoded as (month, day).</param>
     /// <returns>An integer between 1 and 4 representing the resolved quarter number.</returns>
-    /// <remarks>
-    /// If <paramref name="dateTime"/> falls before the anchor day in the quarter's first month, it is considered part of the previous quarter.
-    /// </remarks>
+    /// <remarks>If <paramref name="dateTime"/> falls before the anchor day in the quarter's first month, it is considered part of the previous quarter.</remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetQuarterForDate(this DateTime dateTime, (uint defMonth, uint defDay) definition)
     {

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.StartOfDay.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.StartOfDay.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.StartOfDay.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,35 +11,19 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the start of the calendar day that contains the specified <paramref name="dateTime"/>.
+    /// Returns a new <see cref="DateTime"/> representing the start of the calendar day (00:00:00) that contains the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> whose date component is preserved while the time is reset to midnight.</param>
-    /// <returns>
-    /// A <see cref="DateTime"/> set to 00:00:00 on the same day as <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value whose date is preserved while the time is reset to midnight.</param>
+    /// <returns>An object whose value is set to 00:00:00 on the same calendar day as <paramref name="dateTime"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// This method is functionally equivalent to accessing <c>dateTime.Date</c>, but unlike <c>DateTime.Date</c>, it preserves
-    /// the original <see cref="DateTime.Kind"/> value (e.g., <see cref="DateTimeKind.Utc"/>, <see cref="DateTimeKind.Local"/>, or
-    /// <see cref="DateTimeKind.Unspecified"/>).
-    /// </para>
-    /// <para>
-    /// This makes the method more suitable in contexts where preserving the time zone context of a <see cref="DateTime"/> is important,
-    /// such as when working with scheduled events or cross-system date calculations.
-    /// </para>
-    /// <para>
-    /// The <see cref="DateTime.Kind"/> property of the returned instance matches that of the original <paramref name="dateTime"/>.
-    /// </para>
-    /// <example>
-    /// The following example demonstrates how <see cref="StartOfDay"/> differs from <c>DateTime.Date</c>:
+    /// <para>This method is functionally equivalent to <see cref="Midnight(DateTime)"/> and to accessing <see cref="DateTime.Date"/>. It normalises the time component to midnight while retaining the date and <see cref="DateTime.Kind"/> of the input.</para>
+    /// <para><b>Example:</b></para>
     /// <code>
     ///<![CDATA[
-    /// var original = new DateTime(2024, 12, 5, 10, 45, 0, DateTimeKind.Utc);
-    /// var startOfDay = original.StartOfDay(); // 2024-12-05T00:00:00Z
-    /// var builtInDate = original.Date;        // 2024-12-05T00:00:00 (Kind = Unspecified)
+    /// var dt = new DateTime(2024, 12, 5, 10, 45, 0, DateTimeKind.Utc);
+    /// var result = dt.StartOfDay(); // → 2024-12-05 00:00:00 (Kind = Utc)
     ///]]>
     /// </code>
-    /// </example>
     /// </remarks>
     public static DateTime StartOfDay(this DateTime dateTime) => new DateTime(TruncateToDateTicks(dateTime), dateTime.Kind);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToDateOnly.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToDateOnly.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.ToDateOnly.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,27 +13,19 @@ public static partial class DateTimeExtensions
 #if NET6_0_OR_GREATER // Uses DateOnly for .NET 6 or greater
 
     /// <summary>
-    /// Returns a new <see cref="DateOnly"/> representing the calendar date of the specified <paramref name="dateTime"/>,
-    /// excluding any time-of-day or <see cref="DateTime.Kind"/> information.
+    /// Returns a new <see cref="DateOnly"/> representing the calendar date of the specified <paramref name="dateTime"/>, excluding any time-of-day or <see cref="DateTime.Kind"/> information.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> instance to convert.</param>
-    /// <returns>
-    /// A <see cref="DateOnly"/> whose value is set to the year, month, and day components of <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value to convert.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the year, month, and day components of <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method is supported in .NET 6.0 or later. The returned <see cref="DateOnly"/> is constructed using the
-    /// <see cref="DateTime.Year"/>, <see cref="DateTime.Month"/>, and <see cref="DateTime.Day"/> components of the input.
-    /// </para>
-    /// <example>
-    /// The following example demonstrates converting a <see cref="DateTime"/> to a <see cref="DateOnly"/>:
+    /// <para>This method is supported on .NET 6.0 and later. The returned <see cref="DateOnly"/> is constructed using the <see cref="DateTime.Year"/>, <see cref="DateTime.Month"/>, and <see cref="DateTime.Day"/> components of the input. Any time-of-day component and the <see cref="DateTime.Kind"/> property are discarded.</para>
+    /// <para><b>Example:</b></para>
     /// <code>
     ///<![CDATA[
-    /// var dateTime = new DateTime(2025, 7, 7, 15, 30, 0);
-    /// var dateOnly = dateTime.ToDateOnly(); // 2025-07-07
+    /// var dt = new DateTime(2025, 7, 7, 15, 30, 0);
+    /// var result = dt.ToDateOnly(); // → 2025-07-07
     ///]]>
     /// </code>
-    /// </example>
     /// </remarks>
     public static DateOnly ToDateOnly(this DateTime dateTime) => DateOnly.FromDayNumber(GetDayNumber(dateTime));
 

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToDateTimeOffset.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToDateTimeOffset.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.ToDateTimeOffset.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,55 +11,34 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTimeOffset"/> representing the same moment as the specified <paramref name="dateTime"/>, with the
-    /// offset inferred from its <see cref="DateTime.Kind"/>.
+    /// Returns a new <see cref="DateTimeOffset"/> representing the same moment as the specified <paramref name="dateTime"/>, with the offset inferred from its <see cref="DateTime.Kind"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to convert.</param>
-    /// <returns>
-    /// A <see cref="DateTimeOffset"/> representing the same point in time as <paramref name="dateTime"/>, with the offset derived from
-    /// its <see cref="DateTime.Kind"/> (i.e., <c>Local</c>, <c>Utc</c>, or <c>Unspecified</c>).
-    /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting UTC time is outside the supported range of <see cref="DateTimeOffset"/>.</exception>
+    /// <param name="dateTime">The date and time value to convert.</param>
+    /// <returns>A <see cref="DateTimeOffset"/> representing the same point in time as <paramref name="dateTime"/>, with the offset derived from its <see cref="DateTime.Kind"/>.</returns>
     /// <remarks>
     /// <para>The behaviour depends on the <see cref="DateTime.Kind"/> of the input:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <term><see cref="DateTimeKind.Utc"/></term>
-    /// <description>Applies a zero offset (UTC).</description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeKind.Local"/></term>
-    /// <description>Applies the system’s local time zone offset.</description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeKind.Unspecified"/></term>
-    /// <description>Treats the value as local time and applies the system’s local offset.</description>
-    /// </item>
+    /// <item><term><see cref="DateTimeKind.Utc"/></term><description>applies a zero offset (UTC).</description></item>
+    /// <item><term><see cref="DateTimeKind.Local"/></term><description>applies the system's local time zone offset.</description></item>
+    /// <item><term><see cref="DateTimeKind.Unspecified"/></term><description>treats the value as local time and applies the system's local offset.</description></item>
     /// </list>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting UTC time is outside the supported range of <see cref="DateTimeOffset"/>.</exception>
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime) => new DateTimeOffset(dateTime);
 
     /// <summary>
-    /// Returns a new <see cref="DateTimeOffset"/> representing the same clock time as the specified <paramref name="dateTime"/>, with the
-    /// specified <paramref name="offset"/> applied.
+    /// Returns a new <see cref="DateTimeOffset"/> representing the same clock time as the specified <paramref name="dateTime"/>, with the supplied <paramref name="offset"/> applied.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to convert.</param>
-    /// <param name="offset">The UTC <see cref="TimeSpan"/> offset to associate with the resulting <see cref="DateTimeOffset"/>.</param>
-    /// <returns>
-    /// A <see cref="DateTimeOffset"/> with the same local time as <paramref name="dateTime"/>, and the specified
-    /// <paramref name="offset"/> applied.
-    /// </returns>
+    /// <param name="dateTime">The date and time value to convert.</param>
+    /// <param name="offset">The UTC <see cref="TimeSpan"/> offset to associate with the resulting <see cref="DateTimeOffset"/>. Must be within the range ±14 hours.</param>
+    /// <returns>A <see cref="DateTimeOffset"/> with the same local time as <paramref name="dateTime"/> and the supplied <paramref name="offset"/> applied.</returns>
+    /// <remarks>
+    /// <para>Use this overload to explicitly associate a non-local offset — for example when dealing with fixed time zones, historical data, or offset-based scheduling.</para>
+    /// </remarks>
     /// <exception cref="ArgumentException">
-    /// Thrown if <paramref name="offset"/> is not within the range ±14 hours, or if it is incompatible with the
-    /// <see cref="DateTime.Kind"/> of <paramref name="dateTime"/>.
+    /// Thrown if <paramref name="offset"/> is not within the range ±14 hours,
+    /// -or- <paramref name="offset"/> is incompatible with the <see cref="DateTime.Kind"/> of <paramref name="dateTime"/>.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting UTC time is outside the supported range of <see cref="DateTimeOffset"/>.</exception>
-    /// <remarks>
-    /// <para>
-    /// Use this overload to explicitly associate a non-local offset—such as when dealing with fixed time zones, historical data, or
-    /// offset-based scheduling.
-    /// </para>
-    /// <para>The <paramref name="offset"/> must be within the range ±14:00.</para>
-    /// </remarks>
     public static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, TimeSpan offset) => new DateTimeOffset(dateTime, offset);
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
@@ -45,7 +45,7 @@ public static partial class DateTimeExtensions
     /// <param name="dateTime">The <see cref="DateTime"/> value to convert.</param>
     /// <param name="includeFractionalSeconds">Indicates whether to include fractional seconds (7 digits) in the output.</param>
     /// <returns>A string representation of <paramref name="dateTime"/> in ISO 8601 format, with or without fractional seconds.</returns>
-    /// <remarks>Uses the "o" (round-trip) format when <paramref name="includeFractionalSeconds"/> is <c>true</c>; otherwise, uses "yyyy-MM-ddTHH:mm:ss".</remarks>
+    /// <remarks>Uses the "o" (round-trip) format when <paramref name="includeFractionalSeconds"/> is <see langword="true"/>; otherwise, uses "yyyy-MM-ddTHH:mm:ss".</remarks>
     public static string ToIsoString(this DateTime dateTime, bool includeFractionalSeconds)
     {
         string format = includeFractionalSeconds ? "o" : "yyyy-MM-ddTHH:mm:ss";
@@ -85,10 +85,7 @@ public static partial class DateTimeExtensions
     /// </summary>
     /// <param name="dateTime">The <see cref="DateTime"/> value to format.</param>
     /// <param name="format">A valid date-time format string (e.g., "yyyy-MM-ddTHH:mm:ss").</param>
-    /// <param name="culture">
-    /// An optional <see cref="CultureInfo"/> for culture-specific formatting. If <c>null</c>, <see cref="CultureInfo.InvariantCulture"/>
-    /// is used.
-    /// </param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> used for culture-specific formatting. If <see langword="null"/>, <see cref="CultureInfo.InvariantCulture"/> is used.</param>
     /// <returns>A formatted string representation of <paramref name="dateTime"/> using the specified format and culture.</returns>
     /// <exception cref="ArgumentNullException">Thrown if <paramref name="format"/> is <see langword="null"/> or empty.</exception>
     public static string ToIsoString(this DateTime dateTime, string format, CultureInfo? culture = null)

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.ToIsoString.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,25 +13,20 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Converts the specified <see cref="DateTime"/> to an ISO 8601 formatted string, using its <see cref="DateTime.Kind"/> to determine
-    /// the appropriate format suffix.
+    /// Returns a string representation of the specified <paramref name="dateTime"/> in ISO 8601 format, using its <see cref="DateTime.Kind"/> to determine the appropriate format suffix.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to convert.</param>
+    /// <param name="dateTime">The date and time value to convert.</param>
     /// <returns>
-    /// A string representation of <paramref name="dateTime"/> in ISO 8601 format:
+    /// A <see cref="string"/> representation of <paramref name="dateTime"/> in ISO 8601 format:
     /// <list type="bullet">
-    /// <item>
-    /// <description>Ends with <c>'Z'</c> if <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Utc"/>.</description>
-    /// </item>
-    /// <item>
-    /// <description>Includes local time zone offset if <see cref="DateTimeKind.Local"/>.</description>
-    /// </item>
-    /// <item>
-    /// <description>Omits offset for <see cref="DateTimeKind.Unspecified"/>.</description>
-    /// </item>
+    /// <item><description>ends with <c>'Z'</c> if <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Utc"/>;</description></item>
+    /// <item><description>includes the local time zone offset if <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Local"/>;</description></item>
+    /// <item><description>omits any offset if <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/>.</description></item>
     /// </list>
     /// </returns>
-    /// <remarks>Uses the "o" (round-trip) format for <c>Local</c> and <c>Unspecified</c>, and a custom UTC format for <c>Utc</c>.</remarks>
+    /// <remarks>
+    /// <para>Uses the <c>"o"</c> (round-trip) format for <see cref="DateTimeKind.Local"/> and <see cref="DateTimeKind.Unspecified"/>, and a custom UTC format (<c>"yyyy-MM-ddTHH:mm:ss.fffffffZ"</c>) for <see cref="DateTimeKind.Utc"/>.</para>
+    /// </remarks>
     public static string ToIsoString(this DateTime dateTime) => dateTime.Kind switch
     {
         DateTimeKind.Utc => dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
@@ -40,12 +35,14 @@ public static partial class DateTimeExtensions
     };
 
     /// <summary>
-    /// Converts the specified <see cref="DateTime"/> to an ISO 8601 formatted string, optionally omitting fractional seconds.
+    /// Returns a string representation of the specified <paramref name="dateTime"/> in ISO 8601 format, optionally omitting fractional seconds.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to convert.</param>
+    /// <param name="dateTime">The date and time value to convert.</param>
     /// <param name="includeFractionalSeconds">Indicates whether to include fractional seconds (7 digits) in the output.</param>
-    /// <returns>A string representation of <paramref name="dateTime"/> in ISO 8601 format, with or without fractional seconds.</returns>
-    /// <remarks>Uses the "o" (round-trip) format when <paramref name="includeFractionalSeconds"/> is <see langword="true"/>; otherwise, uses "yyyy-MM-ddTHH:mm:ss".</remarks>
+    /// <returns>A <see cref="string"/> representation of <paramref name="dateTime"/> in ISO 8601 format, with or without fractional seconds.</returns>
+    /// <remarks>
+    /// <para>Uses the <c>"o"</c> (round-trip) format when <paramref name="includeFractionalSeconds"/> is <see langword="true"/>; otherwise uses <c>"yyyy-MM-ddTHH:mm:ss"</c>.</para>
+    /// </remarks>
     public static string ToIsoString(this DateTime dateTime, bool includeFractionalSeconds)
     {
         string format = includeFractionalSeconds ? "o" : "yyyy-MM-ddTHH:mm:ss";
@@ -53,25 +50,19 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Converts the specified <see cref="DateTime"/> to an ISO 8601 formatted string, using an explicit <see cref="DateTimeKind"/> override.
+    /// Returns a string representation of the specified <paramref name="dateTime"/> in ISO 8601 format, using an explicit <see cref="DateTimeKind"/> override.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to convert.</param>
+    /// <param name="dateTime">The date and time value to convert.</param>
     /// <param name="kind">The <see cref="DateTimeKind"/> to apply before formatting.</param>
     /// <returns>
-    /// A string representation of the input <see cref="DateTime"/> in ISO 8601 format:
+    /// A <see cref="string"/> representation of <paramref name="dateTime"/> in ISO 8601 format:
     /// <list type="bullet">
-    /// <item>
-    /// <description><see cref="DateTimeKind.Utc"/> → Ends with <c>'Z'</c>.</description>
-    /// </item>
-    /// <item>
-    /// <description><see cref="DateTimeKind.Local"/> → Includes local time zone offset.</description>
-    /// </item>
-    /// <item>
-    /// <description><see cref="DateTimeKind.Unspecified"/> → No offset information.</description>
-    /// </item>
+    /// <item><description><see cref="DateTimeKind.Utc"/> — ends with <c>'Z'</c>;</description></item>
+    /// <item><description><see cref="DateTimeKind.Local"/> — includes the local time zone offset;</description></item>
+    /// <item><description><see cref="DateTimeKind.Unspecified"/> — omits any offset.</description></item>
     /// </list>
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="kind"/> is not a valid value of <see cref="DateTimeKind"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="kind"/> is not a defined value of the <see cref="DateTimeKind"/> enumeration.</exception>
     public static string ToIsoString(this DateTime dateTime, DateTimeKind kind) => kind switch
     {
         DateTimeKind.Utc => dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
@@ -81,17 +72,16 @@ public static partial class DateTimeExtensions
     };
 
     /// <summary>
-    /// Converts the specified <see cref="DateTime"/> to a string using a custom format and optional culture.
+    /// Returns a string representation of the specified <paramref name="dateTime"/> using a custom format and an optional culture.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to format.</param>
-    /// <param name="format">A valid date-time format string (e.g., "yyyy-MM-ddTHH:mm:ss").</param>
+    /// <param name="dateTime">The date and time value to format.</param>
+    /// <param name="format">A valid date-time format string (e.g. <c>"yyyy-MM-ddTHH:mm:ss"</c>). Must not be <see langword="null"/> or whitespace.</param>
     /// <param name="culture">An optional <see cref="CultureInfo"/> used for culture-specific formatting. If <see langword="null"/>, <see cref="CultureInfo.InvariantCulture"/> is used.</param>
-    /// <returns>A formatted string representation of <paramref name="dateTime"/> using the specified format and culture.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="format"/> is <see langword="null"/> or empty.</exception>
+    /// <returns>A formatted <see cref="string"/> representation of <paramref name="dateTime"/> using the supplied format and culture.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="format"/> is <see langword="null"/>, empty, or whitespace.</exception>
     public static string ToIsoString(this DateTime dateTime, string format, CultureInfo? culture = null)
     {
-        if (string.IsNullOrWhiteSpace(format))
-            throw new ArgumentNullException(nameof(format), "Format string must be specified.");
+        if (string.IsNullOrWhiteSpace(format)) throw new ArgumentNullException(nameof(format), "Format string must be specified.");
 
         return dateTime.ToString(format, culture ?? CultureInfo.InvariantCulture);
     }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToTimeSpan.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToTimeSpan.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.ToTimeSpan.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,15 +11,12 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="TimeSpan"/> representing the time-of-day portion of the specified <see cref="DateTime"/>.
+    /// Returns a new <see cref="TimeSpan"/> representing the time-of-day portion of the specified <paramref name="dateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> from which to extract the time component.</param>
-    /// <returns>
-    /// An object whose value is set to the hours, minutes, seconds, and fractional seconds that have elapsed since midnight on the same
-    /// calendar day as <paramref name="dateTime"/>.
-    /// </returns>
+    /// <param name="dateTime">The date and time value from which to extract the time-of-day component.</param>
+    /// <returns>A <see cref="TimeSpan"/> value representing the hours, minutes, seconds, and fractional seconds that have elapsed since midnight on the same calendar day as <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// The returned value is equivalent to <see cref="DateTime.TimeOfDay"/> and is unaffected by the <see cref="DateTime.Kind"/> property.
+    /// <para>The returned value is equivalent to <see cref="DateTime.TimeOfDay"/> and is unaffected by the <see cref="DateTime.Kind"/> property.</para>
     /// </remarks>
     public static TimeSpan ToTimeSpan(this DateTime dateTime) => dateTime.TimeOfDay;
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Truncate.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Truncate.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.Truncate.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,63 +11,27 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the specified <paramref name="dateTime"/> truncated to the given
-    /// <paramref name="resolution"/>, with all smaller time components set to zero.
+    /// Returns a new <see cref="DateTime"/> obtained by truncating the specified <paramref name="dateTime"/> to the supplied <paramref name="resolution"/>, with all smaller time components reset to zero.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to truncate.</param>
+    /// <param name="dateTime">The date and time value to truncate.</param>
     /// <param name="resolution">The <see cref="DateTimeResolution"/> level to truncate to.</param>
-    /// <returns>
-    /// An object whose value is set to the <paramref name="dateTime"/> truncated to the specified <paramref name="resolution"/>,
-    /// preserving the original <see cref="DateTime.Kind"/>.
-    /// </returns>
-    /// <exception cref="ArgumentException">
-    /// Thrown if <paramref name="resolution"/> is not a valid member of the <see cref="DateTimeResolution"/> enumeration.
-    /// </exception>
+    /// <returns>An object whose value is the result of truncating <paramref name="dateTime"/> to the supplied <paramref name="resolution"/>, with the original <see cref="DateTime.Kind"/> preserved.</returns>
     /// <remarks>
-    /// <para>
-    /// Truncation resets all components smaller than the specified resolution to their minimum values. For example, truncating to
-    /// <see cref="DateTimeResolution.Minute"/> clears seconds and fractional seconds.
-    /// </para>
+    /// <para>Truncation resets all components smaller than the supplied resolution to their minimum values. For example, truncating to <see cref="DateTimeResolution.Minute"/> clears seconds and fractional seconds.</para>
     /// <para>The following examples show the result of truncating <c>2024-04-18T14:37:56.7891234</c>:</para>
     /// <list type="table">
-    /// <listheader>
-    /// <term>Resolution</term>
-    /// <description>Result</description>
-    /// </listheader>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Year"/></term>
-    /// <description><c>2024-01-01T00:00:00.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Month"/></term>
-    /// <description><c>2024-04-01T00:00:00.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Day"/></term>
-    /// <description><c>2024-04-18T00:00:00.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Hour"/></term>
-    /// <description><c>2024-04-18T14:00:00.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Minute"/></term>
-    /// <description><c>2024-04-18T14:37:00.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Second"/></term>
-    /// <description><c>2024-04-18T14:37:56.0000000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Millisecond"/></term>
-    /// <description><c>2024-04-18T14:37:56.7890000</c></description>
-    /// </item>
-    /// <item>
-    /// <term><see cref="DateTimeResolution.Tick"/></term>
-    /// <description><c>2024-04-18T14:37:56.7891234</c> (unchanged)</description>
-    /// </item>
+    /// <listheader><term>Resolution</term><description>Result</description></listheader>
+    /// <item><term><see cref="DateTimeResolution.Year"/></term><description><c>2024-01-01T00:00:00.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Month"/></term><description><c>2024-04-01T00:00:00.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Day"/></term><description><c>2024-04-18T00:00:00.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Hour"/></term><description><c>2024-04-18T14:00:00.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Minute"/></term><description><c>2024-04-18T14:37:00.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Second"/></term><description><c>2024-04-18T14:37:56.0000000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Millisecond"/></term><description><c>2024-04-18T14:37:56.7890000</c></description></item>
+    /// <item><term><see cref="DateTimeResolution.Tick"/></term><description><c>2024-04-18T14:37:56.7891234</c> (unchanged)</description></item>
     /// </list>
     /// </remarks>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="resolution"/> is not a defined value of the <see cref="DateTimeResolution"/> enumeration.</exception>
     public static DateTime Truncate(this DateTime dateTime, DateTimeResolution resolution)
     {
         switch (resolution)

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.UnixTime(Epoch).cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.UnixTime(Epoch).cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.UnixTime(Epoch).cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -11,22 +11,22 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Represents the maximum number of milliseconds since the Unix epoch that can be converted to <see cref="DateTime"/>.
+    /// Represents the maximum number of milliseconds since the Unix epoch that can be converted to a <see cref="DateTime"/>.
     /// </summary>
     internal const long MaxEpochMilliseconds = (MaxTicks / TicksPerMillisecond) - UnixEpochMilliseconds;
 
     /// <summary>
-    /// Represents the maximum number of seconds since the Unix epoch that can be converted to <see cref="DateTime"/>.
+    /// Represents the maximum number of seconds since the Unix epoch that can be converted to a <see cref="DateTime"/>.
     /// </summary>
     internal const long MaxEpochSeconds = (MaxTicks / TicksPerSecond) - UnixEpochSeconds;
 
     /// <summary>
-    /// Represents the minimum number of milliseconds since the Unix epoch that can be converted to <see cref="DateTime"/>.
+    /// Represents the minimum number of milliseconds since the Unix epoch that can be converted to a <see cref="DateTime"/>.
     /// </summary>
     internal const long MinEpochMilliseconds = (MinTicks / TicksPerMillisecond) - UnixEpochMilliseconds;
 
     /// <summary>
-    /// Represents the minimum number of seconds since the Unix epoch that can be converted to <see cref="DateTime"/>.
+    /// Represents the minimum number of seconds since the Unix epoch that can be converted to a <see cref="DateTime"/>.
     /// </summary>
     internal const long MinEpochSeconds = (MinTicks / TicksPerSecond) - UnixEpochSeconds;
 
@@ -46,15 +46,14 @@ public static partial class DateTimeExtensions
     internal const long UnixEpochTicks = TicksPerDay * DaysTo1970;
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the point in time corresponding to the specified Unix timestamp, expressed in
-    /// milliseconds since 1970-01-01T00:00:00Z.
+    /// Returns a new <see cref="DateTime"/> representing the point in time corresponding to the specified Unix timestamp, expressed in milliseconds since 1970-01-01T00:00:00Z.
     /// </summary>
-    /// <param name="timestamp">The number of milliseconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z).</param>
-    /// <returns>An object whose value is set to the UTC date and time corresponding to <paramref name="timestamp"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="timestamp"/> is outside the valid range of supported Unix timestamps.
-    /// </exception>
-    /// <remarks>The returned <see cref="DateTime"/> has its <see cref="DateTime.Kind"/> set to <see cref="DateTimeKind.Utc"/>.</remarks>
+    /// <param name="timestamp">The number of milliseconds that have elapsed since the Unix epoch.</param>
+    /// <returns>An object whose value is set to the UTC date and time corresponding to <paramref name="timestamp"/>, with <see cref="DateTime.Kind"/> equal to <see cref="DateTimeKind.Utc"/>.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="ToUnixTimeMilliseconds(DateTime)"/> to perform the inverse conversion.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="timestamp"/> is outside the range supported for conversion to <see cref="DateTime"/>.</exception>
     /// <seealso cref="ToUnixTimeMilliseconds(DateTime)"/>
     public static DateTime FromUnixTimeMilliseconds(long timestamp)
     {
@@ -63,15 +62,14 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns a new <see cref="DateTime"/> representing the point in time corresponding to the specified Unix timestamp, expressed in
-    /// seconds since 1970-01-01T00:00:00Z.
+    /// Returns a new <see cref="DateTime"/> representing the point in time corresponding to the specified Unix timestamp, expressed in seconds since 1970-01-01T00:00:00Z.
     /// </summary>
-    /// <param name="timestamp">The number of seconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z).</param>
-    /// <returns>An object whose value is set to the UTC date and time corresponding to <paramref name="timestamp"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="timestamp"/> is outside the valid range of supported Unix timestamps.
-    /// </exception>
-    /// <remarks>The returned <see cref="DateTime"/> has its <see cref="DateTime.Kind"/> set to <see cref="DateTimeKind.Utc"/>.</remarks>
+    /// <param name="timestamp">The number of seconds that have elapsed since the Unix epoch.</param>
+    /// <returns>An object whose value is set to the UTC date and time corresponding to <paramref name="timestamp"/>, with <see cref="DateTime.Kind"/> equal to <see cref="DateTimeKind.Utc"/>.</returns>
+    /// <remarks>
+    /// <para>Use <see cref="ToUnixTimeSeconds(DateTime)"/> to perform the inverse conversion.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="timestamp"/> is outside the range supported for conversion to <see cref="DateTime"/>.</exception>
     /// <seealso cref="ToUnixTimeSeconds(DateTime)"/>
     public static DateTime FromUnixTimeSeconds(long timestamp)
     {
@@ -80,24 +78,23 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the number of milliseconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z), based on the specified <see cref="DateTime"/>.
+    /// Returns the number of milliseconds that have elapsed between the Unix epoch (1970-01-01T00:00:00Z) and the specified <see cref="DateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to convert. It is first converted to UTC using <see cref="DateTime.ToUniversalTime()"/>.</param>
+    /// <param name="dateTime">The date and time value to convert. The value is first normalised to UTC using <see cref="DateTime.ToUniversalTime()"/>.</param>
     /// <returns>The total number of milliseconds since the Unix epoch.</returns>
     /// <remarks>
-    /// This method normalises the input to UTC before computing the elapsed time. Use <see cref="FromUnixTimeMilliseconds(long)"/> to
-    /// convert back.
+    /// <para>This method normalises the input to UTC before computing the elapsed time. Use <see cref="FromUnixTimeMilliseconds(long)"/> to convert back.</para>
     /// </remarks>
     /// <seealso cref="FromUnixTimeMilliseconds(long)"/>
     public static long ToUnixTimeMilliseconds(this DateTime dateTime) => (dateTime.ToUniversalTime().Ticks / TicksPerMillisecond) - UnixEpochMilliseconds;
 
     /// <summary>
-    /// Returns the number of seconds that have elapsed since the Unix epoch (1970-01-01T00:00:00Z), based on the specified <see cref="DateTime"/>.
+    /// Returns the number of seconds that have elapsed between the Unix epoch (1970-01-01T00:00:00Z) and the specified <see cref="DateTime"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> to convert. It is first converted to UTC using <see cref="DateTime.ToUniversalTime()"/>.</param>
+    /// <param name="dateTime">The date and time value to convert. The value is first normalised to UTC using <see cref="DateTime.ToUniversalTime()"/>.</param>
     /// <returns>The total number of seconds since the Unix epoch.</returns>
     /// <remarks>
-    /// This method normalises the input to UTC before computing the elapsed time. Use <see cref="FromUnixTimeSeconds(long)"/> to convert back.
+    /// <para>This method normalises the input to UTC before computing the elapsed time. Use <see cref="FromUnixTimeSeconds(long)"/> to convert back.</para>
     /// </remarks>
     /// <seealso cref="FromUnixTimeSeconds(long)"/>
     public static long ToUnixTimeSeconds(this DateTime dateTime) => (dateTime.ToUniversalTime().Ticks / TicksPerSecond) - UnixEpochSeconds;

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.WeekOfMonth.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.WeekOfMonth.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.WeekOfMonth.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -14,23 +14,14 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using the current culture’s
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="dateTime">The date to evaluate.</param>
-    /// <returns>An integer value indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// <para>
-    /// The calculation is based on the difference between the week-of-year for <paramref name="dateTime"/> and the week-of-year for the
-    /// first day of its month, plus one.
-    /// </para>
-    /// <para>
-    /// Week numbering is determined by the current thread’s <see cref="CultureInfo.CurrentCulture"/>, specifically its
-    /// <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.
-    /// </para>
+    /// <para>The result is calculated by comparing the week-of-year for <paramref name="dateTime"/> against the week-of-year for the first day of its month, plus one.</para>
+    /// <para>Week numbering is determined by <see cref="CultureInfo.CurrentCulture"/>, specifically its <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
     /// </remarks>
-    /// <seealso cref="WeekOfMonth(DateTime, CultureInfo?)"/>
-    /// <seealso cref="WeekOfMonth(DateTime, CalendarWeekRule, DayOfWeek)"/>
     public static int WeekOfMonth(this DateTime dateTime)
     {
         CultureInfo culture = CultureInfo.CurrentCulture;
@@ -38,22 +29,14 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using calendar settings from the specified <paramref name="culture"/>.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using the calendar settings of the supplied or current culture.
     /// </summary>
-    /// <param name="dateTime">The date to evaluate.</param>
-    /// <param name="culture">
-    /// A <see cref="CultureInfo"/> that provides the calendar week rule and first day of the week. If <c>null</c>,
-    /// <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>An integer value indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// <para>
-    /// This method uses the provided culture’s <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and
-    /// <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> to calculate the result.
-    /// </para>
+    /// <para>This overload uses the supplied culture's <see cref="DateTimeFormatInfo.CalendarWeekRule"/> and <see cref="DateTimeFormatInfo.FirstDayOfWeek"/> to compute the result.</para>
     /// </remarks>
-    /// <seealso cref="WeekOfMonth(DateTime)"/>
-    /// <seealso cref="WeekOfMonth(DateTime, CalendarWeekRule, DayOfWeek)"/>
     public static int WeekOfMonth(this DateTime dateTime, CultureInfo? culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
@@ -61,24 +44,19 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using the given <paramref name="weekRule"/>
-    /// and <paramref name="weekStart"/> values.
+    /// Returns the 1-based week number of the month for the specified <see cref="DateTime"/>, using the supplied <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> as the week-starting day.
     /// </summary>
-    /// <param name="dateTime">The date to evaluate.</param>
-    /// <param name="weekRule">The rule used to determine the first week of the year.</param>
-    /// <param name="weekStart">The first day of the week.</param>
-    /// <returns>An integer value indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekRule"/> or <paramref name="weekStart"/> is not a defined value of the corresponding enum.
-    /// </exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="weekRule">The <see cref="CalendarWeekRule"/> that defines how the first week of the year is identified.</param>
+    /// <param name="weekStart">The <see cref="DayOfWeek"/> on which each week begins.</param>
+    /// <returns>An integer indicating the week of the month in which <paramref name="dateTime"/> falls, starting at <c>1</c>.</returns>
     /// <remarks>
-    /// <para>
-    /// The week of month is calculated by comparing the week-of-year for the target <paramref name="dateTime"/> with that of the first day
-    /// of the same month, using the specified rule and start day.
-    /// </para>
+    /// <para>The result is calculated by comparing the week-of-year for <paramref name="dateTime"/> against the week-of-year for the first day of its month, using the supplied rule and start day.</para>
     /// </remarks>
-    /// <seealso cref="WeekOfMonth(DateTime)"/>
-    /// <seealso cref="WeekOfMonth(DateTime, CultureInfo?)"/>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekRule"/> is not a defined value of the <see cref="CalendarWeekRule"/> enumeration,
+    /// -or- <paramref name="weekStart"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
     public static int WeekOfMonth(this DateTime dateTime, CalendarWeekRule weekRule, DayOfWeek weekStart)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekRule);
@@ -88,13 +66,13 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Calculates the 1-based week-of-month using raw tick data and specified calendar rules.
+    /// Calculates the 1-based week-of-month using the supplied calendar rules.
     /// </summary>
-    /// <param name="dateTime">The date to evaluate.</param>
-    /// <param name="weekRule">The <see cref="CalendarWeekRule" /> defining how the first week of the
-    /// month is identified.</param>
-    /// <param name="weekStart">The <see cref="DayOfWeek" /> on which each week begins.</param>
-    /// <returns>The 1-based week number of <paramref name="dateTime" /> within its month.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="weekRule">The <see cref="CalendarWeekRule"/> that defines how the first week of the month is identified.</param>
+    /// <param name="weekStart">The <see cref="DayOfWeek"/> on which each week begins.</param>
+    /// <returns>The 1-based week number of <paramref name="dateTime"/> within its month.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where all arguments are known to be valid.</remarks>
     private static int GetWeekOfMonth(DateTime dateTime, CalendarWeekRule weekRule, DayOfWeek weekStart)
     {
         DateTime firstOfMonth = new DateTime(dateTime.Year, dateTime.Month, 1);

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.WeekOfYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.WeekOfYear.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateTimeExtensions.WeekOfYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -13,35 +13,28 @@ namespace Bodu.Extensions;
 public static partial class DateTimeExtensions
 {
     /// <summary>
-    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the current culture’s
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings of <see cref="CultureInfo.CurrentCulture"/>.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <returns>An integer in the range 1–53 representing the week of the year containing <paramref name="dateTime"/>.</returns>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// Week numbering is based on <see cref="CultureInfo.CurrentCulture"/>, which may follow different conventions:
+    /// <para>Week numbering is determined by <see cref="CultureInfo.CurrentCulture"/>, which may follow different conventions:</para>
     /// <list type="bullet">
-    /// <item>
-    /// <description>U.S. system: Week 1 starts on Sunday and includes January 1.</description>
-    /// </item>
-    /// <item>
-    /// <description>ISO 8601: Week 1 starts on Monday and includes the first Thursday of the year.</description>
-    /// </item>
+    /// <item><description>U.S. system: week 1 starts on Sunday and includes January 1.</description></item>
+    /// <item><description>ISO 8601: week 1 starts on Monday and includes the first Thursday of the year.</description></item>
     /// </list>
     /// </remarks>
     public static int WeekOfYear(this DateTime dateTime) => dateTime.WeekOfYear(null);
 
     /// <summary>
-    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the calendar rules from the
-    /// specified <paramref name="culture"/>.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the calendar rules of the supplied or current culture.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <param name="culture">
-    /// A <see cref="CultureInfo"/> that provides the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings. If
-    /// <c>null</c>, <see cref="CultureInfo.CurrentCulture"/> is used.
-    /// </param>
-    /// <returns>An integer in the range 1–53 representing the week of the year containing <paramref name="dateTime"/>.</returns>
-    /// <remarks>This overload allows culture-specific calculation of week numbers (e.g., for Gregorian or ISO calendars).</remarks>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> settings. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="dateTime"/>.</returns>
+    /// <remarks>
+    /// <para>This overload allows culture-specific calculation of week numbers (e.g. for Gregorian or ISO 8601 calendars).</para>
+    /// </remarks>
     public static int WeekOfYear(this DateTime dateTime, CultureInfo? culture)
     {
         DateTimeFormatInfo info = (culture ?? Thread.CurrentThread.CurrentCulture).DateTimeFormat;
@@ -49,20 +42,19 @@ public static partial class DateTimeExtensions
     }
 
     /// <summary>
-    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the specified
-    /// <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> as the week starting day.
+    /// Returns the 1-based week number of the year that contains the specified <see cref="DateTime"/>, using the supplied <see cref="CalendarWeekRule"/> and <see cref="DayOfWeek"/> as the week-starting day.
     /// </summary>
-    /// <param name="dateTime">The <see cref="DateTime"/> value to evaluate.</param>
-    /// <param name="weekRule">The rule used to define the first week of the year.</param>
-    /// <param name="weekStart">The day considered the first day of the week.</param>
-    /// <returns>An integer in the range 1–53 representing the week of the year containing <paramref name="dateTime"/>.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="weekRule"/> or <paramref name="weekStart"/> is not a defined enum value.
-    /// </exception>
+    /// <param name="dateTime">The date and time value to evaluate.</param>
+    /// <param name="weekRule">The <see cref="CalendarWeekRule"/> that defines how the first week of the year is identified.</param>
+    /// <param name="weekStart">The <see cref="DayOfWeek"/> on which each week begins.</param>
+    /// <returns>An integer in the range 1 – 53 representing the week of the year that contains <paramref name="dateTime"/>.</returns>
     /// <remarks>
-    /// This overload enables custom calendar logic such as ISO 8601 ( <c>CalendarWeekRule.FirstFourDayWeek</c>, <c>DayOfWeek.Monday</c>) or
-    /// localized U.S./European systems.
+    /// <para>This overload enables custom calendar logic such as ISO 8601 (<see cref="CalendarWeekRule.FirstFourDayWeek"/>, <see cref="DayOfWeek.Monday"/>) or localised U.S./European systems.</para>
     /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="weekRule"/> is not a defined value of the <see cref="CalendarWeekRule"/> enumeration,
+    /// -or- <paramref name="weekStart"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
     public static int WeekOfYear(this DateTime dateTime, CalendarWeekRule weekRule, DayOfWeek weekStart)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(weekRule);


### PR DESCRIPTION
Mirror First/Last DayOf{Month,Year,Quarter,Week} XML documentation across the
DateTime and DateOnly extension halves. Each pair now shares the same element
shape, sentence templates, exception phrasing (-or- form), and example block —
differing only in type, parameter name, and genuinely type-specific clauses
(DateTime.Kind preservation, midnight time component).

- Level up DateOnly docs to match richer DateTime docs (added remarks/examples).
- Mirror invariants across First/Last group members (Gregorian rules, leap-year
  note on LastDayOfMonth) so siblings document the same calendar context.
- Standardise British spelling (normalised) and use canonical year-bound prose.
- Fix stale remark on LastDayOfYear that described January 1.