### PR TITLE
[CLOSE — DO NOT MERGE] improve-hashing-crypto-extension-docs (degrades current master)

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
@@ -16,8 +16,33 @@ namespace Bodu.IO.Hashing.Checksums;
 /// library. It produces a 32-bit checksum by maintaining two running sums (A and B) and combining them as
 /// <c><![CDATA[(B << 16) | A]]></c>, using the modulus 65521 (the largest prime less than 2<sup>16</sup>).
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes).</description></item>
+///   <item><description>Modulus: <c>65521</c> (largest prime &lt; 2<sup>16</sup>).</description></item>
+///   <item><description>Specification: zlib (RFC 1950); standard for deflate / PNG chunk integrity.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Adler32.</strong> The right choice whenever interoperability with zlib, deflate,
+/// gzip, or PNG is required — every Adler-32 produced or consumed by those formats is bit-identical to this
+/// class's output. Faster than CRC at the cost of weaker error coverage; pick <see cref="Crc"/> with
+/// <see cref="CrcStandard.CRC32_ISOHDLC"/> when error-detection guarantees matter more than throughput, and
+/// <see cref="Adler64"/> for very large inputs where the Adler-32 collision floor becomes a concern.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // zlib-compatible Adler-32 of a deflate payload.
+/// var adler = new Adler32();
+/// byte[] checksum = adler.ComputeHash(deflateBlock);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Adler32
     : Adler32Base

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
@@ -17,8 +17,33 @@ namespace Bodu.IO.Hashing.Checksums;
 /// cheaper modular reductions in vectorised code paths. Outputs differ from standard <see cref="Adler32" />
 /// and are not interchangeable.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes).</description></item>
+///   <item><description>Modulus: <c>65536</c> (power of two; SIMD-friendly).</description></item>
+///   <item><description>Compatibility: <strong>not</strong> interchangeable with <see cref="Adler32"/> outputs.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Adler32C.</strong> Pick <see cref="Adler32C"/> when both endpoints are under your
+/// control and SIMD throughput on the modular-reduction step is the bottleneck — large in-memory streams,
+/// internal block-level integrity checks, content-defined chunking. For any boundary that interoperates with
+/// zlib, deflate, gzip, PNG, or other external systems, use <see cref="Adler32"/> instead — its output is the
+/// only one those systems will accept.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // SIMD-friendly Adler variant for high-throughput internal pipelines.
+/// var adler = new Adler32C();
+/// byte[] checksum = adler.ComputeHash(largeBlock);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Adler32C
     : Adler32Base

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64.cs
@@ -16,8 +16,32 @@ namespace Bodu.IO.Hashing.Checksums;
 /// prime less than 2<sup>32</sup>) reduces overflow pressure and improves checksum stability over large
 /// inputs compared to Adler-32.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 64 bits (8 bytes).</description></item>
+///   <item><description>Modulus: <c>4294967291</c> (largest prime &lt; 2<sup>32</sup>).</description></item>
+///   <item><description>Compatibility: <strong>not</strong> a standardised wire format — consumers must agree on Adler-64 explicitly.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Adler64.</strong> Pick <see cref="Adler64"/> when 32 bits are not enough — very
+/// large datasets where the Adler-32 collision floor becomes a concern, multi-gigabyte block-storage
+/// checksums, or high-throughput logging pipelines. For interoperability with deflate / gzip / PNG use
+/// <see cref="Adler32"/>; for stronger error detection at 64 bits prefer <see cref="Crc"/> with
+/// <see cref="CrcStandard.CRC64_XZ"/>.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var adler = new Adler64();
+/// byte[] checksum = adler.ComputeHash(largePayload);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Adler64
     : Adler64Base

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
@@ -24,9 +24,41 @@ namespace Bodu.IO.Hashing.Checksums;
 /// fallback; the SIMD path applies the canonical positionally weighted block recurrence so that both paths
 /// produce identical digests for any input.
 /// </para>
+/// <para>
+/// <strong>When to choose Adler.</strong> Adler-32 is the canonical checksum used by zlib (RFC 1950) — pick
+/// <see cref="Adler32"/> any time interoperability with zlib, deflate, or PNG's chunk integrity is required.
+/// It is faster than CRC at the cost of weaker error-detection guarantees, and is therefore preferred where
+/// throughput matters more than rigorous coverage of burst errors. <see cref="Adler64"/> generalises the
+/// construction to 64 bits for very large inputs where the Adler-32 collision floor becomes a concern;
+/// <see cref="Adler32C"/> swaps the prime modulus 65521 for the power-of-two 65536 to enable cheaper modular
+/// reductions in vectorised paths — its outputs are <em>not</em> interchangeable with standard Adler-32.
+/// For stronger error detection prefer <see cref="Crc"/>; for hash-table keying prefer
+/// <see cref="Bodu.IO.Hashing.MurmurHash3{T}"/> or <see cref="Bodu.IO.Hashing.CityHash{T}"/>.
+/// </para>
+/// <para>
+/// <strong>Lifecycle and threading.</strong> Inherits the standard
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> shape; snapshotting is
+/// non-destructive. Instances are not thread-safe; share behind explicit synchronisation.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // zlib-compatible Adler-32 of a deflate payload.
+/// var adler = new Adler32();
+/// byte[] checksum = adler.ComputeHash(deflateBlock);
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="Adler32"/>
+/// <seealso cref="Adler32C"/>
+/// <seealso cref="Adler64"/>
+/// <seealso cref="Crc"/>
 public abstract class Adler<T>
     : NonCryptographicHashAlgorithm
     where T : unmanaged, INumber<T>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -15,26 +15,98 @@ using System.IO.Hashing;
 using System.Runtime.CompilerServices;
 
 /// <summary>
-/// Computes CRC (Cyclic Redundancy Check) values for arbitrary input data using a configurable <see cref="CrcStandard" />.
-/// This class cannot be inherited.
+/// General-purpose CRC (Cyclic Redundancy Check) engine driven by a <see cref="CrcStandard"/> parameter set —
+/// supports any catalogue width from 1 to 64 bits, snapshot-style intermediate digests, and resumption of a previous
+/// digest with additional input.
 /// </summary>
 /// <remarks>
 /// <para>
-/// <see cref="Crc" /> supports CRC widths from 1 to 64 bits and honours the polynomial, initial value, input/output
-/// reflection, and final XOR value supplied by <see cref="CrcStandard" />. Precomputed lookup tables are cached via
-/// <see cref="GlobalCache" /> and shared across instances that use identical parameters.
+/// CRCs are the workhorse of integrity checks in storage, networking, and file formats: every <c>.zip</c>, <c>.png</c>,
+/// Ethernet frame, USB packet, and Modbus message uses one. Each protocol bakes in slightly different choices —
+/// polynomial, initial value, input/output bit reflection, final XOR — and the same byte sequence can produce a
+/// different digest under <c>CRC-16/ARC</c>, <c>CRC-16/MODBUS</c>, or <c>CRC-32/ISO-HDLC</c>. Rather than ship a class
+/// per variant, <see cref="Crc"/> consumes the parameters from a <see cref="CrcStandard"/> and the same engine
+/// computes the right answer for every catalogue entry.
 /// </para>
 /// <para>
-/// Instances derive from <see cref="NonCryptographicHashAlgorithm" />, exposing the standard
-/// <see cref="NonCryptographicHashAlgorithm.Append(ReadOnlySpan{byte})" /> / <see cref="NonCryptographicHashAlgorithm.Reset" /> /
-/// <see cref="NonCryptographicHashAlgorithm.GetCurrentHash()" /> surface. The final reflection, XOR-out, and
-/// width-masking step is performed on a snapshot of the accumulator, so
-/// <see cref="NonCryptographicHashAlgorithm.GetCurrentHash()" /> is non-destructive and may be called multiple times
-/// without disturbing in-progress hashing.
+/// <strong>Picking a standard.</strong> The full RevEng catalogue is exposed two ways:
 /// </para>
-/// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for
-/// password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <list type="bullet">
+///   <item>
+///     <term><see cref="CrcStandard"/> static properties</term>
+///     <description>For the common entries (<see cref="CrcStandard.CRC32_ISOHDLC"/>,
+///     <see cref="CrcStandard.CRC32_ISCSI"/>, <see cref="CrcStandard.CRC16_MODBUS"/>, …) — direct, allocation-free
+///     references to the canonical instance.</description>
+///   </item>
+///   <item>
+///     <term><see cref="CrcStandard.Get(CrcStandards)"/> with a <see cref="CrcStandards"/> enum value</term>
+///     <description>For programmatic look-up across the full catalogue (e.g. when reading a configuration value).</description>
+///   </item>
+///   <item>
+///     <term><see cref="CrcStandard.FromName(string)"/></term>
+///     <description>Resolves both canonical names and aliases — <c>"CRC-32"</c>, <c>"PKZIP"</c>,
+///     <c>"CRC-32/ISO-HDLC"</c> all return the same instance.</description>
+///   </item>
+/// </list>
+/// <para>
+/// <strong>API surface.</strong> <see cref="Crc"/> derives from
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/> and exposes the standard
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> shape. The
+/// <see cref="Bodu.IO.Hashing.Extensions.NonCryptographicHashAlgorithmExtensions"/> companion adds one-shot
+/// <c>ComputeHash</c>, stream variants, and constant-time <c>VerifyHash</c> / <c>TryVerifyHash</c> on top.
+/// </para>
+/// <para>
+/// <strong>Snapshot semantics.</strong> The final reflection, XOR-out, and width mask are applied to a
+/// <em>copy</em> of the running accumulator, so <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/>
+/// can be called as often as the caller likes without disturbing further <c>Append</c> calls — useful for emitting
+/// progressive checksums of an unfinished stream.
+/// </para>
+/// <para>
+/// <strong>Resumption.</strong> <see cref="Crc"/> implements <see cref="IResumableHashAlgorithm"/>: given a previously
+/// emitted digest and additional bytes, it produces the digest of the concatenated input <em>without</em> needing the
+/// original bytes back — handy for log-tail integrity checks and content-addressed storage. Resumption is only valid
+/// against a digest produced by an instance configured with the same <see cref="CrcStandard"/>.
+/// </para>
+/// <para>
+/// <strong>Performance.</strong> Lookup tables are precomputed once per
+/// <c>(width, polynomial, reflectIn)</c> tuple and shared via <see cref="GlobalCache"/>, so creating multiple
+/// <see cref="Crc"/> instances for the same standard is cheap. The hot path uses byte-at-a-time table lookups; for
+/// throughput-critical code consider re-using a single instance and feeding it large spans rather than repeatedly
+/// constructing new ones. Instances are <strong>not thread-safe</strong>; share behind explicit synchronisation.
+/// </para>
+/// <note type="important">CRC is <strong>not</strong> cryptographically secure. It detects accidental corruption,
+/// not adversarial tampering — collisions are easy to construct. Use a member of <c>Bodu.Security.Cryptography</c> or
+/// <see cref="System.Security.Cryptography.HashAlgorithm"/> for password hashing, digital signatures, message
+/// authentication, or any context where a determined attacker could choose the input.</note>
+/// <example>
+/// <code language="csharp">
+/// using System.IO.Hashing;
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 1. Standard PKZIP / Ethernet CRC-32 of a buffer.
+/// var crc32 = new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] digest = crc32.ComputeHash(File.ReadAllBytes("payload.bin"));
+///
+/// // 2. Modbus RTU — different polynomial/init/reflect choices, same engine.
+/// var modbus = new Crc(CrcStandard.CRC16_MODBUS);
+/// modbus.Append(frameHeader);
+/// modbus.Append(framePayload);
+/// byte[] frameCrc = modbus.GetCurrentHash();   // non-destructive snapshot
+///
+/// // 3. Resumption — fold an appended log segment into yesterday's digest without re-reading the original bytes.
+/// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] updated = resumable.ComputeHashFrom(digest, File.ReadAllBytes("payload.appended.bin"));
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="CrcStandard"/>
+/// <seealso cref="CrcStandards"/>
+/// <seealso cref="CrcLookupTableCache"/>
+/// <seealso cref="IResumableHashAlgorithm"/>
 public sealed class Crc
     : NonCryptographicHashAlgorithm
     , IResumableHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableBuilder.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableBuilder.cs
@@ -4,20 +4,40 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-
-// ---------------------------------------------------------------------------------------------------------------
-// <copyright file="CrcLookupTableBuilder.cs" company="PlaceholderCompany">
-//     Copyright (c) PlaceholderCompany. All rights reserved.
-// </copyright>
-// ---------------------------------------------------------------------------------------------------------------
-
 using Bodu.Extensions;
 
 namespace Bodu.IO.Hashing.Checksums;
 
 /// <summary>
-/// A utility class for handling CRC operations such as generating CRC lookup tables.
+/// Generates the precomputed lookup tables that drive the byte-at-a-time inner loop of <see cref="Crc"/>, given the
+/// width, polynomial, and input-reflection mode of a <see cref="CrcStandard"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The naive bit-by-bit CRC algorithm is straightforward but processes only one input bit per iteration. The standard
+/// production technique is to precompute a small table of partial CRCs — one entry per possible input byte under the
+/// chosen polynomial — so the per-byte cost collapses to a single XOR plus a table lookup. <see cref="CrcLookupTableBuilder"/>
+/// is the routine that builds that table; <see cref="Crc"/> consumes it and <see cref="CrcLookupTableCache"/> caches it
+/// across instances so the construction cost is paid at most once per <c>(width, polynomial, reflectIn)</c> tuple.
+/// </para>
+/// <para>
+/// <strong>When you would call this directly.</strong> Most callers should not — <see cref="Crc"/> resolves its lookup
+/// table automatically through <see cref="Crc.GlobalCache"/>. Reach for <see cref="BuildLookupTable(int, ulong, bool)"/>
+/// directly when implementing a custom CRC engine outside the <see cref="Crc"/> hierarchy, when running diagnostics
+/// against a known-good table, or when populating a hand-rolled cache for an unusual polynomial that the global cache
+/// is not the right home for.
+/// </para>
+/// <para>
+/// <strong>Output shape.</strong> The returned table contains <c>1 &lt;&lt; min(size, 8)</c> entries (256 for any width
+/// of 8 bits or more, smaller for sub-byte widths). Each entry is masked to <c>size</c> bits and is suitable for direct
+/// XOR into a CRC register of the corresponding width. Output bit reflection (the <c>ReflectOut</c> step) is <em>not</em>
+/// applied here — that is a finalisation step performed by the engine after the table-driven loop completes.
+/// </para>
+/// <para>The method is pure, deterministic, and allocation-bounded by the table size; results are safe to cache and share.</para>
+/// </remarks>
+/// <seealso cref="Crc"/>
+/// <seealso cref="CrcStandard"/>
+/// <seealso cref="CrcLookupTableCache"/>
 public static class CrcLookupTableBuilder
 {
     /// <summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
@@ -9,8 +9,54 @@ using System.Collections.Concurrent;
 namespace Bodu.IO.Hashing.Checksums;
 
 /// <summary>
-/// Thread-safe cache of precomputed CRC lookup tables keyed by width, polynomial, and input reflection.
+/// Thread-safe cache of precomputed CRC lookup tables keyed by width, polynomial, and input reflection — amortises
+/// the per-tuple build cost of <see cref="CrcLookupTableBuilder.BuildLookupTable(int, ulong, bool)"/> across every
+/// <see cref="Crc"/> instance that uses the same <see cref="CrcStandard"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Building a CRC lookup table is cheap in absolute terms but not free, and the same table is needed every time a
+/// <see cref="Crc"/> instance is constructed for a given <see cref="CrcStandard"/>. <see cref="CrcLookupTableCache"/>
+/// memoises tables under the unique key <c>(width, polynomial, reflectIn)</c>: the first lookup for a tuple builds and
+/// stores the table; subsequent lookups return the same shared array.
+/// </para>
+/// <para>
+/// <strong>Default and custom caches.</strong> A process-wide default lives at <see cref="Crc.GlobalCache"/> and is
+/// used implicitly by every <see cref="Crc"/> instance — most callers never need to construct a cache by hand. Reach
+/// for a custom <see cref="CrcLookupTableCache"/> only when you want a scoped cache (e.g. per AppDomain, per test
+/// fixture) that the global default should not see, or when running diagnostic code that needs deterministic cache
+/// state. Custom caches can be installed by assigning to <see cref="Crc.GlobalCache"/>.
+/// </para>
+/// <para>
+/// <strong>Thread safety and aliasing.</strong> Internally backed by <see cref="ConcurrentDictionary{TKey, TValue}"/>;
+/// concurrent <see cref="GetLookupTable(int, ulong, bool)"/> calls are safe and the build delegate runs at most once
+/// per key. The returned array is <strong>shared across all callers</strong> with the same parameters and must be
+/// treated as read-only — mutating it would corrupt every <see cref="Crc"/> instance that uses the same standard.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+///
+/// // Most callers do not interact with the cache directly — Crc resolves it through Crc.GlobalCache.
+/// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+///
+/// // Use a scoped cache for an isolated test, then restore the default.
+/// CrcLookupTableCache previous = Crc.GlobalCache;
+/// try
+/// {
+///     Crc.GlobalCache = new CrcLookupTableCache();
+///     // ... run isolated tests against a fresh cache ...
+/// }
+/// finally
+/// {
+///     Crc.GlobalCache = previous;
+/// }
+/// </code>
+/// </example>
+/// <seealso cref="Crc"/>
+/// <seealso cref="CrcStandard"/>
+/// <seealso cref="CrcLookupTableBuilder"/>
 public class CrcLookupTableCache
 {
     private readonly ConcurrentDictionary<string, ulong[]> localCache;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
@@ -9,8 +9,95 @@ using System.Runtime.Serialization;
 namespace Bodu.IO.Hashing.Checksums;
 
 /// <summary>
-/// Represents an immutable set of parameters (polynomial, width, reflection, initial value, final XOR) that describe a specific CRC algorithm.
+/// Immutable parameter bundle that fully describes a CRC variant — width, polynomial, initial value, input/output bit
+/// reflection, and final XOR — and serves as the lookup key into the RevEng catalogue used by <see cref="Crc"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Every CRC variant in the wild differs from every other along the same five dimensions — the polynomial, the
+/// initial register value, whether input bits are reflected as they enter the register, whether the final register is
+/// reflected on the way out, and what value the register is XOR-ed with at the end. <c>CRC-32/ISO-HDLC</c> and
+/// <c>CRC-32/BZIP2</c> share a polynomial but disagree on reflection; <c>CRC-16/MODBUS</c> and <c>CRC-16/USB</c> share
+/// nearly everything but the initial value. <see cref="CrcStandard"/> captures one such parameter bundle as an
+/// immutable, equatable, serialisable value, decoupling the choice of variant from the engine that runs it.
+/// </para>
+/// <para>
+/// <strong>Three ways to obtain a standard.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Catalogue properties</term>
+///     <description><see cref="CRC32_ISOHDLC"/>, <see cref="CRC32_ISCSI"/>, <see cref="CRC16_MODBUS"/>,
+///     <see cref="CRC16_KERMIT"/>, <see cref="CRC64_XZ"/>, … — direct named accessors for the common entries that
+///     return the canonical, cached <see cref="CrcStandard"/> instance.</description>
+///   </item>
+///   <item>
+///     <term><see cref="Get(CrcStandards)"/></term>
+///     <description>Materialises any catalogue entry from its <see cref="CrcStandards"/> enum value — useful when the
+///     choice is data-driven (e.g. read from configuration).</description>
+///   </item>
+///   <item>
+///     <term><see cref="FromName(string)"/></term>
+///     <description>Resolves canonical names <em>and</em> published aliases — <c>"CRC-32"</c>, <c>"PKZIP"</c>,
+///     <c>"CRC-32/XZ"</c>, <c>"CRC-32/ADCCP"</c> all return the same <see cref="CRC32_ISOHDLC"/> instance.</description>
+///   </item>
+///   <item>
+///     <term>Direct construction</term>
+///     <description>The
+///     <see cref="CrcStandard(string, int, ulong, ulong, bool, bool, ulong)"/> constructor accepts custom parameters
+///     for variants that are not in the RevEng catalogue. Width must lie within
+///     <see cref="MinSize"/>..<see cref="MaxSize"/>.</description>
+///   </item>
+/// </list>
+/// <para>
+/// <strong>How it pairs with <see cref="Crc"/>.</strong> The hash engine reads <see cref="Polynomial"/> and
+/// <see cref="ReflectIn"/> to fetch (or build) a precomputed lookup table from
+/// <see cref="CrcLookupTableCache"/>, seeds the running register with <see cref="InitialValue"/>, and applies
+/// <see cref="ReflectOut"/> + <see cref="XOrOut"/> when emitting the final digest. Multiple <see cref="Crc"/>
+/// instances configured with the same <see cref="CrcStandard"/> share the same lookup table, so creating fresh
+/// engines for the same standard is inexpensive.
+/// </para>
+/// <para>
+/// <strong>Equality and serialisation.</strong> <see cref="CrcStandard"/> is a value-style type: two instances are
+/// equal iff every parameter matches (the <see cref="Name"/> is informational only and does not affect identity).
+/// <see cref="System.Runtime.Serialization.ISerializable"/> support is provided so a chosen standard can survive
+/// process boundaries unchanged.
+/// </para>
+/// <para>
+/// <strong>Coverage and limits.</strong> Sizes are constrained to <see cref="MinSize"/>..<see cref="MaxSize"/> bits;
+/// any wider variant in the RevEng catalogue (currently only <c>CRC-82/DARC</c>) is intentionally omitted because it
+/// will not fit in the <see cref="ulong"/>-backed register. Instances are immutable and therefore safe to share
+/// across threads.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+///
+/// // 1. Direct named accessor — most callers want exactly this.
+/// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+///
+/// // 2. Data-driven look-up — pick the variant from a configuration value.
+/// CrcStandards configured = Enum.Parse&lt;CrcStandards&gt;(config["CrcVariant"]);
+/// var configuredCrc = new Crc(CrcStandard.Get(configured));
+///
+/// // 3. Look-up by alias — accept legacy or vendor names supplied by users.
+/// CrcStandard pkzip = CrcStandard.FromName("PKZIP");          // same instance as CRC32_ISOHDLC
+/// CrcStandard ccitt = CrcStandard.FromName("CRC-CCITT");      // resolves to CRC16_KERMIT
+///
+/// // 4. Custom variant (not in the RevEng catalogue): a 12-bit CRC with bespoke parameters.
+/// var custom = new CrcStandard(
+///     name: "CRC-12/MY-SPEC",
+///     size: 12,
+///     polynomial:   0x80F,
+///     initialValue: 0x000,
+///     reflectIn: false, reflectOut: false,
+///     xOrOut: 0x000);
+/// </code>
+/// </example>
+/// </remarks>
+/// <seealso cref="Crc"/>
+/// <seealso cref="CrcStandards"/>
+/// <seealso cref="CrcLookupTableCache"/>
 [Serializable]
 public sealed partial class CrcStandard
     : System.Runtime.Serialization.ISerializable

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.16.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.16.cs
@@ -18,8 +18,32 @@ namespace Bodu.IO.Hashing.Checksums;
 /// used in network protocols, embedded systems, and file integrity checks where performance and simplicity are preferred
 /// over cryptographic strength.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 16 bits (2 bytes).</description></item>
+///   <item><description>Accumulator width: two 8-bit rolling sums (A and B).</description></item>
+///   <item><description>Modulus: <c>255</c>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fletcher16.</strong> Pick <see cref="Fletcher16"/> for embedded protocols and
+/// short-frame links where 16 bits is enough — Modbus ASCII, RPL message integrity, and similar
+/// resource-constrained settings. For general file integrity prefer <see cref="Fletcher32"/>; for stronger
+/// error-detection guarantees prefer a 16-bit CRC such as <see cref="Crc"/> with
+/// <see cref="CrcStandard.CRC16_MODBUS"/>.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password
 /// hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f16 = new Fletcher16();
+/// byte[] checksum = f16.ComputeHash(framePayload);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fletcher16
     : Fletcher<Fletcher16>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.32.cs
@@ -18,8 +18,31 @@ namespace Bodu.IO.Hashing.Checksums;
 /// used in networking, file validation, and embedded systems where error detection is required but cryptographic strength
 /// is not.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes).</description></item>
+///   <item><description>Accumulator width: two 16-bit rolling sums (A and B).</description></item>
+///   <item><description>Modulus: <c>65535</c>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fletcher32.</strong> The general-purpose Fletcher variant — TCP/UDP-style packet
+/// checks, file integrity in streaming pipelines, and ZFS-class block sums. Faster than CRC at the cost of
+/// weaker burst-error coverage; pick <see cref="Crc"/> with a 32-bit standard such as
+/// <see cref="CrcStandard.CRC32_ISOHDLC"/> when error-detection guarantees matter more than throughput.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password
 /// hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f32 = new Fletcher32();
+/// byte[] checksum = f32.ComputeHash(payload);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fletcher32
     : Fletcher<Fletcher32>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.64.cs
@@ -18,8 +18,31 @@ namespace Bodu.IO.Hashing.Checksums;
 /// commonly used in applications such as network protocols, data validation, and embedded systems where simple and
 /// efficient error detection is sufficient.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 64 bits (8 bytes).</description></item>
+///   <item><description>Accumulator width: two 32-bit rolling sums (A and B).</description></item>
+///   <item><description>Modulus: <c>4294967295</c>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fletcher64.</strong> Pick <see cref="Fletcher64"/> for very large datasets where
+/// the 32-bit collision floor becomes a concern — multi-gigabyte file integrity, large block-storage
+/// checksums, or high-throughput logging pipelines. For stronger error detection at comparable width prefer
+/// <see cref="Crc"/> with <see cref="CrcStandard.CRC64_XZ"/> or <see cref="CrcStandard.CRC64_ECMA182"/>.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password
 /// hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f64 = new Fletcher64();
+/// byte[] checksum = f64.ComputeHash(largePayload);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fletcher64
     : Fletcher<Fletcher64>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
@@ -22,9 +22,44 @@ using System.Runtime.CompilerServices;
 /// combines them into the final hash. Derived types <see cref="Fletcher16" />, <see cref="Fletcher32" />, and
 /// <see cref="Fletcher64" /> select the output width.
 /// </para>
+/// <para>
+/// <strong>When to choose Fletcher.</strong> Fletcher was designed as a cheaper alternative to CRC for
+/// detecting accidental corruption in network protocols and file formats — TCP, Modbus ASCII, and ZFS all use
+/// a Fletcher variant. It catches single-bit errors and many burst errors at a fraction of CRC's per-byte
+/// cost, making it attractive on resource-constrained microcontrollers and in tight inner loops. Pick
+/// <see cref="Fletcher16"/> for embedded protocols where 16 bits is enough,
+/// <see cref="Fletcher32"/> as the workhorse for general file-integrity work, and <see cref="Fletcher64"/>
+/// when a wider checksum reduces collision pressure on large datasets. For stronger error-detection
+/// guarantees prefer <see cref="Crc"/>; for hash-table keying prefer
+/// <see cref="Bodu.IO.Hashing.MurmurHash3{T}"/> or <see cref="Bodu.IO.Hashing.CityHash{T}"/>, which give
+/// better avalanche than any positional-sum scheme.
+/// </para>
+/// <para>
+/// <strong>Lifecycle and threading.</strong> Inherits the standard
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset"/> /
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> shape via
+/// <see cref="BlockNonCryptographicHashAlgorithm{T}"/>. Snapshotting is non-destructive — call
+/// <c>GetCurrentHash</c> as often as needed. Instances are not thread-safe; share behind explicit
+/// synchronisation, or allocate one per consumer.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used for password
 /// hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 32-bit Fletcher checksum of a packet payload.
+/// var fletcher = new Fletcher32();
+/// byte[] checksum = fletcher.ComputeHash(payload);
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="Fletcher16"/>
+/// <seealso cref="Fletcher32"/>
+/// <seealso cref="Fletcher64"/>
+/// <seealso cref="Crc"/>
 public abstract class Fletcher<TSelf>
     : BlockNonCryptographicHashAlgorithm<TSelf>
     where TSelf : Fletcher<TSelf>, new()

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
@@ -9,9 +9,75 @@ using System.IO.Hashing;
 namespace Bodu.IO.Hashing.Extensions;
 
 /// <summary>
-/// Provides a set of <see langword="static" /> (<see langword="Shared" /> in Visual Basic) extension methods that extend the
-/// <see cref="NonCryptographicHashAlgorithm" /> class with verification, comparison, and incremental hashing capabilities.
+/// Extends <see cref="NonCryptographicHashAlgorithm"/> with one-shot hashing, streaming and async input,
+/// and constant-time hash verification — the high-level surface that <see cref="NonCryptographicHashAlgorithm"/>
+/// itself omits.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="NonCryptographicHashAlgorithm"/> intentionally exposes only the low-level
+/// <see cref="NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> /
+/// <see cref="NonCryptographicHashAlgorithm.GetCurrentHash()"/> primitives. Real-world callers want to ask higher-level
+/// questions: "compute the hash of this byte array", "stream-hash this file", "does this download match the expected
+/// digest?". This class adds those operations as a coherent set, mirroring the shape of
+/// <see cref="System.Security.Cryptography.HashAlgorithm"/> so the same call patterns work whether the underlying
+/// algorithm is cryptographic (SHA-256) or non-cryptographic (CRC, xxHash, Fletcher).
+/// </para>
+/// <para>
+/// The API surface clusters into four groups:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Append</term>
+///     <description><c>AppendData</c> / <c>AppendDataAsync</c> — feed a buffer or stream into the algorithm's running
+///     state, with a tunable read-buffer size for stream input.</description>
+///   </item>
+///   <item>
+///     <term>One-shot compute</term>
+///     <description><c>ComputeHash</c> / <c>ComputeHashAsync</c> — append, finalise, and reset in a single call,
+///     returning the digest as a freshly allocated <see cref="byte"/> array. Inputs include byte arrays, byte-array
+///     slices, <see cref="System.ReadOnlyMemory{T}"/>, and <see cref="System.IO.Stream"/>.</description>
+///   </item>
+///   <item>
+///     <term>Throwing verification</term>
+///     <description><c>VerifyHash</c> / <c>VerifyHashAsync</c> — compute the digest of an input and compare it against
+///     an expected value supplied as either bytes or a hexadecimal string. Returns <see langword="true"/> on match,
+///     throws on argument problems.</description>
+///   </item>
+///   <item>
+///     <term>Try-pattern verification</term>
+///     <description><c>TryVerifyHash</c> / <c>TryVerifyHashAsync</c> — non-throwing counterparts. Suitable when the
+///     expected hash is user-supplied and a malformed input should not surface as an exception.</description>
+///   </item>
+/// </list>
+/// <para>
+/// All hash comparisons go through
+/// <see cref="System.Security.Cryptography.CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/>,
+/// so verification is constant-time and safe to use against attacker-supplied digests even though the underlying
+/// algorithm itself provides no preimage resistance. The algorithm instance is stateful and reset after each
+/// <c>ComputeHash</c> or <c>VerifyHash</c> call, but it is not thread-safe — share instances only behind explicit
+/// synchronisation. Stream overloads do not dispose the supplied stream.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 1. One-shot hash of a byte buffer using xxHash64.
+/// var xx = new XxHash64();
+/// byte[] digest = xx.ComputeHash(File.ReadAllBytes("payload.bin"));
+///
+/// // 2. Stream-hash a large file without loading it into memory.
+/// using FileStream fs = File.OpenRead("payload.bin");
+/// byte[] streamDigest = xx.ComputeHash(fs);
+///
+/// // 3. Verify a downloaded artefact against an expected hex digest, without throwing on a malformed string.
+/// var crc = new Crc32();
+/// if (crc.TryVerifyHash(File.ReadAllBytes("artefact.zip"), expectedHex: "deadbeef"))
+///     Console.WriteLine("artefact verified");
+/// </code>
+/// </example>
+/// </remarks>
 public static partial class NonCryptographicHashAlgorithmExtensions
 {
 }

--- a/Bodu.IO.Hashing/src/IO.Hashing/ApHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/ApHash.cs
@@ -19,8 +19,30 @@ namespace Bodu.IO.Hashing;
 /// XOR/shift mixes depending on whether the byte's position is even or odd. It is intended for hash-table
 /// lookups and similar non-cryptographic use cases.
 /// </para>
+/// <para>
+/// <strong>When to choose APHash.</strong> APHash is one of the simplest position-aware mixes in the lib —
+/// pick it when a small, dependency-free 32-bit hash is enough and the performance budget per byte is tight.
+/// For better avalanche on hash-table keys prefer <see cref="Fnv1a32"/> or <see cref="MurmurHash3_32"/>; for
+/// content fingerprinting prefer <see cref="CityHash{T}"/>. APHash, <see cref="JSHash"/>, <see cref="SDBM"/>,
+/// and <see cref="Pjw32"/> are siblings in the same low-cost niche and produce comparable distribution; the
+/// choice between them is usually driven by interop with an existing system that standardises on one.
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive; instances
+/// are not thread-safe and should be allocated per consumer.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var ap = new ApHash();
+/// byte[] digest = ap.ComputeHash(System.Text.Encoding.UTF8.GetBytes("dictionary-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class ApHash
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
@@ -21,8 +21,32 @@ namespace Bodu.IO.Hashing;
 /// multiplier must be one of the supported values (31, 131, 1313, 13131, 131313, 1313131, 13131313, 131313131,
 /// 1313131313) and can be reassigned only while the algorithm has not yet consumed any input.
 /// </para>
+/// <para>
+/// <strong>When to choose BKDR.</strong> BKDR is the polynomial rolling hash from K&amp;R's "The C Programming
+/// Language" — a textbook choice for symbol tables, lexer keyword maps, and other small-string keying tasks.
+/// Pick it when interoperating with code that already uses the K&amp;R formulation, or when the input is a
+/// short identifier and avalanche quality matters less than predictable behaviour. For modern hash-table
+/// workloads prefer <see cref="Fnv1a32"/> (better avalanche on the same per-byte cost) or
+/// <see cref="MurmurHash3_32"/> (much better distribution on inputs longer than ~16 bytes).
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset"/> returns the instance to its
+/// reconfigurable, pre-input state. Instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default seed (131); appropriate for short identifier keys.
+/// var bkdr = new BKDR();
+/// byte[] digest = bkdr.ComputeHash(System.Text.Encoding.UTF8.GetBytes("Identifier"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class BKDR
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
@@ -26,8 +26,37 @@ namespace Bodu.IO.Hashing;
 /// algorithm has not yet consumed input. <see cref="Reset" /> returns the instance to the reconfigurable
 /// state.
 /// </para>
+/// <para>
+/// <strong>When to choose Bernstein.</strong> djb2 is the canonical "C-style" hash for short string keys —
+/// language symbol tables, environment-variable maps, and small associative containers. Pick it when
+/// interoperating with code that has standardised on djb2 (Perl, Python's older string hash, Tcl variable
+/// tables, etc.) or when the seed/variant flexibility is useful. Empirically the XOR-modified form
+/// (<c>djb2a</c>, <see cref="UseModifiedAlgorithm"/> set to <see langword="true"/>) gives slightly better
+/// avalanche than the default additive form. For new code without an interop constraint, <see cref="Fnv1a32"/>
+/// is a closely related but better-distributing default; <see cref="MurmurHash3_32"/> is preferable for
+/// inputs longer than a few dozen bytes.
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default djb2 with the canonical 5381 seed.
+/// var djb2 = new Bernstein();
+/// byte[] digest = djb2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
+///
+/// // XOR-modified djb2a, generally better distribution.
+/// var djb2a = new Bernstein { UseModifiedAlgorithm = true };
+/// byte[] digestA = djb2a.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Bernstein
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
@@ -11,29 +11,93 @@ using System;
 using System.IO.Hashing;
 
 /// <summary>
-/// Base class for non-cryptographic hash algorithms that consume input in fixed-size blocks. Handles residual buffering,
-/// block alignment, total-length tracking, and optional final-block padding on behalf of derived implementations.
+/// Base class for non-cryptographic hash algorithms whose internal state advances one fixed-size block at a time —
+/// handles residual buffering, block alignment, total-length tracking, snapshot-based <c>GetCurrentHash</c>, and
+/// optional final-block padding so that derived implementations only need to express the per-block compression step.
 /// </summary>
-/// <typeparam name="T">The concrete hash algorithm derived from this class. Must expose a public parameterless constructor.</typeparam>
+/// <typeparam name="T">
+/// The concrete hash algorithm type derived from this class. Must expose a public parameterless constructor so the base
+/// class can satisfy its <c>new()</c> constraint when constructing snapshot clones.
+/// </typeparam>
 /// <remarks>
 /// <para>
-/// Input data is accumulated into an internal buffer until a complete block of <see cref="BlockSizeBytes" /> is available,
-/// at which point it is passed to <see cref="ProcessBlock" />. Any residual bytes left over when
-/// <see cref="GetCurrentHashCore" /> is invoked are padded via <see cref="PadBlock" /> before a final call to
-/// <see cref="ProcessFinalBlock" /> produces the digest.
+/// Many non-cryptographic hashes — Murmur, CityHash, Pearson, the FNV variants — define their compression step over a
+/// fixed block size (4, 8, 16, or 32 bytes) and must buffer trailing bytes that do not fill a complete block. Writing
+/// that buffering loop correctly is fiddly: handle straddling input, accumulate the running message length, and pad
+/// once on finalisation. <see cref="BlockNonCryptographicHashAlgorithm{T}"/> centralises that machinery so derived
+/// types only express the algorithm-specific behaviour.
 /// </para>
-/// <para>Derived classes must implement the following:</para>
+/// <para>
+/// <strong>Inheritance contract.</strong> Derived classes implement four members and may override two more:
+/// </para>
 /// <list type="bullet">
-/// <item><description><see cref="ProcessBlock" /> processes a single complete block of input data.</description></item>
-/// <item><description><see cref="PadBlock" /> pads the final input segment and encodes the total message length.</description></item>
-/// <item><description><see cref="ProcessFinalBlock" /> finalises the hash computation and returns the resulting digest.</description></item>
+///   <item><description><see cref="ProcessBlock(System.ReadOnlySpan{byte})"/> — compress a single complete block.</description></item>
+///   <item><description><see cref="PadBlock(System.ReadOnlySpan{byte}, ulong)"/> — pad the final partial block and encode the total message length.</description></item>
+///   <item><description><see cref="ProcessFinalBlock"/> — emit the final digest from the accumulator.</description></item>
+///   <item><description><see cref="Clone"/> — produce a state-equivalent copy used for non-destructive snapshotting.</description></item>
+///   <item><description><see cref="ResetState"/> (optional) — restore algorithm-specific accumulators on <see cref="Reset"/>.</description></item>
+///   <item><description><see cref="ShouldPadFinalBlock"/> / <see cref="AllowUnalignedFinalBlock"/> (optional) — opt out of padding, or pass the padded result as a single block instead of splitting it block-aligned.</description></item>
 /// </list>
 /// <para>
-/// Unlike cryptographic hashes derived from <see cref="System.Security.Cryptography.HashAlgorithm" />, instances of
-/// <see cref="BlockNonCryptographicHashAlgorithm{T}" /> do not participate in <see cref="System.Security.Cryptography.ICryptoTransform" />
-/// pipelines. They are intended for integrity checks, fingerprinting, and hash-table workloads — not for security-sensitive contexts.
+/// <strong>Lifecycle.</strong> Input arrives via the standard
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> entry point and is
+/// drained block-by-block into the residual buffer. <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/>
+/// is intentionally non-destructive: the base class clones the live instance via <see cref="Clone"/>, runs padding and
+/// finalisation on the clone, and copies the digest into the destination span. Callers may inspect the running hash as
+/// often as they like without disturbing further input. <see cref="Reset"/> clears the residual buffer and total length
+/// before invoking <see cref="ResetState"/>.
 /// </para>
+/// <para>
+/// <strong>Snapshot helpers for derived <see cref="Clone"/> implementations.</strong> Three protected accessors —
+/// <see cref="ResidualByteCount"/>, <see cref="ResidualBytes"/>, and <see cref="TotalLength"/> — expose the base-class
+/// state, and <see cref="CopyResidualStateFrom(BlockNonCryptographicHashAlgorithm{T})"/> performs the corresponding
+/// write-side step. Derived <see cref="Clone"/> implementations typically allocate a new instance, copy
+/// algorithm-specific accumulators field-by-field, and finish with a call to
+/// <see cref="CopyResidualStateFrom(BlockNonCryptographicHashAlgorithm{T})"/>.
+/// </para>
+/// <para>
+/// <strong>Suitability.</strong> Like every other type in <c>Bodu.IO.Hashing</c>, derivations of this class produce
+/// <em>non-cryptographic</em> digests intended for integrity checks, fingerprinting, hash-table keys, and bloom-filter
+/// inputs. They do not provide preimage or collision resistance and must not be used for password hashing, message
+/// authentication, or any security-sensitive context — use a member of <c>Bodu.Security.Cryptography</c> or the BCL's
+/// <see cref="System.Security.Cryptography.HashAlgorithm"/> hierarchy instead. Instances are not thread-safe; share
+/// behind explicit synchronisation.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// // Sketch of a derived block hash. The base class drives buffering and snapshotting;
+/// // the derived type only expresses how a single block changes the accumulator.
+/// public sealed class MyBlockHash : BlockNonCryptographicHashAlgorithm&lt;MyBlockHash&gt;
+/// {
+///     private uint _state;
+///
+///     public MyBlockHash() : base(hashLengthInBytes: 4, blockSize: 16) { }
+///
+///     protected override void ProcessBlock(ReadOnlySpan&lt;byte&gt; block)
+///     {
+///         // mix the 16-byte block into _state ...
+///     }
+///
+///     protected override byte[] PadBlock(ReadOnlySpan&lt;byte&gt; trailing, ulong messageLength)
+///     {
+///         // append a 0x80 byte, zero-pad, then write `messageLength` little-endian, return one or more whole blocks.
+///         return Array.Empty&lt;byte&gt;();
+///     }
+///
+///     protected override byte[] ProcessFinalBlock() =&gt; BitConverter.GetBytes(_state);
+///
+///     protected override MyBlockHash Clone()
+///     {
+///         var copy = new MyBlockHash { _state = _state };
+///         copy.CopyResidualStateFrom(this);
+///         return copy;
+///     }
+/// }
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/>
+/// <seealso cref="IResumableHashAlgorithm"/>
 public abstract class BlockNonCryptographicHashAlgorithm<T>
     : NonCryptographicHashAlgorithm
     where T : BlockNonCryptographicHashAlgorithm<T>, new()

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
@@ -26,10 +26,35 @@ namespace Bodu.IO.Hashing;
 /// The digest is emitted as two consecutive little-endian 64-bit words (<c>First</c> followed by
 /// <c>Second</c>), matching the encoding convention used by <see cref="CityHash64" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 128 bits (16 bytes), little-endian, two 64-bit words.</description></item>
+///   <item><description>Variant: <c>CityHash128</c>.</description></item>
+///   <item><description>Length-dispatched mixing: &lt;128-byte and 128+-byte paths.</description></item>
+///   <item><description>Block size on the long path: 128 bytes.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose CityHash128.</strong> Pick <see cref="CityHash128"/> for low-collision fingerprinting
+/// of large key spaces — content-addressed storage, deduplication, two-hash cuckoo / split-key schemes that
+/// can use the two 64-bit halves independently. <see cref="MurmurHash3_128"/> is the closest alternative; it
+/// supports a constructor seed but is typically slightly slower on long inputs on 64-bit CPUs.
+/// </para>
 /// <note type="important">
 /// This algorithm is <b>not</b> cryptographically secure and must <b>not</b> be used for password hashing,
 /// digital signatures, or any application requiring adversarial collision resistance.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var city = new CityHash128();
+/// byte[] fingerprint = city.ComputeHash(blob);
+/// // fingerprint = [low 64 bits || high 64 bits], each little-endian.
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class CityHash128
     : CityHash<CityHash128>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
@@ -20,10 +20,34 @@ namespace Bodu.IO.Hashing;
 /// three interleaved accumulators for 25 or more bytes. All paths converge through the <c>Mur</c> and <c>Mix</c> primitives defined in
 /// <see cref="CityHash{T}" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes), little-endian.</description></item>
+///   <item><description>Variant: <c>CityHash32</c>.</description></item>
+///   <item><description>Length-dispatched mixing: 0–4, 5–12, 13–24, and 25+ byte paths.</description></item>
+///   <item><description>Seedless — for seeded variants prefer <see cref="MurmurHash3_32"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose CityHash32.</strong> Pick <see cref="CityHash32"/> for 32-bit slot indexes when
+/// throughput on long inputs matters — it edges <see cref="MurmurHash3_32"/> on 64-bit hosts. For short
+/// fixed-length keys <see cref="Fnv1a32"/> is simpler and competitive; if a seed is needed (bloom filters,
+/// hash-flooding mitigation) prefer <see cref="MurmurHash3_32"/>.
+/// </para>
 /// <note type="important">
 /// This algorithm is <b>not</b> cryptographically secure and must <b>not</b> be used for password hashing, digital signatures, or
 /// any application requiring adversarial collision resistance.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var city = new CityHash32();
+/// byte[] digest = city.ComputeHash(System.Text.Encoding.UTF8.GetBytes("session-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class CityHash32
     : CityHash<CityHash32>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.64.cs
@@ -20,10 +20,34 @@ namespace Bodu.IO.Hashing;
 /// consumes 64-byte blocks using two pairs of seeded weak hash accumulators for inputs of 65 bytes or more. All paths converge through
 /// the shared <c>HashLen16</c> finaliser, which applies two rounds of multiply-shift-XOR to distribute entropy across all output bits.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 64 bits (8 bytes), little-endian.</description></item>
+///   <item><description>Variant: <c>CityHash64</c>.</description></item>
+///   <item><description>Length-dispatched mixing: 0–16, 17–32, 33–64, and 65+ byte paths.</description></item>
+///   <item><description>Block size on the long path: 64 bytes.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose CityHash64.</strong> The general-purpose default for 64-bit non-cryptographic
+/// hashing — fingerprints, content-based sharding, deduplication keys. <see cref="MurmurHash3_128"/> gives
+/// twice the bits at slightly lower throughput on long inputs; <see cref="Fnv1a64"/> is preferable only for
+/// very small fixed-length keys where simplicity matters more than distribution.
+/// </para>
 /// <note type="important">
 /// This algorithm is <b>not</b> cryptographically secure and must <b>not</b> be used for password hashing, digital signatures, or any
 /// application requiring adversarial collision resistance.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var city = new CityHash64();
+/// byte[] fingerprint = city.ComputeHash(blob);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class CityHash64
     : CityHash<CityHash64>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
@@ -37,11 +37,43 @@ using System.Runtime.CompilerServices;
 /// <see cref="Hash64Len0to16(ReadOnlySpan{byte})" />) and algorithm constants are defined here and are
 /// available to all derived variants. Supported output sizes are 32, 64, and 128 bits.
 /// </para>
+/// <para>
+/// <strong>When to choose CityHash.</strong> CityHash was designed for short-to-medium strings on 64-bit
+/// CPUs and tends to outperform <see cref="MurmurHash3{T}"/> on long inputs while matching it on short ones.
+/// It is the typical choice for in-memory hash tables, fingerprinting, and content-based sharding when both
+/// throughput and distribution quality matter. Pick <see cref="CityHash32"/> for 32-bit slot indexes,
+/// <see cref="CityHash64"/> for general-purpose 64-bit hashing, and <see cref="CityHash128"/> for low-collision
+/// fingerprinting of large key spaces. For very small fixed-length keys, <see cref="Fnv{TSelf}"/> is simpler
+/// and competitive; for adversarial inputs use a member of <c>Bodu.Security.Cryptography</c> instead.
+/// </para>
+/// <para>
+/// <strong>Buffering caveat.</strong> Because the algorithm needs the whole message before mixing, the base
+/// class buffers every appended byte until <see cref="GetCurrentHashCore(Span{byte})"/> is called. Memory
+/// consumption grows linearly with input length between resets — avoid feeding it multi-gigabyte streams.
+/// Instances are not thread-safe; share behind explicit synchronisation.
+/// </para>
 /// <note type="important">
 /// CityHash is <b>not</b> cryptographically secure. It must <b>not</b> be used for password hashing, digital
 /// signatures, or any application that requires collision resistance under adversarial conditions.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 64-bit fingerprint of a content blob — typical use case.
+/// var city = new CityHash64();
+/// byte[] fingerprint = city.ComputeHash(blob);
+///
+/// // Stream-hash a moderately sized file. Note: CityHash buffers fully — prefer Crc / xxHash for very large streams.
+/// using FileStream fs = File.OpenRead("payload.bin");
+/// byte[] streamDigest = city.ComputeHash(fs);
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="CityHash32"/>
+/// <seealso cref="CityHash64"/>
+/// <seealso cref="CityHash128"/>
 public abstract class CityHash<T>
     : NonCryptographicHashAlgorithm
     where T : CityHash<T>, new()

--- a/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
@@ -22,8 +22,31 @@ namespace Bodu.IO.Hashing;
 /// is reconfigurable only while the algorithm has not yet consumed any input. <see cref="Reset" /> returns
 /// the instance to the reconfigurable state.
 /// </para>
+/// <para>
+/// <strong>When to choose ELF64.</strong> The ELF hash is the symbol-table hash baked into UNIX System V
+/// object files and the GNU dynamic linker's <c>.gnu.hash</c> section — pick it when interoperating with
+/// ELF-format tooling or when reproducing a digest computed by the system linker. For general-purpose
+/// hash-table keying prefer <see cref="Fnv1a64"/> (better avalanche on the same per-byte cost) or
+/// <see cref="MurmurHash3_128"/> (much better distribution on inputs longer than ~16 bytes). The 64-bit
+/// width makes ELF64 a reasonable choice for medium-sized identifier maps where 32 bits would invite
+/// collisions.
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 64-bit (8-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var elf = new Elf64();
+/// byte[] digest = elf.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Elf64
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv132.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv132.cs
@@ -15,8 +15,31 @@ namespace Bodu.IO.Hashing;
 /// The FNV-1 variant performs multiplication before XOR. The 32-bit configuration uses prime
 /// <c>0x01000193</c> and offset basis <c>0x811C9DC5</c>.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes), little-endian.</description></item>
+///   <item><description>Offset basis: <c>0x811C9DC5</c>.</description></item>
+///   <item><description>FNV prime: <c>0x01000193</c>.</description></item>
+///   <item><description>Variant: FNV-1 (multiply, then XOR).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fnv132.</strong> Pick <see cref="Fnv132"/> only when reproducing a digest from
+/// existing FNV-1 32-bit consumers. For new code prefer <see cref="Fnv1a32"/>: same parameters, better
+/// avalanche, identical cost.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv132();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fnv132
     : Fnv<Fnv132>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv164.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv164.cs
@@ -15,8 +15,31 @@ namespace Bodu.IO.Hashing;
 /// The FNV-1 variant performs multiplication before XOR. The 64-bit configuration uses prime
 /// <c>0x100000001B3</c> and offset basis <c>0xCBF29CE484222325</c>.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 64 bits (8 bytes), little-endian.</description></item>
+///   <item><description>Offset basis: <c>0xCBF29CE484222325</c>.</description></item>
+///   <item><description>FNV prime: <c>0x00000100000001B3</c>.</description></item>
+///   <item><description>Variant: FNV-1 (multiply, then XOR).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fnv164.</strong> Pick <see cref="Fnv164"/> only when reproducing a digest from
+/// existing FNV-1 64-bit consumers. For new code prefer <see cref="Fnv1a64"/>: same parameters, better
+/// avalanche, identical cost.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv164();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fnv164
     : Fnv<Fnv164>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a32.cs
@@ -16,8 +16,32 @@ namespace Bodu.IO.Hashing;
 /// behaviour relative to the original FNV-1 form. The 32-bit configuration uses prime <c>0x01000193</c> and
 /// offset basis <c>0x811C9DC5</c>.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes), little-endian.</description></item>
+///   <item><description>Offset basis: <c>0x811C9DC5</c>.</description></item>
+///   <item><description>FNV prime: <c>0x01000193</c>.</description></item>
+///   <item><description>Variant: FNV-1a (XOR, then multiply).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fnv1a32.</strong> The recommended 32-bit FNV variant — better avalanche than
+/// <see cref="Fnv132"/> at identical cost. Pick it for hash-table keying of short strings or identifiers when
+/// 32 bits is enough; reach for <see cref="MurmurHash3_32"/> on inputs longer than ~16 bytes or when SMHasher
+/// quality matters, and for <see cref="Fnv1a64"/> when 64 bits would meaningfully reduce collisions.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv1a32();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fnv1a32
     : Fnv<Fnv1a32>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a64.cs
@@ -16,8 +16,32 @@ namespace Bodu.IO.Hashing;
 /// behaviour relative to the original FNV-1 form. The 64-bit configuration uses prime <c>0x100000001B3</c>
 /// and offset basis <c>0xCBF29CE484222325</c>.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 64 bits (8 bytes), little-endian.</description></item>
+///   <item><description>Offset basis: <c>0xCBF29CE484222325</c>.</description></item>
+///   <item><description>FNV prime: <c>0x00000100000001B3</c>.</description></item>
+///   <item><description>Variant: FNV-1a (XOR, then multiply).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Fnv1a64.</strong> The recommended FNV variant when 32 bits would invite collisions
+/// — wider key spaces, content fingerprints, distributed cache keys. For inputs longer than ~16 bytes,
+/// <see cref="Bodu.IO.Hashing.MurmurHash3_128"/> or <see cref="Bodu.IO.Hashing.CityHash64"/> generally
+/// distribute better and run faster on modern 64-bit CPUs.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv1a64();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Fnv1a64
     : Fnv<Fnv1a64>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
@@ -25,9 +25,42 @@ namespace Bodu.IO.Hashing;
 /// <item><term>FNV-1</term><description>multiplication followed by XOR.</description></item>
 /// <item><term>FNV-1a</term><description>XOR followed by multiplication.</description></item>
 /// </list>
+/// <para>
+/// <strong>When to choose FNV.</strong> FNV is byte-at-a-time, allocation-free, and trivially fast on small
+/// inputs — a common choice for hashing identifiers, dictionary keys, and cache lookups in hot paths. For most
+/// new code prefer <see cref="Fnv1a32"/> or <see cref="Fnv1a64"/>: the FNV-1a ordering has measurably better
+/// avalanche than the original FNV-1. For inputs longer than a few hundred bytes,
+/// <see cref="MurmurHash3{T}"/> or <see cref="CityHash{T}"/> generally distribute better and are faster on
+/// modern CPUs; FNV's strength is its simplicity and predictable performance on short keys.
+/// </para>
+/// <para>
+/// <strong>Output size and lifecycle.</strong> The digest length is fixed by the constructor's
+/// <c>hashSize</c> argument (32 or 64 bits) and emitted in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive and may
+/// be called any number of times during a running hash; <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Reset"/>
+/// returns the running state to its initial offset basis.
+/// </para>
+/// <para>
+/// <strong>Thread safety.</strong> Instances are not thread-safe; share behind explicit synchronisation, or
+/// allocate one per consumer.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Pick a width and variant; FNV-1a is the recommended default.
+/// var fnv = new Fnv1a64();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="Fnv132"/>
+/// <seealso cref="Fnv1a32"/>
+/// <seealso cref="Fnv164"/>
+/// <seealso cref="Fnv1a64"/>
 public abstract class Fnv<TSelf>
     : NonCryptographicHashAlgorithm
     where TSelf : Fnv<TSelf>, new()

--- a/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
@@ -10,14 +10,70 @@ using System;
 using System.IO.Hashing;
 
 /// <summary>
-/// Represents a non-cryptographic hash algorithm that supports resuming a previously finalised hash state and continuing
-/// the hash computation with additional input data.
+/// Marks a non-cryptographic hash algorithm whose internal state can be reconstructed from a previously emitted digest,
+/// so additional input can be folded into an existing hash <em>without</em> re-reading the bytes that produced it.
 /// </summary>
 /// <remarks>
-/// This interface is intended for use with stateful non-cryptographic hash algorithms (such as CRC, FNV, or Jenkins) that
-/// allow the internal state to be reconstructed from a finalised hash output. Implementations must reverse any
-/// finalisation steps — such as XOR-out or reflection — before resuming the hash process.
+/// <para>
+/// Many simple, additive non-cryptographic hashes — CRC, FNV, Jenkins-style mixes — are <em>linear</em> in the sense
+/// that the running accumulator at any point is fully determined by the bytes seen so far. The published digest hides
+/// that accumulator behind a finalisation step (typically a final XOR, output reflection, or width mask), but the step
+/// is reversible. Implementing <see cref="IResumableHashAlgorithm"/> declares that an algorithm supports that reverse
+/// step and exposes a stable contract for callers who want to incrementally hash a stream that arrives in chunks
+/// across process boundaries — a common pattern in tail-anchored log files, content-addressed stores, or streaming
+/// integrity checks where the running state is not in memory but the previous digest <em>is</em>.
+/// </para>
+/// <para>
+/// <strong>Usage shape.</strong> Pair the previous digest with the new bytes:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term><see cref="ComputeHashFrom(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/></term>
+///     <description>Returns a freshly allocated digest representing
+///     <c>hash(previousInput || newData)</c>. The two array overloads are conveniences for callers without spans.</description>
+///   </item>
+///   <item>
+///     <term><see cref="TryComputeHashFrom(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte}, System.Span{byte}, out int)"/></term>
+///     <description>The allocation-free variant that writes into a caller-supplied buffer; returns
+///     <see langword="false"/> when the destination is too small, leaving <c>bytesWritten</c> at 0.</description>
+///   </item>
+/// </list>
+/// <para>
+/// <strong>Implementation contract.</strong> Implementations must (a) accept any byte sequence of length
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.HashLengthInBytes"/> as a valid <c>previousHash</c>; (b)
+/// reverse any final XOR, reflection, or width mask before resuming; (c) re-apply finalisation before returning the
+/// new digest; and (d) leave the algorithm instance in a clean state on return. The contract is not preserved across
+/// algorithms — a digest produced by <c>CRC-32/ISO-HDLC</c> can only be resumed by an instance configured with the
+/// same <see cref="Bodu.IO.Hashing.Checksums.CrcStandard"/>.
+/// </para>
+/// <para>
+/// <strong>When this is the wrong tool.</strong> Cryptographic hashes (SHA-2, SHA-3, BLAKE) are <em>not</em> resumable
+/// in this sense — their finalisation collapses internal state irreversibly, which is precisely the property that
+/// makes them cryptographically useful. For appending to an in-memory algorithm instance, prefer the standard
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.Append(System.ReadOnlySpan{byte})"/> path.
+/// <see cref="IResumableHashAlgorithm"/> only earns its keep when the running accumulator has already been discarded
+/// and only the digest remains.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Checksums;
+///
+/// // 1. Compute a baseline digest of a file's first segment.
+/// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+/// crc.Append(File.ReadAllBytes("part-1.bin"));
+/// byte[] digest1 = crc.GetCurrentHash();
+///
+/// // 2. Hours (or processes) later, fold an additional segment into the same digest using only `digest1`.
+/// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] digest2 = resumable.ComputeHashFrom(digest1, File.ReadAllBytes("part-2.bin"));
+///
+/// // 3. Same result as if both segments had been appended in one session — without holding the running state.
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/>
+/// <seealso cref="Bodu.IO.Hashing.Checksums.Crc"/>
 public interface IResumableHashAlgorithm
 {
     /// <summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing/JSHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/JSHash.cs
@@ -19,8 +19,30 @@ namespace Bodu.IO.Hashing;
 /// <c><![CDATA[hash ^= (hash << 5) + (hash >> 2) + byte]]></c>, seeded with <c>0x4E67C6A7</c>. The finalised
 /// hash is written to the output buffer in little-endian byte order.
 /// </para>
+/// <para>
+/// <strong>When to choose JSHash.</strong> JSHash is one of the small bitwise-mix hashes — pick it when a
+/// short, dependency-free 32-bit hash is sufficient and the per-byte cost matters. Its distribution is
+/// roughly comparable to <see cref="ApHash"/>, <see cref="SDBM"/>, and <see cref="Pjw32"/>; the choice
+/// between them is usually driven by interop with an existing system. For modern hash-table workloads prefer
+/// <see cref="Fnv1a32"/> (better avalanche, same cost) or <see cref="MurmurHash3_32"/> (markedly better
+/// distribution on inputs longer than ~16 bytes).
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var js = new JSHash();
+/// byte[] digest = js.ComputeHash(System.Text.Encoding.UTF8.GetBytes("input-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class JSHash
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
@@ -25,10 +25,39 @@ using System.Runtime.CompilerServices;
 /// A 32-bit seed may be supplied at construction time. Both accumulators are initialised to the same seed
 /// value, matching the behaviour of the reference <c>MurmurHash3_x64_128</c> implementation.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 128 bits (16 bytes), little-endian.</description></item>
+///   <item><description>Variant: <c>MurmurHash3_x64_128</c> — optimised for 64-bit platforms.</description></item>
+///   <item><description>Block size: 16 bytes; tail pass for remaining 1–15 bytes.</description></item>
+///   <item><description>Seed: 32 bits, applied to both accumulators; defaults to <c>0</c>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose MurmurHash3_128.</strong> Pick this when collision pressure makes 32 or 64 bits
+/// inadequate — content fingerprinting, deduplication keys, large bloom filters. Output is also useful as a
+/// pair of 64-bit halves for two-hash cuckoo or split-key schemes.
+/// <see cref="CityHash128"/> is a comparable alternative with similar quality and slightly better throughput
+/// on long inputs on modern 64-bit CPUs.
+/// </para>
 /// <note type="important">
 /// This algorithm is <b>not</b> cryptographically secure and must <b>not</b> be used for password hashing,
 /// digital signatures, or any application requiring adversarial collision resistance.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 128-bit fingerprint of a content blob.
+/// var m = new MurmurHash3_128();
+/// byte[] fingerprint = m.ComputeHash(blob);
+///
+/// // Custom seed to isolate a second hash family for cuckoo / bloom-filter use.
+/// var m2 = new MurmurHash3_128(seed: 0xC2B2AE35u);
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class MurmurHash3_128
     : MurmurHash3<MurmurHash3_128>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
@@ -23,10 +23,40 @@ using System.Runtime.CompilerServices;
 /// A 32-bit seed may be supplied at construction time to produce independent hash families for identical input,
 /// which is useful for building distributed hash tables and bloom filters.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 32 bits (4 bytes), little-endian.</description></item>
+///   <item><description>Variant: <c>MurmurHash3_x86_32</c>.</description></item>
+///   <item><description>Block size: 4 bytes; tail pass for remaining 1–3 bytes.</description></item>
+///   <item><description>Seed: 32 bits, defaults to <c>0</c>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose MurmurHash3_32.</strong> The default 32-bit hash for in-memory hash tables and
+/// bloom filters. Choose it over <see cref="Fnv1a32"/> when input length exceeds ~16 bytes or when SMHasher
+/// quality matters. Reach for <see cref="MurmurHash3_128"/> when collision pressure (large key spaces,
+/// fingerprinting) calls for more bits, or for <see cref="CityHash32"/> for slightly better throughput on
+/// long inputs on 64-bit CPUs.
+/// </para>
 /// <note type="important">
 /// This algorithm is <b>not</b> cryptographically secure and must <b>not</b> be used for password hashing, digital
 /// signatures, or any application requiring adversarial collision resistance.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default seed, suitable for an in-memory hash table.
+/// var m = new MurmurHash3_32();
+/// byte[] digest = m.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
+///
+/// // Custom seed for a second, independent hash family (useful in bloom filters).
+/// var m2 = new MurmurHash3_32(seed: 0x9E3779B1u);
+/// byte[] digest2 = m2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class MurmurHash3_32
     : MurmurHash3<MurmurHash3_32>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
@@ -33,11 +33,42 @@ using System.Runtime.CompilerServices;
 /// Shared mixing primitives (<see cref="FMix32(uint)" />, <see cref="FMix64(ulong)" />) and algorithm constants
 /// are defined here and are available to all derived variants. Supported output sizes are 32 and 128 bits.
 /// </para>
+/// <para>
+/// <strong>When to choose MurmurHash3.</strong> MurmurHash3 has excellent avalanche, strong distribution under
+/// SMHasher's full battery, and is faster than the FNV family on inputs longer than a few dozen bytes — making
+/// it the default choice for non-distributed in-memory hash tables, bloom filters, and content-based sharding.
+/// Pick <see cref="MurmurHash3_32"/> when 32 bits is sufficient and the host is 32-bit-friendly; pick
+/// <see cref="MurmurHash3_128"/> when collision pressure (large key spaces, fingerprinting) calls for more
+/// bits. <see cref="CityHash{T}"/> typically edges MurmurHash3 on long inputs on 64-bit CPUs;
+/// <see cref="Fnv{TSelf}"/> is preferable only for very small fixed-length keys.
+/// </para>
+/// <para>
+/// <strong>Buffering caveat.</strong> Because the algorithm needs the whole message before mixing, the base
+/// class buffers every appended byte until <see cref="GetCurrentHashCore(Span{byte})"/> is called. Memory
+/// consumption therefore grows linearly with input length between resets — avoid feeding it multi-gigabyte
+/// streams. Instances are not thread-safe; share behind explicit synchronisation.
+/// </para>
 /// <note type="important">
 /// MurmurHash3 is <b>not</b> cryptographically secure. It must <b>not</b> be used for password hashing, digital
 /// signatures, or any application that requires collision resistance under adversarial conditions.
 /// </note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 32-bit hash, default seed, suitable for in-memory hash tables.
+/// var m32 = new MurmurHash3_32();
+/// uint h32 = BinaryPrimitives.ReadUInt32LittleEndian(m32.ComputeHash(keyBytes));
+///
+/// // 128-bit hash, custom seed for shard isolation across services.
+/// var m128 = new MurmurHash3_128(seed: 0xC2B2AE35u);
+/// byte[] fingerprint = m128.ComputeHash(payload);
+/// </code>
+/// </example>
 /// </remarks>
+/// <seealso cref="MurmurHash3_32"/>
+/// <seealso cref="MurmurHash3_128"/>
 public abstract class MurmurHash3<T>
     : NonCryptographicHashAlgorithm
     where T : MurmurHash3<T>, new()

--- a/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
@@ -23,8 +23,34 @@ namespace Bodu.IO.Hashing;
 /// When computing multi-byte hashes (for example a 64-bit digest), the algorithm is repeated for each byte
 /// of the result, using a different initialisation for each output byte to reduce collisions.
 /// </para>
+/// <para>
+/// <strong>When to choose Pearson.</strong> Pearson is interesting in two niches: extremely small lookup
+/// tables — a Pearson byte is the cheapest way to hash a key into a 256-bucket index — and resource-poor
+/// embedded targets where a 256-byte permutation table is small enough to fit in cache and a 64-bit-sized
+/// hash can be assembled from eight independent 8-bit hashes without ever needing wide-integer arithmetic.
+/// For modern hash-table workloads with realistic key spaces, prefer <see cref="Fnv1a32"/> /
+/// <see cref="Fnv1a64"/> or <see cref="MurmurHash3{T}"/>; Pearson's per-byte distribution is weaker than
+/// those alternatives.
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Output size is set by the constructor's <c>hashSize</c> argument
+/// (a multiple of 8 bits, typically 8, 16, 32, or 64). The digest is emitted in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 8-byte (64-bit) Pearson digest assembled from eight permutation passes,
+/// // using one of the canonical lookup tables.
+/// var pearson = new Pearson(hashSizeBits: 64, PearsonTableType.Pearson);
+/// byte[] digest = pearson.ComputeHash(System.Text.Encoding.UTF8.GetBytes("payload"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed partial class Pearson
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/Pjw32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Pjw32.cs
@@ -20,8 +20,30 @@ namespace Bodu.IO.Hashing;
 /// bits is then XOR-folded back into the low-order bits, producing a well-distributed hash for identifier
 /// and symbol-table use.
 /// </para>
+/// <para>
+/// <strong>When to choose PJW32.</strong> PJW is the symbol-table hash from Aho/Sethi/Ullman's "Compilers:
+/// Principles, Techniques, and Tools" (the "Dragon Book") and the precursor to the ELF hash family
+/// (<see cref="Elf64"/>) — pick it when interoperating with compiler-generated symbol tables or reproducing
+/// a digest from an algorithm based on the Dragon Book formulation. For general-purpose hash-table keying
+/// prefer <see cref="Fnv1a32"/> (closely related but better-distributing) or
+/// <see cref="MurmurHash3_32"/> (much better distribution on inputs longer than ~16 bytes).
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var pjw = new Pjw32();
+/// byte[] digest = pjw.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class Pjw32
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/SDBM.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SDBM.cs
@@ -19,8 +19,31 @@ namespace Bodu.IO.Hashing;
 /// <c><![CDATA[hash = byte + (hash << 6) + (hash << 16) - hash]]></c>, producing good distribution for short
 /// and medium-length keys at minimal cost.
 /// </para>
+/// <para>
+/// <strong>When to choose SDBM.</strong> SDBM is the public-domain hash from the NDBM/SDBM database library
+/// and the historical default in many Unix tools — pick it when interoperating with code that has
+/// standardised on the SDBM mix, or when a small, dependency-free 32-bit hash is sufficient. Empirically
+/// SDBM gives slightly better distribution than <see cref="Bernstein"/> and <see cref="ApHash"/> on short
+/// keys at the same per-byte cost. For modern hash-table workloads prefer <see cref="Fnv1a32"/> (better
+/// avalanche, same cost) or <see cref="MurmurHash3_32"/> (markedly better distribution on inputs longer than
+/// ~16 bytes).
+/// </para>
+/// <para>
+/// <strong>Output and lifecycle.</strong> Produces a 32-bit (4-byte) digest in little-endian byte order.
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm.GetCurrentHash()"/> is non-destructive;
+/// instances are not thread-safe.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var sdbm = new SDBM();
+/// byte[] digest = sdbm.ComputeHash(System.Text.Encoding.UTF8.GetBytes("dbm-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class SDBM
     : NonCryptographicHashAlgorithm

--- a/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
@@ -27,8 +27,29 @@ namespace Bodu.IO.Hashing;
 /// use case — but should be avoided for very large streams where a block-oriented, fixed-memory hash would be
 /// more appropriate.
 /// </para>
+/// <para>
+/// <strong>When to choose SuperFastHash.</strong> SuperFastHash predates MurmurHash and was designed by
+/// Paul Hsieh for in-memory hash tables of short keys (32-byte block sums and similar). It has been
+/// superseded by the MurmurHash3 / CityHash / xxHash generation, which beat it on every measurable axis —
+/// pick it only when reproducing a digest from existing SuperFastHash-based code. For new work on short keys
+/// prefer <see cref="MurmurHash3_32"/> or <see cref="Fnv1a32"/>; for streaming and very large inputs prefer
+/// <see cref="CityHash64"/> or a CRC variant via <see cref="Bodu.IO.Hashing.Checksums.Crc"/>.
+/// </para>
+/// <para>
+/// Instances are not thread-safe; share behind explicit synchronisation.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> cryptographically secure and should <b>not</b> be used
 /// for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Suited to short keys; avoid for multi-megabyte streams (the input is fully buffered).
+/// var sfh = new SuperFastHash();
+/// byte[] digest = sfh.ComputeHash(System.Text.Encoding.UTF8.GetBytes("short-key"));
+/// </code>
+/// </example>
 /// </remarks>
 public sealed class SuperFastHash
     : NonCryptographicHashAlgorithm

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -10,23 +10,79 @@ using System.Security.Cryptography;
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Provides one-shot convenience wrappers around <see cref="IAeadBlockCipherModeTransform" />
-/// that handle associated-data processing, output buffer sizing, and the ciphertext + tag layout
-/// in a single call.
+/// Extends <see cref="IAeadBlockCipherModeTransform"/> with one-shot encrypt/decrypt overloads that handle the
+/// associated-data step, size the output buffer correctly, and return the ciphertext + tag (or recovered plaintext) as
+/// a single freshly allocated array.
 /// </summary>
 /// <remarks>
 /// <para>
-/// The raw <see cref="IAeadBlockCipherModeTransform" /> contract requires callers to call
-/// <see cref="IAeadBlockCipherModeTransform.ProcessAssociatedData" /> before <see cref="IAeadBlockCipherModeTransform.Encrypt" />
-/// or <see cref="IAeadBlockCipherModeTransform.Decrypt" />, size the output buffer to
-/// <c>plaintext.Length + TagSize</c> (or <c>ciphertextWithTag.Length - TagSize</c>), and
-/// interpret the return value. These extension methods collapse all of that into a single call
-/// that returns a correctly sized <see cref="byte" /> array.
+/// AEAD ("authenticated encryption with associated data") modes — GCM, CCM, EAX, GCM-SIV, AES-SIV, Ascon — encrypt
+/// confidential plaintext while simultaneously authenticating the ciphertext together with a separate stream of
+/// associated data that travels in the clear (packet headers, message metadata, …). The
+/// <see cref="IAeadBlockCipherModeTransform"/> contract gives callers maximum control: invoke
+/// <see cref="IAeadBlockCipherModeTransform.ProcessAssociatedData"/>, size the output buffer to
+/// <c>plaintext.Length + TagSize</c> (or <c>ciphertextWithTag.Length - TagSize</c>), call
+/// <see cref="IAeadBlockCipherModeTransform.Encrypt"/> or <see cref="IAeadBlockCipherModeTransform.Decrypt"/>, and
+/// interpret the return value. This class collapses that fixed sequence into a single call that returns a correctly
+/// sized array, matching the shape of <c>AesGcm.Encrypt</c> / <c>AesGcm.Decrypt</c> in the BCL but parameterised over
+/// <em>any</em> AEAD transform implementation.
 /// </para>
 /// <para>
-/// AEAD transforms are stateful and single-use. Construct a new transform per message and pass
-/// it to exactly one of these extension methods.
+/// The API surface is symmetric and intentionally small:
 /// </para>
+/// <list type="bullet">
+///   <item>
+///     <term><c>Encrypt(transform, plaintext)</c></term>
+///     <description>One-shot encrypt with no associated data — equivalent to passing
+///     <see cref="System.ReadOnlySpan{T}.Empty"/>.</description>
+///   </item>
+///   <item>
+///     <term><c>Encrypt(transform, plaintext, associatedData)</c></term>
+///     <description>One-shot encrypt with associated data; returns ciphertext concatenated with the
+///     <see cref="IAeadBlockCipherModeTransform.TagSize"/>-byte authentication tag.</description>
+///   </item>
+///   <item>
+///     <term><c>Decrypt(transform, ciphertextWithTag)</c></term>
+///     <description>One-shot decrypt with no associated data; throws on tag mismatch.</description>
+///   </item>
+///   <item>
+///     <term><c>Decrypt(transform, ciphertextWithTag, associatedData)</c></term>
+///     <description>One-shot decrypt and tag-verify; returns the recovered plaintext, or throws
+///     <see cref="CryptographicException"/> on a failed tag check.</description>
+///   </item>
+/// </list>
+/// <para>
+/// AEAD transforms are <strong>stateful and single-use within a message</strong>: instantiate a new transform per
+/// message, call exactly one of these helpers, and dispose. The associated-data argument must match byte-for-byte
+/// between the encrypt and decrypt calls — even a single-bit difference will cause the tag check to fail. Tag
+/// verification is constant-time inside the transform implementation, so timing leaks are not a concern. Output arrays
+/// are always sized exactly: <c>plaintext.Length + TagSize</c> on encrypt, <c>ciphertextWithTag.Length - TagSize</c> on
+/// decrypt.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using System.Text;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// byte[] key    = RandomNumberGenerator.GetBytes(32);
+/// byte[] nonce  = RandomNumberGenerator.GetBytes(12);
+/// byte[] header = Encoding.UTF8.GetBytes("v=1;msg=42");
+///
+/// // 1. Encrypt with associated data; receive ciphertext + tag in a single buffer.
+/// using IAeadBlockCipherModeTransform enc = new GcmModeTransform(key, nonce);
+/// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header);
+///
+/// // 2. Decrypt and verify in one call. A tampered tag or header throws CryptographicException.
+/// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(key, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+///
+/// // 3. Same shape with a different mode — Ascon, EAX, GCM-SIV all interchange behind IAeadBlockCipherModeTransform.
+/// using IAeadBlockCipherModeTransform enc2 = new AsconAead128(key, nonce);
+/// byte[] sealedAscon = enc2.Encrypt(plaintext);
+/// </code>
+/// </example>
 /// </remarks>
 /// <seealso href="../guides/cryptography/aead-modes.html">Using AEAD modes (guide with full encrypt / decrypt examples)</seealso>
 public static class AeadBlockCipherModeTransformExtensions

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
@@ -9,9 +9,76 @@ using System.Security.Cryptography;
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Provides a set of <see langword="static" /> (<see langword="Shared" /> in Visual Basic) extension methods that extend the
-/// <see cref="HashAlgorithm" /> class with verification, comparison, and incremental hashing capabilities.
+/// Extends <see cref="HashAlgorithm"/> with incremental input, async hashing of streams, and constant-time verification
+/// against expected digests supplied as bytes, spans, memory, or hex strings.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="HashAlgorithm"/> base type exposes a low-level API: <c>TransformBlock</c> / <c>TransformFinalBlock</c>
+/// for incremental input, and <see cref="HashAlgorithm.ComputeHash(byte[])"/> for one-shot work. Production code that
+/// hashes streams, verifies downloads, or matches user-supplied digests ends up writing the same boilerplate
+/// repeatedly: read the stream into a buffer, push it through the algorithm, and compare the result with
+/// <see cref="CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/> to avoid
+/// timing leaks. This class collapses that boilerplate into a small, named API surface while keeping every comparison
+/// constant-time.
+/// </para>
+/// <para>
+/// The API surface clusters into three groups:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Append</term>
+///     <description><c>AppendData</c> / <c>AppendDataAsync</c> — feed a span or stream into the algorithm's running
+///     state, equivalent to a chained <c>TransformBlock</c> sequence but cancellation-aware in the async form.</description>
+///   </item>
+///   <item>
+///     <term>Throwing verification</term>
+///     <description><c>VerifyHash</c> / <c>VerifyHashAsync</c> — hash an input (byte array, span, memory, stream, or
+///     <see cref="System.String"/> with a chosen <see cref="System.Text.Encoding"/>) and compare the digest against an
+///     expected value given as bytes or as a hexadecimal string. Throws on a malformed input or hex.</description>
+///   </item>
+///   <item>
+///     <term>Try-pattern verification</term>
+///     <description><c>TryVerifyHash</c> / <c>TryVerifyHashAsync</c> — non-throwing counterparts that return
+///     <see langword="false"/> for malformed expected hashes and <see langword="true"/> only when the inputs round-trip
+///     and match. Suitable when the expected hash is user-supplied.</description>
+///   </item>
+/// </list>
+/// <para>
+/// Every digest comparison routes through
+/// <see cref="CryptographicOperations.FixedTimeEquals(System.ReadOnlySpan{byte}, System.ReadOnlySpan{byte})"/> so an
+/// attacker cannot infer a partial-match by timing the call. The async overloads honour
+/// <see cref="System.Threading.CancellationToken"/> at every read boundary. <see cref="HashAlgorithm"/> instances are
+/// stateful and reset after each verification or compute call; they are not thread-safe, so share instances only behind
+/// explicit synchronisation. Stream overloads do not dispose the supplied <see cref="System.IO.Stream"/>.
+/// </para>
+/// <para>
+/// For non-cryptographic algorithms (CRC, xxHash, Fletcher, …) prefer the
+/// <see cref="Bodu.IO.Hashing.Extensions.NonCryptographicHashAlgorithmExtensions"/> companion in <c>Bodu.IO.Hashing</c>;
+/// both surfaces follow the same naming so call sites read identically.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using System.Text;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var sha = SHA256.Create();
+///
+/// // 1. Verify a UTF-8 string against an expected digest, throwing if anything is wrong.
+/// byte[] expected = Convert.FromHexString("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
+/// bool match = sha.VerifyHash("Hello, World!", Encoding.UTF8, expected);
+///
+/// // 2. Stream-verify a downloaded file against a hex digest, without throwing on malformed hex.
+/// using FileStream fs = File.OpenRead("payload.bin");
+/// bool ok = sha.TryVerifyHash(fs, expectedHex: "ba7816bf...");
+///
+/// // 3. Cancellable async verification of a network stream against a known digest.
+/// await using Stream net = response.Content.ReadAsStream();
+/// bool verified = await sha.VerifyHashAsync(net, expected, cancellationToken);
+/// </code>
+/// </example>
+/// </remarks>
 public static partial class HashAlgorithmExtensions
 {
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
@@ -9,8 +9,77 @@ using System.Security.Cryptography;
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Provides extension methods for performing transformations with an <see cref="ICryptoTransform" />.
+/// Extends <see cref="ICryptoTransform"/> with one-shot, span/memory-aware, stream-to-stream, and async transform
+/// helpers — sized buffers, finalisation, and stream pumping rolled into single calls.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ICryptoTransform"/> is the contract that every block-cipher encryptor or decryptor implements, but its
+/// raw API forces callers to size output buffers, allocate result arrays, distinguish intermediate <c>TransformBlock</c>
+/// calls from the final <c>TransformFinalBlock</c>, and reset the transform between messages. This class wraps those
+/// operations behind two verb-led names — <c>Transform</c> for whole-input processing and <c>TransformFinalBlock</c>
+/// for finalisation — that hide the buffering arithmetic and give the caller back a correctly sized result.
+/// </para>
+/// <para>
+/// The API surface clusters into four groups:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>One-shot in-memory</term>
+///     <description><c>Transform</c> overloads that accept a <see cref="byte"/> array, an array slice
+///     (<c>offset</c>/<c>count</c>), a <see cref="System.ReadOnlySpan{T}"/>, or a <see cref="System.ReadOnlyMemory{T}"/>
+///     and return a freshly allocated output array. Use these when the entire input fits in memory.</description>
+///   </item>
+///   <item>
+///     <term>Caller-supplied buffers</term>
+///     <description><c>Transform(input, destination)</c> overloads for span and memory destinations — for hot paths
+///     that want to reuse a pre-allocated output buffer and have <c>destination</c> written in place. The return value
+///     is the number of bytes written.</description>
+///   </item>
+///   <item>
+///     <term>Stream pumping</term>
+///     <description><c>Transform(sourceStream, targetStream, bufferSize)</c> and the awaitable
+///     <c>TransformAsync</c> overloads, for cases where the input is a stream that should not be fully buffered. The
+///     extension drives the read/transform/write loop with a tunable buffer.</description>
+///   </item>
+///   <item>
+///     <term>Finalisation</term>
+///     <description><c>TransformFinalBlock</c> overloads that mirror the same input shapes (no-arg, byte array, slice,
+///     span, memory) for emitting the final, padded block.</description>
+///   </item>
+/// </list>
+/// <para>
+/// <see cref="ICryptoTransform"/> instances are stateful and single-use within a message — once
+/// <see cref="ICryptoTransform.TransformFinalBlock(byte[], int, int)"/> has run, the transform should be disposed and a
+/// fresh one created for the next message. None of these helpers dispose the transform or the supplied streams; the
+/// caller owns the lifetime. Methods that allocate a result array always return exactly the number of bytes produced.
+/// Async overloads honour <see cref="System.Threading.CancellationToken"/> at every read boundary.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using Aes aes = Aes.Create();
+/// aes.Key = key;
+/// aes.IV  = iv;
+///
+/// // 1. One-shot encrypt of a span into a new byte[].
+/// using ICryptoTransform encryptor = aes.CreateEncryptor();
+/// byte[] ciphertext = encryptor.Transform(plaintext.AsSpan());
+///
+/// // 2. Stream-encrypt a large file end to end with a 64 KiB buffer.
+/// using FileStream src = File.OpenRead("plain.bin");
+/// using FileStream dst = File.Create("cipher.bin");
+/// using ICryptoTransform e2 = aes.CreateEncryptor();
+/// int written = e2.Transform(src, dst, bufferSize: 64 * 1024);
+///
+/// // 3. Cancellable async stream transform, e.g. when piping HTTP content.
+/// using ICryptoTransform e3 = aes.CreateEncryptor();
+/// await e3.TransformAsync(networkStream, output, bufferSize: 16 * 1024, cancellationToken);
+/// </code>
+/// </example>
+/// </remarks>
 public static partial class ICryptoTransformExtensions
 {
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
@@ -7,9 +7,76 @@
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Provides a set of <see langword="static" /> ( <see langword="Shared" /> in Visual Basic) methods that extend the
-/// <see cref="System.Security.Cryptography.SymmetricAlgorithm" /> class.
+/// Extends <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> with one-shot encrypt/decrypt of buffers,
+/// stream-to-stream pipelines, awaitable async variants, and try-pattern transform creation that surfaces validation
+/// failures without exceptions.
 /// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> ships with the building blocks — <c>CreateEncryptor</c>,
+/// <c>CreateDecryptor</c>, and <c>CryptoStream</c> — but stops short of the operations that callers actually want to
+/// invoke: "encrypt this byte array", "decrypt this stream into that one", or "give me back the encryptor only if the
+/// key/IV check out". Production code that does this work tends to repeat the same setup: instantiate the transform,
+/// wrap it in a <see cref="System.Security.Cryptography.CryptoStream"/>, drain the source, dispose everything in the
+/// right order. This class collapses that into a single call per scenario, with overloads aligned to the input shape.
+/// </para>
+/// <para>
+/// The API surface clusters into three groups:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Encrypt / Decrypt — one-shot</term>
+///     <description><c>Encrypt</c> and <c>Decrypt</c> overloads accepting <see cref="byte"/>[], a slice
+///     (<c>offset</c>/<c>count</c>), <see cref="System.ReadOnlySpan{T}"/>, or <see cref="System.ReadOnlyMemory{T}"/>,
+///     returning the result as a freshly allocated array. Use these when the entire payload fits in memory.</description>
+///   </item>
+///   <item>
+///     <term>Encrypt / Decrypt — stream</term>
+///     <description><c>Encrypt(sourceStream, targetStream)</c> / <c>Decrypt(sourceStream, targetStream)</c> with
+///     awaitable <c>EncryptAsync</c> / <c>DecryptAsync</c> variants. The buffer size defaults to
+///     <see cref="DefaultBufferSize"/> (80 KiB); callers can override it with the explicit <c>bufferSize</c> overload.
+///     Streams are not disposed by these methods.</description>
+///   </item>
+///   <item>
+///     <term>Try-pattern transform creation</term>
+///     <description><c>TryCreateEncryptor</c> / <c>TryCreateDecryptor</c> — surface key/IV validation failures as a
+///     <see langword="false"/> return rather than a <see cref="System.Security.Cryptography.CryptographicException"/>.
+///     Useful when accepting key material from configuration or user input.</description>
+///   </item>
+/// </list>
+/// <para>
+/// All operations honour the algorithm's configured <see cref="System.Security.Cryptography.SymmetricAlgorithm.Mode"/>
+/// and <see cref="System.Security.Cryptography.SymmetricAlgorithm.Padding"/>; for AEAD modes (GCM, CCM, EAX, …) prefer
+/// the dedicated <see cref="AeadBlockCipherModeTransformExtensions"/> in the same namespace, which handles associated
+/// data and tag layout. Async overloads honour <see cref="System.Threading.CancellationToken"/> at every read boundary.
+/// <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> instances are not thread-safe; share them only behind
+/// explicit synchronisation.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using Aes aes = Aes.Create();
+/// aes.Key = key;
+/// aes.IV  = iv;
+///
+/// // 1. One-shot encrypt of an in-memory span; one-shot decrypt back.
+/// byte[] ciphertext = aes.Encrypt(plaintext.AsSpan());
+/// byte[] roundTrip  = aes.Decrypt(ciphertext);
+///
+/// // 2. Stream-encrypt a large file with the default 80 KiB buffer.
+/// using FileStream src = File.OpenRead("plain.bin");
+/// using FileStream dst = File.Create("cipher.bin");
+/// int bytesWritten = aes.Encrypt(src, dst);
+///
+/// // 3. Validate caller-supplied key material without catching CryptographicException.
+/// if (!aes.TryCreateDecryptor(suppliedKey, suppliedIv, out ICryptoTransform? decryptor))
+///     return BadRequest("invalid key/iv combination");
+/// using (decryptor) { /* … decrypt with the validated transform … */ }
+/// </code>
+/// </example>
+/// </remarks>
 public static partial class SymmetricAlgorithmExtensions
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
@@ -7,9 +7,63 @@
 namespace Bodu.Security.Cryptography.Extensions;
 
 /// <summary>
-/// Provides a set of <see langword="static" /> ( <see langword="Shared" /> in Visual Basic) methods that extend the
-/// <see cref="Bodu.Security.Cryptography.TweakableSymmetricAlgorithm" /> class.
+/// Extends <see cref="Bodu.Security.Cryptography.TweakableSymmetricAlgorithm"/> with try-pattern transform creation
+/// that surfaces invalid key, IV, or tweak material as a <see langword="false"/> return rather than a thrown
+/// <see cref="System.Security.Cryptography.CryptographicException"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Tweakable block ciphers — Threefish in this library, and tweakable variants used as building blocks for AEAD
+/// constructions — accept a third keying input alongside the key and IV: the <em>tweak</em>. The tweak is a per-message
+/// value that varies the cipher's behaviour without renegotiating a key, making it a natural fit for disk encryption,
+/// authenticated modes, and protocols that bind ciphertext to a position or message identifier. Constructing an
+/// encryptor or decryptor for one of these algorithms requires all three values to be valid in concert; the BCL-style
+/// approach is to throw on the first invalid value, which is awkward when the values are user-supplied.
+/// </para>
+/// <para>
+/// The API surface is intentionally narrow and parallels
+/// <see cref="SymmetricAlgorithmExtensions.TryCreateEncryptor(System.Security.Cryptography.SymmetricAlgorithm, byte[], byte[], out System.Security.Cryptography.ICryptoTransform)"/>:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term><c>TryCreateEncryptor</c></term>
+///     <description>Wraps <see cref="Bodu.Security.Cryptography.TweakableSymmetricAlgorithm.CreateEncryptor()"/> and the
+///     explicit <c>(key, iv, tweak)</c> overload, returning <see langword="false"/> on any cryptographic validation
+///     failure.</description>
+///   </item>
+///   <item>
+///     <term><c>TryCreateDecryptor</c></term>
+///     <description>The matching pair for <see cref="Bodu.Security.Cryptography.TweakableSymmetricAlgorithm.CreateDecryptor()"/>.</description>
+///   </item>
+/// </list>
+/// <para>
+/// All four overloads validate <paramref name="algorithm"/> eagerly and throw <see cref="System.ArgumentNullException"/>
+/// when it is <see langword="null"/>; <em>only</em> cryptographic failures from the underlying transform are converted
+/// to a <see langword="false"/> return. The returned <see cref="System.Security.Cryptography.ICryptoTransform"/> is
+/// owned by the caller and must be disposed.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using TweakableSymmetricAlgorithm tf = new Threefish256();
+///
+/// // 1. Validate user-supplied key/IV/tweak without catching CryptographicException.
+/// if (!tf.TryCreateEncryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? encryptor))
+///     return BadRequest("invalid key, iv, or tweak");
+///
+/// using (encryptor) { /* … encrypt with the validated transform … */ }
+///
+/// // 2. Round-trip pairing — same try-pattern shape for the decryptor.
+/// if (tf.TryCreateDecryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? decryptor))
+/// {
+///     using (decryptor) { /* … decrypt … */ }
+/// }
+/// </code>
+/// </example>
+/// </remarks>
 public static partial class TweakableSymmetricAlgorithmExtensions
 {
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -14,11 +14,29 @@ namespace Bodu.Security.Cryptography;
 /// <c>0x00</c> followed by a trailing byte holding the padding length <c>N</c>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A full block of padding is always added when the input is already block-aligned so
 /// that <see cref="Unpad" /> can unambiguously recover the original length. Valid values
 /// of <c>N</c> lie in the range <c>1..blockSize</c>. <see cref="Unpad" /> validates in
 /// constant time to resist padding-oracle side channels.
+/// </para>
+/// <para>
+/// <strong>When to choose ANSI X.923.</strong> Pick this when interoperating with legacy financial /
+/// banking systems or formats that explicitly require the X.923 layout. For all other cases use
+/// <see cref="Pkcs7Padding"/> — it is the modern standard and is what every mainstream library expects by
+/// default.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Ansix923Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 16);
+/// // padded ends with N-1 zero bytes followed by a single byte holding N.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 16);
+/// </code>
+/// </example>
 public sealed class Ansix923Padding : IPaddingStrategy
 {
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
@@ -56,23 +56,43 @@ namespace Bodu.Security.Cryptography;
 /// Call <see cref="ProcessAssociatedData" /> before <see cref="Encrypt" /> or <see cref="Decrypt" />. Pass an empty span
 /// if there is no associated data.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Key size: 128 bits (16 bytes).</description></item>
+///   <item><description>Nonce size: 128 bits (16 bytes), must be unique per key.</description></item>
+///   <item><description>Tag size: 128 bits (16 bytes).</description></item>
+///   <item><description>State: 320-bit sponge; rate: 16 bytes; permutation Ascon-p12 (init/finalise) + Ascon-p8 (absorb).</description></item>
+///   <item><description>Specification: NIST SP 800-232 (ASCON family).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Ascon-AEAD128.</strong> The right pick when NIST's lightweight-cryptography
+/// selection is required, or for resource-constrained targets (microcontrollers, IoT) where the Ascon
+/// permutation's small state and short round count are an advantage over GCM's GHASH multiplications. For
+/// general-purpose AEAD on commodity x86/ARM hardware <see cref="GcmModeTransform"/> remains faster thanks
+/// to AES-NI/PCLMULQDQ; for nonce-misuse resistance prefer <see cref="GcmSivModeTransform"/> or
+/// <see cref="SivModeTransform"/>. Unlike the AES-based AEAD modes, Ascon does not depend on a separate
+/// block cipher — pair it with the related <see cref="AsconHash256"/> / <see cref="AsconHashA256"/> hashes
+/// or <see cref="AsconXof128"/> XOF when building a fully Ascon-based protocol.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">
-/// // Encryption
-/// using var enc = new AsconAead128(key, nonce);
-/// enc.ProcessAssociatedData(associatedData);
-/// byte[] ciphertext = new byte[plaintext.Length + AsconAead128.TagBytes];
-/// enc.Encrypt(plaintext, ciphertext);
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
 ///
-/// // Decryption
-/// using var dec = new AsconAead128(key, nonce);
-/// dec.ProcessAssociatedData(associatedData);
-/// byte[] recovered = new byte[ciphertext.Length - AsconAead128.TagBytes];
-/// dec.Decrypt(ciphertext, recovered);
+/// // Most callers should reach for the AeadBlockCipherModeTransformExtensions helpers,
+/// // which size the output buffer and return a single freshly allocated array.
+/// using IAeadBlockCipherModeTransform enc = new AsconAead128(key, nonce);
+/// byte[] sealed_   = enc.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new AsconAead128(key, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 /// </code>
 /// </example>
 /// <seealso href="https://doi.org/10.6028/NIST.SP.800-232">NIST SP 800-232 (ASCON)</seealso>
+/// <seealso cref="IAeadBlockCipherModeTransform"/>
+/// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions"/>
 public sealed class AsconAead128 : IAeadBlockCipherModeTransform, IDisposable
 {
     /// <summary>The required key size in bytes (128 bits).</summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconCxof128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconCxof128.cs
@@ -32,6 +32,24 @@ namespace Bodu.Security.Cryptography;
 /// <item><description>Call <see cref="AsconXof{T}.Squeeze" /> to produce output.</description></item>
 /// <item><description>Call <see cref="AsconXof{T}.Initialize" /> to reset for reuse.</description></item>
 /// </list>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: variable, any positive multiple of 8 bits.</description></item>
+///   <item><description>Customisation string: optional bytes absorbed before message data, domain-separates outputs.</description></item>
+///   <item><description>State: 320-bit sponge; rate: 8 bytes (64 bits).</description></item>
+///   <item><description>Permutation: Ascon-p12 for transitions; Ascon-p8 between absorption rounds.</description></item>
+///   <item><description>Specification: NIST SP 800-232 (ASCON family).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Ascon-CXOF128.</strong> Pick the customisable XOF when you need multiple
+/// independent output streams from one primitive — KMAC-style domain separation per protocol layer,
+/// per-purpose KDFs (signing-key vs. encryption-key vs. binding-tag), or hash-based DRBGs that must not
+/// collide across applications. For uncustomised XOF output use <see cref="AsconXof128"/>; for fixed-length
+/// 256-bit hashes use <see cref="AsconHash256"/>; for the AEAD member of the suite use
+/// <see cref="AsconAead128"/>.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash256.cs
@@ -19,6 +19,22 @@ namespace Bodu.Security.Cryptography;
 /// For applications where throughput is a higher priority than maximum security margin, consider
 /// <see cref="AsconHashA256" />, which uses an 8-round permutation during absorption (Ascon-p8) and is otherwise identical.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 256 bits (32 bytes), fixed.</description></item>
+///   <item><description>State: 320 bits sponge; rate: 64 bits (8 bytes).</description></item>
+///   <item><description>Permutation: Ascon-p12 at every phase (initialisation, absorption, squeezing).</description></item>
+///   <item><description>Specification: NIST SP 800-232 (ASCON family).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose ASCON-HASH256.</strong> Pick this when NIST's lightweight-cryptography selection
+/// is the procurement requirement, or for resource-constrained targets (microcontrollers, IoT) where ASCON's
+/// small state and software-friendly permutation are an advantage over SHA-2 / SHA-3. For maximum throughput on
+/// commodity 64-bit hardware <see cref="Blake2b"/> or <see cref="Blake3"/> typically win; for the higher-throughput
+/// ASCON variant accept the smaller absorption-round margin and use <see cref="AsconHashA256"/>.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHashA256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHashA256.cs
@@ -21,6 +21,22 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// For the highest security margin, use <see cref="AsconHash256" />, which applies Ascon-p12 at every phase.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 256 bits (32 bytes), fixed.</description></item>
+///   <item><description>State: 320 bits sponge; rate: 64 bits (8 bytes).</description></item>
+///   <item><description>Permutation: Ascon-p12 for initialisation and the first squeeze; Ascon-p8 for absorption and subsequent squeezes.</description></item>
+///   <item><description>Specification: NIST SP 800-232 (ASCON family).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose ASCON-HASHA256.</strong> Pick this when ASCON-family interop is required and message
+/// throughput matters more than the extra round-count margin of <see cref="AsconHash256"/> — typical for IoT
+/// gateways and lightweight protocols that hash sustained streams of telemetry. For maximum margin use
+/// <see cref="AsconHash256"/>; for non-ASCON throughput-sensitive hashing on commodity hardware
+/// <see cref="Blake3"/> is faster still.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof.cs
@@ -41,7 +41,28 @@ namespace Bodu.Security.Cryptography;
 /// the remaining rate bytes retain their current state values. The transition from absorption to squeezing always applies
 /// the full 12-round permutation (Ascon-p12). Subsequent squeeze blocks use pb rounds between extractions.
 /// </para>
+/// <para>
+/// <strong>Don't derive from this class directly.</strong> Use one of the two concrete XOFs that extend it:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term><see cref="AsconXof128"/></term>
+///     <description>Plain Ascon XOF — variable-length output without a customization string.</description>
+///   </item>
+///   <item>
+///     <term><see cref="AsconCxof128"/></term>
+///     <description>Customizable Ascon XOF — accepts a customization string before absorption to domain-separate output families.</description>
+///   </item>
+/// </list>
+/// <para>
+/// For fixed-length Ascon hashing use <see cref="AsconHash256"/> or <see cref="AsconHashA256"/>; for the AEAD
+/// member of the Ascon suite use <see cref="AsconAead128"/>.
+/// </para>
 /// </remarks>
+/// <seealso cref="AsconXof128"/>
+/// <seealso cref="AsconCxof128"/>
+/// <seealso cref="AsconHash{T}"/>
+/// <seealso href="https://doi.org/10.6028/NIST.SP.800-232">NIST SP 800-232 (ASCON)</seealso>
 public abstract class AsconXof<T>
     : IDisposable
     where T : AsconXof<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof128.cs
@@ -21,6 +21,24 @@ namespace Bodu.Security.Cryptography;
 /// For a fixed-length 256-bit digest, consider <see cref="AsconHash256" />. For output with a customization string, use
 /// <see cref="AsconCxof128" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: variable, any positive multiple of 8 bits.</description></item>
+///   <item><description>State: 320-bit sponge; rate: 8 bytes (64 bits).</description></item>
+///   <item><description>Permutation: Ascon-p12 for absorption-to-squeeze transition; Ascon-p8 elsewhere.</description></item>
+///   <item><description>Security level: 128 bits (for outputs ≥ 32 bytes).</description></item>
+///   <item><description>Specification: NIST SP 800-232 (ASCON family).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Ascon-XOF128.</strong> Pick this when an extendable-output function is required
+/// inside an Ascon-based protocol — variable-length KDF outputs, hash-based DRBGs, or any context that needs
+/// more than the 256-bit fixed output of <see cref="AsconHash256"/>. For non-Ascon settings <see cref="Shake"/>
+/// (NIST FIPS 202) or <see cref="Blake3"/>'s XOF mode is faster on commodity hardware. For domain-separated
+/// output families (KMAC-style or per-purpose XOF instances), use <see cref="AsconCxof128"/> to bind a
+/// customization string into the initial state.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -33,6 +33,22 @@ namespace Bodu.Security.Cryptography;
 /// 128 bytes and prepended as the first message block, and the key length is encoded into the parameter block so
 /// that keyed and unkeyed digests of the same message are always distinct.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: configurable — 128, 160, 192, 224, 256, 384, or 512 bits.</description></item>
+///   <item><description>Block size: 128 bytes (1024 bits); 8 × 64-bit state words; 12 rounds.</description></item>
+///   <item><description>Optional key: 1–64 bytes for BLAKE2b-MAC mode (RFC 7693 §2.8).</description></item>
+///   <item><description>Specification: RFC 7693; optimised for 64-bit hosts.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose BLAKE2b.</strong> The right pick on 64-bit platforms when SHA-2 / SHA-3 throughput
+/// matters but compatibility with those standards is not required — BLAKE2b is faster than SHA-512 in software
+/// while offering the same security level. Use <see cref="Blake2s"/> on 32-bit hosts or for output sizes up to
+/// 32 bytes. For tree-hashing or genuinely large parallel workloads <see cref="Blake3"/> is faster again. As a
+/// keyed MAC, BLAKE2b-MAC is competitive with HMAC-SHA-256 / Poly1305 and avoids the double-hash overhead of HMAC.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -33,6 +33,21 @@ namespace Bodu.Security.Cryptography;
 /// 64 bytes and prepended as the first message block, and the key length is encoded into the parameter block so
 /// that keyed and unkeyed digests of the same message are always distinct.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: configurable — 128, 160, 192, 224, or 256 bits.</description></item>
+///   <item><description>Block size: 64 bytes (512 bits); 8 × 32-bit state words; 10 rounds.</description></item>
+///   <item><description>Optional key: 1–32 bytes for BLAKE2s-MAC mode (RFC 7693 §2.8).</description></item>
+///   <item><description>Specification: RFC 7693; optimised for 8/16/32-bit hosts.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose BLAKE2s.</strong> Pick BLAKE2s on 32-bit hosts, embedded targets, or any time the
+/// output is at most 32 bytes — the 32-bit-word design beats <see cref="Blake2b"/> on those platforms.
+/// On 64-bit hosts and for outputs longer than 32 bytes, <see cref="Blake2b"/> is faster. For very large
+/// parallel workloads <see cref="Blake3"/> is faster still and supports tree hashing natively.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -40,6 +40,23 @@ namespace Bodu.Security.Cryptography;
 /// This implementation supports the standard, unkeyed hash mode only. Keyed-hash and
 /// key-derivation modes are not exposed.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 256 bits (32 bytes), fixed.</description></item>
+///   <item><description>Block size: 64 bytes; chunk size: 1024 bytes (the leaf of the hash tree).</description></item>
+///   <item><description>Construction: binary Merkle tree over chunks, ARX compression derived from BLAKE2 / ChaCha.</description></item>
+///   <item><description>Mode: standard unkeyed hash only — keyed hash and KDF modes are not exposed.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose BLAKE3.</strong> Reach for BLAKE3 when raw throughput on long inputs is the priority
+/// — its tree structure is naturally parallel-friendly and outperforms <see cref="Blake2b"/>, SHA-2, and SHA-3
+/// on multi-megabyte messages. For short inputs the difference shrinks and any of the BLAKE2 / SHA-2 variants is
+/// fine. Use <see cref="Blake2b"/> if a configurable output size or RFC 7693-compatible MAC mode is required;
+/// use <see cref="MerkleTreeHash"/> or <see cref="ParallelMerkleTreeHash"/> if you want explicit control over the
+/// tree shape and the underlying leaf hash.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
@@ -11,6 +11,22 @@ namespace Bodu.Security.Cryptography;
 /// <summary>
 /// Creates <see cref="IBlockCipherModeTransform" /> instances that wrap an <see cref="IBlockCipher" /> with a standard chaining mode.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The factory dispatches a <see cref="CipherBlockMode"/> enumeration value to the matching mode-transform
+/// implementation. Used internally by every <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> in
+/// this library when its <see cref="System.Security.Cryptography.SymmetricAlgorithm.Mode"/> is set, so that
+/// the same enum value selects the appropriate transform regardless of which cipher is in play.
+/// </para>
+/// <para>
+/// <strong>What this factory covers and does not cover.</strong> Only the classic confidentiality-only modes
+/// (ECB, CBC, CFB, OFB, CTR) are dispatched here. <see cref="CtsModeTransform"/> and <see cref="XtsModeTransform"/>
+/// are not in the <see cref="CipherBlockMode"/> enumeration and must be constructed directly. Authenticated
+/// modes have their own contract and lifecycle — construct an
+/// <see cref="IAeadBlockCipherModeTransform"/> implementation directly, or use the helpers on
+/// <see cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions"/>.
+/// </para>
+/// </remarks>
 /// <example>
 /// The following example composes a block cipher, a CBC mode transform, and PKCS#7 padding to encrypt a message:
 /// <code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -29,7 +29,26 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="BlockCipherTransform(IBlockCipher, CipherBlockMode, PaddingMode, byte[], bool)" /> with the
 /// appropriate arguments. All transform logic is handled by this base class.
 /// </para>
+/// <para>
+/// <strong>How this fits with the rest of the library.</strong> <see cref="BlockCipherTransform"/> is the
+/// glue layer that turns a low-level <see cref="IBlockCipher"/> into the
+/// <see cref="System.Security.Cryptography.ICryptoTransform"/> contract that
+/// <see cref="System.Security.Cryptography.CryptoStream"/>, <c>SymmetricAlgorithm.CreateEncryptor()</c>, and
+/// the rest of the BCL crypto pipeline expect. Every <see cref="System.Security.Cryptography.SymmetricAlgorithm"/>
+/// in this library returns an instance of a derived class from its <c>CreateEncryptor</c> /
+/// <c>CreateDecryptor</c> overrides — for example, <c>BlowfishTransform</c>, <c>CamelliaTransform</c>,
+/// <c>SkipjackTransform</c>, <c>TwofishTransform</c>, <c>SerpentTransform</c>, <c>ThreefishTransform</c>.
+/// </para>
+/// <para>
+/// Derive from this class only when adding a new symmetric algorithm to the library. Most callers never
+/// touch this type directly — they use <see cref="System.Security.Cryptography.SymmetricAlgorithm.Mode"/>
+/// and <see cref="System.Security.Cryptography.SymmetricAlgorithm.Padding"/> to configure encryption and let
+/// the existing transform infrastructure handle the wiring.
+/// </para>
 /// </remarks>
+/// <seealso cref="IBlockCipher"/>
+/// <seealso cref="IBlockCipherModeTransform"/>
+/// <seealso cref="IPaddingStrategy"/>
 public abstract class BlockCipherTransform : ICryptoTransform
 {
     private readonly IBlockCipher _cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
@@ -30,7 +30,22 @@ namespace Bodu.Security.Cryptography;
 /// <item><description><see cref="PadBlock" /> pads the final input segment and encodes the total message length.</description></item>
 /// <item><description><see cref="ProcessFinalBlock" /> finalises the hash computation and returns the resulting digest.</description></item>
 /// </list>
+/// <para>
+/// <strong>When to derive from this class.</strong> Pick <see cref="BlockHashAlgorithm{T}"/> for any classic
+/// Merkle–Damgård cryptographic hash — the family includes the SHA-2 hashes, Tiger, Whirlpool, Snefru, and
+/// similar designs that finalise by appending a length-encoding pad to the last partial block. For the
+/// BLAKE-family pattern (final-block flag, no length-encoding pad) derive from
+/// <see cref="DeferredFinalBlockHashAlgorithm{T}"/> instead. For a keyed Merkle–Damgård hash (Poly1305,
+/// SipHash) derive from <see cref="KeyedBlockHashAlgorithm{T}"/>, which adds key handling on top of this
+/// base. For non-cryptographic block hashes (Fletcher, CRC) the parallel
+/// <see cref="Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm{T}"/> base is the right pick — it integrates
+/// with <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/> rather than <see cref="HashAlgorithm"/>.
+/// </para>
 /// </remarks>
+/// <seealso cref="BufferedBlockHashAlgorithm{T}"/>
+/// <seealso cref="DeferredFinalBlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedBlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/>
 public abstract class BlockHashAlgorithm<T>
     : BufferedBlockHashAlgorithm<T>
     where T : BlockHashAlgorithm<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
@@ -28,11 +28,40 @@ namespace Bodu.Security.Cryptography;
 /// For further details on the algorithm, see
 /// <a href="https://www.schneier.com/academic/blowfish/">https://www.schneier.com/academic/blowfish/</a>.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 64 bits (8 bytes).</description></item>
+///   <item><description>Key size: variable, 32–448 bits (4–56 bytes).</description></item>
+///   <item><description>16-round Feistel network with key-dependent S-boxes initialised from the digits of π.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Blowfish.</strong> Pick Blowfish only for interoperability with legacy systems that
+/// already use it — its 64-bit block size invites SWEET32 birthday-bound attacks once roughly 32 GiB has been
+/// encrypted under one key. For new designs use <see cref="System.Security.Cryptography.Aes"/>; bcrypt-style
+/// password hashing schemes that derive from Blowfish are not in scope of this class.
+/// </para>
 /// <note type="important">
 /// Blowfish has a 64-bit block size, which makes it vulnerable to birthday-bound attacks (SWEET32) when large volumes of data are
 /// encrypted under the same key. For new applications, a cipher with a 128-bit or larger block size (such as AES) should be preferred.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // Legacy interop only.
+/// using var blowfish = new Blowfish();
+/// blowfish.Key = legacyKeyMaterial;             // 4–56 bytes
+/// blowfish.IV  = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block
+///
+/// byte[] ciphertext = blowfish.Encrypt(legacyPlaintext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/blowfish.html">Using Blowfish (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BoduPaddingMode.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BoduPaddingMode.cs
@@ -25,7 +25,17 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="PaddingFactory.Create(BoduPaddingMode)" /> to obtain the matching
 /// <see cref="IPaddingStrategy" /> implementation.
 /// </para>
+/// <para>
+/// <strong>When to use this enum vs the framework <see cref="PaddingMode"/>.</strong> Use
+/// <see cref="PaddingMode"/> for any code path that interoperates with
+/// <see cref="System.Security.Cryptography.SymmetricAlgorithm.Padding"/>; use
+/// <see cref="BoduPaddingMode"/> only when <see cref="ISO7816_4"/> is required. The two are interchangeable
+/// for the first five values — a <see cref="PaddingMode"/> value can be assigned to a
+/// <see cref="BoduPaddingMode"/> by cast and will behave identically.
+/// </para>
 /// </remarks>
+/// <seealso cref="PaddingFactory"/>
+/// <seealso cref="IPaddingStrategy"/>
 public enum BoduPaddingMode
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -37,6 +37,38 @@ namespace Bodu.Security.Cryptography;
 /// <item><description><see cref="HashAlgorithm.HashCore(ReadOnlySpan{byte})" /> consumes the input span using the buffering shape required by the algorithm family.</description></item>
 /// <item><description><see cref="HashAlgorithm.HashFinal" /> finalises the computation and returns the digest.</description></item>
 /// </list>
+/// <para>
+/// <strong>Don't derive from this class directly.</strong> Use one of the four pattern-specific bases that
+/// extend it — the buffering loops and finalisation shapes differ enough that the right derivation point
+/// depends on which family the algorithm belongs to:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Merkle–Damgård, unkeyed</term>
+///     <description><see cref="BlockHashAlgorithm{T}"/> — Tiger, Whirlpool, Snefru, the SHA-2 family,
+///     classic block-padding hashes that finalise by padding the last partial block.</description>
+///   </item>
+///   <item>
+///     <term>Merkle–Damgård, keyed</term>
+///     <description><see cref="KeyedBlockHashAlgorithm{T}"/> — Poly1305, SipHash, and any keyed hash whose
+///     finalisation is "pad then compress".</description>
+///   </item>
+///   <item>
+///     <term>Blake-style, unkeyed</term>
+///     <description><see cref="DeferredFinalBlockHashAlgorithm{T}"/> — BLAKE3 and other algorithms that need
+///     to defer the last full block so a finalisation flag can be set.</description>
+///   </item>
+///   <item>
+///     <term>Blake-style, optionally keyed</term>
+///     <description><see cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/> — BLAKE2b, BLAKE2s, and the RFC 7693
+///     keyed-MAC variants of BLAKE-family hashes.</description>
+///   </item>
+/// </list>
+/// <para>
+/// Derive from <see cref="BufferedBlockHashAlgorithm{T}"/> directly only when implementing a <em>new</em>
+/// buffering pattern that doesn't fit either family — e.g. a sponge construction with a non-Merkle–Damgård
+/// finalisation step.
+/// </para>
 /// </remarks>
 public abstract class BufferedBlockHashAlgorithm<T>
     : HashAlgorithm

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
@@ -26,7 +26,37 @@ namespace Bodu.Security.Cryptography;
 /// cipher modes via the <see cref="BlockMode" /> property. The default mode is <see cref="CipherBlockMode.CBC" />
 /// with <see cref="PaddingMode.PKCS7" /> padding and a default key size of 256 bits.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 128 bits (16 bytes).</description></item>
+///   <item><description>Key sizes: 128 (18 rounds), 192 or 256 bits (24 rounds).</description></item>
+///   <item><description>Specification: RFC 3713; approved by ISO/IEC, CRYPTREC, and NESSIE.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Camellia.</strong> Pick Camellia when standards-body approval matters — Japanese
+/// CRYPTREC, European NESSIE, and ISO/IEC all list Camellia. It is the standard alternative to AES in many
+/// non-US jurisdictions and TLS implementations. Performance characteristics are comparable to AES in software;
+/// for new general-purpose work without a procurement constraint <see cref="System.Security.Cryptography.Aes"/>
+/// is the more widely accelerated default.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var camellia = new Camellia();
+/// camellia.GenerateKey(); // 256-bit by default
+/// camellia.GenerateIV();
+///
+/// byte[] ciphertext = camellia.Encrypt(plaintext);
+/// byte[] roundTrip  = camellia.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/camellia.html">Using Camellia</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
@@ -26,7 +26,34 @@ namespace Bodu.Security.Cryptography;
 /// under the same key weakens confidentiality. The instance retains the most recent ciphertext block as the chaining value, so
 /// successive calls to <see cref="Transform" /> continue the stream.
 /// </para>
+/// <para>
+/// <strong>When to use CBC.</strong> The traditional confidentiality-only mode — the right pick when
+/// interoperating with legacy protocols (TLS up to 1.2, JCE defaults, many file formats) or when an
+/// authenticated mode is impractical. CBC requires plaintext to be a multiple of the block size, so it is
+/// almost always paired with <see cref="Pkcs7Padding"/>. For new designs prefer <see cref="GcmModeTransform"/>
+/// or <see cref="EaxModeTransform"/>, both of which authenticate as well as encrypt; CBC plus a separate
+/// MAC is fragile and easy to misuse. Decryption with strippable padding is vulnerable to padding-oracle
+/// attacks unless the padding check is performed in constant time and never leaks via timing or error messages.
+/// </para>
+/// <para>
+/// CBC is sequential — neither encryption nor decryption parallelises across blocks within a single message.
+/// Random access into the ciphertext is not supported.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CBC instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize); // unique per message
+/// IBlockCipherModeTransform cbc = new CbcModeTransform(cipher, iv);
+///
+/// byte[] ciphertext = new byte[paddedPlaintext.Length];
+/// int written = cbc.Transform(paddedPlaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/cipher-modes.html#cbc--the-default">CBC walk-through in the cipher-modes guide</seealso>
 public sealed class CbcModeTransform
     : IBlockCipherModeTransform

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -37,7 +37,30 @@ namespace Bodu.Security.Cryptography;
 /// Counter block A_i: byte 0 = 0x02, bytes 1–12 = nonce, bytes 13–15 = counter (big-endian).
 /// AAD length is encoded as a 2-byte big-endian prefix (supports up to 65 279 bytes).
 /// </para>
+/// <para>
+/// <strong>When to use CCM.</strong> Pick CCM when interoperability with constrained-environment standards
+/// is required — IEEE 802.15.4 / Zigbee, Bluetooth Mesh, IPsec ESP, and TLS 1.2 with the AES-CCM cipher
+/// suites all use it. CCM is two-pass over the message (CBC-MAC then CTR), so it is slower than
+/// <see cref="GcmModeTransform"/> on commodity hardware, but it has no Galois-field arithmetic and is easier
+/// to implement correctly on minimal microcontrollers. For new general-purpose AEAD on x86/ARM hosts prefer
+/// GCM; for nonce-misuse resistance prefer <see cref="GcmSivModeTransform"/> or <see cref="SivModeTransform"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = BuildCcmIv(nonce); // 12-byte nonce in the first 12 bytes of the IV
+/// using IAeadBlockCipherModeTransform ccm = new CcmModeTransform(cipher, iv);
+///
+/// byte[] sealed_   = ccm.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new CcmModeTransform(cipher, iv);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#ccm--a-two-pass-alternative">CCM walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -26,7 +26,33 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// The initialisation vector must equal the cipher block size in length and should be unique and unpredictable per message under a given key.
 /// </para>
+/// <para>
+/// <strong>When to use CFB.</strong> Pick CFB only for interoperability with legacy formats — it was the
+/// stream-cipher mode of choice in PGP / OpenPGP and certain disk-encryption layouts. CFB removes the padding
+/// requirement that <see cref="CbcModeTransform"/> imposes, but inherits the same lack of authentication and
+/// adds bit-flip propagation across multiple blocks. For new code prefer <see cref="CtrModeTransform"/> for
+/// stream-cipher behaviour, or an AEAD mode (<see cref="GcmModeTransform"/>, <see cref="EaxModeTransform"/>)
+/// for authenticated encryption.
+/// </para>
+/// <para>
+/// CFB is sequential at the block level: each ciphertext block must be produced before the next can be
+/// computed, so the mode does not parallelise within a message.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CFB instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize);
+/// IBlockCipherModeTransform cfb = new CfbModeTransform(cipher, iv);
+///
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = cfb.Transform(plaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/cipher-modes.html#cfb--self-synchronising-stream-cipher">CFB walk-through in the cipher-modes guide</seealso>
 public sealed class CfbModeTransform : IBlockCipherModeTransform
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
@@ -34,7 +34,35 @@ namespace Bodu.Security.Cryptography;
 /// recovers the XOR of the two plaintexts — so callers must ensure each counter value is used at
 /// most once per key.
 /// </para>
+/// <para>
+/// <strong>When to use CTR.</strong> The right confidentiality-only mode for new code that needs random
+/// access, parallelisable encryption, or a stream-cipher shape — disk encryption layers without
+/// authentication, network protocols where authentication is provided separately, and anywhere a precomputed
+/// keystream is useful. CTR is also the keystream layer of the major AEAD modes; if you need authentication
+/// as well, reach for <see cref="GcmModeTransform"/> (CTR + GHASH) or <see cref="EaxModeTransform"/>
+/// (CTR + OMAC) directly rather than building it on top of bare CTR.
+/// </para>
+/// <para>
+/// The counter increment is parallelisable: every block's keystream can be produced independently, so
+/// throughput scales with available cores or SIMD width.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTR instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// // Initial counter is typically `nonce || zero-counter`; the nonce must never repeat under one key.
+/// byte[] initialCounter = BuildInitialCounter(nonce);
+/// IBlockCipherModeTransform ctr = new CtrModeTransform(cipher, initialCounter);
+///
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = ctr.Transform(plaintext, ciphertext, encrypt: true);
+/// // The same call shape decrypts: encrypt: true / encrypt: false produce identical results.
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/cipher-modes.html#ctr--parallel-seekable-stream-shaped">CTR walk-through in the cipher-modes guide</seealso>
 public sealed class CtrModeTransform : IBlockCipherModeTransform
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
@@ -38,7 +38,30 @@ namespace Bodu.Security.Cryptography;
 /// The input to <see cref="Transform" /> must be at least one full block long. For inputs of exactly
 /// one block, the result is identical to standard CBC encryption or decryption.
 /// </para>
+/// <para>
+/// <strong>When to use CTS.</strong> Pick CTS when ciphertext length must equal plaintext length and the
+/// input is not block-aligned — typical in fixed-size record formats, network frames with strict size
+/// budgets, and on-disk layouts where adding padding bytes is impossible. CTS shares CBC's lack of
+/// authentication and its sequential nature; for new general-purpose encryption an AEAD mode
+/// (<see cref="GcmModeTransform"/>, <see cref="EaxModeTransform"/>) is preferable. The variant implemented
+/// here is CS3 / IEEE 1619 (the order used by NIST SP 800-38A Addendum and most modern interop).
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTS instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize);
+/// IBlockCipherModeTransform cts = new CtsModeTransform(cipher, iv);
+///
+/// // CTS preserves length: plaintext.Length == ciphertext.Length, no padding required.
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = cts.Transform(plaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 public sealed class CtsModeTransform : IBlockCipherModeTransform
 {
     private readonly IBlockCipher _cipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -22,7 +22,31 @@ namespace Bodu.Security.Cryptography;
 /// operations. The number of initialisation, transformation, and finalisation rounds, the hash output size, and the input block size
 /// are all configurable. See <a href="https://en.wikipedia.org/wiki/CubeHash">Wikipedia</a> for an overview.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>State size: 1024 bits (32 × 32-bit words).</description></item>
+///   <item><description>Output size: configurable, <see cref="MinHashSize"/>–<see cref="MaxHashSize"/> bits (default 512).</description></item>
+///   <item><description>Input block size: configurable, <see cref="MinInputBlockSize"/>–<see cref="MaxInputBlockSize"/> bytes (default 32).</description></item>
+///   <item><description>Rounds: initialisation, per-block, and finalisation counts each independently configurable up to <see cref="MaxRounds"/>; defaults are 16 / 16 / 32.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose CubeHash.</strong> Pick CubeHash for academic study, cryptographic competition
+/// reproducibility, or interop with code that has settled on a specific CubeHash parameterisation. The defaults
+/// (CubeHash 16/32/+160/512) match the SHA-3 competition submission. For new general-purpose cryptographic
+/// hashing prefer SHA-2, SHA-3, or <see cref="Blake2b"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// // Default parameters: 512-bit output, 32-byte input block, 16/16/32 rounds.
+/// using var cube = new CubeHash();
+/// byte[] digest = cube.ComputeHash(message);
+/// </code>
+/// </example>
 public sealed class CubeHash
     : System.Security.Cryptography.HashAlgorithm
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
@@ -40,7 +40,20 @@ namespace Bodu.Security.Cryptography;
 /// <item><description><see cref="ProcessBlock" /> compresses a single block, receiving the per-block counter and the finalisation flag.</description></item>
 /// <item><description><see cref="ProcessFinalBlock" /> extracts the digest from the chaining variables after the final compression has run.</description></item>
 /// </list>
+/// <para>
+/// <strong>When to derive from this class.</strong> Pick <see cref="DeferredFinalBlockHashAlgorithm{T}"/> for
+/// the BLAKE family and any other algorithm whose compression function takes an explicit
+/// "is this the final block?" flag rather than padding the trailing partial block with a length encoding —
+/// <see cref="Blake3"/> is the canonical user. For BLAKE2-style hashes that also accept an optional secret
+/// key (<see cref="Blake2b"/>, <see cref="Blake2s"/>) derive from
+/// <see cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/>, which adds RFC 7693 key-block handling on top of
+/// this base. For Merkle–Damgård hashes (SHA-2, Tiger, Whirlpool) use <see cref="BlockHashAlgorithm{T}"/>.
+/// </para>
 /// </remarks>
+/// <seealso cref="BufferedBlockHashAlgorithm{T}"/>
+/// <seealso cref="BlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedBlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/>
 public abstract class DeferredFinalBlockHashAlgorithm<T>
     : BufferedBlockHashAlgorithm<T>
     where T : DeferredFinalBlockHashAlgorithm<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DelegateHashAlgorithmFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DelegateHashAlgorithmFactory.cs
@@ -14,12 +14,24 @@ namespace Bodu.Security.Cryptography;
 /// </summary>
 /// <typeparam name="T">The concrete <see cref="HashAlgorithm" /> type this factory produces.</typeparam>
 /// <remarks>
+/// <para>
 /// This factory allows consumers to specify the construction logic for the hash algorithm via a delegate. It is particularly useful for
 /// scenarios requiring configuration of keyed or parameterized algorithms where DI or explicit configuration is preferred.
+/// </para>
 /// <para>
 /// Common use cases include configuring <see cref="KeyedHashAlgorithm" /> instances or variant-based hashes such as SipHash or CubeHash.
 /// </para>
+/// <para>
+/// <strong>Construction.</strong> Most callers use <see cref="HashAlgorithmFactory.From{T}(System.Func{T})"/>
+/// to wrap a delegate rather than calling this constructor directly — the static helper makes the call site
+/// read more naturally and avoids the trailing generic-type repetition. Direct construction is appropriate
+/// when the type needs to be assigned to a field that has the concrete <see cref="DelegateHashAlgorithmFactory{T}"/>
+/// type rather than the <see cref="IHashAlgorithmFactory{T}"/> interface.
+/// </para>
 /// </remarks>
+/// <seealso cref="IHashAlgorithmFactory{T}"/>
+/// <seealso cref="HashAlgorithmFactory"/>
+/// <seealso cref="HashAlgorithmHelper"/>
 public sealed class DelegateHashAlgorithmFactory<T> :
     Bodu.Security.Cryptography.IHashAlgorithmFactory<T>
     where T : System.Security.Cryptography.HashAlgorithm

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -40,7 +40,31 @@ namespace Bodu.Security.Cryptography;
 /// computes <c>N'</c> internally. Ciphertext is output as <c>C ‖ T</c> (ciphertext then tag),
 /// consistent with the <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
+/// <para>
+/// <strong>When to use EAX.</strong> Pick EAX when an unencumbered, two-pass AEAD with a flexible nonce
+/// length (the OMAC-derived <c>N'</c> means EAX accepts nonces up to the cipher block size) is wanted —
+/// some embedded protocols and historical industry standards require it. EAX is roughly half the throughput
+/// of <see cref="GcmModeTransform"/> on commodity hardware but does not depend on Galois-field arithmetic
+/// and has no patent concerns. For new general-purpose AEAD prefer GCM; for nonce-misuse resistance prefer
+/// <see cref="GcmSivModeTransform"/> or <see cref="SivModeTransform"/>; for single-pass AEAD without GCM's
+/// catastrophic-on-reuse profile prefer <see cref="OcbModeTransform"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] nonce = RandomNumberGenerator.GetBytes(cipher.BlockSize); // unique per message
+/// using IAeadBlockCipherModeTransform eax = new EaxModeTransform(cipher, nonce);
+///
+/// byte[] sealed_   = eax.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new EaxModeTransform(cipher, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#eax--two-pass-fse-2004">EAX walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -26,7 +26,32 @@ namespace Bodu.Security.Cryptography;
 /// blocks always yield identical ciphertext blocks, leaking structural information. Prefer CBC, CTR, or an
 /// authenticated mode unless ECB is required as a primitive inside a larger construction.
 /// </para>
+/// <para>
+/// <strong>When to use ECB.</strong> Only as a building block inside a larger, well-understood construction —
+/// for example, encrypting a single fixed-length tweak inside an XTS or wide-block scheme. For protecting
+/// arbitrary plaintext, use <see cref="CbcModeTransform"/> as a baseline, <see cref="CtrModeTransform"/> when
+/// random access or stream-cipher behaviour is wanted, or one of the AEAD modes
+/// (<see cref="GcmModeTransform"/>, <see cref="EaxModeTransform"/>, …) when authentication matters.
+/// </para>
+/// <para>
+/// Because ECB has no chaining state, the transform is stateless — repeated <see cref="Transform"/> calls produce
+/// the same result for the same input — and is trivially parallelisable.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should reach for SymmetricAlgorithm.Mode = ECB instead of constructing this directly.
+/// // Direct use is appropriate only inside larger primitives (e.g. wide-block constructions, KDFs).
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// IBlockCipherModeTransform ecb = new EcbModeTransform(cipher);
+///
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = ecb.Transform(plaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/cipher-modes.html#ecb--almost-never">ECB walk-through in the cipher-modes guide</seealso>
 public sealed class EcbModeTransform : IBlockCipherModeTransform
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
@@ -41,7 +41,33 @@ namespace Bodu.Security.Cryptography;
 /// The tag size is fixed at 16 bytes (the full GHASH output). The IV is used directly as the initial
 /// counter J0; for standard GCM with 96-bit nonces, the caller should pad to blockSize.
 /// </para>
+/// <para>
+/// <strong>When to use GCM.</strong> The default modern AEAD mode — TLS 1.2/1.3, IPsec ESP, SSH, QUIC, and
+/// most file-format AEAD layers all use AES-GCM. Single-pass, parallelisable, hardware-accelerated on
+/// AES-NI / PCLMULQDQ, and the fastest AEAD on commodity x86/ARM. The cost is fragility under nonce reuse:
+/// a single repeated <c>(key, nonce)</c> pair leaks the GHASH key and forfeits authentication forever.
+/// Use only when the caller can <em>guarantee</em> nonce uniqueness — usually via a 96-bit counter or
+/// a random nonce drawn from a large enough space. For nonce-misuse resistance prefer
+/// <see cref="GcmSivModeTransform"/> or <see cref="SivModeTransform"/>; for constrained environments prefer
+/// <see cref="CcmModeTransform"/>; for a single-pass alternative without GCM's fragility profile prefer
+/// <see cref="OcbModeTransform"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = BuildGcmIv(nonce); // standard 96-bit nonce padded to the cipher block size
+/// using IAeadBlockCipherModeTransform gcm = new GcmModeTransform(cipher, iv);
+///
+/// byte[] sealed_   = gcm.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(cipher, iv);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#gcm--the-workhorse">GCM walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -44,7 +44,33 @@ namespace Bodu.Security.Cryptography;
 /// Ciphertext is output as <c>C || Tag</c> (16-byte tag appended), consistent with the
 /// <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
+/// <para>
+/// <strong>When to use GCM-SIV.</strong> The right modern AEAD pick when nonce uniqueness cannot be
+/// guaranteed — distributed systems where a coordinator might re-issue the same nonce after a crash, key
+/// wrapping, deduplication, or any context where a fresh nonce per message is impractical. Under nonce
+/// reuse, GCM-SIV's only leak is that two identical <c>(plaintext, AAD)</c> pairs encrypt to identical
+/// ciphertexts — confidentiality and authenticity for distinct messages remain intact. Throughput is lower
+/// than <see cref="GcmModeTransform"/> because of the two-pass MAC-then-encrypt structure; for
+/// nonce-disciplined high-throughput contexts prefer GCM. <see cref="SivModeTransform"/> is the AES-SIV
+/// (RFC 5297) sibling — also misuse-resistant but with a different MAC (S2V) and key schedule.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher master = new AesBlockCipher(masterKey);
+/// byte[] iv = BuildSivIv(nonce); // 12-byte nonce padded to the cipher block size
+/// using IAeadBlockCipherModeTransform sivlike = new GcmSivModeTransform(
+///     masterCipher: master,
+///     cipherFactory: derivedKey =&gt; new AesBlockCipher(derivedKey),
+///     iv: iv);
+///
+/// byte[] sealed_ = sivlike.Encrypt(plaintext, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#gcm-siv--the-modern-replacement-for-gcm">GCM-SIV walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmFactory.cs
@@ -13,14 +13,34 @@ namespace Bodu.Security.Cryptography;
 /// Provides static factory helpers for constructing delegate-based implementations of <see cref="IHashAlgorithmFactory{T}" />.
 /// </summary>
 /// <remarks>
+/// <para>
 /// This class simplifies creation of lightweight hash algorithm factories that encapsulate algorithm configuration logic, particularly
 /// useful for one-shot hashing scenarios where consumers need to consistently configure algorithm instances (e.g., setting a key,
 /// tuning rounds, or enabling specific variants).
+/// </para>
 /// <para>
 /// The returned factory instances are typically passed into <see cref="HashAlgorithmHelper" /> methods to compute hashes from spans,
-/// streams, or buffers in a memory-safe and reusable way.
+/// streams, or buffers in a memory-safe and reusable way. The same factory works with <see cref="MerkleTreeHash"/> and
+/// <see cref="ParallelMerkleTreeHash"/> for tree-hashing pipelines that need a fresh leaf-hash instance per node.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // 1. Bare SHA-256 factory.
+/// IHashAlgorithmFactory&lt;SHA256&gt; sha256 = HashAlgorithmFactory.From(() =&gt; SHA256.Create());
+/// byte[] digest = HashAlgorithmHelper.HashData(sha256, payload);
+///
+/// // 2. Configured keyed-hash factory — applied consistently every time the consumer constructs an instance.
+/// IHashAlgorithmFactory&lt;SipHash64&gt; sip = HashAlgorithmFactory.From(() =&gt; new SipHash64 { Key = sessionKey });
+/// byte[] tag = HashAlgorithmHelper.HashData(sip, message);
+/// </code>
+/// </example>
+/// <seealso cref="IHashAlgorithmFactory{T}"/>
+/// <seealso cref="DelegateHashAlgorithmFactory{T}"/>
+/// <seealso cref="HashAlgorithmHelper"/>
 public static class HashAlgorithmFactory
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
@@ -18,25 +18,40 @@ namespace Bodu.Security.Cryptography;
 /// Provides high-performance utility methods for one-shot hashing using factory-created <see cref="HashAlgorithm" /> instances.
 /// </summary>
 /// <remarks>
+/// <para>
 /// These methods simplify hashing workflows by accepting an <see cref="IHashAlgorithmFactory{T}" /> implementation, allowing
 /// consumers to construct and configure hash algorithms (including keyed or parameterized variants) without managing lifecycle manually.
+/// </para>
 /// <para>
 /// This is ideal for use cases that require stateless or ephemeral hashing operations without incremental updates or state reuse.
+/// Each call constructs a fresh algorithm instance, runs the hash, and disposes deterministically — callers do not need to
+/// track <see cref="System.IDisposable"/> lifetimes themselves.
 /// </para>
+/// <para>
+/// <strong>When to choose this over the BCL.</strong> Pick <see cref="HashAlgorithmHelper"/> when the algorithm
+/// requires per-call configuration (a key, round counts, a variant flag) — the factory consistently applies
+/// it to every fresh instance. For stateless one-shot hashing of unconfigured algorithms (SHA-256, SHA-512)
+/// the BCL's static <c>HashData</c> on each algorithm class is simpler and faster. For tree-hashing workloads
+/// pass the same factory into <see cref="MerkleTreeHash"/> or <see cref="ParallelMerkleTreeHash"/>.
+/// </para>
+/// </remarks>
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// var factory = HashAlgorithmFactory.From(() => new SipHash
+/// // Configured SipHash-2-4 factory; the configuration applies to every call to HashData.
+/// var factory = HashAlgorithmFactory.From(() => new SipHash64
 /// {
 ///     Key = key,
 ///     CompressionRounds = 2,
-///     FinalizationRounds = 4
+///     FinalizationRounds = 4,
 /// });
 /// byte[] hash = HashAlgorithmHelper.HashData(factory, input);
 ///]]>
 /// </code>
 /// </example>
-/// </remarks>
+/// <seealso cref="IHashAlgorithmFactory{T}"/>
+/// <seealso cref="HashAlgorithmFactory"/>
+/// <seealso cref="DelegateHashAlgorithmFactory{T}"/>
 public static class HashAlgorithmHelper
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
@@ -36,6 +36,37 @@ namespace Bodu.Security.Cryptography;
 /// All implementations are stateful and not thread-safe. A new instance must be created for each
 /// message.
 /// </para>
+/// <para>
+/// <strong>API surface.</strong> The library ships several implementations clustered by trade-off:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Default high-throughput AEAD</term>
+///     <description><see cref="GcmModeTransform"/> — single-pass, hardware-accelerated, fragile under nonce reuse.</description>
+///   </item>
+///   <item>
+///     <term>Constrained-environment AEAD</term>
+///     <description><see cref="CcmModeTransform"/> — two-pass, no Galois-field arithmetic, used by Zigbee / Bluetooth Mesh.</description>
+///   </item>
+///   <item>
+///     <term>Two-pass alternatives</term>
+///     <description><see cref="EaxModeTransform"/> — flexible nonce length, OMAC-based authentication.</description>
+///   </item>
+///   <item>
+///     <term>Misuse-resistant</term>
+///     <description><see cref="GcmSivModeTransform"/> (RFC 8452) and <see cref="SivModeTransform"/> (RFC 5297) — nonce reuse only leaks message-equality.</description>
+///   </item>
+///   <item>
+///     <term>Single-pass without GCM's failure profile</term>
+///     <description><see cref="OcbModeTransform"/> — RFC 7253, single-pass, graceful nonce-reuse failure.</description>
+///   </item>
+/// </list>
+/// <para>
+/// Most callers should reach for the helper methods on
+/// <see cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions"/> instead of calling
+/// <see cref="ProcessAssociatedData"/> + <see cref="Encrypt"/>/<see cref="Decrypt"/> directly — those wrappers
+/// size the output buffer correctly and return a single freshly allocated array.
+/// </para>
 /// </remarks>
 /// <seealso href="../guides/cryptography/aead-modes.html">Using AEAD modes (guide with GCM, CCM, OCB3, SIV, and GCM-SIV examples)</seealso>
 /// <seealso cref="AesBlockCipher" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IBlockCipher.cs
@@ -21,7 +21,30 @@ namespace Bodu.Security.Cryptography;
 /// Implementations must release all sensitive key material when <see cref="IDisposable.Dispose" /> is called and should be safe to
 /// invoke repeatedly for the lifetime of the instance.
 /// </para>
+/// <para>
+/// <strong>How this fits with the rest of the library.</strong> <see cref="IBlockCipher"/> is the lowest-level
+/// primitive in the cipher stack. Three layers sit on top of it:
+/// </para>
+/// <list type="bullet">
+///   <item><description>An <see cref="IBlockCipherModeTransform"/> wraps a cipher with a chaining strategy
+///   (CBC, CTR, …) — built via <see cref="BlockCipherModeFactory.Create(CipherBlockMode, IBlockCipher, byte[])"/>.</description></item>
+///   <item><description>An <see cref="IPaddingStrategy"/> aligns input to the cipher block size — built via
+///   <see cref="PaddingFactory.Create(System.Security.Cryptography.PaddingMode)"/>.</description></item>
+///   <item><description><see cref="BlockCipherTransform"/> bundles a cipher, mode, and padding into a single
+///   <see cref="System.Security.Cryptography.ICryptoTransform"/> — the integration point used by every
+///   <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> in this library.</description></item>
+/// </list>
+/// <para>
+/// Most callers never instantiate <see cref="IBlockCipher"/> directly — they use a
+/// <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> (Aes, Twofish, Camellia, Threefish, Serpent,
+/// Skipjack, Blowfish), set Key/IV/Mode/Padding, and let the library compose the layers. Direct use of this
+/// interface is appropriate when implementing a new mode, plugging a non-<c>SymmetricAlgorithm</c> cipher
+/// engine into the existing mode infrastructure, or building higher-level constructions on top.
+/// </para>
 /// </remarks>
+/// <seealso cref="IBlockCipherModeTransform"/>
+/// <seealso cref="IAeadBlockCipherModeTransform"/>
+/// <seealso cref="BlockCipherTransform"/>
 public interface IBlockCipher
     : System.IDisposable
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IBlockCipherModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IBlockCipherModeTransform.cs
@@ -22,6 +22,36 @@ namespace Bodu.Security.Cryptography;
 /// Padding is not handled by this interface. Callers must align input to the cipher block size using an
 /// <see cref="IPaddingStrategy" /> before invoking <see cref="Transform" />.
 /// </para>
+/// <para>
+/// <strong>API surface.</strong> The library ships several implementations clustered into three groups:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <term>Classic confidentiality-only modes</term>
+///     <description><see cref="EcbModeTransform"/>, <see cref="CbcModeTransform"/>, <see cref="CfbModeTransform"/>,
+///     <see cref="OfbModeTransform"/>, <see cref="CtrModeTransform"/>, <see cref="CtsModeTransform"/>.</description>
+///   </item>
+///   <item>
+///     <term>Disk-encryption mode</term>
+///     <description><see cref="XtsModeTransform"/>.</description>
+///   </item>
+///   <item>
+///     <term>Authenticated modes (AEAD)</term>
+///     <description>Implement the richer <see cref="IAeadBlockCipherModeTransform"/> contract instead —
+///     <see cref="GcmModeTransform"/>, <see cref="CcmModeTransform"/>, <see cref="EaxModeTransform"/>,
+///     <see cref="GcmSivModeTransform"/>, <see cref="OcbModeTransform"/>, <see cref="SivModeTransform"/>.</description>
+///   </item>
+/// </list>
+/// <para>
+/// Most callers should configure modes through <see cref="System.Security.Cryptography.SymmetricAlgorithm.Mode"/>
+/// (which accepts a <see cref="CipherBlockMode"/> and dispatches via <see cref="BlockCipherModeFactory"/>) rather
+/// than constructing this interface directly. Direct use is appropriate when wiring a custom block cipher into the
+/// existing mode infrastructure or building a higher-level construction on top.
+/// </para>
+/// <para>
+/// Implementations are stateful and not thread-safe; share behind explicit synchronisation, or allocate one per
+/// consumer. Most modes reset cleanly when constructed afresh — there is no in-place reset method on this interface.
+/// </para>
 /// </remarks>
 public interface IBlockCipherModeTransform
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IHashAlgorithmFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IHashAlgorithmFactory.cs
@@ -13,10 +13,29 @@ namespace Bodu.Security.Cryptography;
 /// </summary>
 /// <typeparam name="T">The concrete type of <see cref="HashAlgorithm" /> this factory creates. Must inherit from <see cref="HashAlgorithm" />.</typeparam>
 /// <remarks>
+/// <para>
 /// This interface decouples the creation and configuration of hash algorithm instances from the logic that consumes them,
 /// enabling reusable, testable, and extensible one-shot hash operations via the <see cref="HashAlgorithmHelper" /> utility class.
 /// Implementations may return newly constructed or pooled algorithm instances depending on lifecycle management requirements.
+/// </para>
+/// <para>
+/// <strong>How to obtain an instance.</strong> Most callers do not implement this interface directly. Use
+/// <see cref="HashAlgorithmFactory.From{T}(System.Func{T})"/> to wrap an algorithm-construction delegate as
+/// a <see cref="DelegateHashAlgorithmFactory{T}"/> — the right pick whenever the algorithm needs configuration
+/// (a key, a round count, a variant flag) at the construction site. Implement
+/// <see cref="IHashAlgorithmFactory{T}"/> directly only when adding instance pooling, telemetry, or other
+/// cross-cutting behaviour around algorithm creation.
+/// </para>
+/// <para>
+/// <strong>How it is consumed.</strong> Pass the factory to the static helpers on
+/// <see cref="HashAlgorithmHelper"/>, <see cref="MerkleTreeHash"/>, or
+/// <see cref="ParallelMerkleTreeHash"/>. Each call gets a fresh, fully configured algorithm instance — the
+/// callers do not need to manage <see cref="System.IDisposable"/> lifecycles or thread-safety.
+/// </para>
 /// </remarks>
+/// <seealso cref="HashAlgorithmFactory"/>
+/// <seealso cref="DelegateHashAlgorithmFactory{T}"/>
+/// <seealso cref="HashAlgorithmHelper"/>
 public interface IHashAlgorithmFactory<out T>
     where T : System.Security.Cryptography.HashAlgorithm
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IPaddingStrategy.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IPaddingStrategy.cs
@@ -20,6 +20,32 @@ namespace Bodu.Security.Cryptography;
 /// Implementations must ensure that padding is applied correctly and that unpadding validates or strips padding bytes in accordance
 /// with the scheme’s rules.
 /// </para>
+/// <para>
+/// <strong>Built-in implementations.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="Pkcs7Padding"/> — RFC 5652 / PKCS#7 (the de-facto standard).</description></item>
+///   <item><description><see cref="Ansix923Padding"/> — ANSI X.923 (zero pad with length byte).</description></item>
+///   <item><description><see cref="Iso10126Padding"/> — ISO 10126 (random pad with length byte).</description></item>
+///   <item><description><see cref="Iso7816_4Padding"/> — ISO/IEC 7816-4 (<c>0x80</c> sentinel followed by zeros).</description></item>
+///   <item><description><see cref="ZeroPadding"/> — pad with zero bytes; <strong>not</strong> length-recoverable.</description></item>
+///   <item><description><see cref="NoPadding"/> — pass-through; the caller guarantees alignment.</description></item>
+/// </list>
+/// <para>
+/// <strong>Choosing a scheme.</strong> Pick <see cref="Pkcs7Padding"/> for any new design that requires
+/// length-recoverable padding under a confidentiality-only mode (CBC, ECB). Pick <see cref="Iso7816_4Padding"/>
+/// when interoperating with smartcard / EMV / ISO crypto tooling. Pick <see cref="ZeroPadding"/> only when the
+/// plaintext format itself encodes its length (so the trailing zeros can be discarded by the application
+/// layer) — and prefer one of the self-describing schemes otherwise. <see cref="NoPadding"/> is appropriate
+/// when the surrounding mode handles alignment itself (CTR, CTS, AEAD modes).
+/// </para>
+/// <para>
+/// Most callers go through <see cref="System.Security.Cryptography.SymmetricAlgorithm.Padding"/> (which
+/// dispatches via <see cref="PaddingFactory"/>) rather than constructing implementations directly. Direct
+/// use is appropriate when wiring custom transforms that do not extend
+/// <see cref="System.Security.Cryptography.SymmetricAlgorithm"/>. Implementations are stateless and safe to
+/// share across threads.
+/// </para>
 /// </remarks>
 public interface IPaddingStrategy
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -14,12 +14,29 @@ namespace Bodu.Security.Cryptography;
 /// random bytes followed by a trailing byte holding the padding length <c>N</c>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A full block of padding is always added when the input is already block-aligned so
 /// that <see cref="Unpad" /> can unambiguously recover the original length. The interior
 /// pad bytes are not reconstructable on decryption, so only the trailing length byte is
 /// validated. ISO 10126 was withdrawn by ISO in 2007; it is supported for interoperability
 /// with existing ciphertexts.
+/// </para>
+/// <para>
+/// <strong>When to choose ISO 10126.</strong> Only for legacy interop. The random pad bytes carry no
+/// security benefit over <see cref="Pkcs7Padding"/> and the standard has been formally withdrawn. For new
+/// designs use PKCS#7 with an authenticated mode, or pair an AEAD mode with <see cref="NoPadding"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// // Legacy interop only — padding bytes are random; only the final length byte is validated.
+/// IPaddingStrategy padding = new Iso10126Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 16);
+/// byte[] recovered = padding.Unpad(padded, blockSize: 16);
+/// </code>
+/// </example>
 public sealed class Iso10126Padding : IPaddingStrategy
 {
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -14,12 +14,31 @@ namespace Bodu.Security.Cryptography;
 /// padding). The first pad byte is <c>0x80</c> and remaining pad bytes are <c>0x00</c>.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A full block of padding is always added when the input is already block-aligned so
 /// that <see cref="Unpad" /> can unambiguously recover the original length by locating
 /// the terminator. The scheme is widely used in smart-card protocols, SHA-3/Keccak and
 /// CMAC. <see cref="Unpad" /> validates in constant time over the final block to resist
 /// padding-oracle side channels.
+/// </para>
+/// <para>
+/// <strong>When to choose ISO/IEC 7816-4.</strong> Pick this when interoperating with smart-card, EMV, or
+/// ISO crypto tooling — the <c>0x80</c>/<c>0x00</c> sentinel scheme is the standard there. It is also the
+/// padding used by the SHA-3 / Keccak family and by CMAC. For general-purpose .NET / Java / OpenSSL interop
+/// prefer <see cref="Pkcs7Padding"/>; for AEAD modes that handle their own alignment use
+/// <see cref="NoPadding"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Iso7816_4Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 16);
+/// // padded ends with 0x80 followed by zero or more 0x00 bytes.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 16);
+/// </code>
+/// </example>
 public sealed class Iso7816_4Padding : IPaddingStrategy
 {
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -27,7 +27,17 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="Key" /> property setter validates the supplied byte array against that length, stores a defensive copy in
 /// <see cref="KeyValue" />, and then invokes <see cref="OnKeyChanged" /> so the derived algorithm can rebuild any key-dependent state.
 /// </para>
+/// <para>
+/// <strong>When to derive from this class.</strong> Pick <see cref="KeyedBlockHashAlgorithm{T}"/> for keyed
+/// hashes that follow the Merkle–Damgård pad-and-finalise pattern and require a fixed-length key —
+/// <see cref="Poly1305"/> (32-byte key) and <see cref="SipHash{T}"/> (16-byte key) are the canonical users.
+/// For BLAKE-family hashes that accept an <em>optional</em> variable-length key derive from
+/// <see cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/> instead. For unkeyed Merkle–Damgård hashes use
+/// <see cref="BlockHashAlgorithm{T}"/> directly.
+/// </para>
 /// </remarks>
+/// <seealso cref="BlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/>
 public abstract class KeyedBlockHashAlgorithm<T>
     : BlockHashAlgorithm<T>
     where T : KeyedBlockHashAlgorithm<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
@@ -35,7 +35,16 @@ namespace Bodu.Security.Cryptography;
 /// variables and encode the key length into the parameter block, and <see cref="DeferredFinalBlockHashAlgorithm{T}.ProcessBlock" /> /
 /// <see cref="DeferredFinalBlockHashAlgorithm{T}.ProcessFinalBlock" /> as required by the grandparent.
 /// </para>
+/// <para>
+/// <strong>When to derive from this class.</strong> Pick <see cref="KeyedDeferredFinalBlockHashAlgorithm{T}"/>
+/// for BLAKE-family hashes that accept an optional, variable-length key per RFC 7693 §2.8 — the canonical
+/// users are <see cref="Blake2b"/> and <see cref="Blake2s"/>. For BLAKE-family hashes without a key (e.g.
+/// <see cref="Blake3"/>) derive from <see cref="DeferredFinalBlockHashAlgorithm{T}"/>. For Merkle–Damgård
+/// keyed hashes with a fixed-length key (Poly1305, SipHash) derive from <see cref="KeyedBlockHashAlgorithm{T}"/>.
+/// </para>
 /// </remarks>
+/// <seealso cref="DeferredFinalBlockHashAlgorithm{T}"/>
+/// <seealso cref="KeyedBlockHashAlgorithm{T}"/>
 public abstract class KeyedDeferredFinalBlockHashAlgorithm<T>
     : DeferredFinalBlockHashAlgorithm<T>
     where T : KeyedDeferredFinalBlockHashAlgorithm<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -43,7 +43,37 @@ namespace Bodu.Security.Cryptography;
 /// For a concurrent level-worker pipeline over the same tree structure, see
 /// <see cref="ParallelMerkleTreeHash" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Leaf algorithm: any <see cref="HashAlgorithm"/>, supplied via an <see cref="IHashAlgorithmFactory{T}"/> or factory delegate.</description></item>
+///   <item><description>Block size: configurable, default 1024 bytes — the input chunk that becomes one leaf.</description></item>
+///   <item><description>Fan-out: configurable, default 3 — number of children combined into each parent.</description></item>
+///   <item><description>Tail handling: partial final blocks are zero-padded; short final groups at internal levels promote without padding.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose MerkleTreeHash.</strong> Pick this when you need explicit control over the leaf hash,
+/// block size, or fan-out — content-addressed storage with audit-friendly tree shapes, BitTorrent-style chunked
+/// integrity, or producing root hashes whose construction must match a specific protocol. For maximum throughput
+/// over very large inputs use <see cref="ParallelMerkleTreeHash"/>; if a fixed tree shape with a fixed leaf hash
+/// is acceptable, <see cref="Blake3"/> is faster and ships its own tree mode internally.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // SHA-256 leaves, 4 KiB blocks, fan-out of 4.
+/// using var merkle = new MerkleTreeHash(
+///     algorithmFactory: () =&gt; SHA256.Create(),
+///     blockSize: 4096,
+///     fanOut: 4);
+///
+/// byte[] root = merkle.ComputeHash(payload);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/hashing.html#pattern-6--merkle-trees">Merkle-tree recipes in the hashing guide</seealso>
 public sealed class MerkleTreeHash : IDisposable
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -14,9 +14,29 @@ namespace Bodu.Security.Cryptography;
 /// already a multiple of the cipher block size.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Use this strategy only when the plaintext length is guaranteed to be block-aligned, for example when encrypting fixed-size records
 /// or when another framing layer already handles length information.
+/// </para>
+/// <para>
+/// <strong>When to choose no padding.</strong> The right pick under modes that handle alignment themselves —
+/// CTR (<see cref="CtrModeTransform"/>), CTS (<see cref="CtsModeTransform"/>), and every AEAD mode
+/// (<see cref="GcmModeTransform"/>, <see cref="CcmModeTransform"/>, <see cref="EaxModeTransform"/>,
+/// <see cref="GcmSivModeTransform"/>, <see cref="OcbModeTransform"/>, <see cref="SivModeTransform"/>) — none
+/// of which require the caller to align input to the cipher block size. Also the right pick when encrypting
+/// fixed-size on-disk records under XTS. For length-recoverable padding under CBC or ECB use
+/// <see cref="Pkcs7Padding"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// // Caller guarantees that `plaintext.Length` is a multiple of the block size.
+/// IPaddingStrategy padding = new NoPadding();
+/// byte[] aligned = padding.Pad(plaintext, blockSize: 16); // throws if not aligned
+/// </code>
+/// </example>
 public sealed class NoPadding : IPaddingStrategy
 {
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -43,7 +43,29 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// The L array uses GF(2^128) doubling with polynomial x^128 + x^7 + x^2 + x + 1 (big-endian).
 /// </para>
+/// <para>
+/// <strong>When to use OCB3.</strong> Pick OCB3 when you want a single-pass AEAD mode without GCM's
+/// catastrophic-on-nonce-reuse profile — OCB still requires nonces to be unique per key, but the failure
+/// mode is graceful (only that one message's confidentiality is lost; the GHASH-key-leak amplification
+/// does not apply). OCB historically had patent encumbrances that limited adoption; the patents have since
+/// been placed into the public domain, but <see cref="GcmModeTransform"/> remains the more widely deployed
+/// choice in practice. For nonce-misuse resistance prefer <see cref="GcmSivModeTransform"/> or
+/// <see cref="SivModeTransform"/>; for constrained environments prefer <see cref="CcmModeTransform"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = BuildOcbIv(nonce); // first 12 bytes of the IV are the nonce
+/// using IAeadBlockCipherModeTransform ocb = new OcbModeTransform(cipher, iv, tagLen: 16);
+///
+/// byte[] sealed_ = ocb.Encrypt(plaintext, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#ocb3--single-pass-rfc-7253">OCB3 walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -27,7 +27,33 @@ namespace Bodu.Security.Cryptography;
 /// The initialisation vector must equal the cipher block size in length and must never be reused under the same
 /// key, otherwise keystreams collide and confidentiality is lost.
 /// </para>
+/// <para>
+/// <strong>When to use OFB.</strong> Pick OFB only for legacy interop. For stream-cipher behaviour
+/// <see cref="CtrModeTransform"/> is the modern default — it parallelises, supports random access, and is the
+/// mode used by every major AEAD construction. OFB's main historical advantage was that bit errors in
+/// transmission do not propagate, but unauthenticated stream ciphers cannot detect those errors at all, so the
+/// guarantee is rarely useful in practice. As with CFB, OFB has no built-in authentication; reach for an AEAD
+/// mode (<see cref="GcmModeTransform"/>, <see cref="EaxModeTransform"/>) when integrity matters.
+/// </para>
+/// <para>
+/// OFB's keystream depends only on the IV and the key, so it is sequential at generation but the resulting
+/// keystream can be precomputed and cached if needed.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.OFB instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize); // unique per message
+/// IBlockCipherModeTransform ofb = new OfbModeTransform(cipher, iv);
+///
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = ofb.Transform(plaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/cipher-modes.html#ofb--synchronous-stream-cipher">OFB walk-through in the cipher-modes guide</seealso>
 public sealed class OfbModeTransform : IBlockCipherModeTransform
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
@@ -17,6 +17,20 @@ namespace Bodu.Security.Cryptography;
 /// Creates <see cref="IPaddingStrategy" /> instances for the framework
 /// <see cref="PaddingMode" /> values and for the extended <see cref="BoduPaddingMode" /> values.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The factory dispatches a padding-scheme enumeration value to the matching <see cref="IPaddingStrategy"/>
+/// implementation. Used internally by every <see cref="System.Security.Cryptography.SymmetricAlgorithm"/> in
+/// this library when its <see cref="System.Security.Cryptography.SymmetricAlgorithm.Padding"/> is set.
+/// </para>
+/// <para>
+/// Two overloads are provided. <see cref="Create(PaddingMode)"/> dispatches the BCL-standard
+/// <see cref="PaddingMode"/> values (PKCS7, Zeros, None, ANSI X.923, ISO 10126).
+/// <see cref="Create(BoduPaddingMode)"/> additionally supports <see cref="BoduPaddingMode.ISO7816_4"/>, the
+/// "one-and-zeros" scheme used by smart cards and SHA-3 / Keccak — pick this overload when integrating with
+/// code that uses the <see cref="BoduPaddingMode"/> superset.
+/// </para>
+/// </remarks>
 /// <seealso href="../guides/cryptography/padding.html">Padding guide — PKCS7, Zeros, None, ANSI X.923, ISO 10126 and ISO/IEC 7816-4 with worked examples</seealso>
 public static class PaddingFactory
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -93,7 +93,31 @@ namespace Bodu.Security.Cryptography;
 /// guarantees that every node a worker promotes into level N+1 arrives before level N+1's channel
 /// is closed, eliminating the lost-node race that would otherwise cause finalisation to deadlock.
 /// </para>
+/// <para>
+/// <strong>When to choose ParallelMerkleTreeHash.</strong> Pick this for very large inputs where
+/// leaf hashing dominates the cost and the tree shape (block size, fan-out, leaf algorithm) must
+/// match a specific protocol — multi-gigabyte content stores, distributed integrity checks, log
+/// audits. For smaller inputs the channel/task setup overhead can outweigh the parallel speed-up;
+/// reach for <see cref="MerkleTreeHash"/> when the workload is short or single-threaded simplicity
+/// is preferable. If a fixed tree shape is acceptable, <see cref="Blake3"/>'s built-in tree mode is
+/// faster again and avoids the per-leaf <see cref="HashAlgorithm"/> instantiation cost.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // SHA-256 leaves, 64 KiB blocks, fan-out of 4 — a typical large-content configuration.
+/// using var merkle = new ParallelMerkleTreeHash(
+///     algorithmFactory: () =&gt; SHA256.Create(),
+///     blockSize: 64 * 1024,
+///     fanOut: 4);
+///
+/// using FileStream fs = File.OpenRead("very-large.bin");
+/// byte[] root = await merkle.ComputeHashAsync(fs, cancellationToken);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/hashing.html#pattern-6--merkle-trees">Merkle-tree recipes in the hashing guide</seealso>
 public sealed class ParallelMerkleTreeHash : IDisposable
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -14,9 +14,33 @@ namespace Bodu.Security.Cryptography;
 /// block size.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A full block of padding is always added when the input length is already a multiple of the block size, so that <see cref="Unpad" />
 /// can unambiguously recover the original plaintext length. Valid values of <c>N</c> lie in the range <c>1..blockSize</c>.
+/// </para>
+/// <para>
+/// <strong>When to choose PKCS7.</strong> The default for confidentiality-only block-cipher modes (CBC, ECB) —
+/// PKCS#7 is what every mainstream library, JCE, OpenSSL, .NET, and Bouncy Castle ship as the default padding,
+/// and what every interoperable file format expects. For ISO/EMV environments use <see cref="Iso7816_4Padding"/>;
+/// when integrating with code that emits trailing zeros use <see cref="ZeroPadding"/>; when the surrounding
+/// mode (CTR, CTS, AEAD) provides its own alignment use <see cref="NoPadding"/>.
+/// </para>
+/// <note type="caution">
+/// PKCS#7 unpadding under CBC is the canonical setting for the padding-oracle attack. Always pair PKCS#7-padded
+/// CBC with a separate authenticator (HMAC over the ciphertext) or, preferably, replace the whole construction
+/// with an AEAD mode such as <see cref="GcmModeTransform"/> or <see cref="EaxModeTransform"/>.
+/// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Pkcs7Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 16);
+/// // padded.Length is a multiple of 16; the trailing N bytes each equal N.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 16);
+/// </code>
+/// </example>
 public sealed class Pkcs7Padding : IPaddingStrategy
 {
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -33,9 +33,38 @@ namespace Bodu.Security.Cryptography;
 /// and accumulated using modular arithmetic modulo <c>2¹³⁰ - 5</c>. After processing all blocks, the accumulator is finalized by adding
 /// the second half of the key <c>s</c> and serialising the result as the final MAC tag.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Tag size: 128 bits (16 bytes), fixed.</description></item>
+///   <item><description>Key size: 256 bits (32 bytes) — first half is clamped to <c>r</c>, second half is the nonce-derived <c>s</c>.</description></item>
+///   <item><description>Block size: 16 bytes; arithmetic modulo <c>2¹³⁰ − 5</c>.</description></item>
+///   <item><description>Specification: RFC 8439 (ChaCha20-Poly1305).</description></item>
+///   <item><description><strong>Single-use:</strong> a key must authenticate exactly one message.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Poly1305.</strong> Reach for Poly1305 when implementing or extending a Poly1305-based
+/// AEAD (ChaCha20-Poly1305 in TLS 1.3, SSH, WireGuard, Noise) or when authenticating a single message with a
+/// fresh per-message key derived from a stream cipher. For multi-message keyed authentication use HMAC-SHA-256,
+/// <see cref="Blake2b"/>-MAC, or <see cref="SipHash64"/> / <see cref="SipHash128"/> — none of which share Poly1305's
+/// one-time-key restriction.
+/// </para>
 /// <note type="important">This algorithm is a <b>one-time authenticator</b> and must <b>not</b> be used with the same key for multiple
 /// messages. Reusing a key with different inputs <b>compromises</b> the cryptographic security and may lead to forgery attacks.</note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // The 32-byte key MUST be unique per message — typically derived from a stream cipher's keystream.
+/// byte[] oneTimeKey = DerivePoly1305KeyFromChaCha20(sessionKey, nonce);
+///
+/// using var poly = new Poly1305 { Key = oneTimeKey };
+/// byte[] tag = poly.ComputeHash(message);
+/// </code>
+/// </example>
 public sealed class Poly1305
     : KeyedBlockHashAlgorithm<Poly1305>
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.1024.cs
@@ -21,11 +21,42 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// For other block sizes, see <see cref="Serpent256" /> and <see cref="Serpent512" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 1024 bits (128 bytes).</description></item>
+///   <item><description>Key size: 1024 bits (128 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>80 rounds; tweak subkey injected every 4 rounds.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Serpent-1024.</strong> The widest wide-block Serpent variant — purely experimental, for
+/// scenarios where a 1024-bit tweakable block with Serpent's round function is required. <see cref="Threefish1024"/>
+/// is the better-studied alternative. Throughput drops markedly relative to the 256/512-bit Serpent variants. Use
+/// <see cref="Serpent128"/> for any production scenario that requires interoperable Serpent.
+/// </para>
 /// <note type="important">
-/// Serpent-1024 (this type) is a **non-standard Serpent-derived construction** and is not interoperable with any reference
-/// Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
+/// Serpent-1024 (this type) is a <strong>non-standard Serpent-derived construction</strong> and is not interoperable with any
+/// reference Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent1024.Create();
+/// serpent.Key   = RandomNumberGenerator.GetBytes(128); // 1024-bit key
+/// serpent.IV    = RandomNumberGenerator.GetBytes(128); // matches the 1024-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16);  // 128-bit tweak
+///
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip  = serpent.Decrypt(ciphertext);
+/// </code>
+/// </example>
 public sealed class Serpent1024
     : Serpent
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.256.cs
@@ -21,11 +21,42 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// For other block sizes, see <see cref="Serpent512" /> and <see cref="Serpent1024" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 256 bits (32 bytes).</description></item>
+///   <item><description>Key size: 256 bits (32 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>48 rounds; tweak subkey injected every 4 rounds.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Serpent-256.</strong> Pick the wide-block Serpent variants only for experimental work
+/// where a tweakable wide-block cipher with Serpent's round function is wanted. <see cref="Threefish256"/> is a
+/// better-studied alternative for the same role. Use <see cref="Serpent128"/> for any production scenario that
+/// requires interoperable Serpent.
+/// </para>
 /// <note type="important">
-/// Serpent-256 (this type) is a **non-standard Serpent-derived construction** and is not interoperable with any reference
-/// Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
+/// Serpent-256 (this type) is a <strong>non-standard Serpent-derived construction</strong> and is not interoperable with any
+/// reference Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent256.Create();
+/// serpent.Key   = RandomNumberGenerator.GetBytes(32); // 256-bit key
+/// serpent.IV    = RandomNumberGenerator.GetBytes(32); // matches the 256-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+///
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip  = serpent.Decrypt(ciphertext);
+/// </code>
+/// </example>
 public sealed class Serpent256
     : Serpent
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.512.cs
@@ -21,11 +21,42 @@ namespace Bodu.Security.Cryptography;
 /// <para>
 /// For other block sizes, see <see cref="Serpent256" /> and <see cref="Serpent1024" />.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 512 bits (64 bytes).</description></item>
+///   <item><description>Key size: 512 bits (64 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>64 rounds; tweak subkey injected every 4 rounds.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Serpent-512.</strong> Pick the wide-block Serpent variants only for experimental work
+/// where a tweakable wide-block cipher with Serpent's round function is wanted. <see cref="Threefish512"/> is a
+/// better-studied alternative for the same role. Use <see cref="Serpent128"/> for any production scenario that
+/// requires interoperable Serpent.
+/// </para>
 /// <note type="important">
-/// Serpent-512 (this type) is a **non-standard Serpent-derived construction** and is not interoperable with any reference
-/// Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
+/// Serpent-512 (this type) is a <strong>non-standard Serpent-derived construction</strong> and is not interoperable with any
+/// reference Serpent implementation. For standard, externally vetted Serpent, use <see cref="Serpent128" />.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent512.Create();
+/// serpent.Key   = RandomNumberGenerator.GetBytes(64); // 512-bit key
+/// serpent.IV    = RandomNumberGenerator.GetBytes(64); // matches the 512-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+///
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip  = serpent.Decrypt(ciphertext);
+/// </code>
+/// </example>
 public sealed class Serpent512
     : Serpent
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
@@ -30,7 +30,38 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="Serpent1024" />. Those variants are a non-standard Serpent-derived construction; the type on this page is the
 /// canonical, externally vetted 128-bit cipher.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 128 bits (16 bytes).</description></item>
+///   <item><description>Key sizes: 128, 192, or 256 bits.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+///   <item><description>32 rounds, 8 × 4-bit S-boxes, bitsliced linear transform.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Serpent128.</strong> Pick Serpent when a deliberately conservative AES alternative is
+/// wanted — the 32-round design has a wider security margin than AES's 14 rounds at 256-bit key, at the cost of
+/// noticeably lower throughput. For general-purpose encryption with hardware acceleration prefer
+/// <see cref="System.Security.Cryptography.Aes"/>; for an alternative AES finalist with better software
+/// performance prefer <see cref="Twofish"/>. Use <see cref="Camellia"/> when ISO/IEC, CRYPTREC, or NESSIE approval
+/// is a procurement requirement.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = new Serpent128();
+/// serpent.GenerateKey(); // 256-bit by default
+/// serpent.GenerateIV();
+///
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip  = serpent.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>
 /// <seealso href="../guides/cryptography/padding.html">Padding</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -34,6 +34,23 @@ namespace Bodu.Security.Cryptography;
 /// <c>securityLevel</c> selects the SHAKE variant. <see cref="HashAlgorithm.ComputeHash(byte[])" /> therefore produces
 /// exactly <c>outputBits / 8</c> bytes regardless of which security level is chosen.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>State: 1600 bits (200 bytes); Keccak-f[1600] permutation.</description></item>
+///   <item><description>Output size: configurable, any positive multiple of 8 bits.</description></item>
+///   <item><description>Security level: 128 (SHAKE128) or 256 (SHAKE256).</description></item>
+///   <item><description>Domain separation: <c>0x1F</c>; multi-rate padding (pad10*1).</description></item>
+///   <item><description>Specification: NIST FIPS 202.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose SHAKE.</strong> Pick SHAKE when an extendable-output function is genuinely required
+/// — KMAC inputs, post-quantum signature schemes, hash-based DRBGs, and any protocol that needs more than the
+/// fixed-length output of SHA-3 / SHA-256. For ordinary fixed-length hashing prefer SHA-3 (FIPS 202) or
+/// <see cref="Blake3"/> (faster on commodity hardware). Use SHAKE128 when 128-bit security is sufficient and
+/// throughput matters; use SHAKE256 when the higher capacity is required.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
@@ -18,7 +18,30 @@ namespace Bodu.Security.Cryptography;
 /// <c>d</c> is the number of finalisation rounds. The default configuration corresponds to <c>SipHash-2-4</c>.
 /// </para>
 /// <para>See <see cref="SipHash{T}" /> for a description of the round structure.</para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Tag size: 128 bits (16 bytes).</description></item>
+///   <item><description>Key size: 128 bits (16 bytes).</description></item>
+///   <item><description>Default parameterisation: SipHash-2-4 (2 compression rounds, 4 finalisation rounds).</description></item>
+///   <item><description>Multi-message key reuse is supported — unlike <see cref="Poly1305"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose SipHash128.</strong> Pick <see cref="SipHash128"/> over <see cref="SipHash64"/> when
+/// the wider 128-bit tag is required — multi-tenant hash tables with very large key spaces, fingerprint-style
+/// cache keys, or short-message authentication where 64 bits would be marginal. For protocol-level MACs over
+/// long messages prefer HMAC-SHA-256 or <see cref="Blake2b"/>-MAC.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// using var sip = new SipHash128 { Key = sessionKey };
+/// byte[] tag = sip.ComputeHash(message);
+/// </code>
+/// </example>
 public sealed class SipHash128
     : SipHash<SipHash128>
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
@@ -21,7 +21,34 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="SipHash{T}.FinalizationRounds" />.
 /// </para>
 /// <para>See <see cref="SipHash{T}" /> for a description of the round structure.</para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Tag size: 64 bits (8 bytes).</description></item>
+///   <item><description>Key size: 128 bits (16 bytes).</description></item>
+///   <item><description>Default parameterisation: SipHash-2-4 (2 compression rounds, 4 finalisation rounds).</description></item>
+///   <item><description>Multi-message key reuse is supported — unlike <see cref="Poly1305"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose SipHash64.</strong> The right keyed hash for protecting in-memory hash tables and
+/// bloom filters against collision-based denial-of-service attacks — fast, fixed cost, and the de-facto standard
+/// in language runtimes (Python, Ruby, Rust, Perl). For 128-bit tag width or stronger long-term authentication
+/// guarantees pick <see cref="SipHash128"/>; for protocol-level message authentication use HMAC-SHA-256 or
+/// <see cref="Blake2b"/>-MAC.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// // 16-byte secret key — keep it private to your process; SipHash assumes attackers cannot guess it.
+/// byte[] hashTableKey = RandomNumberGenerator.GetBytes(16);
+///
+/// using var sip = new SipHash64 { Key = hashTableKey };
+/// byte[] tag = sip.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user-supplied-key"));
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/hashing.html#pattern-2--a-keyed-hash-siphash">Keyed-hash (SipHash) guide</seealso>
 public sealed class SipHash64
     : SipHash<SipHash64>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -37,6 +37,14 @@ namespace Bodu.Security.Cryptography;
 /// input has been processed, <see cref="FinalizationRounds" /> rounds are applied to produce the final digest. The defaults
 /// (<c>c = 2</c>, <c>d = 4</c>) correspond to the standard <c>SipHash-2-4</c> parameterisation.
 /// </para>
+/// <para>
+/// <strong>When to choose SipHash.</strong> SipHash is the de-facto standard for protecting hash tables and
+/// bloom filters against collision-based denial-of-service attacks — Python, Ruby, Rust, Perl, and OpenBSD's
+/// stdlib all use it for that purpose. Pick <see cref="SipHash64"/> when 64 bits is enough; pick
+/// <see cref="SipHash128"/> when collision pressure on the tag width matters. For protocol-level message
+/// authentication over long messages prefer HMAC-SHA-256 or <see cref="Blake2b"/>-MAC. Do not use SipHash
+/// where the key may be exposed — its security target is hash-flooding resistance, not generic MAC strength.
+/// </para>
 /// </remarks>
 /// <example>
 /// The following example configures a <see cref="SipHash64" /> instance to use the stronger <c>SipHash-4-8</c> parameter set.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -46,7 +46,32 @@ namespace Bodu.Security.Cryptography;
 /// Ciphertext is output as <c>C || SIV</c> (ciphertext then tag), consistent with the
 /// <see cref="IAeadBlockCipherModeTransform" /> convention.
 /// </para>
+/// <para>
+/// <strong>When to use SIV.</strong> Pick AES-SIV when deterministic authenticated encryption is wanted —
+/// key wrapping (RFC 5297 §6 / RFC 5649), envelope encryption schemes that need stable ciphertext for
+/// deduplication, or any context that cannot maintain a per-message nonce. SIV is two-pass and slower than
+/// <see cref="GcmModeTransform"/> on commodity hardware, but it has the strongest misuse-resistance profile
+/// in this library: re-encrypting the same <c>(plaintext, AAD)</c> tuple produces the same ciphertext, but
+/// distinct messages remain confidential and authentic. <see cref="GcmSivModeTransform"/> is the RFC 8452
+/// alternative — same misuse-resistance category, different MAC (POLYVAL) and key schedule, typically
+/// faster on AES-NI/PCLMULQDQ hardware.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // SIV uses a doubled key: first half drives the MAC, second half drives CTR encryption.
+/// using IBlockCipher s2v = new AesBlockCipher(macKey);
+/// using IBlockCipher ctr = new AesBlockCipher(encKey);
+/// byte[] iv = new byte[s2v.BlockSize]; // ignored by SIV — present for interface compatibility
+/// using IAeadBlockCipherModeTransform siv = new SivModeTransform(s2v, ctr, iv);
+///
+/// byte[] sealed_ = siv.Encrypt(plaintext, associatedData: header);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/aead-modes.html#siv--misuse-resistant">SIV walk-through in the AEAD-modes guide</seealso>
 /// <seealso cref="AesBlockCipher" />
 /// <seealso cref="Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions" />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.1024.cs
@@ -21,6 +21,21 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="Skein{T}.Key" /> turns the instance into the keyed Skein-MAC-1024 variant by prepending a <c>KEY</c> UBI
 /// phase to the standard <c>CFG → MSG → OUT</c> pipeline.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>State / block size: 1024 bits (128 bytes).</description></item>
+///   <item><description>Output sizes: 384, 512, or 1024 bits — default 1024.</description></item>
+///   <item><description>Underlying cipher: <see cref="Threefish1024Cipher"/> tweakable block cipher under UBI mode.</description></item>
+///   <item><description>Optional variable-length key: 0–<see cref="Skein{T}.MaxKeySizeBytes"/> bytes.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Skein-1024.</strong> The widest-state Skein variant — pick it when you want the
+/// largest security margin in the Skein family or when the surrounding system explicitly requires Skein-1024.
+/// Throughput on short inputs is lower than <see cref="Skein512"/>; for general use the 512-bit variant is the
+/// recommended Skein default.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.256.cs
@@ -21,6 +21,22 @@ namespace Bodu.Security.Cryptography;
 /// a <c>KEY</c> UBI phase to the standard <c>CFG → MSG → OUT</c> pipeline. The key length is not fixed: any byte
 /// sequence from zero up to <see cref="Skein{T}.MaxKeySizeBytes" /> bytes is valid.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>State / block size: 256 bits (32 bytes).</description></item>
+///   <item><description>Output sizes: 128, 160, 224, or 256 bits — default 256.</description></item>
+///   <item><description>Underlying cipher: <see cref="Threefish256Cipher"/> tweakable block cipher under UBI mode.</description></item>
+///   <item><description>Optional variable-length key: 0–<see cref="Skein{T}.MaxKeySizeBytes"/> bytes.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Skein-256.</strong> The narrowest Skein variant — pick it when 32-byte output is enough
+/// and the surrounding system has standardised on Skein. <see cref="Skein512"/> is the more common default and
+/// offers a stronger security margin; <see cref="Skein1024"/> is for cases that want the widest state. For new
+/// general-purpose hashing without an interop constraint <see cref="Blake2b"/> or SHA-2 is the more widely
+/// deployed default.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.512.cs
@@ -21,6 +21,21 @@ namespace Bodu.Security.Cryptography;
 /// a <c>KEY</c> UBI phase to the standard <c>CFG → MSG → OUT</c> pipeline. The key length is not fixed: any byte
 /// sequence from zero up to <see cref="Skein{T}.MaxKeySizeBytes" /> bytes is valid.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>State / block size: 512 bits (64 bytes).</description></item>
+///   <item><description>Output sizes: 128, 160, 224, 256, 384, or 512 bits — default 512.</description></item>
+///   <item><description>Underlying cipher: <see cref="Threefish512Cipher"/> tweakable block cipher under UBI mode.</description></item>
+///   <item><description>Optional variable-length key: 0–<see cref="Skein{T}.MaxKeySizeBytes"/> bytes.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Skein-512.</strong> The general-purpose Skein default, recommended by the Skein 1.3
+/// specification — pick this when reproducing or interoperating with Skein-based digests. For new code without
+/// an interop requirement <see cref="Blake2b"/> is faster on contemporary 64-bit hardware and SHA-2 / SHA-3 are
+/// more widely deployed. Use <see cref="Skein256"/> for narrower state, <see cref="Skein1024"/> for the widest.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -44,7 +44,20 @@ namespace Bodu.Security.Cryptography;
 /// key-derivation identifiers, and nonce modes are not exposed; the corresponding Skein tweak types are reserved for
 /// potential future extension (see <see cref="SkeinTweakType" />).
 /// </para>
+/// <para>
+/// <strong>When to choose Skein.</strong> Pick the Skein family for interop with code that has standardised on
+/// it (the SHA-3 finalist round attracted a long tail of adopters, and Skein remains common in research code).
+/// Skein-512 is the recommended default; Skein-256 is the narrower variant and Skein-1024 the widest. For new
+/// general-purpose cryptographic hashing without an interop requirement <see cref="Blake2b"/> is faster on
+/// commodity 64-bit hardware and SHA-2 / SHA-3 are more widely deployed. The Threefish primitive itself is
+/// also available standalone via <see cref="Threefish"/>.
+/// </para>
 /// </remarks>
+/// <seealso cref="Skein256"/>
+/// <seealso cref="Skein512"/>
+/// <seealso cref="Skein1024"/>
+/// <seealso cref="Threefish"/>
+/// <seealso cref="KeyedBlockHashAlgorithm{T}"/>
 public abstract partial class Skein<T>
     : KeyedBlockHashAlgorithm<T>
     where T : Skein<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -24,12 +24,40 @@ namespace Bodu.Security.Cryptography;
 /// <see cref="BlockMode" /> property. The default mode is <see cref="CipherBlockMode.CBC" /> with
 /// <see cref="PaddingMode.PKCS7" /> padding.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 64 bits (8 bytes).</description></item>
+///   <item><description>Key size: 80 bits (10 bytes), fixed.</description></item>
+///   <item><description>32 rounds, unbalanced Feistel network.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Skipjack.</strong> Only when reading or producing data encrypted under a Skipjack-based
+/// legacy system, or when reproducing published test vectors for research. For any new design use
+/// <see cref="System.Security.Cryptography.Aes"/> or another 128-bit block cipher.
+/// </para>
 /// <note type="important">
 /// Because of its 80-bit key and 64-bit block, Skipjack offers no modern security margin and must not be used to protect sensitive
 /// data in new applications. The 64-bit block size also exposes it to birthday-bound attacks (SWEET32) when large volumes of data
 /// are encrypted under the same key. Prefer a modern cipher such as AES.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // Legacy interop only — do not use Skipjack to protect new data.
+/// using var skipjack = new Skipjack();
+/// skipjack.Key = legacyKeyMaterial;       // exactly 10 bytes
+/// skipjack.IV  = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block
+///
+/// byte[] ciphertext = skipjack.Encrypt(legacyPlaintext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/skipjack.html">Using Skipjack (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
@@ -17,9 +17,30 @@ namespace Bodu.Security.Cryptography;
 /// applying 8 rounds of S-box substitution and word rotation per block. On finalisation the state is XOR-folded from the permuted
 /// buffer and serialised in big-endian byte order. See <see cref="Snefru{T}" /> for shared background.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 128 bits (16 bytes).</description></item>
+///   <item><description>Block size: 48 bytes; 4-word internal state; 8 rounds per block.</description></item>
+///   <item><description>Status: <strong>broken</strong> — practical collision attacks are known.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Snefru128.</strong> For academic study and interop with archival data only. For new
+/// security-sensitive work use SHA-2 or <see cref="Blake2b"/>; for 128-bit non-cryptographic fingerprinting use a
+/// <c>Bodu.IO.Hashing</c> algorithm such as <see cref="Bodu.IO.Hashing.MurmurHash3_128"/>.
+/// </para>
 /// <note type="important">Snefru is considered broken and <b>not</b> suitable for password hashing, digital signatures, or secure
 /// data integrity checks.</note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// using var snefru = new Snefru128();
+/// byte[] digest = snefru.ComputeHash(legacyMessage);
+/// </code>
+/// </example>
 public sealed class Snefru128 : Snefru<Snefru128>
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.256.cs
@@ -17,9 +17,30 @@ namespace Bodu.Security.Cryptography;
 /// applying 8 rounds of S-box substitution and word rotation per block. On finalisation the state is XOR-folded from the permuted
 /// buffer and serialised in big-endian byte order. See <see cref="Snefru{T}" /> for shared background.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 256 bits (32 bytes).</description></item>
+///   <item><description>Block size: 32 bytes; 8-word internal state; 8 rounds per block.</description></item>
+///   <item><description>Status: <strong>broken</strong> — practical collision attacks are known.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Snefru256.</strong> Academic study and legacy interop only. For new security-sensitive
+/// 256-bit hashing use SHA-256 or <see cref="Blake2b"/>; for fingerprinting use a 256-bit non-cryptographic hash
+/// from <c>Bodu.IO.Hashing</c>.
+/// </para>
 /// <note type="important">Snefru is considered broken and <b>not</b> suitable for password hashing, digital signatures, or secure
 /// data integrity checks.</note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// using var snefru = new Snefru256();
+/// byte[] digest = snefru.ComputeHash(legacyMessage);
+/// </code>
+/// </example>
 public sealed class Snefru256
     : Snefru<Snefru256>
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.cs
@@ -36,9 +36,19 @@ namespace Bodu.Security.Cryptography;
 /// Each input block is processed by 8 rounds consisting of an S-box substitution step followed by a word-wise circular rotation.
 /// After all input has been absorbed, the internal state is serialised in big-endian byte order to produce the final digest.
 /// </para>
+/// <para>
+/// <strong>When to choose Snefru.</strong> Academic study and legacy interop only — Snefru has practical
+/// collision attacks against both the 2-pass and 4-pass variants and is one of the earliest cryptographic
+/// hashes ever published. Pick <see cref="Snefru128"/> for 128-bit output and <see cref="Snefru256"/> for
+/// 256-bit output. For any new security-sensitive cryptographic hashing use SHA-2, SHA-3, or
+/// <see cref="Blake2b"/>; for non-cryptographic fingerprinting use a member of <c>Bodu.IO.Hashing</c>.
+/// </para>
 /// <note type="important">This algorithm is <b>not</b> considered secure by modern cryptographic standards and should <b>not</b> be
 /// used for password hashing, digital signatures, or integrity validation in security-sensitive applications.</note>
 /// </remarks>
+/// <seealso cref="Snefru128"/>
+/// <seealso cref="Snefru256"/>
+/// <seealso cref="BlockHashAlgorithm{T}"/>
 public abstract partial class Snefru<T>
     : BlockHashAlgorithm<T>
     where T : Snefru<T>, new()

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
@@ -21,7 +21,37 @@ namespace Bodu.Security.Cryptography;
 /// or format-preserving encryption where a tweak is useful.
 /// </para>
 /// <para>For other block sizes, see <see cref="Threefish256" /> and <see cref="Threefish512" />.</para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 1024 bits (128 bytes).</description></item>
+///   <item><description>Key size: 1024 bits (128 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Threefish-1024.</strong> The widest Threefish variant — pick it when the surrounding
+/// construction (Skein-1024, custom long-tweak schemes, or extreme-margin disk-encryption layouts) requires the
+/// 1024-bit block. Throughput is lower than the 512-bit variant; the 256/512-bit variants are more practical
+/// defaults unless the wider block is a hard requirement.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish1024.Create();
+/// tf.Key   = RandomNumberGenerator.GetBytes(128); // 1024-bit key
+/// tf.IV    = RandomNumberGenerator.GetBytes(128); // matches the 1024-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16);  // 128-bit tweak
+///
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip  = tf.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/threefish-1024.html">Using Threefish-1024 (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
@@ -21,7 +21,39 @@ namespace Bodu.Security.Cryptography;
 /// or format-preserving encryption where a tweak is useful.
 /// </para>
 /// <para>For other block sizes, see <see cref="Threefish512" /> and <see cref="Threefish1024" />.</para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 256 bits (32 bytes).</description></item>
+///   <item><description>Key size: 256 bits (32 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Threefish-256.</strong> Pick the 256-bit variant when you want a tweakable block cipher
+/// at a comparable security margin to AES-256 with a smaller block than the wider Threefish variants — useful for
+/// per-record encryption or short-tweak-driven schemes. Reach for <see cref="Threefish512"/> when a wider block
+/// reduces birthday-bound exposure on long messages, or for <see cref="Threefish1024"/> when the surrounding
+/// construction (e.g. a custom Skein-based AEAD) demands the widest block. For general-purpose encryption without a
+/// tweak requirement, prefer <see cref="System.Security.Cryptography.Aes"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish256.Create();
+/// tf.Key   = RandomNumberGenerator.GetBytes(32); // 256-bit key
+/// tf.IV    = RandomNumberGenerator.GetBytes(32); // matches the 256-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+///
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip  = tf.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/threefish-256.html">Using Threefish-256 (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
@@ -21,7 +21,38 @@ namespace Bodu.Security.Cryptography;
 /// or format-preserving encryption where a tweak is useful.
 /// </para>
 /// <para>For other block sizes, see <see cref="Threefish256" /> and <see cref="Threefish1024" />.</para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 512 bits (64 bytes).</description></item>
+///   <item><description>Key size: 512 bits (64 bytes).</description></item>
+///   <item><description>Tweak size: 128 bits (16 bytes).</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Threefish-512.</strong> The most common Threefish width — the wider 512-bit block lifts
+/// the birthday bound to <c>~2<sup>256</sup></c> blocks, removing the SWEET32-style concerns that 64-bit and 128-bit
+/// block ciphers run into when re-used heavily under one key. A natural fit when building Skein-style constructions
+/// (Skein-512 wraps this engine under the UBI mode). Use <see cref="Threefish256"/> when the smaller block matches
+/// the surrounding scheme; use <see cref="Threefish1024"/> when even more block width is required.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish512.Create();
+/// tf.Key   = RandomNumberGenerator.GetBytes(64); // 512-bit key
+/// tf.IV    = RandomNumberGenerator.GetBytes(64); // matches the 512-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+///
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip  = tf.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/threefish-512.html">Using Threefish-512 (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
@@ -25,9 +25,29 @@ namespace Bodu.Security.Cryptography;
 /// The <see cref="BlockMode" /> property replaces the standard <see cref="SymmetricAlgorithm.Mode" /> property, enabling the use of
 /// additional or non-standard block cipher modes such as <see cref="CipherBlockMode.CTR" /> and <see cref="CipherBlockMode.OFB" />.
 /// </para>
+/// <para>
+/// <strong>Concrete variants.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description><see cref="Threefish256"/> — 256-bit block, 256-bit key, 128-bit tweak.</description></item>
+///   <item><description><see cref="Threefish512"/> — 512-bit block, 512-bit key, 128-bit tweak (the recommended general-purpose default).</description></item>
+///   <item><description><see cref="Threefish1024"/> — 1024-bit block, 1024-bit key, 128-bit tweak.</description></item>
+/// </list>
+/// <para>
+/// Threefish is the cipher under the UBI mode of <see cref="Skein{T}"/> — the same key-and-tweak primitive that
+/// drives Skein's hash compression. For a non-tweakable, hardware-accelerated default prefer
+/// <see cref="System.Security.Cryptography.Aes"/>. For try-pattern transform creation that surfaces bad
+/// key/IV/tweak combinations as a <see langword="false"/> return, see
+/// <see cref="Bodu.Security.Cryptography.Extensions.TweakableSymmetricAlgorithmExtensions"/>.
+/// </para>
 /// <note type="important">This class is not intended to be instantiated directly. Use <see cref="Threefish256" />,
 /// <see cref="Threefish512" />, or <see cref="Threefish1024" /> instead.</note>
 /// </remarks>
+/// <seealso cref="Threefish256"/>
+/// <seealso cref="Threefish512"/>
+/// <seealso cref="Threefish1024"/>
+/// <seealso cref="TweakableSymmetricAlgorithm"/>
+/// <seealso cref="Skein{T}"/>
 public abstract class Threefish
     : TweakableSymmetricAlgorithm
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -32,6 +32,21 @@ namespace Bodu.Security.Cryptography;
 /// Although no longer recommended for new security-sensitive applications, Tiger has not been broken in the classical collision
 /// sense and is still useful for legacy interoperability and as a fast integrity hash.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 128, 160, or 192 bits — internally always 192 bits, then truncated.</description></item>
+///   <item><description>Block size: 64 bytes (512 bits); three 64-bit state variables.</description></item>
+///   <item><description>Three passes per block, eight S-box rounds per pass; optimised for 64-bit hosts.</description></item>
+///   <item><description>Padding variant: <see cref="TigerHashingVariant.Tiger"/> (<c>0x01</c>) or <see cref="TigerHashingVariant.Tiger2"/> (<c>0x80</c>).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Tiger.</strong> Pick Tiger only for legacy interoperability — TigerTree (Merkle hash
+/// of Tiger-192 leaves) is still seen in older P2P and content-addressed storage systems. For any new security
+/// design use a SHA-2 family member or <see cref="Blake2b"/>; for fast non-cryptographic fingerprinting the
+/// algorithms in <c>Bodu.IO.Hashing</c> are usually a better fit.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TigerHashingVariant.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TigerHashingVariant.cs
@@ -16,10 +16,20 @@ namespace Bodu.Security.Cryptography;
 /// Specifies the padding variant used by the <see cref="Bodu.Security.Cryptography.Tiger" /> hashing algorithm.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The <see cref="TigerHashingVariant" /> enumeration differentiates between the original Tiger algorithm and the modified Tiger2
 /// variant. These variants are identical in their core compression function but differ in how the final padding byte is applied during
 /// hash finalization.
+/// </para>
+/// <para>
+/// Pick <see cref="Tiger"/> when reproducing or interoperating with output from the original Anderson/Biham
+/// reference implementation, and <see cref="Tiger2"/> when matching modern Tiger-based tooling or
+/// TigerTree variants — most contemporary code paths use <see cref="Tiger2"/> by default. Aside from the
+/// final padding byte the two variants are bit-identical, so the same key material and message produce
+/// otherwise indistinguishable internal computation.
+/// </para>
 /// </remarks>
+/// <seealso cref="Bodu.Security.Cryptography.Tiger"/>
 public enum TigerHashingVariant
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TransformMode.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TransformMode.cs
@@ -9,7 +9,14 @@ namespace Bodu.Security.Cryptography;
 /// <summary>
 /// Defines the direction of a cryptographic transformation.
 /// </summary>
-/// <remarks>This enumeration is used to distinguish between encryption and decryption operations in cryptographic transform implementations.</remarks>
+/// <remarks>
+/// <para>
+/// Used by helper APIs that take a single direction argument rather than separate <c>Encrypt</c> /
+/// <c>Decrypt</c> overloads. The lower-level <see cref="IBlockCipherModeTransform.Transform(System.ReadOnlySpan{byte}, System.Span{byte}, bool)"/>
+/// uses a <see cref="bool"/> instead because the transform contract predates this enumeration; either
+/// representation expresses the same choice.
+/// </para>
+/// </remarks>
 public enum TransformMode
 {
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TweakableSymmetricAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TweakableSymmetricAlgorithm.cs
@@ -26,7 +26,30 @@ namespace Bodu.Security.Cryptography;
 /// Derived classes must override <see cref="CreateEncryptor(byte[], byte[], byte[])" />,
 /// <see cref="CreateDecryptor(byte[], byte[], byte[])" />, and <see cref="GenerateTweak" />.
 /// </para>
+/// <para>
+/// <strong>What is a tweak?</strong> A tweak is a third keying input alongside key and IV — a per-message
+/// (or per-position) value that varies the cipher's behaviour without renegotiating the key. Tweaks are
+/// what make tweakable block ciphers a natural fit for disk encryption (the sector number is the tweak),
+/// authenticated modes built from the cipher (the message position is the tweak), and protocols that need
+/// to bind ciphertext to a position or message identifier.
+/// </para>
+/// <para>
+/// <strong>Concrete implementations.</strong> The library ships <see cref="Threefish256"/>,
+/// <see cref="Threefish512"/>, and <see cref="Threefish1024"/> as the production tweakable ciphers (Threefish
+/// is the cipher under the hood of Skein). The <see cref="Serpent256"/>/<see cref="Serpent512"/>/<see cref="Serpent1024"/>
+/// wide-block variants are also tweakable but non-standard — see their headers for the experimental-only caveat.
+/// </para>
+/// <para>
+/// <strong>Companion try-pattern helpers.</strong> The
+/// <see cref="Bodu.Security.Cryptography.Extensions.TweakableSymmetricAlgorithmExtensions"/> class adds
+/// <c>TryCreateEncryptor</c> and <c>TryCreateDecryptor</c> wrappers that return <see langword="false"/> when
+/// the supplied key/IV/tweak combination is invalid — useful when keying material is user-supplied.
+/// </para>
 /// </remarks>
+/// <seealso cref="Threefish256"/>
+/// <seealso cref="Threefish512"/>
+/// <seealso cref="Threefish1024"/>
+/// <seealso cref="Bodu.Security.Cryptography.Extensions.TweakableSymmetricAlgorithmExtensions"/>
 public abstract class TweakableSymmetricAlgorithm
     : System.Security.Cryptography.SymmetricAlgorithm
 {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
@@ -23,11 +23,42 @@ namespace Bodu.Security.Cryptography;
 /// cipher modes via the <see cref="BlockMode" /> property. The default mode is <see cref="CipherBlockMode.CBC" />
 /// with <see cref="PaddingMode.PKCS7" /> padding.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Block size: 128 bits (16 bytes).</description></item>
+///   <item><description>Key sizes: 128, 192, or 256 bits.</description></item>
+///   <item><description>16-round Feistel structure with key-dependent S-boxes and an MDS-based linear layer.</description></item>
+///   <item><description>Default mode: <see cref="CipherBlockMode.CBC"/>; default padding: <see cref="PaddingMode.PKCS7"/>.</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Twofish.</strong> Pick Twofish when interoperability with existing Twofish-based code
+/// or formats is required, or when you want an AES finalist with strong software performance and a different
+/// design philosophy from AES. For new general-purpose work, <see cref="System.Security.Cryptography.Aes"/> is
+/// the right default — hardware acceleration on most modern CPUs makes it the fastest option as well as the most
+/// widely vetted. Reach for <see cref="Serpent128"/> when you specifically want the higher round count
+/// conservatism of that AES finalist.
+/// </para>
 /// <note type="important">
 /// For new general-purpose application encryption, prefer <see cref="Aes" /> unless Twofish compatibility is
 /// specifically required.
 /// </note>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var twofish = new Twofish();
+/// twofish.GenerateKey(); // 256-bit by default
+/// twofish.GenerateIV();
+///
+/// byte[] ciphertext = twofish.Encrypt(plaintext);
+/// byte[] roundTrip  = twofish.Decrypt(ciphertext);
+/// </code>
+/// </example>
 /// <seealso href="../guides/cryptography/twofish.html">Using Twofish (guide with full encrypt / decrypt examples)</seealso>
 /// <seealso href="../guides/cryptography/encryption-basics.html">Encryption basics</seealso>
 /// <seealso href="../guides/cryptography/cipher-modes.html">Cipher block modes</seealso>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -30,6 +30,21 @@ namespace Bodu.Security.Cryptography;
 /// hashing has started throws <see cref="CryptographicUnexpectedOperationException" />. Calling
 /// <see cref="Initialize" /> returns the instance to the reconfigurable state.
 /// </para>
+/// <para>
+/// <strong>Parameters at a glance.</strong>
+/// </para>
+/// <list type="bullet">
+///   <item><description>Output size: 512 bits (64 bytes), fixed.</description></item>
+///   <item><description>Block size: 64 bytes (512 bits); 256-bit big-endian length field.</description></item>
+///   <item><description>Internal cipher <c>W</c> on the wide-trail (Rijndael-family) design principle.</description></item>
+///   <item><description>Selectable revision: <see cref="WhirlpoolVersion.WhirlpoolInfo0"/> (2000), <see cref="WhirlpoolVersion.WhirlpoolInfo1"/> (Whirlpool-T, 2001), or <see cref="WhirlpoolVersion.WhirlpoolInfo3"/> (ISO/IEC 10118-3, 2003 — default).</description></item>
+/// </list>
+/// <para>
+/// <strong>When to choose Whirlpool.</strong> Pick Whirlpool when interoperability with software that produces
+/// or expects ISO/IEC 10118-3 Whirlpool digests is required — TrueCrypt-era disk encryption metadata, certain
+/// European e-government standards, and some content-addressed stores. For a modern 512-bit cryptographic hash
+/// without an interop constraint use SHA-512 or <see cref="Blake2b"/>; both are faster on contemporary hardware.
+/// </para>
 /// </remarks>
 /// <example>
 /// <code language="csharp">

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
@@ -40,7 +40,33 @@ namespace Bodu.Security.Cryptography;
 /// GF(2^128) multiplication uses the primitive polynomial x^128 + x^7 + x^2 + x + 1 with
 /// little-endian bit representation (byte 0, bit 0 = coefficient of x^0), identical to IEEE 1619.
 /// </para>
+/// <para>
+/// <strong>When to use XTS.</strong> The standard mode for sector-level disk encryption — used by
+/// BitLocker, FileVault, dm-crypt/LUKS, VeraCrypt, and the IEEE 1619 disk-encryption specification. XTS is
+/// designed specifically for the random-access, fixed-size-block setting where ciphertext expansion is
+/// impossible (the on-disk sector size cannot grow), which means it provides confidentiality but
+/// <em>no authentication</em>. Do not use XTS for protecting messages over untrusted channels — pick an
+/// AEAD mode (<see cref="GcmModeTransform"/>, <see cref="EaxModeTransform"/>) for that. For new disk
+/// encryption designs that can afford a per-sector tag, AEAD-based alternatives (Adiantum, AES-XTS-HMAC,
+/// or storage-specific AEAD modes) provide stronger guarantees.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // XTS uses two independent keys — Key1 for data, Key2 for the tweak. Never share keys.
+/// using IBlockCipher data  = new AesBlockCipher(key1);
+/// using IBlockCipher tweak = new AesBlockCipher(key2);
+/// byte[] sectorNumber = BitConverter.GetBytes((long)42); // little-endian sector number, padded to block size
+/// Array.Resize(ref sectorNumber, data.BlockSize);
+/// IBlockCipherModeTransform xts = new XtsModeTransform(data, tweak, sectorNumber);
+///
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = xts.Transform(plaintext, ciphertext, encrypt: true);
+/// </code>
+/// </example>
 public sealed class XtsModeTransform : IBlockCipherModeTransform
 {
     private readonly IBlockCipher _dataCipher;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
@@ -13,9 +13,28 @@ namespace Bodu.Security.Cryptography;
 /// Implements zero-byte padding, appending <c>0x00</c> bytes until the input aligns with the cipher block size.
 /// </summary>
 /// <remarks>
+/// <para>
 /// Zero padding is not self-describing and cannot be unambiguously removed when the plaintext itself may end in zero bytes. Use this
 /// strategy only when the original plaintext length is recorded out-of-band or the data is known never to contain trailing zeros.
+/// </para>
+/// <para>
+/// <strong>When to choose zero padding.</strong> Pick zero padding only when the surrounding format already
+/// records the plaintext length explicitly (e.g. a length-prefixed protocol frame or fixed-size record), or
+/// when the plaintext is text that cannot legitimately contain trailing <c>0x00</c> bytes. For ordinary
+/// length-recoverable padding pick <see cref="Pkcs7Padding"/>; for AEAD modes that handle alignment
+/// internally pick <see cref="NoPadding"/>.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+/// using Bodu.Security.Cryptography;
+///
+/// // Caller is responsible for tracking the original plaintext length —
+/// // Unpad here returns the padded buffer unchanged.
+/// IPaddingStrategy padding = new ZeroPadding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 16);
+/// </code>
+/// </example>
 public sealed class ZeroPadding : IPaddingStrategy
 {
     /// <inheritdoc />


### PR DESCRIPTION
**Recommendation: close without merge. Branch degrades current master.**

The 30 commits on `claude/improve-hashing-crypto-extension-docs` are valuable XML doc improvements across the cryptography surface, but the branch is based on a snapshot of master that pre-dates a substantial body of subsequent work. Merging it as-is would **revert** the following changes that have since landed via #200, #198, and #146:

### Specific regressions that would result from merging this branch

Inspecting `CcmModeTransform.cs` as a representative sample:

```diff
- public sealed class CcmModeTransform
-     : IAeadBlockCipherModeTransform
-     , IDisposable
+ public sealed class CcmModeTransform : IAeadBlockCipherModeTransform
```

The `IDisposable` interface (added in #200 via `claude/mode-transform-disposal`) would be removed.

```diff
-    private bool _completed;
-    private bool _disposed;
```

The single-use lifecycle bookkeeping fields (added in #200 via `claude/aead-tier3-single-use`) would be removed.

```diff
- /// <strong>Lifecycle.</strong> Each instance encrypts or decrypts exactly one message. A second call
- /// to <see cref="Encrypt" /> or <see cref="Decrypt" /> — including after a tag-mismatch failure —
- /// throws <see cref="InvalidOperationException" />. The supplied <see cref="IBlockCipher" /> is not
- /// disposed by this type; ownership remains with the caller. <see cref="Dispose" /> clears the
- /// retained nonce and cached associated-data state.
- /// </para>
- /// <para>
```

The Lifecycle xml-doc paragraph (added in #200 via `claude/aead-tier2-tests`) would be removed.

The same pattern repeats for `EaxModeTransform`, `OcbModeTransform`, `SivModeTransform`, `GcmSivModeTransform`, and likely others — every AEAD mode that #200 promoted to `IDisposable` plus single-use enforcement.

### Recommended path forward

The doc improvements themselves are good and should land — they need to be **redone on top of current master** so they don't clobber the lifecycle work. A future contributor should:

1. Start fresh from current master.
2. Cherry-pick or manually replay the 30 doc-improvement commits, accepting the source side of every conflict (so the lifecycle additions are preserved).
3. Open a new PR.

Closing this PR without merging.

https://claude.ai/code/session_01F2M2C7yQPj5AbZc3Yy5VLF

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2M2C7yQPj5AbZc3Yy5VLF)_