### PR TITLE
Hash-algorithm review: bitwise + lifecycle + dispose + naming consolidation

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
@@ -84,7 +84,7 @@ public abstract partial class AsconHash<T>
     /// <value>A string such as <c>"ASCON-HASH256"</c> or <c>"ASCON-HASHA256"</c> identifying the variant.</value>
     /// <returns>The algorithm identifier string supplied at construction.</returns>
     /// <exception cref="ObjectDisposedException">The algorithm instance has been disposed.</exception>
-    public string AlgorithmName
+    public override string AlgorithmName
     {
         get
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
@@ -104,8 +104,9 @@ public abstract partial class AsconHash<T>
     /// Loads the pre-computed initial state directly — no permutation is needed because the constants
     /// supplied by the derived class are already the result of applying Ascon-p12 to the raw IV.
     /// </remarks>
-    protected override void OnInitialize()
+    public override void Initialize()
     {
+        base.Initialize();
         this._state = new AsconState { S0 = this._iv0, S1 = this._iv1, S2 = this._iv2, S3 = this._iv3, S4 = this._iv4 };
         this._useP12ForFinalPad = false;
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
@@ -100,13 +100,12 @@ public abstract partial class AsconHash<T>
     public override bool CanTransformMultipleBlocks => true;
 
     /// <inheritdoc />
-    public override void Initialize()
+    /// <remarks>
+    /// Loads the pre-computed initial state directly — no permutation is needed because the constants
+    /// supplied by the derived class are already the result of applying Ascon-p12 to the raw IV.
+    /// </remarks>
+    protected override void OnInitialize()
     {
-        this.ThrowIfDisposed();
-        base.Initialize();
-
-        // Load the pre-computed initial state directly — no permutation is needed because these
-        // values are already the result of applying Ascon-p12 to the raw IV constant.
         this._state = new AsconState { S0 = this._iv0, S1 = this._iv1, S2 = this._iv2, S3 = this._iv3, S4 = this._iv4 };
         this._useP12ForFinalPad = false;
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash.cs
@@ -42,7 +42,6 @@ public abstract partial class AsconHash<T>
     private readonly ulong _iv3;
     private readonly ulong _iv4;
 
-    private bool _disposed;
     private bool _useP12ForFinalPad;
     private AsconState _state;
 
@@ -120,16 +119,13 @@ public abstract partial class AsconHash<T>
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
             this._state.Clear();
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconState.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconState.cs
@@ -5,8 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Buffers.Binary;
-using System.Numerics;
 using System.Runtime.CompilerServices;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -96,11 +96,11 @@ internal struct AsconState
             s1 ^= s0; s0 ^= s4; s3 ^= s2; s2 = ~s2;
 
             // Linear diffusion layer: each word XORed with two rotated copies.
-            s0 ^= BitOperations.RotateRight(s0, 19) ^ BitOperations.RotateRight(s0, 28);
-            s1 ^= BitOperations.RotateRight(s1, 61) ^ BitOperations.RotateRight(s1, 39);
-            s2 ^= BitOperations.RotateRight(s2,  1) ^ BitOperations.RotateRight(s2,  6);
-            s3 ^= BitOperations.RotateRight(s3, 10) ^ BitOperations.RotateRight(s3, 17);
-            s4 ^= BitOperations.RotateRight(s4,  7) ^ BitOperations.RotateRight(s4, 41);
+            s0 ^= s0.RotateBitsRightUnchecked(19) ^ s0.RotateBitsRightUnchecked(28);
+            s1 ^= s1.RotateBitsRightUnchecked(61) ^ s1.RotateBitsRightUnchecked(39);
+            s2 ^= s2.RotateBitsRightUnchecked( 1) ^ s2.RotateBitsRightUnchecked( 6);
+            s3 ^= s3.RotateBitsRightUnchecked(10) ^ s3.RotateBitsRightUnchecked(17);
+            s4 ^= s4.RotateBitsRightUnchecked( 7) ^ s4.RotateBitsRightUnchecked(41);
         }
 
         this.S0 = s0; this.S1 = s1; this.S2 = s2; this.S3 = s3; this.S4 = s4;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -129,6 +129,17 @@ public sealed class Blake2b : KeyedDeferredFinalBlockHashAlgorithm<Blake2b>
     /// <inheritdoc />
     public override bool CanTransformMultipleBlocks => true;
 
+    /// <inheritdoc />
+    /// <remarks>The format is <c>"BLAKE2b-<i>n</i>"</c>, where <i>n</i> is the configured digest size in bits.</remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return $"BLAKE2b-{this.HashSizeValue}";
+        }
+    }
+
     /// <summary>
     /// Gets or sets the size, in bits, of the final computed hash output.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -200,11 +200,11 @@ public sealed class Blake2b : KeyedDeferredFinalBlockHashAlgorithm<Blake2b>
     /// </remarks>
     protected override void Dispose(bool disposing)
     {
+        if (this.IsDisposed) return;
+
         if (disposing)
         {
             CryptoHelpers.Clear(this._h);
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this.HashSizeValue = 0;
         }
 
         base.Dispose(disposing);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -7,6 +7,7 @@
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -319,22 +320,12 @@ public sealed class Blake2b : KeyedDeferredFinalBlockHashAlgorithm<Blake2b>
     private static void G(Span<ulong> v, int a, int b, int c, int d, ulong x, ulong y)
     {
         v[a] += v[b] + x;
-        v[d] = RotateRight(v[d] ^ v[a], 32);
+        v[d] = (v[d] ^ v[a]).RotateBitsRightUnchecked(32);
         v[c] += v[d];
-        v[b] = RotateRight(v[b] ^ v[c], 24);
+        v[b] = (v[b] ^ v[c]).RotateBitsRightUnchecked(24);
         v[a] += v[b] + y;
-        v[d] = RotateRight(v[d] ^ v[a], 16);
+        v[d] = (v[d] ^ v[a]).RotateBitsRightUnchecked(16);
         v[c] += v[d];
-        v[b] = RotateRight(v[b] ^ v[c], 63);
+        v[b] = (v[b] ^ v[c]).RotateBitsRightUnchecked(63);
     }
-
-    /// <summary>
-    /// Rotates a 64-bit unsigned integer right by the specified number of bits.
-    /// </summary>
-    /// <param name="value">The value to rotate.</param>
-    /// <param name="bits">The number of positions to rotate right.</param>
-    /// <returns>The rotated value.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ulong RotateRight(ulong value, int bits) =>
-        (value >> bits) | (value << (64 - bits));
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -199,11 +199,11 @@ public sealed class Blake2s : KeyedDeferredFinalBlockHashAlgorithm<Blake2s>
     /// </remarks>
     protected override void Dispose(bool disposing)
     {
+        if (this.IsDisposed) return;
+
         if (disposing)
         {
             CryptoHelpers.Clear(this._h);
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this.HashSizeValue = 0;
         }
 
         base.Dispose(disposing);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -128,6 +128,17 @@ public sealed class Blake2s : KeyedDeferredFinalBlockHashAlgorithm<Blake2s>
     /// <inheritdoc />
     public override bool CanTransformMultipleBlocks => true;
 
+    /// <inheritdoc />
+    /// <remarks>The format is <c>"BLAKE2s-<i>n</i>"</c>, where <i>n</i> is the configured digest size in bits.</remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return $"BLAKE2s-{this.HashSizeValue}";
+        }
+    }
+
     /// <summary>
     /// Gets or sets the size, in bits, of the final computed hash output.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -7,6 +7,7 @@
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -318,22 +319,12 @@ public sealed class Blake2s : KeyedDeferredFinalBlockHashAlgorithm<Blake2s>
     private static void G(Span<uint> v, int a, int b, int c, int d, uint x, uint y)
     {
         v[a] += v[b] + x;
-        v[d] = RotateRight(v[d] ^ v[a], 16);
+        v[d] = (v[d] ^ v[a]).RotateBitsRightUnchecked(16);
         v[c] += v[d];
-        v[b] = RotateRight(v[b] ^ v[c], 12);
+        v[b] = (v[b] ^ v[c]).RotateBitsRightUnchecked(12);
         v[a] += v[b] + y;
-        v[d] = RotateRight(v[d] ^ v[a], 8);
+        v[d] = (v[d] ^ v[a]).RotateBitsRightUnchecked(8);
         v[c] += v[d];
-        v[b] = RotateRight(v[b] ^ v[c], 7);
+        v[b] = (v[b] ^ v[c]).RotateBitsRightUnchecked(7);
     }
-
-    /// <summary>
-    /// Rotates a 32-bit unsigned integer right by the specified number of bits.
-    /// </summary>
-    /// <param name="value">The value to rotate.</param>
-    /// <param name="bits">The number of positions to rotate right.</param>
-    /// <returns>The rotated value.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static uint RotateRight(uint value, int bits) =>
-        (value >> bits) | (value << (32 - bits));
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -202,12 +202,12 @@ public sealed class Blake3
     /// </remarks>
     protected override void Dispose(bool disposing)
     {
+        if (this.IsDisposed) return;
+
         if (disposing)
         {
             _cvStack.Clear();
             CryptoHelpers.Clear(_chunkCv);
-            CryptoHelpers.ClearAndNullify(ref HashValue);
-            HashSizeValue = 0;
         }
 
         base.Dispose(disposing);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -168,6 +168,17 @@ public sealed class Blake3
     public override bool CanTransformMultipleBlocks => true;
 
     /// <inheritdoc />
+    /// <remarks>BLAKE3 has a fixed 256-bit default output; the published name is simply <c>"BLAKE3"</c>.</remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return "BLAKE3";
+        }
+    }
+
+    /// <inheritdoc />
     /// <remarks>
     /// Clears the CV stack and restores <see cref="_chunkCv" /> to the BLAKE3 initialisation vector, ready for a new
     /// chunk. The inherited residual buffer and counters are cleared by the base call (which also throws

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -168,24 +168,19 @@ public sealed class Blake3
     public override bool CanTransformMultipleBlocks => true;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// Clears the CV stack and restores <see cref="_chunkCv" /> to the BLAKE3 initialisation vector, ready for a new
+    /// chunk. The inherited residual buffer and counters are cleared by the base call (which also throws
+    /// <see cref="ObjectDisposedException" /> if the instance has been disposed).
+    /// </remarks>
     public override void Initialize()
     {
-        ThrowIfDisposed();
         base.Initialize();
-    }
-
-    // ---- DeferredFinalBlockHashAlgorithm<T> implementation ----
-
-    /// <inheritdoc />
-    /// <remarks>
-    /// Clears the CV stack and restores <see cref="_chunkCv" /> to the BLAKE3 initialisation
-    /// vector, ready for a new chunk.
-    /// </remarks>
-    protected override void OnInitialize()
-    {
         _cvStack.Clear();
         s_iv.CopyTo(_chunkCv, 0);
     }
+
+    // ---- DeferredFinalBlockHashAlgorithm<T> implementation ----
 
     /// <remarks>
     /// Clears the CV stack, zeroes <see cref="_chunkCv" />, releases the framework

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -7,6 +7,7 @@
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -423,24 +424,14 @@ public sealed class Blake3
     private static void G(uint[] state, int a, int b, int c, int d, uint mx, uint my)
     {
         state[a] = state[a] + state[b] + mx;
-        state[d] = RotateRight(state[d] ^ state[a], 16);
+        state[d] = (state[d] ^ state[a]).RotateBitsRightUnchecked(16);
         state[c] = state[c] + state[d];
-        state[b] = RotateRight(state[b] ^ state[c], 12);
+        state[b] = (state[b] ^ state[c]).RotateBitsRightUnchecked(12);
         state[a] = state[a] + state[b] + my;
-        state[d] = RotateRight(state[d] ^ state[a], 8);
+        state[d] = (state[d] ^ state[a]).RotateBitsRightUnchecked(8);
         state[c] = state[c] + state[d];
-        state[b] = RotateRight(state[b] ^ state[c], 7);
+        state[b] = (state[b] ^ state[c]).RotateBitsRightUnchecked(7);
     }
-
-    /// <summary>
-    /// Rotates <paramref name="value" /> right by <paramref name="bits" /> positions.
-    /// </summary>
-    /// <param name="value">The value to rotate.</param>
-    /// <param name="bits">The number of bit positions to rotate right.</param>
-    /// <returns>The rotated value.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static uint RotateRight(uint value, int bits) =>
-        (value >> bits) | (value << (32 - bits));
 
     // ---- block and parent processing ----
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
@@ -86,15 +86,6 @@ public abstract class BlockHashAlgorithm<T>
     /// </summary>
     protected virtual bool AllowUnalignedFinalBlock => false;
 
-    /// <inheritdoc />
-    /// <remarks>
-    /// The Merkle&#8211;Damg&#229;rd base owns no algorithm-side state &#8212; the chaining variables, IV, and any
-    /// schedule live entirely in derived classes. The empty body satisfies the grandparent's abstract contract.
-    /// </remarks>
-    protected override void OnInitialize()
-    {
-    }
-
     /// <summary>
     /// Processes the entirety of the input <paramref name="source" /> and feeds it into the computation pipeline. This method updates
     /// the internal hash state accordingly by consuming the entire input span.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -201,8 +201,10 @@ public abstract class BufferedBlockHashAlgorithm<T>
         if (disposing)
         {
             CryptoHelpers.Clear(this._residualBlock);
+            CryptoHelpers.ClearAndNullify(ref this.HashValue);
             this._residualBytes = 0;
             this._totalBytes = 0UL;
+            this.HashSizeValue = 0;
         }
 
         this._disposed = true;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -75,6 +75,20 @@ public abstract class BufferedBlockHashAlgorithm<T>
     where T : BufferedBlockHashAlgorithm<T>, new()
 {
     /// <summary>
+    /// Gets the canonical, fully-qualified algorithm name for this instance, including any size or variant
+    /// qualifiers (for example, <c>"Tiger/192"</c>, <c>"Skein-512-256"</c>, <c>"BLAKE2b-512"</c>,
+    /// <c>"ASCON-HASH256"</c>, <c>"SipHash-2-4-64"</c>).
+    /// </summary>
+    /// <returns>A string identifying the algorithm and its current configuration.</returns>
+    /// <remarks>
+    /// Derived classes implement this property to expose a stable, consumer-facing identifier suitable for
+    /// logging, telemetry, registry keys, or interop with hash-name catalogues. Implementations should be
+    /// pure and side-effect-free — the value may be queried before any input has been consumed and after
+    /// disposal as part of error reporting.
+    /// </remarks>
+    public abstract string AlgorithmName { get; }
+
+    /// <summary>
     /// The fixed size, in bytes, of each block consumed by the algorithm.
     /// </summary>
     protected readonly int BlockSizeBytes;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -141,6 +141,7 @@ public abstract class BufferedBlockHashAlgorithm<T>
     /// invokes <see cref="OnInitialize" /> so that derived classes may reset any algorithm-specific state such as
     /// chaining variables or key-derived schedule.
     /// </summary>
+    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
     /// <remarks>
     /// This method does not reset the <see cref="HashAlgorithm.State" /> property explicitly on .NET 6+ targets &#8212;
     /// the framework manages that transition. On earlier targets, derived classes that need the already-finalised
@@ -148,6 +149,7 @@ public abstract class BufferedBlockHashAlgorithm<T>
     /// </remarks>
     public override void Initialize()
     {
+        this.ThrowIfDisposed();
         this._residualBlock.Span.Clear();
         this._residualBytes = 0;
         this._totalBytes = 0UL;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -261,6 +261,20 @@ public abstract class BufferedBlockHashAlgorithm<T>
     }
 
     /// <summary>
+    /// Gets a value indicating whether this instance has been disposed. Read-only and updated exactly once by
+    /// <see cref="Dispose(bool)" /> after the residual buffer and counters have been cleared.
+    /// </summary>
+    /// <returns><see langword="true" /> once disposal has begun; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// Derived classes follow the canonical dispose pattern — guard the body of their own
+    /// <see cref="Dispose(bool)" /> override with <c>if (this.IsDisposed) return;</c>, clear their own state when
+    /// <c>disposing</c> is <see langword="true" />, and call <c>base.Dispose(disposing)</c> last. Derived classes
+    /// must not declare a private <c>_disposed</c> field of their own — the latch is owned exclusively by this
+    /// base class.
+    /// </remarks>
+    protected bool IsDisposed => this._disposed;
+
+    /// <summary>
     /// Throws an <see cref="ObjectDisposedException" /> if the instance has been disposed.
     /// </summary>
     /// <exception cref="ObjectDisposedException">Thrown when the instance has already been disposed.</exception>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -33,7 +33,7 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// <para>Derived classes must implement the following:</para>
 /// <list type="bullet">
-/// <item><description><see cref="OnInitialize" /> resets any algorithm-specific state (chaining variables, IV, schedule).</description></item>
+/// <item><description><see cref="HashAlgorithm.Initialize" /> resets any algorithm-specific state (chaining variables, IV, schedule). Override and call <c>base.Initialize()</c> first.</description></item>
 /// <item><description><see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> consumes the input span using the buffering shape required by the algorithm family.</description></item>
 /// <item><description><see cref="HashAlgorithm.HashFinal" /> finalises the computation and returns the digest.</description></item>
 /// </list>
@@ -125,9 +125,9 @@ public abstract class BufferedBlockHashAlgorithm<T>
     /// Thrown when <paramref name="blockSize" /> is less than or equal to zero.
     /// </exception>
     /// <remarks>
-    /// Allocates the residual buffer at <paramref name="blockSize" /> bytes. Derived classes are expected to call
-    /// their own <c>InitializeState()</c> equivalent from their constructor (and again from <see cref="OnInitialize" />)
-    /// so that the algorithm state matches the freshly-cleared residual buffer.
+    /// Allocates the residual buffer at <paramref name="blockSize" /> bytes. Derived classes are expected to override
+    /// <see cref="Initialize" />, call <c>base.Initialize()</c> first to clear the inherited buffer and counters, then
+    /// reset their own algorithm-specific state so the two halves stay in sync.
     /// </remarks>
     protected BufferedBlockHashAlgorithm(int blockSize)
     {
@@ -137,15 +137,23 @@ public abstract class BufferedBlockHashAlgorithm<T>
     }
 
     /// <summary>
-    /// Resets the algorithm to its initial state. Clears the residual buffer, resets the running byte total, and then
-    /// invokes <see cref="OnInitialize" /> so that derived classes may reset any algorithm-specific state such as
-    /// chaining variables or key-derived schedule.
+    /// Resets the algorithm to its initial state by clearing the residual buffer and the running byte total.
+    /// Derived classes override this method, call <c>base.Initialize()</c> first, and then reset their own
+    /// algorithm-specific state (chaining variables, IV, key-derived schedule).
     /// </summary>
     /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
     /// <remarks>
+    /// <para>
     /// This method does not reset the <see cref="HashAlgorithm.State" /> property explicitly on .NET 6+ targets &#8212;
     /// the framework manages that transition. On earlier targets, derived classes that need the already-finalised
     /// guard should reset their <c>_finalized</c> backing field from their own <c>Initialize</c> override.
+    /// </para>
+    /// <para>
+    /// Derived classes that need to validate state before the reset (for example, a keyed MAC that refuses to be
+    /// re-initialised when no key has been set) should perform that validation before calling
+    /// <c>base.Initialize()</c>. Once the base call returns, the residual buffer is empty,
+    /// <see cref="_residualBytes" /> is <c>0</c>, and <see cref="_totalBytes" /> is <c>0</c>.
+    /// </para>
     /// </remarks>
     public override void Initialize()
     {
@@ -153,20 +161,7 @@ public abstract class BufferedBlockHashAlgorithm<T>
         this._residualBlock.Span.Clear();
         this._residualBytes = 0;
         this._totalBytes = 0UL;
-        this.OnInitialize();
     }
-
-    /// <summary>
-    /// Hook invoked by <see cref="Initialize" /> after the shared residual buffer and counters have been cleared.
-    /// Derived classes implement this to reset their algorithm-specific state, for example chaining variables, the
-    /// initialisation vector, or key-derived schedule.
-    /// </summary>
-    /// <remarks>
-    /// By contract, when this method runs the residual buffer is empty, <see cref="_residualBytes" /> is <c>0</c>,
-    /// and <see cref="_totalBytes" /> is <c>0</c>. Implementations should not touch the buffer or the counter; doing
-    /// so risks desynchronising the two halves of the algorithm state.
-    /// </remarks>
-    protected abstract void OnInitialize();
 
     /// <summary>
     /// Releases the resources used by the algorithm and zeros the residual buffer.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -329,6 +329,12 @@ public sealed class CubeHash
                 CryptoHelpers.ClearAndNullify(ref this._initializedState!);
                 this._isInitializedStateCached = false;
             }
+
+            this._finalizationRounds = 0;
+            this._initializationRounds = 0;
+            this._rounds = 0;
+            this._inputBlockSizeBytes = 0;
+            this._pendingBytes = 0;
         }
 
         this._disposed = true;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -5,10 +5,10 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Buffers.Binary;
-using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -301,8 +301,8 @@ public sealed class CubeHash
     {
         this.ThrowIfDisposed();
 #if !NET6_0_OR_GREATER
-        State = 0;
-        finalized = false;
+        this.State = 0;
+        this._finalized = false;
 #endif
         this._pendingBytes = 0;
 
@@ -367,7 +367,7 @@ public sealed class CubeHash
         ThrowHelper.ThrowIfLessThan(ibStart, 0);
         ThrowHelper.ThrowIfLessThan(cbSize, 0);
         ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, ibStart, cbSize);
-        if (finalized)
+        if (this._finalized)
             throw new CryptographicUnexpectedOperationException(CryptoResourceStrings.CryptographicException_AlreadyFinalized);
 #endif
         this.EnsureInitialized();
@@ -435,10 +435,10 @@ public sealed class CubeHash
     {
         this.ThrowIfDisposed();
 #if !NET6_0_OR_GREATER
-        if (finalized)
+        if (this._finalized)
             throw new CryptographicUnexpectedOperationException(CryptoResourceStrings.CryptographicException_AlreadyFinalized);
-        finalized = true;
-        State = 2;
+        this._finalized = true;
+        this.State = 2;
 #endif
         this.EnsureInitialized();
 
@@ -509,7 +509,7 @@ public sealed class CubeHash
 
             // Steps 3+4: rotate temp left by 7 into lower; XOR lower with upper
             for (int i = 0; i < 16; i++)
-                lower[i] = BitOperations.RotateLeft(temp[i], 7) ^ upper[i];
+                lower[i] = temp[i].RotateBitsLeftUnchecked(7) ^ upper[i];
 
             // Step 5: scatter upper into temp via XOR-2 permutation; copy back to upper
             for (int i = 0; i < 16; i++)
@@ -525,7 +525,7 @@ public sealed class CubeHash
 
             // Steps 8+9: rotate temp left by 11 into lower; XOR lower with upper
             for (int i = 0; i < 16; i++)
-                lower[i] = BitOperations.RotateLeft(temp[i], 11) ^ upper[i];
+                lower[i] = temp[i].RotateBitsLeftUnchecked(11) ^ upper[i];
 
             // Step 10: scatter upper into temp via XOR-1 permutation; copy back to upper
             for (int i = 0; i < 16; i++)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -323,16 +323,11 @@ public sealed class CubeHash
 
         if (disposing)
         {
-            this._finalizationRounds = this._initializationRounds = this._rounds = this._inputBlockSizeBytes = this._pendingBytes = 0;
-
-            if (this._state != null)
+            if (this._state is not null)
             {
-                CryptoHelpers.ClearAndNullify(ref this.HashValue);
                 CryptoHelpers.ClearAndNullify(ref this._state!);
                 CryptoHelpers.ClearAndNullify(ref this._initializedState!);
-
                 this._isInitializedStateCached = false;
-                this.HashSizeValue = 0;
             }
         }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
@@ -36,7 +36,7 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// <para>Derived classes must implement the following:</para>
 /// <list type="bullet">
-/// <item><description><see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> resets the algorithm-specific chaining variables to their initial state.</description></item>
+/// <item><description><see cref="HashAlgorithm.Initialize" /> resets the algorithm-specific chaining variables to their initial state. Override and call <c>base.Initialize()</c> first.</description></item>
 /// <item><description><see cref="ProcessBlock" /> compresses a single block, receiving the per-block counter and the finalisation flag.</description></item>
 /// <item><description><see cref="ProcessFinalBlock" /> extracts the digest from the chaining variables after the final compression has run.</description></item>
 /// </list>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -144,7 +144,7 @@ public abstract class KeyedBlockHashAlgorithm<T>
         // Reset state and finalised flag so a freshly-initialised instance may accept
         // new input. On .NET 6+ the framework manages these transitions automatically.
         this.State = 0;
-        this.finalized = false;
+        this._finalized = false;
 #endif
 
         // A keyed MAC is unusable without a key. We refuse to silently regenerate one:

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -137,15 +137,9 @@ public abstract class KeyedBlockHashAlgorithm<T>
     /// </exception>
     public override void Initialize()
     {
-        this.ThrowIfDisposed();
+        // base.Initialize() throws ObjectDisposedException on a disposed instance, clears the residual
+        // buffer and counters, and invokes the OnInitialize hook on the most-derived class.
         base.Initialize();
-
-#if !NET6_0_OR_GREATER
-        // Reset state and finalised flag so a freshly-initialised instance may accept
-        // new input. On .NET 6+ the framework manages these transitions automatically.
-        this.State = 0;
-        this._finalized = false;
-#endif
 
         // A keyed MAC is unusable without a key. We refuse to silently regenerate one:
         // callers must explicitly set Key (or invoke GenerateKey on subclasses that

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -45,7 +45,14 @@ public abstract class KeyedBlockHashAlgorithm<T>
     /// <summary>
     /// Internal storage for the key used by the algorithm. Always assigned via defensive copy and cleared on disposal.
     /// </summary>
-    protected byte[] KeyValue = null!;
+    /// <remarks>
+    /// Declared <see cref="byte" />[] nullable to honestly reflect that the field can be observed in three states:
+    /// <see langword="null" /> on a freshly-constructed instance whose constructor has not yet seeded a key, after
+    /// <see cref="Dispose(bool)" /> has cleared it, and between assignments. The <see cref="Key" /> getter and
+    /// <see cref="Initialize" /> validation both treat a <see langword="null" /> value as a contract violation and
+    /// throw a <see cref="CryptographicException" />.
+    /// </remarks>
+    protected byte[]? KeyValue;
 
     /// <summary>
     /// Holds the required key size, in bytes, that the derived algorithm accepts. Supplied via the constructor.
@@ -103,6 +110,10 @@ public abstract class KeyedBlockHashAlgorithm<T>
         get
         {
             this.ThrowIfDisposed();
+
+            if (this.KeyValue is null)
+                throw new CryptographicException(CryptoResourceStrings.CryptographicException_KeyNotSet);
+
             return this.KeyValue.Copy();
         }
 
@@ -183,7 +194,7 @@ public abstract class KeyedBlockHashAlgorithm<T>
 
         if (disposing)
         {
-            CryptoHelpers.ClearAndNullify(ref this.KeyValue!);
+            CryptoHelpers.ClearAndNullify(ref this.KeyValue);
         }
 
         this._disposed = true;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -59,8 +59,6 @@ public abstract class KeyedBlockHashAlgorithm<T>
     /// </summary>
     protected readonly int KeySizeValue;
 
-    private bool _disposed = false;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="KeyedBlockHashAlgorithm{T}" /> class with the specified input block size and
     /// required key size.
@@ -190,14 +188,13 @@ public abstract class KeyedBlockHashAlgorithm<T>
     /// <remarks>Ensures all internal secrets are overwritten with zeros before releasing resources.</remarks>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
             CryptoHelpers.ClearAndNullify(ref this.KeyValue);
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -137,8 +137,9 @@ public abstract class KeyedBlockHashAlgorithm<T>
     /// </exception>
     public override void Initialize()
     {
-        // base.Initialize() throws ObjectDisposedException on a disposed instance, clears the residual
-        // buffer and counters, and invokes the OnInitialize hook on the most-derived class.
+        // base.Initialize() throws ObjectDisposedException on a disposed instance and clears the residual
+        // buffer and counters. Derived classes follow the BCL convention of calling base.Initialize() and
+        // then resetting their own state in their own Initialize override.
         base.Initialize();
 
         // A keyed MAC is unusable without a key. We refuse to silently regenerate one:

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
@@ -155,13 +155,6 @@ public abstract class KeyedDeferredFinalBlockHashAlgorithm<T>
         }
     }
 
-    /// <inheritdoc />
-    public override void Initialize()
-    {
-        this.ThrowIfDisposed();
-        base.Initialize();
-    }
-
     /// <summary>
     /// Resets the algorithm-specific hash state and, if a key has been set, injects the key block as the first
     /// message block. Sealed so that the key-injection protocol cannot be accidentally bypassed by derived classes.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
@@ -21,8 +21,8 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// This class extends <see cref="DeferredFinalBlockHashAlgorithm{T}" /> with optional key-handling logic shared by
 /// keyed BLAKE-family hashes such as <see cref="Blake2b" /> and <see cref="Blake2s" />. It centralises defensive
-/// copying, key-length validation, secure disposal of secret material, and the sealed <see cref="OnInitialize" />
-/// hook that orchestrates hash-state reset followed by key-block injection when a key is set.
+/// copying, key-length validation, secure disposal of secret material, and the sealed <see cref="Initialize" />
+/// override that orchestrates hash-state reset followed by key-block injection when a key is set.
 /// </para>
 /// <para>
 /// The key is optional: assigning an empty array (or never assigning a key) places the instance in the standard
@@ -156,16 +156,15 @@ public abstract class KeyedDeferredFinalBlockHashAlgorithm<T>
     }
 
     /// <summary>
-    /// Resets the algorithm-specific hash state and, if a key has been set, injects the key block as the first
-    /// message block. Sealed so that the key-injection protocol cannot be accidentally bypassed by derived classes.
+    /// Resets the algorithm to its initial state. Clears the inherited residual buffer and counters via
+    /// <c>base.Initialize()</c>, then rebuilds the algorithm-specific hash state through
+    /// <see cref="InitializeHashState" /> and, when a key has been set, injects the key block as the first message
+    /// block. Sealed so that the key-injection protocol cannot be accidentally bypassed by derived classes.
     /// </summary>
-    /// <remarks>
-    /// Invoked by <see cref="HashAlgorithm.Initialize" /> after the inherited residual buffer and counters have
-    /// been cleared. Calls <see cref="InitializeHashState" /> first, then feeds the zero-padded key block through
-    /// the buffering infrastructure when <see cref="KeyValue" /> is non-<see langword="null" />.
-    /// </remarks>
-    protected sealed override void OnInitialize()
+    /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
+    public sealed override void Initialize()
     {
+        base.Initialize();
         this.InitializeHashState();
 
         if (this.KeyValue is not null)
@@ -175,12 +174,12 @@ public abstract class KeyedDeferredFinalBlockHashAlgorithm<T>
     /// <summary>
     /// Resets the algorithm-specific chaining variables to their initialisation values and encodes any
     /// configuration parameters (such as digest length and key length) into the parameter block. Called by the
-    /// sealed <see cref="OnInitialize" /> before key-block injection.
+    /// sealed <see cref="Initialize" /> before key-block injection.
     /// </summary>
     /// <remarks>
     /// Implementations should read <see cref="KeyValue" /> to determine the key length (<c>kk</c>) for
     /// parameter-block encoding, as <see cref="KeyValue" /> is already updated to the new value before
-    /// <see cref="OnInitialize" /> runs.
+    /// <see cref="Initialize" /> runs.
     /// </remarks>
     protected abstract void InitializeHashState();
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -128,6 +128,17 @@ public sealed class Poly1305
     /// <inheritdoc />
     public override bool CanTransformMultipleBlocks => true;
 
+    /// <inheritdoc />
+    /// <remarks>The published name is simply <c>"Poly1305"</c>; the 128-bit tag width is fixed by the specification.</remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return "Poly1305";
+        }
+    }
+
     /// <summary>
     /// Releases the unmanaged resources used by the algorithm and clears the key from memory.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -89,15 +89,20 @@ public sealed class Poly1305
     private bool _disposed = false;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Poly1305" /> class.
+    /// Initializes a new instance of the <see cref="Poly1305" /> class with no key set.
     /// </summary>
+    /// <remarks>
+    /// Unlike most keyed hash algorithms, <see cref="Poly1305" /> deliberately does not auto-generate a random key
+    /// in its constructor. Poly1305 is a one-time authenticator and reusing the same key against multiple messages
+    /// breaks its security guarantees; an instance with an unsolicited random key tempts callers to drive
+    /// <see cref="HashAlgorithm.ComputeHash(byte[])" /> twice and silently produce a forgeable tag the second time.
+    /// Callers must therefore set <see cref="KeyedBlockHashAlgorithm{T}.Key" /> explicitly before computing a hash;
+    /// failing to do so causes <see cref="Initialize" /> to raise a <see cref="CryptographicException" />.
+    /// </remarks>
     public Poly1305()
         : base(BlockSize, KeySize)
     {
         this.HashSizeValue = 128;
-        this.KeyValue = new byte[KeySize];
-        CryptoHelpers.FillWithRandomNonZeroBytes(this.KeyValue);
-        this.OnKeyChanged();
     }
 
     /// <summary>
@@ -251,12 +256,13 @@ public sealed class Poly1305
         // is retained until Dispose so that the framework's automatic re-initialisation
         // (invoked by ComputeHash via CaptureHashCodeAndReinitialize) can succeed without
         // tripping the key-set check in Initialize.
-        this.finalized = true;
+        this._finalized = true;
         this.State = 2;
 #endif
         // Key material is no longer needed — zero it immediately to enforce
         // Poly1305's one-time-use guarantee and limit key exposure in memory.
-        CryptoHelpers.Clear(this.KeyValue);
+        if (this.KeyValue is not null)
+            CryptoHelpers.Clear(this.KeyValue);
 
         return tag.ToArray();
     }
@@ -279,7 +285,9 @@ public sealed class Poly1305
         // the constructor's default-key setup.
         Array.Clear(this._acc);
 
-        ReadOnlySpan<byte> key = this.KeyValue;
+        // OnKeyChanged is only invoked by the Key setter and Initialize, both of which guarantee
+        // KeyValue is non-null and of the expected length before this point.
+        ReadOnlySpan<byte> key = this.KeyValue!;
 
         // Load and clamp the first 128 bits of the key as the polynomial 'r' key Clamp 'r' by setting/clearing specific bits to avoid
         // vulnerabilities as per RFC 8439, Section 2.5.1

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -86,8 +86,6 @@ public sealed class Poly1305
 
     // Polynomial accumulator
 
-    private bool _disposed = false;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="Poly1305" /> class with no key set.
     /// </summary>
@@ -148,20 +146,16 @@ public sealed class Poly1305
     /// <remarks>Ensures all internal secrets are overwritten with zeros before releasing resources.</remarks>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
             CryptoHelpers.Clear(this._acc);
             CryptoHelpers.Clear(this._r);
             CryptoHelpers.Clear(this._key);
             CryptoHelpers.Clear(this._s);
-
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -104,7 +104,6 @@ public sealed class Shake : BufferedBlockHashAlgorithm<Shake>
 
     private readonly ulong[] _state = new ulong[StateWords];
     private readonly int _securityLevel;
-    private bool _disposed;
 
     /// <summary>
     /// Initialises a new instance of the <see cref="Shake" /> class with a 256-bit output using SHAKE128 internals.
@@ -247,16 +246,13 @@ public sealed class Shake : BufferedBlockHashAlgorithm<Shake>
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
             CryptoHelpers.Clear(this._state);
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -164,6 +164,20 @@ public sealed class Shake : BufferedBlockHashAlgorithm<Shake>
     /// <inheritdoc />
     public override bool CanTransformMultipleBlocks => true;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns either <c>"SHAKE128"</c> or <c>"SHAKE256"</c> matching the security level selected at construction.
+    /// The output length is independent of the algorithm name and is reflected by <see cref="HashSize" />.
+    /// </remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return $"SHAKE{this._securityLevel}";
+        }
+    }
+
     /// <summary>
     /// Gets the security level, in bits, of the SHAKE variant in use.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -7,6 +7,7 @@
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography;
 
@@ -320,14 +321,17 @@ public sealed class Shake : HashAlgorithm
 
             for (int x = 0; x < 5; x++)
             {
-                ulong d = c[(x + 4) % 5] ^ RotateLeft(c[(x + 1) % 5], 1);
+                ulong d = c[(x + 4) % 5] ^ c[(x + 1) % 5].RotateBitsLeftUnchecked(1);
                 for (int y = 0; y < 5; y++)
                     state[x + y * 5] ^= d;
             }
 
             // ρ and π combined: rotate each lane and scatter to the π-permuted position.
+            // s_rho[0] is 0; RotateBitsLeftUnchecked delegates to BitOperations.RotateLeft, which
+            // handles a zero shift correctly without the undefined `value >> 64` shift the hand-rolled
+            // form would produce.
             for (int i = 0; i < StateWords; i++)
-                b[s_pi[i]] = RotateLeft(state[i], s_rho[i]);
+                b[s_pi[i]] = state[i].RotateBitsLeftUnchecked(s_rho[i]);
 
             // χ (chi): non-linear mixing within each row.
             for (int y = 0; y < 5; y++)
@@ -389,16 +393,6 @@ public sealed class Shake : HashAlgorithm
                 destination[baseOffset + b] = (byte)(lane >> (8 * b));
         }
     }
-
-    /// <summary>
-    /// Rotates a 64-bit value left by the specified number of bits.
-    /// </summary>
-    /// <param name="value">The value to rotate.</param>
-    /// <param name="shift">The number of bit positions to rotate left. Must be in the range [0, 63].</param>
-    /// <returns>The value rotated left by <paramref name="shift" /> positions.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static ulong RotateLeft(ulong value, int shift) =>
-        shift == 0 ? value : (value << shift) | (value >> (64 - shift));
 
     /// <summary>
     /// Absorbs the supplied span into the sponge, filling the internal rate buffer and invoking

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -64,7 +64,7 @@ namespace Bodu.Security.Cryptography;
 /// byte[] longer = shake256.ComputeHash(message);
 /// </code>
 /// </example>
-public sealed class Shake : HashAlgorithm
+public sealed class Shake : BufferedBlockHashAlgorithm<Shake>
 {
     private const int StateWords = 25;
     private const byte DomainSuffix = 0x1F;
@@ -103,10 +103,7 @@ public sealed class Shake : HashAlgorithm
     };
 
     private readonly ulong[] _state = new ulong[StateWords];
-    private readonly byte[] _buffer;
-    private readonly int _rateBytes;
     private readonly int _securityLevel;
-    private int _buffered;
     private bool _disposed;
 
     /// <summary>
@@ -131,6 +128,24 @@ public sealed class Shake : HashAlgorithm
     /// 128 or 256.
     /// </exception>
     public Shake(int outputBits, int securityLevel)
+        : base(ValidateAndComputeRateBytes(outputBits, securityLevel))
+    {
+        this.HashSizeValue = outputBits;
+        this._securityLevel = securityLevel;
+    }
+
+    /// <summary>
+    /// Validates the constructor arguments and returns the absorption rate, in bytes, used to size the inherited
+    /// residual buffer.
+    /// </summary>
+    /// <param name="outputBits">The candidate output size in bits.</param>
+    /// <param name="securityLevel">The candidate SHAKE security level.</param>
+    /// <returns>The absorption rate in bytes (168 for SHAKE128, 136 for SHAKE256).</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="outputBits" /> is not a positive multiple of 8, or <paramref name="securityLevel" /> is not
+    /// 128 or 256.
+    /// </exception>
+    private static int ValidateAndComputeRateBytes(int outputBits, int securityLevel)
     {
         if (outputBits <= 0 || outputBits % 8 != 0)
             throw new ArgumentOutOfRangeException(nameof(outputBits),
@@ -140,10 +155,7 @@ public sealed class Shake : HashAlgorithm
             throw new ArgumentOutOfRangeException(nameof(securityLevel),
                 string.Format(CryptoResourceStrings.CryptographicException_InvalidHashSize, securityLevel, string.Join(", ", s_validSecurityLevels)));
 
-        this.HashSizeValue = outputBits;
-        this._securityLevel = securityLevel;
-        this._rateBytes = (1600 - 2 * securityLevel) / 8;
-        this._buffer = new byte[this._rateBytes];
+        return (1600 - 2 * securityLevel) / 8;
     }
 
     /// <inheritdoc />
@@ -205,13 +217,8 @@ public sealed class Shake : HashAlgorithm
     }
 
     /// <inheritdoc />
-    public override void Initialize()
-    {
-        this.ThrowIfDisposed();
-        Array.Clear(this._state);
-        Array.Clear(this._buffer);
-        this._buffered = 0;
-    }
+    /// <remarks>Clears the 1600-bit Keccak state. The inherited residual rate buffer is cleared by the base class.</remarks>
+    protected override void OnInitialize() => Array.Clear(this._state);
 
     /// <summary>
     /// Releases the resources used by this instance and clears the internal sponge state.
@@ -227,9 +234,7 @@ public sealed class Shake : HashAlgorithm
         if (disposing)
         {
             CryptoHelpers.Clear(this._state);
-            CryptoHelpers.Clear(this._buffer);
             CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this._buffered = 0;
             this.HashSizeValue = 0;
         }
 
@@ -237,30 +242,35 @@ public sealed class Shake : HashAlgorithm
         base.Dispose(disposing);
     }
 
-    /// <summary>
-    /// Absorbs a segment of input data into the sponge state, processing complete rate-sized blocks as they
-    /// become available.
-    /// </summary>
-    /// <param name="array">The input byte array containing the data to hash.</param>
-    /// <param name="ibStart">The zero-based index in <paramref name="array" /> at which to begin reading.</param>
-    /// <param name="cbSize">The number of bytes to process from <paramref name="array" />.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="array" /> is <see langword="null" />.</exception>
-    protected override void HashCore(byte[] array, int ibStart, int cbSize)
-    {
-        ThrowHelper.ThrowIfNull(array);
-        this.ThrowIfDisposed();
-        this.Absorb(array.AsSpan(ibStart, cbSize));
-    }
-
-    /// <summary>
-    /// Absorbs a span of input data into the sponge state, processing complete rate-sized blocks as they
-    /// become available.
-    /// </summary>
-    /// <param name="source">The input byte span containing the data to hash.</param>
+    /// <inheritdoc />
+    /// <remarks>
+    /// Accumulates input bytes in the inherited residual rate buffer. Whenever a complete rate block has been
+    /// gathered the buffer is XORed into the sponge state, the Keccak-f permutation is applied, and the buffer is
+    /// cleared ready for the next block.
+    /// </remarks>
     protected override void HashCore(ReadOnlySpan<byte> source)
     {
         this.ThrowIfDisposed();
-        this.Absorb(source);
+        Span<byte> rateBuffer = this._residualBlock.Span;
+        int rateBytes = this.BlockSizeBytes;
+
+        while (source.Length > 0)
+        {
+            int available = rateBytes - this._residualBytes;
+            int take = Math.Min(available, source.Length);
+
+            source.Slice(0, take).CopyTo(rateBuffer.Slice(this._residualBytes));
+            this._residualBytes += take;
+            source = source.Slice(take);
+
+            if (this._residualBytes == rateBytes)
+            {
+                XorBlockIntoState(rateBuffer, this._state, rateBytes);
+                KeccakF(this._state);
+                rateBuffer.Clear();
+                this._residualBytes = 0;
+            }
+        }
     }
 
     /// <summary>
@@ -273,13 +283,15 @@ public sealed class Shake : HashAlgorithm
     protected override byte[] HashFinal()
     {
         this.ThrowIfDisposed();
+        Span<byte> rateBuffer = this._residualBlock.Span;
+        int rateBytes = this.BlockSizeBytes;
 
         // Apply multi-rate padding: domain suffix byte at the current buffer position, then 0x80 at the last byte.
-        this._buffer[this._buffered] ^= DomainSuffix;
-        this._buffer[this._rateBytes - 1] ^= 0x80;
+        rateBuffer[this._residualBytes] ^= DomainSuffix;
+        rateBuffer[rateBytes - 1] ^= 0x80;
 
         // Absorb the final padded block into the state.
-        XorBlockIntoState(this._buffer, this._state, this._rateBytes);
+        XorBlockIntoState(rateBuffer, this._state, rateBytes);
         KeccakF(this._state);
 
         // Squeeze output bytes from the state (little-endian lane serialisation).
@@ -290,7 +302,7 @@ public sealed class Shake : HashAlgorithm
 
         while (remaining > 0)
         {
-            int take = Math.Min(remaining, this._rateBytes);
+            int take = Math.Min(remaining, rateBytes);
             WriteLanesToBytes(this._state, output.AsSpan(written, take));
             written += take;
             remaining -= take;
@@ -348,15 +360,15 @@ public sealed class Shake : HashAlgorithm
     /// <summary>
     /// XORs a byte block into the Keccak state using little-endian 64-bit lane interpretation.
     /// </summary>
-    /// <param name="block">The byte block to XOR into the state. Must be at most <paramref name="rateBytes" /> bytes long.</param>
+    /// <param name="block">The byte block to XOR into the state. Must be at least <paramref name="rateBytes" /> bytes long.</param>
     /// <param name="state">The 25-element state array to update.</param>
-    /// <param name="rateBytes">The number of bytes in <paramref name="block" /> to process.</param>
+    /// <param name="rateBytes">The number of bytes from <paramref name="block" /> to absorb.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void XorBlockIntoState(byte[] block, ulong[] state, int rateBytes)
+    private static void XorBlockIntoState(ReadOnlySpan<byte> block, ulong[] state, int rateBytes)
     {
         int lanes = rateBytes / 8;
         for (int i = 0; i < lanes; i++)
-            state[i] ^= BinaryPrimitives.ReadUInt64LittleEndian(block.AsSpan(i * 8, 8));
+            state[i] ^= BinaryPrimitives.ReadUInt64LittleEndian(block.Slice(i * 8, 8));
 
         // Handle any trailing bytes that do not fill a complete 8-byte lane.
         int remainder = rateBytes % 8;
@@ -394,47 +406,4 @@ public sealed class Shake : HashAlgorithm
         }
     }
 
-    /// <summary>
-    /// Absorbs the supplied span into the sponge, filling the internal rate buffer and invoking
-    /// <c>Keccak-f</c> whenever a full rate block has accumulated.
-    /// </summary>
-    /// <param name="source">The bytes to absorb.</param>
-    private void Absorb(ReadOnlySpan<byte> source)
-    {
-        while (source.Length > 0)
-        {
-            int available = this._rateBytes - this._buffered;
-            int take = Math.Min(available, source.Length);
-
-            source.Slice(0, take).CopyTo(this._buffer.AsSpan(this._buffered));
-            this._buffered += take;
-            source = source.Slice(take);
-
-            if (this._buffered == this._rateBytes)
-            {
-                XorBlockIntoState(this._buffer, this._state, this._rateBytes);
-                KeccakF(this._state);
-                Array.Clear(this._buffer);
-                this._buffered = 0;
-            }
-        }
-    }
-
-    /// <summary>
-    /// Throws <see cref="ObjectDisposedException" /> if this instance has already been disposed.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfDisposed() =>
-        ObjectDisposedException.ThrowIf(this._disposed, this);
-
-    /// <summary>
-    /// Throws <see cref="CryptographicUnexpectedOperationException" /> if the algorithm has already started
-    /// processing input and can no longer be reconfigured.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void ThrowIfInvalidState()
-    {
-        if (this.State != 0)
-            throw new CryptographicUnexpectedOperationException(CryptoResourceStrings.CryptographicException_ReconfigurationNotAllowed);
-    }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -217,8 +217,12 @@ public sealed class Shake : BufferedBlockHashAlgorithm<Shake>
     }
 
     /// <inheritdoc />
-    /// <remarks>Clears the 1600-bit Keccak state. The inherited residual rate buffer is cleared by the base class.</remarks>
-    protected override void OnInitialize() => Array.Clear(this._state);
+    /// <remarks>Clears the 1600-bit Keccak state. The inherited residual rate buffer and counters are cleared by the base call.</remarks>
+    public override void Initialize()
+    {
+        base.Initialize();
+        Array.Clear(this._state);
+    }
 
     /// <summary>
     /// Releases the resources used by this instance and clears the internal sponge state.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -304,9 +304,12 @@ public abstract class SipHash<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     protected override void OnKeyChanged()
     {
-        // Fix: use little-endian reads to match the SipHash specification and ProcessBlock; prior code used host-endian BitConverter, which would produce incorrect digests on big-endian hosts.
-        ulong k0 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue.AsSpan(0));
-        ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue.AsSpan(8));
+        // OnKeyChanged is only invoked by the Key setter and Initialize, both of which guarantee
+        // KeyValue is non-null and of the expected length before this point.
+        // Use little-endian reads to match the SipHash specification and ProcessBlock; prior code used
+        // host-endian BitConverter, which would produce incorrect digests on big-endian hosts.
+        ulong k0 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue!.AsSpan(0));
+        ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue!.AsSpan(8));
         this._v0 = InitialStates[0] ^ k0;
         this._v1 = InitialStates[1] ^ k1;
         this._v2 = InitialStates[2] ^ k0;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -130,7 +130,7 @@ public abstract class SipHash<T>
     /// </item>
     /// </list>
     /// </remarks>          
-    public string AlgorithmName
+    public override string AlgorithmName
     {
         get
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -91,7 +91,7 @@ public abstract class SipHash<T>
     private int _compressionRounds;
     private bool _disposed = false;
     private int _finalizationRounds;
-    private ulong v0, v1, v2, v3;
+    private ulong _v0, _v1, _v2, _v3;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SipHash{T}" /> class with a specified hash size.
@@ -222,7 +222,7 @@ public abstract class SipHash<T>
         {
             CryptoHelpers.ClearAndNullify(ref this.HashValue);
 
-            this.v0 = this.v1 = this.v2 = this.v3 = 0;
+            this._v0 = this._v1 = this._v2 = this._v3 = 0;
             this._compressionRounds = 0;
             this._finalizationRounds = 0;
             this.HashSizeValue = 0;
@@ -263,16 +263,11 @@ public abstract class SipHash<T>
     protected override void ProcessBlock(ReadOnlySpan<byte> block)
     {
         var b = BinaryPrimitives.ReadUInt64LittleEndian(block);
-        this.v3 ^= b;
+        this._v3 ^= b;
         this.PerformSipRounds(this._compressionRounds);
-        this.v0 ^= b;
+        this._v0 ^= b;
     }
 
-    //    // Buffer any remaining residual bytes
-    //    residualBytes = end - pos;
-    //    if (residualBytes > 0)
-    //        buffer.AsSpan(pos, residualBytes).CopyTo(residualSpan);
-    //}
     /// <summary>
     /// Finalizes the hash computation and produces the output hash value.
     /// </summary>
@@ -280,22 +275,22 @@ public abstract class SipHash<T>
     /// <remarks>Combines all partial input and applies the finalization round logic based on the configured output size.</remarks>
     protected override byte[] ProcessFinalBlock()
     {
-        this.v2 ^= (this.HashSizeValue == 64) ? 0xffUL : 0xeeUL;
+        this._v2 ^= (this.HashSizeValue == 64) ? 0xffUL : 0xeeUL;
         this.PerformSipRounds(this._finalizationRounds);
 
         byte[] hash = new byte[this.HashSizeValue / 8];
 
         // First 64-bit output
-        ulong h0 = this.v0 ^ this.v1 ^ this.v2 ^ this.v3;
+        ulong h0 = this._v0 ^ this._v1 ^ this._v2 ^ this._v3;
         MemoryMarshal.Write(hash.AsSpan(0, 8), in h0);
 
         // Optional second block for SipHash-128
         if (this.HashSizeValue == 128)
         {
-            this.v1 ^= 0xdd;
+            this._v1 ^= 0xdd;
             this.PerformSipRounds(this._finalizationRounds);
 
-            ulong h1 = this.v0 ^ this.v1 ^ this.v2 ^ this.v3;
+            ulong h1 = this._v0 ^ this._v1 ^ this._v2 ^ this._v3;
             MemoryMarshal.Write(hash.AsSpan(8, 8), in h1);
         }
 
@@ -312,12 +307,12 @@ public abstract class SipHash<T>
         // Fix: use little-endian reads to match the SipHash specification and ProcessBlock; prior code used host-endian BitConverter, which would produce incorrect digests on big-endian hosts.
         ulong k0 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue.AsSpan(0));
         ulong k1 = BinaryPrimitives.ReadUInt64LittleEndian(this.KeyValue.AsSpan(8));
-        this.v0 = InitialStates[0] ^ k0;
-        this.v1 = InitialStates[1] ^ k1;
-        this.v2 = InitialStates[2] ^ k0;
-        this.v3 = InitialStates[3] ^ k1;
+        this._v0 = InitialStates[0] ^ k0;
+        this._v1 = InitialStates[1] ^ k1;
+        this._v2 = InitialStates[2] ^ k0;
+        this._v3 = InitialStates[3] ^ k1;
 
-        if (this.HashSizeValue == 128) this.v1 ^= 0xee;
+        if (this.HashSizeValue == 128) this._v1 ^= 0xee;
     }
 
     /// <summary>
@@ -328,7 +323,7 @@ public abstract class SipHash<T>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void PerformSipRounds(int iterations)
     {
-        ulong r0 = this.v0, r1 = this.v1, r2 = this.v2, r3 = this.v3;
+        ulong r0 = this._v0, r1 = this._v1, r2 = this._v2, r3 = this._v3;
 
         for (int i = 0; i < iterations; i++)
         {
@@ -348,29 +343,6 @@ public abstract class SipHash<T>
             r2 = r2.RotateBitsLeftUnchecked(32);
         }
 
-        this.v0 = r0; this.v1 = r1; this.v2 = r2; this.v3 = r3;
+        this._v0 = r0; this._v1 = r1; this._v2 = r2; this._v3 = r3;
     }
-
-    ///// <summary>
-    ///// Processes one or more blocks of input data into the SipHash internal state.
-    ///// </summary>
-    ///// <param name="buffer">The byte array containing the input data.</param>
-    ///// <param name="offset">The byte offset in the buffer to start reading from.</param>
-    ///// <param name="length">The number of bytes to process.</param>
-    ///// <remarks>Handles buffering of partial blocks and invokes <see cref="ProcessBlock" /> for each complete block.</remarks>
-    //private void ProcessBlocks(byte[] buffer, int offset, int length)
-    //{
-    //    int pos = offset;
-    //    Span<byte> residualSpan = residualByteBuffer.Span;
-
-    // Handle residual bytes from the previous call if (residualBytes > 0) { int remaining = BlockSize - residualBytes;
-
-    // if (length >= remaining) { // Fill up the buffer and process one full block buffer.AsSpan(pos,
-    // remaining).CopyTo(residualSpan[residualBytes..]); ulong block = MemoryMarshal.Read<ulong>(residualSpan); ProcessBlock(block);
-
-    // residualBytes = 0; pos += remaining; } else { // Not enough to complete a block, just append to residuals buffer.AsSpan(pos,
-    // length).CopyTo(residualSpan[residualBytes..]); residualBytes += length; return; } }
-
-    // Process full blocks directly from the input int end = offset + length; while (pos + BlockSize <= end) { ulong block =
-    // MemoryMarshal.Read<ulong>(buffer.AsSpan(pos, BlockSize)); ProcessBlock(block); pos += BlockSize; }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -89,7 +89,6 @@ public abstract class SipHash<T>
 
     private static readonly int[] ValidHashSizes = { 64, 128 };
     private int _compressionRounds;
-    private bool _disposed = false;
     private int _finalizationRounds;
     private ulong _v0, _v1, _v2, _v3;
 
@@ -216,19 +215,13 @@ public abstract class SipHash<T>
     /// <remarks>Ensures all internal secrets are overwritten with zeros before releasing resources.</remarks>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-
             this._v0 = this._v1 = this._v2 = this._v3 = 0;
-            this._compressionRounds = 0;
-            this._finalizationRounds = 0;
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -220,6 +220,8 @@ public abstract class SipHash<T>
         if (disposing)
         {
             this._v0 = this._v1 = this._v2 = this._v3 = 0;
+            this._compressionRounds = 0;
+            this._finalizationRounds = 0;
         }
 
         base.Dispose(disposing);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -310,34 +310,50 @@ public abstract partial class Skein<T>
         return digest;
     }
 
-    /// <summary>
-    /// Processes a single aligned message block. Unused — Skein overrides <see cref="HashCore(ReadOnlySpan{byte})" />
-    /// and <see cref="HashFinal" /> directly rather than participating in the
-    /// <see cref="BlockHashAlgorithm{T}" /> <c>ProcessBlock → PadBlock → ProcessFinalBlock</c> pipeline, because the
-    /// UBI mode requires a one-block lookahead that the pipeline does not express.
-    /// </summary>
-    /// <param name="block">Ignored.</param>
-    /// <exception cref="InvalidOperationException">Always thrown — this method is not expected to be invoked.</exception>
-    protected override void ProcessBlock(ReadOnlySpan<byte> block) =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessBlock pipeline.");
+    // ----------------------------------------------------------------------------------------------------
+    // Pipeline-bypass overrides.
+    //
+    // Skein inherits the Merkle–Damgård <c>ProcessBlock → PadBlock → ProcessFinalBlock</c> abstracts from
+    // <see cref="KeyedBlockHashAlgorithm{T}" /> for compatibility with the keyed-block test infrastructure,
+    // but the UBI compression mode requires a one-block lookahead that the pipeline does not express. The
+    // overrides above (Initialize, HashCore, HashFinal) drive UBI directly, so the inherited pipeline
+    // methods are unreachable from any happy-path code path. They remain present as defensive contract
+    // markers — anyone routing input through the inherited pipeline by mistake gets a loud, immediate
+    // <see cref="InvalidOperationException" /> rather than silently incorrect output. Re-parenting Skein
+    // onto a non-pipeline base would remove these throws but would also force a parallel refactor of the
+    // shared keyed-block test infrastructure (SkeinTests → KeyedBlockHashAlgorithmTests → BlockHashAlgorithmTests),
+    // which exceeds the value of removing the markers.
+    // ----------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Pads the final partial block. Unused — see <see cref="ProcessBlock" />.
+    /// Pipeline contract marker — see the section comment above. Skein's UBI lookahead bypasses
+    /// <c>ProcessBlock</c> entirely; this override exists only to fail loudly if the inherited
+    /// Merkle–Damgård pipeline is ever wired up against a Skein instance.
+    /// </summary>
+    /// <param name="block">Ignored.</param>
+    /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
+    protected override void ProcessBlock(ReadOnlySpan<byte> block) =>
+        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessBlock pipeline; UBI lookahead requires HashCore / HashFinal to drive compression directly.");
+
+    /// <summary>
+    /// Pipeline contract marker — see the section comment above. Skein's UBI tweak field carries the
+    /// equivalent of the Merkle–Damgård length encoding, so <c>PadBlock</c> is unreachable.
     /// </summary>
     /// <param name="block">Ignored.</param>
     /// <param name="messageLength">Ignored.</param>
     /// <returns>Never returns — always throws.</returns>
-    /// <exception cref="InvalidOperationException">Always thrown — this method is not expected to be invoked.</exception>
+    /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
     protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm PadBlock pipeline.");
+        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm PadBlock pipeline; UBI encodes message length in the tweak.");
 
     /// <summary>
-    /// Finalises the computation via the block pipeline. Unused — see <see cref="ProcessBlock" />.
+    /// Pipeline contract marker — see the section comment above. Skein finalises via the OUTPUT UBI phase
+    /// driven from <see cref="HashFinal" />.
     /// </summary>
     /// <returns>Never returns — always throws.</returns>
-    /// <exception cref="InvalidOperationException">Always thrown — this method is not expected to be invoked.</exception>
+    /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
     protected override byte[] ProcessFinalBlock() =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessFinalBlock pipeline.");
+        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessFinalBlock pipeline; the OUTPUT UBI phase is driven from HashFinal.");
 
     /// <summary>
     /// Releases the unmanaged resources used by the algorithm, securely clears all intermediate state, and disposes the

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -197,7 +197,7 @@ public abstract partial class Skein<T>
     /// </summary>
     /// <returns>A string of the form <c>"Skein-<i>s</i>-<i>h</i>"</c> — e.g. <c>"Skein-512-256"</c>.</returns>
     /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
-    public string AlgorithmName
+    public override string AlgorithmName
     {
         get
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -374,6 +374,11 @@ public abstract partial class Skein<T>
             CryptoHelpers.Clear(this._ubiCipherOutput);
 
             this._cipher.Dispose();
+
+            this._isChainingValueCached = false;
+            this._pendingBytes = 0;
+            this._messageBytesProcessed = 0UL;
+            this._hasProcessedAnyMessageBlock = false;
         }
 
         base.Dispose(disposing);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -93,7 +93,6 @@ public abstract partial class Skein<T>
     private ulong _messageBytesProcessed;
     private bool _hasProcessedAnyMessageBlock;
     private bool _isChainingValueCached;
-    private bool _disposed;
 
 #if !NET6_0_OR_GREATER
     private bool _finalized;
@@ -349,7 +348,7 @@ public abstract partial class Skein<T>
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
@@ -357,17 +356,10 @@ public abstract partial class Skein<T>
             CryptoHelpers.Clear(this._initialChainingValue);
             CryptoHelpers.Clear(this._pendingBlock);
             CryptoHelpers.Clear(this._ubiCipherOutput);
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
 
             this._cipher.Dispose();
-            this._isChainingValueCached = false;
-            this._pendingBytes = 0;
-            this._messageBytesProcessed = 0UL;
-            this._hasProcessedAnyMessageBlock = false;
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
@@ -75,7 +75,7 @@ public abstract partial class Snefru<T>
             throw new ArgumentOutOfRangeException(nameof(hashSize),
                 string.Format(CryptoResourceStrings.CryptographicException_InvalidHashSize, hashSize, string.Join(", ", ValidHashSizes)));
 
-        // _state is zero-filled by `new`; OnInitialize re-clears it on every Initialize() call.
+        // _state is zero-filled by `new`; Initialize re-clears it on every reset.
         this._state = new uint[hashSize >> 5];
         HashSizeValue = hashSize;
     }
@@ -88,7 +88,11 @@ public abstract partial class Snefru<T>
 
     /// <inheritdoc />
     /// <remarks>Clears the Snefru chaining state to all zeros, as required by the algorithm specification.</remarks>
-    protected override void OnInitialize() => Array.Clear(this._state);
+    public override void Initialize()
+    {
+        base.Initialize();
+        Array.Clear(this._state);
+    }
 
     /// <summary>
     /// Releases resources used by the algorithm and clears the internal state and working buffer.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
@@ -63,12 +63,6 @@ public abstract partial class Snefru<T>
 
     private bool _disposed = false;
 
-#if !NET6_0_OR_GREATER
-
-    // Required for .NET Standard 2.0 or older frameworks
-    private bool _finalized;
-#endif
-
     /// <summary>
     /// Initializes a new instance of the <see cref="Snefru{T}" /> class with the specified output hash size.
     /// </summary>
@@ -81,10 +75,9 @@ public abstract partial class Snefru<T>
             throw new ArgumentOutOfRangeException(nameof(hashSize),
                 string.Format(CryptoResourceStrings.CryptographicException_InvalidHashSize, hashSize, string.Join(", ", ValidHashSizes)));
 
+        // _state is zero-filled by `new`; OnInitialize re-clears it on every Initialize() call.
         this._state = new uint[hashSize >> 5];
         HashSizeValue = hashSize;
-
-        InitializeState();
     }
 
     /// <inheritdoc />
@@ -94,13 +87,8 @@ public abstract partial class Snefru<T>
     public override bool CanTransformMultipleBlocks => true;
 
     /// <inheritdoc />
-    public override void Initialize()
-    {
-        this.ThrowIfDisposed();
-
-        base.Initialize();
-        InitializeState();
-    }
+    /// <remarks>Clears the Snefru chaining state to all zeros, as required by the algorithm specification.</remarks>
+    protected override void OnInitialize() => Array.Clear(this._state);
 
     /// <summary>
     /// Releases resources used by the algorithm and clears the internal state and working buffer.
@@ -239,12 +227,6 @@ public abstract partial class Snefru<T>
             this._buffer[last] ^= sboxEntry;
         }
     }
-
-    /// <summary>
-    /// Clears the internal state array to prepare for new input.
-    /// </summary>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private void InitializeState() => Array.Clear(this._state);
 
     /// <summary>
     /// Performs a circular right bitwise rotation on each word in the internal buffer.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
@@ -87,6 +87,17 @@ public abstract partial class Snefru<T>
     public override bool CanTransformMultipleBlocks => true;
 
     /// <inheritdoc />
+    /// <remarks>The format is <c>"Snefru/<i>n</i>"</c>, where <i>n</i> is the configured output size in bits.</remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return $"Snefru/{this.HashSizeValue}";
+        }
+    }
+
+    /// <inheritdoc />
     /// <remarks>Clears the Snefru chaining state to all zeros, as required by the algorithm specification.</remarks>
     public override void Initialize()
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
@@ -61,8 +61,6 @@ public abstract partial class Snefru<T>
     private readonly uint[] _buffer = new uint[TotalWords];          // internal working buffer used for permutation and round processing.
     private readonly uint[] _state;                                  // internal state used to accumulate the hash output across input blocks.
 
-    private bool _disposed = false;
-
     /// <summary>
     /// Initializes a new instance of the <see cref="Snefru{T}" /> class with the specified output hash size.
     /// </summary>
@@ -113,18 +111,14 @@ public abstract partial class Snefru<T>
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
             CryptoHelpers.Clear(this._buffer);
             CryptoHelpers.Clear(this._state);
-            CryptoHelpers.ClearAndNullify(ref HashValue);
-
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -199,8 +199,8 @@ public sealed partial class Tiger
         this.ThrowIfDisposed();
         base.Initialize();
 #if !NET6_0_OR_GREATER
-        State = 0;
-        finalized = false;
+        this.State = 0;
+        this._finalized = false;
 #endif
         this._state0 = 0x0123456789ABCDEF;
         this._state1 = 0xFEDCBA9876543210;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -62,7 +62,6 @@ public sealed partial class Tiger
 
     private static readonly int[] ValidHashSizes = { 128, 160, 192 };
 
-    private bool _disposed = false;
     private ulong _state0 = 0x0123456789ABCDEF;
     private ulong _state1 = 0xFEDCBA9876543210;
     private ulong _state2 = 0xF096A5B4C3B2E187;
@@ -211,16 +210,13 @@ public sealed partial class Tiger
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
+
         if (disposing)
         {
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-
             this._state0 = this._state1 = this._state2 = 0;
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -104,7 +104,7 @@ public sealed partial class Tiger
     /// finalization to match the configured <see cref="HashSize" />.
     /// </para>
     /// </remarks>
-    public string AlgorithmName
+    public override string AlgorithmName
     {
         get
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -195,8 +195,9 @@ public sealed partial class Tiger
 
     /// <inheritdoc />
     /// <remarks>Restores the three 64-bit chaining variables to their Tiger-specified initial constants.</remarks>
-    protected override void OnInitialize()
+    public override void Initialize()
     {
+        base.Initialize();
         this._state0 = 0x0123456789ABCDEF;
         this._state1 = 0xFEDCBA9876543210;
         this._state2 = 0xF096A5B4C3B2E187;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -194,14 +194,9 @@ public sealed partial class Tiger
     }
 
     /// <inheritdoc />
-    public override void Initialize()
+    /// <remarks>Restores the three 64-bit chaining variables to their Tiger-specified initial constants.</remarks>
+    protected override void OnInitialize()
     {
-        this.ThrowIfDisposed();
-        base.Initialize();
-#if !NET6_0_OR_GREATER
-        this.State = 0;
-        this._finalized = false;
-#endif
         this._state0 = 0x0123456789ABCDEF;
         this._state1 = 0xFEDCBA9876543210;
         this._state2 = 0xF096A5B4C3B2E187;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -120,10 +120,9 @@ public sealed partial class Whirlpool
     }
 
     /// <inheritdoc />
-    public override void Initialize()
+    /// <remarks>Clears the eight 64-bit chaining variables and unlatches the <see cref="Version" /> setter.</remarks>
+    protected override void OnInitialize()
     {
-        this.ThrowIfDisposed();
-        base.Initialize();
         Array.Clear(this._state);
         this._inputConsumed = false;
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -81,6 +81,25 @@ public sealed partial class Whirlpool
     /// <inheritdoc />
     public override bool CanTransformMultipleBlocks => true;
 
+    /// <inheritdoc />
+    /// <remarks>
+    /// Returns one of <c>"Whirlpool-0"</c>, <c>"Whirlpool-T"</c>, or <c>"Whirlpool"</c> matching the configured
+    /// <see cref="Version" /> — corresponding to the 2000, 2001, and ISO/IEC 10118-3 (2003) revisions respectively.
+    /// </remarks>
+    public override string AlgorithmName
+    {
+        get
+        {
+            this.ThrowIfDisposed();
+            return this._version switch
+            {
+                WhirlpoolVersion.WhirlpoolInfo1 => "Whirlpool-0",
+                WhirlpoolVersion.WhirlpoolInfo2 => "Whirlpool-T",
+                _ => "Whirlpool",
+            };
+        }
+    }
+
     /// <summary>
     /// Gets or sets the published <see cref="WhirlpoolVersion" /> used to compute the hash value.
     /// </summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -63,7 +63,6 @@ public sealed partial class Whirlpool
     private readonly ulong[] _state = new ulong[8];
     private WhirlpoolVersion _version = WhirlpoolVersion.WhirlpoolInfo3;
     private bool _inputConsumed;
-    private bool _disposed;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Whirlpool" /> class configured for
@@ -170,16 +169,13 @@ public sealed partial class Whirlpool
     /// </param>
     protected override void Dispose(bool disposing)
     {
-        if (this._disposed) return;
+        if (this.IsDisposed) return;
 
         if (disposing)
         {
             CryptoHelpers.Clear(this._state);
-            CryptoHelpers.ClearAndNullify(ref this.HashValue);
-            this.HashSizeValue = 0;
         }
 
-        this._disposed = true;
         base.Dispose(disposing);
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -121,8 +121,9 @@ public sealed partial class Whirlpool
 
     /// <inheritdoc />
     /// <remarks>Clears the eight 64-bit chaining variables and unlatches the <see cref="Version" /> setter.</remarks>
-    protected override void OnInitialize()
+    public override void Initialize()
     {
+        base.Initialize();
         Array.Clear(this._state);
         this._inputConsumed = false;
     }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -42,11 +42,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     /// because its public constructor accepts a block-sized IV — no nonce-length special-casing —
     /// keeping the test focus on the wrapper, not the underlying mode.
     /// </summary>
-    [TestMethod]
-    public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
     private static IAeadBlockCipherModeTransform NewTransform() =>
         new CcmModeTransform(new AesBlockCipher(NewKey()), NewIv());
 
@@ -216,23 +211,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var decTransform = NewTransform();
         byte[] recovered = decTransform.Decrypt(ciphertextWithTag);
 
-    /// <summary>
-    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
-    /// throws <see cref="ArgumentException" /> when the ciphertext+tag input is shorter than the tag size.
-    /// </summary>
-    [TestMethod]
-    public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-        using var cipher = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher, iv);
-
-        byte[] tooShort = new byte[aead.TagSize - 1];
-        Assert.ThrowsExactly<ArgumentException>(() =>
-        {
-            aead.Decrypt(tooShort, AssociatedData);
-        });
         CollectionAssert.AreEqual(Plaintext, recovered,
             "Decrypt without AAD must recover plaintext encrypted with the matching no-AAD overload.");
     }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Security.Cryptography;
+using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography.Extensions;
 

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BufferedBlockHashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BufferedBlockHashAlgorithmTests.cs
@@ -55,18 +55,18 @@ public sealed class BufferedBlockHashAlgorithmTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> invokes the
-    /// <see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> hook.
+    /// Verifies that calling <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> on a derived class invokes the
+    /// derived override.
     /// </summary>
     [TestMethod]
-    public void Initialize_WhenCalled_ShouldInvokeOnInitialize()
+    public void Initialize_WhenCalled_ShouldRunDerivedOverride()
     {
         using var sut = new MonitoringBufferedBlockHashAlgorithm();
-        int baseline = sut.OnInitializeCallCount;
+        int baseline = sut.InitializeCallCount;
 
         sut.Initialize();
 
-        Assert.AreEqual(baseline + 1, sut.OnInitializeCallCount);
+        Assert.AreEqual(baseline + 1, sut.InitializeCallCount);
     }
 
     /// <summary>
@@ -87,21 +87,20 @@ public sealed class BufferedBlockHashAlgorithmTests
     }
 
     /// <summary>
-    /// Verifies that repeated calls to <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> invoke
-    /// <see cref="BufferedBlockHashAlgorithm{T}.OnInitialize" /> on every call, ensuring derived state is rebuilt
-    /// each time.
+    /// Verifies that repeated calls to <see cref="BufferedBlockHashAlgorithm{T}.Initialize" /> run the derived
+    /// override on every call, ensuring derived state is rebuilt each time.
     /// </summary>
     [TestMethod]
-    public void Initialize_WhenCalledMultipleTimes_ShouldInvokeOnInitializeEachTime()
+    public void Initialize_WhenCalledMultipleTimes_ShouldRunDerivedOverrideEachTime()
     {
         using var sut = new MonitoringBufferedBlockHashAlgorithm();
-        int baseline = sut.OnInitializeCallCount;
+        int baseline = sut.InitializeCallCount;
 
         sut.Initialize();
         sut.Initialize();
         sut.Initialize();
 
-        Assert.AreEqual(baseline + 3, sut.OnInitializeCallCount);
+        Assert.AreEqual(baseline + 3, sut.InitializeCallCount);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/DeferredFinalBlockHashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/DeferredFinalBlockHashAlgorithmTests.cs
@@ -166,18 +166,18 @@ public sealed class DeferredFinalBlockHashAlgorithmTests
     }
 
     /// <summary>
-    /// Verifies that <c>Initialize</c> propagates through to the <see cref="DeferredFinalBlockHashAlgorithm{T}.OnInitialize" />
-    /// hook, ensuring derived algorithm-specific state is reset on every <c>ComputeHash</c> call.
+    /// Verifies that calling <c>Initialize</c> on a derived <see cref="DeferredFinalBlockHashAlgorithm{T}" /> runs the
+    /// derived override, ensuring algorithm-specific state is reset on every <c>ComputeHash</c> call.
     /// </summary>
     [TestMethod]
-    public void Initialize_WhenCalled_ShouldInvokeOnInitialize()
+    public void Initialize_WhenCalled_ShouldRunDerivedOverride()
     {
         using var sut = new MonitoringDeferredFinalBlockHashAlgorithm(BlockSize);
-        int baseline = sut.OnInitializeCallCount;
+        int baseline = sut.InitializeCallCount;
 
         sut.Initialize();
 
-        Assert.AreEqual(baseline + 1, sut.OnInitializeCallCount);
+        Assert.AreEqual(baseline + 1, sut.InitializeCallCount);
     }
 
     private static byte[] SequentialBytes(int length)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.cs
@@ -197,6 +197,12 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
                 "HashSize",
                 "InputBlockSize",
                 "OutputBlockSize",
+
+                // IsDisposed is the protected disposed-state probe on BufferedBlockHashAlgorithm{T}.
+                // It exists specifically so derived classes can no-op a second Dispose() without throwing,
+                // so it must remain readable after disposal — the inverse of the rule this test enforces
+                // for every other property.
+                "IsDisposed",
             ])
             .Distinct()
             .ToArray();

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
@@ -42,6 +42,9 @@ public sealed class MonitoringBufferedBlockHashAlgorithm
     /// </summary>
     public bool? LastDisposeFlag { get; private set; }
 
+    /// <inheritdoc />
+    public override string AlgorithmName => nameof(MonitoringBufferedBlockHashAlgorithm);
+
     /// <summary>
     /// Initialises a new instance with the default 8-byte block size.
     /// </summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringBufferedBlockHashAlgorithm.cs
@@ -23,9 +23,9 @@ public sealed class MonitoringBufferedBlockHashAlgorithm
     public List<int> CapturedSpanLengths { get; } = new();
 
     /// <summary>
-    /// Number of times <see cref="OnInitialize" /> has been invoked across the lifetime of the instance.
+    /// Number of times <see cref="Initialize" /> has been invoked across the lifetime of the instance.
     /// </summary>
-    public int OnInitializeCallCount { get; private set; }
+    public int InitializeCallCount { get; private set; }
 
     /// <summary>
     /// Number of times this test instance has observed the first call to <see cref="Dispose(bool)" />.
@@ -110,9 +110,10 @@ public sealed class MonitoringBufferedBlockHashAlgorithm
     }
 
     /// <inheritdoc />
-    protected override void OnInitialize()
+    public override void Initialize()
     {
-        this.OnInitializeCallCount++;
+        base.Initialize();
+        this.InitializeCallCount++;
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
@@ -22,9 +22,9 @@ public sealed class MonitoringDeferredFinalBlockHashAlgorithm
     public List<(byte[] Block, ulong Counter, bool IsFinal)> ProcessBlockInvocations { get; } = new();
 
     /// <summary>
-    /// Number of times <see cref="OnInitialize" /> has been invoked across the lifetime of the instance.
+    /// Number of times <see cref="Initialize" /> has been invoked across the lifetime of the instance.
     /// </summary>
-    public int OnInitializeCallCount { get; private set; }
+    public int InitializeCallCount { get; private set; }
 
     /// <summary>
     /// Initialises a new instance with the default 8-byte block size and an 8-bit digest.
@@ -56,9 +56,10 @@ public sealed class MonitoringDeferredFinalBlockHashAlgorithm
     }
 
     /// <inheritdoc />
-    protected override void OnInitialize()
+    public override void Initialize()
     {
-        this.OnInitializeCallCount++;
+        base.Initialize();
+        this.InitializeCallCount++;
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MonitoringDeferredFinalBlockHashAlgorithm.cs
@@ -26,6 +26,9 @@ public sealed class MonitoringDeferredFinalBlockHashAlgorithm
     /// </summary>
     public int InitializeCallCount { get; private set; }
 
+    /// <inheritdoc />
+    public override string AlgorithmName => nameof(MonitoringDeferredFinalBlockHashAlgorithm);
+
     /// <summary>
     /// Initialises a new instance with the default 8-byte block size and an 8-bit digest.
     /// </summary>


### PR DESCRIPTION
Six-commit consolidation pass over `Bodu.Security.Cryptography`'s hash-algorithm hierarchy. Each commit is independently reviewable.

## Commits

| SHA | Topic |
|---|---|
| `c6f22f1` | Consolidate bitwise rotates onto `NumericExtensions` (Blake2b/2s/3, Shake, CubeHash, AsconState); remove SipHash dead code; rename `v0..v3` → `_v0.._v3`; fix broken `_finalized` references in dead `#if` blocks |
| `d4685fe` | Convert `Tiger` / `Whirlpool` / `Snefru` / `AsconHash` to use the `OnInitialize` hook; simplify `KeyedBlockHashAlgorithm` / `KeyedDeferredFinalBlockHashAlgorithm`; re-parent `Shake` onto `BufferedBlockHashAlgorithm` |
| `20ed334` | Remove `OnInitialize` hook entirely — every derived class now overrides `Initialize` directly and calls `base.Initialize()` first, matching BCL convention |
| `c9c9f4d` | `KeyedBlockHashAlgorithm.KeyValue` typed honestly as `byte[]?`; `Key` getter throws `CryptographicException(KeyNotSet)` when null; **Poly1305 stops auto-generating a key in its constructor** (one-time MAC; reuse via auto-Initialize would silently produce a forgeable second tag) |
| `d705bf9` | Promote `AlgorithmName` to `public abstract string` on `BufferedBlockHashAlgorithm<T>` and implement on every concrete hash — Tiger, Snefru, Whirlpool, Blake2b/2s/3, Poly1305, Shake, SipHash, Skein, AsconHash. Yields stable identifiers like `"Tiger/192"`, `"BLAKE2b-512"`, `"SHAKE128"`, `"Skein-512-256"`, `"Poly1305"` |
| `615db17` | Make `_disposed` truly base-private. Apply canonical dispose pattern (`if (this.IsDisposed) return;` → clear class state → `base.Dispose(disposing)`) to every hash class. Remove redundant `HashValue` clears (the framework does it), `HashSizeValue = 0` defensiveness, and clearing of non-secret config fields |
| `22b934f` | Skein structural refactor deferred — instead, doc-clarify the intentional pipeline-bypass throws so the LSP "violation" is visible as a defensive contract marker, not code rot |

## Issues addressed

From the multi-pass review:

- **Bitwise consolidation** — every hash primitive now goes through `RotateBitsLeftUnchecked` / `RotateBitsRightUnchecked` from `Bodu.Core.NumericExtensions`. Five private rotate helpers and ten direct `BitOperations.Rotate*` calls deleted.
- **`Initialize` lifecycle** — the project converged on the BCL convention: every derived class overrides `Initialize` and calls `base.Initialize()` first. The `OnInitialize` hook (introduced and then withdrawn during the review) is gone.
- **`KeyValue` nullability** — honest `byte[]?` on `KeyedBlockHashAlgorithm`; `Key` getter fails closed with `CryptographicException` when no key has been set.
- **Poly1305 key default** — auto-generation removed. One-time MAC; reuse foot-gun closed.
- **`AlgorithmName`** — universal abstract member on the hash-algorithm base; every concrete hash returns a canonical identifier string.
- **Dispose pattern** — canonical, base-owned `_disposed` latch; ~14 hash classes simplified.
- **Skein LSP "violation"** — doc-clarified as intentional. Structural refactor deferred (would need a new `IKeyedHashAlgorithm` interface and parallel test base for ~250 lines of test plumbing duplication, no functional coverage gain).

## What's still open

- Cipher / AEAD-mode classes (`AesBlockCipher`, `Blowfish`, `Camellia`, `Twofish`, `Threefish`, `Serpent*`, the various `*ModeTransform`, `TweakableSymmetricAlgorithm`) still redeclare `_disposed` — same pattern from the hash sweep applies if you want a follow-up.
- `MurmurHash3` in `Bodu.IO.Hashing` has the same private-rotate pattern that was consolidated here — out of scope for this hash-focused review.
- Skein structural refactor (LSP cleanup) — see commit `22b934f` for the cost/benefit rationale and what re-parenting would require.

## Test plan

CI's `build-test` job exercises the full unit-test suite. Local `dotnet build` / `dotnet test` not run (no SDK in the review sandbox). Key risk areas to watch:

- [ ] All hash known-answer tests still pass (Tiger, Whirlpool, Snefru, Blake2b/2s/3, Skein256/512/1024, AsconHash256/A256, Shake, CubeHash, SipHash, Poly1305).
- [ ] `Initialize` after `Dispose` still throws `ObjectDisposedException` (validated by `Initialize_WhenDisposed_ShouldThrowExactly`).
- [ ] `Poly1305Tests` still pass with no auto-generated key — the test fixture sets the key explicitly via `CreateAlgorithm`, so no expected breakage, but worth confirming.
- [ ] Renamed monitoring tests (`Initialize_WhenCalled_ShouldRunDerivedOverride` and the multiple-times variant) still execute.

https://claude.ai/code/session_016NGcb5a7Udqq7z1uiUAreS