### PR TITLE
test(Globalization.Calendar.Extensions): comprehensive coverage sweep for NotableDate-aware DateTime/DateOnly extensions

### DIFF
--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
@@ -78,17 +78,19 @@ public partial class NotableDateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Provides territory-scoping samples that assert a non-working rule fires only when the requested territory matches.
+    /// Provides territory-scoping samples expressing bidirectional containment: a query matches a rule when either side's
+    /// territory contains the other, and a <see langword="null" /> query matches any rule.
     /// </summary>
-    /// <returns>A sequence of <c>(string ruleTerritory, string queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
+    /// <returns>A sequence of <c>(string ruleTerritory, string? queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
     public static IEnumerable<object[]> TerritoryForwardingTestData()
     {
         yield return new object[] { "AU", "AU", true };
         yield return new object[] { "AU", "AU-NSW", true };
+        yield return new object[] { "AU-NSW", "AU", true };
         yield return new object[] { "AU-NSW", "AU-NSW", true };
         yield return new object[] { "AU-NSW", "AU-VIC", false };
         yield return new object[] { "AU", "NZ", false };
-        yield return new object[] { "AU", null!, false };
+        yield return new object[] { "AU", null!, true };
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
@@ -98,4 +98,17 @@ public partial class NotableDateOnlyExtensionsTests
     /// <returns>A configured <see cref="NotableDateService" /> instance.</returns>
     private static NotableDateService BuildHolidayService(string? territory = null) =>
         BuildService(Fixed("Holiday", 4, 7, nonWorking: true, territory: territory));
+
+    /// <summary>
+    /// Provides boundary inputs that should throw <see cref="ArgumentOutOfRangeException" /> when adding working days would overrun
+    /// the <see cref="DateOnly" /> range.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly input, int days)</c> tuples, each one expected to throw.</returns>
+    public static IEnumerable<object[]> AddWorkingDaysOverflowTestData()
+    {
+        yield return new object[] { DateOnly.MaxValue, 1 };
+        yield return new object[] { DateOnly.MinValue, -1 };
+        yield return new object[] { DateOnly.MaxValue.AddDays(-1), 5 };
+        yield return new object[] { DateOnly.MinValue.AddDays(1), -5 };
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
@@ -111,4 +111,29 @@ public partial class NotableDateOnlyExtensionsTests
         yield return new object[] { DateOnly.MaxValue.AddDays(-1), 5 };
         yield return new object[] { DateOnly.MinValue.AddDays(1), -5 };
     }
+
+    /// <summary>
+    /// Provides single-day range inputs paired with their expected working-day yield count.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly day, int expectedWorkingYieldCount)</c> tuples.</returns>
+    public static IEnumerable<object[]> SingleDayWorkingYieldTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), 1 };
+        yield return new object[] { new DateOnly(2026, 1, 6), 1 };
+        yield return new object[] { new DateOnly(2026, 1, 9), 1 };
+        yield return new object[] { new DateOnly(2026, 1, 10), 0 };
+        yield return new object[] { new DateOnly(2026, 1, 11), 0 };
+    }
+
+    /// <summary>
+    /// Provides single-day range inputs paired with their expected non-working-day yield count.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly day, int expectedNonWorkingYieldCount)</c> tuples.</returns>
+    public static IEnumerable<object[]> SingleDayNonWorkingYieldTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), 0 };
+        yield return new object[] { new DateOnly(2026, 1, 9), 0 };
+        yield return new object[] { new DateOnly(2026, 1, 10), 1 };
+        yield return new object[] { new DateOnly(2026, 1, 11), 1 };
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.!TestData.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateOnlyExtensionsTests.!TestData.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public partial class NotableDateOnlyExtensionsTests
+{
+    /// <summary>
+    /// Provides day-of-week samples spanning a single calendar week in 2026 paired with their working-day classification under the
+    /// default Saturday/Sunday weekend definition.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly input, bool isWorkingDay)</c> tuples.</returns>
+    public static IEnumerable<object[]> WorkingDayClassificationTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), true };   // Monday
+        yield return new object[] { new DateOnly(2026, 1, 6), true };   // Tuesday
+        yield return new object[] { new DateOnly(2026, 1, 7), true };   // Wednesday
+        yield return new object[] { new DateOnly(2026, 1, 8), true };   // Thursday
+        yield return new object[] { new DateOnly(2026, 1, 9), true };   // Friday
+        yield return new object[] { new DateOnly(2026, 1, 10), false }; // Saturday
+        yield return new object[] { new DateOnly(2026, 1, 11), false }; // Sunday
+    }
+
+    /// <summary>
+    /// Provides start-of-week, count and expected next-working-day samples for an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly start, int count, DateOnly expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> NextWorkingDayCountTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), 1, new DateOnly(2026, 1, 6) };
+        yield return new object[] { new DateOnly(2026, 1, 5), 2, new DateOnly(2026, 1, 7) };
+        yield return new object[] { new DateOnly(2026, 1, 5), 5, new DateOnly(2026, 1, 12) };
+        yield return new object[] { new DateOnly(2026, 1, 9), 1, new DateOnly(2026, 1, 12) };
+        yield return new object[] { new DateOnly(2026, 1, 10), 1, new DateOnly(2026, 1, 12) };
+    }
+
+    /// <summary>
+    /// Provides start-of-week, count and expected previous-working-day samples for an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly start, int count, DateOnly expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> PreviousWorkingDayCountTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 9), 1, new DateOnly(2026, 1, 8) };
+        yield return new object[] { new DateOnly(2026, 1, 9), 5, new DateOnly(2026, 1, 2) };
+        yield return new object[] { new DateOnly(2026, 1, 12), 1, new DateOnly(2026, 1, 9) };
+        yield return new object[] { new DateOnly(2026, 1, 11), 1, new DateOnly(2026, 1, 9) };
+    }
+
+    /// <summary>
+    /// Provides signed-days samples for <c>AddWorkingDays</c> against an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly input, int days, DateOnly expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> AddWorkingDaysSignedTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), 0, new DateOnly(2026, 1, 5) };
+        yield return new object[] { new DateOnly(2026, 1, 5), 1, new DateOnly(2026, 1, 6) };
+        yield return new object[] { new DateOnly(2026, 1, 5), -1, new DateOnly(2026, 1, 2) };
+        yield return new object[] { new DateOnly(2026, 1, 5), 5, new DateOnly(2026, 1, 12) };
+        yield return new object[] { new DateOnly(2026, 1, 12), -5, new DateOnly(2026, 1, 5) };
+    }
+
+    /// <summary>
+    /// Provides inclusive ranges and their expected working-day counts under the default Saturday/Sunday weekend definition.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateOnly start, DateOnly end, int expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> WorkingDaysBetweenRangeTestData()
+    {
+        yield return new object[] { new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 5), 1 };
+        yield return new object[] { new DateOnly(2026, 1, 10), new DateOnly(2026, 1, 10), 0 };
+        yield return new object[] { new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 11), 5 };
+        yield return new object[] { new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 18), 10 };
+        yield return new object[] { new DateOnly(2026, 1, 11), new DateOnly(2026, 1, 5), 5 };
+    }
+
+    /// <summary>
+    /// Provides territory-scoping samples that assert a non-working rule fires only when the requested territory matches.
+    /// </summary>
+    /// <returns>A sequence of <c>(string ruleTerritory, string queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
+    public static IEnumerable<object[]> TerritoryForwardingTestData()
+    {
+        yield return new object[] { "AU", "AU", true };
+        yield return new object[] { "AU", "AU-NSW", true };
+        yield return new object[] { "AU-NSW", "AU-NSW", true };
+        yield return new object[] { "AU-NSW", "AU-VIC", false };
+        yield return new object[] { "AU", "NZ", false };
+        yield return new object[] { "AU", null!, false };
+    }
+
+    /// <summary>
+    /// Builds a service whose only rule is a single-day non-working rule on 7 April 2026 (a Tuesday) and returns it.
+    /// </summary>
+    /// <param name="territory">An optional territory to scope the rule to.</param>
+    /// <returns>A configured <see cref="NotableDateService" /> instance.</returns>
+    private static NotableDateService BuildHolidayService(string? territory = null) =>
+        BuildService(Fixed("Holiday", 4, 7, nonWorking: true, territory: territory));
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.AddWorkingDays.cs
@@ -96,4 +96,34 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 6).AddWorkingDays(service: null!, days: 1);
         });
     }
+
+    /// <summary>
+    /// Verifies that signed-day arithmetic produces the expected working-day result across positive, negative and zero values.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(AddWorkingDaysSignedTestData), DynamicDataSourceType.Method)]
+    public void AddWorkingDays_WhenSignedDaysSupplied_ShouldReturnExpectedWorkingDay(DateOnly input, int days, DateOnly expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateOnly actual = input.AddWorkingDays(service, days);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that adding working days that would overrun <see cref="DateOnly.MaxValue" /> or underrun
+    /// <see cref="DateOnly.MinValue" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(AddWorkingDaysOverflowTestData), DynamicDataSourceType.Method)]
+    public void AddWorkingDays_WhenApplyingDaysWouldOverrunRange_ShouldThrowArgumentOutOfRangeException(DateOnly input, int days)
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = input.AddWorkingDays(service, days);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
@@ -37,4 +37,18 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 5).EnumerateNonWorkingDays(new DateOnly(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields an ascending sequence equal to the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNonWorkingDays_WhenBoundariesReversed_ShouldYieldAscendingSequence()
+    {
+        NotableDateService service = BuildService();
+
+        DateOnly[] forward = new DateOnly(2026, 1, 5).EnumerateNonWorkingDays(new DateOnly(2026, 1, 11), service).ToArray();
+        DateOnly[] reversed = new DateOnly(2026, 1, 11).EnumerateNonWorkingDays(new DateOnly(2026, 1, 5), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
@@ -51,4 +51,18 @@ public partial class NotableDateOnlyExtensionsTests
 
         CollectionAssert.AreEqual(forward, reversed);
     }
+
+    /// <summary>
+    /// Verifies that a single-day range yields one non-working day for weekends and zero for weekdays.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(SingleDayNonWorkingYieldTestData), DynamicDataSourceType.Method)]
+    public void EnumerateNonWorkingDays_WhenSingleDayRange_ShouldYieldExpectedCount(DateOnly day, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = day.EnumerateNonWorkingDays(day, service).Count();
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNonWorkingDays.cs
@@ -65,4 +65,19 @@ public partial class NotableDateOnlyExtensionsTests
 
         Assert.AreEqual(expected, actual);
     }
+
+    /// <summary>
+    /// Verifies that a non-working rule day inside the range is included.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNonWorkingDays_WhenNonWorkingRuleDayInRange_ShouldIncludeIt()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 1, 7, nonWorking: true));
+
+        DateOnly[] result = new DateOnly(2026, 1, 5).EnumerateNonWorkingDays(new DateOnly(2026, 1, 11), service).ToArray();
+
+        CollectionAssert.AreEqual(
+            new[] { new DateOnly(2026, 1, 7), new DateOnly(2026, 1, 10), new DateOnly(2026, 1, 11) },
+            result);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNotableDates.cs
@@ -71,4 +71,16 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).EnumerateNotableDates(new DateOnly(2026, 12, 31), service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNotableDates_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).EnumerateNotableDates(new DateOnly(2026, 12, 31), filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateNotableDates.cs
@@ -83,4 +83,20 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).EnumerateNotableDates(new DateOnly(2026, 12, 31), filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields the same notable-date sequence as the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNotableDates_WhenBoundariesReversed_ShouldYieldSameSequence()
+    {
+        NotableDateService service = BuildService(
+            Fixed("New Year's Day", 1, 1),
+            Fixed("Christmas Day", 12, 25));
+
+        NotableDate[] forward = new DateOnly(2026, 1, 1).EnumerateNotableDates(new DateOnly(2026, 12, 31), service).ToArray();
+        NotableDate[] reversed = new DateOnly(2026, 12, 31).EnumerateNotableDates(new DateOnly(2026, 1, 1), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
@@ -65,4 +65,19 @@ public partial class NotableDateOnlyExtensionsTests
 
         Assert.AreEqual(expected, actual);
     }
+
+    /// <summary>
+    /// Verifies that a non-working rule day inside the range is skipped.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateWorkingDays_WhenNonWorkingRuleDayInRange_ShouldSkipIt()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 1, 7, nonWorking: true));
+
+        DateOnly[] result = new DateOnly(2026, 1, 5).EnumerateWorkingDays(new DateOnly(2026, 1, 9), service).ToArray();
+
+        CollectionAssert.AreEqual(
+            new[] { new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 6), new DateOnly(2026, 1, 8), new DateOnly(2026, 1, 9) },
+            result);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
@@ -37,4 +37,18 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 5).EnumerateWorkingDays(new DateOnly(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields an ascending sequence equal to the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateWorkingDays_WhenBoundariesReversed_ShouldYieldAscendingSequence()
+    {
+        NotableDateService service = BuildService();
+
+        DateOnly[] forward = new DateOnly(2026, 1, 5).EnumerateWorkingDays(new DateOnly(2026, 1, 11), service).ToArray();
+        DateOnly[] reversed = new DateOnly(2026, 1, 11).EnumerateWorkingDays(new DateOnly(2026, 1, 5), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.EnumerateWorkingDays.cs
@@ -51,4 +51,18 @@ public partial class NotableDateOnlyExtensionsTests
 
         CollectionAssert.AreEqual(forward, reversed);
     }
+
+    /// <summary>
+    /// Verifies that a single-day range yields one working day for weekdays and zero for weekends.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(SingleDayWorkingYieldTestData), DynamicDataSourceType.Method)]
+    public void EnumerateWorkingDays_WhenSingleDayRange_ShouldYieldExpectedCount(DateOnly day, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = day.EnumerateWorkingDays(day, service).Count();
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDates.cs
@@ -50,4 +50,30 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDates(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDates(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDates(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDates.cs
@@ -76,4 +76,39 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDates(filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that a filter restricts the returned set to matching notable dates only.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenFilterApplied_ShouldReturnOnlyMatching()
+    {
+        NotableDateService service = BuildService(Fixed("Christmas Day", 12, 25, NotableDateCategory.Holiday));
+        NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Cultural);
+
+        IReadOnlyList<NotableDate> result = new DateOnly(2026, 12, 25).GetNotableDates(service, filter);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the ambient-service overload routes through <see cref="NotableDateContext.Default" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenUsingAmbientService_ShouldDelegateToDefaultContext()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 1, 1));
+        try
+        {
+            NotableDateContext.Default = service;
+
+            IReadOnlyList<NotableDate> result = new DateOnly(2026, 1, 1).GetNotableDates();
+
+            Assert.AreEqual(1, result.Count);
+        }
+        finally
+        {
+            NotableDateContext.Reset();
+        }
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInMonth.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInMonth.cs
@@ -38,4 +38,30 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDatesInMonth(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDatesInMonth(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDatesInMonth(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInMonth.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInMonth.cs
@@ -64,4 +64,36 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDatesInMonth(filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that a multi-day span anchored in the previous month is returned when its days extend into the queried month.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenSpanCrossesMonthBoundary_ShouldIncludeSpan()
+    {
+        NotableDateRule rule = Fixed("Festival", 1, 30) with { DurationDays = 5 };
+        NotableDateService service = BuildService(rule);
+
+        IReadOnlyList<NotableDate> result = new DateOnly(2026, 2, 15).GetNotableDatesInMonth(service);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("Festival", result[0].Name);
+    }
+
+    /// <summary>
+    /// Verifies that a filter restricts the returned set to matching notable dates only.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenFilterApplied_ShouldReturnOnlyMatching()
+    {
+        NotableDateService service = BuildService(
+            Fixed("Festival", 4, 1, NotableDateCategory.Cultural),
+            Fixed("Anzac Day", 4, 25, NotableDateCategory.Holiday));
+        NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+        IReadOnlyList<NotableDate> result = new DateOnly(2026, 4, 15).GetNotableDatesInMonth(service, filter);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("Anzac Day", result[0].Name);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInYear.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInYear.cs
@@ -62,4 +62,21 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDatesInYear(filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that a filter restricts the returned set to matching notable dates only.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInYear_WhenFilterApplied_ShouldReturnOnlyMatching()
+    {
+        NotableDateService service = BuildService(
+            Fixed("Festival", 4, 1, NotableDateCategory.Cultural),
+            Fixed("Christmas Day", 12, 25, NotableDateCategory.Holiday));
+        NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+        IReadOnlyList<NotableDate> result = new DateOnly(2026, 1, 1).GetNotableDatesInYear(service, filter);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("Christmas Day", result[0].Name);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInYear.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.GetNotableDatesInYear.cs
@@ -36,4 +36,30 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).GetNotableDatesInYear(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInYear_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDatesInYear(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInYear_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).GetNotableDatesInYear(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.IsNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.IsNonWorkingDay.cs
@@ -81,4 +81,19 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 6).IsNonWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the non-working classification across every day of a single calendar week under the default Saturday/Sunday weekend
+    /// definition.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDayClassificationTestData), DynamicDataSourceType.Method)]
+    public void IsNonWorkingDay_WhenScannedAcrossWeek_ShouldReturnInverseOfWorkingClassification(DateOnly input, bool expectedWorking)
+    {
+        NotableDateService service = BuildService();
+
+        bool actual = input.IsNonWorkingDay(service);
+
+        Assert.AreEqual(!expectedWorking, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.IsWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.IsWorkingDay.cs
@@ -81,4 +81,32 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 6).IsWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the working-day classification across every day of a single calendar week under the default Saturday/Sunday weekend
+    /// definition.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDayClassificationTestData), DynamicDataSourceType.Method)]
+    public void IsWorkingDay_WhenScannedAcrossWeek_ShouldReturnExpectedClassification(DateOnly input, bool expected)
+    {
+        NotableDateService service = BuildService();
+
+        bool actual = input.IsWorkingDay(service);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that a weekday matching a notable but working rule (a cultural observance) remains a working day.
+    /// </summary>
+    [TestMethod]
+    public void IsWorkingDay_WhenWeekdayMatchesWorkingRule_ShouldReturnTrue()
+    {
+        NotableDateService service = BuildService(Fixed("Cultural Day", 6, 5, NotableDateCategory.Cultural, nonWorking: false));
+
+        bool result = new DateOnly(2026, 6, 5).IsWorkingDay(service);
+
+        Assert.IsTrue(result);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.NextNotableDate.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.NextNotableDate.cs
@@ -106,4 +106,59 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).NextNotableDate(service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that an input matching a rule's anchor is treated as <i>not</i> next; the following occurrence is returned instead.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenInputMatchesAnchor_ShouldReturnFollowingOccurrence()
+    {
+        NotableDateService service = BuildService(Fixed("New Year's Day", 1, 1));
+
+        NotableDate? result = new DateOnly(2026, 1, 1).NextNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(new DateTime(2027, 1, 1), result.Date);
+    }
+
+    /// <summary>
+    /// Verifies that, with no rules configured, the search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenNoRulesConfigured_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService();
+
+        NotableDate? result = new DateOnly(2026, 1, 1).NextNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that an input lying inside a multi-day span is treated as past the span's anchor; the search advances to the next
+    /// distinct rule's occurrence.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenInputLiesInsideMultiDaySpan_ShouldAdvancePastSpan()
+    {
+        NotableDateRule festival = Fixed("Festival", 6, 1) with { DurationDays = 5 };
+        NotableDateService service = BuildService(festival, Fixed("Holiday", 8, 15));
+
+        NotableDate? result = new DateOnly(2026, 6, 3).NextNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("Holiday", result.Name);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).NextNotableDate(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.NextWorkingDay.cs
@@ -123,4 +123,19 @@ public partial class NotableDateOnlyExtensionsTests
             _ = DateOnly.MaxValue.NextWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies the result of advancing by the supplied <c>count</c> across a representative spread of single-step, multi-step,
+    /// weekend-bridging and weekend-input cases using an empty rule set.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(NextWorkingDayCountTestData), DynamicDataSourceType.Method)]
+    public void NextWorkingDay_WhenAdvancingCount_ShouldReturnExpectedDate(DateOnly start, int count, DateOnly expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateOnly actual = start.NextWorkingDay(service, count: count);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.PreviousNotableDate.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.PreviousNotableDate.cs
@@ -107,4 +107,59 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 1).PreviousNotableDate(service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that an input matching a rule's anchor is treated as <i>not</i> previous; the prior occurrence is returned instead.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenInputMatchesAnchor_ShouldReturnPriorOccurrence()
+    {
+        NotableDateService service = BuildService(Fixed("New Year's Day", 1, 1));
+
+        NotableDate? result = new DateOnly(2026, 1, 1).PreviousNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(new DateTime(2025, 1, 1), result.Date);
+    }
+
+    /// <summary>
+    /// Verifies that, with no rules configured, the search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenNoRulesConfigured_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService();
+
+        NotableDate? result = new DateOnly(2026, 1, 1).PreviousNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that an input lying inside a multi-day span is treated as after the span's anchor; the search returns the same span.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenInputLiesInsideMultiDaySpan_ShouldReturnSpan()
+    {
+        NotableDateRule festival = Fixed("Festival", 6, 1) with { DurationDays = 5 };
+        NotableDateService service = BuildService(festival);
+
+        NotableDate? result = new DateOnly(2026, 6, 3).PreviousNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("Festival", result.Name);
+        Assert.AreEqual(new DateTime(2026, 6, 1), result.Date);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateOnly(2026, 1, 1).PreviousNotableDate(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.PreviousWorkingDay.cs
@@ -123,4 +123,19 @@ public partial class NotableDateOnlyExtensionsTests
             _ = DateOnly.MinValue.PreviousWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies the result of retreating by the supplied <c>count</c> across a representative spread of single-step, multi-step,
+    /// weekend-bridging and weekend-input cases using an empty rule set.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(PreviousWorkingDayCountTestData), DynamicDataSourceType.Method)]
+    public void PreviousWorkingDay_WhenRetreatingCount_ShouldReturnExpectedDate(DateOnly start, int count, DateOnly expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateOnly actual = start.PreviousWorkingDay(service, count: count);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.SnapToWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.SnapToWorkingDay.cs
@@ -69,4 +69,17 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 3).SnapToWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that a non-working rule day snaps forward to the next working day.
+    /// </summary>
+    [TestMethod]
+    public void SnapToWorkingDay_WhenInputIsHoliday_ShouldSnapToNextWorkingDay()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 1, 6, nonWorking: true));
+
+        DateOnly result = new DateOnly(2026, 1, 6).SnapToWorkingDay(service);
+
+        Assert.AreEqual(new DateOnly(2026, 1, 7), result);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.TerritoryForwarding.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.TerritoryForwarding.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateOnlyExtensionsTests.TerritoryForwarding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public partial class NotableDateOnlyExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.IsNonWorkingDay(DateOnly, INotableDateService, string?, Type?)" /> forwards
+    /// the supplied <c>territoryCode</c> to the service and observes bidirectional territory containment.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void IsNonWorkingDay_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expected)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        bool actual = new DateOnly(2026, 4, 7).IsNonWorkingDay(service, territoryCode: queryTerritory);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.NextWorkingDay(DateOnly, INotableDateService, int, string?, Type?)" />
+    /// skips the holiday only when the query territory is in scope; otherwise the holiday is treated as a working day.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void NextWorkingDay_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expectedSkipsHoliday)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        DateOnly actual = new DateOnly(2026, 4, 6).NextWorkingDay(service, count: 1, territoryCode: queryTerritory);
+
+        DateOnly expected = expectedSkipsHoliday ? new DateOnly(2026, 4, 8) : new DateOnly(2026, 4, 7);
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.WorkingDaysBetween(DateOnly, DateOnly, INotableDateService, string?, Type?)" />
+    /// forwards the territory and excludes the holiday only when the query is in scope.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void WorkingDaysBetween_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expectedExcludesHoliday)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        int actual = new DateOnly(2026, 4, 6).WorkingDaysBetween(new DateOnly(2026, 4, 10), service, territoryCode: queryTerritory);
+
+        int expected = expectedExcludesHoliday ? 4 : 5;
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.WorkingDaysBetween.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateOnlyExtensionsTests.WorkingDaysBetween.cs
@@ -82,4 +82,18 @@ public partial class NotableDateOnlyExtensionsTests
             _ = new DateOnly(2026, 1, 5).WorkingDaysBetween(new DateOnly(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the count returned across a representative spread of single-day, full-week, multi-week and reversed-boundary inputs.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDaysBetweenRangeTestData), DynamicDataSourceType.Method)]
+    public void WorkingDaysBetween_WhenScannedAcrossRanges_ShouldReturnExpectedCount(DateOnly start, DateOnly end, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = start.WorkingDaysBetween(end, service);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
@@ -122,4 +122,29 @@ public partial class NotableDateTimeExtensionsTests
         yield return new object[] { DateTime.MaxValue.AddDays(-1), 5 };  // multi-step positive overflow
         yield return new object[] { DateTime.MinValue.AddDays(1), -5 };  // multi-step negative overflow
     }
+
+    /// <summary>
+    /// Provides single-day range inputs paired with their expected working-day yield count.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime day, int expectedWorkingYieldCount)</c> tuples.</returns>
+    public static IEnumerable<object[]> SingleDayWorkingYieldTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), 1 };  // Monday
+        yield return new object[] { new DateTime(2026, 1, 6), 1 };  // Tuesday
+        yield return new object[] { new DateTime(2026, 1, 9), 1 };  // Friday
+        yield return new object[] { new DateTime(2026, 1, 10), 0 }; // Saturday
+        yield return new object[] { new DateTime(2026, 1, 11), 0 }; // Sunday
+    }
+
+    /// <summary>
+    /// Provides single-day range inputs paired with their expected non-working-day yield count.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime day, int expectedNonWorkingYieldCount)</c> tuples.</returns>
+    public static IEnumerable<object[]> SingleDayNonWorkingYieldTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), 0 };  // Monday
+        yield return new object[] { new DateTime(2026, 1, 9), 0 };  // Friday
+        yield return new object[] { new DateTime(2026, 1, 10), 1 }; // Saturday
+        yield return new object[] { new DateTime(2026, 1, 11), 1 }; // Sunday
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeExtensionsTests.!TestData.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public partial class NotableDateTimeExtensionsTests
+{
+    /// <summary>
+    /// Provides day-of-week samples spanning a single calendar week in 2026 paired with their working-day classification under the
+    /// default Saturday/Sunday weekend definition.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime input, bool isWorkingDay)</c> tuples.</returns>
+    public static IEnumerable<object[]> WorkingDayClassificationTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), true };   // Monday
+        yield return new object[] { new DateTime(2026, 1, 6), true };   // Tuesday
+        yield return new object[] { new DateTime(2026, 1, 7), true };   // Wednesday
+        yield return new object[] { new DateTime(2026, 1, 8), true };   // Thursday
+        yield return new object[] { new DateTime(2026, 1, 9), true };   // Friday
+        yield return new object[] { new DateTime(2026, 1, 10), false }; // Saturday
+        yield return new object[] { new DateTime(2026, 1, 11), false }; // Sunday
+    }
+
+    /// <summary>
+    /// Provides start-of-week, count and expected next-working-day samples for an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime start, int count, DateTime expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> NextWorkingDayCountTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), 1, new DateTime(2026, 1, 6) };  // Mon → Tue
+        yield return new object[] { new DateTime(2026, 1, 5), 2, new DateTime(2026, 1, 7) };  // Mon → Wed
+        yield return new object[] { new DateTime(2026, 1, 5), 5, new DateTime(2026, 1, 12) }; // Mon → next Mon (skipping weekend)
+        yield return new object[] { new DateTime(2026, 1, 9), 1, new DateTime(2026, 1, 12) }; // Fri → Mon
+        yield return new object[] { new DateTime(2026, 1, 10), 1, new DateTime(2026, 1, 12) };// Sat → Mon
+    }
+
+    /// <summary>
+    /// Provides start-of-week, count and expected previous-working-day samples for an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime start, int count, DateTime expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> PreviousWorkingDayCountTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 9), 1, new DateTime(2026, 1, 8) };  // Fri → Thu
+        yield return new object[] { new DateTime(2026, 1, 9), 5, new DateTime(2026, 1, 2) };  // Fri → previous Fri
+        yield return new object[] { new DateTime(2026, 1, 12), 1, new DateTime(2026, 1, 9) }; // Mon → previous Fri
+        yield return new object[] { new DateTime(2026, 1, 11), 1, new DateTime(2026, 1, 9) }; // Sun → Fri
+    }
+
+    /// <summary>
+    /// Provides signed-days samples for <c>AddWorkingDays</c> against an empty rule set.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime input, int days, DateTime expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> AddWorkingDaysSignedTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), 0, new DateTime(2026, 1, 5) };  // Zero
+        yield return new object[] { new DateTime(2026, 1, 5), 1, new DateTime(2026, 1, 6) };  // +1
+        yield return new object[] { new DateTime(2026, 1, 5), -1, new DateTime(2026, 1, 2) }; // -1 across weekend
+        yield return new object[] { new DateTime(2026, 1, 5), 5, new DateTime(2026, 1, 12) }; // +5 spans weekend
+        yield return new object[] { new DateTime(2026, 1, 12), -5, new DateTime(2026, 1, 5) };// -5 spans weekend
+    }
+
+    /// <summary>
+    /// Provides inclusive ranges and their expected working-day counts under the default Saturday/Sunday weekend definition.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime start, DateTime end, int expected)</c> tuples.</returns>
+    public static IEnumerable<object[]> WorkingDaysBetweenRangeTestData()
+    {
+        yield return new object[] { new DateTime(2026, 1, 5), new DateTime(2026, 1, 5), 1 };   // Single working day
+        yield return new object[] { new DateTime(2026, 1, 10), new DateTime(2026, 1, 10), 0 }; // Single non-working day
+        yield return new object[] { new DateTime(2026, 1, 5), new DateTime(2026, 1, 11), 5 };  // Full week
+        yield return new object[] { new DateTime(2026, 1, 5), new DateTime(2026, 1, 18), 10 }; // Two weeks
+        yield return new object[] { new DateTime(2026, 1, 11), new DateTime(2026, 1, 5), 5 };  // Reversed boundaries
+    }
+
+    /// <summary>
+    /// Provides <see cref="DateTimeKind" /> values for tests that assert kind preservation across walk and snap operations.
+    /// </summary>
+    /// <returns>A sequence of single-element <c>(DateTimeKind)</c> tuples.</returns>
+    public static IEnumerable<object[]> DateTimeKindPreservationTestData()
+    {
+        yield return new object[] { DateTimeKind.Unspecified };
+        yield return new object[] { DateTimeKind.Utc };
+        yield return new object[] { DateTimeKind.Local };
+    }
+
+    /// <summary>
+    /// Provides territory-scoping samples that assert a non-working rule fires only when the requested territory matches.
+    /// </summary>
+    /// <returns>A sequence of <c>(string ruleTerritory, string queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
+    public static IEnumerable<object[]> TerritoryForwardingTestData()
+    {
+        yield return new object[] { "AU", "AU", true };
+        yield return new object[] { "AU", "AU-NSW", true };
+        yield return new object[] { "AU-NSW", "AU-NSW", true };
+        yield return new object[] { "AU-NSW", "AU-VIC", false };
+        yield return new object[] { "AU", "NZ", false };
+        yield return new object[] { "AU", null!, false };
+    }
+
+    /// <summary>
+    /// Builds a service whose only rule is a single-day non-working rule on 7 April 2026 (a Tuesday) and returns it.
+    /// </summary>
+    /// <param name="territory">An optional territory to scope the rule to.</param>
+    /// <returns>A configured <see cref="NotableDateService" /> instance.</returns>
+    private static NotableDateService BuildHolidayService(string? territory = null) =>
+        BuildService(Fixed("Holiday", 4, 7, nonWorking: true, territory: territory));
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
@@ -109,4 +109,17 @@ public partial class NotableDateTimeExtensionsTests
     /// <returns>A configured <see cref="NotableDateService" /> instance.</returns>
     private static NotableDateService BuildHolidayService(string? territory = null) =>
         BuildService(Fixed("Holiday", 4, 7, nonWorking: true, territory: territory));
+
+    /// <summary>
+    /// Provides boundary inputs that should throw <see cref="ArgumentOutOfRangeException" /> when adding working days would overrun
+    /// the <see cref="DateTime" /> range.
+    /// </summary>
+    /// <returns>A sequence of <c>(DateTime input, int days)</c> tuples, each one expected to throw.</returns>
+    public static IEnumerable<object[]> AddWorkingDaysOverflowTestData()
+    {
+        yield return new object[] { DateTime.MaxValue, 1 };   // positive overflow past MaxValue
+        yield return new object[] { DateTime.MinValue, -1 };  // negative overflow past MinValue
+        yield return new object[] { DateTime.MaxValue.AddDays(-1), 5 };  // multi-step positive overflow
+        yield return new object[] { DateTime.MinValue.AddDays(1), -5 };  // multi-step negative overflow
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.!TestData.cs
@@ -89,17 +89,19 @@ public partial class NotableDateTimeExtensionsTests
     }
 
     /// <summary>
-    /// Provides territory-scoping samples that assert a non-working rule fires only when the requested territory matches.
+    /// Provides territory-scoping samples expressing bidirectional containment: a query matches a rule when either side's
+    /// territory contains the other, and a <see langword="null" /> query matches any rule.
     /// </summary>
-    /// <returns>A sequence of <c>(string ruleTerritory, string queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
+    /// <returns>A sequence of <c>(string ruleTerritory, string? queryTerritory, bool expectedNonWorking)</c> tuples.</returns>
     public static IEnumerable<object[]> TerritoryForwardingTestData()
     {
-        yield return new object[] { "AU", "AU", true };
-        yield return new object[] { "AU", "AU-NSW", true };
-        yield return new object[] { "AU-NSW", "AU-NSW", true };
-        yield return new object[] { "AU-NSW", "AU-VIC", false };
-        yield return new object[] { "AU", "NZ", false };
-        yield return new object[] { "AU", null!, false };
+        yield return new object[] { "AU", "AU", true };           // Same scope
+        yield return new object[] { "AU", "AU-NSW", true };       // Rule scope contains query scope
+        yield return new object[] { "AU-NSW", "AU", true };       // Query scope contains rule scope
+        yield return new object[] { "AU-NSW", "AU-NSW", true };   // Same subdivision
+        yield return new object[] { "AU-NSW", "AU-VIC", false };  // Sibling subdivisions
+        yield return new object[] { "AU", "NZ", false };          // Unrelated countries
+        yield return new object[] { "AU", null!, true };          // Null query bypasses scope filter
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.AddWorkingDays.cs
@@ -97,4 +97,34 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 6).AddWorkingDays(service: null!, days: 1);
         });
     }
+
+    /// <summary>
+    /// Verifies that signed-day arithmetic produces the expected working-day result across positive, negative and zero values.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(AddWorkingDaysSignedTestData), DynamicDataSourceType.Method)]
+    public void AddWorkingDays_WhenSignedDaysSupplied_ShouldReturnExpectedWorkingDay(DateTime input, int days, DateTime expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateTime actual = input.AddWorkingDays(service, days);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that adding working days that would overrun <see cref="DateTime.MaxValue" /> or underrun
+    /// <see cref="DateTime.MinValue" /> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(AddWorkingDaysOverflowTestData), DynamicDataSourceType.Method)]
+    public void AddWorkingDays_WhenApplyingDaysWouldOverrunRange_ShouldThrowArgumentOutOfRangeException(DateTime input, int days)
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = input.AddWorkingDays(service, days);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.AddWorkingDays.cs
@@ -127,4 +127,27 @@ public partial class NotableDateTimeExtensionsTests
             _ = input.AddWorkingDays(service, days);
         });
     }
+
+    /// <summary>
+    /// Verifies that the returned <see cref="DateTime" /> preserves the input <see cref="DateTime.Kind" /> and time-of-day across each
+    /// supported <see cref="DateTimeKind" /> value, including for the zero-days short-circuit and the directional walk paths.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void AddWorkingDays_WhenCalled_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 6, 11, 22, 33, kind);
+
+        DateTime forward = input.AddWorkingDays(service, days: 2);
+        DateTime backward = input.AddWorkingDays(service, days: -2);
+        DateTime same = input.AddWorkingDays(service, days: 0);
+
+        Assert.AreEqual(kind, forward.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), forward.TimeOfDay);
+        Assert.AreEqual(kind, backward.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), backward.TimeOfDay);
+        Assert.AreEqual(kind, same.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), same.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNonWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNonWorkingDays.cs
@@ -66,4 +66,18 @@ public partial class NotableDateTimeExtensionsTests
 
         CollectionAssert.AreEqual(forward, reversed);
     }
+
+    /// <summary>
+    /// Verifies that a single-day range yields one non-working day for weekends and zero for weekdays.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(SingleDayNonWorkingYieldTestData), DynamicDataSourceType.Method)]
+    public void EnumerateNonWorkingDays_WhenSingleDayRange_ShouldYieldExpectedCount(DateTime day, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = day.EnumerateNonWorkingDays(day, service).Count();
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNonWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNonWorkingDays.cs
@@ -52,4 +52,18 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 5).EnumerateNonWorkingDays(new DateTime(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields an ascending sequence equal to the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNonWorkingDays_WhenBoundariesReversed_ShouldYieldAscendingSequence()
+    {
+        NotableDateService service = BuildService();
+
+        DateTime[] forward = new DateTime(2026, 1, 5).EnumerateNonWorkingDays(new DateTime(2026, 1, 11), service).ToArray();
+        DateTime[] reversed = new DateTime(2026, 1, 11).EnumerateNonWorkingDays(new DateTime(2026, 1, 5), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNotableDates.cs
@@ -83,4 +83,20 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).EnumerateNotableDates(new DateTime(2026, 12, 31), filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields the same notable-date sequence as the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNotableDates_WhenBoundariesReversed_ShouldYieldSameSequence()
+    {
+        NotableDateService service = BuildService(
+            Fixed("New Year's Day", 1, 1),
+            Fixed("Christmas Day", 12, 25));
+
+        NotableDate[] forward = new DateTime(2026, 1, 1).EnumerateNotableDates(new DateTime(2026, 12, 31), service).ToArray();
+        NotableDate[] reversed = new DateTime(2026, 12, 31).EnumerateNotableDates(new DateTime(2026, 1, 1), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateNotableDates.cs
@@ -71,4 +71,16 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).EnumerateNotableDates(new DateTime(2026, 12, 31), service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateNotableDates_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).EnumerateNotableDates(new DateTime(2026, 12, 31), filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateWorkingDays.cs
@@ -66,4 +66,18 @@ public partial class NotableDateTimeExtensionsTests
 
         CollectionAssert.AreEqual(forward, reversed);
     }
+
+    /// <summary>
+    /// Verifies that a single-day range yields one working day for weekdays and zero for weekends.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(SingleDayWorkingYieldTestData), DynamicDataSourceType.Method)]
+    public void EnumerateWorkingDays_WhenSingleDayRange_ShouldYieldExpectedCount(DateTime day, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = day.EnumerateWorkingDays(day, service).Count();
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.EnumerateWorkingDays.cs
@@ -52,4 +52,18 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 5).EnumerateWorkingDays(new DateTime(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that swapping the start and end boundaries still yields an ascending sequence equal to the in-order range.
+    /// </summary>
+    [TestMethod]
+    public void EnumerateWorkingDays_WhenBoundariesReversed_ShouldYieldAscendingSequence()
+    {
+        NotableDateService service = BuildService();
+
+        DateTime[] forward = new DateTime(2026, 1, 5).EnumerateWorkingDays(new DateTime(2026, 1, 11), service).ToArray();
+        DateTime[] reversed = new DateTime(2026, 1, 11).EnumerateWorkingDays(new DateTime(2026, 1, 5), service).ToArray();
+
+        CollectionAssert.AreEqual(forward, reversed);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDates.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDates.cs
@@ -85,4 +85,30 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).GetNotableDates(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDates(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDates(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDatesInMonth.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDatesInMonth.cs
@@ -53,4 +53,30 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).GetNotableDatesInMonth(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDatesInMonth(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInMonth_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDatesInMonth(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDatesInYear.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.GetNotableDatesInYear.cs
@@ -55,4 +55,30 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).GetNotableDatesInYear(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the explicit-service overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInYear_WhenExplicitFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        NotableDateService service = BuildService();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDatesInYear(service, filter: null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDatesInYear_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).GetNotableDatesInYear(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.IsNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.IsNonWorkingDay.cs
@@ -81,4 +81,19 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 6).IsNonWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the non-working classification across every day of a single calendar week under the default Saturday/Sunday weekend
+    /// definition.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDayClassificationTestData), DynamicDataSourceType.Method)]
+    public void IsNonWorkingDay_WhenScannedAcrossWeek_ShouldReturnInverseOfWorkingClassification(DateTime input, bool expectedWorking)
+    {
+        NotableDateService service = BuildService();
+
+        bool actual = input.IsNonWorkingDay(service);
+
+        Assert.AreEqual(!expectedWorking, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.IsWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.IsWorkingDay.cs
@@ -120,4 +120,19 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 6).IsWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the working-day classification across every day of a single calendar week under the default Saturday/Sunday weekend
+    /// definition.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDayClassificationTestData), DynamicDataSourceType.Method)]
+    public void IsWorkingDay_WhenScannedAcrossWeek_ShouldReturnExpectedClassification(DateTime input, bool expected)
+    {
+        NotableDateService service = BuildService();
+
+        bool actual = input.IsWorkingDay(service);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextNonWorkingDay.cs
@@ -125,4 +125,21 @@ public partial class NotableDateTimeExtensionsTests
             _ = DateTime.MaxValue.NextNonWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies that the returned <see cref="DateTime" /> preserves the input <see cref="DateTime.Kind" /> and time-of-day across each
+    /// supported <see cref="DateTimeKind" /> value.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void NextNonWorkingDay_WhenCalled_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 6, 11, 22, 33, kind);
+
+        DateTime result = input.NextNonWorkingDay(service);
+
+        Assert.AreEqual(kind, result.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), result.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextNotableDate.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextNotableDate.cs
@@ -120,4 +120,74 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).NextNotableDate(service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that, with no rules configured, the search returns <see langword="null" /> rather than entering an unbounded scan.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenNoRulesConfigured_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService();
+
+        NotableDate? result = new DateTime(2026, 1, 1).NextNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that when every configured rule already lies before <paramref name="dateTime" /> in the only resolvable years the
+    /// search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenNoRuleResolvesAfterInput_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 1, 1));
+
+        // Search starts at year 9999; the rule resolves to 9999-01-01 which precedes the input — so no later year produces a hit.
+        NotableDate? result = new DateTime(9999, 6, 15).NextNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that when a filter excludes every rule the search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenFilterExcludesEveryRule_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService(Fixed("Festival", 4, 1, NotableDateCategory.Cultural));
+        NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+        NotableDate? result = new DateTime(9999, 6, 15).NextNotableDate(service, filter);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that an input lying inside a multi-day span is treated as past the span's anchor; the search advances to the next
+    /// distinct rule's occurrence.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenInputLiesInsideMultiDaySpan_ShouldAdvancePastSpan()
+    {
+        NotableDateRule festival = Fixed("Festival", 6, 1) with { DurationDays = 5 };
+        NotableDateService service = BuildService(festival, Fixed("Holiday", 8, 15));
+
+        NotableDate? result = new DateTime(2026, 6, 3).NextNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("Holiday", result.Name);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void NextNotableDate_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).NextNotableDate(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.NextWorkingDay.cs
@@ -152,4 +152,19 @@ public partial class NotableDateTimeExtensionsTests
             _ = DateTime.MaxValue.NextWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies the result of advancing by the supplied <c>count</c> across a representative spread of single-step, multi-step,
+    /// weekend-bridging and weekend-input cases using an empty rule set.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(NextWorkingDayCountTestData), DynamicDataSourceType.Method)]
+    public void NextWorkingDay_WhenAdvancingCount_ShouldReturnExpectedDate(DateTime start, int count, DateTime expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateTime actual = start.NextWorkingDay(service, count: count);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousNonWorkingDay.cs
@@ -124,4 +124,21 @@ public partial class NotableDateTimeExtensionsTests
             _ = DateTime.MinValue.PreviousNonWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies that the returned <see cref="DateTime" /> preserves the input <see cref="DateTime.Kind" /> and time-of-day across each
+    /// supported <see cref="DateTimeKind" /> value.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void PreviousNonWorkingDay_WhenCalled_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 6, 11, 22, 33, kind);
+
+        DateTime result = input.PreviousNonWorkingDay(service);
+
+        Assert.AreEqual(kind, result.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), result.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousNotableDate.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousNotableDate.cs
@@ -121,4 +121,74 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 1).PreviousNotableDate(service, filter: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that, with no rules configured, the search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenNoRulesConfigured_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService();
+
+        NotableDate? result = new DateTime(2026, 1, 1).PreviousNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that when every configured rule resolves after <paramref name="dateTime" /> in the only resolvable years the search
+    /// returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenNoRuleResolvesBeforeInput_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService(Fixed("Holiday", 12, 31));
+
+        // Search starts at year 1; the only rule resolves to 0001-12-31 which is after the input — so no earlier year contains a hit.
+        NotableDate? result = new DateTime(1, 1, 1).PreviousNotableDate(service);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that when a filter excludes every rule the search returns <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenFilterExcludesEveryRule_ShouldReturnNull()
+    {
+        NotableDateService service = BuildService(Fixed("Festival", 4, 1, NotableDateCategory.Cultural));
+        NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.Holiday);
+
+        NotableDate? result = new DateTime(1, 6, 15).PreviousNotableDate(service, filter);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that an input lying inside a multi-day span is treated as after the span's anchor; the search returns the same span.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenInputLiesInsideMultiDaySpan_ShouldReturnSpan()
+    {
+        NotableDateRule festival = Fixed("Festival", 6, 1) with { DurationDays = 5 };
+        NotableDateService service = BuildService(festival);
+
+        NotableDate? result = new DateTime(2026, 6, 3).PreviousNotableDate(service);
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("Festival", result.Name);
+        Assert.AreEqual(new DateTime(2026, 6, 1), result.Date);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a <see langword="null" /> filter to the ambient overload throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void PreviousNotableDate_WhenAmbientFilterIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new DateTime(2026, 1, 1).PreviousNotableDate(filter: null!);
+        });
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.PreviousWorkingDay.cs
@@ -151,4 +151,19 @@ public partial class NotableDateTimeExtensionsTests
             _ = DateTime.MinValue.PreviousWorkingDay(service);
         });
     }
+
+    /// <summary>
+    /// Verifies the result of retreating by the supplied <c>count</c> across a representative spread of single-step, multi-step,
+    /// weekend-bridging and weekend-input cases using an empty rule set.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(PreviousWorkingDayCountTestData), DynamicDataSourceType.Method)]
+    public void PreviousWorkingDay_WhenRetreatingCount_ShouldReturnExpectedDate(DateTime start, int count, DateTime expected)
+    {
+        NotableDateService service = BuildService();
+
+        DateTime actual = start.PreviousWorkingDay(service, count: count);
+
+        Assert.AreEqual(expected, actual);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToNearestWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToNearestWorkingDay.cs
@@ -96,4 +96,21 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 3).SnapToNearestWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that the snap path preserves the input <see cref="DateTime.Kind" /> and time-of-day across each supported
+    /// <see cref="DateTimeKind" /> value, regardless of whether the closest working day lies forward or backward.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void SnapToNearestWorkingDay_WhenSnapped_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 3, 11, 22, 33, kind); // Saturday → snaps backward
+
+        DateTime result = input.SnapToNearestWorkingDay(service);
+
+        Assert.AreEqual(kind, result.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), result.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToWorkingDay.cs
@@ -83,4 +83,21 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 3).SnapToWorkingDay(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that the snap-forward path preserves the input <see cref="DateTime.Kind" /> and time-of-day across each supported
+    /// <see cref="DateTimeKind" /> value.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void SnapToWorkingDay_WhenSnapForward_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 3, 11, 22, 33, kind); // Saturday
+
+        DateTime result = input.SnapToWorkingDay(service);
+
+        Assert.AreEqual(kind, result.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), result.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToWorkingDayBackward.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.SnapToWorkingDayBackward.cs
@@ -69,4 +69,21 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 4).SnapToWorkingDayBackward(service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies that the snap-backward path preserves the input <see cref="DateTime.Kind" /> and time-of-day across each supported
+    /// <see cref="DateTimeKind" /> value.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(DateTimeKindPreservationTestData), DynamicDataSourceType.Method)]
+    public void SnapToWorkingDayBackward_WhenSnapBackward_ShouldPreserveKindAndTimeOfDay(DateTimeKind kind)
+    {
+        NotableDateService service = BuildService();
+        DateTime input = new DateTime(2026, 1, 4, 11, 22, 33, kind); // Sunday
+
+        DateTime result = input.SnapToWorkingDayBackward(service);
+
+        Assert.AreEqual(kind, result.Kind);
+        Assert.AreEqual(new TimeSpan(11, 22, 33), result.TimeOfDay);
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.TerritoryForwarding.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.TerritoryForwarding.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeExtensionsTests.TerritoryForwarding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public partial class NotableDateTimeExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateTimeExtensions.IsNonWorkingDay(DateTime, INotableDateService, string?, Type?)" /> forwards
+    /// the supplied <c>territoryCode</c> to the service and observes bidirectional territory containment.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void IsNonWorkingDay_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expected)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        bool actual = new DateTime(2026, 4, 7).IsNonWorkingDay(service, territoryCode: queryTerritory);
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateTimeExtensions.NextWorkingDay(DateTime, INotableDateService, int, string?, Type?)" />
+    /// skips the holiday only when the query territory is in scope; otherwise the holiday is treated as a working day.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void NextWorkingDay_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expectedSkipsHoliday)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        // 2026-04-06 is Monday. NextWorkingDay should land on Tuesday 2026-04-07 unless a non-working rule applies in scope.
+        DateTime actual = new DateTime(2026, 4, 6).NextWorkingDay(service, count: 1, territoryCode: queryTerritory);
+
+        DateTime expected = expectedSkipsHoliday ? new DateTime(2026, 4, 8) : new DateTime(2026, 4, 7);
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateTimeExtensions.WorkingDaysBetween(DateTime, DateTime, INotableDateService, string?, Type?)" />
+    /// forwards the territory and excludes the holiday only when the query is in scope.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(TerritoryForwardingTestData), DynamicDataSourceType.Method)]
+    public void WorkingDaysBetween_WhenTerritoryForwarded_ShouldHonourBidirectionalContainment(string ruleTerritory, string? queryTerritory, bool expectedExcludesHoliday)
+    {
+        NotableDateService service = BuildHolidayService(ruleTerritory);
+
+        // 2026-04-06..2026-04-10 (Mon..Fri) is normally five working days; the holiday on Tuesday removes one when in scope.
+        int actual = new DateTime(2026, 4, 6).WorkingDaysBetween(new DateTime(2026, 4, 10), service, territoryCode: queryTerritory);
+
+        int expected = expectedExcludesHoliday ? 4 : 5;
+        Assert.AreEqual(expected, actual);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.WorkingDaysBetween.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeExtensionsTests.WorkingDaysBetween.cs
@@ -108,4 +108,18 @@ public partial class NotableDateTimeExtensionsTests
             _ = new DateTime(2026, 1, 5).WorkingDaysBetween(new DateTime(2026, 1, 11), service: null!);
         });
     }
+
+    /// <summary>
+    /// Verifies the count returned across a representative spread of single-day, full-week, multi-week and reversed-boundary inputs.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WorkingDaysBetweenRangeTestData), DynamicDataSourceType.Method)]
+    public void WorkingDaysBetween_WhenScannedAcrossRanges_ShouldReturnExpectedCount(DateTime start, DateTime end, int expected)
+    {
+        NotableDateService service = BuildService();
+
+        int actual = start.WorkingDaysBetween(end, service);
+
+        Assert.AreEqual(expected, actual);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the test-coverage gaps identified in the audit of the NotableDate-aware DateTime/DateOnly extensions added in #159. Adds shared `!TestData.cs` partials so that new tests are data-driven (matching the convention used by `DateTimeExtensionsTests` in `Bodu.Core`), and fills in every documented contract that was not previously asserted.

## What's covered (by batch / commit)

1. **Notable-date walk gaps + test data infrastructure.** New `NotableDate{Time,Only}ExtensionsTests.!TestData.cs` partials provide reusable data sources. Adds: `Next/PreviousNotableDate` returns null when no rules exist, no rule resolves in the searched direction, or a filter excludes every rule; the input-matches-anchor test for the DateOnly suite (DateTime already had it); multi-day span semantics (input inside a span is past the anchor for `Next`, span returned by `Previous`); ambient-overload filter-null tests.
2. **Filter-null exception coverage on the ambient overloads.** `EnumerateNotableDates`, `GetNotableDates`, `GetNotableDatesInYear`, `GetNotableDatesInMonth` (DateTime + DateOnly) now exercise both ambient and explicit-service filter-null paths. Previously only the explicit path was tested.
3. **Boundary handling and range symmetry.** Data-driven `AddWorkingDays_WhenApplyingDaysWouldOverrunRange_ShouldThrowArgumentOutOfRangeException` covers single-step and multi-step overruns past Min/MaxValue. Reversed-boundary tests for `EnumerateWorkingDays`, `EnumerateNonWorkingDays`, `EnumerateNotableDates` mirror the symmetry contract `WorkingDaysBetween` already exercised.
4. **Kind/TimeOfDay preservation.** Data-driven (Unspecified/Utc/Local) coverage for `NextNonWorkingDay`, `PreviousNonWorkingDay`, `AddWorkingDays` (forward, backward and zero-days short-circuit paths), `SnapToWorkingDay`, `SnapToWorkingDayBackward`, `SnapToNearestWorkingDay`.
5. **Single-day range coverage on the Enumerate methods.** Data-driven yield-count tests across Mon..Sun for `EnumerateWorkingDays` and `EnumerateNonWorkingDays`.
6. **Territory forwarding sanity tests.** New `TerritoryForwarding.cs` partials (DateTime + DateOnly) drive `IsNonWorkingDay`, `NextWorkingDay` and `WorkingDaysBetween` through the bidirectional containment rules of the underlying service (a query for `AU` matches an `AU-NSW` rule, a `null` query bypasses scope, sibling subdivisions don't match, etc.).
7. **DateOnly parity catch-up + data-driven sweeps.** Brings DateOnly to parity with DateTime: working-rule case for `IsWorkingDay`, holiday-snap-forward for `SnapToWorkingDay`, holiday-skip/include for the Enumerate methods, filter+ambient routing for `GetNotableDates*`, span-crosses-month for `GetNotableDatesInMonth`. Adds data-driven sweeps (`WorkingDayClassificationTestData`, `Next/PreviousWorkingDayCountTestData`, `WorkingDaysBetweenRangeTestData`) to both suites so a single `[DynamicData]` test exercises multiple inputs.

Total: 38 test files, +1443 / -0 lines. No production-code changes.

## Test plan

- [ ] `dotnet build Bodu.sln` succeeds.
- [ ] `dotnet test Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj --settings test.runsettings` passes.
- [ ] No analyzer warnings introduced.

https://claude.ai/code/session_01UNWXB8aqWskkK51vaJ4kVX