### PR TITLE
Prototype range-resolution pipeline alongside existing engine

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheEntry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheEntry.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateCacheEntry.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Represents a single entry in the chronological range-resolution cache, carrying the originating rule profile, the materialised
+/// base notable date, an optional adjusted form, and the entry's emission qualification state.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Entries are mutable on the <see cref="State" /> and <see cref="Adjusted" /> fields so the pipeline can promote a
+/// <see cref="NotableDateCacheState.Computed" /> entry to <see cref="NotableDateCacheState.InWindow" /> or
+/// <see cref="NotableDateCacheState.Adjusted" /> as more information becomes available during processing.
+/// </para>
+/// </remarks>
+internal sealed class NotableDateCacheEntry
+{
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateCacheEntry" /> class.
+	/// </summary>
+	/// <param name="profile">The static profile of the originating rule.</param>
+	/// <param name="anchorYear">The civil year of the anchor date used to materialise <paramref name="baseNotable" />.</param>
+	/// <param name="baseNotable">The materialised base notable date (pre-adjustment).</param>
+	/// <param name="state">The initial qualification state.</param>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="profile" /> or <paramref name="baseNotable" /> is <see langword="null" />.
+	/// </exception>
+	public NotableDateCacheEntry(
+		RuleStaticProfile profile,
+		int anchorYear,
+		NotableDate baseNotable,
+		NotableDateCacheState state)
+	{
+		Profile = profile ?? throw new ArgumentNullException(nameof(profile));
+		AnchorYear = anchorYear;
+		BaseNotable = baseNotable ?? throw new ArgumentNullException(nameof(baseNotable));
+		State = state;
+	}
+
+	/// <summary>
+	/// Gets the static profile of the originating rule.
+	/// </summary>
+	public RuleStaticProfile Profile { get; }
+
+	/// <summary>
+	/// Gets the civil year of the anchor date used to materialise <see cref="BaseNotable" />.
+	/// </summary>
+	public int AnchorYear { get; }
+
+	/// <summary>
+	/// Gets the materialised base notable date (pre-adjustment).
+	/// </summary>
+	public NotableDate BaseNotable { get; }
+
+	/// <summary>
+	/// Gets or sets the materialised observed notable date produced by an observance adjustment, or <see langword="null" /> when no
+	/// adjustment has been applied.
+	/// </summary>
+	public NotableDate? Adjusted { get; set; }
+
+	/// <summary>
+	/// Gets or sets the entry's emission qualification state.
+	/// </summary>
+	public NotableDateCacheState State { get; set; }
+
+	/// <summary>
+	/// Gets the originating rule.
+	/// </summary>
+	public NotableDateRule Rule => Profile.Rule;
+
+	/// <summary>
+	/// Gets a value indicating whether the entry should be emitted to the caller in the resolution output.
+	/// </summary>
+	public bool IsEmissable =>
+		State == NotableDateCacheState.InWindow || State == NotableDateCacheState.Adjusted;
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheKey.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheKey.cs
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateCacheKey.cs" company="PlaceholderCompany." />
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Identifies a unique entry within the chronological range-resolution cache.
+/// </summary>
+/// <param name="RuleName">The notable-date rule name.</param>
+/// <param name="AnchorYear">The civil year of the rule's anchor date.</param>
+/// <param name="TerritoryCode">The territory the entry was materialised for, or <see langword="null" /> for territory-neutral.</param>
+/// <param name="CalendarType">The calendar type the entry was materialised against, or <see langword="null" /> for calendar-neutral.</param>
+/// <remarks>
+/// <para>
+/// Cache keys preserve the rule's authored territory and calendar context so that the same rule materialised against multiple
+/// territories does not collapse into a single entry.
+/// </para>
+/// </remarks>
+internal readonly record struct NotableDateCacheKey(
+	string RuleName,
+	int AnchorYear,
+	string? TerritoryCode,
+	Type? CalendarType);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheState.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateCacheState.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateCacheState.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Identifies the current qualification state of a <see cref="NotableDateCacheEntry" /> within the chronological range-resolution
+/// pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The state distinguishes entries that are eligible for emission to the caller from those that are present only as adjustment
+/// context. Adjustment chains may need to consult dates that lie outside the requested window — for example a prior-year
+/// <c>31 December</c> non-working day used as a blocker for a new-year roll-forward — without those dates appearing in the
+/// caller's output.
+/// </para>
+/// </remarks>
+internal enum NotableDateCacheState
+{
+	/// <summary>
+	/// The entry is computed and cached but its observed date does not intersect the requested window. The entry participates only
+	/// as adjustment context (for example, as a non-working blocker).
+	/// </summary>
+	Computed = 0,
+
+	/// <summary>
+	/// The entry's base observed date intersects the requested window and is eligible for emission.
+	/// </summary>
+	InWindow,
+
+	/// <summary>
+	/// An observance adjustment was applied and the resulting adjusted date intersects the requested window. The adjusted date is
+	/// eligible for emission.
+	/// </summary>
+	Adjusted,
+
+	/// <summary>
+	/// An observance adjustment was applied but the resulting adjusted date lies outside the requested window. The adjusted date is
+	/// retained as adjustment context only.
+	/// </summary>
+	AdjustedBlocker,
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -1,0 +1,425 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePipeline.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using BoduExt = Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Orchestrates the chronological range-resolution pipeline: planning, tiered occurrence materialisation, observance adjustment,
+/// and emission ordering.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The pipeline is the prototype replacement for <see cref="NotableDateResolutionEngine" /> and
+/// <see cref="NotableDateResolutionAdjustmentProcessor" />. It is intentionally implemented as a single class so the four tiers and
+/// the adjustment phase are visible together; production code may decompose this into separate processors.
+/// </para>
+/// <para>
+/// Tiered processing order (each tier reads from the cache populated by earlier tiers):
+/// </para>
+/// <list type="number">
+///   <item><description><see cref="RuleTier.Fixed" /> — direct fixed-date and day-of-week-in-month rules.</description></item>
+///   <item><description><see cref="RuleTier.OffsetFromFixed" /> — offset rules whose root anchor is a fixed-date rule.</description></item>
+///   <item><description><see cref="RuleTier.Algorithmic" /> — algorithm-backed anchors, computed once per (anchor name, year).</description></item>
+///   <item><description><see cref="RuleTier.OffsetFromAlgorithmic" /> — offset rules whose root anchor is algorithmic (for example <c>Start of Lent</c> = <c>Easter Sunday − 46</c>).</description></item>
+/// </list>
+/// </remarks>
+internal sealed class NotableDateRangePipeline
+{
+	private readonly RuleStaticAnalysis _analysis;
+	private readonly NotableDateRuleResolver _ruleResolver;
+	private readonly NotableDateRangePlanner _planner;
+	private readonly BoduExt.CalendarWeekendDefinition _weekendDefinition;
+	private readonly BoduExt.IWeekendDefinitionProvider? _weekendProvider;
+	private readonly IAdjustmentHandlerRegistry? _handlerRegistry;
+
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateRangePipeline" /> class.
+	/// </summary>
+	/// <param name="analysis">The static rule analysis.</param>
+	/// <param name="ruleResolver">The resolver used to compute fixed and algorithmic anchor dates.</param>
+	/// <param name="weekendDefinition">The weekend definition used during adjustment evaluation.</param>
+	/// <param name="weekendProvider">The optional custom weekend provider.</param>
+	/// <param name="handlerRegistry">The optional custom adjustment handler registry.</param>
+	/// <exception cref="ArgumentNullException">
+	/// <paramref name="analysis" /> or <paramref name="ruleResolver" /> is <see langword="null" />.
+	/// </exception>
+	public NotableDateRangePipeline(
+		RuleStaticAnalysis analysis,
+		NotableDateRuleResolver ruleResolver,
+		BoduExt.CalendarWeekendDefinition weekendDefinition,
+		BoduExt.IWeekendDefinitionProvider? weekendProvider = null,
+		IAdjustmentHandlerRegistry? handlerRegistry = null)
+	{
+		_analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
+		_ruleResolver = ruleResolver ?? throw new ArgumentNullException(nameof(ruleResolver));
+		_planner = new NotableDateRangePlanner(analysis);
+		_weekendDefinition = weekendDefinition;
+		_weekendProvider = weekendProvider;
+		_handlerRegistry = handlerRegistry;
+	}
+
+	/// <summary>
+	/// Resolves notable dates whose observed date intersects the supplied request window.
+	/// </summary>
+	/// <param name="request">The range request.</param>
+	/// <returns>The resolved notable dates, ordered by observed date.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="request" /> is <see langword="null" />.</exception>
+	public IReadOnlyList<NotableDate> Resolve(NotableDateRangeRequest request)
+	{
+		if (request is null) throw new ArgumentNullException(nameof(request));
+
+		NotableDateRangePlan plan = _planner.Plan(request);
+		NotableDateRangeResolutionCache cache = new();
+
+		// Tier 1: Fixed and DayOfWeekInMonth.
+		foreach (RuleStaticProfile profile in plan.EligibleRules)
+		{
+			if (profile.Tier != RuleTier.Fixed) continue;
+			ProcessDirect(profile, plan, cache);
+		}
+
+		// Tier 2: OffsetFromFixed — anchor already computed in Tier 1.
+		foreach (RuleStaticProfile profile in plan.EligibleRules)
+		{
+			if (profile.Tier != RuleTier.OffsetFromFixed) continue;
+			ProcessOffsetFromCached(profile, plan, cache);
+		}
+
+		// Tier 3: Algorithmic anchors — compute exactly the demanded years.
+		ProcessAlgorithmicAnchors(plan, cache);
+
+		// Tier 4: OffsetFromAlgorithmic — anchor available in the cache from Tier 3.
+		foreach (RuleStaticProfile profile in plan.EligibleRules)
+		{
+			if (profile.Tier != RuleTier.OffsetFromAlgorithmic) continue;
+			ProcessOffsetFromCached(profile, plan, cache);
+		}
+
+		// Adjustment phase — uses the cache as non-working day context.
+		ApplyAdjustments(plan, cache);
+
+		return BuildEmissionList(plan, cache);
+	}
+
+	/// <summary>
+	/// Materialises Tier 1 (Fixed / DayOfWeekInMonth) rules across every candidate year and territory.
+	/// </summary>
+	/// <param name="profile">The rule profile to materialise.</param>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	private void ProcessDirect(RuleStaticProfile profile, NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		foreach (int year in plan.CandidateYears)
+		{
+			if (!NotableDateRuleResolver.IsApplicable(profile.Rule, year))
+				continue;
+
+			DateTime? anchor;
+			try
+			{
+				anchor = _ruleResolver.ResolveAnchorDate(profile.Rule, year);
+			}
+			catch (InvalidOperationException)
+			{
+				continue;
+			}
+
+			if (anchor is null) continue;
+
+			AddEntries(profile, year, anchor.Value, plan, cache);
+		}
+	}
+
+	/// <summary>
+	/// Materialises Tier 3 algorithmic rules for the years demanded by <see cref="NotableDateRangePlan.GetAnchorYears" />.
+	/// </summary>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	private void ProcessAlgorithmicAnchors(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		foreach (string anchorName in plan.RequiredAnchorNames())
+		{
+			if (!_analysis.TryGetProfile(anchorName, out RuleStaticProfile profile)) continue;
+			if (profile.Tier != RuleTier.Algorithmic) continue;
+
+			IReadOnlyList<int> years = plan.GetAnchorYears(anchorName);
+			foreach (int year in years)
+			{
+				if (!NotableDateRuleResolver.IsApplicable(profile.Rule, year))
+					continue;
+
+				DateTime? anchor;
+				try
+				{
+					anchor = _ruleResolver.ResolveAnchorDate(profile.Rule, year);
+				}
+				catch (InvalidOperationException)
+				{
+					continue;
+				}
+
+				if (anchor is null) continue;
+
+				AddEntries(profile, year, anchor.Value, plan, cache);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Materialises a Tier 2 or Tier 4 offset rule by reading its root anchor from the cache and applying the static
+	/// <see cref="RuleStaticProfile.OffsetFromRoot" />.
+	/// </summary>
+	/// <param name="profile">The offset rule profile.</param>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	private void ProcessOffsetFromCached(RuleStaticProfile profile, NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		if (string.IsNullOrWhiteSpace(profile.RootAnchorRuleName)) return;
+
+		IEnumerable<int> years = profile.Tier == RuleTier.OffsetFromAlgorithmic
+			? plan.GetAnchorYears(profile.RootAnchorRuleName!)
+			: plan.CandidateYears;
+
+		foreach (int year in years)
+		{
+			if (!NotableDateRuleResolver.IsApplicable(profile.Rule, year))
+				continue;
+
+			DateTime? anchor = cache.ResolveAnchor(profile.RootAnchorRuleName!, year);
+			if (anchor is null) continue;
+
+			DateTime occurrence;
+			try
+			{
+				occurrence = anchor.Value.Date.AddDays(profile.OffsetFromRoot);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
+				continue;
+			}
+
+			AddEntries(profile, year, occurrence, plan, cache);
+		}
+	}
+
+	/// <summary>
+	/// Builds and adds cache entries for the supplied rule, anchor year, and anchor date, expanding the rule's authored territory
+	/// list into one entry per territory that matches the request context.
+	/// </summary>
+	/// <param name="profile">The rule profile being materialised.</param>
+	/// <param name="year">The anchor year.</param>
+	/// <param name="anchorDate">The resolved anchor date.</param>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	private static void AddEntries(
+		RuleStaticProfile profile,
+		int year,
+		DateTime anchorDate,
+		NotableDateRangePlan plan,
+		NotableDateRangeResolutionCache cache)
+	{
+		foreach (string? territory in EnumerateApplicableTerritories(profile.Rule, plan.Request.TerritoryCode))
+		{
+			NotableDate notable = BuildNotableDate(profile.Rule, anchorDate, territory, adjustmentReason: null);
+
+			NotableDateCacheState state = NotableDateCacheState.Computed;
+			if (Intersects(plan.Request.StartDate, plan.Request.EndDate, notable.Date, notable.EndDate))
+			{
+				if (plan.Request.Filter is null || plan.Request.Filter.IsMatch(notable))
+					state = NotableDateCacheState.InWindow;
+			}
+
+			NotableDateCacheEntry entry = new(profile, year, notable, state);
+			cache.Add(entry);
+		}
+	}
+
+	/// <summary>
+	/// Applies observance adjustments to every cache entry that has at least one configured adjustment.
+	/// </summary>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache.</param>
+	private void ApplyAdjustments(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		NotableDateAdjuster adjuster = new(
+			IsWeekend,
+			(date, territory, calendar) => IsNonWorkingDay(cache, date, territory, calendar),
+			_weekendDefinition,
+			_weekendProvider,
+			_handlerRegistry,
+			(name, year, territory, calendar) => cache.ResolveObservedByName(name, year, territory, calendar));
+
+		// Snapshot first — entries can be mutated as adjustments are applied.
+		List<NotableDateCacheEntry> snapshot = cache.Entries.ToList();
+
+		foreach (NotableDateCacheEntry entry in snapshot)
+		{
+			if (entry.Rule.Adjustments.IsDefaultOrEmpty) continue;
+
+			foreach (ObservanceAdjustment adjustment in entry.Rule.Adjustments.OrderBy(a => a.Priority))
+			{
+				if (!NotableDateAdjuster.IsInScope(adjustment, entry.AnchorYear, entry.BaseNotable.TerritoryCode, entry.Rule.CalendarType))
+					continue;
+
+				AdjustmentApplyResult result = adjuster.Apply(
+					adjustment,
+					entry.Rule,
+					entry.BaseNotable.Date,
+					entry.BaseNotable.TerritoryCode,
+					entry.Rule.CalendarType);
+
+				if (!result.Activated || result.AdjustedDate.Date == entry.BaseNotable.Date.Date)
+					continue;
+
+				string? emittedTerritory = !string.IsNullOrEmpty(adjustment.TerritoryCode)
+					? adjustment.TerritoryCode
+					: entry.BaseNotable.TerritoryCode;
+
+				bool isNonWorking = result.IsNonWorkingOverride ?? entry.Rule.IsNonWorkingDay ?? false;
+				AdjustmentReason reason = new(entry.BaseNotable.Date, result.Trigger, result.Action, result.HandlerKey);
+				NotableDate adjusted = BuildNotableDate(entry.Rule, result.AdjustedDate, emittedTerritory, reason, isNonWorking);
+
+				entry.Adjusted = adjusted;
+
+				bool adjustedIntersects = Intersects(plan.Request.StartDate, plan.Request.EndDate, adjusted.Date, adjusted.EndDate);
+				bool filterMatch = plan.Request.Filter is null || plan.Request.Filter.IsMatch(adjusted);
+
+				if (adjustedIntersects && filterMatch)
+					entry.State = entry.State == NotableDateCacheState.InWindow ? NotableDateCacheState.InWindow : NotableDateCacheState.Adjusted;
+				else if (entry.State == NotableDateCacheState.Computed)
+					entry.State = NotableDateCacheState.AdjustedBlocker;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Builds the final emission list from emissable cache entries.
+	/// </summary>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache.</param>
+	/// <returns>The emission list, ordered by observed date and rule name.</returns>
+	private static IReadOnlyList<NotableDate> BuildEmissionList(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		List<NotableDate> emitted = new();
+
+		foreach (NotableDateCacheEntry entry in cache.EmissableEntries())
+		{
+			if (entry.State == NotableDateCacheState.InWindow)
+				emitted.Add(entry.BaseNotable);
+
+			if (entry.State == NotableDateCacheState.Adjusted && entry.Adjusted is not null)
+			{
+				// Emit both the base and the adjusted form when the base date also lies inside the window.
+				if (Intersects(plan.Request.StartDate, plan.Request.EndDate, entry.BaseNotable.Date, entry.BaseNotable.EndDate)
+					&& (plan.Request.Filter is null || plan.Request.Filter.IsMatch(entry.BaseNotable)))
+				{
+					emitted.Add(entry.BaseNotable);
+				}
+
+				emitted.Add(entry.Adjusted);
+			}
+		}
+
+		return emitted
+			.OrderBy(n => n.Date)
+			.ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
+			.ThenBy(n => n.TerritoryCode, StringComparer.OrdinalIgnoreCase)
+			.ToList();
+	}
+
+	/// <summary>
+	/// Determines whether the supplied date is a non-working day from the cache's perspective. Falls back to weekend evaluation.
+	/// </summary>
+	/// <param name="cache">The active cache.</param>
+	/// <param name="date">The date to test.</param>
+	/// <param name="territoryCode">The territory context.</param>
+	/// <param name="calendarType">The calendar context.</param>
+	/// <returns><see langword="true" /> when the date is non-working in context.</returns>
+	private bool IsNonWorkingDay(NotableDateRangeResolutionCache cache, DateTime date, string? territoryCode, Type? calendarType)
+	{
+		if (IsWeekend(date)) return true;
+		return cache.IsNonWorkingDay(date, territoryCode, calendarType);
+	}
+
+	/// <summary>
+	/// Determines whether the supplied date falls on a weekend under the configured weekend definition.
+	/// </summary>
+	/// <param name="date">The date to test.</param>
+	/// <returns><see langword="true" /> when the date is a weekend; otherwise, <see langword="false" />.</returns>
+	private bool IsWeekend(DateTime date) =>
+		BoduExt.DateTimeExtensions.IsWeekend(date, _weekendDefinition, _weekendProvider);
+
+	/// <summary>
+	/// Constructs a <see cref="NotableDate" /> from a rule, its resolved date, and any observance-adjustment metadata.
+	/// </summary>
+	/// <param name="rule">The originating notable-date rule.</param>
+	/// <param name="date">The resolved observed date for the rule.</param>
+	/// <param name="territory">The territory code, or <see langword="null" />.</param>
+	/// <param name="adjustmentReason">The adjustment reason, or <see langword="null" /> when the date is the base anchor.</param>
+	/// <param name="isNonWorkingOverride">An optional override for the non-working flag.</param>
+	/// <returns>The constructed <see cref="NotableDate" />.</returns>
+	private static NotableDate BuildNotableDate(
+		NotableDateRule rule,
+		DateTime date,
+		string? territory,
+		AdjustmentReason? adjustmentReason,
+		bool? isNonWorkingOverride = null) =>
+		new()
+		{
+			Date = date.Date,
+			Name = rule.Name,
+			Category = rule.Category,
+			DurationDays = Math.Max(1, rule.DurationDays),
+			IsNonWorkingDay = isNonWorkingOverride ?? rule.IsNonWorkingDay ?? false,
+			CalendarType = rule.CalendarType,
+			TerritoryCode = territory,
+			Tags = rule.Tags,
+			Comment = rule.Comment,
+			AdjustmentReason = adjustmentReason,
+		};
+
+	/// <summary>
+	/// Splits a comma-separated territory list and returns the entries that overlap the requested territory under parent / child
+	/// containment, or yields a single <see langword="null" /> when the rule is territory-neutral.
+	/// </summary>
+	/// <param name="rule">The rule whose territory list is being expanded.</param>
+	/// <param name="requestedTerritory">The requested territory, or <see langword="null" />.</param>
+	/// <returns>The applicable territory codes.</returns>
+	private static IEnumerable<string?> EnumerateApplicableTerritories(NotableDateRule rule, string? requestedTerritory)
+	{
+		if (string.IsNullOrEmpty(rule.TerritoryCode))
+		{
+			yield return null;
+			yield break;
+		}
+
+		TerritoryCode? requested = null;
+		if (!string.IsNullOrEmpty(requestedTerritory) &&
+			TerritoryCode.TryParse(requestedTerritory, out TerritoryCode parsed))
+		{
+			requested = parsed;
+		}
+
+		foreach (TerritoryCode owned in TerritoryCode.ParseList(rule.TerritoryCode))
+		{
+			if (requested is null || owned.Contains(requested.Value) || requested.Value.Contains(owned))
+				yield return owned.ToString();
+		}
+	}
+
+	/// <summary>
+	/// Determines whether two inclusive date spans intersect.
+	/// </summary>
+	/// <param name="leftStart">The first span's start date.</param>
+	/// <param name="leftEnd">The first span's end date.</param>
+	/// <param name="rightStart">The second span's start date.</param>
+	/// <param name="rightEnd">The second span's end date.</param>
+	/// <returns><see langword="true" /> when the spans intersect.</returns>
+	private static bool Intersects(DateTime leftStart, DateTime leftEnd, DateTime rightStart, DateTime rightEnd) =>
+		rightStart.Date <= leftEnd.Date && rightEnd.Date >= leftStart.Date;
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlan.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlan.cs
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePlan.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Captures the per-request resolution plan computed by <see cref="NotableDateRangePlanner" /> from a
+/// <see cref="NotableDateRangeRequest" /> and a <see cref="RuleStaticAnalysis" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The plan holds the effective resolution range (the request window expanded by the global static reach), the rules eligible to
+/// contribute to the request, and the precise civil years per algorithmic anchor that must be computed. The pipeline iterates the
+/// plan exactly — no rule is processed and no algorithm is invoked outside of what the plan authorises.
+/// </para>
+/// </remarks>
+internal sealed class NotableDateRangePlan
+{
+	private readonly Dictionary<string, IReadOnlyList<int>> _anchorYearsByName;
+
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateRangePlan" /> class.
+	/// </summary>
+	/// <param name="request">The originating request.</param>
+	/// <param name="effectiveRangeStart">The inclusive start of the effective range.</param>
+	/// <param name="effectiveRangeEnd">The inclusive end of the effective range.</param>
+	/// <param name="eligibleRules">The rule profiles that may contribute to the request.</param>
+	/// <param name="candidateYears">The civil years considered by the planner for direct rule materialisation.</param>
+	/// <param name="anchorYearsByName">The civil years per algorithmic anchor that must be computed.</param>
+	public NotableDateRangePlan(
+		NotableDateRangeRequest request,
+		DateTime effectiveRangeStart,
+		DateTime effectiveRangeEnd,
+		IReadOnlyList<RuleStaticProfile> eligibleRules,
+		IReadOnlyList<int> candidateYears,
+		Dictionary<string, IReadOnlyList<int>> anchorYearsByName)
+	{
+		Request = request;
+		EffectiveRangeStart = effectiveRangeStart;
+		EffectiveRangeEnd = effectiveRangeEnd;
+		EligibleRules = eligibleRules;
+		CandidateYears = candidateYears;
+		_anchorYearsByName = anchorYearsByName;
+	}
+
+	/// <summary>
+	/// Gets the originating request.
+	/// </summary>
+	public NotableDateRangeRequest Request { get; }
+
+	/// <summary>
+	/// Gets the inclusive start of the effective range — the request start expanded by the global static reach so that all rules
+	/// whose adjustments may roll into the request window are visible.
+	/// </summary>
+	public DateTime EffectiveRangeStart { get; }
+
+	/// <summary>
+	/// Gets the inclusive end of the effective range — the request end expanded by the global static reach.
+	/// </summary>
+	public DateTime EffectiveRangeEnd { get; }
+
+	/// <summary>
+	/// Gets the rule profiles that may contribute to the request, in input order.
+	/// </summary>
+	public IReadOnlyList<RuleStaticProfile> EligibleRules { get; }
+
+	/// <summary>
+	/// Gets the civil years considered for direct rule materialisation (one per year between the effective range start and end).
+	/// </summary>
+	public IReadOnlyList<int> CandidateYears { get; }
+
+	/// <summary>
+	/// Gets the civil years that must be resolved for each algorithmic anchor name.
+	/// </summary>
+	/// <param name="anchorRuleName">The algorithmic anchor rule name.</param>
+	/// <returns>The required civil years; an empty list when the anchor has no dependents that touch the request window.</returns>
+	public IReadOnlyList<int> GetAnchorYears(string anchorRuleName) =>
+		_anchorYearsByName.TryGetValue(anchorRuleName, out IReadOnlyList<int>? list)
+			? list
+			: Array.Empty<int>();
+
+	/// <summary>
+	/// Enumerates the algorithmic anchor names whose computation is demanded by at least one eligible rule.
+	/// </summary>
+	/// <returns>The required anchor names.</returns>
+	public IEnumerable<string> RequiredAnchorNames() => _anchorYearsByName.Keys;
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePlanner.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Builds a per-request <see cref="NotableDateRangePlan" /> from a <see cref="NotableDateRangeRequest" /> and a
+/// <see cref="RuleStaticAnalysis" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The planner is the deterministic, side-effect-free step that decides which rules and which civil years are eligible to be
+/// materialised for the request. It expands the request window by the rule set's static reach to admit collateral dates that may
+/// roll into or out of the request through observance adjustments.
+/// </para>
+/// </remarks>
+internal sealed class NotableDateRangePlanner
+{
+	private readonly RuleStaticAnalysis _analysis;
+
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateRangePlanner" /> class.
+	/// </summary>
+	/// <param name="analysis">The static rule analysis to use when planning requests.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="analysis" /> is <see langword="null" />.</exception>
+	public NotableDateRangePlanner(RuleStaticAnalysis analysis)
+	{
+		_analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
+	}
+
+	/// <summary>
+	/// Builds a <see cref="NotableDateRangePlan" /> for the supplied request.
+	/// </summary>
+	/// <param name="request">The originating range request.</param>
+	/// <returns>The constructed plan.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="request" /> is <see langword="null" />.</exception>
+	public NotableDateRangePlan Plan(NotableDateRangeRequest request)
+	{
+		if (request is null) throw new ArgumentNullException(nameof(request));
+
+		// To find rule anchors that may land inside the request window after observance adjustment / duration:
+		//   An anchor with a forward-most shift of GlobalMaxReach can land as late as anchor + GlobalMaxReach. For it to reach
+		//   request.Start, the anchor must be on or after request.Start - GlobalMaxReach.
+		//   An anchor with a backward-most shift of GlobalMinReach (negative) can land as early as anchor + GlobalMinReach. For it
+		//   to be on or before request.End, the anchor must be on or before request.End - GlobalMinReach.
+		DateTime effectiveStart = AddDaysClamped(request.StartDate, -_analysis.GlobalMaxReach);
+		DateTime effectiveEnd = AddDaysClamped(request.EndDate, -_analysis.GlobalMinReach);
+
+		List<RuleStaticProfile> eligible = new();
+		foreach (RuleStaticProfile profile in _analysis.Profiles)
+		{
+			if (IsRuleEligible(profile, request))
+				eligible.Add(profile);
+		}
+
+		List<int> candidateYears = new();
+		for (int year = effectiveStart.Year; year <= effectiveEnd.Year; year++)
+			candidateYears.Add(year);
+
+		Dictionary<string, IReadOnlyList<int>> anchorYearsByName = new(StringComparer.OrdinalIgnoreCase);
+
+		foreach (RuleStaticProfile profile in eligible)
+		{
+			if (!profile.DependsOnAlgorithmicAnchor) continue;
+			if (string.IsNullOrWhiteSpace(profile.RootAnchorRuleName)) continue;
+
+			string anchorName = profile.RootAnchorRuleName!;
+			if (!anchorYearsByName.ContainsKey(anchorName))
+				anchorYearsByName[anchorName] = ComputeAnchorYears(request, profile);
+		}
+
+		return new NotableDateRangePlan(
+			request,
+			effectiveStart,
+			effectiveEnd,
+			eligible,
+			candidateYears,
+			anchorYearsByName);
+	}
+
+	/// <summary>
+	/// Computes the civil years for which an algorithmic anchor must be resolved so that every eligible dependent has access to it.
+	/// </summary>
+	/// <param name="request">The originating request.</param>
+	/// <param name="profile">A profile that depends on the algorithmic anchor.</param>
+	/// <returns>The civil years that must be resolved.</returns>
+	/// <remarks>
+	/// <para>
+	/// The conservative default is <c>[request.Year − 1, request.Year, request.Year + 1, …, request.EndYear + 1]</c>. This covers
+	/// the practical envelope of every algorithmic anchor in use today (Easter, Lunar New Year, Vesak, Asalha Puja, etc.) without
+	/// requiring per-algorithm bounds metadata. Year-by-year over-computation is bounded because <see cref="NotableDateRangeResolutionCache.ResolveAnchor" />
+	/// caches the result.
+	/// </para>
+	/// </remarks>
+	private static IReadOnlyList<int> ComputeAnchorYears(NotableDateRangeRequest request, RuleStaticProfile profile)
+	{
+		_ = profile;
+		List<int> years = new();
+		int startYear = request.StartDate.Year - 1;
+		int endYear = request.EndDate.Year + 1;
+
+		for (int year = startYear; year <= endYear; year++)
+			years.Add(year);
+
+		return years;
+	}
+
+	/// <summary>
+	/// Determines whether the rule may contribute to the request based on territory, calendar, year bounds, and filter eligibility.
+	/// </summary>
+	/// <param name="profile">The profile under test.</param>
+	/// <param name="request">The originating request.</param>
+	/// <returns><see langword="true" /> when the rule is eligible; otherwise, <see langword="false" />.</returns>
+	private static bool IsRuleEligible(RuleStaticProfile profile, NotableDateRangeRequest request)
+	{
+		NotableDateRule rule = profile.Rule;
+
+		if (request.Filter is not null && !request.Filter.IsRuleEligible(rule))
+			return false;
+
+		if (request.CalendarType is not null && rule.CalendarType is not null && rule.CalendarType != request.CalendarType)
+			return false;
+
+		if (!RuleMayApplyToTerritory(rule, request.TerritoryCode))
+			return false;
+
+		// Year applicability is left to the resolver per (rule, year) since it depends on FirstYear/LastYear/OccurrenceYears.
+		return true;
+	}
+
+	/// <summary>
+	/// Returns <see langword="true" /> when the rule's authored territory list intersects the requested territory using parent /
+	/// child containment semantics.
+	/// </summary>
+	/// <param name="rule">The rule to check.</param>
+	/// <param name="requestedTerritory">The requested territory, or <see langword="null" /> for any.</param>
+	/// <returns><see langword="true" /> when the rule may apply.</returns>
+	private static bool RuleMayApplyToTerritory(NotableDateRule rule, string? requestedTerritory)
+	{
+		if (string.IsNullOrEmpty(rule.TerritoryCode)) return true;
+		if (string.IsNullOrEmpty(requestedTerritory)) return true;
+
+		if (!TerritoryCode.TryParse(requestedTerritory, out TerritoryCode requested))
+			return false;
+
+		foreach (TerritoryCode owned in TerritoryCode.ParseList(rule.TerritoryCode))
+		{
+			if (owned.Contains(requested) || requested.Contains(owned))
+				return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Adds days to a date, clamping to the <see cref="DateTime" /> bounds.
+	/// </summary>
+	/// <param name="date">The source date.</param>
+	/// <param name="days">The number of days to add (may be negative).</param>
+	/// <returns>The resulting date, clamped to the supported range.</returns>
+	private static DateTime AddDaysClamped(DateTime date, int days)
+	{
+		DateTime value = date.Date;
+
+		if (days < 0 && value <= DateTime.MinValue.AddDays(-days))
+			return DateTime.MinValue.Date;
+		if (days > 0 && value >= DateTime.MaxValue.AddDays(-days))
+			return DateTime.MaxValue.Date;
+
+		return value.AddDays(days);
+	}
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeRequest.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeRequest.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangeRequest.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Describes a chronological window query against the notable-date range-resolution pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The request identifies the inclusive date range the caller cares about and the optional territory, calendar, and filter
+/// context that should be applied during materialisation and emission.
+/// </para>
+/// </remarks>
+internal sealed record NotableDateRangeRequest
+{
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateRangeRequest" /> class.
+	/// </summary>
+	/// <param name="startDate">The inclusive start date of the requested window.</param>
+	/// <param name="endDate">The inclusive end date of the requested window.</param>
+	/// <param name="territoryCode">The optional territory context.</param>
+	/// <param name="calendarType">The optional calendar context.</param>
+	/// <param name="filter">The optional notable-date filter.</param>
+	/// <exception cref="ArgumentException"><paramref name="endDate" /> is earlier than <paramref name="startDate" />.</exception>
+	public NotableDateRangeRequest(
+		DateTime startDate,
+		DateTime endDate,
+		string? territoryCode = null,
+		Type? calendarType = null,
+		NotableDateFilter? filter = null)
+	{
+		DateTime start = startDate.Date;
+		DateTime end = endDate.Date;
+
+		if (end < start)
+			throw new ArgumentException("The end date must not be earlier than the start date.", nameof(endDate));
+
+		StartDate = start;
+		EndDate = end;
+		TerritoryCode = territoryCode;
+		CalendarType = calendarType;
+		Filter = filter;
+	}
+
+	/// <summary>
+	/// Gets the inclusive start of the requested window.
+	/// </summary>
+	public DateTime StartDate { get; }
+
+	/// <summary>
+	/// Gets the inclusive end of the requested window.
+	/// </summary>
+	public DateTime EndDate { get; }
+
+	/// <summary>
+	/// Gets the optional territory context.
+	/// </summary>
+	public string? TerritoryCode { get; }
+
+	/// <summary>
+	/// Gets the optional calendar context.
+	/// </summary>
+	public Type? CalendarType { get; }
+
+	/// <summary>
+	/// Gets the optional notable-date filter.
+	/// </summary>
+	public NotableDateFilter? Filter { get; }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeResolutionCache.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeResolutionCache.cs
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangeResolutionCache.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Maintains the unified entry set produced by the chronological range-resolution pipeline for a single resolution request.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The cache stores at most one entry per <see cref="NotableDateCacheKey" />. Each entry carries a state flag distinguishing entries
+/// that are eligible for emission from those that are present only as adjustment context. Callers can:
+/// </para>
+/// <list type="bullet">
+///   <item><description>Look up an anchor date by rule name and year via <see cref="ResolveAnchor" /> — used by offset rules to read previously-computed anchors without recalculating them.</description></item>
+///   <item><description>Enumerate emission candidates via <see cref="EmissableEntries" />.</description></item>
+///   <item><description>Probe non-working day context via <see cref="IsNonWorkingDay" /> — used by the adjuster's blocker evaluation.</description></item>
+/// </list>
+/// </remarks>
+internal sealed class NotableDateRangeResolutionCache
+{
+	private readonly Dictionary<NotableDateCacheKey, NotableDateCacheEntry> _entries = new();
+
+	/// <summary>
+	/// Gets the live entry sequence in arbitrary order.
+	/// </summary>
+	public IEnumerable<NotableDateCacheEntry> Entries => _entries.Values;
+
+	/// <summary>
+	/// Gets the number of entries currently in the cache.
+	/// </summary>
+	public int Count => _entries.Count;
+
+	/// <summary>
+	/// Adds an entry to the cache, replacing any existing entry with the same key.
+	/// </summary>
+	/// <param name="entry">The entry to add.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="entry" /> is <see langword="null" />.</exception>
+	public void Add(NotableDateCacheEntry entry)
+	{
+		if (entry is null) throw new ArgumentNullException(nameof(entry));
+
+		NotableDateCacheKey key = new(
+			entry.Rule.Name,
+			entry.AnchorYear,
+			entry.BaseNotable.TerritoryCode,
+			entry.BaseNotable.CalendarType);
+
+		_entries[key] = entry;
+	}
+
+	/// <summary>
+	/// Determines whether an entry exists for the supplied key.
+	/// </summary>
+	/// <param name="key">The cache key.</param>
+	/// <returns><see langword="true" /> when an entry exists; otherwise, <see langword="false" />.</returns>
+	public bool Contains(NotableDateCacheKey key) =>
+		_entries.ContainsKey(key);
+
+	/// <summary>
+	/// Attempts to retrieve an entry by its cache key.
+	/// </summary>
+	/// <param name="key">The cache key to look up.</param>
+	/// <param name="entry">The matching entry when the method returns <see langword="true" />.</param>
+	/// <returns><see langword="true" /> when an entry with the supplied key exists; otherwise, <see langword="false" />.</returns>
+	public bool TryGet(NotableDateCacheKey key, out NotableDateCacheEntry entry)
+	{
+		if (_entries.TryGetValue(key, out NotableDateCacheEntry? found))
+		{
+			entry = found;
+			return true;
+		}
+
+		entry = null!;
+		return false;
+	}
+
+	/// <summary>
+	/// Resolves the cached anchor date for a rule by name and year, regardless of the entry's state.
+	/// </summary>
+	/// <param name="ruleName">The rule name.</param>
+	/// <param name="year">The civil year.</param>
+	/// <returns>The cached anchor date, or <see langword="null" /> when no matching entry exists.</returns>
+	public DateTime? ResolveAnchor(string ruleName, int year)
+	{
+		foreach (NotableDateCacheEntry entry in _entries.Values)
+		{
+			if (entry.AnchorYear != year) continue;
+			if (!string.Equals(entry.Rule.Name, ruleName, StringComparison.OrdinalIgnoreCase)) continue;
+
+			return entry.BaseNotable.Date;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Returns the entries currently flagged as eligible for emission in the resolution output.
+	/// </summary>
+	/// <returns>The emission candidates.</returns>
+	public IEnumerable<NotableDateCacheEntry> EmissableEntries()
+	{
+		foreach (NotableDateCacheEntry entry in _entries.Values)
+		{
+			if (entry.IsEmissable)
+				yield return entry;
+		}
+	}
+
+	/// <summary>
+	/// Determines whether any cached entry flags the supplied date as a non-working day for the requested context.
+	/// </summary>
+	/// <param name="date">The date to test.</param>
+	/// <param name="territoryCode">The territory context, or <see langword="null" />.</param>
+	/// <param name="calendarType">The calendar context, or <see langword="null" />.</param>
+	/// <returns><see langword="true" /> when at least one entry covers the date and is flagged as non-working; otherwise, <see langword="false" />.</returns>
+	public bool IsNonWorkingDay(DateTime date, string? territoryCode, Type? calendarType)
+	{
+		DateTime day = date.Date;
+
+		foreach (NotableDateCacheEntry entry in _entries.Values)
+		{
+			if (EntryCoversDay(entry.BaseNotable, day, territoryCode, calendarType))
+				return true;
+
+			if (entry.Adjusted is { } adjusted && EntryCoversDay(adjusted, day, territoryCode, calendarType))
+				return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Resolves the observed date for the named rule in the supplied year and context, preferring the adjusted date when present.
+	/// </summary>
+	/// <param name="ruleName">The rule name.</param>
+	/// <param name="year">The civil year.</param>
+	/// <param name="territoryCode">The territory context, or <see langword="null" />.</param>
+	/// <param name="calendarType">The calendar context, or <see langword="null" />.</param>
+	/// <returns>The observed date, or <see langword="null" /> when no matching entry exists.</returns>
+	public DateTime? ResolveObservedByName(string ruleName, int year, string? territoryCode, Type? calendarType)
+	{
+		foreach (NotableDateCacheEntry entry in _entries.Values)
+		{
+			if (entry.AnchorYear != year) continue;
+			if (!string.Equals(entry.Rule.Name, ruleName, StringComparison.OrdinalIgnoreCase)) continue;
+			if (!ContextMatches(entry.BaseNotable.TerritoryCode, entry.BaseNotable.CalendarType, territoryCode, calendarType)) continue;
+
+			return (entry.Adjusted ?? entry.BaseNotable).Date;
+		}
+
+		return null;
+	}
+
+	/// <summary>
+	/// Determines whether the supplied notable-date span covers the supplied day, matches the requested territory and calendar
+	/// context, and is flagged as a non-working day.
+	/// </summary>
+	/// <param name="notable">The notable date under test.</param>
+	/// <param name="day">The date to test.</param>
+	/// <param name="territoryCode">The territory context, or <see langword="null" />.</param>
+	/// <param name="calendarType">The calendar context, or <see langword="null" />.</param>
+	/// <returns><see langword="true" /> when the notable date covers the day and is non-working in context.</returns>
+	private static bool EntryCoversDay(NotableDate notable, DateTime day, string? territoryCode, Type? calendarType)
+	{
+		if (!notable.IsNonWorkingDay) return false;
+		if (day < notable.Date.Date || day > notable.EndDate.Date) return false;
+
+		return ContextMatches(notable.TerritoryCode, notable.CalendarType, territoryCode, calendarType);
+	}
+
+	/// <summary>
+	/// Determines whether the entry's owned territory and calendar match the requested context.
+	/// </summary>
+	/// <param name="ownedTerritory">The territory code stored on the entry.</param>
+	/// <param name="ownedCalendar">The calendar type stored on the entry.</param>
+	/// <param name="requestedTerritory">The territory context of the query.</param>
+	/// <param name="requestedCalendar">The calendar context of the query.</param>
+	/// <returns><see langword="true" /> when the contexts match; otherwise, <see langword="false" />.</returns>
+	private static bool ContextMatches(string? ownedTerritory, Type? ownedCalendar, string? requestedTerritory, Type? requestedCalendar)
+	{
+		if (requestedCalendar is not null && ownedCalendar is not null && ownedCalendar != requestedCalendar)
+			return false;
+
+		if (string.IsNullOrEmpty(requestedTerritory) || string.IsNullOrEmpty(ownedTerritory))
+			return true;
+
+		if (!TerritoryCode.TryParse(requestedTerritory, out TerritoryCode requested))
+			return false;
+		if (!TerritoryCode.TryParse(ownedTerritory, out TerritoryCode owned))
+			return false;
+
+		return requested.Contains(owned) || owned.Contains(requested);
+	}
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
@@ -1,0 +1,281 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleStaticAnalysis.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Aggregates the static, year-independent analysis of a notable-date rule set used by the chronological range-resolution
+/// pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The analysis exposes per-rule <see cref="RuleStaticProfile" /> records, look-up indexes for offset-relative dependencies, and the
+/// global day-delta envelope across the entire rule set. It is built once from the effective rule list and re-used by every
+/// range-resolution request.
+/// </para>
+/// </remarks>
+internal sealed class RuleStaticAnalysis
+{
+	private readonly Dictionary<string, RuleStaticProfile> _profilesByRuleName;
+	private readonly Dictionary<string, List<RuleStaticProfile>> _dependentsByAnchor;
+	private readonly List<RuleStaticProfile> _profiles;
+
+	/// <summary>
+	/// Initialises a new instance of the <see cref="RuleStaticAnalysis" /> class.
+	/// </summary>
+	/// <param name="profiles">The static profile per rule.</param>
+	/// <param name="profilesByRuleName">The case-insensitive lookup of profiles by rule name.</param>
+	/// <param name="dependentsByAnchor">The case-insensitive lookup of profiles whose root anchor is the keyed rule name.</param>
+	/// <param name="globalMinReach">The most-negative reach across every profile.</param>
+	/// <param name="globalMaxReach">The most-positive reach across every profile.</param>
+	private RuleStaticAnalysis(
+		List<RuleStaticProfile> profiles,
+		Dictionary<string, RuleStaticProfile> profilesByRuleName,
+		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor,
+		int globalMinReach,
+		int globalMaxReach)
+	{
+		_profiles = profiles;
+		_profilesByRuleName = profilesByRuleName;
+		_dependentsByAnchor = dependentsByAnchor;
+		GlobalMinReach = globalMinReach;
+		GlobalMaxReach = globalMaxReach;
+	}
+
+	/// <summary>
+	/// Gets the profile for every rule processed by the pipeline, in input order.
+	/// </summary>
+	public IReadOnlyList<RuleStaticProfile> Profiles => _profiles;
+
+	/// <summary>
+	/// Gets the most-negative day delta across every rule's observable reach. Used to scope the effective resolution range
+	/// backwards from the request window.
+	/// </summary>
+	public int GlobalMinReach { get; }
+
+	/// <summary>
+	/// Gets the most-positive day delta across every rule's observable reach. Used to scope the effective resolution range
+	/// forwards from the request window.
+	/// </summary>
+	public int GlobalMaxReach { get; }
+
+	/// <summary>
+	/// Attempts to retrieve a profile for the rule with the supplied name.
+	/// </summary>
+	/// <param name="ruleName">The rule name to look up.</param>
+	/// <param name="profile">The matching profile when the method returns <see langword="true" />.</param>
+	/// <returns><see langword="true" /> when a profile exists for the supplied rule name; otherwise, <see langword="false" />.</returns>
+	public bool TryGetProfile(string ruleName, out RuleStaticProfile profile)
+	{
+		if (_profilesByRuleName.TryGetValue(ruleName, out RuleStaticProfile? found))
+		{
+			profile = found;
+			return true;
+		}
+
+		profile = null!;
+		return false;
+	}
+
+	/// <summary>
+	/// Gets the profiles whose root anchor is the rule with the supplied name. Returns an empty list when the anchor has no
+	/// dependents.
+	/// </summary>
+	/// <param name="anchorRuleName">The anchor rule name to look up.</param>
+	/// <returns>The dependent profiles, in declaration order.</returns>
+	public IReadOnlyList<RuleStaticProfile> GetDependents(string anchorRuleName) =>
+		_dependentsByAnchor.TryGetValue(anchorRuleName, out List<RuleStaticProfile>? list)
+			? list
+			: Array.Empty<RuleStaticProfile>();
+
+	/// <summary>
+	/// Builds a <see cref="RuleStaticAnalysis" /> from the supplied rule set.
+	/// </summary>
+	/// <param name="rules">The effective rules to analyse.</param>
+	/// <returns>The constructed analysis.</returns>
+	/// <exception cref="ArgumentNullException"><paramref name="rules" /> is <see langword="null" />.</exception>
+	public static RuleStaticAnalysis Build(IReadOnlyList<NotableDateRule> rules)
+	{
+		if (rules is null) throw new ArgumentNullException(nameof(rules));
+
+		Dictionary<string, NotableDateRule> rulesByName = new(StringComparer.OrdinalIgnoreCase);
+		foreach (NotableDateRule rule in rules)
+		{
+			if (!string.IsNullOrWhiteSpace(rule.Name))
+				rulesByName[rule.Name] = rule;
+		}
+
+		List<RuleStaticProfile> profiles = new();
+		Dictionary<string, RuleStaticProfile> profilesByRuleName = new(StringComparer.OrdinalIgnoreCase);
+		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor = new(StringComparer.OrdinalIgnoreCase);
+
+		foreach (NotableDateRule rule in rules)
+		{
+			RuleStaticProfile profile = BuildProfile(rule, rulesByName);
+			profiles.Add(profile);
+
+			if (!string.IsNullOrWhiteSpace(rule.Name))
+				profilesByRuleName[rule.Name] = profile;
+
+			if (!string.IsNullOrWhiteSpace(profile.RootAnchorRuleName))
+			{
+				if (!dependentsByAnchor.TryGetValue(profile.RootAnchorRuleName!, out List<RuleStaticProfile>? list))
+				{
+					list = new List<RuleStaticProfile>();
+					dependentsByAnchor[profile.RootAnchorRuleName!] = list;
+				}
+
+				list.Add(profile);
+			}
+		}
+
+		int globalMin = 0;
+		int globalMax = 0;
+
+		foreach (RuleStaticProfile profile in profiles)
+		{
+			if (profile.MinObservedReach < globalMin) globalMin = profile.MinObservedReach;
+			if (profile.MaxObservedReach > globalMax) globalMax = profile.MaxObservedReach;
+		}
+
+		return new RuleStaticAnalysis(profiles, profilesByRuleName, dependentsByAnchor, globalMin, globalMax);
+	}
+
+	/// <summary>
+	/// Computes the static profile for a single rule, walking offset chains until the root anchor is identified.
+	/// </summary>
+	/// <param name="rule">The rule to profile.</param>
+	/// <param name="rulesByName">The case-insensitive rule lookup.</param>
+	/// <returns>The constructed profile.</returns>
+	private static RuleStaticProfile BuildProfile(NotableDateRule rule, IReadOnlyDictionary<string, NotableDateRule> rulesByName)
+	{
+		(RuleTier baseTier, string? rootAnchor, int offsetFromRoot) = ClassifyRule(rule, rulesByName);
+
+		ComputeAdjustmentReach(rule, out int adjustmentMin, out int adjustmentMax);
+
+		int durationDays = Math.Max(1, rule.DurationDays);
+
+		// MinObservedReach: the most-negative day delta the rule can produce relative to its own anchor.
+		// MaxObservedReach: the most-positive day delta the rule can produce, including duration end-day.
+		int minReach = Math.Min(0, adjustmentMin);
+		int maxReach = Math.Max(durationDays - 1, adjustmentMax + (durationDays - 1));
+
+		return new RuleStaticProfile(rule, baseTier, rootAnchor, offsetFromRoot, minReach, maxReach);
+	}
+
+	/// <summary>
+	/// Walks the offset-anchor chain to identify the rule's processing tier, root anchor name, and total day offset from the root.
+	/// </summary>
+	/// <param name="rule">The rule to classify.</param>
+	/// <param name="rulesByName">The case-insensitive rule lookup.</param>
+	/// <returns>The classified tier, root anchor rule name (when applicable), and aggregate offset from the root anchor.</returns>
+	private static (RuleTier Tier, string? RootAnchorRuleName, int OffsetFromRoot) ClassifyRule(
+		NotableDateRule rule,
+		IReadOnlyDictionary<string, NotableDateRule> rulesByName)
+	{
+		switch (rule.Strategy)
+		{
+			case DateResolutionStrategy.Algorithm:
+				return (RuleTier.Algorithmic, rule.Name, 0);
+
+			case DateResolutionStrategy.Fixed:
+			case DateResolutionStrategy.DayOfWeekInMonth:
+				return (RuleTier.Fixed, null, 0);
+
+			case DateResolutionStrategy.OffsetFromAnchor:
+				return ClassifyOffsetChain(rule, rulesByName);
+
+			default:
+				return (RuleTier.Fixed, null, 0);
+		}
+	}
+
+	/// <summary>
+	/// Walks an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> chain until a non-offset rule is found, summing the offsets
+	/// along the way.
+	/// </summary>
+	/// <param name="rule">The offset rule.</param>
+	/// <param name="rulesByName">The case-insensitive rule lookup.</param>
+	/// <returns>The classified tier, root anchor rule name, and aggregate offset.</returns>
+	private static (RuleTier Tier, string? RootAnchorRuleName, int OffsetFromRoot) ClassifyOffsetChain(
+		NotableDateRule rule,
+		IReadOnlyDictionary<string, NotableDateRule> rulesByName)
+	{
+		HashSet<string> visited = new(StringComparer.OrdinalIgnoreCase);
+		NotableDateRule current = rule;
+		int aggregateOffset = 0;
+
+		while (current.Strategy == DateResolutionStrategy.OffsetFromAnchor)
+		{
+			if (string.IsNullOrWhiteSpace(current.AnchorRuleName))
+				return (RuleTier.Fixed, null, 0);
+
+			if (!visited.Add(current.Name ?? string.Empty))
+				return (RuleTier.Fixed, null, 0);
+
+			aggregateOffset += current.OffsetDays ?? 0;
+
+			if (!rulesByName.TryGetValue(current.AnchorRuleName!, out NotableDateRule? next))
+				return (RuleTier.Fixed, null, 0);
+
+			current = next;
+		}
+
+		return current.Strategy switch
+		{
+			DateResolutionStrategy.Algorithm => (RuleTier.OffsetFromAlgorithmic, current.Name, aggregateOffset),
+			DateResolutionStrategy.Fixed or DateResolutionStrategy.DayOfWeekInMonth =>
+				(RuleTier.OffsetFromFixed, current.Name, aggregateOffset),
+			_ => (RuleTier.Fixed, null, 0),
+		};
+	}
+
+	/// <summary>
+	/// Calculates the worst-case minimum and maximum day deltas produced by the rule's observance adjustments.
+	/// </summary>
+	/// <param name="rule">The rule whose adjustments are inspected.</param>
+	/// <param name="minDelta">The most-negative day delta any adjustment can produce; never positive.</param>
+	/// <param name="maxDelta">The most-positive day delta any adjustment can produce; never negative.</param>
+	private static void ComputeAdjustmentReach(NotableDateRule rule, out int minDelta, out int maxDelta)
+	{
+		minDelta = 0;
+		maxDelta = 0;
+
+		foreach (ObservanceAdjustment adjustment in rule.Adjustments)
+		{
+			(int low, int high) = EstimateAdjustmentReach(adjustment);
+			if (low < minDelta) minDelta = low;
+			if (high > maxDelta) maxDelta = high;
+		}
+	}
+
+	/// <summary>
+	/// Estimates the worst-case day-delta envelope for a single adjustment.
+	/// </summary>
+	/// <param name="adjustment">The adjustment under analysis.</param>
+	/// <returns>The minimum and maximum day deltas that the adjustment may produce.</returns>
+	/// <remarks>
+	/// <para>
+	/// The estimate is conservative: it overstates rather than understates so that on-demand expansion is rarely required.
+	/// <see cref="AdjustmentAction.MoveToNextNonWorkingDay" /> is bounded by the adjuster's 366-day cap; in practice the chains are
+	/// short and this prototype caps the static estimate at one week.
+	/// </para>
+	/// </remarks>
+	private static (int Min, int Max) EstimateAdjustmentReach(ObservanceAdjustment adjustment) =>
+		adjustment.Action switch
+		{
+			AdjustmentAction.None => (0, 0),
+			AdjustmentAction.AddDays => adjustment.OffsetDays >= 0
+				? (0, adjustment.OffsetDays)
+				: (adjustment.OffsetDays, 0),
+			AdjustmentAction.MoveToNextWeekday => (0, 3),
+			AdjustmentAction.MoveToPreviousWeekday => (-3, 0),
+			AdjustmentAction.MoveToNextNonWorkingDay => (0, 7),
+			AdjustmentAction.ReplaceWithNamedDate => (-31, 31),
+			AdjustmentAction.Custom => (-7, 7),
+			_ => (0, 0),
+		};
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticProfile.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticProfile.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleStaticProfile.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Captures the static, year-independent characteristics of a <see cref="NotableDateRule" /> used by the chronological
+/// range-resolution pipeline to scope per-request processing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A profile records the rule's processing tier, transitive root anchor (when offset-derived), the base offset relative to that
+/// anchor, and the minimum and maximum day deltas that any observance adjustment can produce. Profiles are built once at service
+/// construction by <see cref="RuleStaticAnalysis" /> and re-used across every range-resolution request.
+/// </para>
+/// <para>
+/// <see cref="MinObservedReach" /> and <see cref="MaxObservedReach" /> express the day-delta envelope of the rule's observable date
+/// space relative to the rule's <em>own anchor date</em>. They include every adjustment's worst-case shift and the duration of the
+/// observable span. The pipeline uses this envelope to decide which civil years and which rules can possibly contribute to a
+/// requested chronological window.
+/// </para>
+/// </remarks>
+internal sealed record RuleStaticProfile(
+	NotableDateRule Rule,
+	RuleTier Tier,
+	string? RootAnchorRuleName,
+	int OffsetFromRoot,
+	int MinObservedReach,
+	int MaxObservedReach)
+{
+	/// <summary>
+	/// Gets a value indicating whether this rule depends transitively on an algorithmic anchor.
+	/// </summary>
+	public bool DependsOnAlgorithmicAnchor =>
+		Tier == RuleTier.Algorithmic || Tier == RuleTier.OffsetFromAlgorithmic;
+
+	/// <summary>
+	/// Gets the inclusive upper bound on how far an observed date for this rule can move in the positive direction relative to its
+	/// own anchor.
+	/// </summary>
+	public int MaxForwardReach => MaxObservedReach;
+
+	/// <summary>
+	/// Gets the inclusive lower bound on how far an observed date for this rule can move in the negative direction relative to its
+	/// own anchor.
+	/// </summary>
+	public int MinBackwardReach => MinObservedReach;
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleTier.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleTier.cs
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleTier.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Classifies a <see cref="NotableDateRule" /> by the tier in which it must be processed by the chronological
+/// range-resolution pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tier dictates processing order so that each anchor type is evaluated only after the rules it depends on. Tiers are assigned
+/// once at service construction by <see cref="RuleStaticAnalysis" />.
+/// </para>
+/// </remarks>
+internal enum RuleTier
+{
+	/// <summary>
+	/// The rule produces its date directly without referencing any other rule. Includes
+	/// <see cref="DateResolutionStrategy.Fixed" /> and <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> rules.
+	/// </summary>
+	Fixed = 0,
+
+	/// <summary>
+	/// The rule's date is calculated as an offset from another rule whose tier is <see cref="Fixed" />.
+	/// </summary>
+	OffsetFromFixed,
+
+	/// <summary>
+	/// The rule's date is computed by an algorithm. Includes <see cref="DateResolutionStrategy.Algorithm" /> rules.
+	/// </summary>
+	Algorithmic,
+
+	/// <summary>
+	/// The rule's date is calculated as an offset from a rule whose tier is <see cref="Algorithmic" /> (or transitively from another
+	/// <see cref="OffsetFromAlgorithmic" /> rule rooted at an algorithmic anchor).
+	/// </summary>
+	OffsetFromAlgorithmic,
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -82,6 +82,9 @@ public sealed class NotableDateService : INotableDateService
     /// <summary>The optional registry of custom adjustment handlers used during generation.</summary>
     private readonly IAdjustmentHandlerRegistry? _adjustmentHandlers;
 
+    /// <summary>The lazily constructed prototype range-resolution pipeline used by <see cref="ResolveNotableDatesInRange" />.</summary>
+    private RangeResolution.NotableDateRangePipeline? _rangePipeline;
+
     /// <summary>The resolver that arbitrates when multiple rules produce a date on the same day.</summary>
     private readonly INotableDateCollisionResolver _collisionResolver;
 
@@ -351,12 +354,82 @@ public sealed class NotableDateService : INotableDateService
 	public void Invalidate()
 	{
 		_yearCache.Clear();
+		_rangePipeline = null;
 	}
 
 	/// <inheritdoc />
 	public void Invalidate(int year)
 	{
 		_yearCache.TryRemove(year, out _);
+	}
+
+	// --------------------------------------------------------------------------------------
+	// Prototype range-resolution pipeline
+	// --------------------------------------------------------------------------------------
+
+	/// <summary>
+	/// Resolves notable dates whose observed date intersects the supplied chronological window using the prototype range-resolution
+	/// pipeline. Collateral dates that originate outside the requested range are admitted when an observance adjustment rolls them
+	/// into the window or when an offset rule projects an out-of-window anchor date inside.
+	/// </summary>
+	/// <param name="startDate">The inclusive start date of the requested window.</param>
+	/// <param name="endDate">The inclusive end date of the requested window. Must not be earlier than <paramref name="startDate" />.</param>
+	/// <param name="territoryCode">The optional territory context.</param>
+	/// <param name="calendarType">The optional calendar context.</param>
+	/// <param name="filter">The optional notable-date filter.</param>
+	/// <returns>The resolved notable dates ordered by observed date.</returns>
+	/// <exception cref="ArgumentException"><paramref name="endDate" /> is earlier than <paramref name="startDate" />.</exception>
+	/// <remarks>
+	/// <para>
+	/// TODO: Once the prototype is validated against the existing window-based overloads, evaluate promoting this method to
+	/// <see cref="INotableDateService" /> and routing the existing
+	/// <see cref="GetNotableDates(DateTime, DateTime, string?, Type?)" /> and
+	/// <see cref="GetNotableDates(DateTime, DateTime, NotableDateFilter, string?, Type?)" /> overloads through the new pipeline.
+	/// </para>
+	/// </remarks>
+	public IReadOnlyList<NotableDate> ResolveNotableDatesInRange(
+		DateTime startDate,
+		DateTime endDate,
+		string? territoryCode = null,
+		Type? calendarType = null,
+		NotableDateFilter? filter = null)
+	{
+		RangeResolution.NotableDateRangeRequest request = new(
+			startDate,
+			endDate,
+			territoryCode,
+			calendarType,
+			filter);
+
+		RangeResolution.NotableDateRangePipeline pipeline = _rangePipeline ??= BuildRangePipeline();
+		IReadOnlyList<NotableDate> resolved = pipeline.Resolve(request);
+
+		List<NotableDate> localised = new(resolved.Count);
+		foreach (NotableDate notable in resolved)
+			localised.Add(LocaliseIfNeeded(notable));
+
+		return localised
+			.GroupBy(n => n.Date.Date)
+			.OrderBy(g => g.Key)
+			.SelectMany(g => _collisionResolver.Resolve(g.Key, g.ToList()) ?? Array.Empty<NotableDate>())
+			.ToList();
+	}
+
+	/// <summary>
+	/// Constructs the prototype range-resolution pipeline using the service's effective rule set, resolver, and weekend / handler
+	/// configuration.
+	/// </summary>
+	/// <returns>The constructed pipeline.</returns>
+	private RangeResolution.NotableDateRangePipeline BuildRangePipeline()
+	{
+		RangeResolution.RuleStaticAnalysis analysis = RangeResolution.RuleStaticAnalysis.Build(_effectiveRules);
+
+		return new RangeResolution.NotableDateRangePipeline(
+			analysis,
+			_resolver,
+			_weekendDefinition,
+			_weekendProvider,
+			_adjustmentHandlers);
 	}
 
 	// --------------------------------------------------------------------------------------

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -1,0 +1,249 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePipelineTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Integration tests for the prototype <see cref="NotableDateRangePipeline" /> covering the two motivating scenarios:
+/// successor offset (<em>Start of Lent</em> from <em>Easter Sunday</em> in a Q1 window) and prior-year roll-forward
+/// (<em>31 December</em> rolling into <em>3 January</em> past blockers).
+/// </summary>
+[TestClass]
+public sealed class NotableDateRangePipelineTests
+{
+	/// <summary>
+	/// Verifies that a Q1 window resolves <em>Start of Lent</em> via its <em>Easter Sunday</em> algorithmic anchor without
+	/// emitting Easter itself when Easter falls outside the window.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowContainsLentButNotEaster_ShouldEmitLentOnly()
+	{
+		// Easter Sunday 2026 = 5 April 2026. Lent = Easter − 46 = 18 February 2026.
+		NotableDateRule easter = new()
+		{
+			Name = "Easter Sunday",
+			Strategy = DateResolutionStrategy.Algorithm,
+			Category = NotableDateCategory.Religious,
+			AlgorithmKey = "easter-sunday",
+		};
+
+		NotableDateRule lent = new()
+		{
+			Name = "Start of Lent",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Religious,
+			AnchorRuleName = "Easter Sunday",
+			OffsetDays = -46,
+		};
+
+		NotableDateRule palmSunday = new()
+		{
+			Name = "Palm Sunday",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Religious,
+			AnchorRuleName = "Easter Sunday",
+			OffsetDays = -7,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(easter, lent, palmSunday) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+			algorithmRegistry: new NotableDateAlgorithmRegistry()
+				.Register("easter-sunday", new GregorianEasterSundayAlgorithm()));
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 1, 1),
+			new DateTime(2026, 3, 31));
+
+		Assert.IsTrue(resolved.Any(n => n.Name == "Start of Lent" && n.Date == new DateTime(2026, 2, 18)),
+			"Expected Start of Lent on 18 Feb 2026 to be emitted.");
+
+		Assert.IsTrue(resolved.Any(n => n.Name == "Palm Sunday" && n.Date == new DateTime(2026, 3, 29)),
+			"Expected Palm Sunday on 29 Mar 2026 to be emitted.");
+
+		Assert.IsFalse(resolved.Any(n => n.Name == "Easter Sunday"),
+			"Easter Sunday is on 5 Apr 2026 and must not be emitted for a window ending 31 Mar 2026.");
+	}
+
+	/// <summary>
+	/// Verifies that a request limited to <em>3 January</em> resolves <em>Year-End Holiday</em> (Dec 31, prior year) when its
+	/// roll-forward chain skips <em>1 January</em> (weekend) and <em>2 January</em> (non-working blocker) to land on Jan 3.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenPriorYearHolidayRollsForwardPastBlocker_ShouldEmitObservedDateOnJanuaryThird()
+	{
+		// 31 Dec 2022 was a Saturday. With "2 January" also flagged as non-working, the snap chain should land on Mon 3 Jan 2023.
+		NotableDateRule yearEnd = new()
+		{
+			Name = "Year-End Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 31,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-substitute",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateRule secondJan = new()
+		{
+			Name = "New Year Second Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 2,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(yearEnd, secondJan) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2023, 1, 3),
+			new DateTime(2023, 1, 3));
+
+		NotableDate adjusted = resolved.SingleOrDefault(n => n.Name == "Year-End Holiday" && n.Date == new DateTime(2023, 1, 3))
+			?? throw new AssertFailedException("Expected adjusted Year-End Holiday on 3 Jan 2023.");
+
+		Assert.IsTrue(adjusted.WasAdjusted, "Adjusted occurrence should carry an AdjustmentReason.");
+		Assert.IsNotNull(adjusted.AdjustmentReason);
+		Assert.AreEqual(new DateTime(2022, 12, 31), adjusted.AdjustmentReason.OriginalDate);
+
+		Assert.IsFalse(resolved.Any(n => n.Name == "New Year Second Day"),
+			"The 2 Jan blocker is outside the requested window and must not be emitted.");
+
+		Assert.IsFalse(resolved.Any(n => n.Date == new DateTime(2022, 12, 31)),
+			"The original 31 Dec anchor lies outside the requested window and must not be emitted as a base date.");
+	}
+
+	/// <summary>
+	/// Verifies that a request whose window is entirely outside any rule's projection produces no results.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenNoRuleProjectsIntoWindow_ShouldReturnEmpty()
+	{
+		NotableDateRule christmas = new()
+		{
+			Name = "Christmas Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 25,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(christmas) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 6, 1),
+			new DateTime(2026, 6, 30));
+
+		Assert.AreEqual(0, resolved.Count);
+	}
+
+	/// <summary>
+	/// Verifies that a fixed-date rule whose anchor lies inside the requested window is emitted with its base date intact.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenFixedRuleAnchorIsInsideWindow_ShouldEmitBaseDate()
+	{
+		NotableDateRule christmas = new()
+		{
+			Name = "Christmas Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 25,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(christmas) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 12, 1),
+			new DateTime(2026, 12, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Christmas Day");
+		Assert.AreEqual(new DateTime(2026, 12, 25), match.Date);
+		Assert.IsFalse(match.WasAdjusted);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateService.ResolveNotableDatesInRange" /> throws
+	/// <see cref="ArgumentException" /> when the end date precedes the start date.
+	/// </summary>
+	[TestMethod]
+	public void ResolveNotableDatesInRange_WhenEndDateIsBeforeStartDate_ShouldThrowArgumentException()
+	{
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+		{
+			_ = service.ResolveNotableDatesInRange(
+				new DateTime(2026, 6, 30),
+				new DateTime(2026, 6, 1));
+		});
+
+		Assert.AreEqual("endDate", ex.ParamName);
+	}
+
+	/// <summary>
+	/// In-memory rule provider used by the integration tests.
+	/// </summary>
+	private sealed class InMemoryRuleProvider : INotableDateRuleProvider
+	{
+		private readonly IReadOnlyList<NotableDateRule> _rules;
+
+		public InMemoryRuleProvider(params NotableDateRule[] rules)
+		{
+			_rules = rules;
+		}
+
+		public IEnumerable<NotableDateRule> LoadRules() => _rules;
+	}
+
+	/// <summary>
+	/// Minimal Gregorian Easter Sunday algorithm (Anonymous Gregorian / Meeus / Jones / Butcher) used by the Lent integration test.
+	/// </summary>
+	private sealed class GregorianEasterSundayAlgorithm : INotableDateAlgorithm
+	{
+		public DateTime? GetDate(int year, System.Globalization.Calendar? calendar = null)
+		{
+			int a = year % 19;
+			int b = year / 100;
+			int c = year % 100;
+			int d = b / 4;
+			int e = b % 4;
+			int f = (b + 8) / 25;
+			int g = (b - f + 1) / 3;
+			int h = ((19 * a) + b - d - g + 15) % 30;
+			int i = c / 4;
+			int k = c % 4;
+			int l = (32 + (2 * e) + (2 * i) - h - k) % 7;
+			int m = (a + (11 * h) + (22 * l)) / 451;
+			int month = (h + l - (7 * m) + 114) / 31;
+			int day = ((h + l - (7 * m) + 114) % 31) + 1;
+
+			return new DateTime(year, month, day);
+		}
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
@@ -1,0 +1,216 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RuleStaticAnalysisTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Verifies that <see cref="RuleStaticAnalysis" /> classifies rules into the correct processing tier and computes the day-delta
+/// reach envelope used by the chronological range-resolution pipeline.
+/// </summary>
+[TestClass]
+public sealed class RuleStaticAnalysisTests
+{
+	private static NotableDateRule Fixed(string name, int month, int day) => new()
+	{
+		Name = name,
+		Strategy = DateResolutionStrategy.Fixed,
+		Category = NotableDateCategory.Public,
+		Month = month,
+		Day = day,
+	};
+
+	private static NotableDateRule Algorithmic(string name, string algorithmKey) => new()
+	{
+		Name = name,
+		Strategy = DateResolutionStrategy.Algorithm,
+		Category = NotableDateCategory.Public,
+		AlgorithmKey = algorithmKey,
+	};
+
+	private static NotableDateRule Offset(string name, string anchorRuleName, int offsetDays) => new()
+	{
+		Name = name,
+		Strategy = DateResolutionStrategy.OffsetFromAnchor,
+		Category = NotableDateCategory.Public,
+		AnchorRuleName = anchorRuleName,
+		OffsetDays = offsetDays,
+	};
+
+	/// <summary>
+	/// Verifies that a fixed-date rule is classified as <see cref="RuleTier.Fixed" /> with no root anchor.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenFixedRule_ShouldClassifyAsFixedTier()
+	{
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { Fixed("Christmas Day", 12, 25) });
+
+		RuleStaticProfile profile = analysis.Profiles.Single();
+		Assert.AreEqual(RuleTier.Fixed, profile.Tier);
+		Assert.IsNull(profile.RootAnchorRuleName);
+		Assert.AreEqual(0, profile.OffsetFromRoot);
+	}
+
+	/// <summary>
+	/// Verifies that an algorithmic rule is classified as <see cref="RuleTier.Algorithmic" /> with itself as the root anchor.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenAlgorithmicRule_ShouldClassifyAsAlgorithmicTierWithSelfAsRootAnchor()
+	{
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { Algorithmic("Easter Sunday", "easter-sunday") });
+
+		RuleStaticProfile profile = analysis.Profiles.Single();
+		Assert.AreEqual(RuleTier.Algorithmic, profile.Tier);
+		Assert.AreEqual("Easter Sunday", profile.RootAnchorRuleName);
+		Assert.AreEqual(0, profile.OffsetFromRoot);
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule whose anchor is fixed is classified as <see cref="RuleTier.OffsetFromFixed" />.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenOffsetRuleAnchoredToFixedRule_ShouldClassifyAsOffsetFromFixedTier()
+	{
+		NotableDateRule[] rules =
+		{
+			Fixed("Christmas Day", 12, 25),
+			Offset("Boxing Day", "Christmas Day", 1),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(rules);
+
+		RuleStaticProfile boxing = analysis.Profiles.Single(p => p.Rule.Name == "Boxing Day");
+		Assert.AreEqual(RuleTier.OffsetFromFixed, boxing.Tier);
+		Assert.AreEqual("Christmas Day", boxing.RootAnchorRuleName);
+		Assert.AreEqual(1, boxing.OffsetFromRoot);
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule whose anchor is algorithmic is classified as <see cref="RuleTier.OffsetFromAlgorithmic" />.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenOffsetRuleAnchoredToAlgorithmicRule_ShouldClassifyAsOffsetFromAlgorithmicTier()
+	{
+		NotableDateRule[] rules =
+		{
+			Algorithmic("Easter Sunday", "easter-sunday"),
+			Offset("Start of Lent", "Easter Sunday", -46),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(rules);
+
+		RuleStaticProfile lent = analysis.Profiles.Single(p => p.Rule.Name == "Start of Lent");
+		Assert.AreEqual(RuleTier.OffsetFromAlgorithmic, lent.Tier);
+		Assert.AreEqual("Easter Sunday", lent.RootAnchorRuleName);
+		Assert.AreEqual(-46, lent.OffsetFromRoot);
+	}
+
+	/// <summary>
+	/// Verifies that a chain of offset rules collapses to the transitive root anchor and aggregate offset.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenOffsetChainResolvesToAlgorithmicRoot_ShouldFlattenToRootAnchorAndAggregateOffset()
+	{
+		NotableDateRule[] rules =
+		{
+			Algorithmic("Easter Sunday", "easter-sunday"),
+			Offset("Easter Monday", "Easter Sunday", 1),
+			Offset("Day After Easter Monday", "Easter Monday", 1),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(rules);
+
+		RuleStaticProfile descendant = analysis.Profiles.Single(p => p.Rule.Name == "Day After Easter Monday");
+		Assert.AreEqual(RuleTier.OffsetFromAlgorithmic, descendant.Tier);
+		Assert.AreEqual("Easter Sunday", descendant.RootAnchorRuleName);
+		Assert.AreEqual(2, descendant.OffsetFromRoot);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="RuleStaticAnalysis.GetDependents" /> returns every rule whose root anchor is the supplied name.
+	/// </summary>
+	[TestMethod]
+	public void GetDependents_WhenAnchorHasOffsetDescendants_ShouldReturnAllDescendants()
+	{
+		NotableDateRule[] rules =
+		{
+			Algorithmic("Easter Sunday", "easter-sunday"),
+			Offset("Start of Lent", "Easter Sunday", -46),
+			Offset("Palm Sunday", "Easter Sunday", -7),
+			Offset("Easter Monday", "Easter Sunday", 1),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(rules);
+
+		IReadOnlyList<RuleStaticProfile> dependents = analysis.GetDependents("Easter Sunday");
+		CollectionAssert.AreEquivalent(
+			new[] { "Easter Sunday", "Start of Lent", "Palm Sunday", "Easter Monday" },
+			dependents.Select(d => d.Rule.Name).ToArray());
+	}
+
+	/// <summary>
+	/// Verifies that the global reach envelope reflects the worst-case adjustment shifts and durations across every rule.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenRulesHaveAdjustments_ShouldComputeGlobalReachEnvelope()
+	{
+		NotableDateRule rollForward = Fixed("New Year's Day", 1, 1) with
+		{
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-roll",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateRule longSpan = Fixed("Festival Week", 6, 1) with
+		{
+			DurationDays = 7,
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { rollForward, longSpan });
+
+		// MoveToNextNonWorkingDay is estimated at +7 forward reach in this prototype; duration adds 6 to the festival week.
+		Assert.IsTrue(analysis.GlobalMaxReach >= 7, $"Expected GlobalMaxReach >= 7, got {analysis.GlobalMaxReach}.");
+		Assert.IsTrue(analysis.GlobalMinReach <= 0);
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule referencing a missing anchor degrades safely to the <see cref="RuleTier.Fixed" /> tier so the
+	/// analyser never throws on partially-authored rule sets.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenOffsetRuleReferencesMissingAnchor_ShouldDegradeToFixedTier()
+	{
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[]
+		{
+			Offset("Orphaned", "Does Not Exist", 1),
+		});
+
+		RuleStaticProfile profile = analysis.Profiles.Single();
+		Assert.AreEqual(RuleTier.Fixed, profile.Tier);
+		Assert.IsNull(profile.RootAnchorRuleName);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="RuleStaticAnalysis.Build" /> throws <see cref="ArgumentNullException" /> when the rule list is
+	/// <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenRulesIsNull_ShouldThrowArgumentNullException()
+	{
+		ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = RuleStaticAnalysis.Build(null!);
+		});
+
+		Assert.AreEqual("rules", ex.ParamName);
+	}
+}


### PR DESCRIPTION
Adds a parallel notable-date resolution pipeline under the new Bodu.Globalization.Calendar.RangeResolution sub-namespace so it can be exercised side-by-side with the existing NotableDateResolutionEngine before any deletion or merge.

Pipeline (Globalization.Calendar.RangeResolution/):
- RuleTier, RuleStaticProfile, RuleStaticAnalysis: per-rule classification into Fixed / OffsetFromFixed / Algorithmic / OffsetFromAlgorithmic tiers, transitive root anchor flattening, and adjustment / duration reach envelope for window scoping.
- NotableDateCacheState (Computed / InWindow / Adjusted / AdjustedBlocker), NotableDateCacheEntry, NotableDateCacheKey, NotableDateRangeResolutionCache: unified cache that distinguishes emission candidates from blocker context.
- NotableDateRangeRequest, NotableDateRangePlan, NotableDateRangePlanner: per-request scoping. EffectiveRange = request expanded by global static reach so prior-year anchors whose forward adjustment lands in the window are admitted. AnchorYearsByName covers each algorithmic anchor's [year-1, year+1] envelope.
- NotableDateRangePipeline: orchestrates the four tiers in dependency order and applies observance adjustments using the cache as the non-working-day context.

Public API:
- Adds NotableDateService.ResolveNotableDatesInRange(start, end, ...) on the concrete class only with a TODO to evaluate interface promotion once the prototype is validated. Existing GetNotableDates window overloads remain unchanged.
- Invalidate() now also resets the lazy range pipeline so override changes are picked up.

Tests (Globalization.Calendar.RangeResolution/):
- RuleStaticAnalysisTests covers tier classification (fixed, algorithmic, offset-from-fixed, offset-from-algorithmic, transitive chain flattening), dependency lookup, reach envelope computation, and null / missing-anchor degradation.
- NotableDateRangePipelineTests covers the two motivating scenarios: (a) Lent in Q1 2026 emits Lent and Palm Sunday but not Easter; and (b) prior-year 31 Dec 2022 holiday rolls forward past 1 Jan and 2 Jan blockers to land on 3 Jan 2023, with the original anchor and the blocker not emitted.

https://claude.ai/code/session_01Bt7aVfAshdFniYjdyR77q8