### PR TITLE
Fix concurrent generation allocation ordering in stress test

### DIFF
--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests._Stress.cs
@@ -887,6 +887,11 @@ public partial class ConcurrentCircularBufferTests
         int snapshotFaults = 0;
         int snapshotsTaken = 0;
 
+        // Serialises gen-allocation with the enqueue so the stamped gen matches insertion order; without
+        // this, two writers can allocate gen=N,N+1 and lose the tail-CAS race in the opposite order,
+        // leaving the buffer non-monotonic for reasons unrelated to ToArray's snapshot protocol.
+        object writerLock = new object();
+
         int writerThreads = Math.Max(2, Environment.ProcessorCount);
         int readerThreads = 2;
         const int durationMs = 2000;
@@ -898,8 +903,11 @@ public partial class ConcurrentCircularBufferTests
                 startGate.Wait();
                 while (!cts.Token.IsCancellationRequested)
                 {
-                    int gen = Interlocked.Increment(ref generation);
-                    buffer.TryEnqueue(new TestItem(gen));
+                    lock (writerLock)
+                    {
+                        int gen = ++generation;
+                        buffer.TryEnqueue(new TestItem(gen));
+                    }
                 }
             }));
 


### PR DESCRIPTION
## Summary
Fixed a race condition in the `ToArray_WhenUnderConcurrentEvictionPressure_ShouldNeverReturnTornGen` stress test where concurrent writers could allocate generations out of insertion order, causing false test failures unrelated to the actual `ToArray` snapshot protocol being tested.

## Key Changes
- Added a `writerLock` to serialize generation allocation with enqueue operations
- Changed from `Interlocked.Increment` to a simple locked increment (`++generation`)
- Wrapped both generation increment and buffer enqueue in the same lock to ensure atomicity

## Implementation Details
The issue occurred because two writer threads could allocate consecutive generations (N, N+1) but then lose the tail-CAS race in the opposite order, resulting in a non-monotonic buffer state. This was a test infrastructure problem, not a bug in the `ToArray` implementation itself.

By serializing the generation allocation with the enqueue operation under a single lock, we ensure that:
1. The stamped generation matches the actual insertion order
2. The buffer remains monotonic throughout the test
3. Any non-monotonic snapshots returned by `ToArray` are due to actual snapshot protocol issues, not concurrent allocation races

https://claude.ai/code/session_01VaVD3oHajKy5LbpbUf2QRo