### PR TITLE
Consolidate AEAD cipher mode tests into shared base class

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Encrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Encrypt.cs
@@ -101,6 +101,15 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
     /// the keystream. Skipped for modes whose ciphertext does not depend on the supplied IV
     /// (e.g. SIV, where the IV is ignored).
     /// </summary>
+    /// <remarks>
+    /// Uses a real AES backing cipher rather than <see cref="MonitoringBlockCipher" /> because
+    /// OCB surrounds the cipher call with pre- and post-XOR operations that cancel under a
+    /// linear cipher (RFC 7253 §2.6: <c>C_i = ENCIPHER(K, P_i ⊕ Offset_i) ⊕ Offset_i</c>),
+    /// collapsing OCB ciphertext to <c>P ⊕ mask</c> independent of the nonce. Real AES breaks
+    /// this linearity and exercises the genuine nonce-dependence path. Other AEAD modes
+    /// (GCM, CCM, EAX, GCM-SIV) use the cipher as a CTR/PRF keystream and would observe a
+    /// nonce-dependent ciphertext under either backing cipher.
+    /// </remarks>
     [TestMethod]
     public void Encrypt_WithDifferentNonces_ShouldProduceDifferentCiphertext()
     {
@@ -117,11 +126,14 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
         var iv2 = CreateInitializationVector();
         iv2[0] = 0x02;
 
-        var t1 = MakeTransform(iv1);
+        using var cipher1 = new AesBlockCipherFixture(new byte[16]);
+        using var cipher2 = new AesBlockCipherFixture(new byte[16]);
+
+        var t1 = CreateTransform(cipher1, iv1);
         var out1 = new byte[plaintext.Length + t1.TagSize];
         t1.Encrypt(plaintext, out1);
 
-        var t2 = MakeTransform(iv2);
+        var t2 = CreateTransform(cipher2, iv2);
         var out2 = new byte[plaintext.Length + t2.TagSize];
         t2.Encrypt(plaintext, out2);
 


### PR DESCRIPTION
## Summary
Refactored AEAD block cipher mode tests to consolidate duplicate test logic into the `AeadBlockCipherModeTests<TTest, TTransform>` base class. This eliminates code duplication across GCM, CCM, EAX, OCB, GCM-SIV, and SIV test implementations while maintaining mode-specific test coverage.

## Key Changes

- **Added generic type parameter `TTest`** to `AeadBlockCipherModeTests<TTest, TTransform>` to enable static `DynamicDataAttribute` sources to instantiate test classes and read virtual exclusion lists for disposal validation.

- **Consolidated encryption tests** into the base class:
  - Empty plaintext handling (`Encrypt_WithEmptyPlaintext_ShouldProduceTagOnly`)
  - Non-zero tag verification (`Encrypt_ShouldProduceNonZeroTag`)
  - Nonce sensitivity (`Encrypt_WithDifferentNonces_ShouldProduceDifferentCiphertext`)
  - AAD binding (`Encrypt_WithDifferentAad_ShouldProduceDifferentTag`)
  - Plaintext binding (`Encrypt_WithDifferentPlaintext_ShouldProduceDifferentTag`)

- **Consolidated decryption tests** into the base class:
  - Wrong nonce detection (`Decrypt_WithWrongNonce_ShouldThrowCryptographicException`)
  - Tamper detection for ciphertext, tags, and AAD

- **Added comprehensive disposal validation** via new `AeadBlockCipherModeTests.Dispose.cs`:
  - Sensitive field clearing verification using reflection
  - Writable property post-disposal contract enforcement
  - `ObjectDisposedException` verification for operations on disposed transforms

- **Introduced virtual properties** for mode-specific behavior:
  - `NonceAffectsCiphertext`: Allows SIV mode to opt out of nonce-variation tests (SIV derives IV deterministically)
  - `ExcludedFieldNames` and `ExcludedWriteablePropertyNames`: Enable per-mode customization of disposal validation

- **Removed duplicate test files**:
  - `GcmModeTransformTests.Transform.cs`
  - `CcmModeTransformTests.Transform.cs`
  - `GcmSivModeTransformTests.Transform.cs`
  - `SivModeTransformTests.Transform.cs`
  - `OcbModeTransformTests.ProcessAssociatedData.cs`

- **Updated all concrete test classes** to inherit from the new generic base with both type parameters and implement required virtual methods.

## Implementation Details

- Uses reflection (`TestHelpers.GetFieldInfoForType`, `TestHelpers.GetPropertyInfoForType`) to dynamically enumerate disposable fields and writable properties for validation.
- Employs `DynamicDataAttribute` with custom display names for parameterized disposal tests.
- Maintains backward compatibility by providing sensible defaults for virtual properties in the base class.
- Preserves mode-specific test overrides (e.g., OCB's tag length variations) while sharing common AEAD semantics.

https://claude.ai/code/session_01MQsQYpVKDwRAAXLrKo6CHT