### PR TITLE
CubeHash: clear HashValue and HashSizeValue on Dispose

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -335,6 +335,11 @@ public sealed class CubeHash
             this._rounds = 0;
             this._inputBlockSizeBytes = 0;
             this._pendingBytes = 0;
+
+            // CubeHash extends HashAlgorithm directly (not BufferedBlockHashAlgorithm),
+            // so the centralised HashValue / HashSizeValue clearing in the latter does not apply here.
+            CryptoHelpers.ClearAndNullify(ref this.HashValue);
+            this.HashSizeValue = 0;
         }
 
         this._disposed = true;


### PR DESCRIPTION
Follow-up to PR #198. CubeHash extends `HashAlgorithm` directly rather than `BufferedBlockHashAlgorithm<T>`, so the centralized `HashValue` / `HashSizeValue` clearing that #198 added to the latter does not apply to it. As a result, `Dispose_WhenCalled_ShouldZeroPrivateField` fails for two CubeHash fields after disposal:

- `HashAlgorithm.HashValue` — non-null after dispose (last computed digest still resident).
- `HashAlgorithm.HashSizeValue` — left at `512` after dispose.

This commit clears both locally inside CubeHash's own `Dispose` body so the dispose-zeroing test contract is satisfied for the one hash class outside the `BufferedBlockHashAlgorithm` hierarchy.

## Test plan

- [ ] `Dispose_WhenCalled_ShouldZeroPrivateField(HashValue)` passes for CubeHash.
- [ ] `Dispose_WhenCalled_ShouldZeroPrivateField(HashSizeValue)` passes for CubeHash.
- [ ] All other CubeHash tests still pass (no behavioural change beyond the additional clearing).

https://claude.ai/code/session_016NGcb5a7Udqq7z1uiUAreS

---
_Generated by [Claude Code](https://claude.ai/code/session_016NGcb5a7Udqq7z1uiUAreS)_