### PR TITLE
Expand DateOnly extensions with provider support and overloads

### DIFF
--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInMonth.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.DaysInMonth.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.Globalization;
 
 namespace Bodu.Extensions;
 
@@ -14,9 +15,33 @@ public static partial class DateOnlyExtensions
     /// Returns the number of days in the calendar month of the specified <see cref="DateOnly"/>, using the proleptic Gregorian calendar.
     /// </summary>
     /// <param name="date">The date value whose year and month are used to determine the result.</param>
-    /// <returns>The total number of days in the specified month and year of <paramref name="date"/>, based on the <see cref="System.Globalization.GregorianCalendar"/>.</returns>
+    /// <returns>The total number of days in the specified month and year of <paramref name="date"/>, based on the <see cref="GregorianCalendar"/>.</returns>
     /// <remarks>
-    /// <para>This overload always evaluates the result using the proleptic Gregorian calendar, regardless of the current culture or calendar settings.</para>
+    /// <para>This overload always evaluates the result using the proleptic Gregorian calendar, regardless of the current culture or calendar settings. For culture-specific results, use the <see cref="DaysInMonth(DateOnly, CultureInfo)"/> or <see cref="DaysInMonth(DateOnly, Calendar)"/> overload.</para>
     /// </remarks>
     public static int DaysInMonth(this DateOnly date) => DateTime.DaysInMonth(date.Year, date.Month);
+
+    /// <summary>
+    /// Returns the number of days in the calendar month of the specified <see cref="DateOnly"/>, using the calendar associated with the supplied culture.
+    /// </summary>
+    /// <param name="date">The date value whose year and month are used to determine the result.</param>
+    /// <param name="culture">An optional <see cref="CultureInfo"/> that supplies the calendar. If <see langword="null"/>, <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The total number of days in the specified month and year of <paramref name="date"/>, based on the calendar of <paramref name="culture"/>.</returns>
+    /// <remarks>
+    /// <para>This overload retrieves the <see cref="Calendar"/> from the culture's <see cref="DateTimeFormatInfo.Calendar"/> property and returns the number of days for the month of the supplied <paramref name="date"/>.</para>
+    /// <para>This is useful when working with cultures that use non-Gregorian calendars such as <see cref="HebrewCalendar"/> or <see cref="HijriCalendar"/>. If the calendar supports leap months or eras, this method does not account for them explicitly. For precise control, use the overload that accepts a <see cref="Calendar"/> directly.</para>
+    /// </remarks>
+    public static int DaysInMonth(this DateOnly date, CultureInfo? culture) => (culture ?? CultureInfo.CurrentCulture).DateTimeFormat.Calendar.GetDaysInMonth(date.Year, date.Month);
+
+    /// <summary>
+    /// Returns the number of days in the calendar month of the specified <see cref="DateOnly"/>, using the supplied or current culture's calendar.
+    /// </summary>
+    /// <param name="date">The date value whose year and month are used to determine the result.</param>
+    /// <param name="calendar">An optional <see cref="Calendar"/> instance used to evaluate the result. If <see langword="null"/>, the calendar of <see cref="CultureInfo.CurrentCulture"/> is used.</param>
+    /// <returns>The total number of days in the specified month and year of <paramref name="date"/>, based on the rules of the supplied or current calendar.</returns>
+    /// <remarks>
+    /// <para>This overload supports calendar-aware computations for systems such as <see cref="HebrewCalendar"/>, <see cref="HijriCalendar"/>, <see cref="JapaneseCalendar"/>, and others supported by .NET. The result is equivalent to <c>calendar.GetDaysInMonth(date.Year, date.Month)</c>, or uses the current culture's calendar if <paramref name="calendar"/> is <see langword="null"/>.</para>
+    /// <para>This method does not account for leap months. For calendars that support leap months or multiple eras, consider using <c>GetDaysInMonth(year, month, era)</c> instead.</para>
+    /// </remarks>
+    public static int DaysInMonth(this DateOnly date, Calendar? calendar) => (calendar ?? CultureInfo.CurrentCulture.Calendar).GetDaysInMonth(date.Year, date.Month);
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfQuarter.cs
@@ -70,21 +70,21 @@ public static partial class DateOnlyExtensions
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
     /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
     /// <returns>A <see cref="DateOnly"/> value set to the first day of the specified quarter and year.</returns>
     /// <remarks>
     /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is less than 1 or greater than 4.</exception>
-    public static DateOnly GetFirstDateOfQuarter(int quarter, int year) => GetFirstDateOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
+    public static DateOnly GetFirstDateOfQuarter(int year, int quarter) => GetFirstDateOfQuarter(year, quarter, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
-    /// <param name="quarter">The quarter number, from 1 through 4.</param>
     /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive. If the quarter begins in the next calendar year (based on the definition's anchor), the year will be incremented accordingly.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
     /// <returns>A <see cref="DateOnly"/> value set to the first day of the specified quarter.</returns>
     /// <remarks>
     /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
@@ -94,7 +94,7 @@ public static partial class DateOnlyExtensions
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
     /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
-    public static DateOnly GetFirstDateOfQuarter(CalendarQuarterDefinition definition, int quarter, int year)
+    public static DateOnly GetFirstDateOfQuarter(int year, int quarter, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfWeek.cs
@@ -21,7 +21,7 @@ public static partial class DateOnlyExtensions
     /// <remarks>
     /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the first day of the week, based on <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
     /// </remarks>
-    public static DateOnly FirstDateOfWeek(this DateOnly date) => date.FirstDateOfWeek(null!);
+    public static DateOnly FirstDateOfWeek(this DateOnly date) => date.FirstDateOfWeek((CultureInfo?)null);
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first day of the week that contains the specified <paramref name="date"/>, using the first day of the week defined by the supplied or current culture.
@@ -33,7 +33,7 @@ public static partial class DateOnlyExtensions
     /// <para>This method computes the day offset between <paramref name="date"/> and the culture-specific first day of the week, and subtracts that offset.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.</exception>
-    public static DateOnly FirstDateOfWeek(this DateOnly date, CultureInfo culture)
+    public static DateOnly FirstDateOfWeek(this DateOnly date, CultureInfo? culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
         DayOfWeek firstDayOfWeek = culture.DateTimeFormat.FirstDayOfWeek;

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FirstDateOfWeekInQuarter.cs
@@ -11,6 +11,24 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the calendar quarter that contains the specified <paramref name="date"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>. The search begins on the first day of the quarter and proceeds forward to locate the first matching weekday.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateOnly FirstDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        (int year, int quarter) = GetQuarterAndYearFromDate(CalendarQuarterDefinition.JanuaryToDecember, referenceDate: date);
+        return GetFirstDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, CalendarQuarterDefinition.JanuaryToDecember);
+    }
+
+    /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using the supplied calendar quarter definition.
     /// </summary>
     /// <param name="date">The date value used to determine the containing quarter.</param>
@@ -24,21 +42,70 @@ public static partial class DateOnlyExtensions
     /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly FirstDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
 
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
         (int year, int quarter) = GetQuarterAndYearFromDate(definition, referenceDate: date);
-        int days = ComputeQuarterStartDayNumber(year, quarter, GetQuarterDefinition(definition));
-        days += (dayOfWeek - DateOnlyExtensions.GetDayOfWeekFromDayNumber(days) + 7) % 7;
+        return GetFirstDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, definition);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// </summary>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>The start of the quarter is determined by the supplied <paramref name="provider"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateOnly FirstDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        DateOnly start = provider.GetQuarterStartDate(date);
+        int days = start.DayNumber + ((dayOfWeek - start.DayOfWeek + 7) % 7);
         return DateOnly.FromDayNumber(days);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the specified calendar <paramref name="quarter"/> and <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the specified quarter and year.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
+    public static DateOnly GetFirstDateOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfOutOfRange(year, DateOnly.MinValue.Year, DateOnly.MaxValue.Year);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        return GetFirstDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, CalendarQuarterDefinition.JanuaryToDecember);
     }
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the first occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year of the result.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
     /// <param name="quarter">The quarter number, from 1 through 4.</param>
     /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the first Monday.</param>
     /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
@@ -47,18 +114,39 @@ public static partial class DateOnlyExtensions
     /// <para>The start of the quarter is computed using <paramref name="definition"/>, and the search proceeds forward to the first date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
     /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly GetFirstDateOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
+        ThrowHelper.ThrowIfOutOfRange(year, DateOnly.MinValue.Year, DateOnly.MaxValue.Year);
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
 
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
+        return GetFirstDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, definition);
+    }
+
+    /// <summary>
+    /// Returns the first occurrence of the specified <paramref name="dayOfWeek"/> within the given <paramref name="quarter"/> and <paramref name="year"/>, using a prevalidated calendar quarter <paramref name="definition"/>.
+    /// </summary>
+    /// <param name="year">The calendar year that contains the quarter.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. The method searches forward from the start of the quarter to find the first occurrence.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the first occurrence of <paramref name="dayOfWeek"/> within the specified quarter.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where all arguments are known to be valid.</remarks>
+    private static DateOnly GetFirstDateOfWeekInQuarterInternal(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
+    {
         int days = ComputeQuarterStartDayNumber(year, quarter, GetQuarterDefinition(definition));
-        days += (dayOfWeek - DateOnlyExtensions.GetDayOfWeekFromDayNumber(days) + 7) % 7;
+        days += (dayOfWeek - GetDayOfWeekFromDayNumber(days) + 7) % 7;
         return DateOnly.FromDayNumber(days);
     }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfQuarter.cs
@@ -70,21 +70,21 @@ public static partial class DateOnlyExtensions
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last day of the specified calendar <paramref name="quarter"/> in the given <paramref name="year"/>, using the standard calendar quarter definition.
     /// </summary>
-    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
     /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
     /// <returns>A <see cref="DateOnly"/> value set to the last day of the specified quarter and year.</returns>
     /// <remarks>
     /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="quarter"/> is less than 1 or greater than 4.</exception>
-    public static DateOnly GetLastDateOfQuarter(int quarter, int year) => GetLastDateOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, year);
+    public static DateOnly GetLastDateOfQuarter(int year, int quarter) => GetLastDateOfQuarter(year, quarter, CalendarQuarterDefinition.JanuaryToDecember);
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last day of the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
-    /// <param name="quarter">The quarter number, from 1 through 4.</param>
     /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive. If the quarter ends in the next calendar year (based on the definition's anchor), the year will be incremented accordingly.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarters are aligned.</param>
     /// <returns>A <see cref="DateOnly"/> value set to the last day of the specified quarter.</returns>
     /// <remarks>
     /// <para>The <paramref name="definition"/> controls whether quarters are aligned to the first day of a month or anchored to a custom day-of-month boundary.</para>
@@ -94,7 +94,7 @@ public static partial class DateOnlyExtensions
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
     /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use a provider-based overload instead.</exception>
-    public static DateOnly GetLastDateOfQuarter(CalendarQuarterDefinition definition, int quarter, int year)
+    public static DateOnly GetLastDateOfQuarter(int year, int quarter, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfWeek.cs
@@ -21,7 +21,7 @@ public static partial class DateOnlyExtensions
     /// <remarks>
     /// <para>This overload uses <see cref="CultureInfo.CurrentCulture"/> to determine the last day of the week, inferred from <see cref="DateTimeFormatInfo.FirstDayOfWeek"/>.</para>
     /// </remarks>
-    public static DateOnly LastDateOfWeek(this DateOnly date) => date.LastDateOfWeek(null!);
+    public static DateOnly LastDateOfWeek(this DateOnly date) => date.LastDateOfWeek((CultureInfo?)null);
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last day of the week that contains the specified <paramref name="date"/>, using the last day of the week defined by the supplied or current culture.
@@ -33,7 +33,7 @@ public static partial class DateOnlyExtensions
     /// <para>This method computes the day offset between <paramref name="date"/> and the culture-specific last day of the week, and adds that offset.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if the resulting date is earlier than <see cref="DateOnly.MinValue"/> or later than <see cref="DateOnly.MaxValue"/>.</exception>
-    public static DateOnly LastDateOfWeek(this DateOnly date, CultureInfo culture)
+    public static DateOnly LastDateOfWeek(this DateOnly date, CultureInfo? culture)
     {
         culture ??= Thread.CurrentThread.CurrentCulture;
         DayOfWeek lastDayOfWeek = culture.DateTimeFormat.LastDayOfWeek();

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfWeekInQuarter.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.LastDateOfWeekInQuarter.cs
@@ -11,6 +11,24 @@ namespace Bodu.Extensions;
 public static partial class DateOnlyExtensions
 {
     /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the calendar quarter that contains the specified <paramref name="date"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>. The search begins on the last day of the quarter and proceeds backward to locate the last matching weekday.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateOnly LastDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        (int year, int quarter) = GetQuarterAndYearFromDate(CalendarQuarterDefinition.JanuaryToDecember, referenceDate: date);
+        return GetLastDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, CalendarQuarterDefinition.JanuaryToDecember);
+    }
+
+    /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using the supplied calendar quarter definition.
     /// </summary>
     /// <param name="date">The date value used to determine the containing quarter.</param>
@@ -24,21 +42,70 @@ public static partial class DateOnlyExtensions
     /// Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly LastDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
         ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
 
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
         (int year, int quarter) = GetQuarterAndYearFromDate(definition, referenceDate: date);
-        int dayNumber = ComputeQuarterEndDayNumber(year, quarter, GetQuarterDefinition(definition));
-        dayNumber += (dayOfWeek - DateOnlyExtensions.GetDayOfWeekFromDayNumber(dayNumber) + 7) % 7;
-        return DateOnly.FromDayNumber(dayNumber);
+        return GetLastDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, definition);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the quarter that contains the specified <paramref name="date"/>, using a custom <see cref="IQuarterDefinitionProvider"/>.
+    /// </summary>
+    /// <param name="date">The date value used to determine the containing quarter.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <param name="provider">The <see cref="IQuarterDefinitionProvider"/> that defines custom quarter boundaries. Must not be <see langword="null"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the quarter that contains <paramref name="date"/>.</returns>
+    /// <remarks>
+    /// <para>The end of the quarter is determined by the supplied <paramref name="provider"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="provider"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.</exception>
+    public static DateOnly LastDateOfWeekInQuarter(this DateOnly date, DayOfWeek dayOfWeek, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        DateOnly end = provider.GetQuarterEndDate(date);
+        int days = end.DayNumber + ((dayOfWeek - end.DayOfWeek + 7) % 7);
+        return DateOnly.FromDayNumber(days);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the specified calendar <paramref name="quarter"/> and <paramref name="year"/>, using the standard calendar quarter definition.
+    /// </summary>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
+    /// <param name="quarter">The quarter number, from 1 (Jan – Mar) through 4 (Oct – Dec).</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the specified quarter and year.</returns>
+    /// <remarks>
+    /// <para>This overload uses the standard calendar alignment defined by <see cref="CalendarQuarterDefinition.JanuaryToDecember"/>.</para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration.
+    /// </exception>
+    public static DateOnly GetLastDateOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek)
+    {
+        ThrowHelper.ThrowIfOutOfRange(year, DateOnly.MinValue.Year, DateOnly.MaxValue.Year);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+
+        return GetLastDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, CalendarQuarterDefinition.JanuaryToDecember);
     }
 
     /// <summary>
     /// Returns a new <see cref="DateOnly"/> representing the last occurrence of the specified <see cref="DayOfWeek"/> within the specified <paramref name="quarter"/> and <paramref name="year"/>, using the supplied calendar quarter definition.
     /// </summary>
-    /// <param name="year">The calendar year of the result.</param>
+    /// <param name="year">The calendar year of the result. Must be between the <c>Year</c> property values of <see cref="DateOnly.MinValue"/> and <see cref="DateOnly.MaxValue"/>, inclusive.</param>
     /// <param name="quarter">The quarter number, from 1 through 4.</param>
     /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate within the quarter. For example, <see cref="DayOfWeek.Monday"/> returns the last Monday.</param>
     /// <param name="definition">The <see cref="CalendarQuarterDefinition"/> that determines how quarter boundaries are aligned.</param>
@@ -47,18 +114,39 @@ public static partial class DateOnlyExtensions
     /// <para>The end of the quarter is computed using <paramref name="definition"/>, and the search proceeds backward to the last date that matches the specified <paramref name="dayOfWeek"/>.</para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="quarter"/> is less than 1 or greater than 4,
+    /// Thrown if <paramref name="year"/> is less than the <c>Year</c> of <see cref="DateOnly.MinValue"/> or greater than that of <see cref="DateOnly.MaxValue"/>,
+    /// -or- <paramref name="quarter"/> is less than 1 or greater than 4,
     /// -or- <paramref name="dayOfWeek"/> is not a defined value of the <see cref="DayOfWeek"/> enumeration,
     /// -or- <paramref name="definition"/> is not a defined value of the <see cref="CalendarQuarterDefinition"/> enumeration.
     /// </exception>
+    /// <exception cref="InvalidOperationException">Thrown if <paramref name="definition"/> is <see cref="CalendarQuarterDefinition.Custom"/>; use the provider-based overload instead.</exception>
     public static DateOnly GetLastDateOfWeekInQuarter(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
     {
-        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
+        ThrowHelper.ThrowIfOutOfRange(year, DateOnly.MinValue.Year, DateOnly.MaxValue.Year);
         ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
         ThrowHelper.ThrowIfEnumValueIsUndefined(dayOfWeek);
+        ThrowHelper.ThrowIfEnumValueIsUndefined(definition);
 
+        if (definition == CalendarQuarterDefinition.Custom)
+            throw new InvalidOperationException(
+                string.Format(ResourceStrings.Arg_Required_ProviderInterface, nameof(IQuarterDefinitionProvider)));
+
+        return GetLastDateOfWeekInQuarterInternal(year, quarter, dayOfWeek, definition);
+    }
+
+    /// <summary>
+    /// Returns the last occurrence of the specified <paramref name="dayOfWeek"/> within the given <paramref name="quarter"/> and <paramref name="year"/>, using a prevalidated calendar quarter <paramref name="definition"/>.
+    /// </summary>
+    /// <param name="year">The calendar year that contains the quarter.</param>
+    /// <param name="quarter">The quarter number, from 1 through 4.</param>
+    /// <param name="dayOfWeek">The <see cref="DayOfWeek"/> to locate. The method searches backward from the end of the quarter to find the last occurrence.</param>
+    /// <param name="definition">A defined <see cref="CalendarQuarterDefinition"/> that is not <see cref="CalendarQuarterDefinition.Custom"/>.</param>
+    /// <returns>A <see cref="DateOnly"/> value set to the last occurrence of <paramref name="dayOfWeek"/> within the specified quarter.</returns>
+    /// <remarks>This helper performs no validation and is intended for internal use where all arguments are known to be valid.</remarks>
+    private static DateOnly GetLastDateOfWeekInQuarterInternal(int year, int quarter, DayOfWeek dayOfWeek, CalendarQuarterDefinition definition)
+    {
         int dayNumber = ComputeQuarterEndDayNumber(year, quarter, GetQuarterDefinition(definition));
-        dayNumber += (dayOfWeek - DateOnlyExtensions.GetDayOfWeekFromDayNumber(dayNumber) + 7) % 7;
+        dayNumber += (dayOfWeek - GetDayOfWeekFromDayNumber(dayNumber) + 7) % 7;
         return DateOnly.FromDayNumber(dayNumber);
     }
 }

--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.FirstDateOfQuarter.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.FirstDateOfQuarter.cs
@@ -49,7 +49,7 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="DateOnlyExtensions.GetFirstDateOfQuarter(CalendarQuarterDefinition, int, int)" /> returns the expected quarter-start <see cref="DateOnly" /> for each <c>(year, quarter, definition)</c> triple.
+    /// Verifies that <see cref="DateOnlyExtensions.GetFirstDateOfQuarter(int, int, CalendarQuarterDefinition)" /> returns the expected quarter-start <see cref="DateOnly" /> for each <c>(year, quarter, definition)</c> triple.
     /// </summary>
     [TestMethod]
     [DynamicData(nameof(DateTimeExtensionsTests.FirstDateOfQuarterTestData), typeof(DateTimeExtensionsTests), DynamicDataSourceType.Method)]
@@ -57,7 +57,7 @@ public partial class DateOnlyExtensionsTests
     {
         DateOnly expected = DateOnly.FromDateTime(expectedDateTime);
 
-        var actual = DateOnlyExtensions.GetFirstDateOfQuarter(definition, quarter, year);
+        var actual = DateOnlyExtensions.GetFirstDateOfQuarter(year, quarter, definition);
 
         Assert.AreEqual(expected, actual);
     }
@@ -71,7 +71,7 @@ public partial class DateOnlyExtensionsTests
         {
         DateOnly expected = DateOnly.FromDateTime(expectedDateTime);
 
-        var actual = DateOnlyExtensions.GetFirstDateOfQuarter(quarter, year);
+        var actual = DateOnlyExtensions.GetFirstDateOfQuarter(year, quarter);
 
         Assert.AreEqual(expected, actual);
     }
@@ -157,7 +157,7 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that the static <see cref="DateOnlyExtensions.GetFirstDateOfQuarter(CalendarQuarterDefinition, int, int)" /> overload throws <see cref="ArgumentOutOfRangeException" /> for an undefined definition.
+    /// Verifies that the static <see cref="DateOnlyExtensions.GetFirstDateOfQuarter(int, int, CalendarQuarterDefinition)" /> overload throws <see cref="ArgumentOutOfRangeException" /> for an undefined definition.
     /// </summary>
     [TestMethod]
     public void FirstDateOfQuarter_WhenDefinitionIsInvalidAndQuarterIsValid_ShouldThrowExactly()
@@ -166,7 +166,7 @@ public partial class DateOnlyExtensionsTests
 
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetFirstDateOfQuarter(definition, 1, 2025);
+            _ = DateOnlyExtensions.GetFirstDateOfQuarter(2025, 1, definition);
         });
     }
 
@@ -181,7 +181,7 @@ public partial class DateOnlyExtensionsTests
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetFirstDateOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, 2025);
+            _ = DateOnlyExtensions.GetFirstDateOfQuarter(2025, quarter, CalendarQuarterDefinition.JanuaryToDecember);
         });
     }
 
@@ -196,7 +196,7 @@ public partial class DateOnlyExtensionsTests
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetFirstDateOfQuarter(quarter, 2025);
+            _ = DateOnlyExtensions.GetFirstDateOfQuarter(2025, quarter);
         });
     }
 

--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.LastDateOfQuarter.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.LastDateOfQuarter.cs
@@ -49,7 +49,7 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="DateOnlyExtensions.GetLastDateOfQuarter(CalendarQuarterDefinition, int, int)" /> returns the expected quarter-end <see cref="DateOnly" /> for each <c>(year, quarter, definition)</c> triple.
+    /// Verifies that <see cref="DateOnlyExtensions.GetLastDateOfQuarter(int, int, CalendarQuarterDefinition)" /> returns the expected quarter-end <see cref="DateOnly" /> for each <c>(year, quarter, definition)</c> triple.
     /// </summary>
     [TestMethod]
     [DynamicData(nameof(DateTimeExtensionsTests.LastDateOfQuarterTestData), typeof(DateTimeExtensionsTests), DynamicDataSourceType.Method)]
@@ -57,7 +57,7 @@ public partial class DateOnlyExtensionsTests
     {
         var expected = DateOnly.FromDateTime(expectedDateTime);
 
-        var actual = DateOnlyExtensions.GetLastDateOfQuarter(definition, quarter, year);
+        var actual = DateOnlyExtensions.GetLastDateOfQuarter(year, quarter, definition);
 
         Assert.AreEqual(expected, actual);
     }
@@ -71,7 +71,7 @@ public partial class DateOnlyExtensionsTests
     {
         var expected = DateOnly.FromDateTime(expectedDateTime);
 
-        var actual = DateOnlyExtensions.GetLastDateOfQuarter(quarter, year);
+        var actual = DateOnlyExtensions.GetLastDateOfQuarter(year, quarter);
 
         Assert.AreEqual(expected, actual);
     }
@@ -147,7 +147,7 @@ public partial class DateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that the static <see cref="DateOnlyExtensions.GetLastDateOfQuarter(CalendarQuarterDefinition, int, int)" /> overload throws <see cref="ArgumentOutOfRangeException" /> for an undefined definition.
+    /// Verifies that the static <see cref="DateOnlyExtensions.GetLastDateOfQuarter(int, int, CalendarQuarterDefinition)" /> overload throws <see cref="ArgumentOutOfRangeException" /> for an undefined definition.
     /// </summary>
     [TestMethod]
     public void LastDateOfQuarter_WhenDefinitionIsInvalidAndQuarterIsValid_ShouldThrowExactly()
@@ -156,7 +156,7 @@ public partial class DateOnlyExtensionsTests
 
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetLastDateOfQuarter(definition, 1, 2025);
+            _ = DateOnlyExtensions.GetLastDateOfQuarter(2025, 1, definition);
         });
     }
 
@@ -171,7 +171,7 @@ public partial class DateOnlyExtensionsTests
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetLastDateOfQuarter(CalendarQuarterDefinition.JanuaryToDecember, quarter, 2025);
+            _ = DateOnlyExtensions.GetLastDateOfQuarter(2025, quarter, CalendarQuarterDefinition.JanuaryToDecember);
         });
     }
 
@@ -186,7 +186,7 @@ public partial class DateOnlyExtensionsTests
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            _ = DateOnlyExtensions.GetLastDateOfQuarter(quarter, 2025);
+            _ = DateOnlyExtensions.GetLastDateOfQuarter(2025, quarter);
         });
     }
 


### PR DESCRIPTION
## Summary
This PR significantly expands the `DateOnlyExtensions` class with new method overloads, improved parameter ordering, and support for custom quarter definition providers. The changes enhance API consistency, add culture-aware calendar support, and provide more flexible ways to work with quarters and weeks.

## Key Changes

### First/Last Date of Week in Quarter
- Added new parameterless overloads for `FirstDateOfWeekInQuarter()` and `LastDateOfWeekInQuarter()` that use the standard `JanuaryToDecember` quarter definition
- Added provider-based overloads accepting `IQuarterDefinitionProvider` for custom quarter boundaries
- Added static `GetFirstDateOfWeekInQuarter()` and `GetLastDateOfWeekInQuarter()` methods with year/quarter parameters
- Extracted common logic into private `GetFirstDateOfWeekInQuarterInternal()` and `GetLastDateOfWeekInQuarterInternal()` helper methods
- Added validation to reject `CalendarQuarterDefinition.Custom` with appropriate error messaging directing users to provider-based overloads
- Enhanced XML documentation with comprehensive remarks and exception details

### First/Last Date of Quarter
- Reordered parameters in static `GetFirstDateOfQuarter()` and `GetLastDateOfQuarter()` methods from `(definition, quarter, year)` to `(year, quarter, definition)` for consistency with standard parameter ordering conventions
- Updated all test cases to reflect the new parameter order

### Days in Month
- Added culture-aware overload `DaysInMonth(this DateOnly date, CultureInfo? culture)` supporting non-Gregorian calendars
- Added calendar-aware overload `DaysInMonth(this DateOnly date, Calendar? calendar)` for direct calendar control
- Enhanced documentation to explain support for `HebrewCalendar`, `HijriCalendar`, `JapaneseCalendar`, and other .NET calendars
- Added `using System.Globalization;` directive

### First/Last Date of Week
- Fixed null-coalescing expressions from `null!` to `(CultureInfo?)null` for proper nullable reference handling

## Implementation Details
- All new overloads include comprehensive XML documentation with parameter descriptions, return values, remarks, and exception documentation
- Validation is consistently applied across all public methods using `ThrowHelper` utilities
- The provider-based overloads use `GetQuarterStartDate()` and `GetQuarterEndDate()` from `IQuarterDefinitionProvider`
- Internal helper methods perform no validation, assuming all arguments are pre-validated by public entry points
- Parameter ordering now follows the convention of `(year, quarter, ...)` for consistency across the API

https://claude.ai/code/session_01PwV1htHVEnHzyfWH8rHwiQ