### PR TITLE
Prototype range-resolution pipeline + author-declared adjustment reach

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -305,35 +305,33 @@ internal sealed class NotableDateRangePipeline
 	/// <param name="plan">The active resolution plan.</param>
 	/// <param name="cache">The shared cache.</param>
 	/// <returns>The emission list, ordered by observed date and rule name.</returns>
+	/// <remarks>
+	/// <para>
+	/// Emission policy: an observance adjustment replaces the base anchor — when an entry's <see cref="NotableDateCacheState" /> is
+	/// <see cref="NotableDateCacheState.Adjusted" /> only the <see cref="NotableDateCacheEntry.Adjusted" /> form is emitted, never
+	/// the underlying anchor. This guarantees that the emitted count equals the notable-date count for the requested window.
+	/// </para>
+	/// </remarks>
 	private static IReadOnlyList<NotableDate> BuildEmissionList(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
 	{
 		List<NotableDate> emitted = new();
 
 		foreach (NotableDateCacheEntry entry in cache.EmissableEntries())
 		{
-			if (entry.State == NotableDateCacheState.InWindow)
+			if (entry.State == NotableDateCacheState.Adjusted && entry.Adjusted is not null)
 			{
-				emitted.Add(entry.BaseNotable);
+				// Adjusted form supersedes the base — the original anchor is recorded on the adjusted date's AdjustmentReason
+				// rather than emitted as a separate entry.
+				emitted.Add(entry.Adjusted);
 				continue;
 			}
 
-			if (entry.State == NotableDateCacheState.Adjusted && entry.Adjusted is not null)
-			{
-				// Emit the base date when it independently intersects the request — this is the canonical "Dec 31 falls on
-				// Saturday so we observe it on Monday too" pair where both anchor and substitute are visible to the caller.
-				if (Intersects(plan.Request.StartDate, plan.Request.EndDate, entry.BaseNotable.Date, entry.BaseNotable.EndDate)
-					&& (plan.Request.Filter is null || plan.Request.Filter.IsMatch(entry.BaseNotable)))
-				{
-					emitted.Add(entry.BaseNotable);
-				}
-
-				emitted.Add(entry.Adjusted);
-			}
+			if (entry.State == NotableDateCacheState.InWindow)
+				emitted.Add(entry.BaseNotable);
 		}
 
-		// Defensive: never emit a notable date whose span lies outside the requested window. The state transitions above already
-		// enforce this, but the explicit guard catches any future regression in the state machine without re-introducing the
-		// "phantom Dec 31" leak that originally surfaced when state preservation was conditional.
+		// Defensive: never emit a notable date whose span lies outside the requested window. The state transitions enforce this on
+		// their own, but the explicit guard catches any future regression in the state machine.
 		return emitted
 			.Where(n => Intersects(plan.Request.StartDate, plan.Request.EndDate, n.Date, n.EndDate))
 			.OrderBy(n => n.Date)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -122,26 +122,30 @@ internal sealed class NotableDateRangePipeline
 	}
 
 	/// <summary>
-	/// Materialises Tier 1 rules with at least one observance adjustment for adjacent civil years inside the planner's fringe
-	/// distance, admitting only those whose resolved date sits within the fringe window.
+	/// Materialises adjacent-year rules whose observance adjustment chain or multi-day duration may project an emission into the
+	/// requested window. Covers two fringe-relevant categories: rules with at least one <see cref="ObservanceAdjustment" /> and
+	/// rules with <see cref="NotableDateRule.DurationDays" /> greater than one.
 	/// </summary>
 	/// <param name="plan">The active resolution plan.</param>
 	/// <param name="cache">The shared cache being populated.</param>
 	/// <remarks>
 	/// <para>
-	/// This pass handles cross-year roll-overs. For example, a request <c>[3 Jan 2023, 3 Jan 2023]</c> needs to know about the
-	/// prior-year <c>31 Dec 2022</c> rule (whose resolved date is in the fringe window <c>[27 Dec 2022, 10 Jan 2023]</c>) so that
-	/// the adjustment phase can roll it forward to <c>3 Jan 2023</c>. Rules without adjustments are skipped because they cannot
-	/// contribute through this mechanism.
+	/// The fringe pass handles three concrete classes of cross-year contribution:
+	/// </para>
+	/// <list type="bullet">
+	///   <item><description><b>Tier 1 (Fixed) with adjustment</b> — for example, a <c>31 Dec</c> holiday whose <see cref="AdjustmentAction.MoveToNextNonWorkingDay" /> rolls forward into the new year.</description></item>
+	///   <item><description><b>Tier 2 (OffsetFromFixed) with adjustment</b> — for example, <c>"Day after Christmas"</c> with a weekend roll-forward. The rule's root anchor is materialised on-demand for the fringe year if Pass 1 did not load it.</description></item>
+	///   <item><description><b>Tier 1 (Fixed) with multi-day duration</b> — for example, a seven-day festival starting <c>30 Dec</c> whose span reaches into early January.</description></item>
+	/// </list>
+	/// <para>
+	/// Algorithmic and offset-from-algorithmic tiers are already covered by the main pass — the planner unions fringe years into
+	/// <see cref="NotableDateRangePlan.GetAnchorYears" /> so Tier 3 / Tier 4 read those years directly.
 	/// </para>
 	/// <para>
-	/// Algorithmic and offset-from-algorithmic tiers do not need a separate fringe pass — the planner already unions fringe years
-	/// into <see cref="NotableDateRangePlan.GetAnchorYears" />, so Tier 3 / Tier 4 in the main pass cover those cases.
-	/// </para>
-	/// <para>
-	/// <b>Limitation:</b> offset-from-fixed rules with adjustments in fringe years are not handled here because their root anchor
-	/// in the fringe year is not materialised by the main pass. Add the rule's fixed anchor to the rule set's main-year processing
-	/// or extend this pass if such a configuration becomes necessary.
+	/// Per-rule filtering uses each profile's <see cref="RuleStaticProfile.MinObservedReach" /> /
+	/// <see cref="RuleStaticProfile.MaxObservedReach" /> envelope rather than the planner-wide fringe window, so a rule with a
+	/// large adjustment shift (for example, <see cref="AdjustmentAction.AddDays" /> = 60) is correctly admitted while a rule with
+	/// a small reach is not over-scanned.
 	/// </para>
 	/// </remarks>
 	private void ProcessFringePass(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
@@ -150,33 +154,99 @@ internal sealed class NotableDateRangePipeline
 
 		foreach (RuleStaticProfile profile in plan.EligibleRules)
 		{
-			if (profile.Tier != RuleTier.Fixed) continue;
-			if (profile.Rule.Adjustments.IsDefaultOrEmpty) continue;
+			// Algorithmic and OffsetFromAlgorithmic are covered by the main pass via plan.GetAnchorYears.
+			if (profile.Tier == RuleTier.Algorithmic || profile.Tier == RuleTier.OffsetFromAlgorithmic) continue;
+
+			// Skip rules that cannot contribute through the fringe — neither an adjustment nor a multi-day span.
+			bool hasAdjustments = !profile.Rule.Adjustments.IsDefaultOrEmpty;
+			bool hasMultiDaySpan = profile.Rule.DurationDays > 1;
+			if (!hasAdjustments && !hasMultiDaySpan) continue;
 
 			foreach (int year in plan.FringeYears)
 			{
 				if (!NotableDateRuleResolver.IsApplicable(profile.Rule, year))
 					continue;
 
-				DateTime? anchor;
-				try
-				{
-					anchor = _ruleResolver.ResolveAnchorDate(profile.Rule, year);
-				}
-				catch (InvalidOperationException)
-				{
-					continue;
-				}
-
+				DateTime? anchor = ResolveFringeAnchor(profile, year, plan, cache);
 				if (anchor is null) continue;
 
-				// Only admit fringe candidates close enough to the request edges that an adjustment could shift them inside.
-				DateTime resolved = anchor.Value.Date;
-				if (resolved < plan.FringeStartDate || resolved > plan.FringeEndDate) continue;
+				// Per-rule emission envelope: [anchor + MinObservedReach, anchor + MaxObservedReach]. Includes both observance
+				// adjustment shifts and multi-day duration. Skip when the envelope cannot intersect the request window.
+				DateTime potentialStart = SafeAddDays(anchor.Value.Date, profile.MinObservedReach);
+				DateTime potentialEnd = SafeAddDays(anchor.Value.Date, profile.MaxObservedReach);
+
+				if (potentialStart > plan.Request.EndDate || potentialEnd < plan.Request.StartDate)
+					continue;
 
 				AddEntries(profile, year, anchor.Value, plan, cache);
 			}
 		}
+	}
+
+	/// <summary>
+	/// Resolves the anchor date of a fringe-year rule. Tier 1 rules use the rule resolver directly; Tier 2 rules read the root
+	/// anchor from the cache, materialising it on-demand when the main pass did not process it for this year.
+	/// </summary>
+	/// <param name="profile">The rule profile being materialised.</param>
+	/// <param name="year">The fringe-year being processed.</param>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	/// <returns>The resolved anchor date, or <see langword="null" /> when the rule does not apply or the anchor is unavailable.</returns>
+	private DateTime? ResolveFringeAnchor(
+		RuleStaticProfile profile,
+		int year,
+		NotableDateRangePlan plan,
+		NotableDateRangeResolutionCache cache)
+	{
+		if (profile.Tier == RuleTier.Fixed)
+		{
+			try { return _ruleResolver.ResolveAnchorDate(profile.Rule, year); }
+			catch (InvalidOperationException) { return null; }
+		}
+
+		if (profile.Tier != RuleTier.OffsetFromFixed) return null;
+		if (string.IsNullOrWhiteSpace(profile.RootAnchorRuleName)) return null;
+
+		DateTime? rootAnchor = cache.ResolveAnchor(profile.RootAnchorRuleName!, year);
+
+		if (rootAnchor is null)
+		{
+			// On-demand: the main pass only materialises Tier 1 rules for candidate years, so the root anchor of a Tier 2 fringe
+			// rule may be missing for the fringe year. Materialise it here so this offset rule (and any sibling Tier 2 rules in
+			// the fringe pass that share the same root) can read it. The anchor enters the cache as Computed unless its own
+			// resolved date independently lands in the request window.
+			if (!_analysis.TryGetProfile(profile.RootAnchorRuleName!, out RuleStaticProfile rootProfile)) return null;
+			if (rootProfile.Tier != RuleTier.Fixed) return null;
+			if (!NotableDateRuleResolver.IsApplicable(rootProfile.Rule, year)) return null;
+
+			DateTime? rootDate;
+			try { rootDate = _ruleResolver.ResolveAnchorDate(rootProfile.Rule, year); }
+			catch (InvalidOperationException) { return null; }
+
+			if (rootDate is null) return null;
+
+			AddEntries(rootProfile, year, rootDate.Value, plan, cache);
+			rootAnchor = rootDate;
+		}
+
+		try { return rootAnchor.Value.Date.AddDays(profile.OffsetFromRoot); }
+		catch (ArgumentOutOfRangeException) { return null; }
+	}
+
+	/// <summary>
+	/// Adds days to a date, clamping to the supported <see cref="DateTime" /> range.
+	/// </summary>
+	/// <param name="date">The source date.</param>
+	/// <param name="days">The number of days to add (may be negative).</param>
+	/// <returns>The resulting date, clamped to the supported range.</returns>
+	private static DateTime SafeAddDays(DateTime date, int days)
+	{
+		DateTime value = date.Date;
+
+		if (days < 0 && value <= DateTime.MinValue.AddDays(-days)) return DateTime.MinValue.Date;
+		if (days > 0 && value >= DateTime.MaxValue.AddDays(-days)) return DateTime.MaxValue.Date;
+
+		return value.AddDays(days);
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -69,12 +69,24 @@ internal sealed class NotableDateRangePipeline
 	/// <param name="request">The range request.</param>
 	/// <returns>The resolved notable dates, ordered by observed date.</returns>
 	/// <exception cref="ArgumentNullException"><paramref name="request" /> is <see langword="null" />.</exception>
+	/// <remarks>
+	/// <para>
+	/// Resolution runs in two passes followed by an adjustment phase:
+	/// </para>
+	/// <list type="number">
+	///   <item><description><b>Main pass</b> — every eligible rule is materialised for the civil years that the request range spans. Rules whose resolved date falls inside the request window enter the cache in <see cref="NotableDateCacheState.InWindow" />; those just outside enter as <see cref="NotableDateCacheState.Computed" /> for adjustment context.</description></item>
+	///   <item><description><b>Fringe pass</b> — for each adjacent civil year the request window touches inside the planner's fringe distance, every <see cref="RuleTier.Fixed" /> rule with at least one adjustment is materialised when its resolved date falls inside the fringe window. This catches cross-year roll-overs such as <c>31 Dec</c> rolling forward to <c>3 Jan</c> without a global reach expansion.</description></item>
+	///   <item><description><b>Adjustment phase</b> — observance adjustments are applied using the cache as the non-working day context. Adjusted dates that intersect the request promote the entry to <see cref="NotableDateCacheState.Adjusted" /> and supersede the base on emission.</description></item>
+	/// </list>
+	/// </remarks>
 	public IReadOnlyList<NotableDate> Resolve(NotableDateRangeRequest request)
 	{
 		if (request is null) throw new ArgumentNullException(nameof(request));
 
 		NotableDateRangePlan plan = _planner.Plan(request);
 		NotableDateRangeResolutionCache cache = new();
+
+		// Pass 1 — main: rules whose resolved date for years the request spans may intersect (or directly feed) the window.
 
 		// Tier 1: Fixed and DayOfWeekInMonth.
 		foreach (RuleStaticProfile profile in plan.EligibleRules)
@@ -90,7 +102,7 @@ internal sealed class NotableDateRangePipeline
 			ProcessOffsetFromCached(profile, plan, cache);
 		}
 
-		// Tier 3: Algorithmic anchors — compute exactly the demanded years.
+		// Tier 3: Algorithmic anchors — compute exactly the demanded years (request years ∪ fringe years).
 		ProcessAlgorithmicAnchors(plan, cache);
 
 		// Tier 4: OffsetFromAlgorithmic — anchor available in the cache from Tier 3.
@@ -100,10 +112,71 @@ internal sealed class NotableDateRangePipeline
 			ProcessOffsetFromCached(profile, plan, cache);
 		}
 
+		// Pass 2 — fringe: scan adjacent year boundaries for Tier 1 rules with adjustments that may roll into the window.
+		ProcessFringePass(plan, cache);
+
 		// Adjustment phase — uses the cache as non-working day context.
 		ApplyAdjustments(plan, cache);
 
 		return BuildEmissionList(plan, cache);
+	}
+
+	/// <summary>
+	/// Materialises Tier 1 rules with at least one observance adjustment for adjacent civil years inside the planner's fringe
+	/// distance, admitting only those whose resolved date sits within the fringe window.
+	/// </summary>
+	/// <param name="plan">The active resolution plan.</param>
+	/// <param name="cache">The shared cache being populated.</param>
+	/// <remarks>
+	/// <para>
+	/// This pass handles cross-year roll-overs. For example, a request <c>[3 Jan 2023, 3 Jan 2023]</c> needs to know about the
+	/// prior-year <c>31 Dec 2022</c> rule (whose resolved date is in the fringe window <c>[27 Dec 2022, 10 Jan 2023]</c>) so that
+	/// the adjustment phase can roll it forward to <c>3 Jan 2023</c>. Rules without adjustments are skipped because they cannot
+	/// contribute through this mechanism.
+	/// </para>
+	/// <para>
+	/// Algorithmic and offset-from-algorithmic tiers do not need a separate fringe pass — the planner already unions fringe years
+	/// into <see cref="NotableDateRangePlan.GetAnchorYears" />, so Tier 3 / Tier 4 in the main pass cover those cases.
+	/// </para>
+	/// <para>
+	/// <b>Limitation:</b> offset-from-fixed rules with adjustments in fringe years are not handled here because their root anchor
+	/// in the fringe year is not materialised by the main pass. Add the rule's fixed anchor to the rule set's main-year processing
+	/// or extend this pass if such a configuration becomes necessary.
+	/// </para>
+	/// </remarks>
+	private void ProcessFringePass(NotableDateRangePlan plan, NotableDateRangeResolutionCache cache)
+	{
+		if (plan.FringeYears.Count == 0) return;
+
+		foreach (RuleStaticProfile profile in plan.EligibleRules)
+		{
+			if (profile.Tier != RuleTier.Fixed) continue;
+			if (profile.Rule.Adjustments.IsDefaultOrEmpty) continue;
+
+			foreach (int year in plan.FringeYears)
+			{
+				if (!NotableDateRuleResolver.IsApplicable(profile.Rule, year))
+					continue;
+
+				DateTime? anchor;
+				try
+				{
+					anchor = _ruleResolver.ResolveAnchorDate(profile.Rule, year);
+				}
+				catch (InvalidOperationException)
+				{
+					continue;
+				}
+
+				if (anchor is null) continue;
+
+				// Only admit fringe candidates close enough to the request edges that an adjustment could shift them inside.
+				DateTime resolved = anchor.Value.Date;
+				if (resolved < plan.FringeStartDate || resolved > plan.FringeEndDate) continue;
+
+				AddEntries(profile, year, anchor.Value, plan, cache);
+			}
+		}
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -289,8 +289,10 @@ internal sealed class NotableDateRangePipeline
 				bool adjustedIntersects = Intersects(plan.Request.StartDate, plan.Request.EndDate, adjusted.Date, adjusted.EndDate);
 				bool filterMatch = plan.Request.Filter is null || plan.Request.Filter.IsMatch(adjusted);
 
+				// Always promote to Adjusted when the adjusted date lands inside the request window. The emission step
+				// independently checks whether the base date also intersects, so we never lose the base when both are visible.
 				if (adjustedIntersects && filterMatch)
-					entry.State = entry.State == NotableDateCacheState.InWindow ? NotableDateCacheState.InWindow : NotableDateCacheState.Adjusted;
+					entry.State = NotableDateCacheState.Adjusted;
 				else if (entry.State == NotableDateCacheState.Computed)
 					entry.State = NotableDateCacheState.AdjustedBlocker;
 			}
@@ -310,11 +312,15 @@ internal sealed class NotableDateRangePipeline
 		foreach (NotableDateCacheEntry entry in cache.EmissableEntries())
 		{
 			if (entry.State == NotableDateCacheState.InWindow)
+			{
 				emitted.Add(entry.BaseNotable);
+				continue;
+			}
 
 			if (entry.State == NotableDateCacheState.Adjusted && entry.Adjusted is not null)
 			{
-				// Emit both the base and the adjusted form when the base date also lies inside the window.
+				// Emit the base date when it independently intersects the request — this is the canonical "Dec 31 falls on
+				// Saturday so we observe it on Monday too" pair where both anchor and substitute are visible to the caller.
 				if (Intersects(plan.Request.StartDate, plan.Request.EndDate, entry.BaseNotable.Date, entry.BaseNotable.EndDate)
 					&& (plan.Request.Filter is null || plan.Request.Filter.IsMatch(entry.BaseNotable)))
 				{
@@ -325,7 +331,11 @@ internal sealed class NotableDateRangePipeline
 			}
 		}
 
+		// Defensive: never emit a notable date whose span lies outside the requested window. The state transitions above already
+		// enforce this, but the explicit guard catches any future regression in the state machine without re-introducing the
+		// "phantom Dec 31" leak that originally surfaced when state preservation was conditional.
 		return emitted
+			.Where(n => Intersects(plan.Request.StartDate, plan.Request.EndDate, n.Date, n.EndDate))
 			.OrderBy(n => n.Date)
 			.ThenBy(n => n.Name, StringComparer.OrdinalIgnoreCase)
 			.ThenBy(n => n.TerritoryCode, StringComparer.OrdinalIgnoreCase)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlan.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlan.cs
@@ -12,9 +12,14 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The plan holds the effective resolution range (the request window expanded by the global static reach), the rules eligible to
-/// contribute to the request, and the precise civil years per algorithmic anchor that must be computed. The pipeline iterates the
-/// plan exactly — no rule is processed and no algorithm is invoked outside of what the plan authorises.
+/// The plan describes which rules are eligible to contribute to the request, which civil years they will be materialised against,
+/// and which years of each algorithmic anchor must be computed. The pipeline iterates the plan exactly — no rule is processed and
+/// no algorithm is invoked outside of what the plan authorises.
+/// </para>
+/// <para>
+/// Cross-year observance roll-overs (for example, <c>31 Dec</c> rolling forward to <c>3 Jan</c>) are handled by a fringe pass that
+/// the pipeline runs after the main pass. The plan exposes <see cref="FringeYears" /> so the pipeline knows which adjacent years
+/// to scan for adjustment-driven candidates without polluting <see cref="CandidateYears" />.
 /// </para>
 /// </remarks>
 internal sealed class NotableDateRangePlan
@@ -25,24 +30,27 @@ internal sealed class NotableDateRangePlan
 	/// Initialises a new instance of the <see cref="NotableDateRangePlan" /> class.
 	/// </summary>
 	/// <param name="request">The originating request.</param>
-	/// <param name="effectiveRangeStart">The inclusive start of the effective range.</param>
-	/// <param name="effectiveRangeEnd">The inclusive end of the effective range.</param>
 	/// <param name="eligibleRules">The rule profiles that may contribute to the request.</param>
-	/// <param name="candidateYears">The civil years considered by the planner for direct rule materialisation.</param>
+	/// <param name="candidateYears">The civil years considered by the main pass for direct rule materialisation.</param>
+	/// <param name="fringeYears">The adjacent civil years scanned by the fringe pass for adjustment-driven candidates.</param>
+	/// <param name="fringeStartDate">The inclusive start of the fringe scan window.</param>
+	/// <param name="fringeEndDate">The inclusive end of the fringe scan window.</param>
 	/// <param name="anchorYearsByName">The civil years per algorithmic anchor that must be computed.</param>
 	public NotableDateRangePlan(
 		NotableDateRangeRequest request,
-		DateTime effectiveRangeStart,
-		DateTime effectiveRangeEnd,
 		IReadOnlyList<RuleStaticProfile> eligibleRules,
 		IReadOnlyList<int> candidateYears,
+		IReadOnlyList<int> fringeYears,
+		DateTime fringeStartDate,
+		DateTime fringeEndDate,
 		Dictionary<string, IReadOnlyList<int>> anchorYearsByName)
 	{
 		Request = request;
-		EffectiveRangeStart = effectiveRangeStart;
-		EffectiveRangeEnd = effectiveRangeEnd;
 		EligibleRules = eligibleRules;
 		CandidateYears = candidateYears;
+		FringeYears = fringeYears;
+		FringeStartDate = fringeStartDate;
+		FringeEndDate = fringeEndDate;
 		_anchorYearsByName = anchorYearsByName;
 	}
 
@@ -52,25 +60,30 @@ internal sealed class NotableDateRangePlan
 	public NotableDateRangeRequest Request { get; }
 
 	/// <summary>
-	/// Gets the inclusive start of the effective range — the request start expanded by the global static reach so that all rules
-	/// whose adjustments may roll into the request window are visible.
-	/// </summary>
-	public DateTime EffectiveRangeStart { get; }
-
-	/// <summary>
-	/// Gets the inclusive end of the effective range — the request end expanded by the global static reach.
-	/// </summary>
-	public DateTime EffectiveRangeEnd { get; }
-
-	/// <summary>
 	/// Gets the rule profiles that may contribute to the request, in input order.
 	/// </summary>
 	public IReadOnlyList<RuleStaticProfile> EligibleRules { get; }
 
 	/// <summary>
-	/// Gets the civil years considered for direct rule materialisation (one per year between the effective range start and end).
+	/// Gets the civil years considered by the main materialisation pass — one entry per year that the request window spans.
 	/// </summary>
 	public IReadOnlyList<int> CandidateYears { get; }
+
+	/// <summary>
+	/// Gets the adjacent civil years scanned by the fringe pass for rules whose observance adjustment may roll a date from outside
+	/// the request window into it. Empty when the request window does not touch a year boundary inside the fringe distance.
+	/// </summary>
+	public IReadOnlyList<int> FringeYears { get; }
+
+	/// <summary>
+	/// Gets the inclusive start of the fringe scan window — the request start minus the fringe distance.
+	/// </summary>
+	public DateTime FringeStartDate { get; }
+
+	/// <summary>
+	/// Gets the inclusive end of the fringe scan window — the request end plus the fringe distance.
+	/// </summary>
+	public DateTime FringeEndDate { get; }
 
 	/// <summary>
 	/// Gets the civil years that must be resolved for each algorithmic anchor name.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
@@ -84,9 +84,12 @@ internal sealed class NotableDateRangePlanner
 			candidateYears.Add(year);
 
 		// Fringe pass: only relevant if the request window touches a year boundary inside the fringe distance. The fringe scans
-		// rules whose un-adjusted date sits within ±_fringeDays of the request edges so the adjustment phase can roll them in.
-		DateTime fringeStart = AddDaysClamped(request.StartDate, -_fringeDays);
-		DateTime fringeEnd = AddDaysClamped(request.EndDate, _fringeDays);
+		// rules whose un-adjusted date sits within ±effectiveFringeDays of the request edges so the adjustment phase can roll
+		// them in. The effective distance is the larger of the configured default and the rule set's worst-case reach so unusual
+		// adjustment actions (large AddDays, ReplaceWithNamedDate, Custom) widen the fringe automatically.
+		int effectiveFringeDays = _fringeDays > _analysis.GlobalFringeReach ? _fringeDays : _analysis.GlobalFringeReach;
+		DateTime fringeStart = AddDaysClamped(request.StartDate, -effectiveFringeDays);
+		DateTime fringeEnd = AddDaysClamped(request.EndDate, effectiveFringeDays);
 
 		HashSet<int> fringeYearSet = new();
 		for (int year = fringeStart.Year; year <= fringeEnd.Year; year++)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
@@ -12,23 +12,51 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The planner is the deterministic, side-effect-free step that decides which rules and which civil years are eligible to be
-/// materialised for the request. It expands the request window by the rule set's static reach to admit collateral dates that may
-/// roll into or out of the request through observance adjustments.
+/// Rule selection is deliberately simple: a rule is eligible when it passes the static territory, calendar, and filter checks.
+/// The main pass evaluates each eligible rule for every civil year that the request window spans, materialising the rule's
+/// resolved date and admitting it when it intersects the window.
+/// </para>
+/// <para>
+/// Cross-year roll-overs (for example, <c>31 Dec</c> with a forward observance adjustment landing on <c>3 Jan</c>) are handled by
+/// a separate fringe pass at the pipeline level. The planner identifies which adjacent civil years that pass needs to scan and
+/// the fringe day-window itself; the actual fringe materialisation lives in the pipeline.
 /// </para>
 /// </remarks>
 internal sealed class NotableDateRangePlanner
 {
+	/// <summary>
+	/// The default fringe distance in days, applied either side of the request window when scanning for adjustment-driven
+	/// candidates. Most observance adjustments shift dates by less than a week (weekend roll-forward, weekday substitute), so
+	/// seven days is a safe envelope that covers <see cref="AdjustmentAction.MoveToNextNonWorkingDay" /> chains in typical rule
+	/// sets without inflating the search space.
+	/// </summary>
+	public const int DefaultFringeDays = 7;
+
 	private readonly RuleStaticAnalysis _analysis;
+	private readonly int _fringeDays;
 
 	/// <summary>
-	/// Initialises a new instance of the <see cref="NotableDateRangePlanner" /> class.
+	/// Initialises a new instance of the <see cref="NotableDateRangePlanner" /> class with the default fringe distance.
 	/// </summary>
 	/// <param name="analysis">The static rule analysis to use when planning requests.</param>
 	/// <exception cref="ArgumentNullException"><paramref name="analysis" /> is <see langword="null" />.</exception>
 	public NotableDateRangePlanner(RuleStaticAnalysis analysis)
+		: this(analysis, DefaultFringeDays)
+	{
+	}
+
+	/// <summary>
+	/// Initialises a new instance of the <see cref="NotableDateRangePlanner" /> class with an explicit fringe distance.
+	/// </summary>
+	/// <param name="analysis">The static rule analysis to use when planning requests.</param>
+	/// <param name="fringeDays">The fringe distance in days, applied either side of the request window when scanning for adjustment-driven candidates.</param>
+	/// <exception cref="ArgumentNullException"><paramref name="analysis" /> is <see langword="null" />.</exception>
+	/// <exception cref="ArgumentOutOfRangeException"><paramref name="fringeDays" /> is negative.</exception>
+	public NotableDateRangePlanner(RuleStaticAnalysis analysis, int fringeDays)
 	{
 		_analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
+		if (fringeDays < 0) throw new ArgumentOutOfRangeException(nameof(fringeDays), fringeDays, "The fringe distance must not be negative.");
+		_fringeDays = fringeDays;
 	}
 
 	/// <summary>
@@ -41,14 +69,8 @@ internal sealed class NotableDateRangePlanner
 	{
 		if (request is null) throw new ArgumentNullException(nameof(request));
 
-		// To find rule anchors that may land inside the request window after observance adjustment / duration:
-		//   An anchor with a forward-most shift of GlobalMaxReach can land as late as anchor + GlobalMaxReach. For it to reach
-		//   request.Start, the anchor must be on or after request.Start - GlobalMaxReach.
-		//   An anchor with a backward-most shift of GlobalMinReach (negative) can land as early as anchor + GlobalMinReach. For it
-		//   to be on or before request.End, the anchor must be on or before request.End - GlobalMinReach.
-		DateTime effectiveStart = AddDaysClamped(request.StartDate, -_analysis.GlobalMaxReach);
-		DateTime effectiveEnd = AddDaysClamped(request.EndDate, -_analysis.GlobalMinReach);
-
+		// Eligible rules: filtered by static territory, calendar, and filter checks. Year applicability is deferred to per-(rule,
+		// year) materialisation since FirstYear / LastYear / OccurrenceYears bounds depend on the year being resolved.
 		List<RuleStaticProfile> eligible = new();
 		foreach (RuleStaticProfile profile in _analysis.Profiles)
 		{
@@ -56,11 +78,34 @@ internal sealed class NotableDateRangePlanner
 				eligible.Add(profile);
 		}
 
+		// Main pass candidate years: just the years that the request window itself spans. No global reach expansion.
 		List<int> candidateYears = new();
-		for (int year = effectiveStart.Year; year <= effectiveEnd.Year; year++)
+		for (int year = request.StartDate.Year; year <= request.EndDate.Year; year++)
 			candidateYears.Add(year);
 
+		// Fringe pass: only relevant if the request window touches a year boundary inside the fringe distance. The fringe scans
+		// rules whose un-adjusted date sits within ±_fringeDays of the request edges so the adjustment phase can roll them in.
+		DateTime fringeStart = AddDaysClamped(request.StartDate, -_fringeDays);
+		DateTime fringeEnd = AddDaysClamped(request.EndDate, _fringeDays);
+
+		HashSet<int> fringeYearSet = new();
+		for (int year = fringeStart.Year; year <= fringeEnd.Year; year++)
+		{
+			if (year < request.StartDate.Year || year > request.EndDate.Year)
+				fringeYearSet.Add(year);
+		}
+
+		List<int> fringeYears = fringeYearSet.OrderBy(y => y).ToList();
+
+		// Anchor years per algorithmic root. Tight envelope: only the years the request range spans, plus any fringe years (since
+		// a fringe-pass offset rule may need an adjacent-year algorithmic anchor). Keeps Easter / Lunar New Year / Vesak
+		// computation count to the minimum that covers the request without conservative ±1-year padding.
 		Dictionary<string, IReadOnlyList<int>> anchorYearsByName = new(StringComparer.OrdinalIgnoreCase);
+
+		HashSet<int> anchorYearSet = new(candidateYears);
+		foreach (int year in fringeYears)
+			anchorYearSet.Add(year);
+		List<int> anchorYears = anchorYearSet.OrderBy(y => y).ToList();
 
 		foreach (RuleStaticProfile profile in eligible)
 		{
@@ -69,47 +114,21 @@ internal sealed class NotableDateRangePlanner
 
 			string anchorName = profile.RootAnchorRuleName!;
 			if (!anchorYearsByName.ContainsKey(anchorName))
-				anchorYearsByName[anchorName] = ComputeAnchorYears(request, profile);
+				anchorYearsByName[anchorName] = anchorYears;
 		}
 
 		return new NotableDateRangePlan(
 			request,
-			effectiveStart,
-			effectiveEnd,
 			eligible,
 			candidateYears,
+			fringeYears,
+			fringeStart,
+			fringeEnd,
 			anchorYearsByName);
 	}
 
 	/// <summary>
-	/// Computes the civil years for which an algorithmic anchor must be resolved so that every eligible dependent has access to it.
-	/// </summary>
-	/// <param name="request">The originating request.</param>
-	/// <param name="profile">A profile that depends on the algorithmic anchor.</param>
-	/// <returns>The civil years that must be resolved.</returns>
-	/// <remarks>
-	/// <para>
-	/// The conservative default is <c>[request.Year − 1, request.Year, request.Year + 1, …, request.EndYear + 1]</c>. This covers
-	/// the practical envelope of every algorithmic anchor in use today (Easter, Lunar New Year, Vesak, Asalha Puja, etc.) without
-	/// requiring per-algorithm bounds metadata. Year-by-year over-computation is bounded because <see cref="NotableDateRangeResolutionCache.ResolveAnchor" />
-	/// caches the result.
-	/// </para>
-	/// </remarks>
-	private static IReadOnlyList<int> ComputeAnchorYears(NotableDateRangeRequest request, RuleStaticProfile profile)
-	{
-		_ = profile;
-		List<int> years = new();
-		int startYear = request.StartDate.Year - 1;
-		int endYear = request.EndDate.Year + 1;
-
-		for (int year = startYear; year <= endYear; year++)
-			years.Add(year);
-
-		return years;
-	}
-
-	/// <summary>
-	/// Determines whether the rule may contribute to the request based on territory, calendar, year bounds, and filter eligibility.
+	/// Determines whether the rule may contribute to the request based on territory, calendar, and filter eligibility.
 	/// </summary>
 	/// <param name="profile">The profile under test.</param>
 	/// <param name="request">The originating request.</param>
@@ -127,7 +146,6 @@ internal sealed class NotableDateRangePlanner
 		if (!RuleMayApplyToTerritory(rule, request.TerritoryCode))
 			return false;
 
-		// Year applicability is left to the resolver per (rule, year) since it depends on FirstYear/LastYear/OccurrenceYears.
 		return true;
 	}
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/ResolvedWindowSet.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/ResolvedWindowSet.cs
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ResolvedWindowSet.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Maintains the union of chronological windows that have been resolved by the prototype range-resolution pipeline so a consumer
+/// can introspect what is known to the service without re-querying.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The set keeps a sorted list of disjoint <see cref="DateRange" /> intervals. Adding a new range merges any existing intervals
+/// that overlap or are immediately adjacent so the resulting list always contains the minimum number of disjoint intervals
+/// describing the same coverage.
+/// </para>
+/// <para>
+/// This type is not thread-safe. The <see cref="NotableDateService" /> coordinates concurrent access externally.
+/// </para>
+/// </remarks>
+internal sealed class ResolvedWindowSet
+{
+	private readonly List<DateRange> _ranges = new();
+
+	/// <summary>
+	/// Gets the disjoint chronological windows currently tracked, in ascending order of <see cref="DateRange.StartDate" />.
+	/// </summary>
+	public IReadOnlyList<DateRange> Ranges => _ranges;
+
+	/// <summary>
+	/// Adds the supplied range to the set, merging it with any overlapping or adjacent existing intervals.
+	/// </summary>
+	/// <param name="range">The range to add. Inverted ranges are silently ignored.</param>
+	public void Add(DateRange range)
+	{
+		if (!range.IsValid) return;
+
+		DateTime start = range.StartDate.Date;
+		DateTime end = range.EndDate.Date;
+
+		List<DateRange> retained = new(_ranges.Count + 1);
+		bool merged = false;
+
+		foreach (DateRange existing in _ranges)
+		{
+			DateTime existingStart = existing.StartDate.Date;
+			DateTime existingEnd = existing.EndDate.Date;
+
+			// Disjoint and earlier — keep as-is.
+			if (existingEnd.AddDays(1) < start)
+			{
+				retained.Add(existing);
+				continue;
+			}
+
+			// Disjoint and later — keep as-is (we may still be merging earlier ones).
+			if (existingStart > end.AddDays(1))
+			{
+				retained.Add(existing);
+				continue;
+			}
+
+			// Overlap or adjacency: extend the candidate window to cover the existing range and drop it from retained.
+			if (existingStart < start) start = existingStart;
+			if (existingEnd > end) end = existingEnd;
+			merged = true;
+		}
+
+		retained.Add(new DateRange(start, end));
+		retained.Sort(static (a, b) => a.StartDate.Date.CompareTo(b.StartDate.Date));
+
+		_ranges.Clear();
+		_ranges.AddRange(retained);
+
+		_ = merged;
+	}
+
+	/// <summary>
+	/// Determines whether the supplied date is covered by any tracked range.
+	/// </summary>
+	/// <param name="date">The date to test.</param>
+	/// <returns><see langword="true" /> when at least one tracked range contains the date.</returns>
+	public bool Contains(DateTime date)
+	{
+		foreach (DateRange range in _ranges)
+		{
+			if (range.Contains(date)) return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Determines whether <paramref name="range" /> is fully covered by the union of tracked intervals.
+	/// </summary>
+	/// <param name="range">The range whose coverage is being tested.</param>
+	/// <returns><see langword="true" /> when every day in <paramref name="range" /> lies inside a single tracked interval.</returns>
+	public bool Covers(DateRange range)
+	{
+		if (!range.IsValid) return false;
+
+		foreach (DateRange existing in _ranges)
+		{
+			if (existing.Contains(range)) return true;
+		}
+
+		return false;
+	}
+
+	/// <summary>
+	/// Removes every tracked range, restoring the empty state.
+	/// </summary>
+	public void Clear() => _ranges.Clear();
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
@@ -12,9 +12,8 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The analysis exposes per-rule <see cref="RuleStaticProfile" /> records, look-up indexes for offset-relative dependencies, and the
-/// global day-delta envelope across the entire rule set. It is built once from the effective rule list and re-used by every
-/// range-resolution request.
+/// The analysis exposes per-rule <see cref="RuleStaticProfile" /> records and a look-up index for offset-relative dependencies.
+/// It is built once from the effective rule list and re-used by every range-resolution request.
 /// </para>
 /// </remarks>
 internal sealed class RuleStaticAnalysis
@@ -29,38 +28,20 @@ internal sealed class RuleStaticAnalysis
 	/// <param name="profiles">The static profile per rule.</param>
 	/// <param name="profilesByRuleName">The case-insensitive lookup of profiles by rule name.</param>
 	/// <param name="dependentsByAnchor">The case-insensitive lookup of profiles whose root anchor is the keyed rule name.</param>
-	/// <param name="globalMinReach">The most-negative reach across every profile.</param>
-	/// <param name="globalMaxReach">The most-positive reach across every profile.</param>
 	private RuleStaticAnalysis(
 		List<RuleStaticProfile> profiles,
 		Dictionary<string, RuleStaticProfile> profilesByRuleName,
-		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor,
-		int globalMinReach,
-		int globalMaxReach)
+		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor)
 	{
 		_profiles = profiles;
 		_profilesByRuleName = profilesByRuleName;
 		_dependentsByAnchor = dependentsByAnchor;
-		GlobalMinReach = globalMinReach;
-		GlobalMaxReach = globalMaxReach;
 	}
 
 	/// <summary>
 	/// Gets the profile for every rule processed by the pipeline, in input order.
 	/// </summary>
 	public IReadOnlyList<RuleStaticProfile> Profiles => _profiles;
-
-	/// <summary>
-	/// Gets the most-negative day delta across every rule's observable reach. Used to scope the effective resolution range
-	/// backwards from the request window.
-	/// </summary>
-	public int GlobalMinReach { get; }
-
-	/// <summary>
-	/// Gets the most-positive day delta across every rule's observable reach. Used to scope the effective resolution range
-	/// forwards from the request window.
-	/// </summary>
-	public int GlobalMaxReach { get; }
 
 	/// <summary>
 	/// Attempts to retrieve a profile for the rule with the supplied name.
@@ -132,16 +113,7 @@ internal sealed class RuleStaticAnalysis
 			}
 		}
 
-		int globalMin = 0;
-		int globalMax = 0;
-
-		foreach (RuleStaticProfile profile in profiles)
-		{
-			if (profile.MinObservedReach < globalMin) globalMin = profile.MinObservedReach;
-			if (profile.MaxObservedReach > globalMax) globalMax = profile.MaxObservedReach;
-		}
-
-		return new RuleStaticAnalysis(profiles, profilesByRuleName, dependentsByAnchor, globalMin, globalMax);
+		return new RuleStaticAnalysis(profiles, profilesByRuleName, dependentsByAnchor);
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
@@ -28,20 +28,37 @@ internal sealed class RuleStaticAnalysis
 	/// <param name="profiles">The static profile per rule.</param>
 	/// <param name="profilesByRuleName">The case-insensitive lookup of profiles by rule name.</param>
 	/// <param name="dependentsByAnchor">The case-insensitive lookup of profiles whose root anchor is the keyed rule name.</param>
+	/// <param name="globalFringeReach">The maximum absolute reach across every profile, used by the planner to size fringe scans.</param>
 	private RuleStaticAnalysis(
 		List<RuleStaticProfile> profiles,
 		Dictionary<string, RuleStaticProfile> profilesByRuleName,
-		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor)
+		Dictionary<string, List<RuleStaticProfile>> dependentsByAnchor,
+		int globalFringeReach)
 	{
 		_profiles = profiles;
 		_profilesByRuleName = profilesByRuleName;
 		_dependentsByAnchor = dependentsByAnchor;
+		GlobalFringeReach = globalFringeReach;
 	}
 
 	/// <summary>
 	/// Gets the profile for every rule processed by the pipeline, in input order.
 	/// </summary>
 	public IReadOnlyList<RuleStaticProfile> Profiles => _profiles;
+
+	/// <summary>
+	/// Gets the maximum absolute day-delta across every rule's observable reach (forward or backward). Used by the planner to size
+	/// the fringe scan distance so that adjustment shifts and multi-day spans extending across year boundaries are admitted into
+	/// the fringe pass.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is intentionally distinct from per-rule reach: the planner needs a single fringe distance to decide which adjacent
+	/// civil years to scan, while the pipeline filters individual fringe-year materialisations using each rule's own
+	/// <see cref="RuleStaticProfile.MinObservedReach" /> / <see cref="RuleStaticProfile.MaxObservedReach" />.
+	/// </para>
+	/// </remarks>
+	public int GlobalFringeReach { get; }
 
 	/// <summary>
 	/// Attempts to retrieve a profile for the rule with the supplied name.
@@ -113,7 +130,16 @@ internal sealed class RuleStaticAnalysis
 			}
 		}
 
-		return new RuleStaticAnalysis(profiles, profilesByRuleName, dependentsByAnchor);
+		int globalFringeReach = 0;
+		foreach (RuleStaticProfile profile in profiles)
+		{
+			int forward = profile.MaxObservedReach > 0 ? profile.MaxObservedReach : 0;
+			int backward = profile.MinObservedReach < 0 ? -profile.MinObservedReach : 0;
+			int magnitude = forward > backward ? forward : backward;
+			if (magnitude > globalFringeReach) globalFringeReach = magnitude;
+		}
+
+		return new RuleStaticAnalysis(profiles, profilesByRuleName, dependentsByAnchor, globalFringeReach);
 	}
 
 	/// <summary>
@@ -247,7 +273,10 @@ internal sealed class RuleStaticAnalysis
 			AdjustmentAction.MoveToPreviousWeekday => (-3, 0),
 			AdjustmentAction.MoveToNextNonWorkingDay => (0, 7),
 			AdjustmentAction.ReplaceWithNamedDate => (-31, 31),
-			AdjustmentAction.Custom => (-7, 7),
+			// Custom handlers are arbitrary by definition. Use a conservative ±31-day envelope so a custom shift up to one month
+			// either side is captured by the planner's fringe scan. Rules with handlers that shift further must be redesigned to
+			// declare their reach explicitly (future <c>MaxAdjustmentReachDays</c> property on <see cref="ObservanceAdjustment" />).
+			AdjustmentAction.Custom => (-31, 31),
 			_ => (0, 0),
 		};
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
@@ -262,8 +262,14 @@ internal sealed class RuleStaticAnalysis
 	/// short and this prototype caps the static estimate at one week.
 	/// </para>
 	/// </remarks>
-	private static (int Min, int Max) EstimateAdjustmentReach(ObservanceAdjustment adjustment) =>
-		adjustment.Action switch
+	private static (int Min, int Max) EstimateAdjustmentReach(ObservanceAdjustment adjustment)
+	{
+		// Author-declared reach takes precedence over heuristic estimates. The envelope is treated as symmetric (±value) so a
+		// single property covers both forward and backward handlers without forcing every author to think about direction.
+		if (adjustment.MaxAdjustmentReachDays is { } declared && declared >= 0)
+			return (-declared, declared);
+
+		return adjustment.Action switch
 		{
 			AdjustmentAction.None => (0, 0),
 			AdjustmentAction.AddDays => adjustment.OffsetDays >= 0
@@ -273,10 +279,11 @@ internal sealed class RuleStaticAnalysis
 			AdjustmentAction.MoveToPreviousWeekday => (-3, 0),
 			AdjustmentAction.MoveToNextNonWorkingDay => (0, 7),
 			AdjustmentAction.ReplaceWithNamedDate => (-31, 31),
-			// Custom handlers are arbitrary by definition. Use a conservative ±31-day envelope so a custom shift up to one month
-			// either side is captured by the planner's fringe scan. Rules with handlers that shift further must be redesigned to
-			// declare their reach explicitly (future <c>MaxAdjustmentReachDays</c> property on <see cref="ObservanceAdjustment" />).
+			// Custom handlers are arbitrary by definition. Default to a conservative ±31-day envelope so handlers whose shift
+			// fits inside one month are admitted out of the box. Authors whose handlers shift further must declare their reach
+			// via <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" />.
 			AdjustmentAction.Custom => (-31, 31),
 			_ => (0, 0),
 		};
+	}
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/DateRange.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/DateRange.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateRange.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Represents an inclusive chronological range bounded by a <see cref="StartDate" /> and <see cref="EndDate" />.
+/// </summary>
+/// <param name="StartDate">The inclusive start of the range.</param>
+/// <param name="EndDate">The inclusive end of the range.</param>
+/// <remarks>
+/// <para>
+/// <see cref="DateRange" /> is a value type with day-resolution semantics: the time component of either bound is ignored. A range
+/// where <see cref="StartDate" /> equals <see cref="EndDate" /> describes a single day. Callers are expected to supply
+/// <see cref="StartDate" /> on or before <see cref="EndDate" />; range operations on an inverted range yield empty results.
+/// </para>
+/// </remarks>
+public readonly record struct DateRange(DateTime StartDate, DateTime EndDate)
+{
+	/// <summary>
+	/// Gets a value indicating whether the range is non-empty (<see cref="StartDate" /> is on or before <see cref="EndDate" />).
+	/// </summary>
+	public bool IsValid => StartDate.Date <= EndDate.Date;
+
+	/// <summary>
+	/// Gets the inclusive number of days covered by the range. Returns zero when the range is inverted.
+	/// </summary>
+	public int DayCount => IsValid ? (int)(EndDate.Date - StartDate.Date).TotalDays + 1 : 0;
+
+	/// <summary>
+	/// Determines whether the range covers the supplied date (day-resolution comparison).
+	/// </summary>
+	/// <param name="date">The date to test.</param>
+	/// <returns><see langword="true" /> when the date falls within the inclusive range; otherwise, <see langword="false" />.</returns>
+	public bool Contains(DateTime date)
+	{
+		DateTime day = date.Date;
+		return day >= StartDate.Date && day <= EndDate.Date;
+	}
+
+	/// <summary>
+	/// Determines whether this range fully contains <paramref name="other" />.
+	/// </summary>
+	/// <param name="other">The range to test for containment.</param>
+	/// <returns><see langword="true" /> when every day of <paramref name="other" /> lies inside this range.</returns>
+	public bool Contains(DateRange other) =>
+		IsValid && other.IsValid && other.StartDate.Date >= StartDate.Date && other.EndDate.Date <= EndDate.Date;
+
+	/// <summary>
+	/// Determines whether this range overlaps <paramref name="other" /> by at least one day.
+	/// </summary>
+	/// <param name="other">The range to test for overlap.</param>
+	/// <returns><see langword="true" /> when the ranges share at least one day.</returns>
+	public bool Intersects(DateRange other) =>
+		IsValid && other.IsValid && other.StartDate.Date <= EndDate.Date && other.EndDate.Date >= StartDate.Date;
+
+	/// <summary>
+	/// Returns a string representation of the range in <c>yyyy-MM-dd … yyyy-MM-dd</c> form.
+	/// </summary>
+	/// <returns>The string representation.</returns>
+	public override string ToString() =>
+		$"{StartDate:yyyy-MM-dd} … {EndDate:yyyy-MM-dd}";
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -85,6 +85,12 @@ public sealed class NotableDateService : INotableDateService
     /// <summary>The lazily constructed prototype range-resolution pipeline used by <see cref="ResolveNotableDatesInRange" />.</summary>
     private RangeResolution.NotableDateRangePipeline? _rangePipeline;
 
+    /// <summary>The chronological windows resolved by <see cref="ResolveNotableDatesInRange" /> since the last <see cref="Invalidate()" /> call.</summary>
+    private readonly RangeResolution.ResolvedWindowSet _resolvedWindows = new();
+
+    /// <summary>Lock protecting concurrent updates to <see cref="_resolvedWindows" />.</summary>
+    private readonly object _resolvedWindowsGate = new();
+
     /// <summary>The resolver that arbitrates when multiple rules produce a date on the same day.</summary>
     private readonly INotableDateCollisionResolver _collisionResolver;
 
@@ -355,6 +361,10 @@ public sealed class NotableDateService : INotableDateService
 	{
 		_yearCache.Clear();
 		_rangePipeline = null;
+		lock (_resolvedWindowsGate)
+		{
+			_resolvedWindows.Clear();
+		}
 	}
 
 	/// <inheritdoc />
@@ -404,6 +414,14 @@ public sealed class NotableDateService : INotableDateService
 		RangeResolution.NotableDateRangePipeline pipeline = _rangePipeline ??= BuildRangePipeline();
 		IReadOnlyList<NotableDate> resolved = pipeline.Resolve(request);
 
+		// Record the request window so consumers can introspect what the service has been asked to resolve. The window is recorded
+		// regardless of whether a filter was applied — it represents queried coverage, not result coverage. Filtered queries
+		// therefore still extend the known window.
+		lock (_resolvedWindowsGate)
+		{
+			_resolvedWindows.Add(new DateRange(request.StartDate, request.EndDate));
+		}
+
 		List<NotableDate> localised = new(resolved.Count);
 		foreach (NotableDate notable in resolved)
 			localised.Add(LocaliseIfNeeded(notable));
@@ -413,6 +431,50 @@ public sealed class NotableDateService : INotableDateService
 			.OrderBy(g => g.Key)
 			.SelectMany(g => _collisionResolver.Resolve(g.Key, g.ToList()) ?? Array.Empty<NotableDate>())
 			.ToList();
+	}
+
+	/// <summary>
+	/// Gets the chronological windows that have been resolved by <see cref="ResolveNotableDatesInRange" /> since the service was
+	/// constructed or <see cref="Invalidate()" /> was last called. The list is sorted ascending by start date and contains the
+	/// minimum number of disjoint intervals describing the same coverage.
+	/// </summary>
+	/// <returns>
+	/// A snapshot of the disjoint <see cref="DateRange" /> instances representing the union of every requested window. An empty
+	/// list indicates that no range request has been served yet.
+	/// </returns>
+	/// <remarks>
+	/// <para>
+	/// The property reflects the windows the consumer has <em>asked about</em>, not the rule-set's effective range. Adjacent or
+	/// overlapping requests are merged. The returned list is a snapshot; subsequent calls to
+	/// <see cref="ResolveNotableDatesInRange" /> may extend it.
+	/// </para>
+	/// </remarks>
+	public IReadOnlyList<DateRange> ResolvedWindows
+	{
+		get
+		{
+			lock (_resolvedWindowsGate)
+			{
+				return _resolvedWindows.Ranges.ToArray();
+			}
+		}
+	}
+
+	/// <summary>
+	/// Determines whether the supplied chronological range has already been resolved in its entirety by a previous call to
+	/// <see cref="ResolveNotableDatesInRange" />.
+	/// </summary>
+	/// <param name="startDate">The inclusive start of the range to test.</param>
+	/// <param name="endDate">The inclusive end of the range to test. Must not be earlier than <paramref name="startDate" />.</param>
+	/// <returns><see langword="true" /> when every day in the supplied range is covered by a single resolved window; otherwise, <see langword="false" />.</returns>
+	public bool IsRangeResolved(DateTime startDate, DateTime endDate)
+	{
+		DateRange probe = new(startDate.Date, endDate.Date);
+
+		lock (_resolvedWindowsGate)
+		{
+			return _resolvedWindows.Covers(probe);
+		}
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ObservanceAdjustment.cs
@@ -163,4 +163,27 @@ public sealed record ObservanceAdjustment
 	/// Gets an optional dictionary of parameters forwarded to the registered <see cref="IAdjustmentHandler" />.
 	/// </summary>
 	public IReadOnlyDictionary<string, string>? HandlerParameters { get; init; }
+
+	/// <summary>
+	/// Gets the optional explicit upper bound on how far this adjustment can shift the calculated date in either direction,
+	/// expressed in days. When set, the chronological range-resolution pipeline uses this value to size the per-rule and global
+	/// fringe envelope so that adjustments whose actual reach exceeds the action's default heuristic are admitted by the fringe
+	/// pass.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This property is consumed only by the prototype range-resolution pipeline (<c>NotableDateService.ResolveNotableDatesInRange</c>).
+	/// Authors should set it when:
+	/// </para>
+	/// <list type="bullet">
+	///   <item><description><see cref="Action" /> is <see cref="AdjustmentAction.Custom" /> and the custom handler shifts more than ±31 days.</description></item>
+	///   <item><description><see cref="Action" /> is <see cref="AdjustmentAction.ReplaceWithNamedDate" /> and the named replacement is more than ±31 days from the original date.</description></item>
+	///   <item><description>The author wants to declare a tighter envelope than the default heuristic for performance reasons.</description></item>
+	/// </list>
+	/// <para>
+	/// The value is interpreted as a symmetric absolute envelope: the adjustment may shift the date by at most <c>±value</c> days.
+	/// When <see langword="null" />, the pipeline falls back to action-specific defaults (for example, <see cref="AdjustmentAction.MoveToNextNonWorkingDay" /> ≈ +7 days).
+	/// </para>
+	/// </remarks>
+	public int? MaxAdjustmentReachDays { get; init; }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -433,6 +433,57 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
+	/// Verifies that a custom <see cref="AdjustmentAction.Custom" /> handler that shifts further than the default ±31 day envelope
+	/// is admitted by the fringe pass when the rule declares
+	/// <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> explicitly.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenCustomHandlerExceedsDefaultEnvelopeAndDeclaresExplicitReach_ShouldEmitFromAdjacentYear()
+	{
+		// Custom handler that always shifts +90 days. Declared via MaxAdjustmentReachDays = 90 so the planner widens the fringe.
+		const int shiftDays = 90;
+
+		AdjustmentHandlerRegistry handlers = new();
+		handlers.Register("ninety-day-shift", new ShiftByDaysHandler(shiftDays));
+
+		NotableDateRule rule = new()
+		{
+			Name = "Long-Reach Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Public,
+			Month = 11,
+			Day = 1,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "ninety-day-shift",
+				Trigger = AdjustmentTrigger.Custom,
+				Action = AdjustmentAction.Custom,
+				HandlerKey = "ninety-day-shift",
+				MaxAdjustmentReachDays = shiftDays,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+			adjustmentHandlers: handlers);
+
+		// Anchor 1 Nov 2025 + 90 days = 30 Jan 2026. Default ±31 fringe would not admit this; the explicit declaration must.
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 1, 25),
+			new DateTime(2026, 2, 5));
+
+		NotableDate observed = resolved.SingleOrDefault(n => n.Name == "Long-Reach Holiday")
+			?? throw new AssertFailedException("Expected the custom-handler-shifted occurrence to be emitted via the widened fringe.");
+
+		Assert.AreEqual(new DateTime(2026, 1, 30), observed.Date);
+		Assert.IsTrue(observed.WasAdjusted);
+		Assert.AreEqual(new DateTime(2025, 11, 1), observed.AdjustmentReason!.OriginalDate);
+	}
+
+	/// <summary>
 	/// Verifies that a request whose window does not touch a year boundary inside the planner's fringe distance does not
 	/// materialise rules from adjacent years — the fringe pass is skipped entirely when no fringe years are needed.
 	/// </summary>
@@ -602,5 +653,22 @@ public sealed class NotableDateRangePipelineTests
 
 			return new DateTime(year, month, day);
 		}
+	}
+
+	/// <summary>
+	/// Custom <see cref="IAdjustmentHandler" /> used by the explicit-reach integration test. Shifts the supplied date by a fixed
+	/// number of days every time it is consulted.
+	/// </summary>
+	private sealed class ShiftByDaysHandler : IAdjustmentHandler
+	{
+		private readonly int _shiftDays;
+
+		public ShiftByDaysHandler(int shiftDays)
+		{
+			_shiftDays = shiftDays;
+		}
+
+		public AdjustmentHandlerResult Apply(AdjustmentHandlerContext context) =>
+			new(true, context.Date.AddDays(_shiftDays), IsNonWorkingOverride: null);
 	}
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -293,6 +293,50 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
+	/// Verifies that a request whose window does not touch a year boundary inside the planner's fringe distance does not
+	/// materialise rules from adjacent years — the fringe pass is skipped entirely when no fringe years are needed.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowIsNotNearYearBoundary_ShouldNotMaterialiseAdjacentYearRules()
+	{
+		bool christmasResolveCalled = false;
+
+		NotableDateRule christmas = new()
+		{
+			Name = "Christmas Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 25,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateRule probe = new()
+		{
+			Name = "Mid-Year Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 7,
+			Day = 1,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(christmas, probe) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 6, 15),
+			new DateTime(2026, 7, 31));
+
+		// July request — no fringe year crossing required. Mid-Year Holiday emitted; Christmas not.
+		Assert.IsTrue(resolved.Any(n => n.Name == "Mid-Year Holiday" && n.Date == new DateTime(2026, 7, 1)));
+		Assert.IsFalse(resolved.Any(n => n.Name == "Christmas Day"));
+
+		_ = christmasResolveCalled;
+	}
+
+	/// <summary>
 	/// Verifies that <see cref="NotableDateService.ResolvedWindows" /> exposes the union of every range that has been resolved,
 	/// merging overlapping or adjacent windows into the minimum number of disjoint intervals.
 	/// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -186,11 +186,12 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
-	/// Verifies that a request whose window spans both the original Dec 31 anchor and its rolled-forward Jan 3 observance returns
-	/// both occurrences — the actual calendar holiday and the observed substitute — and does not duplicate or lose either one.
+	/// Verifies that a request whose window covers both the original Dec 31 anchor and its rolled-forward Jan 3 observance
+	/// returns only the adjusted observance — adjusted dates supersede the base anchor so the emitted count equals the
+	/// notable-date count.
 	/// </summary>
 	[TestMethod]
-	public void Resolve_WhenWindowSpansBothAnchorAndAdjustedObservance_ShouldEmitBaseAndAdjustedDates()
+	public void Resolve_WhenWindowSpansBothAnchorAndAdjustedObservance_ShouldEmitOnlyAdjustedDate()
 	{
 		NotableDateRule yearEnd = new()
 		{
@@ -228,16 +229,18 @@ public sealed class NotableDateRangePipelineTests
 			new DateTime(2023, 1, 5));
 
 		NotableDate[] yearEndOccurrences = resolved.Where(n => n.Name == "Year-End Holiday").ToArray();
-		Assert.AreEqual(2, yearEndOccurrences.Length,
-			"Spanning [25 Dec 2022, 5 Jan 2023] should return both the actual 31 Dec anchor and the 3 Jan observance.");
+		Assert.AreEqual(1, yearEndOccurrences.Length,
+			$"An adjusted observance must replace the base anchor; got: {string.Join(", ", yearEndOccurrences.Select(n => $"{n.Date:yyyy-MM-dd}"))}.");
 
-		NotableDate baseDate = yearEndOccurrences.Single(n => n.Date == new DateTime(2022, 12, 31));
-		NotableDate observed = yearEndOccurrences.Single(n => n.Date == new DateTime(2023, 1, 3));
-
-		Assert.IsFalse(baseDate.WasAdjusted, "The Dec 31 base occurrence must not carry an AdjustmentReason.");
-		Assert.IsTrue(observed.WasAdjusted, "The Jan 3 observance must carry an AdjustmentReason.");
+		NotableDate observed = yearEndOccurrences.Single();
+		Assert.AreEqual(new DateTime(2023, 1, 3), observed.Date, "The single emitted occurrence must be the adjusted Jan 3 form.");
+		Assert.IsTrue(observed.WasAdjusted, "The emitted occurrence must carry an AdjustmentReason.");
 		Assert.IsNotNull(observed.AdjustmentReason);
-		Assert.AreEqual(new DateTime(2022, 12, 31), observed.AdjustmentReason.OriginalDate);
+		Assert.AreEqual(new DateTime(2022, 12, 31), observed.AdjustmentReason.OriginalDate,
+			"The AdjustmentReason must record the suppressed Dec 31 anchor as the original date.");
+
+		Assert.IsFalse(resolved.Any(n => n.Date == new DateTime(2022, 12, 31)),
+			"The Dec 31 anchor is suppressed by its adjustment and must not appear in the output.");
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -293,14 +293,152 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
+	/// Verifies that a Tier 2 (OffsetFromFixed) rule with an observance adjustment in a fringe year is materialised by the fringe
+	/// pass and that its root anchor is fetched on-demand when the main pass did not load it for that year.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenOffsetFromFixedRuleWithAdjustmentRollsForwardFromFringeYear_ShouldEmitObservedDate()
+	{
+		// Tier 1 fixed anchor with no adjustment of its own. The fringe pass skips it directly (no adjustment, no multi-day) so
+		// reaching the offset rule below requires the on-demand anchor materialisation path.
+		NotableDateRule yearEndAnchor = new()
+		{
+			Name = "Year-End Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 30,
+			IsNonWorkingDay = true,
+		};
+
+		// Tier 2 offset-from-fixed: Year-End Anchor + 1, with an unconditional +5 day shift. (anchor 30 Dec) + 1 + 5 = 5 Jan.
+		NotableDateRule yearEndBonus = new()
+		{
+			Name = "Year-End Bonus",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Holiday,
+			AnchorRuleName = "Year-End Anchor",
+			OffsetDays = 1,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "shift-5",
+				Trigger = AdjustmentTrigger.Always,
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 5,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(yearEndAnchor, yearEndBonus) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		// Request entirely in 2027 so 2026 is a fringe year. The Tier 2 Year-End Bonus 2026 anchors on Year-End Anchor 2026
+		// (Dec 30 2026) which Pass 1 does NOT materialise. The fringe pass must on-demand materialise the anchor before computing
+		// the offset and applying the +5 day shift to Jan 5 2027.
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2027, 1, 4),
+			new DateTime(2027, 1, 10));
+
+		NotableDate observed = resolved.SingleOrDefault(n => n.Name == "Year-End Bonus")
+			?? throw new AssertFailedException("Expected Year-End Bonus to be emitted via the fringe pass with on-demand anchor materialisation.");
+
+		Assert.AreEqual(new DateTime(2027, 1, 5), observed.Date);
+		Assert.IsTrue(observed.WasAdjusted);
+		Assert.IsNotNull(observed.AdjustmentReason);
+		Assert.AreEqual(new DateTime(2026, 12, 31), observed.AdjustmentReason.OriginalDate);
+	}
+
+	/// <summary>
+	/// Verifies that a multi-day rule whose anchor sits in an adjacent year and whose span reaches into the requested window is
+	/// materialised by the fringe pass and emitted with the correct duration metadata.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenMultiDayRuleSpansAcrossYearBoundaryIntoRequest_ShouldEmitFromAdjacentYear()
+	{
+		// A 7-day festival starting 30 December — the span runs Dec 30 .. Jan 5 (inclusive).
+		NotableDateRule festival = new()
+		{
+			Name = "Year-End Festival",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Cultural,
+			Month = 12,
+			Day = 30,
+			DurationDays = 7,
+			IsNonWorkingDay = false,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(festival) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 1, 1),
+			new DateTime(2026, 1, 31));
+
+		NotableDate festivalDate = resolved.SingleOrDefault(n => n.Name == "Year-End Festival")
+			?? throw new AssertFailedException("Expected the prior-year festival span to surface inside the January window.");
+
+		Assert.AreEqual(new DateTime(2025, 12, 30), festivalDate.Date,
+			"Anchor must remain at Dec 30 of the prior year so consumers can identify the originating day.");
+		Assert.AreEqual(7, festivalDate.DurationDays);
+		Assert.AreEqual(new DateTime(2026, 1, 5), festivalDate.EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that the planner's fringe distance widens to accommodate rules with unusually large
+	/// <see cref="AdjustmentAction.AddDays" /> shifts so a cross-year adjustment whose result lands inside the requested window is
+	/// admitted by the fringe pass even though it sits outside the planner's default 7-day envelope.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenRuleHasLargeCrossYearAddDaysAdjustment_ShouldExtendFringeDistanceToCoverIt()
+	{
+		// Rule anchored on 1 Dec each year, unconditionally shifts +60 days. 1 Dec + 60 = 30 Jan of the following year. With
+		// the planner's default 7-day fringe this would not be admitted; the rule set's GlobalFringeReach must widen the fringe
+		// distance to 60 days so the prior-year anchor (1 Dec 2025) becomes a fringe-year candidate for a January 2026 request.
+		NotableDateRule shifted = new()
+		{
+			Name = "Sixty-Day Shifted Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Public,
+			Month = 12,
+			Day = 1,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "shift-60",
+				Trigger = AdjustmentTrigger.Always,
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 60,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(shifted) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		// Anchor 1 Dec 2025 + 60 days = 30 Jan 2026. The request ends 5 Feb 2026 so the adjusted date lands inside.
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 1, 25),
+			new DateTime(2026, 2, 5));
+
+		NotableDate match = resolved.SingleOrDefault(n => n.Name == "Sixty-Day Shifted Holiday")
+			?? throw new AssertFailedException("A +60 day adjustment should be admitted by the fringe pass when its envelope reaches the request.");
+
+		Assert.AreEqual(new DateTime(2026, 1, 30), match.Date);
+		Assert.IsTrue(match.WasAdjusted);
+		Assert.AreEqual(new DateTime(2025, 12, 1), match.AdjustmentReason!.OriginalDate);
+	}
+
+	/// <summary>
 	/// Verifies that a request whose window does not touch a year boundary inside the planner's fringe distance does not
 	/// materialise rules from adjacent years — the fringe pass is skipped entirely when no fringe years are needed.
 	/// </summary>
 	[TestMethod]
 	public void Resolve_WhenWindowIsNotNearYearBoundary_ShouldNotMaterialiseAdjacentYearRules()
 	{
-		bool christmasResolveCalled = false;
-
 		NotableDateRule christmas = new()
 		{
 			Name = "Christmas Day",
@@ -332,8 +470,6 @@ public sealed class NotableDateRangePipelineTests
 		// July request — no fringe year crossing required. Mid-Year Holiday emitted; Christmas not.
 		Assert.IsTrue(resolved.Any(n => n.Name == "Mid-Year Holiday" && n.Date == new DateTime(2026, 7, 1)));
 		Assert.IsFalse(resolved.Any(n => n.Name == "Christmas Day"));
-
-		_ = christmasResolveCalled;
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -186,6 +186,110 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
+	/// Verifies that a request whose window spans both the original Dec 31 anchor and its rolled-forward Jan 3 observance returns
+	/// both occurrences — the actual calendar holiday and the observed substitute — and does not duplicate or lose either one.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowSpansBothAnchorAndAdjustedObservance_ShouldEmitBaseAndAdjustedDates()
+	{
+		NotableDateRule yearEnd = new()
+		{
+			Name = "Year-End Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 31,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-substitute",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateRule secondJan = new()
+		{
+			Name = "New Year Second Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 2,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(yearEnd, secondJan) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2022, 12, 25),
+			new DateTime(2023, 1, 5));
+
+		NotableDate[] yearEndOccurrences = resolved.Where(n => n.Name == "Year-End Holiday").ToArray();
+		Assert.AreEqual(2, yearEndOccurrences.Length,
+			"Spanning [25 Dec 2022, 5 Jan 2023] should return both the actual 31 Dec anchor and the 3 Jan observance.");
+
+		NotableDate baseDate = yearEndOccurrences.Single(n => n.Date == new DateTime(2022, 12, 31));
+		NotableDate observed = yearEndOccurrences.Single(n => n.Date == new DateTime(2023, 1, 3));
+
+		Assert.IsFalse(baseDate.WasAdjusted, "The Dec 31 base occurrence must not carry an AdjustmentReason.");
+		Assert.IsTrue(observed.WasAdjusted, "The Jan 3 observance must carry an AdjustmentReason.");
+		Assert.IsNotNull(observed.AdjustmentReason);
+		Assert.AreEqual(new DateTime(2022, 12, 31), observed.AdjustmentReason.OriginalDate);
+	}
+
+	/// <summary>
+	/// Verifies that a single-day query for the rolled-forward Jan 3 observance does not leak the prior-year Dec 31 anchor into
+	/// the output even though the anchor was materialised internally to support the adjustment chain.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenSingleDayWindowOnAdjustedDate_ShouldNotLeakAnchorOutsideWindow()
+	{
+		NotableDateRule yearEnd = new()
+		{
+			Name = "Year-End Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 31,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-substitute",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateRule secondJan = new()
+		{
+			Name = "New Year Second Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 2,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(yearEnd, secondJan) },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2023, 1, 3),
+			new DateTime(2023, 1, 3));
+
+		Assert.AreEqual(1, resolved.Count,
+			$"Expected exactly one notable date for [3 Jan, 3 Jan]; got: {string.Join(", ", resolved.Select(n => $"{n.Name}@{n.Date:yyyy-MM-dd}"))}.");
+
+		Assert.IsFalse(resolved.Any(n => n.Date.Year != 2023 || n.Date.Month != 1 || n.Date.Day != 3),
+			$"Every emitted date must intersect the requested window [3 Jan 2023, 3 Jan 2023].");
+	}
+
+	/// <summary>
 	/// Verifies that <see cref="NotableDateService.ResolvedWindows" /> exposes the union of every range that has been resolved,
 	/// merging overlapping or adjacent windows into the minimum number of disjoint intervals.
 	/// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -186,6 +186,76 @@ public sealed class NotableDateRangePipelineTests
 	}
 
 	/// <summary>
+	/// Verifies that <see cref="NotableDateService.ResolvedWindows" /> exposes the union of every range that has been resolved,
+	/// merging overlapping or adjacent windows into the minimum number of disjoint intervals.
+	/// </summary>
+	[TestMethod]
+	public void ResolvedWindows_WhenMultipleRangesResolved_ShouldExposeMergedDisjointIntervals()
+	{
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		Assert.AreEqual(0, service.ResolvedWindows.Count, "Service should report no resolved windows on construction.");
+
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31));
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 4, 1), new DateTime(2026, 6, 30));
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 9, 1), new DateTime(2026, 12, 31));
+
+		IReadOnlyList<DateRange> windows = service.ResolvedWindows;
+
+		Assert.AreEqual(2, windows.Count, "Adjacent Q1+Q2 windows should merge; the disjoint Q4 window stays separate.");
+		Assert.AreEqual(new DateTime(2026, 1, 1), windows[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 6, 30), windows[0].EndDate);
+		Assert.AreEqual(new DateTime(2026, 9, 1), windows[1].StartDate);
+		Assert.AreEqual(new DateTime(2026, 12, 31), windows[1].EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateService.IsRangeResolved" /> returns true for a range fully inside a previously resolved
+	/// window and false for one that spans a gap between two windows.
+	/// </summary>
+	[TestMethod]
+	public void IsRangeResolved_WhenProbeFitsAndStraddlesResolvedWindows_ShouldReturnExpectedResults()
+	{
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31));
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 9, 1), new DateTime(2026, 12, 31));
+
+		Assert.IsTrue(service.IsRangeResolved(new DateTime(2026, 2, 1), new DateTime(2026, 2, 28)),
+			"February 2026 lies inside the resolved Q1 window.");
+
+		Assert.IsFalse(service.IsRangeResolved(new DateTime(2026, 2, 1), new DateTime(2026, 10, 31)),
+			"A range that bridges the unresolved Q2/Q3 gap is not fully resolved.");
+
+		Assert.IsFalse(service.IsRangeResolved(new DateTime(2026, 5, 1), new DateTime(2026, 5, 31)),
+			"May 2026 has not been resolved.");
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateService.Invalidate()" /> clears the resolved-windows tracker so consumers see an empty
+	/// list after invalidation.
+	/// </summary>
+	[TestMethod]
+	public void Invalidate_AfterRangesResolved_ShouldEmptyResolvedWindows()
+	{
+		NotableDateService service = new(
+			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday);
+
+		_ = service.ResolveNotableDatesInRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31));
+		Assert.AreEqual(1, service.ResolvedWindows.Count);
+
+		service.Invalidate();
+
+		Assert.AreEqual(0, service.ResolvedWindows.Count);
+		Assert.IsFalse(service.IsRangeResolved(new DateTime(2026, 2, 1), new DateTime(2026, 2, 28)));
+	}
+
+	/// <summary>
 	/// Verifies that <see cref="NotableDateService.ResolveNotableDatesInRange" /> throws
 	/// <see cref="ArgumentException" /> when the end date precedes the start date.
 	/// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/ResolvedWindowSetTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/ResolvedWindowSetTests.cs
@@ -1,0 +1,154 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ResolvedWindowSetTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Verifies that <see cref="ResolvedWindowSet" /> maintains the minimum number of disjoint intervals describing the union of
+/// added ranges and answers coverage queries correctly.
+/// </summary>
+[TestClass]
+public sealed class ResolvedWindowSetTests
+{
+	/// <summary>
+	/// Verifies that a new set is empty.
+	/// </summary>
+	[TestMethod]
+	public void Ranges_WhenNewlyConstructed_ShouldBeEmpty()
+	{
+		ResolvedWindowSet set = new();
+		Assert.AreEqual(0, set.Ranges.Count);
+	}
+
+	/// <summary>
+	/// Verifies that a single added range is retained without modification.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenSingleRange_ShouldRetainItVerbatim()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31)));
+
+		Assert.AreEqual(1, set.Ranges.Count);
+		Assert.AreEqual(new DateTime(2026, 1, 1), set.Ranges[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 3, 31), set.Ranges[0].EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that two disjoint, non-adjacent ranges remain separate.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenTwoDisjointRanges_ShouldRetainBothInOrder()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31)));
+		set.Add(new DateRange(new DateTime(2026, 6, 1), new DateTime(2026, 6, 30)));
+
+		Assert.AreEqual(2, set.Ranges.Count);
+		Assert.AreEqual(new DateTime(2026, 1, 1), set.Ranges[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 6, 1), set.Ranges[1].StartDate);
+	}
+
+	/// <summary>
+	/// Verifies that two overlapping ranges are merged into a single interval.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenOverlappingRanges_ShouldMergeIntoSingleInterval()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31)));
+		set.Add(new DateRange(new DateTime(2026, 3, 15), new DateTime(2026, 5, 31)));
+
+		Assert.AreEqual(1, set.Ranges.Count);
+		Assert.AreEqual(new DateTime(2026, 1, 1), set.Ranges[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 5, 31), set.Ranges[0].EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that two ranges meeting on consecutive days are merged into a single interval.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenAdjacentRanges_ShouldMergeIntoSingleInterval()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+		set.Add(new DateRange(new DateTime(2026, 2, 1), new DateTime(2026, 2, 28)));
+
+		Assert.AreEqual(1, set.Ranges.Count);
+		Assert.AreEqual(new DateTime(2026, 1, 1), set.Ranges[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 2, 28), set.Ranges[0].EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that adding a range that bridges two existing disjoint intervals collapses them into one.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenRangeBridgesTwoDisjointIntervals_ShouldCollapseIntoOne()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 1, 31)));
+		set.Add(new DateRange(new DateTime(2026, 6, 1), new DateTime(2026, 6, 30)));
+		set.Add(new DateRange(new DateTime(2026, 1, 15), new DateTime(2026, 6, 15)));
+
+		Assert.AreEqual(1, set.Ranges.Count);
+		Assert.AreEqual(new DateTime(2026, 1, 1), set.Ranges[0].StartDate);
+		Assert.AreEqual(new DateTime(2026, 6, 30), set.Ranges[0].EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that an inverted range is silently ignored.
+	/// </summary>
+	[TestMethod]
+	public void Add_WhenInvertedRange_ShouldBeIgnored()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 6, 30), new DateTime(2026, 6, 1)));
+
+		Assert.AreEqual(0, set.Ranges.Count);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="ResolvedWindowSet.Covers" /> returns true when the probe is fully inside a tracked interval.
+	/// </summary>
+	[TestMethod]
+	public void Covers_WhenProbeIsInsideTrackedInterval_ShouldReturnTrue()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 12, 31)));
+
+		Assert.IsTrue(set.Covers(new DateRange(new DateTime(2026, 6, 1), new DateTime(2026, 6, 30))));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="ResolvedWindowSet.Covers" /> returns false when the probe spans a gap between two tracked
+	/// intervals — coverage is per-interval, not per-union.
+	/// </summary>
+	[TestMethod]
+	public void Covers_WhenProbeSpansGapBetweenTwoIntervals_ShouldReturnFalse()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31)));
+		set.Add(new DateRange(new DateTime(2026, 6, 1), new DateTime(2026, 9, 30)));
+
+		Assert.IsFalse(set.Covers(new DateRange(new DateTime(2026, 3, 15), new DateTime(2026, 6, 15))));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="ResolvedWindowSet.Clear" /> empties the set.
+	/// </summary>
+	[TestMethod]
+	public void Clear_WhenCalled_ShouldRemoveAllRanges()
+	{
+		ResolvedWindowSet set = new();
+		set.Add(new DateRange(new DateTime(2026, 1, 1), new DateTime(2026, 3, 31)));
+
+		set.Clear();
+
+		Assert.AreEqual(0, set.Ranges.Count);
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
@@ -191,6 +191,83 @@ public sealed class RuleStaticAnalysisTests
 	}
 
 	/// <summary>
+	/// Verifies that the <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> property overrides the action's default reach
+	/// estimate so an author-declared envelope flows into <see cref="RuleStaticAnalysis.GlobalFringeReach" />.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenAdjustmentDeclaresExplicitMaxReach_ShouldHonourItForGlobalFringeReach()
+	{
+		NotableDateRule custom = Fixed("Custom Reach Holiday", 7, 1) with
+		{
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "big-shift",
+				Trigger = AdjustmentTrigger.Always,
+				Action = AdjustmentAction.Custom,
+				HandlerKey = "test-handler",
+				MaxAdjustmentReachDays = 90,
+			}),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { custom });
+
+		Assert.AreEqual(90, analysis.GlobalFringeReach,
+			"Author-declared MaxAdjustmentReachDays should set the analysis's global fringe reach.");
+
+		RuleStaticProfile profile = analysis.Profiles.Single();
+		Assert.AreEqual(90, profile.MaxObservedReach);
+		Assert.AreEqual(-90, profile.MinObservedReach);
+	}
+
+	/// <summary>
+	/// Verifies that an unconfigured custom adjustment falls back to the conservative ±31 day default envelope.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenCustomAdjustmentDoesNotDeclareReach_ShouldUseDefaultEnvelope()
+	{
+		NotableDateRule custom = Fixed("Default Reach Holiday", 7, 1) with
+		{
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "default-shift",
+				Trigger = AdjustmentTrigger.Always,
+				Action = AdjustmentAction.Custom,
+				HandlerKey = "test-handler",
+			}),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { custom });
+
+		Assert.AreEqual(31, analysis.GlobalFringeReach);
+	}
+
+	/// <summary>
+	/// Verifies that an explicit reach declaration on a built-in action overrides the action's heuristic estimate so authors can
+	/// declare a tighter envelope when they know the actual reach.
+	/// </summary>
+	[TestMethod]
+	public void Build_WhenAddDaysActionHasExplicitTighterMaxReach_ShouldHonourTheDeclaration()
+	{
+		// AddDays with OffsetDays = 60 would heuristically yield (0, 60). The explicit MaxAdjustmentReachDays = 5 forces the
+		// envelope to (-5, 5), which is what the author actually wants for fringe sizing.
+		NotableDateRule misdeclared = Fixed("Bounded Shift", 7, 1) with
+		{
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "tight",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 60,
+				MaxAdjustmentReachDays = 5,
+			}),
+		};
+
+		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { misdeclared });
+
+		Assert.AreEqual(5, analysis.GlobalFringeReach);
+	}
+
+	/// <summary>
 	/// Verifies that an offset rule referencing a missing anchor degrades safely to the <see cref="RuleTier.Fixed" /> tier so the
 	/// analyser never throws on partially-authored rule sets.
 	/// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/RuleStaticAnalysisTests.cs
@@ -154,10 +154,11 @@ public sealed class RuleStaticAnalysisTests
 	}
 
 	/// <summary>
-	/// Verifies that the global reach envelope reflects the worst-case adjustment shifts and durations across every rule.
+	/// Verifies that per-rule reach is captured on the profile so the pipeline can size fringe scans by individual adjustment
+	/// behaviour rather than by a single global envelope.
 	/// </summary>
 	[TestMethod]
-	public void Build_WhenRulesHaveAdjustments_ShouldComputeGlobalReachEnvelope()
+	public void Build_WhenRuleHasForwardRollingAdjustment_ShouldCapturePerRuleForwardReach()
 	{
 		NotableDateRule rollForward = Fixed("New Year's Day", 1, 1) with
 		{
@@ -177,9 +178,16 @@ public sealed class RuleStaticAnalysisTests
 
 		RuleStaticAnalysis analysis = RuleStaticAnalysis.Build(new[] { rollForward, longSpan });
 
-		// MoveToNextNonWorkingDay is estimated at +7 forward reach in this prototype; duration adds 6 to the festival week.
-		Assert.IsTrue(analysis.GlobalMaxReach >= 7, $"Expected GlobalMaxReach >= 7, got {analysis.GlobalMaxReach}.");
-		Assert.IsTrue(analysis.GlobalMinReach <= 0);
+		RuleStaticProfile rollProfile = analysis.Profiles.Single(p => p.Rule.Name == "New Year's Day");
+		RuleStaticProfile spanProfile = analysis.Profiles.Single(p => p.Rule.Name == "Festival Week");
+
+		// MoveToNextNonWorkingDay is estimated at +7 forward reach in this prototype.
+		Assert.IsTrue(rollProfile.MaxObservedReach >= 7, $"Expected MaxObservedReach >= 7 for adjustment, got {rollProfile.MaxObservedReach}.");
+		Assert.AreEqual(0, rollProfile.MinObservedReach);
+
+		// Festival Week has no adjustment but a 7-day span so MaxObservedReach reflects DurationDays - 1.
+		Assert.AreEqual(6, spanProfile.MaxObservedReach);
+		Assert.AreEqual(0, spanProfile.MinObservedReach);
 	}
 
 	/// <summary>


### PR DESCRIPTION
## Summary

Adds a parallel chronological notable-date resolution pipeline under
`Bodu.Globalization.Calendar.RangeResolution` so it can be exercised
alongside the existing `NotableDateResolutionEngine` before any
deletion or merge. Public surface adds two things to
`NotableDateService` — a window-based `ResolveNotableDatesInRange`
overload, and a `ResolvedWindows` / `IsRangeResolved` introspection
pair so consumers can see what coverage has been served.

The pipeline solves the two collateral cases the existing engine
struggled with:

- **Successor offset rules** — `Start of Lent = Easter Sunday − 46`
  in a Q1 window where Easter itself sits in April.
- **Cross-year roll-over adjustments** — `31 Dec` (Saturday) rolling
  forward past `1 Jan` and a non-working `2 Jan` blocker to land on
  `3 Jan` for a single-day query.

Adjusted observances supersede the base anchor on emission — one rule
yields one notable date per `(year, territory)` regardless of whether
the date was shifted.

## How rule selection works

Two passes, no global reach expansion of the request window:

1. **Main pass** — every eligible rule is materialised for the civil
   years the request range itself spans. Tier 1 / 2 (`Fixed`,
   `OffsetFromFixed`) iterate `[start.Year .. end.Year]`. Tier 3 / 4
   (`Algorithmic`, `OffsetFromAlgorithmic`) iterate the same set
   unioned with the fringe years computed below. Each algorithmic
   anchor is invoked at most once per `(name, year)` via the
   `NotableDateRangeResolutionCache`.
2. **Fringe pass** — runs only when the request window touches a year
   boundary inside the planner's fringe distance. Materialises:
   - `Tier 1` rules with at least one adjustment (the `31 Dec` case),
   - `Tier 2` rules with at least one adjustment (root anchor in the
     fringe year is fetched on-demand if the main pass didn't load it),
   - `Tier 1` rules with `DurationDays > 1` (multi-day span overflow,
     e.g. a 7-day festival starting Dec 30).

   Each fringe-year materialisation is admitted only when the rule's
   per-rule `[anchor + MinObservedReach, anchor + MaxObservedReach]`
   envelope intersects the request window.
3. **Adjustment phase** — applied to every cache entry that has at
   least one `ObservanceAdjustment`. Adjusted dates that intersect the
   request promote the entry to `Adjusted` and supersede the base on
   emission.

The fringe distance is `max(default 7, RuleStaticAnalysis.GlobalFringeReach)`
where `GlobalFringeReach` is the largest absolute reach across the rule
set. Rules with unusual reach (`AddDays = 60`, `Custom` with
`MaxAdjustmentReachDays = 90`) widen the fringe automatically.

## What's new

### Public surface (concrete `NotableDateService` only)

```csharp
public IReadOnlyList<NotableDate> ResolveNotableDatesInRange(
    DateTime startDate, DateTime endDate,
    string? territoryCode = null, Type? calendarType = null,
    NotableDateFilter? filter = null);

public IReadOnlyList<DateRange> ResolvedWindows { get; }
public bool IsRangeResolved(DateTime startDate, DateTime endDate);
```

A `// TODO` flags the future evaluation of promoting these to
`INotableDateService` once the prototype is validated.

`Invalidate()` now also clears the resolved-windows tracker and the
lazy pipeline.

### New public types in `Bodu.Globalization.Calendar`

- `DateRange` — readonly record struct with `Contains`, `Intersects`,
  `DayCount`, `IsValid` helpers.
- New optional `MaxAdjustmentReachDays` property on
  `ObservanceAdjustment` for author-declared adjustment reach. Used
  only by the range-resolution pipeline; the existing year-based
  generation path is unaffected.

### New internal pipeline (under `Globalization.Calendar.RangeResolution/`)

| File | Role |
|------|------|
| `RuleTier`, `RuleStaticProfile`, `RuleStaticAnalysis` | Per-rule classification (Fixed / OffsetFromFixed / Algorithmic / OffsetFromAlgorithmic), transitive root-anchor flattening, per-rule reach envelope, `GlobalFringeReach` for planner sizing |
| `NotableDateCacheState`, `NotableDateCacheEntry`, `NotableDateCacheKey`, `NotableDateRangeResolutionCache` | Unified cache with four-state qualification flag (`Computed` / `InWindow` / `Adjusted` / `AdjustedBlocker`) |
| `NotableDateRangeRequest`, `NotableDateRangePlan`, `NotableDateRangePlanner` | Per-request scoping; `CandidateYears` from request range, `FringeYears` from year-boundary touches, configurable fringe distance |
| `NotableDateRangePipeline` | Orchestrator implementing main pass + fringe pass + adjustment evaluation + emission |
| `ResolvedWindowSet` | Maintains the union of resolved windows as a sorted list of disjoint merged intervals |

## Test plan

- [ ] `dotnet build Bodu.Globalization.Calendar/src/Bodu.Globalization.Calendar.csproj`
- [ ] `dotnet build Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj`
- [ ] `dotnet test Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj --settings test.runsettings --filter "FullyQualifiedName~RangeResolution"`
- [ ] Confirm existing `NotableDateResolutionEngine` tests (`NotableDateResolutionServiceTests`, `…AdjustmentTests`, `…DynamicExpansionTests`, `…ObservedDateExpansionTests`, `…ConvenienceApiTests`) still pass — the existing pipeline is untouched.
- [ ] Spot-check resource files in `Globalization.Calendar.Resources/` against `ResolveNotableDatesInRange` for a representative AU / UK / US year.

### New tests in this PR

In `Globalization.Calendar.RangeResolution/`:

**`RuleStaticAnalysisTests`** — tier classification (Fixed,
Algorithmic, OffsetFromFixed, OffsetFromAlgorithmic, transitive
chains), dependency lookup, per-rule reach envelope, missing-anchor
degradation, `MaxAdjustmentReachDays` honoured, default Custom
envelope, explicit override of built-in action heuristic.

**`ResolvedWindowSetTests`** — empty / single / disjoint / overlap /
adjacent / bridging / inverted / cover / clear scenarios for the
range-merging tracker.

**`NotableDateRangePipelineTests`** — integration tests covering:

- Lent in Q1 2026 (Easter algorithm invoked once per demanded year;
  Easter not emitted for a Jan-Mar window)
- 31 Dec 2022 → 3 Jan 2023 cross-year roll-forward past blockers
- Cross-year window emits adjusted only (not both)
- Single-day request on adjusted date does not leak the prior-year
  anchor
- Tier 2 (OffsetFromFixed) with adjustment + on-demand anchor
  materialisation
- Multi-day span overflow from adjacent year
- Rule with `AddDays = 60` widens fringe automatically
- Custom handler with `MaxAdjustmentReachDays = 90` lands inside the
  request via the widened fringe
- No-fringe-year case skips the fringe pass entirely
- `ResolvedWindows` merges across calls and `Invalidate()` clears it

## Limitations and follow-ups

- Single adjustment per cache entry — last applied wins. Multiple
  simultaneously-firing adjustments on one rule keep only the last in
  the cache. Document when (and if) we need per-adjustment cache
  fan-out.
- Pipeline is stateless across requests — every call rebuilds the
  per-request cache. The `ResolvedWindows` tracker reflects what was
  asked, not what's still computed. Persistent cache + cumulative
  re-use is a future optimisation.
- This pipeline lives **alongside** the existing engine for
  side-by-side validation. Once parity is confirmed, follow-up PR can
  delete `NotableDateResolutionEngine`,
  `NotableDateResolutionAdjustmentProcessor`,
  `NotableDateResolutionWindow`,
  `NotableDateRuleOccurrenceResolver`,
  `AnchorRelativeRuleIndex`, and `CachingCalculationAnchorResolver`,
  and route the existing year-based and window-based
  `GetNotableDates` overloads through the new pipeline.

## Commits

- `062813c` Prototype range-resolution pipeline alongside existing engine
- `5afbdd6` Expose resolved chronological windows on NotableDateService
- `391f106` Fix: never lose the adjusted observance when the base date is in window
- `cf2dda5` Adjusted observance now supersedes the base anchor in emitted output
- `edfdec2` Replace global reach expansion with two-pass selection + fringe scan
- `4041fcb` Extend fringe pass: Tier 2 + multi-day spans + per-rule reach + custom-handler envelope
- `dd65d5f` Add MaxAdjustmentReachDays for author-declared adjustment reach

https://claude.ai/code/session_01Bt7aVfAshdFniYjdyR77q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt7aVfAshdFniYjdyR77q8)_