### PR TITLE
Fix infinite recursion in IsWeekday(DayOfWeek) overload

### DIFF
--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsWeekday.cs
@@ -50,9 +50,5 @@ public static partial class DateTimeExtensions
     /// Thrown if <paramref name="weekend"/> is not a defined value of the <see cref="CalendarWeekendDefinition"/> enumeration,
     /// -or- <paramref name="weekend"/> is <see cref="CalendarWeekendDefinition.Custom"/> and <paramref name="provider"/> is <see langword="null"/>.
     /// </exception>
-#pragma warning disable S2190 // Loops and recursions should not be infinite
-
-    public static bool IsWeekday(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekday(dayOfWeek, weekend, provider);
-
-#pragma warning restore S2190 // Loops and recursions should not be infinite
+    public static bool IsWeekday(DayOfWeek dayOfWeek, CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null) => !IsWeekend(dayOfWeek, weekend, provider);
 }

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsWeekday.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsWeekday.cs
@@ -41,4 +41,32 @@ public partial class DateTimeExtensionsTests
         });
     }
 
+    /// <summary>
+    /// Verifies that the static <see cref="DateTimeExtensions.IsWeekday(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// overload returns the dual of <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// without recursing infinitely, regressing the bug fixed in issue #160.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(WeekendTestData), DynamicDataSourceType.Method)]
+    public void IsWeekday_WhenCalledOnDayOfWeek_ShouldReturnNegationOfIsWeekend(DateTime input, CalendarWeekendDefinition weekend, Type? providerType, bool expected)
+    {
+        IWeekendDefinitionProvider? provider = providerType is null ? null : (IWeekendDefinitionProvider)Activator.CreateInstance(providerType)!;
+
+        bool actual = DateTimeExtensions.IsWeekday(input.DayOfWeek, weekend, provider);
+
+        Assert.AreEqual(!expected, actual, $"Failed for {input.DayOfWeek} with weekend {weekend}");
+    }
+
+    /// <summary>
+    /// Verifies that the static <see cref="DateTimeExtensions.IsWeekday(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// overload throws <see cref="ArgumentOutOfRangeException" /> when invoked with <see cref="CalendarWeekendDefinition.Custom" /> and no provider.
+    /// </summary>
+    [TestMethod]
+    public void IsWeekday_WhenCalledOnDayOfWeekWithCustomRuleMissingProvider_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = DateTimeExtensions.IsWeekday(DayOfWeek.Monday, CalendarWeekendDefinition.Custom, null);
+        });
+    }
 }


### PR DESCRIPTION
## Summary
Fixed a critical bug in the `DateTimeExtensions.IsWeekday(DayOfWeek, ...)` overload that was causing infinite recursion by calling itself instead of delegating to `IsWeekend`.

## Changes
- **Fixed infinite recursion**: Changed the implementation from `!IsWeekday(...)` to `!IsWeekend(...)` to properly delegate to the weekend check method
- **Removed pragma suppression**: Eliminated the `S2190` SonarQube pragma that was masking the infinite recursion warning, as the underlying issue is now resolved
- **Added comprehensive tests**: 
  - Test verifying that `IsWeekday` returns the logical negation of `IsWeekend` across all weekend definition types
  - Test ensuring `ArgumentOutOfRangeException` is thrown when using `Custom` weekend definition without a provider

## Implementation Details
The bug was in the static overload that accepts a `DayOfWeek` parameter. It was recursively calling itself instead of calling the corresponding `IsWeekend` overload, which would have caused a stack overflow at runtime. The fix ensures proper delegation to the `IsWeekend` method, maintaining the intended behavior that a day is a weekday if and only if it is not a weekend.

Fixes issue #160.

https://claude.ai/code/session_013AM7JX65YPZPS3ybbHAvRg