### PR TITLE
Fix documentation links and add missing GetHashCode override

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -318,6 +318,10 @@ public sealed class Crc
     public override bool Equals(object? obj)
         => obj is Crc other && this._standard.Equals(other._standard);
 
+    /// <inheritdoc />
+    public override int GetHashCode()
+        => this._standard.GetHashCode();
+
     /// <summary>
     /// Returns the working-state representation of <see cref="CrcStandard.InitialValue" />, applying input reflection
     /// when required.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
@@ -54,7 +54,7 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// </para>
 /// <para>
 /// For non-cryptographic algorithms (CRC, xxHash, Fletcher, …) prefer the
-/// <see cref="Bodu.IO.Hashing.Extensions.NonCryptographicHashAlgorithmExtensions"/> companion in <c>Bodu.IO.Hashing</c>;
+/// <c>Bodu.IO.Hashing.Extensions.NonCryptographicHashAlgorithmExtensions</c> companion in <c>Bodu.IO.Hashing</c>;
 /// both surfaces follow the same naming so call sites read identically.
 /// </para>
 /// <example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -143,7 +143,7 @@ public sealed class Blake2b : KeyedDeferredFinalBlockHashAlgorithm<Blake2b>
     /// The full BLAKE2b compression is always run using all 512 bits of internal state. Shorter output lengths
     /// are produced by truncating the serialised state after finalisation. The property may only be changed
     /// before hashing has begun; once <see cref="HashAlgorithm.TransformBlock" /> or a <c>ComputeHash</c>
-    /// overload has been called, the value is immutable until <see cref="Initialize" /> is called.
+    /// overload has been called, the value is immutable until <see cref="HashAlgorithm.Initialize" /> is called.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
     /// The assigned value is not one of 128, 160, 192, 224, 256, 384, or 512.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -142,7 +142,7 @@ public sealed class Blake2s : KeyedDeferredFinalBlockHashAlgorithm<Blake2s>
     /// The full BLAKE2s compression is always run using all 256 bits of internal state. Shorter output lengths
     /// are produced by truncating the serialised state after finalisation. The property may only be changed
     /// before hashing has begun; once <see cref="HashAlgorithm.TransformBlock" /> or a <c>ComputeHash</c>
-    /// overload has been called, the value is immutable until <see cref="Initialize" /> is called.
+    /// overload has been called, the value is immutable until <see cref="HashAlgorithm.Initialize" /> is called.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
     /// The assigned value is not one of 128, 160, 192, 224, or 256.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
@@ -38,8 +38,8 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="DeferredFinalBlockHashAlgorithm{T}"/> instead. For a keyed Merkle–Damgård hash (Poly1305,
 /// SipHash) derive from <see cref="KeyedBlockHashAlgorithm{T}"/>, which adds key handling on top of this
 /// base. For non-cryptographic block hashes (Fletcher, CRC) the parallel
-/// <see cref="Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm{T}"/> base is the right pick — it integrates
-/// with <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/> rather than <see cref="HashAlgorithm"/>.
+/// <c>Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm&lt;T&gt;</c> base is the right pick — it integrates
+/// with <c>System.IO.Hashing.NonCryptographicHashAlgorithm</c> rather than <see cref="HashAlgorithm"/>.
 /// </para>
 /// </remarks>
 /// <seealso cref="BufferedBlockHashAlgorithm{T}"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
@@ -36,7 +36,7 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// <para>Derived classes must implement the following:</para>
 /// <list type="bullet">
-/// <item><description><see cref="OnInitialize" /> resets the algorithm-specific chaining variables to their initial state.</description></item>
+/// <item><description><see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> resets the algorithm-specific chaining variables to their initial state.</description></item>
 /// <item><description><see cref="ProcessBlock" /> compresses a single block, receiving the per-block counter and the finalisation flag.</description></item>
 /// <item><description><see cref="ProcessFinalBlock" /> extracts the digest from the chaining variables after the final compression has run.</description></item>
 /// </list>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -16,7 +16,7 @@ namespace Bodu.Security.Cryptography;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="Shake" /> is built on the same <c>Keccak-f[1600]</c> permutation as <see cref="Sha3" />, operating over
+/// <see cref="Shake" /> is built on the same <c>Keccak-f[1600]</c> permutation as <c>SHA-3</c>, operating over
 /// a 1600-bit (200-byte) state. The two SHAKE variants differ only in their rate and, therefore, their security margin:
 /// </para>
 /// <list type="bullet">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
@@ -69,7 +69,7 @@ public sealed class SipHash128
     /// <description>128</description>
     /// </item>
     /// <item>
-    /// <term><see cref="SipHash{T}.Key" /></term>
+    /// <term><see cref="KeyedBlockHashAlgorithm{T}.Key" /></term>
     /// <description>Cryptographically random 16-byte key containing no zero bytes.</description>
     /// </item>
     /// </list>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
@@ -77,7 +77,7 @@ public sealed class SipHash64
     /// <description>64</description>
     /// </item>
     /// <item>
-    /// <term><see cref="SipHash{T}.Key" /></term>
+    /// <term><see cref="KeyedBlockHashAlgorithm{T}.Key" /></term>
     /// <description>Cryptographically random 16-byte key containing no zero bytes.</description>
     /// </item>
     /// </list>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -385,30 +385,6 @@ public abstract partial class Skein<T>
     }
 
     /// <summary>
-    /// Throws an <see cref="ObjectDisposedException" /> if the instance has already been disposed.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfDisposed()
-    {
-#if NET8_0_OR_GREATER
-        ObjectDisposedException.ThrowIf(this._disposed, this);
-#else
-        if (this._disposed)
-            throw new ObjectDisposedException(this.GetType().Name);
-#endif
-    }
-
-    /// <summary>
-    /// Throws if the algorithm has begun processing input and can no longer be reconfigured.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfInvalidState()
-    {
-        if (this.State != 0)
-            throw new CryptographicUnexpectedOperationException(ResourceStrings.CryptographicException_ReconfigurationNotAllowed);
-    }
-
-    /// <summary>
     /// Ensures the initial chaining value derived from the configuration (and optional key) UBI phases has been
     /// computed and cached for fast reuse on subsequent <see cref="Initialize" /> calls.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
@@ -140,7 +141,7 @@ public sealed class Skipjack
     /// <exception cref="CryptographicException">
     /// <paramref name="rgbKey" /> is not exactly 10 bytes in length, or <paramref name="rgbIV" /> is not exactly 8 bytes in length.
     /// </exception>
-    public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[] rgbIV)
+    public override ICryptoTransform CreateDecryptor(byte[] rgbKey, byte[]? rgbIV)
     {
         this.ThrowIfDisposed();
         this.Validate(rgbKey, rgbIV);
@@ -166,7 +167,7 @@ public sealed class Skipjack
     /// <exception cref="CryptographicException">
     /// <paramref name="rgbKey" /> is not exactly 10 bytes in length, or <paramref name="rgbIV" /> is not exactly 8 bytes in length.
     /// </exception>
-    public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[] rgbIV)
+    public override ICryptoTransform CreateEncryptor(byte[] rgbKey, byte[]? rgbIV)
     {
         this.ThrowIfDisposed();
         this.Validate(rgbKey, rgbIV);
@@ -270,7 +271,7 @@ public sealed class Skipjack
     /// <param name="iv">The initialisation vector to validate.</param>
     /// <exception cref="ArgumentNullException"><paramref name="key" /> or <paramref name="iv" /> is <see langword="null" />.</exception>
     /// <exception cref="CryptographicException">The key or IV length is not valid for this algorithm.</exception>
-    private void Validate(byte[] key, byte[] iv)
+    private void Validate(byte[] key, [NotNull] byte[]? iv)
     {
         ThrowHelper.ThrowIfNull(key);
         ThrowHelper.ThrowIfNull(iv);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
@@ -28,7 +28,7 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// <strong>When to choose Snefru128.</strong> For academic study and interop with archival data only. For new
 /// security-sensitive work use SHA-2 or <see cref="Blake2b"/>; for 128-bit non-cryptographic fingerprinting use a
-/// <c>Bodu.IO.Hashing</c> algorithm such as <see cref="Bodu.IO.Hashing.MurmurHash3_128"/>.
+/// <c>Bodu.IO.Hashing</c> algorithm such as <c>Bodu.IO.Hashing.MurmurHash3_128</c>.
 /// </para>
 /// <note type="important">Snefru is considered broken and <b>not</b> suitable for password hashing, digital signatures, or secure
 /// data integrity checks.</note>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -37,7 +37,7 @@ namespace Bodu.Security.Cryptography;
 ///   <item><description>Output size: 512 bits (64 bytes), fixed.</description></item>
 ///   <item><description>Block size: 64 bytes (512 bits); 256-bit big-endian length field.</description></item>
 ///   <item><description>Internal cipher <c>W</c> on the wide-trail (Rijndael-family) design principle.</description></item>
-///   <item><description>Selectable revision: <see cref="WhirlpoolVersion.WhirlpoolInfo0"/> (2000), <see cref="WhirlpoolVersion.WhirlpoolInfo1"/> (Whirlpool-T, 2001), or <see cref="WhirlpoolVersion.WhirlpoolInfo3"/> (ISO/IEC 10118-3, 2003 — default).</description></item>
+///   <item><description>Selectable revision: <see cref="WhirlpoolVersion.WhirlpoolInfo1"/> (Whirlpool-0, 2000), <see cref="WhirlpoolVersion.WhirlpoolInfo2"/> (Whirlpool-T, 2001), or <see cref="WhirlpoolVersion.WhirlpoolInfo3"/> (ISO/IEC 10118-3, 2003 — default).</description></item>
 /// </list>
 /// <para>
 /// <strong>When to choose Whirlpool.</strong> Pick Whirlpool when interoperability with software that produces

--- a/Bodu.Test/src/Test.IO/NonSeekableStream.cs
+++ b/Bodu.Test/src/Test.IO/NonSeekableStream.cs
@@ -14,7 +14,7 @@ namespace Bodu.Test.IO;
 /// <para>
 /// <see cref="CanSeek" /> returns <see langword="false" /> and both <see cref="Position" /> and
 /// <see cref="Length" /> throw <see cref="NotSupportedException" />, matching the contract of
-/// streams such as <see cref="NetworkStream" /> or a raw pipe endpoint. Any attempt to call
+/// streams such as <see cref="System.Net.Sockets.NetworkStream" /> or a raw pipe endpoint. Any attempt to call
 /// <see cref="Seek" /> or set <see cref="Position" /> also throws.
 /// </para>
 /// <para>

--- a/Bodu.Test/src/Test.IO/ThrottledIncrementingByteStream.cs
+++ b/Bodu.Test/src/Test.IO/ThrottledIncrementingByteStream.cs
@@ -6,8 +6,9 @@
 
 namespace Bodu.Test.IO;
 
-// <summary>
-/// A test stream that simulates slow I/O by sleeping on each read, to trigger cancellation scenarios. </summary>
+/// <summary>
+/// A test stream that simulates slow I/O by sleeping on each read, to trigger cancellation scenarios.
+/// </summary>
 public sealed class ThrottledIncrementingByteStream
     : IncrementingByteStream
 {

--- a/Bodu.Test/src/Test/TestHelpers.GetPropertyInfoForType.cs
+++ b/Bodu.Test/src/Test/TestHelpers.GetPropertyInfoForType.cs
@@ -27,7 +27,7 @@ public static partial class TestHelpers
     /// The binding flags used to select properties on each type in the inheritance chain.
     /// </param>
     /// <returns>
-    /// A sequence of <see cref="object[]" /> values, each containing a single <see cref="PropertyInfo" />.
+    /// A sequence of <c>object[]</c> values, each containing a single <see cref="PropertyInfo" />.
     /// If no matching properties are found, a single row containing <see langword="null" /> is returned.
     /// </returns>
     public static IEnumerable<object[]> GetPropertyInfoForType<T>(

--- a/docs/apidoc/Bodu.Collections.Generic.md
+++ b/docs/apidoc/Bodu.Collections.Generic.md
@@ -21,7 +21,7 @@ Related namespaces in the same library:
 
 - <xref:Bodu.Buffers> — low-overhead conversion helpers between raw byte arrays and arrays of unmanaged types (`BufferConverter`).
 - <xref:Bodu.Extensions> — array helpers (`ArrayExtensions`) for slicing, copying, clearing, and reversing.
-- <xref:Bodu.Text> — `BaseEncoding` entry points for Base16, Base24, Base32, and Base64.
+- <xref:Bodu.Text.BaseEncoding> — `BaseEncoding` entry points for Base16, Base24, Base32, and Base64.
 - <xref:Bodu> — `ThrowHelper` centralises argument validation; `IRandomGenerator` abstracts random generation for testability.
 
 ## Example

--- a/docs/apidoc/Bodu.Globalization.Calendar.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.md
@@ -29,9 +29,9 @@ Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you
 
 **Dynamic calculators**
 
-- <xref:Bodu.Globalization.Calendar.INotableDateCalculator>, <xref:Bodu.Globalization.Calendar.INotableDateCalculatorRegistry>, <xref:Bodu.Globalization.Calendar.NotableDateCalculatorRegistry> — the contract and registry for year-keyed date computation.
-- <xref:Bodu.Globalization.Calendar.Calculators.EasterSundayNotableDateCalculator> — Gregorian Computus from 1583 onwards; falls back to the Julian algorithm for earlier years. Results are cached per year.
-- <xref:Bodu.Globalization.Calendar.Calculators.LunarNewYearNotableDateCalculator> — Lunar New Year from lunar-calendar computation.
+- <xref:Bodu.Globalization.Calendar.INotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.INotableDateAlgorithmRegistry>, <xref:Bodu.Globalization.Calendar.NotableDateAlgorithmRegistry> — the contract and registry for year-keyed date computation.
+- <xref:Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateAlgorithm> — Gregorian Computus from 1583 onwards; falls back to the Julian algorithm for earlier years. Results are cached per year.
+- <xref:Bodu.Globalization.Calendar.Algorithms.HinduLunarNotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.Algorithms.LosarNotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.Algorithms.VesakNotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.Algorithms.AsalhaPujaNotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.Algorithms.QingmingNotableDateAlgorithm> — lunar- and solar-term based notable-date algorithms.
 
 **Adjustment pipeline**
 
@@ -67,4 +67,4 @@ DateTime goodFriday2026 = easter2026.AddDays(-2);
 - **Thread safety.** Calculators cache their results per year internally and are **safe for concurrent reads** after any first-compute. A `NotableDateService` built with a stable set of definitions may be shared across requests.
 - **Culture and adjustment.** A <xref:Bodu.Globalization.Calendar.NotableDate> tracks both its original calculated date and its adjusted date — so a rule like "if a fixed holiday falls on a Saturday, observe it on the preceding Friday" is applied transparently while still preserving the original for audit and display.
 - **Target framework.** `net8.0`.
-- **Extensibility.** Implement <xref:Bodu.Globalization.Calendar.INotableDateCalculator> to add your own dynamic calculator (e.g. Orthodox Easter, Rosh Hashanah, Diwali) and register it with <xref:Bodu.Globalization.Calendar.NotableDateService> alongside the built-in fixed, rule-based, and offset-based definitions — or plug a custom <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider> to source rules from somewhere other than the embedded XML.
+- **Extensibility.** Implement <xref:Bodu.Globalization.Calendar.INotableDateAlgorithm> to add your own dynamic calculator (e.g. Orthodox Easter, Rosh Hashanah, Diwali) and register it with <xref:Bodu.Globalization.Calendar.NotableDateService> alongside the built-in fixed, rule-based, and offset-based definitions — or plug a custom <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider> to source rules from somewhere other than the embedded XML.

--- a/docs/apidoc/Bodu.IO.Hashing.md
+++ b/docs/apidoc/Bodu.IO.Hashing.md
@@ -14,22 +14,22 @@ Reach for this library when you need a fast, deterministic checksum for error de
 
 **CRC family**
 
-- <xref:Bodu.IO.Hashing.Crc> — the single CRC engine. Configured with a <xref:Bodu.IO.Hashing.CrcStandard>, it handles widths from 1 to 64 bits, honours polynomial, initial value, input / output reflection, and final XOR, and ships with a shared lookup-table cache.
-- <xref:Bodu.IO.Hashing.CrcStandard> — an immutable parameter set: name, width, polynomial, initial value, reflect-in, reflect-out, XOR-out. Exposes common standards as named properties (`CRC32_ISOHDLC`, `CRC32_ISCSI`, `CRC16_MODBUS`, `CRC64_XZ`, …) and provides `FromName` / `TryFromName` over canonical names and published aliases.
-- <xref:Bodu.IO.Hashing.CrcStandards> — an enum covering every canonical CRC RevEng entry (113 standards as of the last catalogue fetch).
-- <xref:Bodu.IO.Hashing.CrcLookupTableCache> — thread-safe cache of 256-entry lookup tables, keyed by (width, polynomial, reflect-in), shared process-wide through <xref:Bodu.IO.Hashing.Crc.GlobalCache>.
-- <xref:Bodu.IO.Hashing.CrcLookupTableBuilder> — builds a lookup table from parameters; used by the cache on first miss.
+- <xref:Bodu.IO.Hashing.Checksums.Crc> — the single CRC engine. Configured with a <xref:Bodu.IO.Hashing.Checksums.CrcStandard>, it handles widths from 1 to 64 bits, honours polynomial, initial value, input / output reflection, and final XOR, and ships with a shared lookup-table cache.
+- <xref:Bodu.IO.Hashing.Checksums.CrcStandard> — an immutable parameter set: name, width, polynomial, initial value, reflect-in, reflect-out, XOR-out. Exposes common standards as named properties (`CRC32_ISOHDLC`, `CRC32_ISCSI`, `CRC16_MODBUS`, `CRC64_XZ`, …) and provides `FromName` / `TryFromName` over canonical names and published aliases.
+- <xref:Bodu.IO.Hashing.Checksums.CrcStandards> — an enum covering every canonical CRC RevEng entry (113 standards as of the last catalogue fetch).
+- <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableCache> — thread-safe cache of 256-entry lookup tables, keyed by (width, polynomial, reflect-in), shared process-wide through <xref:Bodu.IO.Hashing.Checksums.Crc.GlobalCache>.
+- <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableBuilder> — builds a lookup table from parameters; used by the cache on first miss.
 
 **Fletcher family**
 
-- <xref:Bodu.IO.Hashing.Fletcher16> — 16-bit position-dependent checksum; 1-byte block.
-- <xref:Bodu.IO.Hashing.Fletcher32> — 32-bit position-dependent checksum; 2-byte block.
-- <xref:Bodu.IO.Hashing.Fletcher64> — 64-bit position-dependent checksum; 4-byte block.
+- <xref:Bodu.IO.Hashing.Checksums.Fletcher16> — 16-bit position-dependent checksum; 1-byte block.
+- <xref:Bodu.IO.Hashing.Checksums.Fletcher32> — 32-bit position-dependent checksum; 2-byte block.
+- <xref:Bodu.IO.Hashing.Checksums.Fletcher64> — 64-bit position-dependent checksum; 4-byte block.
 
 **Building blocks**
 
 - <xref:Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm`1> — an abstract CRTP base for block-oriented non-cryptographic hashes. Provides residual-buffering, finalisation, and clone semantics that the Fletcher family builds on.
-- <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — a contract for hashes that can reconstruct their state from a previously finalised digest and continue appending new data, implemented by <xref:Bodu.IO.Hashing.Crc>.
+- <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — a contract for hashes that can reconstruct their state from a previously finalised digest and continue appending new data, implemented by <xref:Bodu.IO.Hashing.Checksums.Crc>.
 
 ## Example
 
@@ -56,9 +56,9 @@ byte[] combined = crc.ComputeHashFrom(previous, Encoding.UTF8.GetBytes(" jumps o
 
 ## Notes
 
-- **Not cryptographically secure.** Every algorithm here is designed for error detection and hash-table distribution, not authentication. An attacker who can choose the input can trivially forge the output. Pair with a MAC or signature if integrity against an adversary matters — see <xref:Bodu.Security.Cryptography.SipHash64> for a keyed short-input hash, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> for a full cryptographic digest.
-- **Shared lookup tables.** <xref:Bodu.IO.Hashing.Crc> instances with identical (width, polynomial, reflect-in) triples share a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Crc.GlobalCache>. Constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
-- **Non-destructive `GetCurrentHash`.** Calling <xref:System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash*> snapshots the accumulator and applies the final reflect / XOR / width-mask on the copy, so in-progress hashing is not disturbed. Call it as many times as you like.
-- **Resumable.** <xref:Bodu.IO.Hashing.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — reverse-finalise a stored digest, append further data, re-finalise. Handy for chunked streams where re-reading earlier bytes is expensive.
+- **Not cryptographically secure.** Every algorithm here is designed for error detection and hash-table distribution, not authentication. An attacker who can choose the input can trivially forge the output. Pair with a MAC or signature if integrity against an adversary matters — see <xref:Bodu.Security.Cryptography.SipHash64> for a keyed short-input hash, or `System.Security.Cryptography.SHA256` for a full cryptographic digest.
+- **Shared lookup tables.** <xref:Bodu.IO.Hashing.Checksums.Crc> instances with identical (width, polynomial, reflect-in) triples share a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Checksums.Crc.GlobalCache>. Constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
+- **Non-destructive `GetCurrentHash`.** Calling `NonCryptographicHashAlgorithm.GetCurrentHash` snapshots the accumulator and applies the final reflect / XOR / width-mask on the copy, so in-progress hashing is not disturbed. Call it as many times as you like.
+- **Resumable.** <xref:Bodu.IO.Hashing.Checksums.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — reverse-finalise a stored digest, append further data, re-finalise. Handy for chunked streams where re-reading earlier bytes is expensive.
 - **Determinism and portability.** All algorithms produce identical byte-for-byte output across platforms and architectures for the same input and configuration.
 - **See also:** the [Using CRC](../guides/io-hashing/crc.md) and [Using Fletcher](../guides/io-hashing/fletcher.md) guides, and the [full CRC catalogue](../guides/io-hashing/crc-catalogue.md).

--- a/docs/apidoc/Bodu.Security.Cryptography.md
+++ b/docs/apidoc/Bodu.Security.Cryptography.md
@@ -35,7 +35,7 @@ For non-cryptographic checksums and hash-table hashes (CRC, Fletcher, Adler, FNV
 - <xref:Bodu.Security.Cryptography.SipHash128> — 128-bit SipHash variant for longer-output keyed hashing.
 - <xref:Bodu.Security.Cryptography.Poly1305> — one-time authenticator; pairs with a stream cipher for a MAC-with-AEAD construction.
 - <xref:Bodu.Security.Cryptography.Tiger> — cryptographic hash by Anderson and Biham optimised for 64-bit platforms; supports 128 / 160 / 192-bit output with Tiger or Tiger2 padding.
-- <xref:Bodu.Security.Cryptography.Snefru> — a cryptographic hash by Ralph Merkle (broken; included for research).
+- <xref:Bodu.Security.Cryptography.Snefru128>, <xref:Bodu.Security.Cryptography.Snefru256> — a cryptographic hash by Ralph Merkle (broken; included for research).
 - <xref:Bodu.Security.Cryptography.CubeHash> — Bernstein's SHA-3 competition candidate.
 - <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> — Merkle-tree root hashing with partial verification.
 

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -1,6 +1,6 @@
 # Articles
 
-Narrative documentation and library overviews complement the auto-generated [API reference](../api/).
+Narrative documentation and library overviews complement the auto-generated [API reference](xref:Bodu).
 
 ## Library overviews
 
@@ -20,10 +20,10 @@ Each library has a dedicated overview page that introduces its purpose, lists it
 
 ## Guides
 
-- **[Bodu.Core guides](../guides/core/)** — circular buffer, deque, evicting dictionary, week pattern.
-- **[Bodu.IO.Hashing guides](../guides/io-hashing/)** — fingerprints, checksums (CRC, Fletcher, Adler), and check digits.
-- **[Bodu.Security.Cryptography guides](../guides/cryptography/)** — encryption basics, cipher block modes, AEAD, padding, composing primitives, keyed and cryptographic hashing, the ASCON family.
-- **[Bodu.Globalization.Calendar guides](../guides/calendar/)** — `NotableDateService`, calculators, rule authoring, data packs.
+- **[Bodu.Core guides](../guides/core/index.md)** — circular buffer, deque, evicting dictionary, week pattern.
+- **[Bodu.IO.Hashing guides](../guides/io-hashing/index.md)** — fingerprints, checksums (CRC, Fletcher, Adler), and check digits.
+- **[Bodu.Security.Cryptography guides](../guides/cryptography/index.md)** — encryption basics, cipher block modes, AEAD, padding, composing primitives, keyed and cryptographic hashing, the ASCON family.
+- **[Bodu.Globalization.Calendar guides](../guides/calendar/index.md)** — `NotableDateService`, calculators, rule authoring, data packs.
 
 ## Project documentation
 

--- a/docs/docs/algorithm-families.md
+++ b/docs/docs/algorithm-families.md
@@ -317,4 +317,4 @@ See the [ASCON family guide](../guides/cryptography/ascon.md) for selection guid
 - [Bodu.Globalization.Calendar](calendar/index.md) — notable date resolution and calculators.
 
 **Guides**
-- [Bodu.Core guides](../guides/core/) · [Bodu.IO.Hashing guides](../guides/io-hashing/) · [Bodu.Security.Cryptography guides](../guides/cryptography/) · [Bodu.Globalization.Calendar guides](../guides/calendar/)
+- [Bodu.Core guides](../guides/core/index.md) · [Bodu.IO.Hashing guides](../guides/io-hashing/index.md) · [Bodu.Security.Cryptography guides](../guides/cryptography/index.md) · [Bodu.Globalization.Calendar guides](../guides/calendar/index.md)

--- a/docs/docs/calendar/getting-started.md
+++ b/docs/docs/calendar/getting-started.md
@@ -114,5 +114,5 @@ INotableDateService service = NotableDateService.Create(
 ## Where to go next
 
 - **[Bodu.Globalization.Calendar introduction](index.md)** — namespaces, headline types, scenarios.
-- **[Bodu.Globalization.Calendar guides](../../guides/calendar/)** — `NotableDateService` patterns, algorithms, rule authoring, data packs.
+- **[Bodu.Globalization.Calendar guides](../../guides/calendar/index.md)** — `NotableDateService` patterns, algorithms, rule authoring, data packs.
 - **[Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md)** — full type-by-type docs.

--- a/docs/docs/calendar/index.md
+++ b/docs/docs/calendar/index.md
@@ -93,5 +93,5 @@ Companion-pack rule providers (Americas / Europe / AsiaPacific). The data ships 
 ## Where to go next
 
 - **[Getting started](getting-started.md)** — install + minimal samples for the algorithm, the service, and working-day arithmetic.
-- **[Bodu.Globalization.Calendar guides](../../guides/calendar/)** — using `NotableDateService`, calculators, rule authoring, data packs.
+- **[Bodu.Globalization.Calendar guides](../../guides/calendar/index.md)** — using `NotableDateService`, calculators, rule authoring, data packs.
 - **[Bodu.Globalization.Calendar API reference](../../apidoc/Bodu.Globalization.Calendar.md)** — full type-by-type docs.

--- a/docs/docs/core/getting-started.md
+++ b/docs/docs/core/getting-started.md
@@ -105,5 +105,5 @@ public static double Average(IReadOnlyList<int> values)
 ## Where to go next
 
 - **[Bodu.Core introduction](index.md)** — namespaces, headline types, scenarios.
-- **[Bodu.Core guides](../../guides/core/)** — recipe-style walk-throughs.
+- **[Bodu.Core guides](../../guides/core/index.md)** — recipe-style walk-throughs.
 - **[Bodu.Collections.Generic API reference](../../apidoc/Bodu.Collections.Generic.md)** — full type-by-type docs.

--- a/docs/docs/core/index.md
+++ b/docs/docs/core/index.md
@@ -79,6 +79,6 @@ Small text and XML helpers used internally by the other Bodu packages; available
 ## Where to go next
 
 - **[Getting started](getting-started.md)** — install the package and run a minimal sample for each scenario above.
-- **[Bodu.Core guides](../../guides/core/)** — recipe-style walk-throughs for the headline types.
+- **[Bodu.Core guides](../../guides/core/index.md)** — recipe-style walk-throughs for the headline types.
 - **[Bodu.Collections.Generic API reference](../../apidoc/Bodu.Collections.Generic.md)** — full namespace overview.
 - **[Algorithm families](../algorithm-families.md)** — how Bodu.Core relates to the hashing and cryptography libraries (it doesn't directly — but its `ThrowHelper` is used everywhere).

--- a/docs/docs/cryptography/getting-started.md
+++ b/docs/docs/cryptography/getting-started.md
@@ -146,5 +146,5 @@ byte[] root = tree.GetHashAndReset();
 
 - **[Bodu.Security.Cryptography introduction](index.md)** — namespaces, headline types, scenarios.
 - **[Algorithm families](../algorithm-families.md)** — cipher subtypes, hash shapes, and the cross-library map.
-- **[Bodu.Security.Cryptography guides](../../guides/cryptography/)** — encryption basics, modes, padding, AEAD, hashing.
+- **[Bodu.Security.Cryptography guides](../../guides/cryptography/index.md)** — encryption basics, modes, padding, AEAD, hashing.
 - **[Bodu.Security.Cryptography API reference](../../apidoc/Bodu.Security.Cryptography.md)** — full type-by-type docs.

--- a/docs/docs/cryptography/index.md
+++ b/docs/docs/cryptography/index.md
@@ -129,5 +129,5 @@ The package contains five subfamilies. They share base classes but differ struct
 
 - **[Getting started](getting-started.md)** — install + minimal sample for a cipher, an AEAD round-trip, a keyed hash, and a digest.
 - **[Algorithm families](../algorithm-families.md)** — cipher subtypes, hash structural shapes, and the cross-library map.
-- **[Bodu.Security.Cryptography guides](../../guides/cryptography/)** — recipe-style walk-throughs.
+- **[Bodu.Security.Cryptography guides](../../guides/cryptography/index.md)** — recipe-style walk-throughs.
 - **[Bodu.Security.Cryptography API reference](../../apidoc/Bodu.Security.Cryptography.md)** — full type-by-type docs.

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -106,5 +106,5 @@ For the rule-driven `NotableDateService`, territory filtering, the observance-ad
 - **[Introduction](introduction.md)** — what each library is for and how they fit together.
 - **[Algorithm families](algorithm-families.md)** — the cross-library taxonomy if your problem touches hashing, checksums, or encryption.
 - **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md).
-- **[API reference](../api/)** — the full auto-generated type-by-type documentation.
-- **Guides:** [Bodu.Core](../guides/core/) · [Bodu.IO.Hashing](../guides/io-hashing/) · [Bodu.Security.Cryptography](../guides/cryptography/) · [Bodu.Globalization.Calendar](../guides/calendar/).
+- **[API reference](xref:Bodu)** — the full auto-generated type-by-type documentation.
+- **Guides:** [Bodu.Core](../guides/core/index.md) · [Bodu.IO.Hashing](../guides/io-hashing/index.md) · [Bodu.Security.Cryptography](../guides/cryptography/index.md) · [Bodu.Globalization.Calendar](../guides/calendar/index.md).

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -31,7 +31,7 @@ Each library has a dedicated introduction page that explains its namespaces, the
   <div class="bodu-card-links">
     <a href="core/index.html">Introduction</a>
     <a href="core/getting-started.html">Getting started</a>
-    <a href="../guides/core/">Guides</a>
+    <a href="../guides/core/index.html">Guides</a>
   </div>
 </div>
 
@@ -41,7 +41,7 @@ Each library has a dedicated introduction page that explains its namespaces, the
   <div class="bodu-card-links">
     <a href="io-hashing/index.html">Introduction</a>
     <a href="io-hashing/getting-started.html">Getting started</a>
-    <a href="../guides/io-hashing/">Guides</a>
+    <a href="../guides/io-hashing/index.html">Guides</a>
   </div>
 </div>
 
@@ -51,7 +51,7 @@ Each library has a dedicated introduction page that explains its namespaces, the
   <div class="bodu-card-links">
     <a href="cryptography/index.html">Introduction</a>
     <a href="cryptography/getting-started.html">Getting started</a>
-    <a href="../guides/cryptography/">Guides</a>
+    <a href="../guides/cryptography/index.html">Guides</a>
   </div>
 </div>
 
@@ -61,7 +61,7 @@ Each library has a dedicated introduction page that explains its namespaces, the
   <div class="bodu-card-links">
     <a href="calendar/index.html">Introduction</a>
     <a href="calendar/getting-started.html">Getting started</a>
-    <a href="../guides/calendar/">Guides</a>
+    <a href="../guides/calendar/index.html">Guides</a>
   </div>
 </div>
 
@@ -104,4 +104,4 @@ The solution uses **MSTest** with a partial-class test layout that mirrors the s
 - **[Getting started](getting-started.md)** — prerequisites, install commands, and a one-minute sample from each library.
 - **[Algorithm families](algorithm-families.md)** — the cross-library taxonomy of fingerprints, checksums, check digits, cryptographic hashes, keyed hashes, and symmetric ciphers.
 - **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md).
-- **[API reference](../api/)** — the full auto-generated type-by-type documentation.
+- **[API reference](xref:Bodu)** — the full auto-generated type-by-type documentation.

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -12,10 +12,10 @@ If you are new to Bodu, start with the **library introductions** below to unders
 
 | Package | What it provides | Target framework |
 |---|---|---|
-| **[Bodu.Core](core/)** | Bounded collections (`CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`), a day-of-week `WeekPattern` value type, pooled buffers, and a comprehensive set of date, numeric, span, and text extensions sitting on a centralised `ThrowHelper`. | `net8.0` |
-| **[Bodu.IO.Hashing](io-hashing/)** | Non-cryptographic hashing on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract — fingerprints (FNV, CityHash, MurmurHash3, XxHash, Pearson, Bernstein and the classic string hashes), checksums (CRC, Fletcher, Adler), and check digits (Luhn, Damm, Verhoeff, IBAN, ISBN, …). Nothing here is safe against an adversary; everything is fast and portable. | `net8.0` |
-| **[Bodu.Security.Cryptography](cryptography/)** | Cryptographic primitives on the BCL <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType> and <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contracts — managed block ciphers (Threefish, Serpent, Camellia, Twofish, Blowfish, Skipjack), AES paired with five AEAD mode transforms, keyed hashes (SipHash, Poly1305), cryptographic digests (Tiger, CubeHash, Snefru, Whirlpool, BLAKE2/3), Merkle-tree hashing, and the full ASCON family. | `net8.0` |
-| **[Bodu.Globalization.Calendar](calendar/)** | Rule-driven notable-date resolution — public holidays, observances, religious festivals — for any year, territory, or calendar system. Built-in algorithms cover Gregorian and Orthodox Easter, Hindu Lunar dates, Losar, Vesak, Asalha Puja, and Qingming, with a pluggable algorithm registry, observance-adjustment pipeline, and trust-policy-driven plugin host. | `net8.0` |
+| **[Bodu.Core](core/index.md)** | Bounded collections (`CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`), a day-of-week `WeekPattern` value type, pooled buffers, and a comprehensive set of date, numeric, span, and text extensions sitting on a centralised `ThrowHelper`. | `net8.0` |
+| **[Bodu.IO.Hashing](io-hashing/index.md)** | Non-cryptographic hashing on the BCL <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> contract — fingerprints (FNV, CityHash, MurmurHash3, XxHash, Pearson, Bernstein and the classic string hashes), checksums (CRC, Fletcher, Adler), and check digits (Luhn, Damm, Verhoeff, IBAN, ISBN, …). Nothing here is safe against an adversary; everything is fast and portable. | `net8.0` |
+| **[Bodu.Security.Cryptography](cryptography/index.md)** | Cryptographic primitives on the BCL <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType> and <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contracts — managed block ciphers (Threefish, Serpent, Camellia, Twofish, Blowfish, Skipjack), AES paired with five AEAD mode transforms, keyed hashes (SipHash, Poly1305), cryptographic digests (Tiger, CubeHash, Snefru, Whirlpool, BLAKE2/3), Merkle-tree hashing, and the full ASCON family. | `net8.0` |
+| **[Bodu.Globalization.Calendar](calendar/index.md)** | Rule-driven notable-date resolution — public holidays, observances, religious festivals — for any year, territory, or calendar system. Built-in algorithms cover Gregorian and Orthodox Easter, Hindu Lunar dates, Losar, Vesak, Asalha Puja, and Qingming, with a pluggable algorithm registry, observance-adjustment pipeline, and trust-policy-driven plugin host. | `net8.0` |
 
 Each package is versioned and released independently. Take the one you need and ignore the others — there are no cross-package runtime dependencies. `Bodu.IO.Hashing` and `Bodu.Security.Cryptography` both depend on `Bodu.Core` for shared argument-validation helpers.
 
@@ -26,42 +26,42 @@ Each library has a dedicated introduction page that explains its namespaces, the
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="core/index.html">Bodu.Core</a></h3>
+  <h3><a href="core/index.md">Bodu.Core</a></h3>
   <p>Bounded collections, eviction-aware caches, day-of-week patterns, pooled buffers, and date / numeric / span extensions. Useful in almost any application; depended on internally by the hashing and cryptography packages.</p>
   <div class="bodu-card-links">
-    <a href="core/index.html">Introduction</a>
-    <a href="core/getting-started.html">Getting started</a>
-    <a href="../guides/core/index.html">Guides</a>
+    <a href="core/index.md">Introduction</a>
+    <a href="core/getting-started.md">Getting started</a>
+    <a href="../guides/core/index.md">Guides</a>
   </div>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/index.html">Bodu.IO.Hashing</a></h3>
+  <h3><a href="io-hashing/index.md">Bodu.IO.Hashing</a></h3>
   <p>Non-cryptographic hashes — fingerprints, checksums, and human-readable check digits. Optimised for speed, portability, and error-detection coverage rather than adversary resistance.</p>
   <div class="bodu-card-links">
-    <a href="io-hashing/index.html">Introduction</a>
-    <a href="io-hashing/getting-started.html">Getting started</a>
-    <a href="../guides/io-hashing/index.html">Guides</a>
+    <a href="io-hashing/index.md">Introduction</a>
+    <a href="io-hashing/getting-started.md">Getting started</a>
+    <a href="../guides/io-hashing/index.md">Guides</a>
   </div>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/index.html">Bodu.Security.Cryptography</a></h3>
+  <h3><a href="cryptography/index.md">Bodu.Security.Cryptography</a></h3>
   <p>Block ciphers, authenticated encryption, keyed hashes, and cryptographic digests with a formal adversary model. Drops into any API that expects <code>SymmetricAlgorithm</code> or <code>HashAlgorithm</code>.</p>
   <div class="bodu-card-links">
-    <a href="cryptography/index.html">Introduction</a>
-    <a href="cryptography/getting-started.html">Getting started</a>
-    <a href="../guides/cryptography/index.html">Guides</a>
+    <a href="cryptography/index.md">Introduction</a>
+    <a href="cryptography/getting-started.md">Getting started</a>
+    <a href="../guides/cryptography/index.md">Guides</a>
   </div>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="calendar/index.html">Bodu.Globalization.Calendar</a></h3>
+  <h3><a href="calendar/index.md">Bodu.Globalization.Calendar</a></h3>
   <p>Notable-date resolution and dynamic calendar calculators driven from pluggable XML or JSON rule sources, with an observance-adjustment pipeline, plugin host, and territory filtering.</p>
   <div class="bodu-card-links">
-    <a href="calendar/index.html">Introduction</a>
-    <a href="calendar/getting-started.html">Getting started</a>
-    <a href="../guides/calendar/index.html">Guides</a>
+    <a href="calendar/index.md">Introduction</a>
+    <a href="calendar/getting-started.md">Getting started</a>
+    <a href="../guides/calendar/index.md">Guides</a>
   </div>
 </div>
 

--- a/docs/docs/io-hashing/getting-started.md
+++ b/docs/docs/io-hashing/getting-started.md
@@ -80,7 +80,7 @@ bool valid = Luhn.IsValid("4539 1488 0343 6467".Replace(" ", ""));
 char digit  = Luhn.ComputeCheckDigit("453914880343646");
 ```
 
-Other check-digit types follow the same `IsValid` / `ComputeCheckDigit` contract. For multi-character checksums, see `Iban`, `Isbn13`, `Cusip`, `Lei` in the [Checksums namespace](index.md#bodu-io-hashing-checksums--checksums).
+Other check-digit types follow the same `IsValid` / `ComputeCheckDigit` contract. For multi-character checksums, see `Iban`, `Isbn13`, `Cusip`, `Lei` in the [Checksums namespace](index.md).
 
 ### Check digit — IBAN (multi-character)
 
@@ -107,5 +107,5 @@ bool   match  = hash.VerifyHash(data, expected);
 
 - **[Bodu.IO.Hashing introduction](index.md)** — namespaces, headline types, scenarios.
 - **[Algorithm families](../algorithm-families.md)** — fingerprint vs checksum vs check digit.
-- **[Bodu.IO.Hashing guides](../../guides/io-hashing/)** — per-algorithm walk-throughs.
+- **[Bodu.IO.Hashing guides](../../guides/io-hashing/index.md)** — per-algorithm walk-throughs.
 - **[Bodu.IO.Hashing API reference](../../apidoc/Bodu.IO.Hashing.md)** — full type-by-type docs.

--- a/docs/docs/io-hashing/index.md
+++ b/docs/docs/io-hashing/index.md
@@ -101,5 +101,5 @@ Only `Crc` currently implements `IResumableHashAlgorithm` (reverse-finalise a st
 
 - **[Getting started](getting-started.md)** — install + one minimal sample per subfamily.
 - **[Algorithm families](../algorithm-families.md)** — fingerprints vs checksums vs check digits, plus the cryptographic families.
-- **[Bodu.IO.Hashing guides](../../guides/io-hashing/)** — recipe-style walk-throughs per algorithm.
+- **[Bodu.IO.Hashing guides](../../guides/io-hashing/index.md)** — recipe-style walk-throughs per algorithm.
 - **[Bodu.IO.Hashing API reference](../../apidoc/Bodu.IO.Hashing.md)** — full type-by-type docs.

--- a/docs/guides/calendar/index.md
+++ b/docs/guides/calendar/index.md
@@ -31,12 +31,12 @@ A **`NotableDateRule`** is an authored recipe — strategy, category, territory,
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="notable-dates.html">Using NotableDateService</a></h3>
+  <h3><a href="notable-dates.md">Using NotableDateService</a></h3>
   <p>The main entry point — resolving notable dates for a year, filtering by territory and category, querying a date range, layering override providers, and working-day arithmetic over <code>DateOnly</code> / <code>DateTime</code>.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="rule-authoring.html">Authoring notable date rules</a></h3>
+  <h3><a href="rule-authoring.md">Authoring notable date rules</a></h3>
   <p>How to add your own rules — as in-code objects, embedded XML / JSON resource files, or companion assemblies — and how to layer runtime overrides.</p>
 </div>
 
@@ -47,7 +47,7 @@ A **`NotableDateRule`** is an authored recipe — strategy, category, territory,
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="algorithms.html">Date calculation algorithms</a></h3>
+  <h3><a href="algorithms.md">Date calculation algorithms</a></h3>
   <p>The built-in algorithm types — Easter (Gregorian / Orthodox), Hindu Lunar, Losar, Vesak, Asalha Puja, Qingming, Lunar phase — with registration guidance and a custom-algorithm walk-through.</p>
 </div>
 
@@ -58,7 +58,7 @@ A **`NotableDateRule`** is an authored recipe — strategy, category, territory,
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="data-packs.html">Calendar data packs</a></h3>
+  <h3><a href="data-packs.md">Calendar data packs</a></h3>
   <p>The official <code>Bodu.Globalization.Calendar.Data.*</code> companion assemblies — Americas, Europe, and Asia-Pacific — and how to compose them with the resolution pipeline.</p>
 </div>
 

--- a/docs/guides/core/index.md
+++ b/docs/guides/core/index.md
@@ -13,7 +13,7 @@ If you have not yet installed the package or want the high-level shape of the li
 | Namespace | What lives here | Guides |
 |---|---|---|
 | `Bodu.Collections.Generic` | Bounded ring-backed collections — `CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`, `RingBackedCollection<T>` base. | [Circular buffer](circular-buffer.md) · [Deque](deque.md) · [Evicting dictionary](evicting-dictionary.md) |
-| `Bodu.Collections.Generic.Concurrent` | Thread-safe collection variants — `ConcurrentCircularBuffer<T>`. | (covered in [Circular buffer](circular-buffer.md#thread-safety)) |
+| `Bodu.Collections.Generic.Concurrent` | Thread-safe collection variants — `ConcurrentCircularBuffer<T>`. | (covered in [Circular buffer](circular-buffer.md)) |
 | `Bodu` | Root namespace primitives — `WeekPattern`, `IRandomGenerator`, `XorShiftRandom`, `ThrowHelper`. | [WeekPattern](week-pattern.md) |
 | `Bodu.Buffers` | Pooled buffer infrastructure — `PooledBufferBuilder<T>`. | (no dedicated guide yet — see API reference) |
 | `Bodu.Extensions` | Date, numeric, span, array, and comparable extension methods — `DateTimeExtensions`, `DateOnlyExtensions`, `NumericExtensions`, `ArrayExtensions`, `BufferConverter`, `SpanExtensions`, `IComparableExtensions`. | (no dedicated guide yet — see API reference) |

--- a/docs/guides/core/index.md
+++ b/docs/guides/core/index.md
@@ -26,17 +26,17 @@ If you have not yet installed the package or want the high-level shape of the li
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="circular-buffer.html">Circular buffer</a></h3>
+  <h3><a href="circular-buffer.md">Circular buffer</a></h3>
   <p>Fixed-capacity FIFO ring buffer — single-threaded <code>CircularBuffer&lt;T&gt;</code> and thread-safe <code>ConcurrentCircularBuffer&lt;T&gt;</code>; configurable overwrite-on-full.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="deque.html">Deque</a></h3>
+  <h3><a href="deque.md">Deque</a></h3>
   <p>Double-ended queue — <code>Deque&lt;T&gt;</code> with O(1) <code>AddFirst</code> / <code>AddLast</code> / <code>RemoveFirst</code> / <code>RemoveLast</code>; growable or fixed-capacity.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="evicting-dictionary.html">Evicting dictionary</a></h3>
+  <h3><a href="evicting-dictionary.md">Evicting dictionary</a></h3>
   <p>Capacity-bounded key-value store with FIFO, LRU, and LFU eviction policies.</p>
 </div>
 
@@ -47,7 +47,7 @@ If you have not yet installed the package or want the high-level shape of the li
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="week-pattern.html">WeekPattern</a></h3>
+  <h3><a href="week-pattern.md">WeekPattern</a></h3>
   <p>Immutable bitmask value type for sets of days of the week; supports composition (<code>MTuW</code>), bitwise operators, parsing, and enumeration.</p>
 </div>
 

--- a/docs/guides/cryptography/ascon-hashing.md
+++ b/docs/guides/cryptography/ascon-hashing.md
@@ -153,7 +153,7 @@ Each `ComputeHash` call resets the internal state before processing the next mes
 ## Pattern 6 — verifying a digest in constant time
 
 Always compare digests in constant time. Use the BCL's
-<xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*> directly, or the
+`CryptographicOperations.FixedTimeEquals` directly, or the
 `VerifyHash` extension method from `Bodu.Security.Cryptography.Extensions`:
 
 ```csharp

--- a/docs/guides/cryptography/ascon.md
+++ b/docs/guides/cryptography/ascon.md
@@ -123,7 +123,7 @@ ASCON is a good choice when:
   cryptographic surface area and simplifying key management.
 
 On x86-64 targets with AES-NI and SHA extensions, the BCL's hardware-accelerated
-<xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> and `AesGcm` will
+`System.Security.Cryptography.SHA256` and `AesGcm` will
 typically outperform software ASCON in raw throughput. Use ASCON when standards compliance,
 portability, or XOF/AEAD requirements point to it — not primarily for throughput on
 well-provisioned servers.

--- a/docs/guides/cryptography/cipher-modes.md
+++ b/docs/guides/cryptography/cipher-modes.md
@@ -6,7 +6,7 @@ title: Cipher block modes
 
 This page walks through each of the five classic block cipher modes exposed via <xref:Bodu.Security.Cryptography.CipherBlockMode>, shows a complete encrypt-and-decrypt round-trip for each, and calls out the IV rules and security trade-offs.
 
-For the data-flow visualisation, see the panels on the [CipherBlockMode API page](../../api/Bodu.Security.Cryptography.CipherBlockMode.html). Each panel in that diagram corresponds to one section below.
+For the data-flow visualisation, see the panels on the <xref:Bodu.Security.Cryptography.CipherBlockMode> API page. Each panel in that diagram corresponds to one section below.
 
 ## CBC — the default
 

--- a/docs/guides/cryptography/hashing.md
+++ b/docs/guides/cryptography/hashing.md
@@ -22,12 +22,12 @@ This page is the cross-cutting overview — how the families relate, which to ch
 
 | If you need… | Use | Why |
 |---|---|---|
-| A fast non-cryptographic fingerprint for hash tables, bucketing, caches | <xref:Bodu.IO.Hashing.Adler32>, <xref:Bodu.IO.Hashing.Fnv1a32>, <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.CityHash64> | Cheap, well-spread, **not** cryptographic. |
+| A fast non-cryptographic fingerprint for hash tables, bucketing, caches | <xref:Bodu.IO.Hashing.Checksums.Adler32>, <xref:Bodu.IO.Hashing.Fnv1a32>, <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.CityHash64> | Cheap, well-spread, **not** cryptographic. |
 | A hash-table key or short fingerprint, resistant to collision-DoS | <xref:Bodu.Security.Cryptography.SipHash64>, <xref:Bodu.Security.Cryptography.SipHash128> | Keyed, collision-resistant for short inputs. |
-| A cryptographic digest for signatures, fingerprints, or content addressing | <xref:Bodu.Security.Cryptography.Tiger>, or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> (BCL) | Collision-resistant against active attackers. |
+| A cryptographic digest for signatures, fingerprints, or content addressing | <xref:Bodu.Security.Cryptography.Tiger>, or `System.Security.Cryptography.SHA256` (BCL) | Collision-resistant against active attackers. |
 | A NIST-standardised 256-bit digest with a small state footprint (SP 800-232) | <xref:Bodu.Security.Cryptography.AsconHash256>, <xref:Bodu.Security.Cryptography.AsconHashA256> | Two variants: max margin (`ASCON-HASH256`) or higher throughput (`ASCON-HASHA256`). |
 | A rolling integrity check over a long stream with partial re-verification | <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Subtree recomputation without rehashing the whole input. |
-| An on-the-wire CRC (zlib, PNG, Modbus, iSCSI, …) or a Fletcher checksum | <xref:Bodu.IO.Hashing.Crc>, <xref:Bodu.IO.Hashing.Fletcher32> | Non-cryptographic, `System.IO.Hashing` contract — see the [Bodu.IO.Hashing guides](../io-hashing/). |
+| An on-the-wire CRC (zlib, PNG, Modbus, iSCSI, …) or a Fletcher checksum | <xref:Bodu.IO.Hashing.Checksums.Crc>, <xref:Bodu.IO.Hashing.Checksums.Fletcher32> | Non-cryptographic, `System.IO.Hashing` contract — see the [Bodu.IO.Hashing guides](../io-hashing/). |
 
 ## Pattern 1 — a classic non-cryptographic fingerprint
 
@@ -81,11 +81,11 @@ using var tiger = new Tiger();     // 192-bit default; set HashSize for 128/160
 byte[] digest = tiger.ComputeHash(data);
 ```
 
-For brand-new work, prefer the BCL's <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> or <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType> — they are hardware-accelerated on most modern CPUs.
+For brand-new work, prefer the BCL's `System.Security.Cryptography.SHA256` or `System.Security.Cryptography.SHA512` — they are hardware-accelerated on most modern CPUs.
 
 ## Pattern 4 — verifying a hash
 
-Computing a hash is half the job; comparing it in constant time is the other half. The `HashAlgorithmExtensions` class (in `Bodu.Security.Cryptography.Extensions`) provides a `VerifyHash` helper that does the comparison with <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*>:
+Computing a hash is half the job; comparing it in constant time is the other half. The `HashAlgorithmExtensions` class (in `Bodu.Security.Cryptography.Extensions`) provides a `VerifyHash` helper that does the comparison with `CryptographicOperations.FixedTimeEquals`:
 
 ```csharp
 using Bodu.Security.Cryptography;
@@ -146,11 +146,11 @@ byte[] root = merkle.ComputeHash(stream);
 
 Each leaf is a SHA-256 of a 4 KiB block; each internal node is a SHA-256 of two concatenated child hashes. The root changes if any byte of the input changes.
 
-For large inputs where you want to overlap leaf hashing with tree reduction, use <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> — see the [class documentation](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html) for the swim-lane diagram of how its dispatcher and level-workers interact.
+For large inputs where you want to overlap leaf hashing with tree reduction, use <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> — see the class documentation for the swim-lane diagram of how its dispatcher and level-workers interact.
 
 ## Where to go next
 
 - [Encryption basics](encryption-basics.md) — symmetric encryption in this library.
 - [Cipher block modes](cipher-modes.md) — ECB / CBC / CFB / OFB / CTR with worked examples.
 - [Bodu.IO.Hashing guides](../io-hashing/) — CRC, Fletcher, Adler, FNV, CityHash, and the classic string hashes on `System.IO.Hashing.NonCryptographicHashAlgorithm`.
-- [MerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) · [ParallelMerkleTreeHash class doc](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
+- <xref:Bodu.Security.Cryptography.MerkleTreeHash> · <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash>.

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -22,22 +22,22 @@ For the auto-generated API reference, see the [Bodu.Security.Cryptography namesp
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="encryption-basics.html">Encryption basics</a></h3>
+  <h3><a href="encryption-basics.md">Encryption basics</a></h3>
   <p>The mental model: <code>BlockMode</code> vs .NET's <code>Mode</code>, how Key / IV / Tweak / Padding combine, generating random key material, and disposing safely.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cipher-modes.html">Cipher block modes</a></h3>
+  <h3><a href="cipher-modes.md">Cipher block modes</a></h3>
   <p>ECB, CBC, CFB, OFB, CTR — one worked round-trip per mode, with notes on when each is appropriate and when it is not.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="padding.html">Padding</a></h3>
+  <h3><a href="padding.md">Padding</a></h3>
   <p>PKCS7, Zeros, None — how each one pads, when it round-trips cleanly, and when it silently loses bytes.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="composing-primitives.html">Composing primitives</a></h3>
+  <h3><a href="composing-primitives.md">Composing primitives</a></h3>
   <p>The two patterns side by side — manual <code>IBlockCipher</code> + <code>BlockCipherModeFactory</code> + <code>PaddingFactory</code>, and the equivalent through the <code>SymmetricAlgorithm</code> wrappers.</p>
 </div>
 
@@ -67,7 +67,7 @@ For the auto-generated API reference, see the [Bodu.Security.Cryptography namesp
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="aead-modes.html">AEAD modes</a></h3>
+  <h3><a href="aead-modes.md">AEAD modes</a></h3>
   <p>GCM, CCM, OCB3, EAX, SIV, GCM-SIV — authenticated encryption with associated data using <code>AesBlockCipher</code> + the mode transforms, via the one-shot extension methods.</p>
 </div>
 
@@ -78,27 +78,27 @@ For the auto-generated API reference, see the [Bodu.Security.Cryptography namesp
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="hashing.html">Hashing overview</a></h3>
+  <h3><a href="hashing.md">Hashing overview</a></h3>
   <p>Cross-cutting overview of keyed hashes (SipHash, Poly1305), cryptographic digests (Tiger, CubeHash, Snefru), and Merkle trees.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="tiger.html">Using Tiger</a></h3>
+  <h3><a href="tiger.md">Using Tiger</a></h3>
   <p>128 / 160 / 192-bit cryptographic digest optimised for 64-bit platforms; two padding variants (Tiger / Tiger2).</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cubehash.html">Using CubeHash</a></h3>
+  <h3><a href="cubehash.md">Using CubeHash</a></h3>
   <p>SHA-3 finalist with tunable rounds and block size.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="snefru.html">Using Snefru</a></h3>
+  <h3><a href="snefru.md">Using Snefru</a></h3>
   <p>Snefru-128 / Snefru-256 — legacy cryptographic digest; interoperability use only.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="merkle-trees.html">Using Merkle trees</a></h3>
+  <h3><a href="merkle-trees.md">Using Merkle trees</a></h3>
   <p>Tree-structured streaming integrity over any inner <code>HashAlgorithm</code>.</p>
 </div>
 
@@ -111,12 +111,12 @@ The library also exposes `Whirlpool`, `Blake2b`, `Blake2s`, `Blake3`, `Skein256`
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="siphash.html">Using SipHash</a></h3>
+  <h3><a href="siphash.md">Using SipHash</a></h3>
   <p>SipHash-64 and SipHash-128 — keyed PRF designed for hash-flooding-resistant hash tables.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="poly1305.html">Using Poly1305</a></h3>
+  <h3><a href="poly1305.md">Using Poly1305</a></h3>
   <p>One-time authenticator (RFC 8439); pair with ChaCha20 or AES-CTR.</p>
 </div>
 
@@ -127,22 +127,22 @@ The library also exposes `Whirlpool`, `Blake2b`, `Blake2s`, `Blake3`, `Skein256`
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="ascon.html">ASCON overview</a></h3>
+  <h3><a href="ascon.md">ASCON overview</a></h3>
   <p>All five NIST SP 800-232 types — Hash256, HashA256, XOF128, CXOF128, AEAD128 — with selection guidance.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="ascon-hashing.html">ASCON hashing</a></h3>
+  <h3><a href="ascon-hashing.md">ASCON hashing</a></h3>
   <p><code>AsconHash256</code> (12-round, max margin) and <code>AsconHashA256</code> (8-round, higher throughput).</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="ascon-xof.html">ASCON extendable output (XOF)</a></h3>
+  <h3><a href="ascon-xof.md">ASCON extendable output (XOF)</a></h3>
   <p><code>AsconXof128</code> and <code>AsconCxof128</code> — squeeze any number of bytes; CXOF accepts a domain customisation string.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="ascon-aead.html">ASCON authenticated encryption (AEAD)</a></h3>
+  <h3><a href="ascon-aead.md">ASCON authenticated encryption (AEAD)</a></h3>
   <p><code>AsconAead128</code> — sponge-based AEAD with no separate block cipher dependency.</p>
 </div>
 

--- a/docs/guides/cryptography/merkle-trees.md
+++ b/docs/guides/cryptography/merkle-trees.md
@@ -83,7 +83,7 @@ using var stream = File.OpenRead("large-archive.bin");
 byte[] root = await merkle.ComputeHashAsync(stream, diagnostics: null, CancellationToken.None);
 ```
 
-The parallel version produces the same root as the sequential one when called with the same `(algorithmFactory, blockSize, fanOut)` — the parallelism is in *how* the tree is built, not *what* tree is built. The level-worker / dispatcher layout is drawn in the [`ParallelMerkleTreeHash` class documentation](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
+The parallel version produces the same root as the sequential one when called with the same `(algorithmFactory, blockSize, fanOut)` — the parallelism is in *how* the tree is built, not *what* tree is built. The level-worker / dispatcher layout is drawn in the <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> class documentation.
 
 ![Parallel Merkle tree pipeline](../../images/diagrams/parallel-merkle-tree.svg)
 
@@ -122,10 +122,10 @@ Diagnostics are optional; pass `null` when you don't need them and the pipeline 
 - **Content addressing.** Git, IPFS, and BitTorrent all use Merkle (or Merkle-like) trees so that identical sub-contents can be deduplicated and so that corruption is detected at the chunk level.
 - **Streaming integrity.** You want to authenticate chunks of a stream as they arrive, without waiting for the whole thing to buffer.
 
-For a single end-to-end file digest where partial verification is not a requirement, a plain <xref:Bodu.Security.Cryptography.Tiger> or <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> is simpler and does not need a tree.
+For a single end-to-end file digest where partial verification is not a requirement, a plain <xref:Bodu.Security.Cryptography.Tiger> or `System.Security.Cryptography.SHA256` is simpler and does not need a tree.
 
 ## Where to go next
 
 - [Hashing overview](hashing.md) — where Merkle trees sit alongside the other families.
 - [Using Tiger](tiger.md) — a common leaf-hash choice for content-addressed systems.
-- [`MerkleTreeHash` class doc](../../api/Bodu.Security.Cryptography.MerkleTreeHash.html) · [`ParallelMerkleTreeHash` class doc](../../api/Bodu.Security.Cryptography.ParallelMerkleTreeHash.html).
+- <xref:Bodu.Security.Cryptography.MerkleTreeHash> · <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash>.

--- a/docs/guides/cryptography/poly1305.md
+++ b/docs/guides/cryptography/poly1305.md
@@ -65,11 +65,11 @@ byte[] tag = poly.ComputeHash(input);                    // 16-byte authenticati
 
 The key point: `polyKey` is fresh per message — it's a function of `(chachaKey, nonce)`. If the nonce is unique under a given long-lived key, the Poly1305 key is unique too, and the one-time property holds.
 
-(`ChaCha20Keystream`, `ChaCha20Encrypt`, and `BuildRfc8439Input` are placeholders here — use whichever ChaCha20 implementation you already depend on; the BCL's <xref:System.Security.Cryptography.ChaCha20Poly1305?displayProperty=nameWithType> gives you the whole AEAD in one step if you don't need to decompose the construction.)
+(`ChaCha20Keystream`, `ChaCha20Encrypt`, and `BuildRfc8439Input` are placeholders here — use whichever ChaCha20 implementation you already depend on; the BCL's `System.Security.Cryptography.ChaCha20Poly1305` gives you the whole AEAD in one step if you don't need to decompose the construction.)
 
 ## Pattern 3 — verifying in constant time
 
-Compare a Poly1305 tag with <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*> or the `VerifyHash` helper from `Bodu.Security.Cryptography.Extensions`:
+Compare a Poly1305 tag with `CryptographicOperations.FixedTimeEquals` or the `VerifyHash` helper from `Bodu.Security.Cryptography.Extensions`:
 
 ```csharp
 using Bodu.Security.Cryptography;
@@ -83,7 +83,7 @@ A `SequenceEqual` comparison leaks timing information and is unsafe for MAC veri
 
 ## What Poly1305 is not
 
-- **Not a general-purpose MAC.** A single key authenticates a single message. For a long-lived MAC key, use HMAC (<xref:System.Security.Cryptography.HMACSHA256?displayProperty=nameWithType>) or KMAC.
+- **Not a general-purpose MAC.** A single key authenticates a single message. For a long-lived MAC key, use HMAC (`System.Security.Cryptography.HMACSHA256`) or KMAC.
 - **Not a hash.** Without a key, Poly1305 is trivially collidable. It is a **keyed** authenticator by construction.
 - **Not a standalone AEAD.** The authenticator alone provides integrity; pair it with a cipher (ChaCha20, or another stream-style primitive) to get confidentiality.
 

--- a/docs/guides/cryptography/siphash.md
+++ b/docs/guides/cryptography/siphash.md
@@ -121,7 +121,7 @@ See the [hashing overview](hashing.md#pattern-4--verifying-a-hash) for the gener
 
 ## What SipHash is not
 
-- **Not a MAC for long messages.** SipHash was built specifically for short inputs; if you need a MAC over files or network frames, reach for HMAC-SHA-256 (<xref:System.Security.Cryptography.HMACSHA256?displayProperty=nameWithType>) or <xref:Bodu.Security.Cryptography.Poly1305>.
+- **Not a MAC for long messages.** SipHash was built specifically for short inputs; if you need a MAC over files or network frames, reach for HMAC-SHA-256 (`System.Security.Cryptography.HMACSHA256`) or <xref:Bodu.Security.Cryptography.Poly1305>.
 - **Not a cryptographic hash.** SipHash is a PRF — it resists collision and preimage only while the key stays secret. For a keyless collision-resistant digest, use SHA-256 or <xref:Bodu.Security.Cryptography.Tiger>.
 - **Not deterministic across keys.** Two instances with different keys produce unrelated outputs for the same input. That is the point.
 

--- a/docs/guides/cryptography/snefru.md
+++ b/docs/guides/cryptography/snefru.md
@@ -14,7 +14,7 @@ Snefru is a 1990 cryptographic hash by Ralph Merkle, named after the Egyptian ph
 Both derive from a shared `Snefru<T>` base, which in turn derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>.
 
 > [!IMPORTANT]
-> Snefru is **cryptographically broken**. Eli Biham showed practical collisions on Snefru-2 (the published 2-pass variant) in 2008. The implementation in this package is provided for **interoperability with legacy systems and for research**, not for protecting real data. For any new work where you need a cryptographic hash, use the BCL's <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> / <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType>, or <xref:Bodu.Security.Cryptography.Tiger> if you need 192-bit output.
+> Snefru is **cryptographically broken**. Eli Biham showed practical collisions on Snefru-2 (the published 2-pass variant) in 2008. The implementation in this package is provided for **interoperability with legacy systems and for research**, not for protecting real data. For any new work where you need a cryptographic hash, use the BCL's `System.Security.Cryptography.SHA256` / `System.Security.Cryptography.SHA512`, or <xref:Bodu.Security.Cryptography.Tiger> if you need 192-bit output.
 
 ## Pattern 1 — compute a digest
 

--- a/docs/guides/cryptography/tiger.md
+++ b/docs/guides/cryptography/tiger.md
@@ -8,7 +8,7 @@ title: Using Tiger
 
 Tiger derives from <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType>, so any API that accepts a standard .NET hash accepts Tiger.
 
-> For new work where interoperability isn't a constraint, prefer the BCL's hardware-accelerated <xref:System.Security.Cryptography.SHA256?displayProperty=nameWithType> or <xref:System.Security.Cryptography.SHA512?displayProperty=nameWithType>. Use Tiger when you need to match an existing Tiger-based system, or as part of a Tiger Tree Hash (see the Merkle tree guide).
+> For new work where interoperability isn't a constraint, prefer the BCL's hardware-accelerated `System.Security.Cryptography.SHA256` or `System.Security.Cryptography.SHA512`. Use Tiger when you need to match an existing Tiger-based system, or as part of a Tiger Tree Hash (see the Merkle tree guide).
 
 ## Fixed sizes at a glance
 
@@ -93,7 +93,7 @@ For larger files where you want to verify ranges of the file without rehashing t
 
 ## Pattern 5 — verifying a digest
 
-Compare digests in constant time. The `VerifyHash` helper in `Bodu.Security.Cryptography.Extensions` wraps <xref:System.Security.Cryptography.CryptographicOperations.FixedTimeEquals*>:
+Compare digests in constant time. The `VerifyHash` helper in `Bodu.Security.Cryptography.Extensions` wraps `CryptographicOperations.FixedTimeEquals`:
 
 ```csharp
 using Bodu.Security.Cryptography;

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -20,22 +20,22 @@ General-purpose building blocks: bounded collections, eviction-aware caches, day
 </div>
 
 <div class="bodu-card">
-  <h3><a href="core/circular-buffer.html">Circular buffer</a></h3>
+  <h3><a href="core/circular-buffer.md">Circular buffer</a></h3>
   <p>Fixed-capacity FIFO ring buffer — single-threaded and thread-safe variants, overwrite mode, peek/dequeue/try-enqueue patterns.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="core/deque.html">Deque</a></h3>
+  <h3><a href="core/deque.md">Deque</a></h3>
   <p>Double-ended queue with O(1) add and remove at both ends; growable or fixed-capacity.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="core/evicting-dictionary.html">Evicting dictionary</a></h3>
+  <h3><a href="core/evicting-dictionary.md">Evicting dictionary</a></h3>
   <p>Capacity-bounded key-value store with FIFO, LRU, and LFU eviction.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="core/week-pattern.html">WeekPattern</a></h3>
+  <h3><a href="core/week-pattern.md">WeekPattern</a></h3>
   <p>Immutable bitmask value type for day-of-week sets — composition, parsing, bitwise operators.</p>
 </div>
 
@@ -61,32 +61,32 @@ Non-cryptographic hashing — fingerprints, checksums, and check digits — buil
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/fnv.html">Using FNV</a></h3>
+  <h3><a href="io-hashing/fnv.md">Using FNV</a></h3>
   <p>FNV-1 and FNV-1a at 32- and 64-bit widths — the textbook constant-memory fingerprint.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/cityhash.html">Using CityHash</a></h3>
+  <h3><a href="io-hashing/cityhash.md">Using CityHash</a></h3>
   <p>32-, 64-, and 128-bit Google CityHash — SIMD-friendly fingerprint for long inputs.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/murmurhash3.html">Using MurmurHash3</a></h3>
+  <h3><a href="io-hashing/murmurhash3.md">Using MurmurHash3</a></h3>
   <p>32- and x64-128-bit MurmurHash3 — seeded, excellent avalanche.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/xxhash.html">Using XxHash</a></h3>
+  <h3><a href="io-hashing/xxhash.md">Using XxHash</a></h3>
   <p>XxHash32 and XxHash64 — high-throughput seeded fingerprints.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/pearson.html">Using Pearson</a></h3>
+  <h3><a href="io-hashing/pearson.md">Using Pearson</a></h3>
   <p>Table-driven hash with output widths from 8 to 2048 bits.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/string-hashes.html">Classic string hashes</a></h3>
+  <h3><a href="io-hashing/string-hashes.md">Classic string hashes</a></h3>
   <p>Bernstein, BKDR, SDBM, JSHash, Elf64, ApHash, PJW.</p>
 </div>
 
@@ -97,22 +97,22 @@ Non-cryptographic hashing — fingerprints, checksums, and check digits — buil
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/crc.html">Using CRC</a></h3>
+  <h3><a href="io-hashing/crc.md">Using CRC</a></h3>
   <p>One engine, 113 named standards (CRC-8 through CRC-64), custom parameter sets, shared lookup-table cache.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/crc-catalogue.html">CRC catalogue</a></h3>
+  <h3><a href="io-hashing/crc-catalogue.md">CRC catalogue</a></h3>
   <p>Reference table of every named CRC standard — name, width, polynomial, init, reflect, XOR-out.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/fletcher.html">Using Fletcher</a></h3>
+  <h3><a href="io-hashing/fletcher.md">Using Fletcher</a></h3>
   <p>Twin-accumulator checksums in 16-, 32-, and 64-bit widths.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/adler.html">Using Adler</a></h3>
+  <h3><a href="io-hashing/adler.md">Using Adler</a></h3>
   <p>Adler-32 (zlib), Adler-32C (SIMD), Adler-64.</p>
 </div>
 
@@ -123,7 +123,7 @@ Non-cryptographic hashing — fingerprints, checksums, and check digits — buil
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/check-digits.html">Check digits overview</a></h3>
+  <h3><a href="io-hashing/check-digits.md">Check digits overview</a></h3>
   <p>Luhn, Damm, Verhoeff, EAN, GTIN, ISIN, IBAN, ISBN, SEDOL, CUSIP, ABA routing, LEI — single-character validators for human-typed identifiers.</p>
 </div>
 
@@ -149,22 +149,22 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/encryption-basics.html">Encryption basics</a></h3>
+  <h3><a href="cryptography/encryption-basics.md">Encryption basics</a></h3>
   <p>Key, IV, Tweak, BlockMode, Padding — the mental model every cipher in the library follows.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/cipher-modes.html">Cipher block modes</a></h3>
+  <h3><a href="cryptography/cipher-modes.md">Cipher block modes</a></h3>
   <p>ECB, CBC, CFB, OFB, CTR — one worked round-trip per mode.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/padding.html">Padding</a></h3>
+  <h3><a href="cryptography/padding.md">Padding</a></h3>
   <p>PKCS7, Zeros, None — how each one pads and when it round-trips cleanly.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/composing-primitives.html">Composing primitives</a></h3>
+  <h3><a href="cryptography/composing-primitives.md">Composing primitives</a></h3>
   <p><code>IBlockCipher</code> + <code>BlockCipherModeFactory</code> + <code>PaddingFactory</code> vs the <code>SymmetricAlgorithm</code> wrappers.</p>
 </div>
 
@@ -175,12 +175,12 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/skipjack.html">Using Skipjack</a></h3>
+  <h3><a href="cryptography/skipjack.md">Using Skipjack</a></h3>
   <p>NSA design (declassified 1998); legacy interoperability only.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/blowfish.html">Using Blowfish</a></h3>
+  <h3><a href="cryptography/blowfish.md">Using Blowfish</a></h3>
   <p>Schneier 1993; 64-bit block; expensive key schedule.</p>
 </div>
 
@@ -191,17 +191,17 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/threefish-256.html">Using Threefish-256</a></h3>
+  <h3><a href="cryptography/threefish-256.md">Using Threefish-256</a></h3>
   <p>Smallest Threefish variant; 128-bit tweak.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/threefish-512.html">Using Threefish-512</a></h3>
+  <h3><a href="cryptography/threefish-512.md">Using Threefish-512</a></h3>
   <p>Recommended general-purpose Threefish variant; 128-bit tweak.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/threefish-1024.html">Using Threefish-1024</a></h3>
+  <h3><a href="cryptography/threefish-1024.md">Using Threefish-1024</a></h3>
   <p>Highest Threefish security margin; 128-bit tweak.</p>
 </div>
 
@@ -212,7 +212,7 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/aead-modes.html">AEAD modes</a></h3>
+  <h3><a href="cryptography/aead-modes.md">AEAD modes</a></h3>
   <p>GCM, CCM, OCB3, EAX, SIV, GCM-SIV — authenticated encryption using AES.</p>
 </div>
 
@@ -223,27 +223,27 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/hashing.html">Hashing overview</a></h3>
+  <h3><a href="cryptography/hashing.md">Hashing overview</a></h3>
   <p>Cross-cutting overview of keyed hashes, cryptographic digests, and Merkle trees.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/tiger.html">Using Tiger</a></h3>
+  <h3><a href="cryptography/tiger.md">Using Tiger</a></h3>
   <p>128 / 160 / 192-bit cryptographic digest optimised for 64-bit platforms.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/cubehash.html">Using CubeHash</a></h3>
+  <h3><a href="cryptography/cubehash.md">Using CubeHash</a></h3>
   <p>SHA-3 finalist with tunable rounds and block size.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/snefru.html">Using Snefru</a></h3>
+  <h3><a href="cryptography/snefru.md">Using Snefru</a></h3>
   <p>Legacy cryptographic digest; interop only (cryptanalytically broken).</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/merkle-trees.html">Using Merkle trees</a></h3>
+  <h3><a href="cryptography/merkle-trees.md">Using Merkle trees</a></h3>
   <p>Tree-structured streaming integrity over any inner <code>HashAlgorithm</code>.</p>
 </div>
 
@@ -254,12 +254,12 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/siphash.html">Using SipHash</a></h3>
+  <h3><a href="cryptography/siphash.md">Using SipHash</a></h3>
   <p>SipHash-64 / SipHash-128 — keyed PRF for hash-flooding-resistant tables.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/poly1305.html">Using Poly1305</a></h3>
+  <h3><a href="cryptography/poly1305.md">Using Poly1305</a></h3>
   <p>One-time authenticator (RFC 8439); pair with ChaCha20 or AES-CTR.</p>
 </div>
 
@@ -270,22 +270,22 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/ascon.html">ASCON overview</a></h3>
+  <h3><a href="cryptography/ascon.md">ASCON overview</a></h3>
   <p>All five NIST SP 800-232 types with selection guidance.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/ascon-hashing.html">ASCON hashing</a></h3>
+  <h3><a href="cryptography/ascon-hashing.md">ASCON hashing</a></h3>
   <p><code>AsconHash256</code> and <code>AsconHashA256</code>.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/ascon-xof.html">ASCON XOF</a></h3>
+  <h3><a href="cryptography/ascon-xof.md">ASCON XOF</a></h3>
   <p><code>AsconXof128</code> and <code>AsconCxof128</code>.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cryptography/ascon-aead.html">ASCON AEAD</a></h3>
+  <h3><a href="cryptography/ascon-aead.md">ASCON AEAD</a></h3>
   <p><code>AsconAead128</code> — sponge-based authenticated encryption.</p>
 </div>
 
@@ -305,22 +305,22 @@ Rule-driven notable date (public holiday, observance, festival) resolution for a
 </div>
 
 <div class="bodu-card">
-  <h3><a href="calendar/notable-dates.html">Using NotableDateService</a></h3>
+  <h3><a href="calendar/notable-dates.md">Using NotableDateService</a></h3>
   <p>Resolving for a year, filtering by territory and category, layering overrides.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="calendar/rule-authoring.html">Authoring notable date rules</a></h3>
+  <h3><a href="calendar/rule-authoring.md">Authoring notable date rules</a></h3>
   <p>In-code, embedded XML / JSON, companion assemblies, runtime overrides.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="calendar/algorithms.html">Date calculation algorithms</a></h3>
+  <h3><a href="calendar/algorithms.md">Date calculation algorithms</a></h3>
   <p>Built-in algorithms (Easter, Hindu Lunar, Losar, Vesak, Asalha Puja, Qingming) and custom-algorithm walk-through.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="calendar/data-packs.html">Calendar data packs</a></h3>
+  <h3><a href="calendar/data-packs.md">Calendar data packs</a></h3>
   <p>Official Americas / Europe / Asia-Pacific companion assemblies.</p>
 </div>
 

--- a/docs/guides/io-hashing/adler.md
+++ b/docs/guides/io-hashing/adler.md
@@ -4,15 +4,15 @@ title: Using Adler
 
 # Using Adler
 
-The Adler checksum — introduced by Mark Adler for zlib — maintains two running sums, **A** and **B**, reduced modulo a prime. It is cheap, position-dependent (so it catches transpositions), and the canonical <xref:Bodu.IO.Hashing.Adler32> is the checksum embedded in every zlib stream.
+The Adler checksum — introduced by Mark Adler for zlib — maintains two running sums, **A** and **B**, reduced modulo a prime. It is cheap, position-dependent (so it catches transpositions), and the canonical <xref:Bodu.IO.Hashing.Checksums.Adler32> is the checksum embedded in every zlib stream.
 
 **Bodu.IO.Hashing** provides three variants:
 
 | Type | Width | Modulus | Intended use |
 |---|---|---|---|
-| <xref:Bodu.IO.Hashing.Adler32> | 32 bits | 65521 (largest prime below 2¹⁶) | Canonical Adler-32 — zlib, PNG, rsync. |
-| <xref:Bodu.IO.Hashing.Adler32C> | 32 bits | 65536 | SIMD-friendly variant; faster on vector pipelines, **not** wire-compatible with Adler-32. |
-| <xref:Bodu.IO.Hashing.Adler64> | 64 bits | 4294967291 (largest prime below 2³²) | Extended width for long buffers where a 32-bit space is uncomfortable. |
+| <xref:Bodu.IO.Hashing.Checksums.Adler32> | 32 bits | 65521 (largest prime below 2¹⁶) | Canonical Adler-32 — zlib, PNG, rsync. |
+| <xref:Bodu.IO.Hashing.Checksums.Adler32C> | 32 bits | 65536 | SIMD-friendly variant; faster on vector pipelines, **not** wire-compatible with Adler-32. |
+| <xref:Bodu.IO.Hashing.Checksums.Adler64> | 64 bits | 4294967291 (largest prime below 2³²) | Extended width for long buffers where a 32-bit space is uncomfortable. |
 
 All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType> via a shared `Adler<T>` base.
 
@@ -89,9 +89,9 @@ outputStream.Write(trailer);
 
 ## Picking a variant
 
-- **Need interoperability with zlib, PNG, rsync, or any tool that speaks RFC 1950?** Use <xref:Bodu.IO.Hashing.Adler32>. The modulus (65521) and initial state (`A=1, B=0`) are fixed by the specification.
-- **Hashing large buffers in a hot loop on a SIMD-capable CPU?** Use <xref:Bodu.IO.Hashing.Adler32C>. The power-of-two modulus removes the `% 65521` reduction and lets auto-vectorisation stay vectorised. The digest is **not** interchangeable with Adler-32.
-- **Checksumming very long streams where a 32-bit space is uncomfortable?** Use <xref:Bodu.IO.Hashing.Adler64>. Four bytes of digest become eight.
+- **Need interoperability with zlib, PNG, rsync, or any tool that speaks RFC 1950?** Use <xref:Bodu.IO.Hashing.Checksums.Adler32>. The modulus (65521) and initial state (`A=1, B=0`) are fixed by the specification.
+- **Hashing large buffers in a hot loop on a SIMD-capable CPU?** Use <xref:Bodu.IO.Hashing.Checksums.Adler32C>. The power-of-two modulus removes the `% 65521` reduction and lets auto-vectorisation stay vectorised. The digest is **not** interchangeable with Adler-32.
+- **Checksumming very long streams where a 32-bit space is uncomfortable?** Use <xref:Bodu.IO.Hashing.Checksums.Adler64>. Four bytes of digest become eight.
 
 ## Adler vs Fletcher vs CRC
 

--- a/docs/guides/io-hashing/cityhash.md
+++ b/docs/guides/io-hashing/cityhash.md
@@ -68,7 +68,7 @@ byte[] full = city.GetCurrentHash();
 city.Reset();                              // discards the buffer
 ```
 
-The practical consequence is that memory use grows linearly with the amount of data appended between `Reset` calls. If you need to hash a long stream without buffering, reach for <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Crc>, or one of the <xref:Bodu.IO.Hashing.Fletcher32>-family types — they update in place.
+The practical consequence is that memory use grows linearly with the amount of data appended between `Reset` calls. If you need to hash a long stream without buffering, reach for <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Checksums.Crc>, or one of the <xref:Bodu.IO.Hashing.Checksums.Fletcher32>-family types — they update in place.
 
 ## Pattern 4 — file hashing
 
@@ -85,13 +85,13 @@ using (var stream = File.OpenRead("asset.bin"))
 byte[] fingerprint = city.GetCurrentHash();
 ```
 
-For very large files where you do not want the whole buffer in memory, do the hashing chunk-by-chunk with an incremental non-cryptographic algorithm (<xref:Bodu.IO.Hashing.Crc>, <xref:Bodu.IO.Hashing.Fnv1a64>) or use a Merkle tree — see the [cryptography hashing guide](../cryptography/hashing.md) for the `MerkleTreeHash` pattern.
+For very large files where you do not want the whole buffer in memory, do the hashing chunk-by-chunk with an incremental non-cryptographic algorithm (<xref:Bodu.IO.Hashing.Checksums.Crc>, <xref:Bodu.IO.Hashing.Fnv1a64>) or use a Merkle tree — see the [cryptography hashing guide](../cryptography/hashing.md) for the `MerkleTreeHash` pattern.
 
 ## CityHash vs the other non-cryptographic hashes in this package
 
 - **vs <xref:Bodu.IO.Hashing.Fnv1a64>** — CityHash is faster on long inputs (SIMD-friendly); FNV uses constant memory regardless of input size.
-- **vs <xref:Bodu.IO.Hashing.Adler32>** — Adler is tuned for short checksums and has a fixed 4-byte digest. CityHash dominates for general-purpose in-memory fingerprinting.
-- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is defined by wire specifications and has provable burst-error detection; CityHash is a better default when you control both endpoints and want the best speed/quality trade-off.
+- **vs <xref:Bodu.IO.Hashing.Checksums.Adler32>** — Adler is tuned for short checksums and has a fixed 4-byte digest. CityHash dominates for general-purpose in-memory fingerprinting.
+- **vs <xref:Bodu.IO.Hashing.Checksums.Crc>** — CRC is defined by wire specifications and has provable burst-error detection; CityHash is a better default when you control both endpoints and want the best speed/quality trade-off.
 - **vs <xref:Bodu.Security.Cryptography.SipHash64>** — SipHash is keyed and resists adversarial collisions; CityHash does not. Use SipHash whenever untrusted input can reach the hash function.
 
 CityHash is **not cryptographic**. An attacker who can choose inputs can construct collisions trivially. Do not use it to authenticate or to key-derive.

--- a/docs/guides/io-hashing/crc-catalogue.md
+++ b/docs/guides/io-hashing/crc-catalogue.md
@@ -4,7 +4,7 @@ title: CRC catalogue
 
 # CRC catalogue
 
-The <xref:Bodu.IO.Hashing.CrcStandard> type (in the **Bodu.IO.Hashing** package) exposes a broad catalogue of named CRC parameter sets that can be passed to <xref:Bodu.IO.Hashing.Crc> for CRC computation. The catalogue is mechanically derived from the **CRC RevEng** project.
+The <xref:Bodu.IO.Hashing.Checksums.CrcStandard> type (in the **Bodu.IO.Hashing** package) exposes a broad catalogue of named CRC parameter sets that can be passed to <xref:Bodu.IO.Hashing.Checksums.Crc> for CRC computation. The catalogue is mechanically derived from the **CRC RevEng** project.
 
 For walk-through usage of the CRC engine, see [Using CRC](crc.md).
 
@@ -20,7 +20,7 @@ The catalogue is distributed as part of the CRC RevEng project at <https://reven
 
 ## Accessing standards
 
-The catalogue is a **lazy-materialised data table**. Loading <xref:Bodu.IO.Hashing.Checksum.CrcStandard> allocates only the packed spec rows and the per-entry cache slots — individual <xref:Bodu.IO.Hashing.Checksum.CrcStandard> instances are constructed on first access and then memoised, so a process that uses only a handful of standards pays for only a handful of allocations.
+The catalogue is a **lazy-materialised data table**. Loading <xref:Bodu.IO.Hashing.Checksums.CrcStandard> allocates only the packed spec rows and the per-entry cache slots — individual <xref:Bodu.IO.Hashing.Checksums.CrcStandard> instances are constructed on first access and then memoised, so a process that uses only a handful of standards pays for only a handful of allocations.
 
 Three entry points:
 
@@ -45,13 +45,13 @@ foreach (CrcStandard std in CrcStandard.All) { ... }
 
 ## Support policy
 
-`CrcStandard` represents all scalar parameters as <xref:System.UInt64>, so the library can materialise any CRC of width 1–64 bits. Entries whose width exceeds 64 bits are listed below for completeness but are **not** exposed by <xref:Bodu.IO.Hashing.Checksum.CrcStandards> and cannot be constructed through `CrcStandard`.
+`CrcStandard` represents all scalar parameters as <xref:System.UInt64>, so the library can materialise any CRC of width 1–64 bits. Entries whose width exceeds 64 bits are listed below for completeness but are **not** exposed by <xref:Bodu.IO.Hashing.Checksums.CrcStandards> and cannot be constructed through `CrcStandard`.
 
 Aliases share a single catalogue instance with their canonical standard. `CrcStandard.FromName` resolves both canonical and alias names, so `FromName("CRC-32")` and `FromName("CRC-32/ISO-HDLC")` return the same instance.
 
 ## Common standards (strongly-typed)
 
-These are exposed as `public static CrcStandard` properties on <xref:Bodu.IO.Hashing.Checksum.CrcStandard> for convenience — the underlying cache is still shared with the enum-based lookup.
+These are exposed as `public static CrcStandard` properties on <xref:Bodu.IO.Hashing.Checksums.CrcStandard> for convenience — the underlying cache is still shared with the enum-based lookup.
 
 | Name | Width | Property | Aliases |
 |---|---:|---|---|

--- a/docs/guides/io-hashing/crc.md
+++ b/docs/guides/io-hashing/crc.md
@@ -4,7 +4,7 @@ title: Using CRC
 
 # Using CRC
 
-**Bodu.IO.Hashing** ships a single <xref:Bodu.IO.Hashing.Checksum.Crc> engine that can compute any CRC of widths 1–64 bits. The parameters — polynomial, initial value, input / output reflection, XOR-out — are packed into an immutable <xref:Bodu.IO.Hashing.Checksum.CrcStandard> that you pass to the constructor.
+**Bodu.IO.Hashing** ships a single <xref:Bodu.IO.Hashing.Checksums.Crc> engine that can compute any CRC of widths 1–64 bits. The parameters — polynomial, initial value, input / output reflection, XOR-out — are packed into an immutable <xref:Bodu.IO.Hashing.Checksums.CrcStandard> that you pass to the constructor.
 
 ![Table-driven CRC pipeline](../../images/diagrams/crc-pipeline.svg)
 
@@ -27,7 +27,7 @@ The default constructor `new Crc()` is equivalent to `new Crc(CrcStandard.CRC32_
 
 ## Pattern 2 — pick from the enum
 
-For anything outside the short list of strongly-typed properties, use the <xref:Bodu.IO.Hashing.Checksum.CrcStandards> enum. Every canonical CRC RevEng entry has a member.
+For anything outside the short list of strongly-typed properties, use the <xref:Bodu.IO.Hashing.Checksums.CrcStandards> enum. Every canonical CRC RevEng entry has a member.
 
 ```csharp
 using Bodu.IO.Hashing;
@@ -36,7 +36,7 @@ using var crc16 = new Crc(CrcStandard.Get(CrcStandards.CRC16_XMODEM));
 using var crc8  = new Crc(CrcStandard.Get(CrcStandards.CRC8_SAEJ1850));
 ```
 
-Instances are memoised inside <xref:Bodu.IO.Hashing.Checksum.CrcStandard>, so repeated calls to `Get` for the same entry return the same reference.
+Instances are memoised inside <xref:Bodu.IO.Hashing.Checksums.CrcStandard>, so repeated calls to `Get` for the same entry return the same reference.
 
 ## Pattern 3 — look up by name (including aliases)
 
@@ -51,7 +51,7 @@ using var b = new Crc(CrcStandard.FromName("PKZIP"));          // same underlyin
 
 ## Pattern 4 — a custom parameter set
 
-If your target isn't in the catalogue, construct a <xref:Bodu.IO.Hashing.Checksum.CrcStandard> directly.
+If your target isn't in the catalogue, construct a <xref:Bodu.IO.Hashing.Checksums.CrcStandard> directly.
 
 ```csharp
 using Bodu.IO.Hashing;
@@ -73,7 +73,7 @@ Widths 1–64 bits are supported. `CrcStandard` validates the width at construct
 
 ## Pattern 5 — streaming over bytes
 
-Because <xref:Bodu.IO.Hashing.Checksum.Crc> derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>, the BCL streaming helpers apply. Call `Append` as many times as you like, then `GetCurrentHash` to finalise.
+Because <xref:Bodu.IO.Hashing.Checksums.Crc> derives from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>, the BCL streaming helpers apply. Call `Append` as many times as you like, then `GetCurrentHash` to finalise.
 
 ```csharp
 using Bodu.IO.Hashing;
@@ -97,7 +97,7 @@ byte[] fingerprint = crc.GetCurrentHash();
 
 ## Pattern 6 — resume from a stored digest
 
-<xref:Bodu.IO.Hashing.Checksum.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm>, which lets you reverse-finalise a digest you computed earlier, append new bytes, and finalise again. Handy for append-only logs and chunked uploads where rehashing the whole input is expensive.
+<xref:Bodu.IO.Hashing.Checksums.Crc> implements <xref:Bodu.IO.Hashing.IResumableHashAlgorithm>, which lets you reverse-finalise a digest you computed earlier, append new bytes, and finalise again. Handy for append-only logs and chunked uploads where rehashing the whole input is expensive.
 
 ```csharp
 using System.Text;
@@ -117,7 +117,7 @@ The combined digest is identical to what you'd get from a single pass over the c
 
 ## Pattern 7 — sharing lookup tables
 
-Every `Crc` instance with the same (width, polynomial, reflect-in) triple shares a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Checksum.Crc.GlobalCache>. This means constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
+Every `Crc` instance with the same (width, polynomial, reflect-in) triple shares a single 256-entry lookup table through <xref:Bodu.IO.Hashing.Checksums.Crc.GlobalCache>. This means constructing a hundred `Crc(CrcStandard.CRC32_ISOHDLC)` instances allocates one table, not a hundred.
 
 ```csharp
 using Bodu.IO.Hashing;

--- a/docs/guides/io-hashing/fletcher.md
+++ b/docs/guides/io-hashing/fletcher.md
@@ -8,7 +8,7 @@ The Fletcher checksum family maintains two running accumulators, **A** and **B**
 
 ![Fletcher twin-accumulator structure](../../images/diagrams/fletcher-accumulators.svg)
 
-**Bodu.IO.Hashing** provides three widths: <xref:Bodu.IO.Hashing.Fletcher16>, <xref:Bodu.IO.Hashing.Fletcher32>, and <xref:Bodu.IO.Hashing.Fletcher64>. All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
+**Bodu.IO.Hashing** provides three widths: <xref:Bodu.IO.Hashing.Checksums.Fletcher16>, <xref:Bodu.IO.Hashing.Checksums.Fletcher32>, and <xref:Bodu.IO.Hashing.Checksums.Fletcher64>. All three derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
 
 ## Pattern 1 — compute a digest in one call
 
@@ -72,9 +72,9 @@ Fletcher's block size is fixed by the width (Fletcher-16 works in 1-byte words, 
 
 | Width | Use when | Notes |
 |---|---|---|
-| <xref:Bodu.IO.Hashing.Fletcher16> | Tiny frames, embedded protocols, when 16 bits of collision space is enough. | 1-byte blocks, fastest; same collision properties as CRC-16 for short inputs. |
-| <xref:Bodu.IO.Hashing.Fletcher32> | General-purpose file and buffer checksums; the most common choice. | 2-byte blocks; comparable to CRC-32 for error detection on uncorrelated noise, cheaper to compute. |
-| <xref:Bodu.IO.Hashing.Fletcher64> | Large buffers where a 32-bit space is uncomfortable. | 4-byte blocks; rarely needed, but useful for very long streams. |
+| <xref:Bodu.IO.Hashing.Checksums.Fletcher16> | Tiny frames, embedded protocols, when 16 bits of collision space is enough. | 1-byte blocks, fastest; same collision properties as CRC-16 for short inputs. |
+| <xref:Bodu.IO.Hashing.Checksums.Fletcher32> | General-purpose file and buffer checksums; the most common choice. | 2-byte blocks; comparable to CRC-32 for error detection on uncorrelated noise, cheaper to compute. |
+| <xref:Bodu.IO.Hashing.Checksums.Fletcher64> | Large buffers where a 32-bit space is uncomfortable. | 4-byte blocks; rarely needed, but useful for very long streams. |
 
 ## Fletcher vs CRC
 

--- a/docs/guides/io-hashing/fnv.md
+++ b/docs/guides/io-hashing/fnv.md
@@ -104,9 +104,9 @@ fnv.Reset();                          // back to FNV offset basis
 
 ## FNV vs the other non-cryptographic hashes in this package
 
-- **vs <xref:Bodu.IO.Hashing.Adler32>** — FNV distributes shorter inputs more evenly; Adler is marginally faster on long buffers and is the checksum specified by zlib / PNG.
+- **vs <xref:Bodu.IO.Hashing.Checksums.Adler32>** — FNV distributes shorter inputs more evenly; Adler is marginally faster on long buffers and is the checksum specified by zlib / PNG.
 - **vs <xref:Bodu.IO.Hashing.CityHash64>** — CityHash is substantially faster on long inputs (SIMD-friendly by design) and distributes better on both short and long data. FNV wins on code simplicity and on determinism across languages/libraries.
-- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is specified for wire formats and has provably good burst-error detection; FNV is a better default for in-memory fingerprinting where you control both ends.
+- **vs <xref:Bodu.IO.Hashing.Checksums.Crc>** — CRC is specified for wire formats and has provably good burst-error detection; FNV is a better default for in-memory fingerprinting where you control both ends.
 - **vs <xref:Bodu.Security.Cryptography.SipHash64>** — SipHash is keyed and resists adversarial collisions; FNV does not. Pick SipHash whenever untrusted input can reach the hash function.
 
 ## Where to go next

--- a/docs/guides/io-hashing/index.md
+++ b/docs/guides/io-hashing/index.md
@@ -26,32 +26,32 @@ For the auto-generated API reference, see the [Bodu.IO.Hashing namespace page](.
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="fnv.html">Using FNV</a></h3>
+  <h3><a href="fnv.md">Using FNV</a></h3>
   <p>FNV-1 and FNV-1a at 32 and 64 bits — simple, fast, textbook fingerprint for in-memory hash tables.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="cityhash.html">Using CityHash</a></h3>
+  <h3><a href="cityhash.md">Using CityHash</a></h3>
   <p>32-, 64-, and 128-bit CityHash — Google's SIMD-friendly fingerprint for long inputs.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="murmurhash3.html">Using MurmurHash3</a></h3>
+  <h3><a href="murmurhash3.md">Using MurmurHash3</a></h3>
   <p>Austin Appleby's MurmurHash3 in 32-bit and x64-128-bit variants — seeded, excellent avalanche.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="xxhash.html">Using XxHash</a></h3>
+  <h3><a href="xxhash.md">Using XxHash</a></h3>
   <p>Yann Collet's XxHash32 and XxHash64 — high-throughput seeded fingerprints.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="pearson.html">Using Pearson</a></h3>
+  <h3><a href="pearson.md">Using Pearson</a></h3>
   <p>Pearson's table-driven hash with output widths from 8 to 2048 bits.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="string-hashes.html">Classic string hashes</a></h3>
+  <h3><a href="string-hashes.md">Classic string hashes</a></h3>
   <p>Bernstein (djb2), BKDR, SDBM, JSHash, Elf64, ApHash, PJW.</p>
 </div>
 
@@ -62,22 +62,22 @@ For the auto-generated API reference, see the [Bodu.IO.Hashing namespace page](.
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="crc.html">Using CRC</a></h3>
+  <h3><a href="crc.md">Using CRC</a></h3>
   <p>The <code>Crc</code> engine and <code>CrcStandard</code>; <code>CrcStandards</code> enum; named lookups; custom parameter sets; lookup-table caches; resumable hashing.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="crc-catalogue.html">CRC catalogue</a></h3>
+  <h3><a href="crc-catalogue.md">CRC catalogue</a></h3>
   <p>The full table of named CRC standards from the RevEng catalogue — name, width, class, enum value, and aliases.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="fletcher.html">Using Fletcher</a></h3>
+  <h3><a href="fletcher.md">Using Fletcher</a></h3>
   <p>Twin-accumulator checksums in 16, 32, and 64 bits — catches transpositions a simple sum or XOR misses.</p>
 </div>
 
 <div class="bodu-card">
-  <h3><a href="adler.html">Using Adler</a></h3>
+  <h3><a href="adler.md">Using Adler</a></h3>
   <p>Adler-32 (zlib), Adler-32C (SIMD), Adler-64.</p>
 </div>
 
@@ -88,7 +88,7 @@ For the auto-generated API reference, see the [Bodu.IO.Hashing namespace page](.
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="check-digits.html">Check digits overview</a></h3>
+  <h3><a href="check-digits.md">Check digits overview</a></h3>
   <p>Luhn, Damm, Verhoeff, EAN, GTIN, UPC, ISIN, ABA routing — single-character validators. Plus IBAN, ISBN, SEDOL, CUSIP, LEI from <code>Bodu.IO.Hashing.Checksums</code>.</p>
 </div>
 

--- a/docs/guides/io-hashing/murmurhash3.md
+++ b/docs/guides/io-hashing/murmurhash3.md
@@ -84,7 +84,7 @@ byte[] full = murmur.GetCurrentHash();
 murmur.Reset();                             // discards the buffer and resets to seed
 ```
 
-> **Memory note.** The internal buffer grows with each `Append`. For very large inputs (hundreds of MB) where you do not want to hold the entire payload in memory, prefer a streaming algorithm such as <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Crc>, or <xref:Bodu.IO.Hashing.Fletcher32>.
+> **Memory note.** The internal buffer grows with each `Append`. For very large inputs (hundreds of MB) where you do not want to hold the entire payload in memory, prefer a streaming algorithm such as <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Checksums.Crc>, or <xref:Bodu.IO.Hashing.Checksums.Fletcher32>.
 
 ## Pattern 5 — Bloom filter with two hash functions
 

--- a/docs/guides/io-hashing/pearson.md
+++ b/docs/guides/io-hashing/pearson.md
@@ -113,7 +113,7 @@ pearson.Reset();                             // back to the initial offsets
 
 - **vs <xref:Bodu.IO.Hashing.Fnv1a32>** — FNV-1a has better distribution on short inputs and no table memory footprint. Pearson wins when you need a specific output width (e.g. 96 or 160 bits) without stretching a native-width hash.
 - **vs <xref:Bodu.IO.Hashing.CityHash64>** — CityHash is much faster on long inputs and distributes better. Reach for Pearson when you want the table to be a tunable parameter — e.g. in academic work on hash-function quality.
-- **vs <xref:Bodu.IO.Hashing.Crc>** — CRC is specified for wire formats and has provable burst-error detection. Pearson is a general-purpose fingerprint, not a checksum with error-detection guarantees.
+- **vs <xref:Bodu.IO.Hashing.Checksums.Crc>** — CRC is specified for wire formats and has provable burst-error detection. Pearson is a general-purpose fingerprint, not a checksum with error-detection guarantees.
 
 Pearson is **not cryptographic**. Choosing a different table does not make it adversary-resistant — an attacker who knows the table can construct collisions immediately. For adversarial settings, use <xref:Bodu.Security.Cryptography.SipHash64>.
 

--- a/docs/guides/io-hashing/xxhash.md
+++ b/docs/guides/io-hashing/xxhash.md
@@ -71,7 +71,7 @@ byte[] full = xxh.GetCurrentHash();
 xxh.Reset();                             // discards the buffer, keeps the seed
 ```
 
-> **Memory note.** The internal buffer grows with each `Append`. For very large inputs where you want constant-memory processing, use a streaming algorithm — <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Crc>, or <xref:Bodu.IO.Hashing.Fletcher32> all update state in place with no internal buffer.
+> **Memory note.** The internal buffer grows with each `Append`. For very large inputs where you want constant-memory processing, use a streaming algorithm — <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Checksums.Crc>, or <xref:Bodu.IO.Hashing.Checksums.Fletcher32> all update state in place with no internal buffer.
 
 ## Pattern 4 — streaming a file
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,8 +34,8 @@ Four independent NuGet packages that share a single solution, a single set of co
   <h3>Bodu.Core</h3>
   <p>Fixed-capacity collections (circular buffer, evicting dictionary), buffer conversion, array and text utilities, and a centralised argument-validation helper.</p>
   <div class="bodu-card-links">
-    <a href="api/Bodu.Collections.Generic.html">Overview</a>
-    <a href="api/Bodu.html">API reference</a>
+    <a href="xref:Bodu.Collections.Generic">Overview</a>
+    <a href="xref:Bodu">API reference</a>
   </div>
 </div>
 
@@ -44,7 +44,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <h3>Bodu.IO.Hashing</h3>
   <p>Non-cryptographic checksums built on <code>System.IO.Hashing.NonCryptographicHashAlgorithm</code> — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher family (16 / 32 / 64 bits), with shared lookup-table caching and resumable hashing.</p>
   <div class="bodu-card-links">
-    <a href="api/Bodu.IO.Hashing.html">Overview</a>
+    <a href="xref:Bodu.IO.Hashing">Overview</a>
     <a href="guides/io-hashing/index.md">Guides</a>
   </div>
 </div>
@@ -54,7 +54,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <h3>Bodu.Security.Cryptography</h3>
   <p>Managed block ciphers (Threefish 256 / 512 / 1024, Serpent 128 / 256 / 512 / 1024, Camellia, Twofish, Blowfish, Skipjack), an AES adapter paired with AEAD mode transforms, keyed and cryptographic hashes (SipHash, Tiger, ASCON), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV-1a, CityHash).</p>
   <div class="bodu-card-links">
-    <a href="api/Bodu.Security.Cryptography.html">Overview</a>
+    <a href="xref:Bodu.Security.Cryptography">Overview</a>
     <a href="guides/cryptography/index.md">Guides</a>
   </div>
 </div>
@@ -64,9 +64,9 @@ Four independent NuGet packages that share a single solution, a single set of co
   <h3>Bodu.Globalization.Calendar</h3>
   <p>Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators — including Gregorian-computus Easter and lunar-calendar Lunar New Year — driven by a pluggable XML rule source and adjustment pipeline. Region-specific public-holiday rules ship in companion <code>Data.Americas</code>, <code>Data.Europe</code>, and <code>Data.AsiaPacific</code> packs that ship and re-release independently of the main library.</p>
   <div class="bodu-card-links">
-    <a href="api/Bodu.Globalization.Calendar.html">Overview</a>
+    <a href="xref:Bodu.Globalization.Calendar">Overview</a>
     <a href="guides/calendar/data-packs.md">Data packs</a>
-    <a href="api/Bodu.Globalization.Calendar.html">API reference</a>
+    <a href="xref:Bodu.Globalization.Calendar">API reference</a>
   </div>
 </div>
 
@@ -103,6 +103,6 @@ dotnet add package Bodu.Globalization.Calendar.Data.AsiaPacific
 <div class="bodu-nav">
   <a href="docs/introduction.md">Introduction</a>
   <a href="docs/getting-started.md">Getting started</a>
-  <a href="api/Bodu.html">API reference</a>
+  <a href="xref:Bodu">API reference</a>
   <a href="articles/index.md">Articles</a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <p>Non-cryptographic checksums built on <code>System.IO.Hashing.NonCryptographicHashAlgorithm</code> — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher family (16 / 32 / 64 bits), with shared lookup-table caching and resumable hashing.</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.IO.Hashing.html">Overview</a>
-    <a href="guides/io-hashing/">Guides</a>
+    <a href="guides/io-hashing/index.html">Guides</a>
   </div>
 </div>
 
@@ -55,7 +55,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <p>Managed block ciphers (Threefish 256 / 512 / 1024, Serpent 128 / 256 / 512 / 1024, Camellia, Twofish, Blowfish, Skipjack), an AES adapter paired with AEAD mode transforms, keyed and cryptographic hashes (SipHash, Tiger, ASCON), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV-1a, CityHash).</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.Security.Cryptography.html">Overview</a>
-    <a href="guides/cryptography/">Guides</a>
+    <a href="guides/cryptography/index.html">Guides</a>
   </div>
 </div>
 
@@ -103,6 +103,6 @@ dotnet add package Bodu.Globalization.Calendar.Data.AsiaPacific
 <div class="bodu-nav">
   <a href="docs/introduction.html">Introduction</a>
   <a href="docs/getting-started.html">Getting started</a>
-  <a href="api/">API reference</a>
-  <a href="articles/">Articles</a>
+  <a href="api/Bodu.html">API reference</a>
+  <a href="articles/index.html">Articles</a>
 </div>

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <p>Non-cryptographic checksums built on <code>System.IO.Hashing.NonCryptographicHashAlgorithm</code> — the full CRC RevEng catalogue (widths 1–64 bits) and the Fletcher family (16 / 32 / 64 bits), with shared lookup-table caching and resumable hashing.</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.IO.Hashing.html">Overview</a>
-    <a href="guides/io-hashing/index.html">Guides</a>
+    <a href="guides/io-hashing/index.md">Guides</a>
   </div>
 </div>
 
@@ -55,7 +55,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <p>Managed block ciphers (Threefish 256 / 512 / 1024, Serpent 128 / 256 / 512 / 1024, Camellia, Twofish, Blowfish, Skipjack), an AES adapter paired with AEAD mode transforms, keyed and cryptographic hashes (SipHash, Tiger, ASCON), Merkle-tree hashing, and the classic non-cryptographic hash families (Adler, FNV-1a, CityHash).</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.Security.Cryptography.html">Overview</a>
-    <a href="guides/cryptography/index.html">Guides</a>
+    <a href="guides/cryptography/index.md">Guides</a>
   </div>
 </div>
 
@@ -65,7 +65,7 @@ Four independent NuGet packages that share a single solution, a single set of co
   <p>Notable-date resolution with fixed, rule-based, offset-based, and dynamic calculators — including Gregorian-computus Easter and lunar-calendar Lunar New Year — driven by a pluggable XML rule source and adjustment pipeline. Region-specific public-holiday rules ship in companion <code>Data.Americas</code>, <code>Data.Europe</code>, and <code>Data.AsiaPacific</code> packs that ship and re-release independently of the main library.</p>
   <div class="bodu-card-links">
     <a href="api/Bodu.Globalization.Calendar.html">Overview</a>
-    <a href="guides/calendar/data-packs.html">Data packs</a>
+    <a href="guides/calendar/data-packs.md">Data packs</a>
     <a href="api/Bodu.Globalization.Calendar.html">API reference</a>
   </div>
 </div>
@@ -101,8 +101,8 @@ dotnet add package Bodu.Globalization.Calendar.Data.AsiaPacific
 ## Where to go next
 
 <div class="bodu-nav">
-  <a href="docs/introduction.html">Introduction</a>
-  <a href="docs/getting-started.html">Getting started</a>
+  <a href="docs/introduction.md">Introduction</a>
+  <a href="docs/getting-started.md">Getting started</a>
   <a href="api/Bodu.html">API reference</a>
-  <a href="articles/index.html">Articles</a>
+  <a href="articles/index.md">Articles</a>
 </div>


### PR DESCRIPTION
## Summary
This PR updates documentation links from `.html` to `.md` extensions throughout the guides and API documentation, and adds a missing `GetHashCode()` override to the `Crc` class to maintain consistency with its `Equals()` implementation.

## Key Changes

**Documentation Updates:**
- Changed all internal documentation links from `.html` to `.md` extensions across guides, API docs, and index pages
- Updated cross-references to use `xref:` syntax for API documentation links where appropriate
- Fixed namespace references in API documentation (e.g., `Bodu.IO.Hashing.Checksums.*` for CRC, Fletcher, and Adler types)
- Corrected relative links in introduction and getting-started pages

**Code Changes:**
- Added `GetHashCode()` override to `Crc` class that delegates to `this._standard.GetHashCode()`, ensuring consistency with the existing `Equals()` implementation
- Removed unused private methods `ThrowIfDisposed()` and `ThrowIfInvalidState()` from `Skein.cs`
- Added `[SuppressMessage]` attribute to `Skipjack.CreateDecryptor()` method
- Fixed XML documentation comment formatting in `ThrottledIncrementingByteStream.cs`

## Notable Details
- The `GetHashCode()` addition follows the standard .NET guideline that if a type overrides `Equals()`, it should also override `GetHashCode()`
- Documentation changes maintain consistency with the site's markdown-based documentation structure
- All namespace updates in documentation reflect the actual code organization in the `Checksums` namespace

https://claude.ai/code/session_011t64LzDqq17W3BkdXvWghH