### PR TITLE
Resolve Adler-32/Fletcher-32 test vector mismatch (issue #167)

### DIFF
--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32.cs
@@ -22,10 +22,11 @@ public sealed partial class Adler32Tests
             Empty = "00000001",
             Abc = "018D00C7",
 
-            // QuickBrownFox suppressed — tracked by issue #167 (Adler/Fletcher KAT mismatch
-            // observed on PR #166 CI: index 1 expected 0xCD, actual 0xDC). Restore once the
-            // root cause is identified and fixed.
-            // QuickBrownFox = "5BCD0FDA",
+            // Canonical zlib Adler-32 of "The quick brown fox jumps over the lazy dog";
+            // cross-checked against Python `zlib.adler32` (= 0x5BDC0FDA). The previously
+            // suppressed value 0x5BCD0FDA (issue #167) was a nibble-swap typo — the
+            // implementation was correct.
+            QuickBrownFox = "5BDC0FDA",
             Zeros16 = "00100001",
 
             // Long-input regression vectors for issue #127 — the buggy SIMD branch was not

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32C.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.Adler32Tests.32C.cs
@@ -22,10 +22,11 @@ public sealed partial class Adler32CTests
             Empty = "00000001",
             Abc = "018D00C7",
 
-            // QuickBrownFox suppressed — tracked by issue #167 (Adler/Fletcher KAT mismatch
-            // observed on PR #166 CI: index 1 expected 0xCD, actual 0xDC). Restore once the
-            // root cause is identified and fixed.
-            // QuickBrownFox = "5BCD0FDA",
+            // Canonical Adler-32C (modulus 65536) of "The quick brown fox jumps over the
+            // lazy dog", derived from the per-byte recurrence and verified against the
+            // scalar reference implementation. Distinct from canonical Adler-32 because
+            // 89037 mod 65536 = 0x5BCD whereas 89037 mod 65521 = 0x5BDC.
+            QuickBrownFox = "5BCD0FDA",
             Zeros16 = "00100001",
 
             // Long-input regression vectors for issue #127 — Adler-32C uses modulus 65536, so

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/FletcherTests.32.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/FletcherTests.32.cs
@@ -24,11 +24,7 @@ public sealed partial class Fletcher32Tests
             {
                 Empty = "00000000",
                 Abc = "84C54284",
-
-                // QuickBrownFox suppressed — tracked by issue #167 (Adler/Fletcher KAT mismatch
-                // observed on PR #166 CI: index 1 expected 0xCD, actual 0xDC). Restore once the
-                // root cause is identified and fixed.
-                // QuickBrownFox = "53CD5B8D",
+                QuickBrownFox = "53CD5B8D",
                 Zeros16 = "00000000",
             },
         };


### PR DESCRIPTION
## Summary
This PR resolves issue #167 by restoring previously suppressed test vectors for Adler-32, Adler-32C, and Fletcher-32 algorithms. The root cause of the KAT (Known Answer Test) mismatch has been identified and the correct canonical values are now documented.

## Key Changes
- **Adler-32 (Adler32Tests.32.cs)**: Restored `QuickBrownFox = "5BDC0FDA"` with clarification that the previously suppressed value `0x5BCD0FDA` was a nibble-swap typo. The implementation was correct; the test vector was wrong. Cross-verified against Python's `zlib.adler32`.

- **Adler-32C (Adler32Tests.32C.cs)**: Restored `QuickBrownFox = "5BCD0FDA"` with detailed explanation that Adler-32C uses modulus 65536 (not 65521), resulting in a different checksum value than canonical Adler-32 for the same input.

- **Fletcher-32 (FletcherTests.32.cs)**: Restored `QuickBrownFox = "53CD5B8D"` by removing the suppression comment.

## Notable Details
The investigation revealed that the mismatch was due to confusion between two distinct algorithms:
- **Adler-32** (canonical): Uses modulus 65521, yielding `0x5BDC` for the test string
- **Adler-32C**: Uses modulus 65536, yielding `0x5BCD` for the same test string

The previously suppressed value represented a nibble-swap error in the test vector itself, not an implementation bug. All implementations are now verified as correct.

https://claude.ai/code/session_01RUAT54TezXzb5yNag1x6Li