### PR TITLE
add Tier 2 universal mode-test coverage

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -52,12 +52,14 @@ namespace Bodu.Security.Cryptography.Extensions;
 ///   </item>
 /// </list>
 /// <para>
-/// AEAD transforms are <strong>stateful and single-use within a message</strong>: instantiate a new transform per
-/// message, call exactly one of these helpers, and dispose. The associated-data argument must match byte-for-byte
-/// between the encrypt and decrypt calls — even a single-bit difference will cause the tag check to fail. Tag
-/// verification is constant-time inside the transform implementation, so timing leaks are not a concern. Output arrays
-/// are always sized exactly: <c>plaintext.Length + TagSize</c> on encrypt, <c>ciphertextWithTag.Length - TagSize</c> on
-/// decrypt.
+/// AEAD transforms are <strong>stateful and single-use per message</strong>: instantiate a new transform per
+/// message, call exactly one of these helpers, and dispose. A second call to <c>Encrypt</c> or <c>Decrypt</c> on
+/// the same underlying transform — including after a tag-mismatch <see cref="CryptographicException"/> — throws
+/// <see cref="InvalidOperationException"/>; recover by constructing a fresh transform with the same
+/// <c>(key, nonce)</c>. The associated-data argument must match byte-for-byte between the encrypt and decrypt calls
+/// — even a single-bit difference will cause the tag check to fail. Tag verification is constant-time inside the
+/// transform implementation, so timing leaks are not a concern. Output arrays are always sized exactly:
+/// <c>plaintext.Length + TagSize</c> on encrypt, <c>ciphertextWithTag.Length - TagSize</c> on decrypt.
 /// </para>
 /// <example>
 /// <code language="csharp">
@@ -132,6 +134,10 @@ public static class AeadBlockCipherModeTransformExtensions
     /// A newly allocated byte array of length <c>plaintext.Length + transform.TagSize</c>.
     /// </returns>
     /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The transform has already encrypted or decrypted a message. AEAD transforms are single-use
+    /// per message — construct a fresh instance.
+    /// </exception>
     public static byte[] Encrypt(
         this IAeadBlockCipherModeTransform transform,
         ReadOnlySpan<byte> plaintext)
@@ -159,6 +165,10 @@ public static class AeadBlockCipherModeTransformExtensions
     /// </exception>
     /// <exception cref="CryptographicException">
     /// The authentication tag did not verify. The returned buffer is not written in this case.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The transform has already encrypted or decrypted a message, including after a previous
+    /// tag-mismatch failure. AEAD transforms are single-use per message — construct a fresh instance.
     /// </exception>
     public static byte[] Decrypt(
         this IAeadBlockCipherModeTransform transform,
@@ -194,6 +204,10 @@ public static class AeadBlockCipherModeTransformExtensions
     /// <returns>A newly allocated byte array containing the recovered plaintext.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="transform" /> is <see langword="null" />.</exception>
     /// <exception cref="CryptographicException">The authentication tag did not verify.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The transform has already encrypted or decrypted a message, including after a previous
+    /// tag-mismatch failure. AEAD transforms are single-use per message — construct a fresh instance.
+    /// </exception>
     public static byte[] Decrypt(
         this IAeadBlockCipherModeTransform transform,
         ReadOnlySpan<byte> ciphertextWithTag)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -38,6 +38,13 @@ namespace Bodu.Security.Cryptography;
 /// AAD length is encoded as a 2-byte big-endian prefix (supports up to 65 279 bytes).
 /// </para>
 /// <para>
+/// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
+/// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
+/// throws <see cref="InvalidOperationException" />. The supplied <see cref="IBlockCipher" /> is not
+/// disposed by this type; ownership remains with the caller. <see cref="Dispose" /> clears the
+/// retained nonce and cached associated-data state.
+/// </para>
+/// <para>
 /// <strong>When to use CCM.</strong> Pick CCM when interoperability with constrained-environment standards
 /// is required — IEEE 802.15.4 / Zigbee, Bluetooth Mesh, IPsec ESP, and TLS 1.2 with the AES-CCM cipher
 /// suites all use it. CCM is two-pass over the message (CBC-MAC then CTR), so it is slower than

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -78,6 +78,7 @@ public sealed class CcmModeTransform
     private readonly byte[] _nonce;
     private byte[]? _aad;
     private bool _aadProcessed;
+    private bool _completed;
     private bool _disposed;
 
     /// <summary>
@@ -118,6 +119,7 @@ public sealed class CcmModeTransform
     public int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        ThrowIfCompleted();
 
         int required = plaintext.Length + TagSize;
         if (output.Length < required)
@@ -130,6 +132,7 @@ public sealed class CcmModeTransform
 
         EncryptCtr(plaintext, output.Slice(0, plaintext.Length), startIndex: 1);
         encTag.AsSpan(0, TagSize).CopyTo(output.Slice(plaintext.Length));
+        this._completed = true;
         return required;
     }
 
@@ -137,6 +140,7 @@ public sealed class CcmModeTransform
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        ThrowIfCompleted();
 
         if (ciphertextWithTag.Length < TagSize)
             throw new ArgumentException($"Input must be at least {TagSize} bytes.", nameof(ciphertextWithTag));
@@ -158,10 +162,23 @@ public sealed class CcmModeTransform
         if (!CryptographicOperations.FixedTimeEquals(encTag.AsSpan(0, TagSize), receivedTag))
         {
             CryptographicOperations.ZeroMemory(output.Slice(0, plaintextLength));
+            this._completed = true;
             throw new CryptographicException("CCM authentication tag verification failed.");
         }
 
+        this._completed = true;
         return plaintextLength;
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException" /> if this transform has already encrypted or
+    /// decrypted a message. CCM transforms are single-use; create a fresh instance per message.
+    /// </summary>
+    private void ThrowIfCompleted()
+    {
+        if (this._completed)
+            throw new InvalidOperationException(
+                "This CCM transform has already completed and cannot be reused. Create a new instance per message.");
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -83,6 +83,7 @@ public sealed class EaxModeTransform
     private readonly byte[] _nonce;     // raw user nonce, defensive clone
     private byte[]? _aad;
     private bool _aadProcessed;
+    private bool _completed;
     private bool _disposed;
 
     /// <summary>
@@ -130,6 +131,7 @@ public sealed class EaxModeTransform
     public int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         int required = plaintext.Length + TagSize;
         if (output.Length < required)
@@ -166,6 +168,7 @@ public sealed class EaxModeTransform
             ClearIfNotNull(nPrime);
             ClearIfNotNull(hPrime);
             ClearIfNotNull(cPrime);
+            this._completed = true;
         }
     }
 
@@ -173,6 +176,7 @@ public sealed class EaxModeTransform
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         if (ciphertextWithTag.Length < TagSize)
             throw new ArgumentException(
@@ -219,7 +223,19 @@ public sealed class EaxModeTransform
             ClearIfNotNull(cPrime);
             ClearIfNotNull(hPrime);
             ClearIfNotNull(nPrime);
+            this._completed = true;
         }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException" /> if this transform has already encrypted or
+    /// decrypted a message. EAX transforms are single-use; create a fresh instance per message.
+    /// </summary>
+    private void ThrowIfCompleted()
+    {
+        if (this._completed)
+            throw new InvalidOperationException(
+                "This EAX transform has already completed and cannot be reused. Create a new instance per message.");
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -41,9 +41,11 @@ namespace Bodu.Security.Cryptography;
 /// consistent with the <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
 /// <para>
-/// <strong>Lifecycle.</strong> The supplied <see cref="IBlockCipher" /> is not disposed by this type;
-/// ownership remains with the caller. <see cref="Dispose" /> clears the retained nonce and cached
-/// associated-data state and prevents further use of the transform.
+/// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
+/// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
+/// throws <see cref="InvalidOperationException" />. The supplied <see cref="IBlockCipher" /> is not
+/// disposed by this type; ownership remains with the caller. <see cref="Dispose" /> clears the
+/// retained nonce and cached associated-data state.
 /// </para>
 /// <para>
 /// <strong>When to use EAX.</strong> Pick EAX when an unencumbered, two-pass AEAD with a flexible nonce

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -45,6 +45,14 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
 /// <para>
+/// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
+/// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
+/// throws <see cref="InvalidOperationException" />. The supplied master cipher is not disposed by
+/// this type; ownership remains with the caller. The derived encryption cipher created by the
+/// supplied factory is owned by this transform and is disposed when <see cref="Dispose" /> is called,
+/// along with the cached authentication key, nonce, and associated-data state.
+/// </para>
+/// <para>
 /// <strong>When to use GCM-SIV.</strong> The right modern AEAD pick when nonce uniqueness cannot be
 /// guaranteed — distributed systems where a coordinator might re-issue the same nonce after a crash, key
 /// wrapping, deduplication, or any context where a fresh nonce per message is impractical. Under nonce

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -86,6 +86,7 @@ public sealed class GcmSivModeTransform
     private readonly byte[] _nonce;            // 12-byte nonce
     private byte[]? _aad;
     private bool _aadProcessed;
+    private bool _completed;
     private bool _disposed;
 
     /// <summary>
@@ -161,26 +162,35 @@ public sealed class GcmSivModeTransform
     public int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         int required = plaintext.Length + TagSize;
         if (output.Length < required)
             throw new ArgumentException($"Output must be at least {required} bytes.", nameof(output));
         EnsureAadProcessed();
 
-        // Tag = E(K_enc, POLYVAL(K_auth, AAD, PT) XOR nonce) with bits [31] and [63] cleared.
-        byte[] tag = ComputeTag(this._aad.AsSpan(), plaintext);
+        try
+        {
+            // Tag = E(K_enc, POLYVAL(K_auth, AAD, PT) XOR nonce) with bits [31] and [63] cleared.
+            byte[] tag = ComputeTag(this._aad.AsSpan(), plaintext);
 
-        // Encrypt plaintext with CTR(K_enc) seeded from tag.
-        byte[] ctrIv = BuildCtrIv(tag);
-        CtrEncrypt(plaintext, output.Slice(0, plaintext.Length), ctrIv);
-        tag.CopyTo(output.Slice(plaintext.Length));
-        return required;
+            // Encrypt plaintext with CTR(K_enc) seeded from tag.
+            byte[] ctrIv = BuildCtrIv(tag);
+            CtrEncrypt(plaintext, output.Slice(0, plaintext.Length), ctrIv);
+            tag.CopyTo(output.Slice(plaintext.Length));
+            return required;
+        }
+        finally
+        {
+            this._completed = true;
+        }
     }
 
     /// <inheritdoc />
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         if (ciphertextWithTag.Length < TagSize)
             throw new ArgumentException($"Input must be at least {TagSize} bytes.", nameof(ciphertextWithTag));
@@ -189,21 +199,39 @@ public sealed class GcmSivModeTransform
             throw new ArgumentException($"Output must be at least {plaintextLength} bytes.", nameof(output));
         EnsureAadProcessed();
 
-        ReadOnlySpan<byte> ciphertext = ciphertextWithTag.Slice(0, plaintextLength);
-        ReadOnlySpan<byte> receivedTag = ciphertextWithTag.Slice(plaintextLength);
-
-        // Decrypt CTR.
-        byte[] ctrIv = BuildCtrIv(receivedTag.ToArray());
-        CtrEncrypt(ciphertext, output.Slice(0, plaintextLength), ctrIv);
-
-        // Recompute and verify tag.
-        byte[] expectedTag = ComputeTag(this._aad.AsSpan(), output.Slice(0, plaintextLength));
-        if (!CryptographicOperations.FixedTimeEquals(expectedTag, receivedTag))
+        try
         {
-            CryptographicOperations.ZeroMemory(output.Slice(0, plaintextLength));
-            throw new CryptographicException("GCM-SIV authentication tag verification failed.");
+            ReadOnlySpan<byte> ciphertext = ciphertextWithTag.Slice(0, plaintextLength);
+            ReadOnlySpan<byte> receivedTag = ciphertextWithTag.Slice(plaintextLength);
+
+            // Decrypt CTR.
+            byte[] ctrIv = BuildCtrIv(receivedTag.ToArray());
+            CtrEncrypt(ciphertext, output.Slice(0, plaintextLength), ctrIv);
+
+            // Recompute and verify tag.
+            byte[] expectedTag = ComputeTag(this._aad.AsSpan(), output.Slice(0, plaintextLength));
+            if (!CryptographicOperations.FixedTimeEquals(expectedTag, receivedTag))
+            {
+                CryptographicOperations.ZeroMemory(output.Slice(0, plaintextLength));
+                throw new CryptographicException("GCM-SIV authentication tag verification failed.");
+            }
+            return plaintextLength;
         }
-        return plaintextLength;
+        finally
+        {
+            this._completed = true;
+        }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException" /> if this transform has already encrypted or
+    /// decrypted a message. GCM-SIV transforms are single-use; create a fresh instance per message.
+    /// </summary>
+    private void ThrowIfCompleted()
+    {
+        if (this._completed)
+            throw new InvalidOperationException(
+                "This GCM-SIV transform has already completed and cannot be reused. Create a new instance per message.");
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
@@ -33,8 +33,10 @@ namespace Bodu.Security.Cryptography;
 /// </code>
 /// </para>
 /// <para>
-/// All implementations are stateful and not thread-safe. A new instance must be created for each
-/// message.
+/// All implementations are stateful, not thread-safe, and <strong>single-use per message</strong>.
+/// A second call to <see cref="Encrypt" /> or <see cref="Decrypt" /> on the same instance — including
+/// after a tag-mismatch failure — throws <see cref="System.InvalidOperationException" />. Construct
+/// a fresh transform for every message and dispose it when finished.
 /// </para>
 /// <para>
 /// <strong>API surface.</strong> The library ships several implementations clustered by trade-off:
@@ -84,6 +86,10 @@ public interface IAeadBlockCipherModeTransform
     /// <param name="associatedData">
     /// The bytes to authenticate. May be empty to indicate no associated data.
     /// </param>
+    /// <exception cref="InvalidOperationException">
+    /// Associated data has already been processed on this instance, or the instance has already
+    /// completed an <see cref="Encrypt" /> or <see cref="Decrypt" /> operation.
+    /// </exception>
     void ProcessAssociatedData(ReadOnlySpan<byte> associatedData);
 
     /// <summary>
@@ -97,6 +103,10 @@ public interface IAeadBlockCipherModeTransform
     /// </param>
     /// <returns>Total bytes written: <c>plaintext.Length + TagSize</c>.</returns>
     /// <exception cref="ArgumentException"><paramref name="output" /> is too small.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The instance has already encrypted or decrypted a message. AEAD transforms are single-use
+    /// per message — construct a fresh instance.
+    /// </exception>
     int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output);
 
     /// <summary>
@@ -115,6 +125,10 @@ public interface IAeadBlockCipherModeTransform
     /// <exception cref="ArgumentException">
     /// <paramref name="ciphertextWithTag" /> is shorter than <see cref="TagSize" /> bytes, or
     /// <paramref name="output" /> is too small.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// The instance has already encrypted or decrypted a message, including after a previous
+    /// tag-mismatch failure. AEAD transforms are single-use per message — construct a fresh instance.
     /// </exception>
     int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output);
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -44,9 +44,11 @@ namespace Bodu.Security.Cryptography;
 /// The L array uses GF(2^128) doubling with polynomial x^128 + x^7 + x^2 + x + 1 (big-endian).
 /// </para>
 /// <para>
-/// <strong>Lifecycle.</strong> The supplied <see cref="IBlockCipher" /> is not disposed by this type;
-/// ownership remains with the caller. <see cref="Dispose" /> clears the retained nonce, OCB offset
-/// constants, cached associated-data state, and prevents further use of the transform.
+/// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
+/// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
+/// throws <see cref="InvalidOperationException" />. The supplied <see cref="IBlockCipher" /> is
+/// not disposed by this type; ownership remains with the caller. <see cref="Dispose" /> clears the
+/// retained nonce, OCB offset constants, and cached associated-data state.
 /// </para>
 /// <para>
 /// <strong>When to use OCB3.</strong> Pick OCB3 when you want a single-pass AEAD mode without GCM's

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -90,6 +90,7 @@ public sealed class OcbModeTransform
     private readonly byte[][] _lArray;     // L[0] = double(L_$), L[1] = double(L[0]), …
     private byte[]? _aad;
     private bool _aadProcessed;
+    private bool _completed;
     private bool _disposed;
 
     /// <summary>
@@ -191,6 +192,7 @@ public sealed class OcbModeTransform
     public int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         int required = plaintext.Length + TagSize;
         if (output.Length < required)
@@ -293,6 +295,7 @@ public sealed class OcbModeTransform
             ClearIfNotNull(block);
             ClearIfNotNull(checksum);
             ClearIfNotNull(offset);
+            this._completed = true;
         }
     }
 
@@ -300,6 +303,7 @@ public sealed class OcbModeTransform
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         if (ciphertextWithTag.Length < TagSize)
             throw new ArgumentException($"Input must be at least {TagSize} bytes.", nameof(ciphertextWithTag));
@@ -412,7 +416,19 @@ public sealed class OcbModeTransform
             ClearIfNotNull(block);
             ClearIfNotNull(checksum);
             ClearIfNotNull(offset);
+            this._completed = true;
         }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException" /> if this transform has already encrypted or
+    /// decrypted a message. OCB transforms are single-use; create a fresh instance per message.
+    /// </summary>
+    private void ThrowIfCompleted()
+    {
+        if (this._completed)
+            throw new InvalidOperationException(
+                "This OCB transform has already completed and cannot be reused. Create a new instance per message.");
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -91,6 +91,7 @@ public sealed class SivModeTransform
     private readonly IBlockCipher _ctrCipher;
     private byte[]? _aad;
     private bool _aadProcessed;
+    private bool _completed;
     private bool _disposed;
 
     /// <summary>
@@ -156,6 +157,7 @@ public sealed class SivModeTransform
     public int Encrypt(ReadOnlySpan<byte> plaintext, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         int required = plaintext.Length + TagSize;
         if (output.Length < required)
@@ -187,6 +189,7 @@ public sealed class SivModeTransform
         {
             ClearIfNotNull(ctrSeed);
             ClearIfNotNull(siv);
+            this._completed = true;
         }
     }
 
@@ -194,6 +197,7 @@ public sealed class SivModeTransform
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         this.ThrowIfDisposed();
+        this.ThrowIfCompleted();
 
         if (ciphertextWithTag.Length < TagSize)
             throw new ArgumentException($"Input must be at least {TagSize} bytes.", nameof(ciphertextWithTag));
@@ -233,7 +237,19 @@ public sealed class SivModeTransform
         {
             ClearIfNotNull(expectedSiv);
             ClearIfNotNull(ctrSeed);
+            this._completed = true;
         }
+    }
+
+    /// <summary>
+    /// Throws <see cref="InvalidOperationException" /> if this transform has already encrypted or
+    /// decrypted a message. SIV transforms are single-use; create a fresh instance per message.
+    /// </summary>
+    private void ThrowIfCompleted()
+    {
+        if (this._completed)
+            throw new InvalidOperationException(
+                "This SIV transform has already completed and cannot be reused. Create a new instance per message.");
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -47,9 +47,11 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
 /// <para>
-/// <strong>Lifecycle.</strong> The supplied <see cref="IBlockCipher" /> instances are not disposed by this
-/// type; ownership remains with the caller. <see cref="Dispose" /> clears cached associated-data state and
-/// prevents further use of the transform.
+/// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
+/// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
+/// throws <see cref="InvalidOperationException" />. The supplied <see cref="IBlockCipher" /> instances
+/// are not disposed by this type; ownership remains with the caller. <see cref="Dispose" /> clears
+/// cached associated-data state.
 /// </para>
 /// <para>
 /// <strong>When to use SIV.</strong> Pick AES-SIV when deterministic authenticated encryption is wanted —

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Decrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Decrypt.cs
@@ -233,4 +233,77 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
 
         Assert.AreEqual(0, written, "Decrypting empty ciphertext must return 0.");
     }
+
+    /// <summary>
+    /// Verifies that <see cref="IAeadBlockCipherModeTransform.Decrypt" /> recovers the original
+    /// plaintext when the associated data spans multiple cipher blocks. AAD processing has a
+    /// distinct full-block code path versus the partial-block path, so a multi-block AAD
+    /// exercises the full-block branch end-to-end.
+    /// </summary>
+    [TestMethod]
+    public void EncryptThenDecrypt_WithMultiBlockAad_ShouldRecoverPlaintext()
+    {
+        using var cipher = new AesBlockCipherFixture(new byte[16]);
+        var iv = CreateInitializationVector();
+
+        // Three full cipher blocks of AAD (48 bytes for a 16-byte block size) so the AAD-hashing
+        // path iterates beyond a single block on every implementation.
+        byte[] aad = new byte[ExpectedBlockSize * 3];
+        for (int i = 0; i < aad.Length; i++) aad[i] = (byte)(i + 0xA0);
+
+        byte[] plaintext = new byte[ExpectedBlockSize * 2];
+        for (int i = 0; i < plaintext.Length; i++) plaintext[i] = (byte)i;
+
+        var encTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        encTransform.ProcessAssociatedData(aad);
+        byte[] buf = new byte[plaintext.Length + encTransform.TagSize];
+        encTransform.Encrypt(plaintext, buf);
+
+        var decTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        decTransform.ProcessAssociatedData(aad);
+        byte[] recovered = new byte[plaintext.Length];
+        decTransform.Decrypt(buf, recovered);
+
+        CollectionAssert.AreEqual(plaintext, recovered,
+            "Decrypt with multi-block AAD must recover the original plaintext.");
+    }
+
+    // ── Security guarantees ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Verifies that <see cref="IAeadBlockCipherModeTransform.Decrypt" /> zeroes the entire output
+    /// buffer before throwing <see cref="CryptographicException" /> when authentication fails,
+    /// preventing unverified plaintext from leaking through the output array.
+    /// </summary>
+    /// <remarks>
+    /// Releasing unverified plaintext to the caller is a well-known AEAD security failure mode.
+    /// Implementations must call <see cref="System.Security.Cryptography.CryptographicOperations.ZeroMemory(System.Span{byte})" />
+    /// on the output span before propagating the tag-mismatch exception. Uses real AES so the
+    /// authentication failure cannot be masked by the linearity of <see cref="MonitoringBlockCipher" />.
+    /// </remarks>
+    [TestMethod]
+    public void Decrypt_OnAuthenticationFailure_ShouldZeroOutputBuffer()
+    {
+        using var cipher = new AesBlockCipherFixture(new byte[16]);
+        var iv = CreateInitializationVector();
+        byte[] plaintext = new byte[ExpectedBlockSize * 2];
+        for (int i = 0; i < plaintext.Length; i++) plaintext[i] = (byte)(i + 1);
+
+        var encTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        byte[] buf = new byte[plaintext.Length + encTransform.TagSize];
+        encTransform.Encrypt(plaintext, buf);
+        buf[0] ^= 0xFF; // tamper the ciphertext
+
+        byte[] output = new byte[plaintext.Length];
+        Array.Fill(output, (byte)0xCC); // sentinel — any non-zero value
+
+        var decTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        Assert.ThrowsExactly<CryptographicException>(() =>
+            decTransform.Decrypt(buf, output));
+
+        CollectionAssert.AreEqual(
+            new byte[plaintext.Length], output,
+            $"{typeof(TTransform).Name} must zero the output buffer on authentication failure " +
+            "(CryptographicOperations.ZeroMemory) so unverified plaintext cannot leak.");
+    }
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Decrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Decrypt.cs
@@ -54,6 +54,30 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
         });
     }
 
+    /// <summary>
+    /// Verifies that <see cref="IAeadBlockCipherModeTransform.Decrypt" /> throws
+    /// <see cref="InvalidOperationException" /> when called a second time on the same instance.
+    /// AEAD transforms are single-use per message; a fresh instance is required for each decrypt.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_WhenCalledTwice_ShouldThrowInvalidOperationException()
+    {
+        var cipher = new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA);
+        var iv = CreateInitializationVector();
+        var plaintext = new byte[ExpectedBlockSize];
+
+        var encTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        var buf = new byte[plaintext.Length + encTransform.TagSize];
+        encTransform.Encrypt(plaintext, buf);
+
+        var decTransform = CreateTransform(cipher, (byte[])iv.Clone());
+        decTransform.Decrypt(buf, new byte[plaintext.Length]);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            decTransform.Decrypt(buf, new byte[plaintext.Length]),
+            $"{typeof(TTransform).Name} must reject a second Decrypt call on the same instance.");
+    }
+
     // ── Tamper detection ──────────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Encrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.Encrypt.cs
@@ -12,6 +12,26 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
 
     /// <summary>
     /// Verifies that <see cref="IAeadBlockCipherModeTransform.Encrypt" /> throws
+    /// <see cref="InvalidOperationException" /> when called a second time on the same instance.
+    /// AEAD transforms are single-use per message — each (key, nonce) pair must be used at most
+    /// once for encryption to preserve the security guarantees of the mode.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_WhenCalledTwice_ShouldThrowInvalidOperationException()
+    {
+        var transform = MakeTransform();
+        var plaintext = new byte[ExpectedBlockSize];
+        var output = new byte[plaintext.Length + transform.TagSize];
+
+        transform.Encrypt(plaintext, output);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+            transform.Encrypt(plaintext, output),
+            $"{typeof(TTransform).Name} must reject a second Encrypt call on the same instance.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IAeadBlockCipherModeTransform.Encrypt" /> throws
     /// <see cref="ArgumentException" /> when the output buffer is too small to hold both
     /// the ciphertext and the authentication tag.
     /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CipherModeTestsBase.Ctors.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CipherModeTestsBase.Ctors.cs
@@ -70,6 +70,30 @@ public abstract partial class CipherModeTestsBase<TTransform>
     }
 
     /// <summary>
+    /// Verifies that constructing the mode transform with a <see langword="null" /> cipher throws
+    /// <see cref="ArgumentNullException" />. Skipped for modes whose test factory deliberately
+    /// ignores the cipher argument (e.g. SIV, which uses fixed AES keys via the test override).
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCipherIsNull_ShouldThrowArgumentNullException()
+    {
+        if (!ValidatesCipherArgument)
+        {
+            Assert.Inconclusive($"{typeof(TTransform).Name}'s test factory does not forward a null cipher to the production constructor.");
+            return;
+        }
+
+        var iv = UsesInitializationVector
+            ? new byte[ExpectedInitializationVectorSize]
+            : Array.Empty<byte>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = CreateTransform(null!, iv);
+        });
+    }
+
+    /// <summary>
     /// Verifies that constructing the mode transform with a valid cipher and a correctly-sized initialisation value
     /// completes without throwing.
     /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CipherModeTestsBase.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CipherModeTestsBase.cs
@@ -57,6 +57,15 @@ public abstract partial class CipherModeTestsBase<TTransform>
     /// </summary>
     protected virtual bool UsesInitializationVector => true;
 
+    /// <summary>
+    /// Gets a value indicating whether this mode's public constructor validates the cipher
+    /// argument and throws <see cref="ArgumentNullException" /> on <see langword="null" />.
+    /// Defaults to <see langword="true" />. SIV overrides to <see langword="false" /> because
+    /// its test factory ignores the cipher argument and uses fixed AES keys, so a null cipher
+    /// never reaches the production constructor through the test surface.
+    /// </summary>
+    protected virtual bool ValidatesCipherArgument => true;
+
     // ── Abstract factory ──────────────────────────────────────────────────────────────────────
 
     /// <summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/OcbModeTransformTests.Decrypt.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/OcbModeTransformTests.Decrypt.cs
@@ -73,41 +73,7 @@ public sealed partial class OcbModeTransformTests
 
     // ── Security properties ───────────────────────────────────────────────────────────────────
 
-    /// <summary>
-    /// Verifies that <see cref="OcbModeTransform.Decrypt" /> zeroes the entire output buffer
-    /// before throwing <see cref="CryptographicException" /> when authentication fails.
-    /// </summary>
-    /// <remarks>
-    /// Releasing unverified plaintext to the caller is a well-known AEAD security failure
-    /// mode. The implementation must call <see cref="CryptographicOperations.ZeroMemory" />
-    /// on the output span before propagating the exception, so that any partially decrypted
-    /// bytes cannot leak through the output array even if the caller catches the exception
-    /// and inspects the buffer.
-    /// </remarks>
-    [TestMethod]
-    public void Decrypt_OnAuthenticationFailure_ShouldZeroOutputBuffer()
-    {
-        using var cipher = new AesBlockCipherFixture(new byte[16]);
-        var iv = new byte[ExpectedBlockSize];
-        var plaintext = new byte[ExpectedBlockSize * 2 + 5]; // multi-block with partial
-
-        var enc = new OcbModeTransform(cipher, (byte[])iv.Clone());
-        var ct = new byte[plaintext.Length + enc.TagSize];
-        enc.Encrypt(plaintext, ct);
-        ct[0] ^= 0xFF;          // corrupt the first ciphertext byte
-
-        var output = new byte[plaintext.Length];
-        Array.Fill(output, (byte)0xCC);     // sentinel: any non-zero value
-
-        var dec = new OcbModeTransform(cipher, (byte[])iv.Clone());
-        Assert.ThrowsExactly<CryptographicException>(() => dec.Decrypt(ct, output));
-
-        CollectionAssert.AreEqual(
-            new byte[plaintext.Length],
-            output,
-            "Output buffer must be completely zeroed after authentication failure " +
-            "(CryptographicOperations.ZeroMemory).");
-    }
+    // Decrypt_OnAuthenticationFailure_ShouldZeroOutputBuffer is now in AeadBlockCipherModeTests.Decrypt.cs.
 
     // ── Return value ──────────────────────────────────────────────────────────────────────────
 

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.cs
@@ -25,6 +25,14 @@ public sealed partial class SivModeTransformTests : AeadBlockCipherModeTests<Siv
     /// </remarks>
     protected override bool NonceAffectsCiphertext => false;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// The test factory below intentionally discards the supplied <paramref name="cipher" /> and
+    /// constructs the transform from fixed AES-128 instances, so a null cipher never reaches
+    /// <see cref="SivModeTransform" />'s production constructor through the test surface.
+    /// </remarks>
+    protected override bool ValidatesCipherArgument => false;
+
     // Fixed keys used for all structural / tamper-detection tests.
     // Using real AES with distinct K1 and K2 prevents the degenerate authentication fixed-point
     // that arises when a simple XOR cipher is used for both S2V (K1) and CTR (K2): with any

--- a/docs/docs/cryptography/getting-started.md
+++ b/docs/docs/cryptography/getting-started.md
@@ -63,18 +63,20 @@ using Bodu.Security.Cryptography;
 using Bodu.Security.Cryptography.Extensions;
 
 byte[] key   = RandomNumberGenerator.GetBytes(32); // AES-256
-byte[] nonce = RandomNumberGenerator.GetBytes(12);
+byte[] nonce = RandomNumberGenerator.GetBytes(12); // GCM requires a 12-byte nonce
 byte[] aad   = "header"u8.ToArray();
 byte[] data  = "the quick brown fox"u8.ToArray();
 
-using var aes = new AesBlockCipher(key);
-var       gcm = new GcmModeTransform();
+byte[] cipherWithTag;
+using (var cipher = new AesBlockCipher(key))
+    cipherWithTag = new GcmModeTransform(cipher, nonce).Encrypt(data, aad);
 
-(byte[] ciphertext, byte[] tag) = aes.EncryptAead(gcm, nonce, data, aad);
-byte[]  recovered                = aes.DecryptAead(gcm, nonce, ciphertext, tag, aad);
+byte[] recovered;
+using (var cipher = new AesBlockCipher(key))
+    recovered = new GcmModeTransform(cipher, nonce).Decrypt(cipherWithTag, aad);
 ```
 
-Swap `GcmModeTransform` for `CcmModeTransform`, `OcbModeTransform`, `EaxModeTransform`, `SivModeTransform`, or `GcmSivModeTransform`.
+Each `GcmModeTransform` is single-use per message — the encrypt and decrypt sides each construct a fresh transform. A second call to `Encrypt` or `Decrypt` on the same instance throws <xref:System.InvalidOperationException>. Swap `GcmModeTransform` for `CcmModeTransform`, `OcbModeTransform`, `EaxModeTransform`, `SivModeTransform`, or `GcmSivModeTransform` (note that GCM specifically requires a 12-byte nonce; the others accept a block-sized IV).
 
 ### AEAD — ASCON-AEAD128 (no separate cipher)
 

--- a/docs/guides/cryptography/aead-modes.md
+++ b/docs/guides/cryptography/aead-modes.md
@@ -198,7 +198,7 @@ The factory expression `static k => new AesBlockCipher(k)` is the canonical form
 
 ## One-transform, one-message
 
-Every AEAD transform in this library is **stateful and single-use**. Construct a new transform for every message — do not attempt to call `Encrypt` twice on the same instance. The extension methods enforce this by invoking `ProcessAssociatedData` internally, which most implementations allow only once.
+Every AEAD transform in this library is **stateful and single-use**. A second call to `Encrypt` or `Decrypt` on the same instance — *including after a tag-mismatch failure* — throws <xref:System.InvalidOperationException>. The contract is enforced uniformly across `GcmModeTransform`, `CcmModeTransform`, `EaxModeTransform`, `OcbModeTransform`, `GcmSivModeTransform`, and `SivModeTransform`.
 
 The pattern throughout these examples —
 
@@ -207,7 +207,24 @@ using (var cipher = new AesBlockCipher(key))
     cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(plaintext, aad);
 ```
 
-— constructs a fresh `AesBlockCipher` and a fresh `GcmModeTransform` inside the `using`, runs one encryption, and lets them both fall out of scope.
+— constructs a fresh `AesBlockCipher` and a fresh `GcmModeTransform` inside the `using`, runs one encryption, and lets them both fall out of scope. Build a separate transform for the matching `Decrypt`:
+
+```csharp
+using (var cipher = new AesBlockCipher(key))
+    recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag, aad);
+```
+
+Reusing the encrypting transform to decrypt the round-tripped output, or calling `Encrypt` a second time to encrypt a follow-up message, will throw:
+
+```csharp
+using var cipher = new AesBlockCipher(key);
+var aead = new GcmModeTransform(cipher, iv);
+
+byte[] first  = aead.Encrypt(plaintextA, aad);
+byte[] second = aead.Encrypt(plaintextB, aad); // throws InvalidOperationException
+```
+
+The same enforcement applies to `Decrypt`. After a `CryptographicException` from a tag-mismatch, the instance is also burned — recover by constructing a fresh transform with the same `(key, nonce)`, never by retrying on the same one.
 
 ## Tamper detection
 


### PR DESCRIPTION
Three holes in the consolidated mode-test base classes are now plugged:

1) Ctor_WhenCipherIsNull_ShouldThrowArgumentNullException — added to
   CipherModeTestsBase.Ctors.cs so every IBlockCipherModeTransform and
   IAeadBlockCipherModeTransform implementation gets a uniform null-cipher
   guard. SIV opts out via a new ValidatesCipherArgument virtual
   property because its test factory deliberately discards the cipher
   argument and uses fixed AES keys.

2) EncryptThenDecrypt_WithMultiBlockAad_ShouldRecoverPlaintext — added
   to AeadBlockCipherModeTests.Decrypt.cs. The existing AAD round-trip
   test uses a 4-byte AAD; multi-block AAD exercises the distinct
   full-block branch in CCM/GCM/EAX/OCB hashing.

3) Decrypt_OnAuthenticationFailure_ShouldZeroOutputBuffer — promoted
   from OcbModeTransformTests.Decrypt.cs into the AEAD base so every
   implementation must zero the output buffer before propagating a
   tag-mismatch exception, preventing unverified plaintext from
   leaking. Uses real AES so authentication failure is not masked by
   the linearity of MonitoringBlockCipher.

The OCB-specific copy of the output-zeroing test is removed in favour
of the base-class version.