### PR TITLE
Expand XML documentation across calendar API surface

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerContext.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerContext.cs
@@ -7,8 +7,23 @@
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Captures the inputs delivered to an <see cref="IAdjustmentHandler" />.
+/// Carries the inputs supplied to an <see cref="IAdjustmentHandler" /> when a custom <see cref="ObservanceAdjustment" /> is being
+/// evaluated against a calculated date.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The context bundles the four facts a handler needs to make a decision: the <see cref="Date" /> the rule originally resolved
+/// to, the <see cref="Adjustment" /> specification authored on the rule (whose <see cref="ObservanceAdjustment.HandlerKey" /> and
+/// <see cref="ObservanceAdjustment.HandlerParameters" /> carry the handler's configuration), the originating <see cref="Rule" />
+/// (including its name, tags, calendar, and surrounding adjustments), and the <see cref="TerritoryCode" /> /
+/// <see cref="CalendarType" /> currently in scope.
+/// </para>
+/// <para>
+/// Handlers should treat the context as read-only. Mutations performed on the embedded <see cref="Rule" /> or
+/// <see cref="Adjustment" /> are not propagated back to the rule store; the only way to influence the resulting
+/// <see cref="NotableDate" /> is through the returned <see cref="AdjustmentHandlerResult" />.
+/// </para>
+/// </remarks>
 /// <param name="Date">The currently resolved date being considered for adjustment.</param>
 /// <param name="Adjustment">The adjustment specification that triggered the handler.</param>
 /// <param name="Rule">The originating <see cref="NotableDateRule" />.</param>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
@@ -6,10 +6,39 @@
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
-/// Provides a thread-safe in-memory implementation of <see cref="IAdjustmentHandlerRegistry" />.
+/// Provides a thread-safe, mutable in-memory implementation of <see cref="IAdjustmentHandlerRegistry" />.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Handlers registered via <see cref="Register(string, IAdjustmentHandler)" /> are looked up case-insensitively by key during
+/// observance-adjustment evaluation. The registry is intended as a composition-time concern: hosts populate it once during
+/// start-up and pass it to <see cref="NotableDateService" /> via the <c>adjustmentHandlers</c> constructor parameter so that
+/// <see cref="ObservanceAdjustment" /> entries declaring <see cref="AdjustmentTrigger.Custom" /> or
+/// <see cref="AdjustmentAction.Custom" /> can resolve to a concrete <see cref="IAdjustmentHandler" /> implementation.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>Register a custom handler and wire it into a service:</para>
+/// <code>
+/// AdjustmentHandlerRegistry handlers = new AdjustmentHandlerRegistry()
+///     .Register("conflict-avoidance", new ConflictAvoidanceHandler("Anzac Day"));
+///
+/// NotableDateService service = new NotableDateService(
+///     ruleProviders: new[] { AustraliaCalendarData.CreateProvider() },
+///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+///     adjustmentHandlers: handlers);
+///
+/// // A rule's adjustment can now reference the handler by key:
+/// ObservanceAdjustment custom = new ObservanceAdjustment
+/// {
+///     Key = "avoid-anzac",
+///     Trigger = AdjustmentTrigger.Custom,
+///     Action = AdjustmentAction.Custom,
+///     HandlerKey = "conflict-avoidance",
+/// };
+/// </code>
+/// </example>
 public sealed class AdjustmentHandlerRegistry : IAdjustmentHandlerRegistry
 {
 	/// <summary>The case-insensitive key-to-handler mapping maintained by this registry.</summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerResult.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerResult.cs
@@ -7,8 +7,40 @@
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Captures the output produced by an <see cref="IAdjustmentHandler" />.
+/// Conveys the outcome of an <see cref="IAdjustmentHandler" /> evaluation back to the adjuster pipeline.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The result tells the adjuster three things, with downstream effects on the emitted <see cref="NotableDate" />:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="Activated" /> indicates whether the handler considered the trigger condition met. When
+/// <see langword="false" />, the original calculated date is preserved and no extra <see cref="NotableDate" /> is emitted; an
+/// <see cref="AdjustmentReason" /> is not attached.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="AdjustedDate" /> supplies the relocated date. When this differs from the originally calculated date the adjuster
+/// emits an additional <see cref="NotableDate" /> with <see cref="NotableDate.AdjustmentReason" /> populated, leaving the
+/// original occurrence in place so consumers can still see the unshifted date if needed.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="IsNonWorkingOverride" /> optionally overrides the non-working flag inherited from the rule or adjustment. Use it
+/// when the handler's outcome materially changes the observance status — for example marking a substitute day off as
+/// non-working even though the rule itself is observance-only.
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// To signal "no change", return <c>new AdjustmentHandlerResult(Activated: false, AdjustedDate: context.Date)</c>. To signal a
+/// shift without changing the working-day status, leave <see cref="IsNonWorkingOverride" /> as <see langword="null" />.
+/// </para>
+/// </remarks>
 /// <param name="Activated">Whether the handler considered its trigger satisfied.</param>
 /// <param name="AdjustedDate">The new date when <paramref name="Activated" /> is <see langword="true" />, otherwise the unchanged date.</param>
 /// <param name="IsNonWorkingOverride">Optional override for the resulting date's non-working flag. <see langword="null" /> preserves the existing value.</param>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentReason.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentReason.cs
@@ -12,11 +12,42 @@ namespace Bodu.Globalization.Calendar;
 /// </summary>
 /// <remarks>
 /// <para>
-/// An <see cref="AdjustmentReason" /> is attached to a <see cref="NotableDate" /> when, and only when, the date was relocated by a
-/// triggered observance adjustment. Consumers can use it for diagnostics ("why is Anzac Day showing on a Monday?") or to render
-/// observed-vs-actual labels in user interfaces.
+/// An <see cref="AdjustmentReason" /> is attached to a <see cref="NotableDate" /> (via
+/// <see cref="NotableDate.AdjustmentReason" />) when, and only when, the date was relocated by a triggered observance adjustment.
+/// The originally calculated date is preserved on <see cref="OriginalDate" /> so consumers can render observed-vs-actual labels
+/// (for example "Observed Monday 27 April — Anzac Day fell on Sunday") and so that diagnostic and audit code can explain why a
+/// holiday is showing in an unexpected place.
+/// </para>
+/// <para>
+/// The presence of this reason is what flips <see cref="NotableDate.WasAdjusted" /> to <see langword="true" />. The base
+/// occurrence — the date the rule originally resolved to — is still emitted alongside the shifted occurrence so that a single
+/// rule produces both the actual and the observed dates. <see cref="HandlerKey" /> is populated only when a custom
+/// <see cref="IAdjustmentHandler" /> performed the shift via <see cref="AdjustmentAction.Custom" />, allowing diagnostics to
+/// trace the responsible component by registry key.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>
+/// Read the adjustment reason off a resolved <see cref="NotableDate" /> and render it to a user. For Anzac Day 2025 (which falls
+/// on a Friday and is unaffected) and Anzac Day 2026 (which falls on Saturday 25 April and is rolled to Monday 27 April for
+/// observance), the resulting <see cref="NotableDate" /> values look like this:
+/// </para>
+/// <code>
+/// foreach (NotableDate date in service.GetNotableDates(2026, territoryCode: "AU"))
+/// {
+///     if (date.AdjustmentReason is { } reason)
+///     {
+///         // date.Date           == 2026-04-27 (Monday — observed)
+///         // reason.OriginalDate == 2026-04-25 (Saturday — actual)
+///         // reason.Trigger      == AdjustmentTrigger.IfWeekend
+///         // reason.Action       == AdjustmentAction.MoveToNextMonday
+///         Console.WriteLine(
+///             $"{date.Name}: observed {date.Date:d} (actual {reason.OriginalDate:d}, " +
+///             $"shifted because {reason.Trigger} via {reason.Action})");
+///     }
+/// }
+/// </code>
+/// </example>
 public sealed record AdjustmentReason
 {
 	/// <summary>
@@ -37,20 +68,24 @@ public sealed record AdjustmentReason
 	/// <summary>
 	/// Gets the date that was originally calculated for the notable date before the adjustment fired.
 	/// </summary>
+	/// <returns>The unshifted anchor date as produced by the rule's <see cref="DateResolutionStrategy" />.</returns>
 	public DateTime OriginalDate { get; }
 
 	/// <summary>
 	/// Gets the trigger condition that activated the adjustment.
 	/// </summary>
+	/// <returns>The <see cref="AdjustmentTrigger" /> value supplied on the <see cref="ObservanceAdjustment" />.</returns>
 	public AdjustmentTrigger Trigger { get; }
 
 	/// <summary>
 	/// Gets the action that the adjustment performed.
 	/// </summary>
+	/// <returns>The <see cref="AdjustmentAction" /> value supplied on the <see cref="ObservanceAdjustment" />.</returns>
 	public AdjustmentAction Action { get; }
 
 	/// <summary>
 	/// Gets the optional key identifying the custom handler that performed a <see cref="AdjustmentAction.Custom" /> action.
 	/// </summary>
+	/// <returns>The <see cref="ObservanceAdjustment.HandlerKey" /> of the custom handler, or <see langword="null" /> for built-in actions.</returns>
 	public string? HandlerKey { get; }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
@@ -17,7 +17,32 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="NotableDate.Name" />. It is used automatically when no custom <see cref="INotableDateCollisionResolver" /> is supplied
 /// to <see cref="NotableDateService" />.
 /// </para>
+/// <para>
+/// The implementation is intentionally conservative: it keeps every distinct occurrence on the colliding day rather than picking a
+/// single "winner". Hosts that need a single canonical entry per day should supply a custom
+/// <see cref="INotableDateCollisionResolver" /> through the <see cref="NotableDateService" /> constructor.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>
+/// Given two notable dates resolving to 25 April 2027 — Anzac Day (a public commemoration) and Easter Sunday (a religious
+/// observance) — the default resolver returns them in category-ascending order:
+/// </para>
+/// <code>
+/// IReadOnlyList&lt;NotableDate&gt; resolved = new DefaultNotableDateCollisionResolver().Resolve(
+///     new DateTime(2027, 4, 25),
+///     new[]
+///     {
+///         new NotableDate { Date = new DateTime(2027, 4, 25), Name = "Easter Sunday",
+///                           Category = NotableDateCategory.Religious },
+///         new NotableDate { Date = new DateTime(2027, 4, 25), Name = "Anzac Day",
+///                           Category = NotableDateCategory.Remembrance },
+///     });
+///
+/// // resolved[0].Name == "Anzac Day"     (Remembrance has the lower category ordinal)
+/// // resolved[1].Name == "Easter Sunday"
+/// </code>
+/// </example>
 public sealed class DefaultNotableDateCollisionResolver : INotableDateCollisionResolver
 {
 	/// <inheritdoc />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="INotableDateAlgorithm.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -9,17 +9,75 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Defines a contract for computing the calendar date of a notable event (e.g., Easter, Lunar New Year) based on a given year and
-/// calendar system.
+/// Computes the anchor date of a single notable event for a supplied year — the calculation strategy plugged in by a
+/// <see cref="NotableDateRule" /> whose <see cref="NotableDateRule.Strategy" /> is <see cref="DateResolutionStrategy.Algorithm" />.
 /// </summary>
 /// <remarks>
-/// Implementations of <see cref="INotableDateAlgorithm" /> provide algorithmic calculation of dates that cannot be represented by a
-/// fixed day and month, often varying by year and calendar type.
+/// <para>
+/// Algorithms are the extensibility seam for notable dates that cannot be expressed as a fixed month/day or as the
+/// <em>n</em>th weekday of a month — for example Easter Sunday (Computus), Lunar New Year, Vesak, Qingming, or any
+/// observance whose date varies by year and depends on a non-Gregorian calendar.
+/// </para>
+/// <para>
+/// During resolution, the <see cref="NotableDateService" /> looks up the implementation associated with the rule's
+/// <see cref="NotableDateRule.AlgorithmKey" /> in an <see cref="INotableDateAlgorithmRegistry" />, calls
+/// <see cref="GetDate" /> for the requested year, and uses the returned <see cref="DateTime" /> as the anchor of the
+/// emitted <see cref="NotableDate" />. All other rule metadata — <see cref="NotableDate.Name" />,
+/// <see cref="NotableDate.Category" />, <see cref="NotableDate.TerritoryCode" />, <see cref="NotableDate.Tags" />,
+/// duration, and any <see cref="ObservanceAdjustment" /> entries — is layered on top by the service. Algorithms therefore
+/// concern themselves only with <em>when</em> the event falls, never with <em>how</em> it is labelled or scoped.
+/// </para>
+/// <para>
+/// Implementations should be deterministic, side-effect-free, and safe to invoke concurrently. The same algorithm
+/// instance may be consulted by multiple rules (for example "Easter Sunday", "Easter Monday" via offset, and "Good
+/// Friday" via offset all share a single Computus implementation) and by multiple threads when filtered queries bypass
+/// the per-year cache.
+/// </para>
+/// <para>
+/// Return <see langword="null" /> for years the algorithm cannot service — for example when a calendar is supplied that
+/// the algorithm does not understand, or when the requested year falls outside the calendar's supported range. A
+/// <see langword="null" /> result causes the rule to produce no occurrence for that year and is preferable to throwing.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>
+/// A minimal algorithm that resolves Australia's Melbourne Cup Day (the first Tuesday of November). In practice an
+/// algorithm of this form would be expressed as a <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> rule rather
+/// than a custom algorithm, but the same shape applies to genuinely complex computations such as Computus or lunar
+/// month resolution:
+/// </para>
+/// <code>
+/// public sealed class MelbourneCupAlgorithm : INotableDateAlgorithm
+/// {
+///     public DateTime? GetDate(int year, System.Globalization.Calendar? calendar = null)
+///     {
+///         if (year &lt; 1) throw new ArgumentOutOfRangeException(nameof(year));
+///
+///         DateTime firstOfNovember = new(year, 11, 1);
+///         int offset = ((int)DayOfWeek.Tuesday - (int)firstOfNovember.DayOfWeek + 7) % 7;
+///         return firstOfNovember.AddDays(offset);
+///     }
+/// }
+///
+/// // Register and bind to a NotableDateRule via algorithm key:
+/// NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+///     .Register("melbourne-cup", new MelbourneCupAlgorithm());
+///
+/// NotableDateRule melbourneCup = new NotableDateRule
+/// {
+///     Name = "Melbourne Cup Day",
+///     Strategy = DateResolutionStrategy.Algorithm,
+///     Category = NotableDateCategory.Cultural,
+///     AlgorithmKey = "melbourne-cup",
+///     TerritoryCode = "AU-VIC",
+///     IsNonWorkingDay = true,
+/// };
+/// </code>
+/// </example>
 public interface INotableDateAlgorithm
 {
 	/// <summary>
-	/// Computes the calendar date of the notable event for the specified year and optional calendar system.
+	/// Computes the anchor date of the notable event for the specified year and optional calendar system.
 	/// </summary>
 	/// <param name="year">The target year for the calculation. Must be greater than or equal to 1.</param>
 	/// <param name="calendar">
@@ -28,7 +86,8 @@ public interface INotableDateAlgorithm
 	/// </param>
 	/// <returns>
 	/// The computed <see cref="DateTime" /> representing the notable event in the given year and calendar system, or
-	/// <see langword="null" /> if the date cannot be determined.
+	/// <see langword="null" /> when no occurrence exists for that year (for example, the year is outside the algorithm's supported
+	/// range or the supplied calendar produces no candidate date).
 	/// </returns>
 	/// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
 	/// <exception cref="NotSupportedException">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="INotableDateProvider.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -9,23 +9,54 @@ using SysGlobal = System.Globalization;
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Defines a contract for computing the calendar date of a notable event (e.g., Easter, Lunar New Year) based on a given year and
-/// calendar system.
+/// Produces fully-populated <see cref="NotableDate" /> instances for a specific notable event, year by year — a self-contained
+/// alternative to authoring a <see cref="NotableDateRule" /> in XML or JSON when the calculation and metadata are best expressed
+/// directly in code.
 /// </summary>
 /// <remarks>
-/// Implementations of <see cref="INotableDateProvider" /> provide algorithmic calculation of dates that cannot be represented by a
-/// fixed day and month, often varying by year and calendar type.
+/// <para>
+/// <see cref="INotableDateProvider" /> differs from <see cref="INotableDateAlgorithm" /> in scope and responsibility:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="INotableDateAlgorithm" /> computes only the <em>anchor date</em> for a year. Surrounding metadata
+/// (<see cref="NotableDate.Name" />, <see cref="NotableDate.Category" />, <see cref="NotableDate.Tags" />, territory, duration)
+/// is supplied by the <see cref="NotableDateRule" /> that references the algorithm. This is the preferred extensibility seam when
+/// the same calculation is reused by multiple rules (Easter Sunday, Easter Monday via offset, Good Friday via offset).
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="INotableDateProvider" /> bundles both the calculation and the metadata into a single self-describing component. It
+/// returns ready-made <see cref="NotableDate" /> values complete with name, category, tags, calendar binding, and non-working
+/// flag. Use it when a notable event has no useful presence in the rule store (it is computed dynamically, sourced from an
+/// external service, or unique to a particular host).
+/// </description>
+/// </item>
+/// </list>
+/// <para>
+/// Implementations should report the supported year range via <see cref="MinSupportedYear" /> and <see cref="MaxSupportedYear" />,
+/// validate the optional calendar argument, and return an empty list rather than throwing for years outside their supported range
+/// or for calendar combinations they cannot service.
+/// </para>
+/// <para>
+/// The built-in base type <c>EasterSundayNotableDateProviderBase</c> demonstrates a typical implementation: it caches the computed
+/// date per year and returns a single <see cref="NotableDate" /> with provider-defined name, category, and tags.
+/// </para>
 /// </remarks>
 public interface INotableDateProvider
 {
     /// <summary>
-    /// Gets the earliest supported year for the provider.
+    /// Gets the earliest year for which the provider can produce a <see cref="NotableDate" />.
     /// </summary>
+    /// <returns>The inclusive minimum year supported by the provider.</returns>
     int MinSupportedYear { get; }
 
     /// <summary>
-    /// Gets the latest supported year for the provider.
+    /// Gets the latest year for which the provider can produce a <see cref="NotableDate" />.
     /// </summary>
+    /// <returns>The inclusive maximum year supported by the provider.</returns>
     int MaxSupportedYear { get; }
 
     /// <summary>
@@ -41,6 +72,13 @@ public interface INotableDateProvider
     /// <summary>
     /// Resolves all notable dates produced by the provider for the specified <paramref name="year" />.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Most providers emit a single <see cref="NotableDate" /> per year. Providers that produce a family of related occurrences
+    /// (for example a multi-day festival exposed as a series of individual <see cref="NotableDate" /> entries rather than a
+    /// single span) may return more than one element.
+    /// </para>
+    /// </remarks>
     /// <param name="year">The year for which notable dates should be resolved.</param>
     /// <param name="calendar">
     /// Optional. A calendar context associated with the resolved dates. Providers may reject unsupported calendar types.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
@@ -15,7 +15,43 @@ namespace Bodu.Globalization.Calendar;
 /// registry intentionally exposes registration as a constructor-time concern; consumers wiring up dependency injection should populate
 /// the registry once during start-up and pass it to <see cref="NotableDateService" />.
 /// </para>
+/// <para>
+/// At resolution time the service consults this registry whenever a <see cref="NotableDateRule" /> declares
+/// <see cref="DateResolutionStrategy.Algorithm" />. The looked-up <see cref="INotableDateAlgorithm" /> supplies the anchor date
+/// only — every other field on the emitted <see cref="NotableDate" /> (name, category, tags, territory, calendar, non-working
+/// flag, duration, observance adjustments) comes from the rule itself. This means a single registered algorithm can power any
+/// number of rules: Easter Sunday, Easter Monday (offset +1 from Easter Sunday), Good Friday (offset −2), and Holy Saturday
+/// (offset −1) typically all resolve through one registered <c>"easter-sunday"</c> algorithm.
+/// </para>
 /// </remarks>
+/// <example>
+/// <para>
+/// Register two Easter algorithms and bind a rule to one by key. The resulting <see cref="NotableDate" /> carries the date
+/// produced by the algorithm, but its name, category, and territory come from the rule:
+/// </para>
+/// <code>
+/// // Compose the registry once at start-up:
+/// NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+///     .Register("easter-sunday",   new GregorianEasterSundayNotableDateProvider())
+///     .Register("orthodox-easter", new OrthodoxEasterSundayNotableDateProvider());
+///
+/// // Author a rule that resolves through the algorithm:
+/// NotableDateRule easterSunday = new NotableDateRule
+/// {
+///     Name = "Easter Sunday",
+///     Strategy = DateResolutionStrategy.Algorithm,
+///     Category = NotableDateCategory.Religious,
+///     AlgorithmKey = "easter-sunday",
+///     Tags = ImmutableHashSet.Create("Christian", "Easter"),
+/// };
+///
+/// // Wire registry into the service so DateResolutionStrategy.Algorithm rules can be resolved:
+/// NotableDateService service = new NotableDateService(
+///     ruleProviders: new[] { new InMemoryRuleProvider(new[] { easterSunday }) },
+///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+///     algorithmRegistry: registry);
+/// </code>
+/// </example>
 public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry
 {
 	/// <summary>The case-insensitive key-to-algorithm mapping maintained by this registry.</summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -21,15 +21,50 @@ namespace Bodu.Globalization.Calendar;
 /// </summary>
 /// <remarks>
 /// <para>
-/// XML inputs are validated against the embedded <c>NotableDates.xsd</c> schema before parsing. The JSON authoring
-/// counterpart lives in <see cref="NotableDateRuleJsonParser" /> and produces the same
-/// <see cref="ParsedNotableDateDocument" /> output.
+/// XML inputs are validated against the embedded <c>NotableDates.xsd</c> schema before parsing. Schema violations surface as
+/// <see cref="XmlSchemaValidationException" /> so authoring errors are caught at parse time rather than at first query. The JSON
+/// authoring counterpart lives in <see cref="NotableDateRuleJsonParser" /> and produces the same
+/// <see cref="ParsedNotableDateDocument" /> output, so downstream loaders can treat both source formats uniformly.
+/// </para>
+/// <para>
+/// The parser is the bottom of the rule-loading stack: it converts authored markup into the in-memory rule objects that
+/// <see cref="XmlResourceNotableDateRuleProvider" /> assembles into a flat rule set, that <see cref="NotableDateService" /> then
+/// resolves into <see cref="NotableDate" /> values. Use the <see cref="ParseXml(string)" /> overloads when only the local rules
+/// matter; use <see cref="ParseDocument(string)" /> when <c>&lt;Use&gt;</c> cherry-pick directives must also be inspected (for
+/// example to walk a graph of imported resources).
 /// </para>
 /// <para>
 /// This class replaces <c>NotableDateDefinitionParser</c>. The new schema vocabulary uses <c>Rule</c> as the per-definition element and
 /// names the strategy child elements <c>Fixed</c>, <c>DayOfWeekInMonth</c>, <c>OffsetFromAnchor</c>, and <c>Algorithm</c>.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Parse an inline XML payload into a list of <see cref="NotableDateRule" /> instances:</para>
+/// <code>
+/// const string xml = """
+///     &lt;NotableDates xmlns="urn:bodu:globalization:calendar"&gt;
+///       &lt;Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true"&gt;
+///         &lt;Fixed month="1" day="26" /&gt;
+///         &lt;Adjustment key="weekend-roll"
+///                     trigger="IfWeekend"
+///                     action="MoveToNextMonday"
+///                     isNonWorkingDay="true" /&gt;
+///       &lt;/Rule&gt;
+///       &lt;Rule name="Easter Sunday" category="Religious"&gt;
+///         &lt;Algorithm key="easter-sunday" /&gt;
+///       &lt;/Rule&gt;
+///     &lt;/NotableDates&gt;
+///     """;
+///
+/// List&lt;NotableDateRule&gt; rules = NotableDateRuleParser.ParseXml(xml);
+/// // rules[0] is the Fixed Australia Day rule with one weekend-roll adjustment.
+/// // rules[1] is the Algorithm-backed Easter Sunday rule.
+///
+/// // When &lt;Use&gt; directives also matter, parse the full document instead:
+/// ParsedNotableDateDocument document = NotableDateRuleParser.ParseDocument(xml);
+/// IReadOnlyList&lt;NotableDateRuleUseGroup&gt; imports = document.UseGroups;
+/// </code>
+/// </example>
 public static class NotableDateRuleParser
 {
 	private static readonly XNamespace Namespace = "urn:bodu:globalization:calendar";

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
@@ -8,12 +8,65 @@ using System.Collections.Immutable;
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Specifies a single cherry-pick of a <see cref="NotableDateRule" /> from another resource, optionally renaming the rule,
 /// overriding scalar properties on the inherited rule, and carrying a richer <see cref="OverrideBody" /> that can replace the
 /// strategy, add tags, or merge adjustments by key.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A directive is the per-rule entry inside a <see cref="NotableDateRuleUseGroup" />. It corresponds to a single <c>&lt;Rule&gt;</c>
+/// child of a <c>&lt;Use&gt;</c> element in XML (or its JSON equivalent), and tells the loader: "import the rule named
+/// <see cref="SourceRuleName" /> from the group's source resource and apply these overrides on top of it." The directive does
+/// not declare a new rule from scratch; for that, author a top-level <c>&lt;Rule&gt;</c> in the document.
+/// </para>
+/// <para>
+/// Override precedence is <em>innermost wins</em>. The flat scalar attributes on the directive — for example
+/// <see cref="TerritoryCode" />, <see cref="IsNonWorkingDay" />, and <see cref="Priority" /> — are applied first, then the nested
+/// <see cref="OverrideBody" /> wins over them when both are present. Each override is treated as either "replace" or "merge" by
+/// kind:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Scalar fields (<see cref="Category" />, <see cref="TerritoryCode" />, <see cref="IsNonWorkingDay" />, year bounds, …) — replace the inherited value when set.</description></item>
+/// <item><description><see cref="NotableDateRuleOverrideBody.Tags" /> — merge additively with inherited tags unless <see cref="ClearTags" /> is <see langword="true" />.</description></item>
+/// <item><description><see cref="NotableDateRuleOverrideBody.Adjustments" /> — merge by <see cref="ObservanceAdjustment.Key" /> (matching keys replace in place; new keys append) unless <see cref="ClearAdjustments" /> is <see langword="true" />.</description></item>
+/// <item><description>Strategy fields (<see cref="NotableDateRuleOverrideBody.Strategy" /> + its attendants) — replace the inherited strategy wholesale when present.</description></item>
+/// </list>
+/// <para>
+/// The merged rule is what eventually drives a <see cref="NotableDate" /> at resolution time, so directives are the right place to
+/// adapt an inherited rule to a host's territory, weekend roll behaviour, or non-working flag without redeclaring the rule in full.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// Inherit Anzac Day from a global definition, retarget it to Western Australia, and override the weekend-roll adjustment by key
+/// so the substitute lands on Tuesday instead of Monday:
+/// </para>
+/// <code>
+/// NotableDateRuleUseDirective directive = new NotableDateRuleUseDirective(
+///     SourceRuleName: "Anzac Day",
+///     TerritoryCode: "AU-WA",
+///     IsNonWorkingDay: true,
+///     OverrideBody: new NotableDateRuleOverrideBody
+///     {
+///         Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+///         {
+///             Key = "weekend-roll",                        // matches the inherited entry by key
+///             Trigger = AdjustmentTrigger.IfWeekend,
+///             Action  = AdjustmentAction.AddDays,
+///             OffsetDays = 2,                              // shift to Tuesday rather than Monday
+///             IsNonWorkingDay = true,
+///         }),
+///     });
+///
+/// // Equivalent XML:
+/// // &lt;Use source="Bodu/Globalization/Calendar/Resources/au-public.xml"&gt;
+/// //   &lt;Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true"&gt;
+/// //     &lt;Adjustment key="weekend-roll" trigger="IfWeekend" action="AddDays" offsetDays="2" isNonWorkingDay="true" /&gt;
+/// //   &lt;/Rule&gt;
+/// // &lt;/Use&gt;
+/// </code>
+/// </example>
 /// <param name="SourceRuleName">The name of the rule to pull from the source resource. Matched case-insensitively.</param>
 /// <param name="LocalName">Optional local name. When supplied, the imported rule is exposed under this name instead of <paramref name="SourceRuleName" />.</param>
 /// <param name="Category">Optional category override applied at the <c>&lt;Use&gt;</c> flat-attribute level.</param>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseGroup.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseGroup.cs
@@ -8,10 +8,54 @@ using System.Collections.Immutable;
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
-/// Cherry-picks one or more <see cref="NotableDateRule" /> instances from a single source resource.
+/// Cherry-picks one or more <see cref="NotableDateRule" /> instances from a single source resource, optionally selecting them
+/// individually with per-rule overrides or pulling the entire source in wholesale.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A use-group is the rendering of a single <c>&lt;Use&gt;</c> element in an authored XML or JSON document. It binds a source
+/// resource (the document to import from) to a set of <see cref="NotableDateRuleUseDirective" /> entries that say <em>which</em>
+/// rules to inherit and <em>how</em> to adapt them. Multiple use-groups in the same document each address a different source
+/// resource; together with the document's local rules, they form the <see cref="ParsedNotableDateDocument" /> that the loader
+/// flattens before <see cref="NotableDateService" /> resolves it into <see cref="NotableDate" /> values.
+/// </para>
+/// <para>
+/// Two import modes are supported. When <see cref="UseAll" /> is <see langword="true" />, every rule from
+/// <see cref="SourceResource" /> is imported; <see cref="Uses" /> may still appear and supply per-rule overrides for specific
+/// inherited rules without affecting the rest. When <see cref="UseAll" /> is <see langword="false" />, only the rules referenced
+/// by <see cref="Uses" /> are imported — making the directive a true cherry-pick.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// Compose a document that imports every public-holiday rule from a global resource and one specific rule from a regional
+/// resource, retargeted to a subdivision:
+/// </para>
+/// <code>
+/// // Pull every rule from the global public-holidays resource, unchanged:
+/// NotableDateRuleUseGroup global = new NotableDateRuleUseGroup(
+///     SourceResource: "Bodu/Globalization/Calendar/Resources/global-public.xml",
+///     UseAll: true,
+///     Uses: ImmutableArray&lt;NotableDateRuleUseDirective&gt;.Empty);
+///
+/// // From the AU public-holidays resource, pull only Anzac Day, retargeted to Western Australia:
+/// NotableDateRuleUseGroup australia = new NotableDateRuleUseGroup(
+///     SourceResource: "Bodu/Globalization/Calendar/Resources/au-public.xml",
+///     UseAll: false,
+///     Uses: ImmutableArray.Create(
+///         new NotableDateRuleUseDirective(
+///             SourceRuleName: "Anzac Day",
+///             TerritoryCode: "AU-WA",
+///             IsNonWorkingDay: true)));
+///
+/// // Equivalent XML:
+/// // &lt;Use source="...global-public.xml" useAll="true" /&gt;
+/// // &lt;Use source="...au-public.xml"&gt;
+/// //   &lt;Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true" /&gt;
+/// // &lt;/Use&gt;
+/// </code>
+/// </example>
 /// <param name="SourceResource">The manifest resource name of the source document. Must not be <see langword="null" /> or whitespace.</param>
 /// <param name="UseAll">
 /// When <see langword="true" />, every rule from <paramref name="SourceResource" /> is pulled in; <paramref name="Uses" /> may still

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
@@ -24,6 +24,14 @@ namespace Bodu.Globalization.Calendar;
 /// targeted and overridden by <c>&lt;Use&gt;</c> directives when the rule is inherited by another resource.
 /// </para>
 /// <para>
+/// When an adjustment activates the <see cref="NotableDateService" /> emits an <em>additional</em> <see cref="NotableDate" />
+/// at the adjusted date, leaving the original calculated date in place so consumers see both the actual and the observed
+/// occurrence. The shifted occurrence carries an <see cref="AdjustmentReason" /> on its
+/// <see cref="NotableDate.AdjustmentReason" /> property, naming the trigger and action that caused the shift; this also flips
+/// <see cref="NotableDate.WasAdjusted" /> to <see langword="true" />. When <see cref="IsNonWorkingDay" /> is set on the
+/// adjustment, that value overrides the rule's non-working flag for the shifted occurrence only.
+/// </para>
+/// <para>
 /// This type replaces the earlier <c>NotableDateAdjustmentRule</c>. The new name distinguishes the adjustment <em>specification</em>
 /// from the resolution <em>rule</em> that owns it.
 /// </para>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ParsedNotableDateDocument.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ParsedNotableDateDocument.cs
@@ -8,27 +8,58 @@ using System.Collections.Immutable;
 
 namespace Bodu.Globalization.Calendar;
 
-
 /// <summary>
 /// Represents the contents of a single notable date XML or JSON document, after parsing but before any cherry-pick directives have
 /// been resolved.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A <see cref="ParsedNotableDateDocument" /> is the unit returned by <see cref="NotableDateRuleParser.ParseDocument(string)" />: it
-/// captures every directive declared inside a single resource (the <see cref="UseGroups" /> that cherry-pick rules from other
-/// resources, and the <see cref="LocalRules" /> that the document declares itself), and lets a higher-level loader such as
-/// <see cref="XmlResourceNotableDateRuleProvider" /> flatten a graph of documents into a single rule set under the project's
-/// override semantics: locally declared rules win over inherited ones with the same name.
+/// A <see cref="ParsedNotableDateDocument" /> is the unit returned by <see cref="NotableDateRuleParser.ParseDocument(string)" /> and
+/// its JSON counterpart <see cref="NotableDateRuleJsonParser" />: it captures every directive declared inside a single resource —
+/// the <see cref="UseGroups" /> that cherry-pick rules from sibling resources, and the <see cref="LocalRules" /> that the document
+/// declares itself.
+/// </para>
+/// <para>
+/// The parsed document is the input to a higher-level loader such as <see cref="XmlResourceNotableDateRuleProvider" />, which
+/// flattens a graph of documents into a single rule set under the project's override semantics: locally declared rules win over
+/// inherited ones with the same name, and inherited rules are merged with any <see cref="NotableDateRuleUseDirective.OverrideBody" />
+/// supplied on the importing <c>&lt;Use&gt;</c> directive.
+/// </para>
+/// <para>
+/// At this point the document still references inherited rules by name only — no resolution or merging has happened. The rules
+/// emitted by the loader (and ultimately the <see cref="NotableDate" /> values produced by <see cref="NotableDateService" />) only
+/// take their final shape after the <see cref="UseGroups" /> have been walked and the resulting <see cref="NotableDateRule" />
+/// instances merged with <see cref="LocalRules" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>Parse a small XML payload and inspect what each collection contains:</para>
+/// <code>
+/// const string xml = """
+///     &lt;NotableDates xmlns="urn:bodu:globalization:calendar"&gt;
+///       &lt;Use source="Bodu/Globalization/Calendar/Resources/global-public.xml"&gt;
+///         &lt;Rule sourceName="New Year's Day" territoryCode="AU" /&gt;
+///       &lt;/Use&gt;
+///       &lt;Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true"&gt;
+///         &lt;Fixed month="1" day="26" /&gt;
+///       &lt;/Rule&gt;
+///     &lt;/NotableDates&gt;
+///     """;
+///
+/// ParsedNotableDateDocument document = NotableDateRuleParser.ParseDocument(xml);
+///
+/// // document.UseGroups[0].SourceResource == ".../global-public.xml"
+/// // document.UseGroups[0].Uses[0].SourceRuleName == "New Year's Day"
+/// // document.LocalRules[0].Name == "Australia Day"
+/// </code>
+/// </example>
 public sealed record ParsedNotableDateDocument
 {
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ParsedNotableDateDocument" /> record.
 	/// </summary>
-	/// <param name="useGroups">The cherry-pick groups that pull rules from other resources.</param>
-	/// <param name="localRules">The notable date rules declared locally in this document.</param>
+	/// <param name="useGroups">The cherry-pick groups that pull rules from other resources. Default-uninitialised arrays are coerced to <see cref="ImmutableArray{T}.Empty" />.</param>
+	/// <param name="localRules">The notable date rules declared locally in this document. Default-uninitialised arrays are coerced to <see cref="ImmutableArray{T}.Empty" />.</param>
 	public ParsedNotableDateDocument(
 		ImmutableArray<NotableDateRuleUseGroup> useGroups,
 		ImmutableArray<NotableDateRule> localRules)
@@ -38,12 +69,14 @@ public sealed record ParsedNotableDateDocument
 	}
 
 	/// <summary>
-	/// Gets the cherry-pick groups that pull rules from other resources.
+	/// Gets the cherry-pick groups that pull rules from other resources, in document order.
 	/// </summary>
+	/// <returns>The <see cref="NotableDateRuleUseGroup" /> entries authored on the document, or <see cref="ImmutableArray{T}.Empty" /> when no <c>&lt;Use&gt;</c> directives were declared.</returns>
 	public ImmutableArray<NotableDateRuleUseGroup> UseGroups { get; }
 
 	/// <summary>
-	/// Gets the notable date rules declared locally in this document.
+	/// Gets the notable date rules declared locally in this document, in document order.
 	/// </summary>
+	/// <returns>The <see cref="NotableDateRule" /> entries authored directly on the document, or <see cref="ImmutableArray{T}.Empty" /> when no local rules were declared.</returns>
 	public ImmutableArray<NotableDateRule> LocalRules { get; }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
@@ -7,10 +7,45 @@
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Specifies that a notable date rule should be suppressed by an <see cref="INotableDateRuleOverrideProvider" />.
+/// Specifies that a notable date rule loaded from a base <see cref="INotableDateRuleProvider" /> should be suppressed by an
+/// <see cref="INotableDateRuleOverrideProvider" />, optionally scoped to a year range and territory.
 /// </summary>
-/// <param name="RuleName">The name of the rule to suppress.</param>
+/// <remarks>
+/// <para>
+/// Rule removals operate at the resolution stage rather than at load time: the base rule remains in the merged rule set, but the
+/// service skips it when generating <see cref="NotableDate" /> instances for any year and territory matched by the removal. This
+/// makes removals composable with additions from the same override provider — a single provider can replace a rule by emitting a
+/// removal alongside a new <see cref="NotableDateRule" /> bearing the same name.
+/// </para>
+/// <para>
+/// All filtering parameters are optional. Leaving every filter unset suppresses the rule unconditionally; any combination of year
+/// bounds and territory narrows the suppression to a specific window.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>Suppress a holiday for a single year, and permanently remove a regional rule for one subdivision:</para>
+/// <code>
+/// // Suppress Boxing Day for the 2026 calendar year only:
+/// RuleRemoval boxingDay2026 = new RuleRemoval(
+///     RuleName: "Boxing Day",
+///     FromYear: 2026,
+///     ToYear: 2026);
+///
+/// // Permanently remove Picnic Day for Northern Territory only (other AU subdivisions unaffected):
+/// RuleRemoval picnicDayNT = new RuleRemoval(
+///     RuleName: "Picnic Day",
+///     TerritoryCode: "AU-NT");
+///
+/// // Returned from an INotableDateRuleOverrideProvider:
+/// public IEnumerable&lt;RuleRemoval&gt; GetRemovals()
+/// {
+///     yield return boxingDay2026;
+///     yield return picnicDayNT;
+/// }
+/// </code>
+/// </example>
+/// <param name="RuleName">The name of the rule to suppress. Matched case-insensitively against <see cref="NotableDateRule.Name" />.</param>
 /// <param name="FromYear">Optional inclusive first year of the suppression. <see langword="null" /> for no lower bound.</param>
 /// <param name="ToYear">Optional inclusive last year of the suppression. <see langword="null" /> for no upper bound.</param>
-/// <param name="TerritoryCode">Optional territory scope. When supplied, suppression applies only when resolving rules for the given territory.</param>
+/// <param name="TerritoryCode">Optional territory scope. When supplied, suppression applies only when the active territory falls within the supplied scope (a country-level scope covers all of its subdivisions).</param>
 public sealed record RuleRemoval(string RuleName, int? FromYear = null, int? ToYear = null, string? TerritoryCode = null);


### PR DESCRIPTION
## Summary
This change significantly expands and improves the XML documentation (doc comments) across the notable date calendar API, bringing comprehensive guidance to public types and members that previously had minimal or generic documentation.

## Key Changes

- **INotableDateAlgorithm**: Completely rewrote the interface documentation with detailed remarks explaining the role of algorithms as the extensibility seam for complex date calculations, their relationship to NotableDateRule and NotableDateService, concurrency and determinism requirements, and a complete working example (Melbourne Cup Day algorithm).

- **INotableDateProvider**: Expanded documentation to clarify how it differs from INotableDateAlgorithm (bundles calculation + metadata vs. anchor date only), when to use each, supported year range semantics, and implementation expectations.

- **NotableDateRuleUseDirective**: Added comprehensive remarks explaining cherry-pick semantics, override precedence (innermost wins), merge vs. replace behavior for different field types, and a practical example showing Anzac Day retargeting with adjustment override.

- **NotableDateRuleUseGroup**: Added remarks covering import modes (UseAll vs. cherry-pick), the relationship to ParsedNotableDateDocument and the loader pipeline, and an example demonstrating both global and regional resource imports.

- **ParsedNotableDateDocument**: Expanded remarks to explain the document's role in the parsing → loading → resolution pipeline, clarified that UseGroups reference inherited rules by name only (no merging yet), and added an example parsing a small XML payload.

- **NotableDateRuleParser**: Added remarks explaining schema validation, the relationship to NotableDateRuleJsonParser, and the position in the rule-loading stack, plus an example parsing inline XML with Fixed and Algorithm strategies.

- **RuleRemoval**: Added comprehensive remarks on removal semantics (operates at resolution time, composable with additions), optional filtering parameters, and examples showing year-scoped and territory-scoped removals.

- **AdjustmentReason**: Expanded remarks explaining when and why the reason is attached, the preservation of OriginalDate for diagnostics, and an example rendering observed-vs-actual labels for Anzac Day 2026.

- **NotableDateAlgorithmRegistry**: Added remarks on registry lookup during resolution, how a single algorithm can power multiple rules (Easter Sunday, Easter Monday, Good Friday), and an example registering two Easter algorithms.

- **AdjustmentHandlerResult**: Added detailed remarks explaining the three outputs (Activated, AdjustedDate, IsNonWorkingOverride) and their downstream effects on NotableDate emission.

- **AdjustmentHandlerRegistry**: Added remarks on composition-time registration, case-insensitive lookup, and an example wiring a custom conflict-avoidance handler.

- **AdjustmentHandlerContext**: Added remarks explaining the four facts bundled in the context and that handlers should treat it as read-only.

- **DefaultNotableDateCollisionResolver**: Added remarks on the conservative approach (keeps all distinct occurrences) and an example showing category-based ordering of colliding dates.

- **ObservanceAdjustment**: Expanded remarks on the dual-emission behavior (original + adjusted occurrence) and the AdjustmentReason attachment.

## Notable Implementation Details

- All documentation additions follow the existing style and conventions (remarks, examples, cross-references via `<see cref>` and `<see langword>`).
- Examples are practical and self-contained, demonstrating real-world usage patterns.
- Documentation clarifies the relationships between related types (e.g., INotableDateAlgorithm vs. INotableDateProvider, NotableDateRule vs. NotableDateRuleUseDirective).
- Remarks explain both the "what" and the "why" to help developers understand design intent and proper usage.
- Minor formatting fixes (removed BOM characters, cleaned up blank lines).

https://claude.ai/code/session_01CSQnuTEuiDYrz9vCNkR9cs