### PR TITLE
Add boundary + leap-year test suites pushing the input-space extremes

### DIFF
--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.Boundaries.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.Boundaries.cs
@@ -1,0 +1,558 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePipelineScenarioTests.Boundaries.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Stress-tests the prototype range-resolution pipeline at the extremes of the supported input space:
+/// <see cref="DateTime.MinValue" /> / <see cref="DateTime.MaxValue" /> proximity, very large windows spanning multiple
+/// decades, single-day windows, multi-day spans whose duration approaches a full year, offset projections that overflow
+/// <see cref="DateTime" />, and adjustments declaring large reach.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These tests pin behaviour at boundaries that ordinary scenario tests do not exercise. Where a boundary triggers the
+/// pipeline's clamp / catch logic (<see cref="DateTime" /> overflow on offset projection, fringe-day arithmetic clamping near
+/// year 1 or year 9999), the assertion describes the expected graceful behaviour.
+/// </para>
+/// </remarks>
+public sealed partial class NotableDateRangePipelineScenarioTests
+{
+	// =====================================================================================================================
+	// Calendar-year boundaries
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a fixed-date rule constrained to civil year 1 emits its anchor when the request window spans year 1.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowIsInYearOne_ShouldEmitYearOneAnchor()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Year One Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 6,
+			Day = 15,
+			FirstYear = 1,
+			LastYear = 1,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(1, 1, 1),
+			new DateTime(1, 12, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Year One Anchor");
+		Assert.AreEqual(new DateTime(1, 6, 15), match.Date);
+	}
+
+	/// <summary>
+	/// Verifies that the planner clamps the fringe-pass start date at <see cref="DateTime.MinValue" /> when the request
+	/// window touches year 1 — no underflow exception, no spurious year-zero materialisation.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenRequestStartIsExactlyDateTimeMinValue_ShouldNotThrowOnFringeArithmetic()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "First Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 1,
+			FirstYear = 1,
+			LastYear = 1,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			DateTime.MinValue.Date,
+			new DateTime(1, 12, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "First Day");
+		Assert.AreEqual(new DateTime(1, 1, 1), match.Date);
+	}
+
+	/// <summary>
+	/// Verifies that a fixed-date rule constrained to civil year 9999 emits its anchor when the request window spans year
+	/// 9999.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowIsInYear9999_ShouldEmitYear9999Anchor()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Year 9999 Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 6,
+			Day = 15,
+			FirstYear = 9999,
+			LastYear = 9999,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(9999, 1, 1),
+			new DateTime(9999, 12, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Year 9999 Anchor");
+		Assert.AreEqual(new DateTime(9999, 6, 15), match.Date);
+	}
+
+	/// <summary>
+	/// Verifies that the planner clamps the fringe-pass end date at <see cref="DateTime.MaxValue" /> when the request window
+	/// reaches the last day of year 9999 — no overflow exception, no spurious year-10000 materialisation.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenRequestEndIsExactlyDateTimeMaxValueDate_ShouldNotThrowOnFringeArithmetic()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Last Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 31,
+			FirstYear = 9999,
+			LastYear = 9999,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(9999, 1, 1),
+			DateTime.MaxValue.Date);
+
+		NotableDate match = resolved.Single(n => n.Name == "Last Day");
+		Assert.AreEqual(new DateTime(9999, 12, 31), match.Date);
+	}
+
+	// =====================================================================================================================
+	// Window-shape extremes
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a request with identical start and end dates is treated as a one-day window — not as an empty
+	/// half-open interval.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenWindowStartEqualsEnd_ShouldQuerySingleDay()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Independence Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 7,
+			Day = 4,
+			FirstYear = 2026,
+			LastYear = 2026,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 7, 4),
+			new DateTime(2026, 7, 4));
+
+		Assert.AreEqual(1, resolved.Count);
+		Assert.AreEqual(new DateTime(2026, 7, 4), resolved[0].Date);
+	}
+
+	/// <summary>
+	/// Verifies that a request spanning many decades emits an annual rule once per civil year in chronological order.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2000, 2009, 10)]
+	[DataRow(1990, 2030, 41)]
+	[DataRow(2020, 2120, 101)]
+	public void Resolve_WhenWindowSpansManyYears_ShouldEmitAnnualRuleOncePerYear(int startYear, int endYear, int expectedCount)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Annual",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 1,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(startYear, 1, 1),
+			new DateTime(endYear, 12, 31));
+
+		NotableDate[] annualEmissions = resolved.Where(n => n.Name == "Annual").OrderBy(n => n.Date).ToArray();
+
+		Assert.AreEqual(expectedCount, annualEmissions.Length,
+			$"Annual rule should emit once per civil year between {startYear} and {endYear} inclusive.");
+
+		for (int i = 0; i < annualEmissions.Length; i++)
+		{
+			Assert.AreEqual(new DateTime(startYear + i, 1, 1), annualEmissions[i].Date);
+		}
+	}
+
+	/// <summary>
+	/// Verifies that a request whose rule set is entirely empty returns an empty result without throwing.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenRuleSetIsEmpty_ShouldReturnEmpty()
+	{
+		NotableDateService service = BuildService();
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 1, 1),
+			new DateTime(2026, 12, 31));
+
+		Assert.AreEqual(0, resolved.Count);
+	}
+
+	// =====================================================================================================================
+	// Long-duration spans
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a 365-day duration rule whose anchor is on 1 January is emitted from a mid-year query because its span
+	/// blankets the entire year.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenDurationSpansEntireYearAndQueryIsMidYear_ShouldEmitFromAnchor()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Year-Long Programme",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Cultural,
+			Month = 1,
+			Day = 1,
+			FirstYear = 2026,
+			LastYear = 2026,
+			DurationDays = 365,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 6, 1),
+			new DateTime(2026, 6, 30));
+
+		NotableDate match = resolved.Single(n => n.Name == "Year-Long Programme");
+		Assert.AreEqual(new DateTime(2026, 1, 1), match.Date);
+		Assert.AreEqual(365, match.DurationDays);
+		Assert.AreEqual(new DateTime(2026, 12, 31), match.EndDate);
+	}
+
+	/// <summary>
+	/// Verifies that a multi-day span whose end date lands on <see cref="DateTime.MaxValue" />.Date is emitted without any
+	/// overflow.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenSpanEndDateIsExactlyDateTimeMaxValueDate_ShouldEmitWithFullDuration()
+	{
+		// Anchor: 25 Dec 9999. DurationDays = 7 → span Dec 25 .. Dec 31 9999 (= MaxValue.Date).
+		NotableDateRule rule = new()
+		{
+			Name = "Year-End Span",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Cultural,
+			Month = 12,
+			Day = 25,
+			FirstYear = 9999,
+			LastYear = 9999,
+			DurationDays = 7,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(9999, 12, 1),
+			DateTime.MaxValue.Date);
+
+		NotableDate match = resolved.Single(n => n.Name == "Year-End Span");
+		Assert.AreEqual(new DateTime(9999, 12, 25), match.Date);
+		Assert.AreEqual(new DateTime(9999, 12, 31), match.EndDate);
+	}
+
+	// =====================================================================================================================
+	// Offset projection overflow / underflow
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that an offset rule whose projection lands inside the supported <see cref="DateTime" /> range emits as
+	/// expected, including offsets that cross many year boundaries.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2026, 7, 1, 1, 2026, 7, 2)]      // +1 day
+	[DataRow(2026, 7, 1, 365, 2027, 7, 1)]    // +1 year
+	[DataRow(2026, 7, 1, 730, 2028, 7, 1)]    // +2 years (leap year between)
+	[DataRow(2026, 7, 1, 3650, 2036, 6, 28)]  // +10 years
+	[DataRow(2026, 7, 1, -1, 2026, 6, 30)]    // -1 day
+	[DataRow(2026, 7, 1, -365, 2025, 7, 1)]   // -1 year
+	[DataRow(2026, 7, 1, -3650, 2016, 7, 4)]  // -10 years
+	public void Resolve_WhenOffsetRuleProjectionStaysInRange_ShouldEmitAtProjectedDate(
+		int anchorYear, int anchorMonth, int anchorDay,
+		int offsetDays,
+		int expectedYear, int expectedMonth, int expectedDay)
+	{
+		NotableDateRule anchor = new()
+		{
+			Name = "Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = anchorMonth,
+			Day = anchorDay,
+			FirstYear = anchorYear,
+			LastYear = anchorYear,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateRule offset = new()
+		{
+			Name = "Offset",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Holiday,
+			AnchorRuleName = "Anchor",
+			OffsetDays = offsetDays,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(anchor, offset);
+
+		DateTime expected = new(expectedYear, expectedMonth, expectedDay);
+		DateTime windowStart = new DateTime(Math.Min(anchorYear, expectedYear), 1, 1);
+		DateTime windowEnd = new DateTime(Math.Max(anchorYear, expectedYear), 12, 31);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(windowStart, windowEnd);
+
+		NotableDate offsetEmission = resolved.Single(n => n.Name == "Offset");
+		Assert.AreEqual(expected, offsetEmission.Date);
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule whose projection would overflow <see cref="DateTime.MaxValue" /> is silently skipped — the
+	/// pipeline catches the <see cref="ArgumentOutOfRangeException" /> from <see cref="DateTime.AddDays" /> rather than
+	/// propagating it.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenOffsetRuleProjectionOverflowsMaxValue_ShouldSilentlySkipOffset()
+	{
+		NotableDateRule anchor = new()
+		{
+			Name = "Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 31,
+			FirstYear = 9999,
+			LastYear = 9999,
+			IsNonWorkingDay = true,
+		};
+
+		// Anchor 31 Dec 9999 + 100 days would land in year 10000 — outside DateTime's supported range.
+		NotableDateRule offset = new()
+		{
+			Name = "Offset",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Holiday,
+			AnchorRuleName = "Anchor",
+			OffsetDays = 100,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(anchor, offset);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(9999, 12, 1),
+			DateTime.MaxValue.Date);
+
+		Assert.IsTrue(resolved.Any(n => n.Name == "Anchor"),
+			"The anchor rule should still emit even though its derived offset rule overflows.");
+		Assert.IsFalse(resolved.Any(n => n.Name == "Offset"),
+			"The overflowing offset rule should be silently skipped.");
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule whose projection would underflow <see cref="DateTime.MinValue" /> is silently skipped.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenOffsetRuleProjectionUnderflowsMinValue_ShouldSilentlySkipOffset()
+	{
+		NotableDateRule anchor = new()
+		{
+			Name = "Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 1,
+			FirstYear = 1,
+			LastYear = 1,
+			IsNonWorkingDay = true,
+		};
+
+		// Anchor 1 Jan year 1 - 100 days would underflow before year 1.
+		NotableDateRule offset = new()
+		{
+			Name = "Offset",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Holiday,
+			AnchorRuleName = "Anchor",
+			OffsetDays = -100,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(anchor, offset);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			DateTime.MinValue.Date,
+			new DateTime(1, 12, 31));
+
+		Assert.IsTrue(resolved.Any(n => n.Name == "Anchor"));
+		Assert.IsFalse(resolved.Any(n => n.Name == "Offset"));
+	}
+
+	/// <summary>
+	/// Verifies that an offset rule whose projection lands exactly on <see cref="DateTime.MaxValue" />.Date emits successfully
+	/// — the boundary value itself is supported.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenOffsetRuleProjectionLandsExactlyOnMaxValueDate_ShouldEmit()
+	{
+		NotableDateRule anchor = new()
+		{
+			Name = "Anchor",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 12,
+			Day = 25,
+			FirstYear = 9999,
+			LastYear = 9999,
+			IsNonWorkingDay = true,
+		};
+
+		// Anchor 25 Dec 9999 + 6 days = 31 Dec 9999 (= MaxValue.Date).
+		NotableDateRule offset = new()
+		{
+			Name = "Offset",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Holiday,
+			AnchorRuleName = "Anchor",
+			OffsetDays = 6,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(anchor, offset);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(9999, 12, 1),
+			DateTime.MaxValue.Date);
+
+		NotableDate offsetEmission = resolved.Single(n => n.Name == "Offset");
+		Assert.AreEqual(new DateTime(9999, 12, 31), offsetEmission.Date);
+	}
+
+	// =====================================================================================================================
+	// Adjustment reach pushed wide — large MaxAdjustmentReachDays forces a multi-year fringe scan
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that an adjustment declaring a 1000-day reach via <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" />
+	/// causes the planner to widen the fringe distance enough that an anchor materialised in a fringe year approximately
+	/// three years away is admitted when its projected adjustment date lands inside the request window.
+	/// </summary>
+	[TestMethod]
+	public void Resolve_WhenAdjustmentDeclaresOneThousandDayReach_ShouldAdmitAnchorFromYearsAway()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Far-Reach Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 1,
+			Day = 1,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "shift-1000",
+				Trigger = AdjustmentTrigger.Always,
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 1000,
+				IsNonWorkingDay = true,
+				MaxAdjustmentReachDays = 1000,
+			}),
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		// Anchor 1 Jan 2024 + 1000 days = 27 Sep 2026.
+		// Request a single-day window on 27 Sep 2026 — without the wide fringe, year 2024 would not be a fringe year and the
+		// adjustment would not surface.
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2026, 9, 27),
+			new DateTime(2026, 9, 27));
+
+		NotableDate match = resolved.Single(n => n.Name == "Far-Reach Holiday");
+		Assert.AreEqual(new DateTime(2026, 9, 27), match.Date);
+		Assert.IsTrue(match.WasAdjusted);
+		Assert.AreEqual(new DateTime(2024, 1, 1), match.AdjustmentReason!.OriginalDate);
+	}
+
+	// =====================================================================================================================
+	// Multiple-decade reach summary
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateService.ResolvedWindows" /> tracks every previously-resolved window across many
+	/// disjoint queries spanning a wide range of years.
+	/// </summary>
+	[TestMethod]
+	public void ResolvedWindows_AfterManyDisjointResolutionsAcrossDecades_ShouldRetainAllAsDisjointIntervals()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Annual",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 6,
+			Day = 15,
+			IsNonWorkingDay = true,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		// Three widely-disjoint windows.
+		_ = service.ResolveNotableDatesInRange(new DateTime(1900, 1, 1), new DateTime(1900, 12, 31));
+		_ = service.ResolveNotableDatesInRange(new DateTime(2000, 6, 1), new DateTime(2001, 6, 30));
+		_ = service.ResolveNotableDatesInRange(new DateTime(2099, 1, 1), new DateTime(2099, 12, 31));
+
+		IReadOnlyList<DateRange> windows = service.ResolvedWindows;
+
+		Assert.AreEqual(3, windows.Count, $"Expected three disjoint resolved windows; got {windows.Count}.");
+		Assert.AreEqual(new DateTime(1900, 1, 1), windows[0].StartDate);
+		Assert.AreEqual(new DateTime(1900, 12, 31), windows[0].EndDate);
+		Assert.AreEqual(new DateTime(2000, 6, 1), windows[1].StartDate);
+		Assert.AreEqual(new DateTime(2001, 6, 30), windows[1].EndDate);
+		Assert.AreEqual(new DateTime(2099, 1, 1), windows[2].StartDate);
+		Assert.AreEqual(new DateTime(2099, 12, 31), windows[2].EndDate);
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.Boundaries.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.Boundaries.cs
@@ -304,12 +304,12 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 	/// </summary>
 	[DataTestMethod]
 	[DataRow(2026, 7, 1, 1, 2026, 7, 2)]      // +1 day
-	[DataRow(2026, 7, 1, 365, 2027, 7, 1)]    // +1 year
-	[DataRow(2026, 7, 1, 730, 2028, 7, 1)]    // +2 years (leap year between)
-	[DataRow(2026, 7, 1, 3650, 2036, 6, 28)]  // +10 years
+	[DataRow(2026, 7, 1, 365, 2027, 7, 1)]    // +1 year (no leap day in [Jul 1 2026, Jul 1 2027))
+	[DataRow(2026, 7, 1, 730, 2028, 6, 30)]   // +2 years − 1 day: Feb 29 2028 falls in [Jul 1 2027, Jul 1 2028) so the second year is 366 days
+	[DataRow(2026, 7, 1, 3650, 2036, 6, 28)]  // +10 years − 3 days: leap days 2028, 2032, 2036 contribute 3 extra days
 	[DataRow(2026, 7, 1, -1, 2026, 6, 30)]    // -1 day
-	[DataRow(2026, 7, 1, -365, 2025, 7, 1)]   // -1 year
-	[DataRow(2026, 7, 1, -3650, 2016, 7, 4)]  // -10 years
+	[DataRow(2026, 7, 1, -365, 2025, 7, 1)]   // -1 year (no leap day in [Jul 1 2025, Jul 1 2026))
+	[DataRow(2026, 7, 1, -3650, 2016, 7, 3)]  // -10 years + 2 days: leap days 2020, 2024 contribute 2 extra days (2016 leap day is before Jul 1 2016)
 	public void Resolve_WhenOffsetRuleProjectionStaysInRange_ShouldEmitAtProjectedDate(
 		int anchorYear, int anchorMonth, int anchorDay,
 		int offsetDays,

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.LeapYear.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.LeapYear.cs
@@ -1,0 +1,431 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRangePipelineScenarioTests.LeapYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Globalization.Calendar.RangeResolution;
+
+/// <summary>
+/// Data-driven tests for notable-date rules that interact with the Gregorian leap-year cycle: Feb-29 anchors, offset rules
+/// projecting from leap-day anchors, <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> rules in February, multi-day spans
+/// crossing 29 February, the <see cref="AdjustmentTrigger.IfLeapYear" /> trigger, the resolver's
+/// <c>ComparisonDate = 29 Feb</c> clamping behaviour, algorithmic Easter across leap and non-leap years, and weekend
+/// roll-forward on a Saturday Feb 29.
+/// </summary>
+public sealed partial class NotableDateRangePipelineScenarioTests
+{
+	// =====================================================================================================================
+	// Feb-29 fixed rule across the leap-year cycle
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a fixed-date rule on 29 February emits only in leap years and is silently skipped in non-leap years
+	/// (including the century rule 2100 and the divisible-by-400 century 2400).
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2020, true)]   // Divisible by 4 → leap
+	[DataRow(2021, false)]
+	[DataRow(2022, false)]
+	[DataRow(2023, false)]
+	[DataRow(2024, true)]   // Leap
+	[DataRow(2025, false)]
+	[DataRow(2026, false)]
+	[DataRow(2027, false)]
+	[DataRow(2028, true)]   // Leap
+	[DataRow(2100, false)]  // Century not divisible by 400 → non-leap
+	[DataRow(2400, true)]   // Century divisible by 400 → leap
+	public void LeapYear_FixedDateOnFeb29_ShouldEmitOnlyInLeapYears(int year, bool isLeapYear)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Leap Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Observance,
+			Month = 2,
+			Day = 29,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 2, 1),
+			new DateTime(year, 3, 31));
+
+		if (isLeapYear)
+		{
+			NotableDate match = resolved.Single(n => n.Name == "Leap Day");
+			Assert.AreEqual(new DateTime(year, 2, 29), match.Date);
+		}
+		else
+		{
+			Assert.IsFalse(resolved.Any(n => n.Name == "Leap Day"),
+				$"Leap Day rule should be silently skipped in non-leap year {year}.");
+		}
+	}
+
+	// =====================================================================================================================
+	// Offset rules anchored on the leap day
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that an offset rule whose root anchor resolves only in leap years ("Day After Leap Day = Feb 29 + 1") emits
+	/// in leap years and is silently skipped in non-leap years because the anchor itself does not resolve.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2020, true, 2020, 3, 1)]
+	[DataRow(2023, false, 0, 0, 0)]
+	[DataRow(2024, true, 2024, 3, 1)]
+	[DataRow(2025, false, 0, 0, 0)]
+	public void LeapYear_OffsetRuleAnchoredOnLeapDay_ShouldEmitOnlyInLeapYears(
+		int year,
+		bool isLeapYear,
+		int expectedYear,
+		int expectedMonth,
+		int expectedDay)
+	{
+		NotableDateRule anchor = new()
+		{
+			Name = "Leap Day",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Observance,
+			Month = 2,
+			Day = 29,
+		};
+
+		NotableDateRule offset = new()
+		{
+			Name = "Day After Leap Day",
+			Strategy = DateResolutionStrategy.OffsetFromAnchor,
+			Category = NotableDateCategory.Observance,
+			AnchorRuleName = "Leap Day",
+			OffsetDays = 1,
+		};
+
+		NotableDateService service = BuildService(anchor, offset);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 2, 1),
+			new DateTime(year, 3, 31));
+
+		if (isLeapYear)
+		{
+			NotableDate match = resolved.Single(n => n.Name == "Day After Leap Day");
+			Assert.AreEqual(new DateTime(expectedYear, expectedMonth, expectedDay), match.Date);
+		}
+		else
+		{
+			Assert.IsFalse(resolved.Any(n => n.Name == "Day After Leap Day"));
+		}
+	}
+
+	// =====================================================================================================================
+	// DayOfWeekInMonth in February
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> rule for the last Monday of February resolves to
+	/// the actual last Monday in both leap and non-leap years (the extra day in a leap year does not change the last-Monday
+	/// position when 29 Feb is not itself a Monday).
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2024, 2, 26)] // Leap year. Feb 29 = Thu; Mondays in Feb: 5, 12, 19, 26. Last Mon = 26 Feb 2024.
+	[DataRow(2025, 2, 24)] // Non-leap. Feb 28 = Fri; Mondays: 3, 10, 17, 24. Last Mon = 24 Feb 2025.
+	[DataRow(2026, 2, 23)] // Non-leap. Feb 28 = Sat; Mondays: 2, 9, 16, 23. Last Mon = 23 Feb 2026.
+	[DataRow(2028, 2, 28)] // Leap year. Feb 28 = Mon, Feb 29 = Tue → last Mon = 28 Feb 2028.
+	public void LeapYear_DayOfWeekInMonthLastMondayOfFebruary_ShouldResolveCorrectlyAcrossLeapAndNonLeap(
+		int year,
+		int expectedMonth,
+		int expectedDay)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Last Monday of February",
+			Strategy = DateResolutionStrategy.DayOfWeekInMonth,
+			Category = NotableDateCategory.Observance,
+			Month = 2,
+			DayOfWeek = DayOfWeek.Monday,
+			WeekOrdinal = WeekOfMonthOrdinal.Last,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 2, 1),
+			new DateTime(year, 2, 28));
+
+		NotableDate match = resolved.Single(n => n.Name == "Last Monday of February");
+		Assert.AreEqual(new DateTime(year, expectedMonth, expectedDay), match.Date);
+	}
+
+	// =====================================================================================================================
+	// Multi-day spans crossing the leap day
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a multi-day span anchored on 27 February with <see cref="NotableDateRule.DurationDays" /> = 4 includes
+	/// 29 February in its end date inside a leap year and skips it in a non-leap year. The end date is computed inclusively
+	/// from <c>Date + (DurationDays - 1)</c>.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2024, 2024, 3, 1)] // Leap year. Span Feb 27, 28, 29, Mar 1.
+	[DataRow(2025, 2025, 3, 2)] // Non-leap. Span Feb 27, 28, Mar 1, Mar 2 — same number of days, different end.
+	public void LeapYear_MultiDaySpanFromFeb27_ShouldStraddleLeapDayCorrectly(
+		int year,
+		int expectedEndYear,
+		int expectedEndMonth,
+		int expectedEndDay)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Feb-End Festival",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Cultural,
+			Month = 2,
+			Day = 27,
+			DurationDays = 4,
+			FirstYear = year,
+			LastYear = year,
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 2, 1),
+			new DateTime(year, 3, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Feb-End Festival");
+		Assert.AreEqual(new DateTime(year, 2, 27), match.Date);
+		Assert.AreEqual(4, match.DurationDays);
+		Assert.AreEqual(new DateTime(expectedEndYear, expectedEndMonth, expectedEndDay), match.EndDate);
+	}
+
+	// =====================================================================================================================
+	// IfLeapYear adjustment fires only in leap years
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a rule with an <see cref="AdjustmentTrigger.IfLeapYear" /> + <see cref="AdjustmentAction.AddDays" />(+1)
+	/// adjustment shifts only in leap years and emits the unchanged base anchor in non-leap years.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2024, true)]   // Leap
+	[DataRow(2025, false)]
+	[DataRow(2026, false)]
+	[DataRow(2027, false)]
+	[DataRow(2028, true)]   // Leap
+	public void LeapYear_AdjustmentIfLeapYear_ShouldFireOnlyInLeapYears(int year, bool expectedFire)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Leap-Aware Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 7,
+			Day = 1,
+			FirstYear = year,
+			LastYear = year,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "leap-year-shift",
+				Trigger = AdjustmentTrigger.IfLeapYear,
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 1,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 6, 1),
+			new DateTime(year, 7, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Leap-Aware Holiday");
+
+		if (expectedFire)
+		{
+			Assert.AreEqual(new DateTime(year, 7, 2), match.Date);
+			Assert.IsTrue(match.WasAdjusted);
+			Assert.AreEqual(new DateTime(year, 7, 1), match.AdjustmentReason!.OriginalDate);
+		}
+		else
+		{
+			Assert.AreEqual(new DateTime(year, 7, 1), match.Date);
+			Assert.IsFalse(match.WasAdjusted);
+		}
+	}
+
+	// =====================================================================================================================
+	// ComparisonDate = Feb 29 — resolver clamps to Feb 28 in non-leap years
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that <see cref="AdjustmentTrigger.IfBeforeFixedDate" /> with a <see cref="ObservanceAdjustment.ComparisonDate" />
+	/// of 29 February correctly clamps to 28 February in non-leap years, matching the resolver's
+	/// <c>ProjectComparisonDate</c> fallback path.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2025, 2, 27, true)]    // Non-leap year. Anchor 27 Feb 2025 < projected 28 Feb 2025 → fires.
+	[DataRow(2025, 2, 28, false)]   // Non-leap year. Anchor 28 Feb 2025 strict < 28 Feb 2025 is false → no fire.
+	[DataRow(2024, 2, 28, true)]    // Leap year. Projected = 29 Feb 2024. Anchor 28 Feb 2024 < 29 Feb 2024 → fires.
+	[DataRow(2024, 2, 29, false)]   // Leap year. Projected = 29 Feb 2024. Anchor 29 Feb 2024 strict < 29 Feb 2024 is false.
+	public void LeapYear_AdjustmentComparisonDateIsFeb29_ShouldClampToFeb28InNonLeapYear(
+		int year,
+		int month,
+		int day,
+		bool expectedFire)
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Probe",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = month,
+			Day = day,
+			FirstYear = year,
+			LastYear = year,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "before-feb-29",
+				Trigger = AdjustmentTrigger.IfBeforeFixedDate,
+				ComparisonDate = new DateTime(2024, 2, 29), // Year is replaced at evaluation; needs to be a leap year for this constructor to succeed.
+				Action = AdjustmentAction.AddDays,
+				OffsetDays = 1,
+			}),
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 2, 1),
+			new DateTime(year, 3, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Probe");
+
+		Assert.AreEqual(expectedFire, match.WasAdjusted);
+		DateTime expected = expectedFire
+			? new DateTime(year, month, day).AddDays(1)
+			: new DateTime(year, month, day);
+		Assert.AreEqual(expected, match.Date);
+	}
+
+	// =====================================================================================================================
+	// Algorithmic Easter across the leap-year cycle
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that the algorithmic Easter Sunday computation produces the correct date in both leap and non-leap years.
+	/// Easter is the first Sunday after the first ecclesiastical full moon following the spring equinox; the leap-year status
+	/// of the year affects the calendar but the algorithm's published outputs are well-defined.
+	/// </summary>
+	[DataTestMethod]
+	[DataRow(2023, 4, 9)]   // Non-leap
+	[DataRow(2024, 3, 31)]  // Leap
+	[DataRow(2025, 4, 20)]
+	[DataRow(2026, 4, 5)]
+	[DataRow(2027, 3, 28)]
+	[DataRow(2028, 4, 16)]  // Leap
+	public void LeapYear_AlgorithmicEasterSundayAcrossLeapAndNonLeapYears_ShouldComputeKnownDates(
+		int year,
+		int expectedMonth,
+		int expectedDay)
+	{
+		NotableDateRule easter = new()
+		{
+			Name = "Easter Sunday",
+			Strategy = DateResolutionStrategy.Algorithm,
+			Category = NotableDateCategory.Religious,
+			AlgorithmKey = EasterAlgorithmKey,
+		};
+
+		NotableDateService service = BuildService(easter);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(year, 1, 1),
+			new DateTime(year, 12, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Easter Sunday");
+		Assert.AreEqual(new DateTime(year, expectedMonth, expectedDay), match.Date);
+	}
+
+	// =====================================================================================================================
+	// Weekend roll-forward on Saturday 29 Feb
+	// =====================================================================================================================
+
+	/// <summary>
+	/// Verifies that a Feb-29 holiday whose adjustment rolls weekend anchors forward emits the Monday substitute when 29 Feb
+	/// itself falls on a Saturday. 29 Feb 2020 = Saturday; the substitute lands on Monday 2 March 2020.
+	/// </summary>
+	[TestMethod]
+	public void LeapYear_AdjustmentRollsLeapDaySaturdayToFollowingMonday_ShouldEmitMondaySubstitute()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Leap Day Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 2,
+			Day = 29,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-substitute",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2020, 2, 1),
+			new DateTime(2020, 3, 31));
+
+		NotableDate substitute = resolved.Single(n => n.Name == "Leap Day Holiday");
+		Assert.AreEqual(new DateTime(2020, 3, 2), substitute.Date);
+		Assert.IsTrue(substitute.WasAdjusted);
+		Assert.AreEqual(new DateTime(2020, 2, 29), substitute.AdjustmentReason!.OriginalDate);
+	}
+
+	/// <summary>
+	/// Verifies that a Feb-29 holiday whose adjustment rolls weekend anchors forward emits the unchanged anchor when 29 Feb
+	/// falls on a weekday. 29 Feb 2024 = Thursday; no adjustment fires.
+	/// </summary>
+	[TestMethod]
+	public void LeapYear_AdjustmentSkipsLeapDayThursday_ShouldEmitBaseAnchor()
+	{
+		NotableDateRule rule = new()
+		{
+			Name = "Leap Day Holiday",
+			Strategy = DateResolutionStrategy.Fixed,
+			Category = NotableDateCategory.Holiday,
+			Month = 2,
+			Day = 29,
+			IsNonWorkingDay = true,
+			Adjustments = ImmutableArray.Create(new ObservanceAdjustment
+			{
+				Key = "weekend-substitute",
+				Trigger = AdjustmentTrigger.IfWeekend,
+				Action = AdjustmentAction.MoveToNextNonWorkingDay,
+				IsNonWorkingDay = true,
+			}),
+		};
+
+		NotableDateService service = BuildService(rule);
+
+		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
+			new DateTime(2024, 2, 1),
+			new DateTime(2024, 3, 31));
+
+		NotableDate match = resolved.Single(n => n.Name == "Leap Day Holiday");
+		Assert.AreEqual(new DateTime(2024, 2, 29), match.Date);
+		Assert.IsFalse(match.WasAdjusted);
+	}
+}


### PR DESCRIPTION
## Summary

Two new partial test files extending `NotableDateRangePipelineScenarioTests` that push the prototype range-resolution
pipeline at the supported-input-space extremes and across the Gregorian leap-year cycle.

## `Boundaries.cs` — 16 tests

| Category | Coverage |
|---|---|
| Calendar-year boundaries | Year 1 anchor; window at `DateTime.MinValue.Date`; year 9999 anchor; window at `DateTime.MaxValue.Date` |
| Window-shape extremes | Single-day window (start == end); multi-decade windows (10 / 41 / 101 years) — DataRow-driven; empty rule set |
| Long-duration spans | `DurationDays = 365` spanning the entire civil year; multi-day span ending exactly on `DateTime.MaxValue.Date` |
| Offset projection overflow / underflow | DataRow ±1, ±365, ±730, ±3650 days within range; +100 offset overflowing past 9999-12-31 → silently skipped; -100 underflow → silently skipped; +6 landing exactly on `DateTime.MaxValue.Date` → emit |
| Adjustment reach pushed wide | `MaxAdjustmentReachDays = 1000` widens the fringe distance enough to admit a 2024 anchor whose +1000-day shift lands on 27 Sep 2026 in a single-day query window |
| Multi-decade `ResolvedWindows` | Three disjoint queries 1900 / 2000-2001 / 2099 retained as three disjoint intervals |

## `LeapYear.cs` — 10 tests

| Category | Coverage |
|---|---|
| Feb-29 fixed rule | DataRow per year 2020-2028 + 2100 (century non-leap) + 2400 (century leap divisible by 400) |
| Offset anchored on leap day | "Day After Leap Day" emits only in leap years (anchor doesn't resolve in non-leap years) |
| DayOfWeekInMonth in February | Last Monday of February: 2024 (leap, 26 Feb), 2025 (non-leap, 24 Feb), 2026 (non-leap, 23 Feb), 2028 (leap, 28 Feb — when it's itself the last Monday) |
| Multi-day span across leap day | Anchor 27 Feb with `DurationDays = 4` → end 1 Mar in leap, 2 Mar in non-leap |
| `IfLeapYear` adjustment trigger | DataRow per year — fires only in leap years, AddDays(+1) shift observable |
| `ComparisonDate = Feb 29` clamping | `IfBeforeFixedDate`: resolver clamps to Feb 28 in non-leap years; pinned for both leap (2024) and non-leap (2025) years across the strict `<` boundary |
| Algorithmic Easter | DataRow Easter Sunday across 2023-2028 (mix of leap and non-leap) |
| Weekend roll-forward Feb 29 | Feb 29 2020 = Sat → walk to Mon 2 Mar; Feb 29 2024 = Thu → no shift |

## Test plan

- [ ] `dotnet test Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj --settings test.runsettings --filter "FullyQualifiedName~Boundaries|FullyQualifiedName~LeapYear"`
- [ ] All existing tests still pass.

## Notes

- All anchor and emission dates are real Gregorian calendar values verifiable against any almanac. Examples: Feb 29 2020 = Sat, Feb 29 2024 = Thu, Easter 2024 = 31 Mar, Easter 2028 = 16 Apr, Last Mon of Feb 2026 = 23 Feb.
- The `MaxAdjustmentReachDays = 1000` test exercises the planner's fringe-distance widening end-to-end: anchor 1 Jan 2024 + 1000 days = 27 Sep 2026; without the explicit reach declaration the default 7-day fringe would not admit year 2024 as a fringe year and the adjustment would be invisible.
- Offset projection overflow / underflow tests rely on the pipeline's existing try/catch around `DateTime.AddDays` in `ProcessOffsetFromCached`. Adjustment-action overflow (e.g. `AddDays = 100` near year 9999) is currently *not* caught and would propagate; pinning that scenario is deliberately deferred to a future fix PR rather than masked here.

https://claude.ai/code/session_01Bt7aVfAshdFniYjdyR77q8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt7aVfAshdFniYjdyR77q8)_