### PR TITLE
Fix remaining DocFX link and xref warnings

### DIFF
--- a/Bodu.Core/src/Bodu.Core.csproj
+++ b/Bodu.Core/src/Bodu.Core.csproj
@@ -36,6 +36,7 @@
     <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netstandard2.1'">
         <Compile Remove="ThrowHelper.NetStandard.cs" />
     </ItemGroup>
+    <!-- Exclude the BaseEncoding helpers from compilation; they are not part of the published API surface. -->
     <ItemGroup>
         <Compile Remove="Text\**" />
         <None Remove="Text\**" />

--- a/docs/apidoc/Bodu.Collections.Generic.md
+++ b/docs/apidoc/Bodu.Collections.Generic.md
@@ -21,7 +21,7 @@ Related namespaces in the same library:
 
 - <xref:Bodu.Buffers> — low-overhead conversion helpers between raw byte arrays and arrays of unmanaged types (`BufferConverter`).
 - <xref:Bodu.Extensions> — array helpers (`ArrayExtensions`) for slicing, copying, clearing, and reversing.
-- <xref:Bodu.Text.BaseEncoding> — `BaseEncoding` entry points for Base16, Base24, Base32, and Base64.
+- `Bodu.Text` — `BaseEncoding` entry points for Base16, Base24, Base32, and Base64.
 - <xref:Bodu> — `ThrowHelper` centralises argument validation; `IRandomGenerator` abstracts random generation for testability.
 
 ## Example

--- a/docs/guides/cryptography/hashing.md
+++ b/docs/guides/cryptography/hashing.md
@@ -16,7 +16,7 @@ This page is the cross-cutting overview — how the families relate, which to ch
 - [Using ASCON-HASH256 and ASCON-HASHA256](ascon.md) — NIST SP 800-232 sponge digests; two variants trading margin for throughput.
 - [Using Merkle trees](merkle-trees.md) — tree-structured streaming integrity.
 
-> **Looking for CRC, Fletcher, Adler, FNV, CityHash, Pearson, Bernstein, BKDR, SDBM, JSHash, Elf64, ApHash, or Pjw32?** Those non-cryptographic families live in the companion <xref:Bodu.IO.Hashing> package, built on <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>. See the [Bodu.IO.Hashing guides](../io-hashing/).
+> **Looking for CRC, Fletcher, Adler, FNV, CityHash, Pearson, Bernstein, BKDR, SDBM, JSHash, Elf64, ApHash, or Pjw32?** Those non-cryptographic families live in the companion <xref:Bodu.IO.Hashing> package, built on <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>. See the [Bodu.IO.Hashing guides](../io-hashing/index.md).
 
 ## Pick the right tool
 
@@ -27,7 +27,7 @@ This page is the cross-cutting overview — how the families relate, which to ch
 | A cryptographic digest for signatures, fingerprints, or content addressing | <xref:Bodu.Security.Cryptography.Tiger>, or `System.Security.Cryptography.SHA256` (BCL) | Collision-resistant against active attackers. |
 | A NIST-standardised 256-bit digest with a small state footprint (SP 800-232) | <xref:Bodu.Security.Cryptography.AsconHash256>, <xref:Bodu.Security.Cryptography.AsconHashA256> | Two variants: max margin (`ASCON-HASH256`) or higher throughput (`ASCON-HASHA256`). |
 | A rolling integrity check over a long stream with partial re-verification | <xref:Bodu.Security.Cryptography.MerkleTreeHash>, <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash> | Subtree recomputation without rehashing the whole input. |
-| An on-the-wire CRC (zlib, PNG, Modbus, iSCSI, …) or a Fletcher checksum | <xref:Bodu.IO.Hashing.Checksums.Crc>, <xref:Bodu.IO.Hashing.Checksums.Fletcher32> | Non-cryptographic, `System.IO.Hashing` contract — see the [Bodu.IO.Hashing guides](../io-hashing/). |
+| An on-the-wire CRC (zlib, PNG, Modbus, iSCSI, …) or a Fletcher checksum | <xref:Bodu.IO.Hashing.Checksums.Crc>, <xref:Bodu.IO.Hashing.Checksums.Fletcher32> | Non-cryptographic, `System.IO.Hashing` contract — see the [Bodu.IO.Hashing guides](../io-hashing/index.md). |
 
 ## Pattern 1 — a classic non-cryptographic fingerprint
 
@@ -152,5 +152,5 @@ For large inputs where you want to overlap leaf hashing with tree reduction, use
 
 - [Encryption basics](encryption-basics.md) — symmetric encryption in this library.
 - [Cipher block modes](cipher-modes.md) — ECB / CBC / CFB / OFB / CTR with worked examples.
-- [Bodu.IO.Hashing guides](../io-hashing/) — CRC, Fletcher, Adler, FNV, CityHash, and the classic string hashes on `System.IO.Hashing.NonCryptographicHashAlgorithm`.
+- [Bodu.IO.Hashing guides](../io-hashing/index.md) — CRC, Fletcher, Adler, FNV, CityHash, and the classic string hashes on `System.IO.Hashing.NonCryptographicHashAlgorithm`.
 - <xref:Bodu.Security.Cryptography.MerkleTreeHash> · <xref:Bodu.Security.Cryptography.ParallelMerkleTreeHash>.

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -8,7 +8,7 @@ Recipe-style walk-throughs for **Bodu.Security.Cryptography**, organised by the 
 
 If you have not yet installed the package or want the high-level shape of the library, start with the [Bodu.Security.Cryptography introduction](../../docs/cryptography/index.md) and the [getting-started page](../../docs/cryptography/getting-started.md). Not sure which primitive to use? See [Algorithm families](../../docs/algorithm-families.md).
 
-For the auto-generated API reference, see the [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md). For non-cryptographic checksums and fingerprints, see the [Bodu.IO.Hashing guides](../io-hashing/).
+For the auto-generated API reference, see the [Bodu.Security.Cryptography namespace page](../../apidoc/Bodu.Security.Cryptography.md). For non-cryptographic checksums and fingerprints, see the [Bodu.IO.Hashing guides](../io-hashing/index.md).
 
 ## Namespace map
 
@@ -153,5 +153,5 @@ The library also exposes `Whirlpool`, `Blake2b`, `Blake2s`, `Blake3`, `Skein256`
 - [Bodu.Security.Cryptography introduction](../../docs/cryptography/index.md) — namespaces, headline types, scenarios.
 - [Bodu.Security.Cryptography getting started](../../docs/cryptography/getting-started.md) — install and minimal samples per subfamily.
 - [Algorithm families](../../docs/algorithm-families.md) — cipher subtypes, hash structural shapes, cross-library map.
-- [Bodu.IO.Hashing guides](../io-hashing/) — non-cryptographic checksums and fingerprints.
+- [Bodu.IO.Hashing guides](../io-hashing/index.md) — non-cryptographic checksums and fingerprints.
 - [Bodu.Security.Cryptography API reference](../../apidoc/Bodu.Security.Cryptography.md) — full type-by-type docs.

--- a/docs/guides/cryptography/siphash.md
+++ b/docs/guides/cryptography/siphash.md
@@ -130,4 +130,4 @@ See the [hashing overview](hashing.md#pattern-4--verifying-a-hash) for the gener
 - [Hashing overview](hashing.md) — how SipHash fits alongside cryptographic digests and non-cryptographic fingerprints.
 - [Using Tiger](tiger.md) — a keyless cryptographic digest when you don't have a secret to carry around.
 - [Using Poly1305](poly1305.md) — one-time authenticator that pairs with a stream cipher (the classic Poly1305/ChaCha20 AEAD construction).
-- [Bodu.IO.Hashing — FNV, CityHash, Adler](../io-hashing/) — the non-keyed, non-adversarial alternatives for trusted inputs.
+- [Bodu.IO.Hashing — FNV, CityHash, Adler](../io-hashing/index.md) — the non-keyed, non-adversarial alternatives for trusted inputs.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -15,7 +15,7 @@ General-purpose building blocks: bounded collections, eviction-aware caches, day
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="core/">Overview</a></h3>
+  <h3><a href="core/index.md">Overview</a></h3>
   <p>Namespace map (<code>Bodu.Collections.Generic</code>, <code>Bodu</code>) — key types and which guide covers each.</p>
 </div>
 
@@ -50,7 +50,7 @@ Non-cryptographic hashing — fingerprints, checksums, and check digits — buil
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="io-hashing/">Overview</a></h3>
+  <h3><a href="io-hashing/index.md">Overview</a></h3>
   <p>Namespace map (<code>Bodu.IO.Hashing</code>, <code>.Checksums</code>, <code>.CheckDigits</code>) — key types and which guide covers each.</p>
 </div>
 
@@ -138,7 +138,7 @@ Cryptographic primitives with a formal adversary model — block ciphers, AEAD c
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="cryptography/">Overview</a></h3>
+  <h3><a href="cryptography/index.md">Overview</a></h3>
   <p>Namespace map and selection table for cipher, hash, and AEAD families.</p>
 </div>
 
@@ -300,7 +300,7 @@ Rule-driven notable date (public holiday, observance, festival) resolution for a
 <div class="bodu-cards">
 
 <div class="bodu-card">
-  <h3><a href="calendar/">Overview</a></h3>
+  <h3><a href="calendar/index.md">Overview</a></h3>
   <p>Resolution pipeline, namespace map, and key-type table.</p>
 </div>
 

--- a/docs/guides/io-hashing/check-digits.md
+++ b/docs/guides/io-hashing/check-digits.md
@@ -246,6 +246,6 @@ bool valid = Lei.IsValid("5493000IBP32UQZ0KL24");   // true
 
 ## Where to go next
 
-- [Algorithm families](../algorithm-families.md) — how check digits relate to checksums, fingerprints, and cryptographic primitives.
+- [Algorithm families](../../docs/algorithm-families.md) — how check digits relate to checksums, fingerprints, and cryptographic primitives.
 - [Bodu.IO.Hashing overview](index.md) — the broader non-cryptographic hashing landscape.
 - [Bodu.IO.Hashing API reference](../../apidoc/Bodu.IO.Hashing.md) — full type documentation.

--- a/docs/guides/io-hashing/murmurhash3.md
+++ b/docs/guides/io-hashing/murmurhash3.md
@@ -147,5 +147,5 @@ Reach for **MurmurHash3** when you need a seeded 32- or 128-bit fingerprint with
 - [Using XxHash](xxhash.md) — another high-quality seeded fingerprint family.
 - [Using FNV](fnv.md) — constant-memory streaming alternative.
 - [Using CityHash](cityhash.md) — fastest throughput on large inputs.
-- [Algorithm families](../algorithm-families.md) — when to use a fingerprint vs a checksum vs a keyed hash.
+- [Algorithm families](../../docs/algorithm-families.md) — when to use a fingerprint vs a checksum vs a keyed hash.
 - [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.

--- a/docs/guides/io-hashing/xxhash.md
+++ b/docs/guides/io-hashing/xxhash.md
@@ -107,5 +107,5 @@ Reach for **XxHash64** when you want seeded, high-throughput 64-bit fingerprints
 - [Using MurmurHash3](murmurhash3.md) — seeded fingerprint with 128-bit output.
 - [Using CityHash](cityhash.md) — fastest throughput on large inputs.
 - [Using FNV](fnv.md) — constant-memory streaming fingerprint.
-- [Algorithm families](../algorithm-families.md) — fingerprints vs checksums vs keyed hashes.
+- [Algorithm families](../../docs/algorithm-families.md) — fingerprints vs checksums vs keyed hashes.
 - [Bodu.IO.Hashing namespace page](../../apidoc/Bodu.IO.Hashing.md) — key types and design notes.


### PR DESCRIPTION
## Summary

Cleans up the residual DocFX warnings still surfacing on `master` after the previous pass. All entries below correspond directly to warnings emitted by the `build-docs` workflow.

### InvalidFileLink — sibling-area markdown directory links
- `docs/guides/cryptography/hashing.md` (lines 19, 30, 155) — `(../io-hashing/)` → `(../io-hashing/index.md)`.
- `docs/guides/cryptography/index.md` (lines 11, 156) — same.
- `docs/guides/cryptography/siphash.md` (line 133) — same.

### InvalidFileLink — HTML directory hrefs in `guides/index.md`
The four area overview cards used `<a href="X/">`; converted to `<a href="X/index.md">` for `core`, `io-hashing`, `cryptography`, and `calendar`.

### InvalidFileLink — wrong relative path to `algorithm-families.md`
`algorithm-families.md` lives under `docs/`, not `guides/`. Fixed in `guides/io-hashing/check-digits.md`, `murmurhash3.md`, and `xxhash.md` (`../algorithm-families.md` → `../../docs/algorithm-families.md`).

### UidNotFound — `<xref:Bodu.Text.BaseEncoding>`
`Bodu.Core/src/Bodu.Core.csproj` excludes `Text\**` from compilation, so the type isn't in the assembly metadata DocFX consumes. Replaced the xref in `apidoc/Bodu.Collections.Generic.md` with prose, and added an explanatory comment above the `<Compile Remove="Text\**" />` item in the csproj so the intentional exclusion is documented.

## Test plan
- [ ] `build-docs` workflow completes with the listed warnings cleared.
- [ ] `build-test` workflow continues to pass (csproj change is comment-only and does not affect compilation).

https://claude.ai/code/session_011t64LzDqq17W3BkdXvWghH

---
_Generated by [Claude Code](https://claude.ai/code/session_011t64LzDqq17W3BkdXvWghH)_