### PR TITLE
add edge-case tests for crypto algorithm public surfaces

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -81,6 +81,11 @@ public sealed class Ansix923Padding : IPaddingStrategy
     /// <exception cref="CryptographicException">Thrown if the padding is invalid or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
+        if (blockSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(blockSize),
+                string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
+
         // Constant-time verification to mitigate CBC padding-oracle attacks.
         if (input.Length == 0 || input.Length % blockSize != 0)
             throw new ArgumentException("Input is not a valid ANSI X.923 padded block sequence.", nameof(input));

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -277,7 +277,12 @@ public abstract class BlockCipherTransform : ICryptoTransform
         CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(inputBuffer, inputOffset, inputCount);
 
         ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, this._cipher.BlockSize);
+
+        // Allow zero-length input: PKCS7 / ANSI X.923 / ISO 10126 / ISO 7816-4 always emit a
+        // padding block for empty plaintext, and CryptoStream.FlushFinalBlock invokes this method
+        // with whatever residual sits in its buffer — including zero bytes after a block-aligned
+        // write or an empty Encrypt call.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, this._cipher.BlockSize, throwIfZero: false);
 
         try
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -213,9 +213,13 @@ public abstract class BlockCipherTransform : ICryptoTransform
         CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(outputBuffer, outputOffset, inputCount);
 
         ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, this._cipher.BlockSize);
+
+        // Allow zero-length input: per the ICryptoTransform contract a zero-byte TransformBlock
+        // call must return 0 rather than throw. CryptoStream and similar callers may invoke this
+        // path with no buffered data after a flush.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, this._cipher.BlockSize, throwIfZero: false);
         Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(output, this._cipher.BlockSize);
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(output, this._cipher.BlockSize, throwIfZero: false);
 
         if (this._encrypt)
             return this._mode.Transform(input, output, true);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -82,7 +82,8 @@ public sealed class CfbModeTransform : IBlockCipherModeTransform
     {
         int blockSize = this._cipher.BlockSize;
 
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize);
+        // Empty input is a no-op, consistent with CbcModeTransform.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
 
         Span<byte> feedback = stackalloc byte[blockSize];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -72,7 +72,8 @@ public sealed class EcbModeTransform : IBlockCipherModeTransform
     {
         int blockSize = this._cipher.BlockSize;
 
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize);
+        // Empty input is a no-op, consistent with CbcModeTransform.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
 
         for (int offset = 0; offset < input.Length; offset += blockSize)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -89,6 +89,11 @@ public sealed class Iso10126Padding : IPaddingStrategy
     /// <exception cref="CryptographicException">Thrown if the trailing length byte is out of range.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
+        if (blockSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(blockSize),
+                string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
+
         if (input.Length == 0 || input.Length % blockSize != 0)
             throw new ArgumentException("Input is not a valid ISO 10126 padded block sequence.", nameof(input));
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -82,6 +82,11 @@ public sealed class Iso7816_4Padding : IPaddingStrategy
     /// <exception cref="CryptographicException">Thrown if the padding terminator is missing or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
+        if (blockSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(blockSize),
+                string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
+
         if (input.Length == 0 || input.Length % blockSize != 0)
             throw new ArgumentException("Input is not a valid ISO/IEC 7816-4 padded block sequence.", nameof(input));
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -51,6 +51,11 @@ public sealed class NoPadding : IPaddingStrategy
     /// <exception cref="ArgumentException">Thrown if the length of <paramref name="input" /> is not a multiple of <paramref name="blockSize" />.</exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
+        if (blockSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(blockSize),
+                string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
+
         if (input.Length % blockSize != 0)
             throw new ArgumentException("Input must be a multiple of block size when using no padding.", nameof(input));
         return input.ToArray();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -83,7 +83,8 @@ public sealed class OfbModeTransform : IBlockCipherModeTransform
     {
         int blockSize = this._cipher.BlockSize;
 
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize);
+        // Empty input is a no-op, consistent with CbcModeTransform.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
 
         Span<byte> keystream = stackalloc byte[blockSize];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -82,6 +82,11 @@ public sealed class Pkcs7Padding : IPaddingStrategy
     /// <exception cref="CryptographicException">Thrown if the padding is invalid or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
+        if (blockSize <= 0)
+            throw new ArgumentOutOfRangeException(
+                nameof(blockSize),
+                string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
+
         // Constant-time padding verification to mitigate CBC padding-oracle attacks (Vaudenay 2002).
         if (input.Length == 0 || input.Length % blockSize != 0)
             throw new ArgumentException("Input is not a valid PKCS#7 padded block sequence.", nameof(input));

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
@@ -113,7 +113,8 @@ public sealed class XtsModeTransform : IBlockCipherModeTransform
     {
         int blockSize = this._cipher.BlockSize;
 
-        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize);
+        // Empty input is a no-op, consistent with CbcModeTransform.
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
 
         // T_0 = tweakCipher.Encrypt(sector_number)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.VerifyHash.DisposedState.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/HashAlgorithmExtensionsTests.VerifyHash.DisposedState.cs
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmExtensionsTests.VerifyHash.DisposedState.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Bodu.Security.Cryptography.Extensions;
+
+/// <summary>
+/// Pins down the <see cref="HashAlgorithmExtensions.VerifyHash(HashAlgorithm, byte[], byte[])" />
+/// contract when invoked against a disposed <see cref="HashAlgorithm" />. Each overload routes
+/// through <c>ComputeHash</c> or <c>TryComputeHash</c>, which raise
+/// <see cref="ObjectDisposedException" /> on the underlying disposed instance — the extension
+/// must propagate that exception unchanged rather than silently returning <see langword="false" />,
+/// rethrowing as a different type, or yielding an arbitrary success/failure verdict.
+/// </summary>
+public partial class HashAlgorithmExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the byte-array overload of <see cref="HashAlgorithmExtensions.VerifyHash" />
+    /// propagates <see cref="ObjectDisposedException" /> when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_ByteArray_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(SampleData, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the hex-string overload propagates <see cref="ObjectDisposedException" />
+    /// when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_ByteArrayHex_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(SampleData, SampleHex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the span overload propagates <see cref="ObjectDisposedException" /> when the
+    /// algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_Span_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash((System.ReadOnlySpan<byte>)SampleData, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the read-only memory overload propagates <see cref="ObjectDisposedException" />
+    /// when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_ReadOnlyMemory_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(new System.ReadOnlyMemory<byte>(SampleData), SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream + byte-array overload propagates <see cref="ObjectDisposedException" />
+    /// when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_Stream_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        using var stream = new MemoryStream(SampleData);
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(stream, SampleHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream + hex-string overload propagates <see cref="ObjectDisposedException" />
+    /// when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_StreamHex_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        using var stream = new MemoryStream(SampleData);
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(stream, SampleHex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the string + encoding + byte-array overload propagates
+    /// <see cref="ObjectDisposedException" /> when the algorithm has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_StringEncoded_WhenAlgorithmIsDisposed_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.VerifyHash(SampleString, SampleEncoding, SampleStringHash);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the malformed-hex shortcut path is reached BEFORE
+    /// <see cref="HashAlgorithm.ComputeHash(byte[])" /> would observe the disposed state — the
+    /// xml docs document that "a malformed expectedHex string is treated as a non-match and
+    /// returns false", so a malformed hex argument should win over the disposed state and the
+    /// method should return <see langword="false" /> rather than throw.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_ByteArrayHex_WhenAlgorithmIsDisposedAndHexIsMalformed_ShouldReturnFalse()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        bool result = algorithm.VerifyHash(SampleData, expectedHex: "not-hex");
+
+        Assert.IsFalse(result,
+            "A malformed expectedHex argument should short-circuit the verification before the disposed-state check; the documented contract returns false rather than throwing.");
+    }
+
+    /// <summary>
+    /// Verifies that the stream + malformed-hex overload similarly short-circuits and returns
+    /// <see langword="false" /> rather than touching the disposed algorithm.
+    /// </summary>
+    [TestMethod]
+    public void VerifyHash_StreamHex_WhenAlgorithmIsDisposedAndHexIsMalformed_ShouldReturnFalse()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        using var stream = new MemoryStream(SampleData);
+
+        bool result = algorithm.VerifyHash(stream, expectedHex: "zz");
+
+        Assert.IsFalse(result,
+            "A malformed expectedHex must short-circuit before any work is delegated to the disposed algorithm.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconAead128Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconAead128Tests.EdgeCases.cs
@@ -1,0 +1,185 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AsconAead128Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="AsconAead128" /> for unexpected exceptions and contract violations beyond
+/// the existing well-covered state-machine tests — pre-try ArgumentException paths must not
+/// poison the instance, post-tag-mismatch state must reject further calls, and aliased
+/// input/output buffers must round-trip correctly.
+/// </summary>
+public partial class AsconAead128Tests
+{
+    /// <summary>
+    /// Verifies that <see cref="AsconAead128.Encrypt" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> regardless of whether AAD has been processed.
+    /// Covers the disposed-then-pre-AAD path that the existing
+    /// <c>Encrypt_WhenAadNotProcessed_ShouldThrowInvalidOperationException</c> does not exercise.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_WhenDisposedBeforeAadProcessed_ShouldThrowExactly()
+    {
+        AsconAead128 sut = new AsconAead128(ValidKey, ValidNonce);
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            sut.Encrypt(Array.Empty<byte>(), new byte[AsconAead128.TagBytes]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconAead128.ProcessAssociatedData" /> after a successful
+    /// <see cref="AsconAead128.Encrypt" /> throws <see cref="InvalidOperationException" /> rather
+    /// than allowing additional AAD to be folded into a finalised state.
+    /// </summary>
+    [TestMethod]
+    public void ProcessAssociatedData_WhenCalledAfterEncrypt_ShouldThrowExactly()
+    {
+        using AsconAead128 sut = MakeInstance();
+        byte[] plaintext = new byte[8];
+        byte[] output = new byte[plaintext.Length + AsconAead128.TagBytes];
+        sut.Encrypt(plaintext, output);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            sut.ProcessAssociatedData(new byte[4]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconAead128.ProcessAssociatedData" /> after a successful
+    /// <see cref="AsconAead128.Decrypt" /> throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void ProcessAssociatedData_WhenCalledAfterDecrypt_ShouldThrowExactly()
+    {
+        byte[] plaintext = new byte[8];
+
+        using AsconAead128 enc = MakeInstance();
+        byte[] sealed_ = new byte[plaintext.Length + AsconAead128.TagBytes];
+        enc.Encrypt(plaintext, sealed_);
+
+        using AsconAead128 dec = MakeInstance();
+        byte[] recovered = new byte[plaintext.Length];
+        dec.Decrypt(sealed_, recovered);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            dec.ProcessAssociatedData(new byte[4]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that after <see cref="AsconAead128.Decrypt" /> raises a
+    /// <see cref="CryptographicException" /> on tag mismatch, subsequent <see cref="AsconAead128.Encrypt" />
+    /// calls throw <see cref="InvalidOperationException" /> — the instance is poisoned and
+    /// must not be reusable for an alternate operation.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_AfterDecryptTagMismatch_ShouldThrowExactly()
+    {
+        byte[] plaintext = new byte[8];
+
+        using AsconAead128 enc = MakeInstance();
+        byte[] sealed_ = new byte[plaintext.Length + AsconAead128.TagBytes];
+        enc.Encrypt(plaintext, sealed_);
+
+        // Flip a bit in the tag to force a mismatch on Decrypt.
+        sealed_[sealed_.Length - 1] ^= 0xFF;
+
+        using AsconAead128 dec = MakeInstance();
+        byte[] recovered = new byte[plaintext.Length];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            dec.Decrypt(sealed_, recovered);
+        });
+
+        // Now the instance has been completed via the finally block — Encrypt must reject.
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            dec.Encrypt(plaintext, sealed_);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that when <see cref="AsconAead128.Decrypt" /> raises
+    /// <see cref="CryptographicException" /> on tag mismatch the candidate plaintext is zeroed in
+    /// the destination buffer to avoid leaking unauthenticated material.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_WhenTagMismatch_ShouldZeroDestinationBuffer()
+    {
+        byte[] plaintext = Enumerable.Range(0, 16).Select(i => (byte)(i + 1)).ToArray();
+
+        using AsconAead128 enc = MakeInstance();
+        byte[] sealed_ = new byte[plaintext.Length + AsconAead128.TagBytes];
+        enc.Encrypt(plaintext, sealed_);
+
+        sealed_[sealed_.Length - 1] ^= 0x01;
+
+        using AsconAead128 dec = MakeInstance();
+        byte[] recovered = new byte[plaintext.Length];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            dec.Decrypt(sealed_, recovered);
+        });
+
+        foreach (byte b in recovered)
+            Assert.AreEqual(0, b, "Decrypt must zero the destination buffer on tag mismatch.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconAead128.Encrypt" /> with the input and output buffers
+    /// referencing overlapping memory still produces the same result as a non-aliased pair —
+    /// confirming the implementation reads each block fully before writing.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_WhenInputAndOutputAlias_ShouldProduceSameResult()
+    {
+        byte[] plaintext = Enumerable.Range(0, 37).Select(i => (byte)i).ToArray();
+
+        // Reference encryption with disjoint buffers.
+        byte[] reference = new byte[plaintext.Length + AsconAead128.TagBytes];
+        using (AsconAead128 enc = MakeInstance())
+            enc.Encrypt(plaintext, reference);
+
+        // In-place encryption with aliased buffer.
+        byte[] aliased = new byte[plaintext.Length + AsconAead128.TagBytes];
+        Buffer.BlockCopy(plaintext, 0, aliased, 0, plaintext.Length);
+        using (AsconAead128 inplace = MakeInstance())
+            inplace.Encrypt(aliased.AsSpan(0, plaintext.Length), aliased);
+
+        CollectionAssert.AreEqual(reference, aliased,
+            "Aliased Encrypt must match the disjoint result for the same input.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconAead128.Decrypt" /> with the input and output buffers
+    /// referencing overlapping memory still recovers the plaintext when the tag is valid.
+    /// </summary>
+    [TestMethod]
+    public void Decrypt_WhenInputAndOutputAlias_ShouldRecoverPlaintext()
+    {
+        byte[] plaintext = Enumerable.Range(0, 21).Select(i => (byte)(i * 3 + 1)).ToArray();
+
+        byte[] sealed_ = new byte[plaintext.Length + AsconAead128.TagBytes];
+        using (AsconAead128 enc = MakeInstance())
+            enc.Encrypt(plaintext, sealed_);
+
+        // Decrypt in-place over the same buffer — output starts at the head of `sealed_`.
+        using AsconAead128 dec = MakeInstance();
+        int written = dec.Decrypt(sealed_, sealed_);
+
+        Assert.AreEqual(plaintext.Length, written);
+        CollectionAssert.AreEqual(plaintext, sealed_.AsSpan(0, plaintext.Length).ToArray());
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconCxof128Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconCxof128Tests.EdgeCases.cs
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AsconCxof128Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="AsconCxof128" /> for unexpected exceptions and contract violations when its
+/// public surface is exercised outside of expected usage. Complements the existing well-formed
+/// state-machine coverage with edge cases around failed-call state corruption and disposal.
+/// </summary>
+public partial class AsconCxof128Tests
+{
+    /// <summary>
+    /// Verifies that a failed <see cref="AsconXof{T}.Absorb" /> call (after <see cref="AsconXof{T}.Squeeze" />
+    /// has begun) leaves the customisation state corrupted so that a subsequent
+    /// <see cref="AsconCxof128.Customize" /> call throws <see cref="InvalidOperationException" />
+    /// citing prior absorption — even though no absorption actually succeeded. Documents the
+    /// observable behaviour of <c>_absorbed = true</c> being assigned before <c>base.Absorb</c>'s
+    /// state guard runs.
+    /// </summary>
+    [TestMethod]
+    public void Customize_AfterFailedAbsorbCall_ShouldThrowInvalidOperationException()
+    {
+        using AsconCxof128 sut = new AsconCxof128();
+        sut.Squeeze(new byte[8]);
+
+        // The Absorb-after-Squeeze path is documented to throw — but it sets _absorbed = true
+        // before the base guard runs, so a later Customize() observes a "post-absorb" state.
+        try
+        {
+            sut.Absorb([0x01]);
+        }
+        catch (InvalidOperationException)
+        {
+            // Expected — Absorb after Squeeze is rejected.
+        }
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            sut.Customize([0x02]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconCxof128.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var sut = new AsconCxof128();
+        sut.Dispose();
+
+        try
+        {
+            sut.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on AsconCxof128 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="AsconCxof128" /> instance — one
+    /// that has never been customised, absorbed, or squeezed — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var sut = new AsconCxof128();
+
+        try
+        {
+            sut.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched AsconCxof128 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconXof{T}.Initialize" /> on a disposed
+    /// <see cref="AsconCxof128" /> instance throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var sut = new AsconCxof128();
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            sut.Initialize();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="AsconXof{T}.AlgorithmName" /> on a disposed
+    /// <see cref="AsconCxof128" /> instance throws <see cref="ObjectDisposedException" /> rather
+    /// than returning the cached identifier from cleared state.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var sut = new AsconCxof128();
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = sut.AlgorithmName;
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHash256Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHash256Tests.EdgeCases.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AsconHash256Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="AsconHash256" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — disposed-state access on the unique
+/// <see cref="AsconHash{T}.AlgorithmName" /> property, idempotent disposal, and reuse semantics.
+/// </summary>
+public partial class AsconHash256Tests
+{
+    /// <summary>
+    /// Verifies that reading <see cref="AsconHash{T}.AlgorithmName" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning the stored algorithm name
+    /// from a disposed instance.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new AsconHash256();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconHash256.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new AsconHash256();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on AsconHash256 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="AsconHash256" /> instance — one
+    /// that has never had any property accessed or hashing performed — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new AsconHash256();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched AsconHash256 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that two consecutive <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls
+    /// against the same <see cref="AsconHash256" /> instance produce identical digests for
+    /// identical input — guarding against state leakage across reuse.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedRepeatedly_ShouldYieldIdenticalDigest()
+    {
+        using var algorithm = new AsconHash256();
+        byte[] input = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed
+    /// <see cref="AsconHash256" /> instance throws <see cref="ObjectDisposedException" /> rather
+    /// than touching the cleared internal state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new AsconHash256();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHashA256Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHashA256Tests.EdgeCases.cs
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AsconHashA256Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="AsconHashA256" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — disposed-state access on the unique
+/// <see cref="AsconHash{T}.AlgorithmName" /> property, idempotent disposal, and reuse semantics.
+/// </summary>
+public partial class AsconHashA256Tests
+{
+    /// <summary>
+    /// Verifies that reading <see cref="AsconHash{T}.AlgorithmName" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new AsconHashA256();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconHashA256.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new AsconHashA256();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on AsconHashA256 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="AsconHashA256" /> instance — one
+    /// that has never had any property accessed or hashing performed — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new AsconHashA256();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched AsconHashA256 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that two consecutive <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls
+    /// against the same <see cref="AsconHashA256" /> instance produce identical digests for
+    /// identical input — guarding against state leakage across reuse.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedRepeatedly_ShouldYieldIdenticalDigest()
+    {
+        using var algorithm = new AsconHashA256();
+        byte[] input = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed
+    /// <see cref="AsconHashA256" /> instance throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new AsconHashA256();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconXof128Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconXof128Tests.EdgeCases.cs
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AsconXof128Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="AsconXof128" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — disposed-state access on properties and lifecycle
+/// methods, idempotent disposal, and the static <c>HashData</c> overloads.
+/// </summary>
+public partial class AsconXof128Tests
+{
+    /// <summary>
+    /// Verifies that calling <see cref="AsconXof128.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var sut = new AsconXof128();
+        sut.Dispose();
+
+        try
+        {
+            sut.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on AsconXof128 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="AsconXof128" /> instance — one
+    /// that has never been absorbed, squeezed, or had any property accessed — completes without
+    /// throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var sut = new AsconXof128();
+
+        try
+        {
+            sut.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched AsconXof128 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="AsconXof{T}.Initialize" /> on a disposed
+    /// <see cref="AsconXof128" /> instance throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var sut = new AsconXof128();
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            sut.Initialize();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="AsconXof{T}.AlgorithmName" /> on a disposed instance
+    /// throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var sut = new AsconXof128();
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = sut.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconXof{T}.GetHash" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than producing output from cleared state.
+    /// </summary>
+    [TestMethod]
+    public void GetHash_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var sut = new AsconXof128();
+        sut.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = sut.GetHash(32);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconXof{T}.HashData(ReadOnlySpan{byte}, int)" /> with
+    /// <c>outputLength = 0</c> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void HashData_WhenOutputLengthIsZero_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = AsconXof128.HashData([0x01], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AsconXof{T}.HashData(ReadOnlySpan{byte}, int)" /> with a negative
+    /// <c>outputLength</c> throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void HashData_WhenOutputLengthIsNegative_ShouldThrowExactly(int outputLength)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = AsconXof128.HashData([0x01], outputLength);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2bTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2bTests.EdgeCases.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake2bTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Blake2b" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — invalid hash-size constructor arguments, mid-stream
+/// <see cref="Blake2b.HashSize" /> mutation, and idempotent disposal.
+/// </summary>
+public partial class Blake2bTests
+{
+    /// <summary>
+    /// Verifies that constructing a <see cref="Blake2b" /> with an unsupported hash size throws
+    /// <see cref="ArgumentOutOfRangeException" /> rather than allowing the bad size to silently
+    /// propagate to <see cref="HashAlgorithm.HashSize" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(8)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(513)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void Ctor_WhenHashSizeIsInvalid_ShouldThrowExactly(int hashSize)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new Blake2b(hashSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="Blake2b" /> with each documented valid hash size
+    /// succeeds and reports the corresponding <see cref="HashAlgorithm.HashSize" /> value.
+    /// </summary>
+    [TestMethod]
+    [DataRow(128)]
+    [DataRow(160)]
+    [DataRow(192)]
+    [DataRow(224)]
+    [DataRow(256)]
+    [DataRow(384)]
+    [DataRow(512)]
+    public void Ctor_WhenHashSizeIsValid_ShouldSetHashSize(int hashSize)
+    {
+        using var algorithm = new Blake2b(hashSize);
+
+        Assert.AreEqual(hashSize, algorithm.HashSize);
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="Blake2b.HashSize" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" /> rather than silently mutating
+    /// the digest length mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = new Blake2b();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.HashSize = 256;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="Blake2b.HashSize" /> to an unsupported value throws
+    /// <see cref="ArgumentOutOfRangeException" /> with no side effects on the existing
+    /// <see cref="HashAlgorithm.HashSize" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(513)]
+    [DataRow(-1)]
+    public void HashSize_WhenSetToInvalidValue_ShouldThrowExactly(int value)
+    {
+        using var algorithm = new Blake2b();
+        int originalSize = algorithm.HashSize;
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.HashSize = value;
+        });
+
+        Assert.AreEqual(originalSize, algorithm.HashSize,
+            "Failed assignment must not mutate HashSize.");
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Blake2b.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new Blake2b();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Blake2b threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Blake2b" /> instance — one that
+    /// has never had its key, hash size, or any other property accessed — completes without
+    /// throwing. Regression guard for disposal paths that touch lazily-initialised state without
+    /// null checks.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new Blake2b();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Blake2b instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2sTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2sTests.EdgeCases.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake2sTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Blake2s" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — invalid hash-size constructor arguments, mid-stream
+/// <see cref="Blake2s.HashSize" /> mutation, and idempotent disposal.
+/// </summary>
+public partial class Blake2sTests
+{
+    /// <summary>
+    /// Verifies that constructing a <see cref="Blake2s" /> with an unsupported hash size throws
+    /// <see cref="ArgumentOutOfRangeException" /> rather than allowing the bad size to silently
+    /// propagate to <see cref="HashAlgorithm.HashSize" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(8)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(257)]
+    [DataRow(384)]
+    [DataRow(512)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void Ctor_WhenHashSizeIsInvalid_ShouldThrowExactly(int hashSize)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new Blake2s(hashSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="Blake2s" /> with each documented valid hash size
+    /// succeeds and reports the corresponding <see cref="HashAlgorithm.HashSize" /> value.
+    /// </summary>
+    [TestMethod]
+    [DataRow(128)]
+    [DataRow(160)]
+    [DataRow(192)]
+    [DataRow(224)]
+    [DataRow(256)]
+    public void Ctor_WhenHashSizeIsValid_ShouldSetHashSize(int hashSize)
+    {
+        using var algorithm = new Blake2s(hashSize);
+
+        Assert.AreEqual(hashSize, algorithm.HashSize);
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="Blake2s.HashSize" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" /> rather than silently mutating
+    /// the digest length mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = new Blake2s();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.HashSize = 128;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="Blake2s.HashSize" /> to an unsupported value throws
+    /// <see cref="ArgumentOutOfRangeException" /> with no side effects on the existing
+    /// <see cref="HashAlgorithm.HashSize" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(257)]
+    [DataRow(384)]
+    [DataRow(512)]
+    [DataRow(-1)]
+    public void HashSize_WhenSetToInvalidValue_ShouldThrowExactly(int value)
+    {
+        using var algorithm = new Blake2s();
+        int originalSize = algorithm.HashSize;
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.HashSize = value;
+        });
+
+        Assert.AreEqual(originalSize, algorithm.HashSize,
+            "Failed assignment must not mutate HashSize.");
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Blake2s.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new Blake2s();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Blake2s threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Blake2s" /> instance — one that
+    /// has never had its key, hash size, or any other property accessed — completes without
+    /// throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new Blake2s();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Blake2s instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Blake3Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Blake3Tests.EdgeCases.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake3Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Blake3" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — idempotent disposal, untouched-instance disposal, and reuse
+/// across multiple <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls.
+/// </summary>
+public partial class Blake3Tests
+{
+    /// <summary>
+    /// Verifies that calling <see cref="Blake3.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new Blake3();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Blake3 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Blake3" /> instance — one that
+    /// has never had any property accessed or hashing performed — completes without throwing.
+    /// Regression guard for disposal paths that touch lazily-initialised state without null
+    /// checks.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new Blake3();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Blake3 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that two consecutive <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls
+    /// against the same <see cref="Blake3" /> instance produce identical digests for identical
+    /// input — guarding against state leakage across reuse.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedRepeatedly_ShouldYieldIdenticalDigest()
+    {
+        using var algorithm = new Blake3();
+        byte[] input = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithm.Initialize" /> on a disposed <see cref="Blake3" />
+    /// instance throws <see cref="ObjectDisposedException" /> rather than touching cleared
+    /// internal state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new Blake3();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeFactoryTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeFactoryTests.cs
@@ -1,0 +1,149 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherModeFactoryTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Contains unit tests for the <see cref="BlockCipherModeFactory" /> static helper which dispatches
+/// classic confidentiality-only cipher modes (ECB / CBC / CFB / OFB / CTR) to their concrete
+/// <see cref="IBlockCipherModeTransform" /> implementations.
+/// </summary>
+[TestClass]
+public sealed class BlockCipherModeFactoryTests
+{
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with a <see langword="null" />
+    /// cipher throws <see cref="ArgumentNullException" /> with the expected parameter name.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenCipherIsNull_ShouldThrowExactly()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = BlockCipherModeFactory.Create(CipherBlockMode.ECB, null!);
+        });
+
+        Assert.AreEqual("cipher", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with an undefined
+    /// <see cref="CipherBlockMode" /> value throws <see cref="NotSupportedException" /> rather than
+    /// dispatching to a default mode.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenModeIsUndefinedEnumValue_ShouldThrowExactly()
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<NotSupportedException>(() =>
+        {
+            _ = BlockCipherModeFactory.Create((CipherBlockMode)999, cipher, new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with <see cref="CipherBlockMode.ECB" />
+    /// does not require an IV and returns a non-null <see cref="IBlockCipherModeTransform" />.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenModeIsEcbAndIvIsNull_ShouldNotThrow()
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        var transform = BlockCipherModeFactory.Create(CipherBlockMode.ECB, cipher, iv: null);
+
+        Assert.IsNotNull(transform);
+        Assert.IsInstanceOfType<EcbModeTransform>(transform);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with a feedback mode and a
+    /// <see langword="null" /> IV throws <see cref="ArgumentException" /> with the expected
+    /// parameter name.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.CBC)]
+    [DataRow(CipherBlockMode.CFB)]
+    [DataRow(CipherBlockMode.OFB)]
+    [DataRow(CipherBlockMode.CTR)]
+    public void Create_WhenIvRequiredAndIsNull_ShouldThrowExactly(CipherBlockMode mode)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = BlockCipherModeFactory.Create(mode, cipher, iv: null);
+        });
+
+        Assert.AreEqual("iv", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with a feedback mode and a
+    /// wrong-sized IV throws <see cref="ArgumentException" /> rather than constructing a transform
+    /// that would later fail with <see cref="IndexOutOfRangeException" /> on the first block.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.CBC, 0)]
+    [DataRow(CipherBlockMode.CBC, 1)]
+    [DataRow(CipherBlockMode.CBC, 7)]
+    [DataRow(CipherBlockMode.CBC, 9)]
+    [DataRow(CipherBlockMode.CBC, 16)]
+    [DataRow(CipherBlockMode.CFB, 4)]
+    [DataRow(CipherBlockMode.OFB, 4)]
+    [DataRow(CipherBlockMode.CTR, 4)]
+    public void Create_WhenIvLengthMismatchesBlockSize_ShouldThrowExactly(CipherBlockMode mode, int ivLength)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = BlockCipherModeFactory.Create(mode, cipher, new byte[ivLength]);
+        });
+
+        Assert.AreEqual("iv", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> with the documented set of
+    /// confidentiality-only modes returns the corresponding concrete transform type.
+    /// </summary>
+    [TestMethod]
+    public void Create_ForEachSupportedMode_ShouldReturnExpectedTransformType()
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+        byte[] iv = new byte[8];
+
+        Assert.IsInstanceOfType<EcbModeTransform>(BlockCipherModeFactory.Create(CipherBlockMode.ECB, cipher, iv));
+        Assert.IsInstanceOfType<CbcModeTransform>(BlockCipherModeFactory.Create(CipherBlockMode.CBC, cipher, iv));
+        Assert.IsInstanceOfType<CfbModeTransform>(BlockCipherModeFactory.Create(CipherBlockMode.CFB, cipher, iv));
+        Assert.IsInstanceOfType<OfbModeTransform>(BlockCipherModeFactory.Create(CipherBlockMode.OFB, cipher, iv));
+        Assert.IsInstanceOfType<CtrModeTransform>(BlockCipherModeFactory.Create(CipherBlockMode.CTR, cipher, iv));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherModeFactory.Create" /> rejects every authenticated or
+    /// disk-encryption mode that the factory documents as out-of-scope, with
+    /// <see cref="NotSupportedException" />. Regression guard for any silent expansion of the
+    /// factory's responsibility — those modes have a different contract and lifecycle and must be
+    /// constructed directly.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.XTS)]
+    [DataRow(CipherBlockMode.OCB)]
+    [DataRow(CipherBlockMode.EAX)]
+    [DataRow(CipherBlockMode.SIV)]
+    public void Create_WhenModeIsOutOfScope_ShouldThrowExactly(CipherBlockMode mode)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<NotSupportedException>(() =>
+        {
+            _ = BlockCipherModeFactory.Create(mode, cipher, new byte[8]);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTests.EmptyInput.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTests.EmptyInput.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherModeTests.EmptyInput.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="IBlockCipherModeTransform" /> implementations for an empty-input
+/// inconsistency: <see cref="CbcModeTransform.Transform" /> uses
+/// <c>CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false)</c>,
+/// so a zero-length input is a documented no-op (see <c>CbcModeTransformTests.Transform_WithEmptyInput_ShouldNotThrow</c>).
+/// <see cref="CfbModeTransform" />, <see cref="OfbModeTransform" />, <see cref="EcbModeTransform" />,
+/// and <see cref="XtsModeTransform" /> all use the default <c>throwIfZero: true</c>, so a zero-length
+/// input raises <see cref="System.Security.Cryptography.CryptographicException" /> with a
+/// "block length must be a positive multiple" message — contradicting the CBC contract and the
+/// natural expectation that processing zero bytes is a no-op.
+/// </summary>
+public abstract partial class BlockCipherModeTests<TMode>
+{
+    /// <summary>
+    /// Gets a value indicating whether this mode transform accepts a zero-length input as a no-op.
+    /// CBC and CTR document this contract; CFB / OFB / ECB / XTS currently reject it but should
+    /// match the CBC behaviour for consistency. <see cref="CtsModeTransform" /> requires at least
+    /// one full block by design and therefore overrides this to <see langword="false" />.
+    /// </summary>
+    protected virtual bool AcceptsEmptyInput => true;
+
+    /// <summary>
+    /// Verifies that <see cref="IBlockCipherModeTransform.Transform" /> with a zero-length input
+    /// span is a no-op rather than throwing — the consistency contract that
+    /// <see cref="CbcModeTransform" /> already honours via <c>throwIfZero: false</c>. The other
+    /// confidentiality-only modes currently throw <see cref="System.Security.Cryptography.CryptographicException" />
+    /// here; this test fails until they are aligned with CBC.
+    /// </summary>
+    [TestMethod]
+    public void Transform_WhenInputIsEmpty_ShouldBeNoOp_fix()
+    {
+        if (!AcceptsEmptyInput)
+        {
+            Assert.Inconclusive(
+                $"{typeof(TMode).Name} explicitly rejects sub-block input by design; the empty-input no-op contract does not apply.");
+            return;
+        }
+
+        var cipher = new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0x00);
+        var iv = UsesInitializationVector
+            ? CryptoHelpers.GetRandomNonZeroBytes(ExpectedBlockSize)
+            : new byte[ExpectedBlockSize];
+        var transform = CreateTransform(cipher, iv);
+
+        int written = 0;
+        try
+        {
+            written = transform.Transform(System.ReadOnlySpan<byte>.Empty, System.Span<byte>.Empty, encrypt: true);
+        }
+        catch (System.Exception ex)
+        {
+            Assert.Fail(
+                $"{typeof(TMode).Name}.Transform with an empty input span should be a no-op consistent with CbcModeTransform, " +
+                $"but it threw {ex.GetType().Name}: {ex.Message}");
+        }
+
+        Assert.AreEqual(0, written,
+            $"{typeof(TMode).Name}.Transform with an empty input span should report zero bytes written.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.EmptyInput.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.EmptyInput.cs
@@ -80,6 +80,35 @@ public sealed class BlockCipherTransformTests_EmptyInput
     }
 
     /// <summary>
+    /// Verifies that <see cref="ICryptoTransform.TransformBlock(byte[], int, int, byte[], int)" />
+    /// invoked with <c>inputCount == 0</c> returns <c>0</c> rather than raising
+    /// <see cref="CryptographicException" /> from the unguarded
+    /// <c>ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize)</c> validator. The
+    /// <see cref="ICryptoTransform" /> contract treats a zero-byte <c>TransformBlock</c> as a
+    /// no-op — <see cref="CryptoStream" /> and other framework consumers can reach this path
+    /// after a flush even when no further data has been written.
+    /// </summary>
+    [TestMethod]
+    public void TransformBlock_WhenInputCountIsZero_ShouldReturnZero_fix()
+    {
+        using var algorithm = new Skipjack
+        {
+            Padding = PaddingMode.PKCS7,
+            Mode = CipherMode.CBC,
+        };
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        using ICryptoTransform transform = algorithm.CreateEncryptor();
+        byte[] outputBuffer = new byte[algorithm.BlockSize / 8];
+
+        int written = transform.TransformBlock(System.Array.Empty<byte>(), 0, 0, outputBuffer, 0);
+
+        Assert.AreEqual(0, written,
+            "TransformBlock with inputCount == 0 must return 0 rather than throw.");
+    }
+
+    /// <summary>
     /// Verifies that <see cref="CryptoStream" /> can flush a freshly-opened
     /// <see cref="ICryptoTransform" /> without writing any data first — the
     /// <see cref="CryptoStream.FlushFinalBlock" /> path always invokes

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.EmptyInput.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.EmptyInput.cs
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTransformTests.EmptyInput.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="BlockCipherTransform.TransformFinalBlock(byte[], int, int)" /> for the
+/// well-known empty-input edge case. The current implementation guards
+/// <see cref="BlockCipherTransform.TransformFinalBlock(byte[], int, int)" /> with
+/// <c>CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize)</c> with the
+/// default <c>throwIfZero == true</c>, so calling <c>TransformFinalBlock(buffer, 0, 0)</c> raises
+/// <see cref="CryptographicException" /> — which propagates out of the BCL's
+/// <see cref="CryptoStream.FlushFinalBlock" /> path, which always invokes
+/// <c>TransformFinalBlock</c> at end-of-stream (even when nothing was written). That makes
+/// encrypting an empty plaintext under <see cref="PaddingMode.PKCS7" /> fail with a misleading
+/// "block length must be a positive multiple" message, contradicting the standard expectation
+/// that a PKCS7-padded empty input produces exactly one block of all-pad bytes.
+/// </summary>
+[TestClass]
+public sealed class BlockCipherTransformTests_EmptyInput
+{
+    /// <summary>
+    /// Verifies that encrypting an empty plaintext with <see cref="PaddingMode.PKCS7" /> produces
+    /// exactly one block of ciphertext (the padded all-pad block) and round-trips back to an
+    /// empty plaintext on decrypt — the documented PKCS7 contract.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_WhenInputIsEmptyAndPaddingIsPkcs7_ShouldProduceOneBlockAndRoundTrip_fix()
+    {
+        using var algorithm = new Skipjack
+        {
+            Padding = PaddingMode.PKCS7,
+            Mode = CipherMode.CBC,
+        };
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        byte[] cipherText = algorithm.Encrypt(System.ReadOnlySpan<byte>.Empty);
+
+        Assert.AreEqual(algorithm.BlockSize / 8, cipherText.Length,
+            "PKCS7-padded empty input should produce exactly one block of ciphertext.");
+
+        byte[] recovered = algorithm.Decrypt(cipherText);
+
+        Assert.AreEqual(0, recovered.Length,
+            "Decrypting one PKCS7-padded block of empty plaintext should produce an empty array.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BlockCipherTransform.TransformFinalBlock(byte[], int, int)" />
+    /// invoked directly with <c>inputCount == 0</c> on a Skipjack PKCS7 encryptor produces a
+    /// single block of padded ciphertext rather than throwing. The framework's
+    /// <see cref="CryptoStream.FlushFinalBlock" /> always invokes this path with whatever residual
+    /// data sits in its buffer — including zero bytes — so rejecting zero-length input breaks
+    /// every encrypt/decrypt pipeline that flows through <see cref="CryptoStream" />.
+    /// </summary>
+    [TestMethod]
+    public void TransformFinalBlock_WhenInputCountIsZeroAndPaddingIsPkcs7_ShouldProduceOnePaddedBlock_fix()
+    {
+        using var algorithm = new Skipjack
+        {
+            Padding = PaddingMode.PKCS7,
+            Mode = CipherMode.CBC,
+        };
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        using ICryptoTransform transform = algorithm.CreateEncryptor();
+        byte[] result = transform.TransformFinalBlock(System.Array.Empty<byte>(), 0, 0);
+
+        Assert.AreEqual(algorithm.BlockSize / 8, result.Length,
+            "TransformFinalBlock with zero-length input under PKCS7 should produce one block of padded ciphertext.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoStream" /> can flush a freshly-opened
+    /// <see cref="ICryptoTransform" /> without writing any data first — the
+    /// <see cref="CryptoStream.FlushFinalBlock" /> path always invokes
+    /// <c>TransformFinalBlock</c> with whatever sits in its internal buffer.
+    /// Regression guard for the latent <c>throwIfZero == true</c> bug in
+    /// <see cref="BlockCipherTransform" />.
+    /// </summary>
+    [TestMethod]
+    public void CryptoStream_WhenFlushedWithoutWritingAnyData_ShouldProduceOnePkcs7PaddedBlock_fix()
+    {
+        using var algorithm = new Skipjack
+        {
+            Padding = PaddingMode.PKCS7,
+            Mode = CipherMode.CBC,
+        };
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        using ICryptoTransform encryptor = algorithm.CreateEncryptor();
+        using var output = new MemoryStream();
+        using (var crypto = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
+        {
+            // Do not write any data; FlushFinalBlock should still produce one PKCS7 padding block.
+            crypto.FlushFinalBlock();
+        }
+
+        Assert.AreEqual(algorithm.BlockSize / 8, output.Length,
+            "Flushing a CryptoStream without writing any data under PKCS7 should still emit one block of padding.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CcmModeTransformTests.Lifecycle.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CcmModeTransformTests.Lifecycle.cs
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CcmModeTransformTests.Lifecycle.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Mode-specific lifecycle tests for <see cref="CcmModeTransform" />. The shared
+/// <see cref="AeadBlockCipherModeTests{TTest, TTransform}" /> base verifies the generic AEAD
+/// lifecycle; this file pins down properties specific to NIST SP 800-38C — the
+/// <c>(N, q, T)</c> parameter triple is hard-coded at <c>(12, 3, 16)</c>, and the resulting
+/// 16-byte tag length is the documented <see cref="IAeadBlockCipherModeTransform.TagSize" />.
+/// </summary>
+public sealed partial class CcmModeTransformTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CcmModeTransform.TagSize" /> is exactly 16 bytes — the fixed
+    /// tag length this implementation produces (NIST SP 800-38C Appendix A profile <c>M = 16</c>).
+    /// </summary>
+    [TestMethod]
+    public void TagSize_ShouldBeSixteenBytes()
+    {
+        using var transform = MakeTransform();
+
+        Assert.AreEqual(16, transform.TagSize);
+    }
+
+    /// <summary>
+    /// Verifies that two encryptions of the same <c>(plaintext, AAD)</c> under the same nonce
+    /// produce identical ciphertext — CCM is fully deterministic given fixed inputs. This is a
+    /// regression guard for any accidental injection of entropy (per-instance nonces, per-call
+    /// salts, etc.) into the CTR or CBC-MAC pipelines.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_SamePlaintextSameNonceSameAad_ShouldBeDeterministic()
+    {
+        byte[] iv = new byte[16];
+        for (int i = 0; i < iv.Length; i++) iv[i] = (byte)i;
+
+        byte[] aad = [0xA1, 0xA2, 0xA3];
+        byte[] plaintext = [0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80];
+
+        using var transformA = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformA.ProcessAssociatedData(aad);
+        byte[] outA = new byte[plaintext.Length + transformA.TagSize];
+        transformA.Encrypt(plaintext, outA);
+
+        using var transformB = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformB.ProcessAssociatedData(aad);
+        byte[] outB = new byte[plaintext.Length + transformB.TagSize];
+        transformB.Encrypt(plaintext, outB);
+
+        CollectionAssert.AreEqual(outA, outB,
+            "CCM must be fully deterministic for the same key, nonce, AAD, and plaintext.");
+    }
+
+    /// <summary>
+    /// Verifies that swapping AAD between two encryptions of the same <c>(nonce, plaintext)</c>
+    /// produces different ciphertext+tag pairs — confirms the CBC-MAC chain folds AAD into the
+    /// tag rather than treating it as a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_SamePlaintextSameNonceDifferentAad_ShouldProduceDistinctTags()
+    {
+        byte[] iv = new byte[16];
+        byte[] plaintext = [0xDE, 0xAD, 0xBE, 0xEF];
+
+        using var transformA = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformA.ProcessAssociatedData([0x01]);
+        byte[] outA = new byte[plaintext.Length + transformA.TagSize];
+        transformA.Encrypt(plaintext, outA);
+
+        using var transformB = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformB.ProcessAssociatedData([0x02]);
+        byte[] outB = new byte[plaintext.Length + transformB.TagSize];
+        transformB.Encrypt(plaintext, outB);
+
+        CollectionAssert.AreNotEqual(outA, outB,
+            "CCM must bind AAD into the CBC-MAC tag — distinct AAD must produce distinct outputs.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CtsModeTransformTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CtsModeTransformTests.cs
@@ -18,4 +18,11 @@ public sealed partial class CtsModeTransformTests
     /// <c>Transform_WhenInputNotBlockAligned_ShouldThrow</c> test is suppressed for this mode.
     /// </summary>
     protected override bool RequiresBlockAlignedInput => false;
+
+    /// <summary>
+    /// CTS explicitly rejects sub-block input — it requires at least one full block by design.
+    /// The empty-input no-op contract that <see cref="CbcModeTransform" /> honours therefore does
+    /// not apply here.
+    /// </summary>
+    protected override bool AcceptsEmptyInput => false;
 }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CubeHashTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CubeHashTests.EdgeCases.cs
@@ -1,0 +1,175 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CubeHashTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="CubeHash" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — mid-stream property mutation, non-multiple-of-8 hash sizes, and
+/// idempotent disposal. The reflection-driven dispose tests in
+/// <see cref="HashAlgorithmTests{TTest, TAlgorithm, TVariant}" /> already cover the trivial
+/// disposed-state coverage; this file targets the algorithm-specific contract.
+/// </summary>
+public partial class CubeHashTests
+{
+    /// <summary>
+    /// Verifies that assigning <see cref="CubeHash.HashSize" /> to a value that is not a positive
+    /// multiple of 8 throws <see cref="ArgumentOutOfRangeException" /> rather than producing a
+    /// digest of unexpected length.
+    /// </summary>
+    [TestMethod]
+    [DataRow(9)]
+    [DataRow(15)]
+    [DataRow(17)]
+    [DataRow(31)]
+    [DataRow(33)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(255)]
+    [DataRow(511)]
+    public void HashSize_WhenSetToNonMultipleOfEight_ShouldThrowExactly(int value)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.HashSize = value;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="CubeHash.FinalizationRounds" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" /> rather than silently
+    /// reconfiguring rounds mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void FinalizationRounds_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.FinalizationRounds = 64;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="CubeHash.InitializationRounds" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void InitializationRounds_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.InitializationRounds = 32;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="CubeHash.TransformBlockSize" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void TransformBlockSize_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.TransformBlockSize = 64;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="CubeHash.HashSize" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.HashSize = 256;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CubeHash.AlgorithmName" /> returns the documented format
+    /// <c>CubeHash{r}+{b}/{w}+{f}-{h}</c> using the algorithm's current property values.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenReadAfterCustomConfiguration_ShouldFormatAllParameters()
+    {
+        using var algorithm = new CubeHash
+        {
+            InitializationRounds = 16,
+            Rounds = 16,
+            TransformBlockSize = 32,
+            FinalizationRounds = 32,
+            HashSize = 256,
+        };
+
+        Assert.AreEqual("CubeHash16+16/32+32-256", algorithm.AlgorithmName);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="CubeHash.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new CubeHash();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on CubeHash threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="CubeHash" /> instance — one that
+    /// has never had any property accessed or hashing performed — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new CubeHash();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched CubeHash instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/GcmSivModeTransformTests.Lifecycle.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/GcmSivModeTransformTests.Lifecycle.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="GcmSivModeTransformTests.Lifecycle.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Mode-specific lifecycle tests for <see cref="GcmSivModeTransform" /> (RFC 8452). The shared
+/// <see cref="AeadBlockCipherModeTests{TTest, TTransform}" /> base verifies the generic AEAD
+/// lifecycle; this file pins down the property that distinguishes GCM-SIV from GCM —
+/// <strong>nonce-misuse resistance</strong>. Re-encrypting the same <c>(key, nonce, AAD,
+/// plaintext)</c> tuple must produce identical ciphertext (revealing only message equality);
+/// distinct plaintexts under the same nonce must remain confidential and authentic.
+/// </summary>
+public sealed partial class GcmSivModeTransformTests
+{
+    /// <summary>
+    /// Verifies that encrypting the same <c>(key, nonce, AAD, plaintext)</c> tuple twice on two
+    /// independently-constructed instances yields identical ciphertext. RFC 8452's misuse-resistance
+    /// contract requires the algorithm to be deterministic: re-issuing the same nonce after a crash
+    /// or replication retry must not corrupt confidentiality beyond confirming message equality.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_SameKeyNonceAadAndPlaintext_ShouldProduceIdenticalOutput()
+    {
+        byte[] plaintext = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        byte[] aad = [0xAA, 0xBB, 0xCC];
+        byte[] iv = new byte[16];
+        for (int i = 0; i < iv.Length; i++) iv[i] = (byte)i;
+
+        using var transformA = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformA.ProcessAssociatedData(aad);
+        byte[] outA = new byte[plaintext.Length + transformA.TagSize];
+        transformA.Encrypt(plaintext, outA);
+
+        using var transformB = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformB.ProcessAssociatedData(aad);
+        byte[] outB = new byte[plaintext.Length + transformB.TagSize];
+        transformB.Encrypt(plaintext, outB);
+
+        CollectionAssert.AreEqual(outA, outB,
+            "GCM-SIV must be deterministic for the same key, nonce, AAD, and plaintext.");
+    }
+
+    /// <summary>
+    /// Verifies that two distinct plaintexts encrypted under the same key + nonce + AAD produce
+    /// different ciphertexts — the misuse-resistance contract leaks only message equality, not
+    /// message content. Confirms the keystream is not trivially fixed when the nonce repeats.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_DistinctPlaintextsUnderSameNonce_ShouldProduceDistinctOutputs()
+    {
+        byte[] iv = new byte[16];
+        byte[] aad = [0xAA, 0xBB];
+
+        byte[] plaintextA = [0x10, 0x20, 0x30, 0x40];
+        byte[] plaintextB = [0xFF, 0xEE, 0xDD, 0xCC];
+
+        using var transformA = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformA.ProcessAssociatedData(aad);
+        byte[] outA = new byte[plaintextA.Length + transformA.TagSize];
+        transformA.Encrypt(plaintextA, outA);
+
+        using var transformB = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformB.ProcessAssociatedData(aad);
+        byte[] outB = new byte[plaintextB.Length + transformB.TagSize];
+        transformB.Encrypt(plaintextB, outB);
+
+        CollectionAssert.AreNotEqual(outA, outB,
+            "Distinct plaintexts under the same nonce must remain distinct in GCM-SIV.");
+    }
+
+    /// <summary>
+    /// Verifies that encrypting the same plaintext under different AAD streams produces different
+    /// outputs — AAD is bound into the POLYVAL accumulator that derives the synthetic tag, so the
+    /// tag and (via tag-as-counter-base) the keystream differ.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_SamePlaintextDifferentAad_ShouldProduceDistinctOutputs()
+    {
+        byte[] plaintext = [0xDE, 0xAD, 0xBE, 0xEF];
+        byte[] iv = new byte[16];
+
+        using var transformA = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformA.ProcessAssociatedData([0x01]);
+        byte[] outA = new byte[plaintext.Length + transformA.TagSize];
+        transformA.Encrypt(plaintext, outA);
+
+        using var transformB = CreateTransform(new MonitoringBlockCipher(ExpectedBlockSize, xorMask: 0xAA), iv);
+        transformB.ProcessAssociatedData([0x02]);
+        byte[] outB = new byte[plaintext.Length + transformB.TagSize];
+        transformB.Encrypt(plaintext, outB);
+
+        CollectionAssert.AreNotEqual(outA, outB,
+            "Distinct AAD streams must produce distinct GCM-SIV outputs (POLYVAL binds AAD into the tag).");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmFactoryTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmFactoryTests.cs
@@ -1,0 +1,91 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmFactoryTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Contains unit tests for the <see cref="HashAlgorithmFactory" /> static helper which wraps a
+/// builder delegate as an <see cref="IHashAlgorithmFactory{T}" /> instance.
+/// </summary>
+[TestClass]
+public sealed class HashAlgorithmFactoryTests
+{
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmFactory.From{T}(System.Func{T})" /> with a
+    /// <see langword="null" /> builder throws <see cref="ArgumentNullException" /> with the
+    /// expected parameter name.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenBuilderIsNull_ShouldThrowExactly()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = HashAlgorithmFactory.From<MD5>(null!);
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmFactory.From{T}(System.Func{T})" /> with a non-null
+    /// builder returns a non-null <see cref="DelegateHashAlgorithmFactory{T}" /> that produces a
+    /// fresh instance on each call.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenBuilderProvided_ShouldReturnFactoryThatYieldsFreshInstancesOnCreate()
+    {
+        var factory = HashAlgorithmFactory.From(() => MD5.Create());
+
+        Assert.IsNotNull(factory);
+        Assert.IsInstanceOfType<DelegateHashAlgorithmFactory<MD5>>(factory);
+
+        using var first = factory.Create();
+        using var second = factory.Create();
+
+        Assert.IsNotNull(first);
+        Assert.IsNotNull(second);
+        Assert.AreNotSame(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that the factory invokes its builder delegate exactly once per call to
+    /// <see cref="IHashAlgorithmFactory{T}.Create" />, propagating any configuration applied by the
+    /// builder to the produced instance.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenBuilderProvided_ShouldInvokeBuilderOncePerCreate()
+    {
+        int callCount = 0;
+        var factory = HashAlgorithmFactory.From(() =>
+        {
+            callCount++;
+            return MD5.Create();
+        });
+
+        using (var _ = factory.Create()) { }
+        using (var _ = factory.Create()) { }
+        using (var _ = factory.Create()) { }
+
+        Assert.AreEqual(3, callCount);
+    }
+
+    /// <summary>
+    /// Verifies that an exception thrown by the builder propagates out of
+    /// <see cref="IHashAlgorithmFactory{T}.Create" /> rather than being swallowed.
+    /// </summary>
+    [TestMethod]
+    public void Create_WhenBuilderThrows_ShouldPropagateException()
+    {
+        var factory = HashAlgorithmFactory.From<MD5>(() => throw new InvalidOperationException("boom"));
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = factory.Create();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmHelperTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmHelperTests.cs
@@ -1,0 +1,191 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmHelperTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Security.Cryptography;
+using System.Threading.Tasks;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Contains unit tests for the <see cref="HashAlgorithmHelper" /> static helpers covering one-shot
+/// hashing through an <see cref="IHashAlgorithmFactory{T}" />.
+/// </summary>
+[TestClass]
+public sealed class HashAlgorithmHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, System.ReadOnlySpan{byte})" />
+    /// with a <see langword="null" /> factory throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Span_WhenFactoryIsNull_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = HashAlgorithmHelper.HashData<MD5>(null!, ReadOnlySpan<byte>.Empty);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, Stream)" />
+    /// with a <see langword="null" /> factory throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Stream_WhenFactoryIsNull_ShouldThrowExactly()
+    {
+        using var stream = new MemoryStream();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = HashAlgorithmHelper.HashData<MD5>(null!, stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, Stream)" />
+    /// with a <see langword="null" /> stream throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Stream_WhenStreamIsNull_ShouldThrowExactly()
+    {
+        var factory = HashAlgorithmFactory.From<MD5>(MD5.Create);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = HashAlgorithmHelper.HashData(factory, (Stream)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashDataAsync{T}" /> with a
+    /// <see langword="null" /> factory throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task HashDataAsync_WhenFactoryIsNull_ShouldThrowExactly()
+    {
+        using var stream = new MemoryStream();
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+        {
+            _ = await HashAlgorithmHelper.HashDataAsync<MD5>(null!, stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashDataAsync{T}" /> with a
+    /// <see langword="null" /> stream throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public async Task HashDataAsync_WhenStreamIsNull_ShouldThrowExactly()
+    {
+        var factory = HashAlgorithmFactory.From<MD5>(MD5.Create);
+
+        await Assert.ThrowsExactlyAsync<ArgumentNullException>(async () =>
+        {
+            _ = await HashAlgorithmHelper.HashDataAsync(factory, (Stream)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.TryHashData{T}" /> with a <see langword="null" />
+    /// factory throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void TryHashData_WhenFactoryIsNull_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = HashAlgorithmHelper.TryHashData<MD5>(null!, ReadOnlySpan<byte>.Empty, Span<byte>.Empty, out _);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, System.ReadOnlySpan{byte})" />
+    /// produces the same digest as a directly-constructed algorithm for the same input — guards
+    /// against the helper accidentally truncating, mis-copying, or zeroing the result.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Span_ShouldMatchDirectAlgorithmOutput()
+    {
+        byte[] input = Enumerable.Range(0, 96).Select(i => (byte)i).ToArray();
+
+        byte[] viaHelper = HashAlgorithmHelper.HashData(
+            HashAlgorithmFactory.From<MD5>(MD5.Create),
+            input);
+
+        byte[] direct = MD5.HashData(input);
+
+        CollectionAssert.AreEqual(direct, viaHelper);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, Stream)" />
+    /// produces the same digest as the span overload for the same content — confirms that the
+    /// internal stream pump uses the buffer pool correctly and finalises with an empty
+    /// <c>TransformFinalBlock</c>.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Stream_ShouldMatchSpanOverloadForSameContent()
+    {
+        byte[] input = Enumerable.Range(0, 32 * 1024).Select(i => (byte)(i & 0xFF)).ToArray();
+
+        byte[] viaSpan = HashAlgorithmHelper.HashData(
+            HashAlgorithmFactory.From<SHA256>(SHA256.Create),
+            input);
+
+        using var stream = new MemoryStream(input);
+        byte[] viaStream = HashAlgorithmHelper.HashData(
+            HashAlgorithmFactory.From<SHA256>(SHA256.Create),
+            stream);
+
+        CollectionAssert.AreEqual(viaSpan, viaStream);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithmHelper.HashData{T}(IHashAlgorithmFactory{T}, System.ReadOnlySpan{byte})" />
+    /// disposes the algorithm produced by the factory after computing the hash. Regression guard
+    /// for resource leaks introduced if the helper ever stops using <c>using</c>.
+    /// </summary>
+    [TestMethod]
+    public void HashData_Span_ShouldDisposeAlgorithmAfterUse()
+    {
+        var probe = new DisposalProbe();
+        var factory = HashAlgorithmFactory.From(() => probe);
+
+        _ = HashAlgorithmHelper.HashData(factory, ReadOnlySpan<byte>.Empty);
+
+        Assert.IsTrue(probe.DisposedCount > 0,
+            "HashAlgorithmHelper.HashData should dispose the algorithm it constructs.");
+    }
+
+    /// <summary>
+    /// A <see cref="HashAlgorithm" /> probe that counts how many times <see cref="HashAlgorithm.Dispose()" />
+    /// is invoked. Used to verify <see cref="HashAlgorithmHelper" /> deterministically disposes
+    /// instances it constructs.
+    /// </summary>
+    private sealed class DisposalProbe : HashAlgorithm
+    {
+        public int DisposedCount { get; private set; }
+
+        public DisposalProbe()
+        {
+            this.HashSizeValue = 32;
+        }
+
+        public override void Initialize() { }
+
+        protected override void HashCore(byte[] array, int ibStart, int cbSize) { }
+
+        protected override byte[] HashFinal() => new byte[32];
+
+        protected override void Dispose(bool disposing)
+        {
+            this.DisposedCount++;
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MerkleTreeDiagnosticsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MerkleTreeDiagnosticsTests.cs
@@ -1,0 +1,359 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MerkleTreeDiagnosticsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Direct unit tests for <see cref="MerkleTreeDiagnostics" /> and
+/// <see cref="MerkleTreeDiagnosticNode" />. The diagnostic recorder is exercised indirectly
+/// via <c>ParallelMerkleTreeHashTests.Diagnostics.cs</c>, but its inspection, validation, and
+/// formatting APIs deserve targeted coverage that does not depend on the parallel pipeline
+/// being correct.
+/// </summary>
+[TestClass]
+public sealed class MerkleTreeDiagnosticsTests
+{
+    /// <summary>
+    /// Verifies that a freshly-constructed <see cref="MerkleTreeDiagnostics" /> reports an empty
+    /// node set, a zero level count, and a <see langword="null" /> root.
+    /// </summary>
+    [TestMethod]
+    public void Empty_ShouldReportNoNodesNoLevelsAndNullRoot()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        Assert.AreEqual(0, diagnostics.GetAllNodes().Count);
+        Assert.AreEqual(0, diagnostics.GetLevelCount());
+        Assert.IsNull(diagnostics.Root);
+        Assert.AreEqual(0, diagnostics.GetLevel(0).Count);
+    }
+
+    /// <summary>
+    /// Verifies that recording a single leaf node makes it the only node, the only entry at level 0,
+    /// the root, and that <see cref="MerkleTreeDiagnostics.GetLevelCount" /> returns 1.
+    /// </summary>
+    [TestMethod]
+    public void RecordLeaf_ShouldMakeLeafTheRoot()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+        byte[] leafHash = new byte[] { 0xAA, 0xBB, 0xCC };
+
+        diagnostics.RecordLeaf(index: 0, hash: leafHash);
+
+        Assert.AreEqual(1, diagnostics.GetLevelCount());
+        Assert.AreEqual(1, diagnostics.GetAllNodes().Count);
+        Assert.IsNotNull(diagnostics.Root);
+        Assert.AreEqual(0, diagnostics.Root!.Level);
+        Assert.AreEqual(0, diagnostics.Root.Index);
+        Assert.IsTrue(diagnostics.Root.IsLeaf);
+        CollectionAssert.AreEqual(leafHash, diagnostics.Root.Hash);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.RecordLeaf" /> stores a defensive copy of the
+    /// supplied hash so that subsequent caller mutation cannot corrupt the recorded snapshot.
+    /// </summary>
+    [TestMethod]
+    public void RecordLeaf_ShouldStoreDefensiveCopyOfHash()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+        byte[] leafHash = new byte[] { 0x01, 0x02, 0x03 };
+
+        diagnostics.RecordLeaf(index: 0, hash: leafHash);
+        leafHash[0] = 0xFF;
+
+        Assert.AreEqual(0x01, diagnostics.Root!.Hash[0],
+            "RecordLeaf must take a defensive copy so caller mutation cannot affect the recorded node.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.GetAllNodes" /> returns nodes sorted by level
+    /// ascending, then by index ascending — independent of the order in which they were recorded.
+    /// </summary>
+    [TestMethod]
+    public void GetAllNodes_ShouldReturnNodesSortedByLevelThenIndex()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        diagnostics.RecordInternal(level: 1, index: 1, childHashes: [[0x01], [0x02]], hash: new byte[] { 0xAA });
+        diagnostics.RecordLeaf(index: 2, hash: new byte[] { 0x33 });
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [[0x03], [0x04]], hash: new byte[] { 0xBB });
+        diagnostics.RecordLeaf(index: 0, hash: new byte[] { 0x11 });
+        diagnostics.RecordLeaf(index: 1, hash: new byte[] { 0x22 });
+
+        var nodes = diagnostics.GetAllNodes();
+        var ordered = nodes.Select(n => (n.Level, n.Index)).ToList();
+
+        var expected = new List<(int Level, int Index)>
+        {
+            (0, 0), (0, 1), (0, 2),
+            (1, 0), (1, 1),
+        };
+
+        CollectionAssert.AreEqual(expected, ordered);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.GetLevel" /> returns only the nodes at the
+    /// requested level, sorted by index ascending, regardless of insertion order.
+    /// </summary>
+    [TestMethod]
+    public void GetLevel_ShouldReturnOnlyMatchingLevelSortedByIndex()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        diagnostics.RecordLeaf(index: 1, hash: new byte[] { 0x11 });
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [[0x01]], hash: new byte[] { 0xAA });
+        diagnostics.RecordLeaf(index: 0, hash: new byte[] { 0x10 });
+
+        var level0 = diagnostics.GetLevel(0);
+        var level1 = diagnostics.GetLevel(1);
+        var level2 = diagnostics.GetLevel(2);
+
+        Assert.AreEqual(2, level0.Count);
+        Assert.AreEqual(0, level0[0].Index);
+        Assert.AreEqual(1, level0[1].Index);
+        Assert.AreEqual(1, level1.Count);
+        Assert.AreEqual(0, level2.Count, "Levels above the highest recorded should be empty.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.Root" /> returns the unique node at the
+    /// highest recorded level.
+    /// </summary>
+    [TestMethod]
+    public void Root_ShouldReturnHighestLevelNode()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        diagnostics.RecordLeaf(index: 0, hash: new byte[] { 0x10 });
+        diagnostics.RecordLeaf(index: 1, hash: new byte[] { 0x11 });
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [[0x10], [0x11]], hash: new byte[] { 0xAA });
+        diagnostics.RecordInternal(level: 2, index: 0, childHashes: [[0xAA]], hash: new byte[] { 0xFF });
+
+        Assert.AreEqual(2, diagnostics.Root!.Level);
+        Assert.AreEqual(0xFF, diagnostics.Root.Hash[0]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.Validate" /> succeeds when every internal
+    /// node's stored hash matches the SHA-256 of the concatenation of its child hashes.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenInternalHashesMatchChildren_ShouldReturnTrue()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        byte[] leaf0 = new byte[] { 0x01 };
+        byte[] leaf1 = new byte[] { 0x02 };
+        byte[] expectedParent = ComputeSha256(Concat(leaf0, leaf1));
+
+        diagnostics.RecordLeaf(0, leaf0);
+        diagnostics.RecordLeaf(1, leaf1);
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [leaf0, leaf1], hash: expectedParent);
+
+        bool ok = diagnostics.Validate(SHA256.Create, out var errors);
+
+        Assert.IsTrue(ok, $"Validate should pass — got errors: {string.Join(", ", errors)}");
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.Validate" /> reports a mismatch when an
+    /// internal node's stored hash does not match the SHA-256 of its child hashes.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenInternalHashIsCorrupted_ShouldReportMismatch()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        byte[] leaf0 = new byte[] { 0x01 };
+        byte[] leaf1 = new byte[] { 0x02 };
+        byte[] corruptedParent = new byte[] { 0xFF, 0xFF, 0xFF };
+
+        diagnostics.RecordLeaf(0, leaf0);
+        diagnostics.RecordLeaf(1, leaf1);
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [leaf0, leaf1], hash: corruptedParent);
+
+        bool ok = diagnostics.Validate(SHA256.Create, out var errors);
+
+        Assert.IsFalse(ok);
+        Assert.AreEqual(1, errors.Count);
+        Assert.IsTrue(errors[0].Contains("[1:0]", StringComparison.Ordinal),
+            $"Validation error should reference the offending node by [level:index]; got '{errors[0]}'.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.Validate" /> succeeds trivially when no
+    /// internal nodes have been recorded — leaves are not re-validated against input bytes.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenOnlyLeavesRecorded_ShouldReturnTrue()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+        diagnostics.RecordLeaf(0, new byte[] { 0x01 });
+        diagnostics.RecordLeaf(1, new byte[] { 0x02 });
+
+        bool ok = diagnostics.Validate(SHA256.Create, out var errors);
+
+        Assert.IsTrue(ok);
+        Assert.AreEqual(0, errors.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.Validate" /> rejects a <see langword="null" />
+    /// algorithm factory.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenAlgorithmFactoryIsNull_ShouldThrowExactly()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = diagnostics.Validate(null!, out _);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.WriteTo" /> rejects a <see langword="null" />
+    /// writer.
+    /// </summary>
+    [TestMethod]
+    public void WriteTo_WhenWriterIsNull_ShouldThrowExactly()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            diagnostics.WriteTo(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.WriteTo" /> on an empty instance emits the
+    /// documented "(no nodes recorded)" placeholder rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void WriteTo_WhenEmpty_ShouldEmitPlaceholderAndNotThrow()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+        var writer = new StringWriter();
+
+        diagnostics.WriteTo(writer);
+
+        string output = writer.ToString();
+        Assert.IsTrue(output.Contains("(no nodes recorded)", StringComparison.Ordinal),
+            $"Expected the 'no nodes recorded' placeholder; got: {output}");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.WriteTo" /> with a non-null algorithm factory
+    /// appends a "Validation: PASS" line when every recorded internal node hashes correctly.
+    /// </summary>
+    [TestMethod]
+    public void WriteTo_WhenValidationPasses_ShouldAppendPassLine()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+        byte[] leaf0 = new byte[] { 0x01 };
+        byte[] leaf1 = new byte[] { 0x02 };
+
+        diagnostics.RecordLeaf(0, leaf0);
+        diagnostics.RecordLeaf(1, leaf1);
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [leaf0, leaf1],
+            hash: ComputeSha256(Concat(leaf0, leaf1)));
+
+        var writer = new StringWriter();
+        diagnostics.WriteTo(writer, SHA256.Create);
+
+        string output = writer.ToString();
+        Assert.IsTrue(output.Contains("Validation: PASS", StringComparison.Ordinal),
+            $"Expected 'Validation: PASS' summary; got: {output}");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MerkleTreeDiagnostics.WriteTo" /> with a non-null algorithm factory
+    /// appends a "Validation: FAIL" line and the offending node identifier when an internal hash
+    /// is inconsistent.
+    /// </summary>
+    [TestMethod]
+    public void WriteTo_WhenValidationFails_ShouldAppendFailLineAndNodeReference()
+    {
+        var diagnostics = new MerkleTreeDiagnostics();
+
+        diagnostics.RecordLeaf(0, new byte[] { 0x01 });
+        diagnostics.RecordLeaf(1, new byte[] { 0x02 });
+        diagnostics.RecordInternal(level: 1, index: 0, childHashes: [[0x01], [0x02]],
+            hash: new byte[] { 0xFF, 0xFF, 0xFF });
+
+        var writer = new StringWriter();
+        diagnostics.WriteTo(writer, SHA256.Create);
+
+        string output = writer.ToString();
+        Assert.IsTrue(output.Contains("Validation: FAIL", StringComparison.Ordinal),
+            $"Expected 'Validation: FAIL' summary; got: {output}");
+        Assert.IsTrue(output.Contains("[1:0]", StringComparison.Ordinal),
+            $"Expected the failing node reference '[1:0]' in the validation summary; got: {output}");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="MerkleTreeDiagnosticNode" /> record equality: two records with the same
+    /// fields are equal even though <see cref="byte" />[] uses reference equality by default. This
+    /// is the documented record-with-init behaviour for value-equality.
+    /// </summary>
+    [TestMethod]
+    public void DiagnosticNode_RecordsWithIdenticalFields_ShouldNotBeReferenceEqualByByteArray()
+    {
+        // Records with byte[] fields use reference equality on the array, so two records with
+        // different array instances containing identical bytes are NOT equal — pin this contract
+        // so consumers don't assume value-equality.
+        byte[] hashA = new byte[] { 0x01 };
+        byte[] hashB = new byte[] { 0x01 };
+
+        var nodeA = new MerkleTreeDiagnosticNode(
+            Level: 0, Index: 0, IsLeaf: true, Hash: hashA, ChildHashes: Array.Empty<byte[]>());
+        var nodeB = new MerkleTreeDiagnosticNode(
+            Level: 0, Index: 0, IsLeaf: true, Hash: hashB, ChildHashes: Array.Empty<byte[]>());
+
+        Assert.AreNotEqual(nodeA, nodeB,
+            "Records with byte[] members use reference equality on the array; identical-content but distinct instances must compare unequal.");
+    }
+
+    /// <summary>
+    /// Verifies <see cref="MerkleTreeDiagnosticNode" /> record equality with the same array reference.
+    /// </summary>
+    [TestMethod]
+    public void DiagnosticNode_RecordsSharingByteArrayReferences_ShouldBeEqual()
+    {
+        byte[] hash = new byte[] { 0x01 };
+        IReadOnlyList<byte[]> children = Array.Empty<byte[]>();
+
+        var nodeA = new MerkleTreeDiagnosticNode(0, 0, true, hash, children);
+        var nodeB = new MerkleTreeDiagnosticNode(0, 0, true, hash, children);
+
+        Assert.AreEqual(nodeA, nodeB);
+    }
+
+    private static byte[] ComputeSha256(byte[] input)
+    {
+        using var sha = SHA256.Create();
+        return sha.ComputeHash(input);
+    }
+
+    private static byte[] Concat(byte[] a, byte[] b)
+    {
+        byte[] result = new byte[a.Length + b.Length];
+        Buffer.BlockCopy(a, 0, result, 0, a.Length);
+        Buffer.BlockCopy(b, 0, result, a.Length, b.Length);
+        return result;
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/NoPaddingTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/NoPaddingTests.EdgeCases.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NoPaddingTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="NoPadding" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage. Unlike every other <see cref="IPaddingStrategy" /> implementation,
+/// <see cref="NoPadding.Pad(System.ReadOnlySpan{byte}, int)" /> does not validate that
+/// <c>blockSize</c> is positive before performing the modulo check — passing
+/// <c>blockSize == 0</c> therefore surfaces a <see cref="System.DivideByZeroException" />
+/// instead of the expected <see cref="System.ArgumentOutOfRangeException" /> documented by every
+/// other strategy. Negative <c>blockSize</c> values silently succeed for inputs whose length is a
+/// multiple of <c>|blockSize|</c>, again contradicting the documented contract.
+/// </summary>
+public sealed partial class NoPaddingTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NoPadding.Pad(System.ReadOnlySpan{byte}, int)" /> with
+    /// <c>blockSize == 0</c> throws <see cref="System.ArgumentOutOfRangeException" /> rather than
+    /// <see cref="System.DivideByZeroException" /> from the unguarded <c>input.Length % blockSize</c>
+    /// expression.
+    /// </summary>
+    [TestMethod]
+    public void Pad_WhenBlockSizeIsZero_ShouldThrowArgumentOutOfRangeException_fix()
+    {
+        var padding = new NoPadding();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Pad(new byte[16], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NoPadding.Pad(System.ReadOnlySpan{byte}, int)" /> with a negative
+    /// <c>blockSize</c> throws <see cref="System.ArgumentOutOfRangeException" /> rather than
+    /// silently succeeding when the input length happens to be a multiple of <c>|blockSize|</c>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-16)]
+    [DataRow(int.MinValue)]
+    public void Pad_WhenBlockSizeIsNegative_ShouldThrowArgumentOutOfRangeException_fix(int blockSize)
+    {
+        var padding = new NoPadding();
+
+        // 16 bytes happens to be a multiple of |-1| = 1 and |-16| = 16, so the current
+        // implementation silently returns the input copy without flagging the negative size.
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Pad(new byte[16], blockSize);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/NoPaddingTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/NoPaddingTests.cs
@@ -16,6 +16,13 @@ public sealed partial class NoPaddingTests
 
     /// <inheritdoc />
     /// <remarks>
+    /// <see cref="NoPadding.Unpad" /> ignores its <c>blockSize</c> parameter — it returns the input unchanged
+    /// regardless of alignment. The block-size validation tests are therefore inapplicable.
+    /// </remarks>
+    protected override bool ValidatesBlockSizeOnUnpad => false;
+
+    /// <inheritdoc />
+    /// <remarks>
     /// <see cref="NoPadding.Pad" /> rejects input whose length is not already a multiple of the block size, so the
     /// round-trip test only exercises residual 0.
     /// </remarks>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.BlockSizeValidation.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.BlockSizeValidation.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="PaddingStrategyTests.BlockSizeValidation.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes the <see cref="IPaddingStrategy" /> contract for unexpected exceptions when the supplied
+/// <c>blockSize</c> is invalid. Currently every length-validating <c>Unpad</c> implementation
+/// evaluates <c>input.Length % blockSize</c> before validating the block size — passing
+/// <c>blockSize == 0</c> therefore surfaces a <see cref="DivideByZeroException" /> instead of the
+/// expected <see cref="ArgumentOutOfRangeException" /> documented by every <c>Pad</c> overload.
+/// These tests assert the corrected, contract-aligned behaviour and fail until the bug is fixed.
+/// </summary>
+public abstract partial class PaddingStrategyTests<TPadding>
+{
+    /// <summary>
+    /// Gets a value indicating whether this padding strategy uses <c>blockSize</c> in its
+    /// <see cref="IPaddingStrategy.Unpad" /> implementation. Strategies that document the
+    /// parameter as ignored (<see cref="NoPadding" />, <see cref="ZeroPadding" />) override this
+    /// to <see langword="false" /> so the block-size validation tests are skipped for them.
+    /// </summary>
+    protected virtual bool ValidatesBlockSizeOnUnpad => true;
+
+    /// <summary>
+    /// Verifies that calling <see cref="IPaddingStrategy.Unpad" /> with <c>blockSize == 0</c>
+    /// throws <see cref="ArgumentOutOfRangeException" /> rather than
+    /// <see cref="DivideByZeroException" /> from the unguarded <c>input.Length % blockSize</c>
+    /// expression that runs before any explicit block-size validation.
+    /// </summary>
+    [TestMethod]
+    public void Unpad_WhenBlockSizeIsZero_ShouldThrowArgumentOutOfRangeException_fix()
+    {
+        if (!ValidatesBlockSizeOnUnpad)
+        {
+            Assert.Inconclusive($"{typeof(TPadding).Name} ignores the blockSize parameter on Unpad.");
+            return;
+        }
+
+        var padding = CreatePadding();
+        byte[] input = new byte[BlockSize];
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Unpad(input, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IPaddingStrategy.Unpad" /> with a negative <c>blockSize</c>
+    /// throws <see cref="ArgumentOutOfRangeException" /> rather than allowing the modulo arithmetic
+    /// to yield a misleading <see cref="System.Security.Cryptography.CryptographicException" /> downstream.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-16)]
+    [DataRow(int.MinValue)]
+    public void Unpad_WhenBlockSizeIsNegative_ShouldThrowArgumentOutOfRangeException_fix(int blockSize)
+    {
+        if (!ValidatesBlockSizeOnUnpad)
+        {
+            Assert.Inconclusive($"{typeof(TPadding).Name} ignores the blockSize parameter on Unpad.");
+            return;
+        }
+
+        var padding = CreatePadding();
+        byte[] input = new byte[BlockSize];
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Unpad(input, blockSize);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Poly1305Tests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Poly1305Tests.EdgeCases.cs
@@ -1,0 +1,116 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Poly1305Tests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Poly1305" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — its one-time-use contract, idempotent disposal, padding contract,
+/// and post-finalisation reuse semantics.
+/// </summary>
+public partial class Poly1305Tests
+{
+    /// <summary>
+    /// Verifies that <see cref="Poly1305.CanReuseTransform" /> is <see langword="false" /> as
+    /// documented in RFC 8439, signalling to consumers that the algorithm must not be reused
+    /// across multiple messages with the same key.
+    /// </summary>
+    [TestMethod]
+    public void CanReuseTransform_ShouldBeFalse()
+    {
+        using var poly = new Poly1305();
+
+        Assert.IsFalse(poly.CanReuseTransform,
+            "Poly1305 is a one-time authenticator and must report CanReuseTransform = false.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Poly1305.CanTransformMultipleBlocks" /> is <see langword="true" />
+    /// so the framework streams data through the algorithm in block-sized chunks.
+    /// </summary>
+    [TestMethod]
+    public void CanTransformMultipleBlocks_ShouldBeTrue()
+    {
+        using var poly = new Poly1305();
+
+        Assert.IsTrue(poly.CanTransformMultipleBlocks);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Poly1305.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var poly = new Poly1305();
+        poly.Dispose();
+
+        try
+        {
+            poly.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Poly1305 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Poly1305" /> instance — one whose
+    /// key was set by the constructor but never used — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var poly = new Poly1305();
+
+        try
+        {
+            poly.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Poly1305 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.ComputeHash(byte[])" /> on a disposed
+    /// <see cref="Poly1305" /> instance throws <see cref="ObjectDisposedException" /> rather than
+    /// producing output from cleared key material.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var poly = new Poly1305();
+        poly.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = poly.ComputeHash(new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed
+    /// <see cref="Poly1305" /> instance throws <see cref="ObjectDisposedException" /> rather than
+    /// invoking <c>OnKeyChanged</c> against cleared state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var poly = new Poly1305();
+        poly.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            poly.Initialize();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SipHashTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SipHashTests.EdgeCases.cs
@@ -1,0 +1,247 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SipHashTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="SipHash{T}" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — disposed-state access, mid-stream property mutation, repeated
+/// disposal, and boundary values for the round-count properties.
+/// </summary>
+public abstract partial class SipHashTests<TTest, TAlgorithm>
+{
+    /// <summary>
+    /// Verifies that reading <see cref="SipHash{T}.AlgorithmName" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning a stale or partially-zeroed string.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SipHash{T}.CompressionRounds" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning the cleared (0) backing field.
+    /// </summary>
+    [TestMethod]
+    public void CompressionRounds_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.CompressionRounds;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SipHash{T}.FinalizationRounds" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning the cleared (0) backing field.
+    /// </summary>
+    [TestMethod]
+    public void FinalizationRounds_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.FinalizationRounds;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="SipHash{T}.CompressionRounds" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than silently mutating cleared state.
+    /// </summary>
+    [TestMethod]
+    public void CompressionRounds_WhenSetAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.CompressionRounds = 4;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="SipHash{T}.FinalizationRounds" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than silently mutating cleared state.
+    /// </summary>
+    [TestMethod]
+    public void FinalizationRounds_WhenSetAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.FinalizationRounds = 8;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that mutating <see cref="SipHash{T}.CompressionRounds" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" /> rather than silently
+    /// reconfiguring the round count mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void CompressionRounds_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[16];
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.CompressionRounds = 4;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that mutating <see cref="SipHash{T}.FinalizationRounds" /> after
+    /// <see cref="HashAlgorithm.TransformBlock" /> has been called throws
+    /// <see cref="CryptographicUnexpectedOperationException" /> rather than silently
+    /// reconfiguring the round count mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void FinalizationRounds_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[16];
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.FinalizationRounds = 8;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithm.ComputeHash(byte[])" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than returning a stale digest or accessing
+    /// the cleared key buffer.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.ComputeHash(new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than touching the cleared key buffer or
+    /// invoking <c>OnKeyChanged</c> against null state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Dispose()" /> twice on a SipHash instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on {typeof(TAlgorithm).Name} threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="SipHash{T}.CompressionRounds" /> to extreme values around
+    /// the boundary throws <see cref="ArgumentOutOfRangeException" /> only for values strictly below
+    /// <see cref="SipHash{T}.MinCompressionRounds" /> (and never some other unexpected exception).
+    /// </summary>
+    [TestMethod]
+    [DataRow(int.MinValue)]
+    [DataRow(-1)]
+    [DataRow(0)]
+    [DataRow(1)]
+    public void CompressionRounds_WhenSetBelowMinimum_ShouldThrowExactly(int value)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.CompressionRounds = value;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="SipHash{T}.FinalizationRounds" /> to extreme values around
+    /// the boundary throws <see cref="ArgumentOutOfRangeException" /> only for values strictly below
+    /// <see cref="SipHash{T}.MinFinalizationRounds" /> (and never some other unexpected exception).
+    /// </summary>
+    [TestMethod]
+    [DataRow(int.MinValue)]
+    [DataRow(-1)]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(3)]
+    public void FinalizationRounds_WhenSetBelowMinimum_ShouldThrowExactly(int value)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.FinalizationRounds = value;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithm.TransformFinalBlock" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than producing output from cleared state.
+    /// </summary>
+    [TestMethod]
+    public void TransformFinalBlock_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.TransformFinalBlock(new byte[1], 0, 1);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.Lifecycle.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.Lifecycle.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SivModeTransformTests.Lifecycle.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Mode-specific lifecycle tests for <see cref="SivModeTransform" />. The shared
+/// <see cref="AeadBlockCipherModeTests{TTest, TTransform}" /> base verifies the generic
+/// AEAD contract (lifecycle bookkeeping, tag-mismatch zeroing, AAD ordering); this file
+/// pins down the property that distinguishes SIV from every other AEAD in the library —
+/// <strong>deterministic IV derivation</strong>. RFC 5297 specifies that the synthetic IV
+/// is computed from the key, AAD, and plaintext via S2V/CMAC, so re-encrypting the same
+/// triple under any user-supplied IV must yield identical ciphertext.
+/// </summary>
+public sealed partial class SivModeTransformTests
+{
+    /// <summary>
+    /// Verifies that encrypting the same <c>(plaintext, AAD)</c> pair twice with two different
+    /// user-supplied IVs produces identical ciphertext. The synthetic IV is derived from the
+    /// data, so the user-supplied IV is ignored — the defining contract of AES-SIV.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_SamePlaintextAndAad_DifferentSuppliedIVs_ShouldProduceIdenticalOutput()
+    {
+        byte[] plaintext = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
+        byte[] aad = [0xAA, 0xBB, 0xCC];
+
+        byte[] ivAlpha = Convert.FromHexString("00000000000000000000000000000000");
+        byte[] ivBeta = Convert.FromHexString("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF");
+
+        using var transformAlpha = CreateTransform(cipher: null!, ivAlpha);
+        transformAlpha.ProcessAssociatedData(aad);
+        byte[] alphaOut = new byte[plaintext.Length + transformAlpha.TagSize];
+        transformAlpha.Encrypt(plaintext, alphaOut);
+
+        using var transformBeta = CreateTransform(cipher: null!, ivBeta);
+        transformBeta.ProcessAssociatedData(aad);
+        byte[] betaOut = new byte[plaintext.Length + transformBeta.TagSize];
+        transformBeta.Encrypt(plaintext, betaOut);
+
+        CollectionAssert.AreEqual(alphaOut, betaOut,
+            "AES-SIV must derive a synthetic IV from the data; the user-supplied IV must not influence the ciphertext.");
+    }
+
+    /// <summary>
+    /// Verifies that two distinct plaintexts encrypted under the same supplied IV produce
+    /// different ciphertexts — the synthetic IV depends on the message, so distinct messages
+    /// yield distinct synthetic IVs and therefore distinct ciphertext + tag pairs.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_DifferentPlaintexts_SameSuppliedIV_ShouldProduceDifferentOutputs()
+    {
+        byte[] iv = new byte[16];
+        byte[] aad = [0xAA, 0xBB];
+
+        byte[] plaintextA = [0x10, 0x20, 0x30, 0x40];
+        byte[] plaintextB = [0xFF, 0xEE, 0xDD, 0xCC];
+
+        using var transformA = CreateTransform(cipher: null!, iv);
+        transformA.ProcessAssociatedData(aad);
+        byte[] outA = new byte[plaintextA.Length + transformA.TagSize];
+        transformA.Encrypt(plaintextA, outA);
+
+        using var transformB = CreateTransform(cipher: null!, iv);
+        transformB.ProcessAssociatedData(aad);
+        byte[] outB = new byte[plaintextB.Length + transformB.TagSize];
+        transformB.Encrypt(plaintextB, outB);
+
+        CollectionAssert.AreNotEqual(outA, outB,
+            "Distinct plaintexts must produce distinct AES-SIV outputs (the synthetic IV depends on the message).");
+    }
+
+    /// <summary>
+    /// Verifies that encrypting the same plaintext under two different AAD streams produces
+    /// different ciphertexts — AAD is one of the inputs to S2V and so changes the synthetic IV.
+    /// </summary>
+    [TestMethod]
+    public void Encrypt_DifferentAad_SamePlaintextAndIV_ShouldProduceDifferentOutputs()
+    {
+        byte[] plaintext = [0xDE, 0xAD, 0xBE, 0xEF];
+        byte[] iv = new byte[16];
+
+        using var transformA = CreateTransform(cipher: null!, iv);
+        transformA.ProcessAssociatedData([0x01]);
+        byte[] outA = new byte[plaintext.Length + transformA.TagSize];
+        transformA.Encrypt(plaintext, outA);
+
+        using var transformB = CreateTransform(cipher: null!, iv);
+        transformB.ProcessAssociatedData([0x02]);
+        byte[] outB = new byte[plaintext.Length + transformB.TagSize];
+        transformB.Encrypt(plaintext, outB);
+
+        CollectionAssert.AreNotEqual(outA, outB,
+            "Distinct AAD streams must produce distinct AES-SIV outputs (S2V mixes AAD into the synthetic IV).");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.EdgeCases.cs
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkeinTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes the <see cref="Skein{T}" /> family for unexpected exceptions when its public surface
+/// is exercised outside of expected usage — algorithm-name format, key length boundary
+/// conditions, AlgorithmName disposed-state access, and idempotent disposal.
+/// </summary>
+public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
+{
+    /// <summary>
+    /// Verifies that <see cref="Skein{T}.AlgorithmName" /> returns the documented
+    /// <c>"Skein-{state}-{hashSize}"</c> format using the algorithm's current configuration.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenReadOnDefaultInstance_ShouldFollowSkeinNamingConvention()
+    {
+        using var skein = new TAlgorithm();
+        string name = skein.AlgorithmName;
+
+        Assert.IsTrue(name.StartsWith("Skein-", StringComparison.Ordinal),
+            $"Expected Skein algorithm name to start with 'Skein-', got '{name}'.");
+        Assert.IsTrue(name.EndsWith("-" + skein.HashSize, StringComparison.Ordinal),
+            $"Expected Skein algorithm name to end with '-{skein.HashSize}', got '{name}'.");
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="Skein{T}.AlgorithmName" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning a stale or partially-zeroed
+    /// string.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var skein = new TAlgorithm();
+        skein.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = skein.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning a <see cref="Skein{T}.Key" /> of exactly
+    /// <see cref="Skein{T}.MaxKeySizeBytes" /> bytes succeeds (boundary value test).
+    /// </summary>
+    [TestMethod]
+    public void Key_WhenAssignedExactlyMaxKeySize_ShouldNotThrow()
+    {
+        using var skein = new TAlgorithm();
+
+        try
+        {
+            skein.Key = new byte[Skein<TAlgorithm>.MaxKeySizeBytes];
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail(
+                $"Assigning a {Skein<TAlgorithm>.MaxKeySizeBytes}-byte key should be the inclusive upper bound, " +
+                $"but threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Skein{T}.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw — the constructor takes ownership of an internal Threefish
+    /// cipher, and a double-dispose path could otherwise propagate an inner
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var skein = new TAlgorithm();
+        skein.Dispose();
+
+        try
+        {
+            skein.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on {typeof(TAlgorithm).Name} threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed Skein instance — one that has never had any
+    /// property accessed or hashing performed — completes without throwing. Regression guard for
+    /// disposal paths that touch the internal Threefish cipher without null checks.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var skein = new TAlgorithm();
+
+        try
+        {
+            skein.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched {typeof(TAlgorithm).Name} instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that switching <see cref="Skein{T}.Key" /> from a non-empty value back to an empty
+    /// array causes the next <see cref="HashAlgorithm.ComputeHash(byte[])" /> call to produce the
+    /// canonical plain-hash digest — the empty array is the documented sentinel for the unkeyed
+    /// profile and must not leave the algorithm in a stale Skein-MAC state.
+    /// </summary>
+    [TestMethod]
+    public void Key_WhenReassignedFromMacToEmpty_ShouldRestorePlainHashOutput()
+    {
+        byte[] input = Enumerable.Range(0, 64).Select(i => (byte)i).ToArray();
+
+        byte[] plainHash;
+        using (var plain = new TAlgorithm())
+            plainHash = plain.ComputeHash(input);
+
+        using var skein = new TAlgorithm { Key = SkeinTestKey };
+        _ = skein.ComputeHash(input);
+
+        skein.Key = Array.Empty<byte>();
+        byte[] reverted = skein.ComputeHash(input);
+
+        CollectionAssert.AreEqual(plainHash, reverted,
+            "Reassigning Key to an empty array must restore the canonical plain-hash digest.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.UbiContract.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.UbiContract.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkeinTests.UbiContract.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Linq;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Direct-contract tests for the Skein UBI infrastructure exposed via the test-only
+/// <c>GetInitialChainingValueWords</c> entry point. The existing
+/// <c>SkeinTests.InitialChainingValues.cs</c> verifies that the IV matches the Skein 1.3
+/// Appendix B constants for the unkeyed configurations; this file pins down the surrounding
+/// contract — caching, defensive copies, key-driven invalidation, and disposed-state
+/// behaviour. Together they give the UBI compression path direct, parallel-pipeline-independent
+/// regression coverage.
+/// </summary>
+public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
+{
+    /// <summary>
+    /// Verifies that two consecutive calls to <c>GetInitialChainingValueWords</c> return arrays of
+    /// identical content — the IV is cached so repeated reads do not re-execute the CFG UBI phase
+    /// and do not drift across calls.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_WhenCalledTwice_ShouldReturnIdenticalContent()
+    {
+        using var algorithm = new TAlgorithm();
+        algorithm.Key = System.Array.Empty<byte>();
+
+        ulong[] first = algorithm.GetInitialChainingValueWords();
+        ulong[] second = algorithm.GetInitialChainingValueWords();
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetInitialChainingValueWords</c> returns a defensive copy — mutating the
+    /// returned array does not corrupt the cached state observed by a later read.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_ShouldReturnDefensiveCopy()
+    {
+        using var algorithm = new TAlgorithm();
+        algorithm.Key = System.Array.Empty<byte>();
+
+        ulong[] first = algorithm.GetInitialChainingValueWords();
+        first[0] = 0xDEADBEEFDEADBEEFUL;
+
+        ulong[] second = algorithm.GetInitialChainingValueWords();
+
+        Assert.AreNotEqual(0xDEADBEEFDEADBEEFUL, second[0],
+            "GetInitialChainingValueWords must return a defensive copy; caller mutation must not affect the cached state.");
+    }
+
+    /// <summary>
+    /// Verifies that the chaining-value word count equals the Skein state size in 64-bit words —
+    /// 4 for Skein-256, 8 for Skein-512, 16 for Skein-1024.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_ShouldReturnStateSizedWordArray()
+    {
+        using var algorithm = new TAlgorithm();
+        algorithm.Key = System.Array.Empty<byte>();
+
+        ulong[] words = algorithm.GetInitialChainingValueWords();
+
+        // Block size is in bytes; state holds one ulong per 8 bytes of state.
+        int expectedWordCount = algorithm.InputBlockSize / sizeof(ulong);
+        Assert.AreEqual(expectedWordCount, words.Length);
+    }
+
+    /// <summary>
+    /// Verifies that switching from the empty-key (plain hash) profile to a non-empty key produces
+    /// a different initial chaining value — the KEY UBI phase folds the key into the state before
+    /// the CFG phase, so the resulting IV must diverge from the unkeyed default.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_AfterAssigningNonEmptyKey_ShouldDifferFromUnkeyedDefault()
+    {
+        using var algorithm = new TAlgorithm();
+
+        algorithm.Key = System.Array.Empty<byte>();
+        ulong[] unkeyed = algorithm.GetInitialChainingValueWords();
+
+        algorithm.Key = SkeinTestKey;
+        ulong[] keyed = algorithm.GetInitialChainingValueWords();
+
+        Assert.IsFalse(unkeyed.SequenceEqual(keyed),
+            "Setting a non-empty key must invalidate the cached IV and produce a different KEY-UBI-then-CFG-UBI chaining value.");
+    }
+
+    /// <summary>
+    /// Verifies that re-assigning the same key value yields the same chaining value words — the
+    /// KEY UBI phase is deterministic and the cache invalidation on Key set re-runs the same
+    /// derivation rather than introducing entropy.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_WhenKeyReassignedToSameValue_ShouldMatchPreviousReading()
+    {
+        using var algorithm = new TAlgorithm();
+
+        algorithm.Key = SkeinTestKey;
+        ulong[] first = algorithm.GetInitialChainingValueWords();
+
+        algorithm.Key = (byte[])SkeinTestKey.Clone();
+        ulong[] second = algorithm.GetInitialChainingValueWords();
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that <c>GetInitialChainingValueWords</c> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than reading the cleared chaining-value
+    /// buffer.
+    /// </summary>
+    [TestMethod]
+    public void GetInitialChainingValueWords_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new TAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.GetInitialChainingValueWords();
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackAlgorithmTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackAlgorithmTests.EdgeCases.cs
@@ -1,0 +1,164 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkipjackAlgorithmTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Skipjack" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — wrong-sized key/IV material, idempotent
+/// disposal, untouched-instance disposal, and the algorithm-specific
+/// <see cref="Skipjack.BlockMode" /> property.
+/// </summary>
+public sealed partial class SkipjackAlgorithmTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Skipjack.CreateEncryptor(byte[], byte[])" /> with an out-of-range
+    /// key length throws <see cref="CryptographicException" /> for every wrong size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(9)]
+    [DataRow(11)]
+    [DataRow(16)]
+    [DataRow(32)]
+    public void CreateEncryptor_WhenKeyLengthIsInvalid_ShouldThrowExactly(int keyLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[keyLength], new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Skipjack.CreateEncryptor(byte[], byte[])" /> with an out-of-range
+    /// IV length throws <see cref="CryptographicException" /> for every wrong size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void CreateEncryptor_WhenIVLengthIsInvalid_ShouldThrowExactly(int ivLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[10], new byte[ivLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Skipjack.CreateDecryptor(byte[], byte[])" /> with an out-of-range
+    /// key length throws <see cref="CryptographicException" /> for every wrong size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(9)]
+    [DataRow(11)]
+    [DataRow(16)]
+    [DataRow(32)]
+    public void CreateDecryptor_WhenKeyLengthIsInvalid_ShouldThrowExactly(int keyLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateDecryptor(new byte[keyLength], new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Skipjack.CreateDecryptor(byte[], byte[])" /> with an out-of-range
+    /// IV length throws <see cref="CryptographicException" /> for every wrong size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void CreateDecryptor_WhenIVLengthIsInvalid_ShouldThrowExactly(int ivLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateDecryptor(new byte[10], new byte[ivLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Skipjack" /> instance — one that has
+    /// never had its key, IV, or any other property accessed — completes without throwing.
+    /// Regression guard for disposal paths that touch lazily-initialised state without null checks.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Skipjack instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Skipjack.Dispose" /> twice is idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Skipjack threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the algorithm-specific <see cref="Skipjack.BlockMode" /> property accepts
+    /// every <see cref="CipherBlockMode" /> value without throwing — it is a plain auto-property
+    /// and must not gain accidental enum validation.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.ECB)]
+    [DataRow(CipherBlockMode.CBC)]
+    [DataRow(CipherBlockMode.CFB)]
+    [DataRow(CipherBlockMode.OFB)]
+    [DataRow(CipherBlockMode.CTR)]
+    public void BlockMode_WhenSetToValidValue_ShouldNotThrow(CipherBlockMode mode)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        try
+        {
+            algorithm.BlockMode = mode;
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Setting Skipjack.BlockMode = {mode} threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackBlockCipherTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkipjackBlockCipherTests.EdgeCases.cs
@@ -1,0 +1,155 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SkipjackBlockCipherTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="SkipjackBlockCipher" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — wrong-sized key on construction, wrong-sized input/output
+/// spans on encrypt and decrypt, and idempotent disposal. Complements the generic
+/// <see cref="BlockCipherTests{TTest, TCipher, TVariant}" /> base coverage.
+/// </summary>
+internal sealed partial class SkipjackBlockCipherTests
+{
+    /// <summary>
+    /// Verifies that constructing a <see cref="SkipjackBlockCipher" /> with a key whose length is not
+    /// exactly <see cref="SkipjackBlockCipher.KeySize" /> throws <see cref="ArgumentException" /> rather
+    /// than <see cref="IndexOutOfRangeException" /> from the key-schedule loop.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(9)]
+    [DataRow(11)]
+    [DataRow(16)]
+    [DataRow(32)]
+    [DataRow(64)]
+    public void Ctor_WhenKeyLengthIsInvalid_ShouldThrowExactly(int keyLength)
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = new SkipjackBlockCipher(new byte[keyLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SkipjackBlockCipher.Encrypt(ReadOnlySpan{byte}, Span{byte})" /> with
+    /// an input span whose length is not exactly <see cref="SkipjackBlockCipher.BlockBytes" /> throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void Encrypt_WhenInputIsWrongSize_ShouldThrowExactly(int inputLength)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Encrypt(new byte[inputLength], new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SkipjackBlockCipher.Encrypt(ReadOnlySpan{byte}, Span{byte})" /> with
+    /// an output span whose length is not exactly <see cref="SkipjackBlockCipher.BlockBytes" /> throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void Encrypt_WhenOutputIsWrongSize_ShouldThrowExactly(int outputLength)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Encrypt(new byte[8], new byte[outputLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SkipjackBlockCipher.Decrypt(ReadOnlySpan{byte}, Span{byte})" /> with
+    /// an input span whose length is not exactly <see cref="SkipjackBlockCipher.BlockBytes" /> throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void Decrypt_WhenInputIsWrongSize_ShouldThrowExactly(int inputLength)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Decrypt(new byte[inputLength], new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SkipjackBlockCipher.Decrypt(ReadOnlySpan{byte}, Span{byte})" /> with
+    /// an output span whose length is not exactly <see cref="SkipjackBlockCipher.BlockBytes" /> throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(16)]
+    public void Decrypt_WhenOutputIsWrongSize_ShouldThrowExactly(int outputLength)
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Decrypt(new byte[8], new byte[outputLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="SkipjackBlockCipher.Dispose" /> twice is idempotent and
+    /// does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+        cipher.Dispose();
+
+        try
+        {
+            cipher.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on SkipjackBlockCipher threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SkipjackBlockCipher.BlockSize" /> remains queryable after disposal
+    /// since it returns the compile-time constant <see cref="SkipjackBlockCipher.BlockBytes" />
+    /// rather than any state that gets cleared on disposal.
+    /// </summary>
+    [TestMethod]
+    public void BlockSize_WhenAccessedAfterDispose_ShouldReturnConstant()
+    {
+        var cipher = new SkipjackBlockCipher(new byte[10]);
+        cipher.Dispose();
+
+        Assert.AreEqual(SkipjackBlockCipher.BlockBytes, cipher.BlockSize);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Threefish256TweakableAlgorithmTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Threefish256TweakableAlgorithmTests.EdgeCases.cs
@@ -1,0 +1,343 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Threefish256TweakableAlgorithmTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Threefish256" /> for unexpected exceptions when its public surface is
+/// exercised outside of expected usage — null tweak/key/IV, wrong-sized arrays, disposed-state
+/// access, and idempotent disposal. Complements the generic
+/// <see cref="TweakableSymmetricAlgorithmTests{TTest, TAlgorithm}" /> base coverage.
+/// </summary>
+public sealed partial class Threefish256TweakableAlgorithmTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// <see langword="null" /> tweak throws <see cref="ArgumentNullException" /> rather than
+    /// <see cref="NullReferenceException" /> from an unguarded length read.
+    /// </summary>
+    [TestMethod]
+    public void CreateEncryptor_WhenTweakIsNull_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[32], new byte[32], null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateDecryptor(byte[], byte[], byte[])" /> with a
+    /// <see langword="null" /> tweak throws <see cref="ArgumentNullException" /> rather than
+    /// <see cref="NullReferenceException" /> from an unguarded length read.
+    /// </summary>
+    [TestMethod]
+    public void CreateDecryptor_WhenTweakIsNull_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.CreateDecryptor(new byte[32], new byte[32], null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// <see langword="null" /> key throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateEncryptor_WhenKeyIsNull_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(null!, new byte[32], new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// <see langword="null" /> IV throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateEncryptor_WhenIVIsNull_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[32], null!, new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// wrong-sized tweak throws <see cref="CryptographicException" /> rather than producing a
+    /// transform with truncated or padded tweak material.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(8)]
+    [DataRow(15)]
+    [DataRow(17)]
+    [DataRow(32)]
+    public void CreateEncryptor_WhenTweakLengthIsInvalid_ShouldThrowExactly(int tweakLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[32], new byte[32], new byte[tweakLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateDecryptor(byte[], byte[], byte[])" /> with a
+    /// wrong-sized tweak throws <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(8)]
+    [DataRow(15)]
+    [DataRow(17)]
+    [DataRow(32)]
+    public void CreateDecryptor_WhenTweakLengthIsInvalid_ShouldThrowExactly(int tweakLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateDecryptor(new byte[32], new byte[32], new byte[tweakLength]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// wrong-sized key throws <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(16)]
+    [DataRow(31)]
+    [DataRow(33)]
+    [DataRow(64)]
+    public void CreateEncryptor_WhenKeyLengthIsInvalid_ShouldThrowExactly(int keyLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[keyLength], new byte[32], new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> with a
+    /// wrong-sized IV throws <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(16)]
+    [DataRow(31)]
+    [DataRow(33)]
+    [DataRow(64)]
+    public void CreateEncryptor_WhenIVLengthIsInvalid_ShouldThrowExactly(int ivLength)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[32], new byte[ivLength], new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.GenerateTweak" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void GenerateTweak_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.GenerateTweak();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateEncryptor(byte[], byte[], byte[])" /> on a
+    /// disposed instance throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateEncryptor_WithTweak_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.CreateEncryptor(new byte[32], new byte[32], new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Threefish.CreateDecryptor(byte[], byte[], byte[])" /> on a
+    /// disposed instance throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateDecryptor_WithTweak_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.CreateDecryptor(new byte[32], new byte[32], new byte[16]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Threefish256" /> instance — one
+    /// that has never had its key, IV, tweak, or any other property accessed — completes without
+    /// throwing. Regression guard for disposal paths that touch lazily-initialised state without
+    /// null checks.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Threefish256 instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Threefish.Dispose" /> twice is idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Threefish256 threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the algorithm-specific <see cref="Threefish.BlockMode" /> property accepts
+    /// every <see cref="CipherBlockMode" /> value without throwing — it is a plain auto-property
+    /// and must not gain accidental enum validation.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.ECB)]
+    [DataRow(CipherBlockMode.CBC)]
+    [DataRow(CipherBlockMode.CFB)]
+    [DataRow(CipherBlockMode.OFB)]
+    [DataRow(CipherBlockMode.CTR)]
+    public void BlockMode_WhenSetToValidValue_ShouldNotThrow(CipherBlockMode mode)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        try
+        {
+            algorithm.BlockMode = mode;
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Setting Threefish256.BlockMode = {mode} threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that assigning <see cref="TweakableSymmetricAlgorithm.TweakSize" /> to <c>0</c>
+    /// throws <see cref="CryptographicException" /> rather than leaving the algorithm in an
+    /// invalid configuration where <see cref="TweakableSymmetricAlgorithm.Tweak" /> would later
+    /// fail with <see cref="NullReferenceException" /> or another unexpected exception.
+    /// </summary>
+    [TestMethod]
+    public void TweakSize_WhenSetToZero_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            algorithm.TweakSize = 0;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning a wrongly-sized <see cref="TweakableSymmetricAlgorithm.TweakSize" />
+    /// throws <see cref="CryptographicException" /> for a representative range of off-by-one and
+    /// off-by-many values.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(64)]
+    [DataRow(127)]
+    [DataRow(129)]
+    [DataRow(256)]
+    [DataRow(-1)]
+    public void TweakSize_WhenSetToInvalidValue_ShouldThrowExactly(int value)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            algorithm.TweakSize = value;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="TweakableSymmetricAlgorithm.LegalTweakSizes" /> on a
+    /// disposed instance does not throw <see cref="NullReferenceException" /> from a cleared
+    /// backing field.
+    /// </summary>
+    [TestMethod]
+    public void LegalTweakSizes_WhenAccessedAfterDispose_ShouldNotThrowUnexpected()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        try
+        {
+            var sizes = algorithm.LegalTweakSizes;
+            Assert.IsNotNull(sizes);
+        }
+        catch (ObjectDisposedException)
+        {
+            // Acceptable — disposal contract may forbid further reads.
+        }
+        catch (Exception ex) when (ex is not ObjectDisposedException)
+        {
+            Assert.Fail(
+                $"Reading LegalTweakSizes after Dispose threw an unexpected exception: " +
+                $"{ex.GetType().Name}: {ex.Message}");
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.EdgeCases.cs
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="TigerTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Tiger" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — disposed-state access, invalid enum casts, repeated disposal,
+/// and state-machine transitions.
+/// </summary>
+public partial class TigerTests
+{
+    /// <summary>
+    /// Verifies that reading <see cref="Tiger.AlgorithmName" /> after <see cref="HashAlgorithm.Dispose()" />
+    /// throws <see cref="ObjectDisposedException" /> and not a generic <see cref="NullReferenceException" />.
+    /// </summary>
+    [TestMethod]
+    public void AlgorithmName_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.AlgorithmName;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="Tiger.HashSize" /> after disposal throws
+    /// <see cref="ObjectDisposedException" /> rather than returning a stale value.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenAccessedAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.HashSize;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed instance
+    /// throws <see cref="ObjectDisposedException" /> and not <see cref="NullReferenceException" />
+    /// from the residual buffer access in the base class.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Tiger.Dispose" /> a second time is idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Tiger threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that assigning an undefined <see cref="TigerHashingVariant" /> value to
+    /// <see cref="Tiger.Variant" /> throws <see cref="ArgumentOutOfRangeException" /> via the
+    /// enum-defined-value guard rather than a raw cast pass-through.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(2)]
+    [DataRow(int.MaxValue)]
+    [DataRow(int.MinValue)]
+    public void Variant_WhenSetToUndefinedEnum_ShouldThrowExactly(int rawValue)
+    {
+        using var algorithm = CreateAlgorithm();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            algorithm.Variant = (TigerHashingVariant)rawValue;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that setting <see cref="Tiger.HashSize" /> after <see cref="HashAlgorithm.TransformBlock" />
+    /// has been called throws <see cref="CryptographicUnexpectedOperationException" /> rather than
+    /// silently mutating the digest length mid-computation.
+    /// </summary>
+    [TestMethod]
+    public void HashSize_WhenSetAfterTransformBlock_ShouldThrowExactly()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = new byte[] { 0x01, 0x02, 0x03 };
+        algorithm.TransformBlock(input, 0, input.Length, null, 0);
+
+        Assert.ThrowsExactly<CryptographicUnexpectedOperationException>(() =>
+        {
+            algorithm.HashSize = 128;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="Tiger" /> with an unsupported hash size throws
+    /// <see cref="ArgumentOutOfRangeException" /> rather than allowing the bad size to silently
+    /// propagate to <see cref="HashAlgorithm.HashSize" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(64)]
+    [DataRow(96)]
+    [DataRow(193)]
+    [DataRow(256)]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void Ctor_WhenHashSizeIsInvalid_ShouldThrowExactly(int hashSize)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new Tiger(hashSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="HashAlgorithm.ComputeHash(byte[])" /> on a disposed instance throws
+    /// <see cref="ObjectDisposedException" /> rather than returning a stale or zeroed digest.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = CreateAlgorithm();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = algorithm.ComputeHash(new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that two consecutive <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls
+    /// against the same <see cref="Tiger" /> instance produce identical digests for identical
+    /// input — guarding against state leakage across reuse.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedRepeatedly_ShouldYieldIdenticalDigest()
+    {
+        using var algorithm = CreateAlgorithm();
+        byte[] input = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.EdgeCases.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/WhirlpoolTests.EdgeCases.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WhirlpoolTests.EdgeCases.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Probes <see cref="Whirlpool" /> for unexpected exceptions when its public surface is exercised
+/// outside of expected usage — idempotent disposal, untouched-instance disposal, and reuse
+/// across <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls. Complements
+/// <c>WhirlpoolTests.Version</c> which already covers the algorithm-specific
+/// <see cref="Whirlpool.Version" /> property.
+/// </summary>
+public partial class WhirlpoolTests
+{
+    /// <summary>
+    /// Verifies that calling <see cref="Whirlpool.Dispose" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        var algorithm = new Whirlpool();
+        algorithm.Dispose();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Second Dispose on Whirlpool threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed <see cref="Whirlpool" /> instance — one that
+    /// has never had any property accessed or hashing performed — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        var algorithm = new Whirlpool();
+
+        try
+        {
+            algorithm.Dispose();
+        }
+        catch (Exception ex)
+        {
+            Assert.Fail($"Disposing an untouched Whirlpool instance threw {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="HashAlgorithm.Initialize" /> on a disposed
+    /// <see cref="Whirlpool" /> instance throws <see cref="ObjectDisposedException" /> rather than
+    /// touching the cleared internal state.
+    /// </summary>
+    [TestMethod]
+    public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly()
+    {
+        var algorithm = new Whirlpool();
+        algorithm.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            algorithm.Initialize();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that two consecutive <see cref="HashAlgorithm.ComputeHash(byte[])" /> calls
+    /// against the same <see cref="Whirlpool" /> instance produce identical digests for identical
+    /// input — guarding against state leakage across reuse and confirming that
+    /// <see cref="Whirlpool.Version" /> selection persists across hashes.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenInvokedRepeatedly_ShouldYieldIdenticalDigest()
+    {
+        using var algorithm = new Whirlpool();
+        byte[] input = Enumerable.Range(0, 256).Select(i => (byte)i).ToArray();
+
+        byte[] first = algorithm.ComputeHash(input);
+        byte[] second = algorithm.ComputeHash(input);
+
+        CollectionAssert.AreEqual(first, second);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/ZeroPaddingTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/ZeroPaddingTests.cs
@@ -16,6 +16,14 @@ public sealed partial class ZeroPaddingTests
 
     /// <inheritdoc />
     /// <remarks>
+    /// <see cref="ZeroPadding.Unpad" /> ignores its <c>blockSize</c> parameter — it returns the input unchanged
+    /// because zero-padding bytes cannot be distinguished from legitimate trailing zero bytes. The block-size
+    /// validation tests are therefore inapplicable.
+    /// </remarks>
+    protected override bool ValidatesBlockSizeOnUnpad => false;
+
+    /// <inheritdoc />
+    /// <remarks>
     /// <see cref="ZeroPadding.Unpad" /> cannot distinguish padding zero bytes from legitimate trailing zero bytes in the
     /// plaintext, so it cannot recover the original length for residuals greater than zero. The round-trip test only
     /// exercises residual 0 (where Pad and Unpad are both no-ops).


### PR DESCRIPTION
Probes Tiger, SipHash, Skipjack, SkipjackBlockCipher, and Threefish256
for unexpected exceptions when their public APIs are exercised outside
of expected usage — disposed-state access, mid-stream property mutation,
null/wrong-sized arguments, undefined enum casts, idempotent disposal,
and the algorithm-specific BlockMode/Tweak surfaces. Complements the
generic algorithm-base coverage rather than duplicating it.