### PR TITLE
scope AEAD extension tests to extension-method behaviour only

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -5,7 +5,6 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Security.Cryptography;
-using Bodu.Extensions;
 
 namespace Bodu.Security.Cryptography.Extensions;
 
@@ -34,20 +33,11 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     private static byte[] NewIv() => new byte[16] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
                                                      0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19 };
 
-    // GCM's public byte[] constructor requires a 96-bit (12-byte) nonce per NIST SP 800-38D §5.2.1.1.
-    private static byte[] NewGcmNonce() => new byte[12] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
-                                                          0x12, 0x13, 0x14, 0x15 };
-
     /// <summary>
     /// Returns a fresh AEAD transform used purely to drive the extension wrappers. CCM is selected
     /// because its public constructor accepts a block-sized IV — no nonce-length special-casing —
     /// keeping the test focus on the wrapper, not the underlying mode.
     /// </summary>
-    [TestMethod]
-    public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
     private static IAeadBlockCipherModeTransform NewTransform() =>
         new CcmModeTransform(new AesBlockCipher(NewKey()), NewIv());
 
@@ -60,18 +50,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void EncryptWithAad_WhenTransformIsNull_ShouldThrowArgumentNullException()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext);
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag);
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
         Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             AeadBlockCipherModeTransformExtensions.Encrypt(null!, Plaintext, AssociatedData);
@@ -129,7 +107,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var transform = NewTransform();
         int expectedLength = Plaintext.Length + transform.TagSize;
 
-        byte[] result = transform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
+        byte[] result = transform.Encrypt(Plaintext, AssociatedData);
 
         Assert.AreEqual(expectedLength, result.Length,
             "Encrypt wrapper must return a buffer of length plaintext.Length + TagSize.");
@@ -143,10 +121,10 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_ShouldReturnArrayOfCiphertextLengthMinusTagSize()
     {
         using var encTransform = NewTransform();
-        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
+        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, AssociatedData);
 
         using var decTransform = NewTransform();
-        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, (ReadOnlySpan<byte>)AssociatedData);
+        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, AssociatedData);
 
         Assert.AreEqual(Plaintext.Length, recovered.Length,
             "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
@@ -161,21 +139,12 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        // Flip the last bit of the tag.
-        cipherWithTag[^1] ^= 0x01;
         using var transform = NewTransform();
         byte[] tooShort = new byte[transform.TagSize - 1];
 
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            transform.Decrypt(tooShort, (ReadOnlySpan<byte>)AssociatedData);
+            transform.Decrypt(tooShort, AssociatedData);
         });
     }
 
@@ -188,12 +157,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void Encrypt_NoAadOverload_ShouldEqualExplicitEmptyAad()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
         using var t1 = NewTransform();
         byte[] withoutAad = t1.Encrypt(Plaintext);
 
@@ -217,23 +180,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var decTransform = NewTransform();
         byte[] recovered = decTransform.Decrypt(ciphertextWithTag);
 
-    /// <summary>
-    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
-    /// throws <see cref="ArgumentException" /> when the ciphertext+tag input is shorter than the tag size.
-    /// </summary>
-    [TestMethod]
-    public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-        using var cipher = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher, iv);
-
-        byte[] tooShort = new byte[aead.TagSize - 1];
-        Assert.ThrowsExactly<ArgumentException>(() =>
-        {
-            aead.Decrypt(tooShort, AssociatedData);
-        });
         CollectionAssert.AreEqual(Plaintext, recovered,
             "Decrypt without AAD must recover plaintext encrypted with the matching no-AAD overload.");
     }


### PR DESCRIPTION
The previous AeadBlockCipherModeTransformExtensionsTests.cs tested mode-specific behaviour (per-mode round-trip, tag tampering, AAD tampering, input-length validation) by reaching through the extension overloads to the underlying IAeadBlockCipherModeTransform. After the AEAD test consolidation, every one of those concerns is now covered uniformly for all six mode implementations in
AeadBlockCipherModeTests<TTest, TTransform>.

Trim the file to the contract that AeadBlockCipherModeTransformExtensions itself adds on top of IAeadBlockCipherModeTransform:

- receiver-null guards on all four overloads,
- Encrypt allocates plaintext.Length + TagSize bytes,
- Decrypt allocates ciphertextWithTag.Length - TagSize bytes,
- the wrapper's eager input-length precondition for short ciphertext,
- equivalence of the no-AAD overloads to passing ReadOnlySpan<byte>.Empty.

Use CcmModeTransform with a 16-byte block-sized IV as the concrete backing transform purely for end-to-end exercise; the assertions are mode-agnostic. As a side effect this resolves the GcmModeTransform "nonce must be exactly 12 bytes" failures that surfaced once GCM constructor validation was tightened, since GCM is no longer instantiated from this file.