### PR TITLE
Cast AssociatedData to ReadOnlySpan<byte> in AEAD cipher tests

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -107,7 +107,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var transform = NewTransform();
         int expectedLength = Plaintext.Length + transform.TagSize;
 
-        byte[] result = transform.Encrypt(Plaintext, AssociatedData);
+        byte[] result = transform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
 
         Assert.AreEqual(expectedLength, result.Length,
             "Encrypt wrapper must return a buffer of length plaintext.Length + TagSize.");
@@ -121,10 +121,10 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_ShouldReturnArrayOfCiphertextLengthMinusTagSize()
     {
         using var encTransform = NewTransform();
-        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, AssociatedData);
+        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
 
         using var decTransform = NewTransform();
-        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, AssociatedData);
+        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, (ReadOnlySpan<byte>)AssociatedData);
 
         Assert.AreEqual(Plaintext.Length, recovered.Length,
             "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
@@ -144,7 +144,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
 
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            transform.Decrypt(tooShort, AssociatedData);
+            transform.Decrypt(tooShort, (ReadOnlySpan<byte>)AssociatedData);
         });
     }
 


### PR DESCRIPTION
## Summary
Updated test cases in `AeadBlockCipherModeTransformExtensionsTests` to explicitly cast `AssociatedData` parameters to `ReadOnlySpan<byte>` when calling `Encrypt` and `Decrypt` methods.

## Key Changes
- Cast `AssociatedData` to `ReadOnlySpan<byte>` in `Encrypt_ShouldReturnArrayOfPlaintextLengthPlusTagSize()` test
- Cast `AssociatedData` to `ReadOnlySpan<byte>` in `Decrypt_ShouldReturnArrayOfCiphertextLengthMinusTagSize()` test (2 occurrences)
- Cast `AssociatedData` to `ReadOnlySpan<byte>` in `Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()` test

## Details
These changes ensure that the test code explicitly uses the `ReadOnlySpan<byte>` overload of the `Encrypt` and `Decrypt` methods, likely to support API changes or to test the span-based variants of these methods specifically.

https://claude.ai/code/session_01MQsQYpVKDwRAAXLrKo6CHT