### PR TITLE
Refactor AEAD extension tests to focus on wrapper contracts

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -27,6 +27,10 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     private static byte[] NewIv() => new byte[16] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
                                                      0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19 };
 
+    // GCM's public byte[] constructor requires a 96-bit (12-byte) nonce per NIST SP 800-38D §5.2.1.1.
+    private static byte[] NewGcmNonce() => new byte[12] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
+                                                          0x12, 0x13, 0x14, 0x15 };
+
     /// <summary>
     /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM + AES recovers the original
     /// plaintext when associated data is supplied on both sides.
@@ -35,7 +39,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
     {
         byte[] key = NewKey();
-        byte[] iv = NewIv();
+        byte[] iv = NewGcmNonce();
 
         byte[] cipherWithTag;
         using (var cipher = new AesBlockCipher(key))
@@ -56,7 +60,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Gcm_RoundTrip_NoAssociatedData_ShouldRecoverPlaintext()
     {
         byte[] key = NewKey();
-        byte[] iv = NewIv();
+        byte[] iv = NewGcmNonce();
 
         byte[] cipherWithTag;
         using (var cipher = new AesBlockCipher(key))
@@ -189,7 +193,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_WhenTagIsTampered_ShouldThrowCryptographicException()
     {
         byte[] key = NewKey();
-        byte[] iv = NewIv();
+        byte[] iv = NewGcmNonce();
 
         byte[] cipherWithTag;
         using (var cipher = new AesBlockCipher(key))
@@ -214,7 +218,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_WhenAssociatedDataDiffers_ShouldThrowCryptographicException()
     {
         byte[] key = NewKey();
-        byte[] iv = NewIv();
+        byte[] iv = NewGcmNonce();
 
         byte[] cipherWithTag;
         using (var cipher = new AesBlockCipher(key))
@@ -264,7 +268,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
     {
         byte[] key = NewKey();
-        byte[] iv = NewIv();
+        byte[] iv = NewGcmNonce();
         using var cipher = new AesBlockCipher(key);
         var aead = new GcmModeTransform(cipher, iv);
 

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -4,16 +4,22 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using Bodu.Extensions;
 using System.Security.Cryptography;
 
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Verifies the one-shot <see cref="AeadBlockCipherModeTransformExtensions" /> wrappers round-trip
-/// correctly against each of the five public AEAD mode transforms when composed with
-/// <see cref="AesBlockCipher" /> as the underlying primitive.
+/// Verifies the contract of the four <see cref="AeadBlockCipherModeTransformExtensions" /> wrappers:
+/// receiver-null guards, eager input-length validation, output-buffer allocation, and equivalence
+/// of the no-AAD overloads to passing an empty associated-data span.
 /// </summary>
+/// <remarks>
+/// Mode-specific correctness — round-trip recovery, tamper detection, AAD-mismatch detection, nonce
+/// sensitivity, lifecycle errors — is covered uniformly for every <see cref="IAeadBlockCipherModeTransform" />
+/// implementation in <c>AeadBlockCipherModeTests&lt;TTest, TTransform&gt;</c> and is not re-asserted here.
+/// These tests use <see cref="CcmModeTransform" /> only as a convenient concrete transform to exercise
+/// the wrapper end-to-end; the assertions are deliberately mode-agnostic.
+/// </remarks>
 [TestClass]
 public sealed class AeadBlockCipherModeTransformExtensionsTests
 {
@@ -22,224 +28,27 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
 
     private static readonly byte[] AssociatedData = System.Text.Encoding.UTF8.GetBytes("context");
 
-    // Predictable keys and nonces keep the tests deterministic under failure triage.
     private static byte[] NewKey() => new byte[16] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16 };
+
     private static byte[] NewIv() => new byte[16] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
                                                      0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19 };
 
-    // GCM's public byte[] constructor requires a 96-bit (12-byte) nonce per NIST SP 800-38D §5.2.1.1.
-    private static byte[] NewGcmNonce() => new byte[12] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
-                                                          0x12, 0x13, 0x14, 0x15 };
-
     /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM + AES recovers the original
-    /// plaintext when associated data is supplied on both sides.
+    /// Returns a fresh AEAD transform used purely to drive the extension wrappers. CCM is selected
+    /// because its public constructor accepts a block-sized IV — no nonce-length special-casing —
+    /// keeping the test focus on the wrapper, not the underlying mode.
     /// </summary>
-    [TestMethod]
-    public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
+    private static IAeadBlockCipherModeTransform NewTransform() =>
+        new CcmModeTransform(new AesBlockCipher(NewKey()), NewIv());
 
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM + AES recovers the original
-    /// plaintext when the overload without associated data is used.
-    /// </summary>
-    [TestMethod]
-    public void Gcm_RoundTrip_NoAssociatedData_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext);
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag);
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using CCM + AES recovers the original
-    /// plaintext with associated data.
-    /// </summary>
-    [TestMethod]
-    public void Ccm_RoundTrip_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewIv();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new CcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new CcmModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using OCB + AES recovers the original
-    /// plaintext with associated data.
-    /// </summary>
-    [TestMethod]
-    public void Ocb_RoundTrip_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewIv();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new OcbModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new OcbModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using SIV + AES recovers the original
-    /// plaintext with associated data. SIV uses two independent AES keys.
-    /// </summary>
-    [TestMethod]
-    public void Siv_RoundTrip_ShouldRecoverPlaintext()
-    {
-        byte[] s2vKey = NewKey();
-        byte[] ctrKey = new byte[16];
-        RandomNumberGenerator.Fill(ctrKey);
-        byte[] iv = NewIv();
-
-        byte[] cipherWithTag;
-        using (var s2v = new AesBlockCipher(s2vKey))
-        using (var ctr = new AesBlockCipher(ctrKey))
-            cipherWithTag = new SivModeTransform(s2v, ctr, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var s2v = new AesBlockCipher(s2vKey))
-        using (var ctr = new AesBlockCipher(ctrKey))
-            recovered = new SivModeTransform(s2v, ctr, iv).Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using GCM-SIV + AES recovers the original
-    /// plaintext. GCM-SIV requires a master cipher plus a factory for the per-message cipher.
-    /// </summary>
-    [TestMethod]
-    public void GcmSiv_RoundTrip_ShouldRecoverPlaintext()
-    {
-        byte[] masterKey = NewKey();
-        byte[] iv = NewIv();
-
-        byte[] cipherWithTag;
-        using (var master = new AesBlockCipher(masterKey))
-            cipherWithTag = new GcmSivModeTransform(master, static k => new AesBlockCipher(k), iv)
-                .Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var master = new AesBlockCipher(masterKey))
-            recovered = new GcmSivModeTransform(master, static k => new AesBlockCipher(k), iv)
-                .Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that <c>Encrypt</c> followed by <c>Decrypt</c> using EAX + AES recovers the original
-    /// plaintext with associated data.
-    /// </summary>
-    [TestMethod]
-    public void Eax_RoundTrip_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewIv();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new EaxModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new EaxModeTransform(cipher, iv).Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
-    }
-
-    /// <summary>
-    /// Verifies that a single flipped bit in the authentication tag causes the
-    /// <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
-    /// overload to throw <see cref="CryptographicException" />.
-    /// </summary>
-    [TestMethod]
-    public void Decrypt_WhenTagIsTampered_ShouldThrowCryptographicException()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        // Flip the last bit of the tag.
-        cipherWithTag[^1] ^= 0x01;
-
-        using var cipher2 = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher2, iv);
-        Assert.ThrowsExactly<CryptographicException>(() =>
-        {
-            aead.Decrypt(cipherWithTag, AssociatedData.AsSpan().AsReadOnly());
-        });
-    }
-
-    /// <summary>
-    /// Verifies that decryption fails with <see cref="CryptographicException" /> when the associated
-    /// data supplied at decrypt time does not match the data supplied at encrypt time.
-    /// </summary>
-    [TestMethod]
-    public void Decrypt_WhenAssociatedDataDiffers_ShouldThrowCryptographicException()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        byte[] otherAad = System.Text.Encoding.UTF8.GetBytes("different-context");
-
-        using var cipher2 = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher2, iv);
-        Assert.ThrowsExactly<CryptographicException>(() =>
-        {
-            aead.Decrypt(cipherWithTag, otherAad.AsSpan().AsReadOnly());
-        });
-    }
+    // ── Receiver-null guards ──────────────────────────────────────────────────────────────────
 
     /// <summary>
     /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Encrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
     /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
     /// </summary>
     [TestMethod]
-    public void Encrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+    public void EncryptWithAad_WhenTransformIsNull_ShouldThrowArgumentNullException()
     {
         Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
@@ -248,11 +57,24 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Encrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte})" />
+    /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            AeadBlockCipherModeTransformExtensions.Encrypt(null!, Plaintext);
+        });
+    }
+
+    /// <summary>
     /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
     /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
     /// </summary>
     [TestMethod]
-    public void Decrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+    public void DecryptWithAad_WhenTransformIsNull_ShouldThrowArgumentNullException()
     {
         Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
@@ -261,21 +83,104 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
-    /// throws <see cref="ArgumentException" /> when the ciphertext+tag input is shorter than the tag size.
+    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte})" />
+    /// throws <see cref="ArgumentNullException" /> when the transform argument is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_WhenTransformIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            AeadBlockCipherModeTransformExtensions.Decrypt(null!, new byte[32]);
+        });
+    }
+
+    // ── Output buffer allocation ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the <see cref="AeadBlockCipherModeTransformExtensions.Encrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+    /// wrapper returns a freshly-allocated array of length <c>plaintext.Length + transform.TagSize</c>.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_ShouldReturnArrayOfPlaintextLengthPlusTagSize()
+    {
+        using var transform = NewTransform();
+        int expectedLength = Plaintext.Length + transform.TagSize;
+
+        byte[] result = transform.Encrypt(Plaintext, AssociatedData);
+
+        Assert.AreEqual(expectedLength, result.Length,
+            "Encrypt wrapper must return a buffer of length plaintext.Length + TagSize.");
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
+    /// wrapper returns a freshly-allocated array of length <c>ciphertextWithTag.Length - transform.TagSize</c>.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_ShouldReturnArrayOfCiphertextLengthMinusTagSize()
+    {
+        using var encTransform = NewTransform();
+        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, AssociatedData);
+
+        using var decTransform = NewTransform();
+        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, AssociatedData);
+
+        Assert.AreEqual(Plaintext.Length, recovered.Length,
+            "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
+    }
+
+    // ── Eager input-length validation ─────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the wrapper's own length precondition rejects a ciphertext input shorter than
+    /// the tag size with <see cref="ArgumentException" /> before the underlying transform is called.
     /// </summary>
     [TestMethod]
     public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-        using var cipher = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher, iv);
+        using var transform = NewTransform();
+        byte[] tooShort = new byte[transform.TagSize - 1];
 
-        byte[] tooShort = new byte[aead.TagSize - 1];
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            aead.Decrypt(tooShort, AssociatedData);
+            transform.Decrypt(tooShort, AssociatedData);
         });
+    }
+
+    // ── No-AAD overload equivalence ───────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that the no-AAD <see cref="AeadBlockCipherModeTransformExtensions.Encrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte})" />
+    /// overload produces output identical to the AAD overload invoked with an empty span.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_NoAadOverload_ShouldEqualExplicitEmptyAad()
+    {
+        using var t1 = NewTransform();
+        byte[] withoutAad = t1.Encrypt(Plaintext);
+
+        using var t2 = NewTransform();
+        byte[] withEmptyAad = t2.Encrypt(Plaintext, ReadOnlySpan<byte>.Empty);
+
+        CollectionAssert.AreEqual(withoutAad, withEmptyAad,
+            "Encrypt without AAD must equal Encrypt with an explicit empty AAD span.");
+    }
+
+    /// <summary>
+    /// Verifies that the no-AAD <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte})" />
+    /// overload recovers plaintext produced by the no-AAD encrypt overload.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_NoAadOverload_ShouldRecoverPlaintextEncryptedWithNoAad()
+    {
+        using var encTransform = NewTransform();
+        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext);
+
+        using var decTransform = NewTransform();
+        byte[] recovered = decTransform.Decrypt(ciphertextWithTag);
+
+        CollectionAssert.AreEqual(Plaintext, recovered,
+            "Decrypt without AAD must recover plaintext encrypted with the matching no-AAD overload.");
     }
 }


### PR DESCRIPTION
## Summary
Refactored `AeadBlockCipherModeTransformExtensionsTests` to shift focus from mode-specific round-trip correctness to the contracts of the extension method wrappers themselves. The test suite now validates wrapper preconditions, output buffer allocation, and overload equivalence rather than duplicating mode-specific correctness testing.

## Key Changes
- **Removed mode-specific round-trip tests**: Eliminated individual test methods for GCM, CCM, OCB, SIV, GCM-SIV, and EAX round-trip encryption/decryption. These are now covered uniformly by dedicated mode test classes.
- **Removed unused import**: Deleted `using Bodu.Extensions;` statement that was no longer referenced.
- **Introduced helper method**: Added `NewTransform()` that creates a `CcmModeTransform` instance for testing wrapper behavior in a mode-agnostic way.
- **Reorganized tests into logical groups**:
  - **Receiver-null guards**: Four tests verifying `ArgumentNullException` is thrown when transform argument is null for all four wrapper overloads.
  - **Output buffer allocation**: Two tests verifying correct buffer sizing for `Encrypt` and `Decrypt` wrappers.
  - **Eager input-length validation**: One test verifying `ArgumentException` is thrown for undersized ciphertext inputs before the underlying transform is invoked.
  - **No-AAD overload equivalence**: Two tests verifying that no-AAD overloads produce identical results to their AAD counterparts invoked with empty spans.
- **Updated class documentation**: Clarified that tests verify wrapper contracts (null guards, validation, allocation, overload equivalence) rather than mode-specific behavior, with remarks explaining that mode-specific correctness is tested elsewhere.

## Implementation Details
- Tests use `CcmModeTransform` as a concrete implementation solely to exercise the wrapper end-to-end; assertions remain deliberately mode-agnostic.
- Removed verbose setup code (key/IV generation per test) in favor of reusable static fields and helper methods.
- Added section comments to visually organize test groups by contract category.

https://claude.ai/code/session_01MQsQYpVKDwRAAXLrKo6CHT