### PR TITLE
Add test tier infrastructure (Smoke/BVT/Regression/Stress)

### DIFF
--- a/Bodu.Core/test/Smoke/SmokeTests.cs
+++ b/Bodu.Core/test/Smoke/SmokeTests.cs
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SmokeTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Bodu.Collections.Generic;
+
+namespace Bodu.Smoke;
+
+/// <summary>
+/// Provides smoke-tier coverage for the primary public types in <c>Bodu.Core</c>. Each test exercises one
+/// happy-path entry point so that catastrophic breakage (constructor regression, null reference, bad
+/// dispatch) is caught by the smallest possible build run.
+/// </summary>
+[TestClass]
+public sealed class SmokeTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CircularBuffer{T}.Enqueue" /> and <see cref="CircularBuffer{T}.Dequeue" /> round-trip a
+    /// single value.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void CircularBuffer_EnqueueDequeue_ShouldRoundTripValue()
+    {
+        CircularBuffer<int> buffer = new(capacity: 4);
+        buffer.Enqueue(42);
+
+        int actual = buffer.Dequeue();
+
+        Assert.AreEqual(42, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Deque{T}.AddLast" /> followed by <see cref="Deque{T}.RemoveFirst" /> recovers the
+    /// inserted value.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Deque_AddLastRemoveFirst_ShouldRecoverValue()
+    {
+        Deque<string> deque = new(capacity: 4);
+        deque.AddLast("hello");
+
+        string actual = deque.RemoveFirst();
+
+        Assert.AreEqual("hello", actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="EvictingDictionary{TKey, TValue}" /> stores and retrieves a key-value pair under
+    /// the default LRU policy.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void EvictingDictionary_AddIndexer_ShouldRoundTripValue()
+    {
+        EvictingDictionary<string, int> dictionary = new(capacity: 4);
+        dictionary.Add("alpha", 1);
+
+        int actual = dictionary["alpha"];
+
+        Assert.AreEqual(1, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="EvictingDictionary{TKey, TValue}" /> evicts the least-recently-used entry once
+    /// capacity is exceeded.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void EvictingDictionary_AddBeyondCapacity_ShouldEvictOldestEntry()
+    {
+        EvictingDictionary<string, int> dictionary = new(capacity: 2);
+        dictionary.Add("a", 1);
+        dictionary.Add("b", 2);
+        dictionary.Add("c", 3);
+
+        Assert.AreEqual(2, dictionary.Count);
+        Assert.IsFalse(dictionary.ContainsKey("a"));
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithmTests.cs
@@ -479,6 +479,7 @@ public sealed class EasterSundayNotableDateAlgorithmTests
     /// Verifies that Easter Sunday is correctly calculated across a known set of years and calendars.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GetInvalidYearTestData), DynamicDataDisplayName = nameof(GetKnownEasterSundayTestDataDisplayName))]
     public void GetDate_WhenGivenKnownYears_ShouldReturnExpectedDate(EasterSundayKnownAnswer knownAnswer)
     {
@@ -696,6 +697,7 @@ public sealed class EasterSundayNotableDateAlgorithmTests
     /// <see href="https://github.com/bslater/bodu/issues/53" />.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GetBrokenOrthodoxTestData), DynamicDataDisplayName = nameof(GetKnownEasterSundayTestDataDisplayName))]
     public void GetDate_WhenGivenOrthodoxKnownYears_ShouldReturnExpectedDate(EasterSundayKnownAnswer knownAnswer)
     {

--- a/Bodu.Globalization.Calendar/test/Smoke/SmokeTests.cs
+++ b/Bodu.Globalization.Calendar/test/Smoke/SmokeTests.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SmokeTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Algorithms;
+
+namespace Bodu.Smoke;
+
+/// <summary>
+/// Provides smoke-tier coverage for the primary public types in <c>Bodu.Globalization.Calendar</c>. Each test
+/// exercises one happy-path entry point so that catastrophic breakage (rule-resolver dispatch fault, calendar
+/// computus regression, service construction error) is caught by the smallest possible build run.
+/// </summary>
+[TestClass]
+public sealed class SmokeTests
+{
+    /// <summary>
+    /// Verifies that <see cref="EasterSundayNotableDateAlgorithm.GetDate(int, System.Globalization.Calendar?)" />
+    /// resolves a known-correct Gregorian Easter Sunday date.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void EasterSundayAlgorithm_GetDate_ForKnownYear_ShouldReturnExpectedDate()
+    {
+        EasterSundayNotableDateAlgorithm algorithm = new();
+
+        DateTime? actual = algorithm.GetDate(2024, null);
+
+        Assert.IsNotNull(actual);
+        Assert.AreEqual(new DateTime(2024, 3, 31), actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService" /> can be constructed and that
+    /// <see cref="NotableDateService.IsWeekend" /> returns true for a Sunday under the default rule set.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void NotableDateService_IsWeekend_ForSunday_ShouldReturnTrue()
+    {
+        NotableDateService service = new();
+
+        bool actual = service.IsWeekend(new DateTime(2024, 6, 9));
+
+        Assert.IsTrue(actual);
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.Append.cs
@@ -17,6 +17,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName =nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -36,6 +37,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -56,6 +58,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check character the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.ComputeStatic.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.ComputeStatic.cs
@@ -17,6 +17,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The expected check character.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void ComputeStatic_WhenKnownAnswer_ShouldReturnExpectedCheckDigit(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.GetCurrentCheckDigit.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.GetCurrentCheckDigit.cs
@@ -32,6 +32,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The full body characters.</param>
     /// <param name="expectedCheck">The expected check character (unused).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void GetCurrentCheckDigit_AtEveryPrefixLength_ShouldAgreeWithStaticCompute(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.IsValid.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.IsValid.cs
@@ -17,6 +17,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The expected check character.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void IsValid_WhenSequenceIncludesComputedCheckDigit_ShouldReturnTrue(string name, string body, char expectedCheck)
     {
@@ -33,6 +34,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The correct check character.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void IsValid_WhenCheckDigitIsTampered_ShouldReturnFalse(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.Reset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithmTests.Reset.cs
@@ -34,6 +34,7 @@ public abstract partial class AlphanumericCheckDigitAlgorithmTests<TTest, TAlgor
     /// <param name="body">The body characters to append in the second run.</param>
     /// <param name="expectedCheck">The check character the algorithm is expected to emit for the second run.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Append.cs
@@ -16,6 +16,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits to append.</param>
     /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -35,6 +36,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits to append.</param>
     /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -54,6 +56,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits to append.</param>
     /// <param name="expectedCheck">The check digit the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -92,6 +95,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The full body digits.</param>
     /// <param name="expectedCheck">The expected check digit for the full body (unused in this test).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void GetCurrentCheckDigit_AtEveryPrefixLength_ShouldAgreeWithStaticCompute(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Compute.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Compute.cs
@@ -16,6 +16,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits.</param>
     /// <param name="expectedCheck">The expected check digit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData))]
     public void Compute_WhenKnownAnswer_ShouldReturnExpectedCheckDigit(string name, string body, char expectedCheck)
     {
@@ -31,6 +32,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits.</param>
     /// <param name="expectedCheck">The expected check digit (unused; cross-comparison is between Compute and Append).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData))]
     public void Compute_WhenInvokedForKnownAnswer_ShouldAgreeWithStreamingAppend(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
@@ -16,6 +16,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits.</param>
     /// <param name="expectedCheck">The expected check digit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData))]
     public void IsValid_WhenSequenceIncludesComputedCheckDigit_ShouldReturnTrue(string name, string body, char expectedCheck)
     {
@@ -32,6 +33,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits.</param>
     /// <param name="expectedCheck">The correct check digit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData))]
     public void IsValid_WhenCheckDigitIsTampered_ShouldReturnFalse(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Reset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.Reset.cs
@@ -32,6 +32,7 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     /// <param name="body">The body digits to append in the second run.</param>
     /// <param name="expectedCheck">The check digit the algorithm is expected to emit for the second run.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData))]
     public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, char expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Append.cs
@@ -31,6 +31,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedInFull_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
     {
@@ -50,6 +51,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsAppendedOneCharAtATime_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
     {
@@ -69,6 +71,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters to append.</param>
     /// <param name="expectedCheck">The check code the algorithm is expected to emit.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenKnownAnswerIsSplitAcrossTwoChunks_ShouldProduceExpectedCheckDigits(string name, string body, string expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Compute.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Compute.cs
@@ -16,6 +16,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The expected check code.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Compute_WhenKnownAnswer_ShouldReturnExpectedCheckDigits(string name, string body, string expectedCheck)
     {
@@ -31,6 +32,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The expected check code (unused; cross-comparison is between Compute and Append).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Compute_WhenInvokedForKnownAnswer_ShouldAgreeWithStreamingAppend(string name, string body, string expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.GetCurrentCheckDigits.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.GetCurrentCheckDigits.cs
@@ -50,6 +50,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters.</param>
     /// <param name="expectedCheck">The expected check code (unused in this cross-check).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void GetCurrentCheckDigits_SpanAndStringOverloads_ShouldAgree(string name, string body, string expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Reset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithmTests.Reset.cs
@@ -35,6 +35,7 @@ public abstract partial class MultiCharCheckDigitAlgorithmTests<TTest, TAlgorith
     /// <param name="body">The body characters to append in the second run.</param>
     /// <param name="expectedCheck">The check code the algorithm is expected to emit for the second run.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Reset_BetweenAppends_ShouldDiscardPriorState(string name, string body, string expectedCheck)
     {

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.Catalog.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.Catalog.cs
@@ -162,6 +162,7 @@ namespace Bodu.IO.Hashing.Checksums
         /// <param name="standardId">The catalogue entry under test, identified by <see cref="CrcStandards" />.</param>
         /// <param name="expectedCheck">The expected CRC value, packed little-endian from the CRC width.</param>
         [TestMethod]
+        [TestCategory("Regression")]
         [DynamicData(nameof(CatalogCheckVectors), DynamicDataDisplayName = nameof(GetCatalogCheckDisplayName))]
         public void ComputeHash_WhenInputIsCheckVector_ForCatalogStandard_ShouldMatchPublishedCheck(string displayName, CrcStandards standardId, ulong expectedCheck)
         {

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
@@ -82,6 +82,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="input">The input bytes being hashed.</param>
     /// <param name="expected">The expected hash digest.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerTestData), DynamicDataDisplayName = nameof(GetKnownAnswerTestName))]
     public void Append_WhenUsingNamedInput_ShouldProduceExpectedHash(TVariant variant, string testName, byte[] input, byte[] expected)
     {

--- a/Bodu.IO.Hashing/test/Smoke/SmokeTests.cs
+++ b/Bodu.IO.Hashing/test/Smoke/SmokeTests.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SmokeTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+using Bodu.IO.Hashing.Checksums;
+
+namespace Bodu.Smoke;
+
+/// <summary>
+/// Provides smoke-tier coverage for the primary public types in <c>Bodu.IO.Hashing</c>. Each test exercises one
+/// happy-path entry point so that catastrophic breakage (constructor regression, lookup-table dispatch fault,
+/// digest sizing error) is caught by the smallest possible build run.
+/// </summary>
+[TestClass]
+public sealed class SmokeTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHash(System.ReadOnlySpan{byte})" /> reproduces the published
+    /// CRC-32/ISO-HDLC check value for the reference input <c>"123456789"</c>.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Crc_ComputeHash_ForCrc32IsoHdlcReferenceInput_ShouldMatchPublishedCheck()
+    {
+        Crc crc = new(CrcStandard.Get(CrcStandards.CRC32_ISOHDLC));
+        byte[] digest = crc.ComputeHash(Encoding.ASCII.GetBytes("123456789"));
+
+        Assert.AreEqual(4, digest.Length);
+        uint actual = (uint)digest[0] | ((uint)digest[1] << 8) | ((uint)digest[2] << 16) | ((uint)digest[3] << 24);
+        Assert.AreEqual(0xCBF43926u, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fletcher16" /> produces a 2-byte digest from a non-empty input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Fletcher16_Append_ShouldProduceTwoByteDigest()
+    {
+        Fletcher16 fletcher = new();
+        fletcher.Append(Encoding.ASCII.GetBytes("abcde"));
+        byte[] digest = fletcher.GetCurrentHash();
+
+        Assert.AreEqual(2, digest.Length);
+        Assert.IsTrue(digest[0] != 0 || digest[1] != 0, "Non-empty input should produce a non-zero Fletcher-16 digest.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fletcher32" /> produces a 4-byte digest from a non-empty input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Fletcher32_Append_ShouldProduceFourByteDigest()
+    {
+        Fletcher32 fletcher = new();
+        fletcher.Append(Encoding.ASCII.GetBytes("abcdefgh"));
+        byte[] digest = fletcher.GetCurrentHash();
+
+        Assert.AreEqual(4, digest.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Adler32" /> produces a 4-byte digest from a non-empty input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Adler32_Append_ShouldProduceFourByteDigest()
+    {
+        Adler32 adler = new();
+        adler.Append(Encoding.ASCII.GetBytes("Wikipedia"));
+        byte[] digest = adler.GetCurrentHash();
+
+        Assert.AreEqual(4, digest.Length);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AeadBlockCipherModeTests.KnownAnswerTests.cs
@@ -19,6 +19,7 @@ public abstract partial class AeadBlockCipherModeTests<TTest, TTransform>
     /// primitive to confirm end-to-end correctness.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void EncryptThenDecrypt_WithRealAesCipher_RandomKey_ShouldRoundTrip()
     {
         byte[] key = new byte[16];

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconCxof128Tests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconCxof128Tests.KnownAnswerTests.cs
@@ -27,6 +27,7 @@ public partial class AsconCxof128Tests
     /// <param name="messageLength">Length of the sequential message.</param>
     /// <param name="outputLength">Requested output length in bytes.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0, 0,  32)]
     [DataRow(0, 1,  32)]
     [DataRow(1, 0,  32)]
@@ -62,6 +63,7 @@ public partial class AsconCxof128Tests
     /// <param name="customizationLength">Length of the sequential customisation string.</param>
     /// <param name="messageLength">Length of the sequential message.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0, 0)]
     [DataRow(0, 8)]
     [DataRow(8, 0)]
@@ -94,6 +96,7 @@ public partial class AsconCxof128Tests
     /// Verifies that incrementing the message length by one byte always changes the output.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0,  0,  1)]
     [DataRow(0,  7,  8)]
     [DataRow(0,  8,  9)]
@@ -132,6 +135,7 @@ public partial class AsconCxof128Tests
     /// <param name="outputLength">Requested output length in bytes.</param>
     /// <param name="expectedHex">Expected digest as an uppercase hex string.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0,  0,  32, "5F3BAD7F21E67C1A86D198604EFB594C096B80C43223679EDE3B16BD1BEE6BE5")]
     [DataRow(0,  1,  32, "410EF74BBF6E16EACAF8EA9E8691CB77E7D6CE449AD8D3DD489965254B5846BF")]
     [DataRow(1,  0,  32, "DD73FB03019376173D6B0DA8C86D3D1CE04607AE7738C99DFAE54710A9702A3D")]

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconXof128Tests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconXof128Tests.KnownAnswerTests.cs
@@ -25,6 +25,7 @@ public partial class AsconXof128Tests
     /// <param name="inputLength">Length of the sequential input message.</param>
     /// <param name="outputLength">Requested output length in bytes.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0,  32)]
     [DataRow(0,  64)]
     [DataRow(1,  32)]
@@ -52,6 +53,7 @@ public partial class AsconXof128Tests
     /// </summary>
     /// <param name="inputLength">Length of the sequential input message.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0)]
     [DataRow(1)]
     [DataRow(7)]
@@ -75,6 +77,7 @@ public partial class AsconXof128Tests
     /// input lengths — i.e., adding one byte to the message always changes the output.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0, 1)]
     [DataRow(1, 2)]
     [DataRow(7, 8)]
@@ -101,6 +104,7 @@ public partial class AsconXof128Tests
     /// <param name="outputLength">Requested output length in bytes.</param>
     /// <param name="expectedHex">Expected digest as an uppercase hex string.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DataRow(0,  32, "D2AE52E6FD7D4925B8A85DD1E3BAC87A5338708D13CE92F851868ED5782EF084")]
     [DataRow(1,  32, "ECF9BA491725E622581E6431AC0BAF832589273CE1E22010B96427BD574F5AAF")]
     [DataRow(7,  32, "00D1187AC3662C5A2EEE4D4EC4D1E66F8760A24FC5B9F3FFBC6A9FCAA12A6525")]

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTests.KnownAnswerTests.cs
@@ -19,6 +19,7 @@ public abstract partial class BlockCipherModeTests<TMode>
     /// primitive to confirm end-to-end correctness.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void Transform_WithRealAesCipher_RandomKey_ShouldRoundTrip()
     {
         byte[] key = new byte[16];

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTransformTests.KnownAnswers.cs
@@ -89,6 +89,7 @@ public abstract partial class BlockCipherTransformTests<TTest, TCryptoTransform>
     /// <param name="answer">The vector under test, or <see langword="null" /> when the subclass declares no
     /// Transform-layer KATs (in which case the test asserts <see cref="Assert.Inconclusive(string)" />).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerDisplayName))]
     public void TransformFinalBlock_WhenEncryptingKnownAnswer_ShouldProduceExpectedCiphertext(BlockCipherKnownAnswer? answer)
     {
@@ -117,6 +118,7 @@ public abstract partial class BlockCipherTransformTests<TTest, TCryptoTransform>
     /// <param name="answer">The vector under test, or <see langword="null" /> when the subclass declares no
     /// Transform-layer KATs (in which case the test asserts <see cref="Assert.Inconclusive(string)" />).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KnownAnswerData), DynamicDataDisplayName = nameof(GetKnownAnswerDisplayName))]
     public void TransformFinalBlock_WhenDecryptingKnownAnswer_ShouldRecoverExpectedPlaintext(BlockCipherKnownAnswer? answer)
     {

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CbcModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CbcModeTransformTests.KnownAnswerTests.cs
@@ -43,6 +43,7 @@ public sealed partial class CbcModeTransformTests
     /// Verifies that <see cref="CbcModeTransform.Transform" />, with NistVector, EncryptCorrectly.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CbcKatVectors))]
     public void Transform_WithNistVector_ShouldEncryptCorrectly(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)
@@ -52,6 +53,7 @@ public sealed partial class CbcModeTransformTests
     /// Verifies that <see cref="CbcModeTransform.Transform" />, with NistVector, DecryptToOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CbcKatVectors))]
     public void Transform_WithNistVector_ShouldDecryptToOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CcmModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CcmModeTransformTests.KnownAnswerTests.cs
@@ -86,6 +86,7 @@ public sealed partial class CcmModeTransformTests
     /// Verifies that <see cref="CcmModeTransform.Encrypt" />, EmptyPlaintextAndAad, TagShouldBe16Bytes, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void Encrypt_EmptyPlaintextAndAad_TagShouldBe16Bytes()
     {
         using var cipher = new AesBlockCipherFixture(new byte[16]);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CfbModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CfbModeTransformTests.KnownAnswerTests.cs
@@ -46,6 +46,7 @@ public sealed partial class CfbModeTransformTests
     /// Verifies that <see cref="CfbModeTransform.Transform" />, with NistVector, EncryptCorrectly.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CfbKatVectors))]
     public void Transform_WithNistVector_ShouldEncryptCorrectly(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)
@@ -55,6 +56,7 @@ public sealed partial class CfbModeTransformTests
     /// Verifies that <see cref="CfbModeTransform.Transform" />, with NistVector, DecryptToOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CfbKatVectors))]
     public void Transform_WithNistVector_ShouldDecryptToOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CtrModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CtrModeTransformTests.KnownAnswerTests.cs
@@ -64,6 +64,7 @@ public sealed partial class CtrModeTransformTests
     /// Verifies that <see cref="CtrModeTransform.Transform" />, with NistVector, EncryptCorrectly.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CtrKatVectors))]
     public void Transform_WithNistVector_ShouldEncryptCorrectly(
         string description, byte[] key, byte[] counter, byte[] plaintext, byte[] expectedCiphertext)
@@ -73,6 +74,7 @@ public sealed partial class CtrModeTransformTests
     /// Verifies that <see cref="CtrModeTransform.Transform" />, with NistVector, DecryptToOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(CtrKatVectors))]
     public void Transform_WithNistVector_ShouldDecryptToOriginalPlaintext(
         string description, byte[] key, byte[] counter, byte[] plaintext, byte[] expectedCiphertext)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CtsModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CtsModeTransformTests.KnownAnswerTests.cs
@@ -24,6 +24,7 @@ public sealed partial class CtsModeTransformTests
     /// exercises the ciphertext-stealing branch of the implementation.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void Transform_WithRealAesCipher_NonAlignedInput_ShouldRoundTrip()
     {
         byte[] key = new byte[16];

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/EaxModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/EaxModeTransformTests.KnownAnswerTests.cs
@@ -137,6 +137,7 @@ public sealed partial class EaxModeTransformTests
     }
 
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(EaxKatVectors), DynamicDataSourceType.Method)]
     public void Encrypt_WithEaxPaperVector_ShouldProduceExpectedCiphertextAndTag(
         string description, byte[] key, byte[] iv, byte[] aad,
@@ -144,6 +145,7 @@ public sealed partial class EaxModeTransformTests
         => AssertKatEncrypt(description, key, iv, aad, plaintext, expectedCiphertext, expectedTag);
 
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(EaxKatVectors), DynamicDataSourceType.Method)]
     public void Decrypt_WithEaxPaperVector_ShouldRecoverOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] aad,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/EcbModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/EcbModeTransformTests.KnownAnswerTests.cs
@@ -48,6 +48,7 @@ public sealed partial class EcbModeTransformTests
     /// Verifies that <see cref="EcbModeTransform.Transform" />, with NistVector, EncryptCorrectly.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(EcbKatVectors))]
     public void Transform_WithNistVector_ShouldEncryptCorrectly(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)
@@ -57,6 +58,7 @@ public sealed partial class EcbModeTransformTests
     /// Verifies that <see cref="EcbModeTransform.Transform" />, with NistVector, DecryptToOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(EcbKatVectors))]
     public void Transform_WithNistVector_ShouldDecryptToOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/GcmModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/GcmModeTransformTests.KnownAnswerTests.cs
@@ -67,6 +67,7 @@ public sealed partial class GcmModeTransformTests
     /// Verifies that <see cref="GcmModeTransform.Encrypt" />, with NistVector, ProduceExpectedCiphertextAndTag.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GcmKatVectors), DynamicDataDisplayName = nameof(GcmKatVectordisplayname))]
     public void Encrypt_WithNistVector_ShouldProduceExpectedCiphertextAndTag(
         string description, byte[] key, byte[] iv, byte[] aad,
@@ -77,6 +78,7 @@ public sealed partial class GcmModeTransformTests
     /// Verifies that <see cref="GcmModeTransform.Decrypt" />, with NistVector, RecoverOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GcmKatVectors))]
     public void Decrypt_WithNistVector_ShouldRecoverOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] aad,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/GcmSivModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/GcmSivModeTransformTests.KnownAnswerTests.cs
@@ -63,6 +63,7 @@ public sealed partial class GcmSivModeTransformTests
     /// Verifies that <see cref="GcmSivModeTransform.Encrypt" />, with Rfc8452 Vector, matches Expected.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GcmSivRfc8452Vectors))]
     public void Encrypt_WithRfc8452Vector_ShouldMatchExpected(
         string keyHex, string nonceHex, string aadHex, string ptHex, string expectedOutputHex)
@@ -82,6 +83,7 @@ public sealed partial class GcmSivModeTransformTests
     /// Verifies that <see cref="GcmSivModeTransform.Decrypt" />, with Rfc8452Vector, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(GcmSivRfc8452Vectors))]
     public void Decrypt_WithRfc8452Vector_ShouldRecoverPlaintext(
         string keyHex, string nonceHex, string aadHex, string ptHex, string expectedOutputHex)
@@ -105,6 +107,7 @@ public sealed partial class GcmSivModeTransformTests
     /// Verifies that <see cref="GcmSivModeTransform.Decrypt" />, when TagIsCorrupted, throws <see cref="CryptographicException" />.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void Decrypt_WhenTagIsCorrupted_ShouldThrowCryptographicException()
     {
         byte[] masterKey = new byte[16];
@@ -129,6 +132,7 @@ public sealed partial class GcmSivModeTransformTests
     /// Verifies that <see cref="GcmSivModeTransform.EncryptThenDecrypt" />, with RandomKey, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void EncryptThenDecrypt_WithRandomKey_ShouldRoundTrip()
     {
         var rng = RandomNumberGenerator.Create();

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/OcbModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/OcbModeTransformTests.KnownAnswerTests.cs
@@ -212,6 +212,7 @@ public sealed partial class OcbModeTransformTests
     /// by RFC 7253 §2.4 when TAGLEN is not a multiple of 128 bits.
     /// </remarks>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(OcbKatData), DynamicDataDisplayName = nameof(GetKatDisplayName))]
     public void Encrypt_WithRfc7253Vector_ShouldMatchExpected(
         string keyHex, string ivHex, string aadHex, string ptHex,
@@ -246,6 +247,7 @@ public sealed partial class OcbModeTransformTests
     /// hex string, guarding against any accidental size mismatch in the test data.
     /// </remarks>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(OcbKatData), DynamicDataDisplayName = nameof(GetKatDisplayName))]
     public void Decrypt_WithRfc7253Vector_ShouldRecoverPlaintext(
         string keyHex, string ivHex, string aadHex, string ptHex,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/OfbModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/OfbModeTransformTests.KnownAnswerTests.cs
@@ -47,6 +47,7 @@ public sealed partial class OfbModeTransformTests
     /// Verifies that <see cref="OfbModeTransform.Transform" />, with NistVector, EncryptCorrectly.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(OfbKatVectors))]
     public void Transform_WithNistVector_ShouldEncryptCorrectly(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)
@@ -56,6 +57,7 @@ public sealed partial class OfbModeTransformTests
     /// Verifies that <see cref="OfbModeTransform.Transform" />, with NistVector, DecryptToOriginalPlaintext.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(OfbKatVectors))]
     public void Transform_WithNistVector_ShouldDecryptToOriginalPlaintext(
         string description, byte[] key, byte[] iv, byte[] plaintext, byte[] expectedCiphertext)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SivModeTransformTests.KnownAnswerTests.cs
@@ -48,6 +48,7 @@ public sealed partial class SivModeTransformTests
     /// Verifies that <see cref="SivModeTransform.Encrypt" />, with Rfc5297 A1 Vector, matches Expected.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(SivKatA1))]
     public void Encrypt_WithRfc5297A1Vector_ShouldMatchExpected(
         string k1Hex, string k2Hex, string adHex, string ptHex, string expectedOutputHex)
@@ -71,6 +72,7 @@ public sealed partial class SivModeTransformTests
     /// Verifies that <see cref="SivModeTransform.Decrypt" />, with Rfc5297A1Vector, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(SivKatA1))]
     public void Decrypt_WithRfc5297A1Vector_ShouldRecoverPlaintext(
         string k1Hex, string k2Hex, string adHex, string ptHex, string expectedOutputHex)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein1024Tests.KnownAnswers.cs
@@ -12,6 +12,7 @@ public partial class Skein1024Tests
     /// Verifies that <see cref="Skein1024.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void AlgorithmName_WhenConfiguredWithOutputSize_ShouldReturnFormattedName()
     {
         using var skein = new Skein1024(512);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein256Tests.KnownAnswers.cs
@@ -12,6 +12,7 @@ public partial class Skein256Tests
     /// Verifies that <see cref="Skein256.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void AlgorithmName_WhenConfiguredWithOutputSize_ShouldReturnFormattedName()
     {
         using var skein = new Skein256(224);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Skein512Tests.KnownAnswers.cs
@@ -12,6 +12,7 @@ public partial class Skein512Tests
     /// Verifies that <see cref="Skein512.AlgorithmName" /> formats the state size and the configured output size.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     public void AlgorithmName_WhenConfiguredWithOutputSize_ShouldReturnFormattedName()
     {
         using var skein = new Skein512(384);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.KnownAnswers.cs
@@ -59,6 +59,7 @@ public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
     /// <param name="input">The message bytes to hash.</param>
     /// <param name="expected">The expected digest bytes.</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(KeyedKnownAnswerTestData))]
     public void ComputeHash_WhenUsingKeyedKnownAnswer_ShouldMatchExpected(
         TVariant variant,

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.KnownAnswers.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SymmetricAlgorithmTests.KnownAnswers.cs
@@ -88,6 +88,7 @@ public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
     /// <param name="answer">The vector under test, or <see langword="null" /> when the subclass declares no
     /// Algorithm-layer KATs (in which case the test asserts <see cref="Assert.Inconclusive(string)" />).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(AlgorithmKnownAnswerData), DynamicDataDisplayName = nameof(GetAlgorithmKnownAnswerDisplayName))]
     public void CreateEncryptor_WhenUsingKnownAnswer_ShouldProduceExpectedCiphertext(BlockCipherKnownAnswer? answer)
     {
@@ -117,6 +118,7 @@ public abstract partial class SymmetricAlgorithmTests<TTest, TAlgorithm>
     /// <param name="answer">The vector under test, or <see langword="null" /> when the subclass declares no
     /// Algorithm-layer KATs (in which case the test asserts <see cref="Assert.Inconclusive(string)" />).</param>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(AlgorithmKnownAnswerData), DynamicDataDisplayName = nameof(GetAlgorithmKnownAnswerDisplayName))]
     public void CreateDecryptor_WhenUsingKnownAnswer_ShouldRecoverExpectedPlaintext(BlockCipherKnownAnswer? answer)
     {

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/XtsModeTransformTests.KnownAnswerTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/XtsModeTransformTests.KnownAnswerTests.cs
@@ -61,6 +61,7 @@ public sealed partial class XtsModeTransformTests
     /// Verifies that <see cref="XtsModeTransform.Transform" />, with Ieee1619Vector, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(XtsKatVectors))]
     public void Transform_WithIeee1619Vector_ShouldEncryptCorrectly(
         string key1Hex, string key2Hex, string tweakHex, string ptHex, string expectedCtHex)
@@ -83,6 +84,7 @@ public sealed partial class XtsModeTransformTests
     /// Verifies that <see cref="XtsModeTransform.Transform" />, with Ieee1619Vector, returns the expected value.
     /// </summary>
     [TestMethod]
+    [TestCategory("Regression")]
     [DynamicData(nameof(XtsKatVectors))]
     public void Transform_WithIeee1619Vector_ShouldDecryptToOriginalPlaintext(
         string key1Hex, string key2Hex, string tweakHex, string ptHex, string expectedCtHex)

--- a/Bodu.Security.Cryptography/test/Smoke/SmokeTests.cs
+++ b/Bodu.Security.Cryptography/test/Smoke/SmokeTests.cs
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SmokeTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Bodu.Smoke;
+
+/// <summary>
+/// Provides smoke-tier coverage for the primary public types in <c>Bodu.Security.Cryptography</c>. Each test
+/// exercises one happy-path entry point so that catastrophic breakage (key-schedule corruption, block-mode
+/// dispatch fault, digest length error) is caught by the smallest possible build run.
+/// </summary>
+[TestClass]
+public sealed class SmokeTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Bodu.Security.Cryptography.Threefish256" /> performs a successful
+    /// encrypt / decrypt round-trip in CBC mode under a freshly generated key and IV.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Threefish256_EncryptDecryptRoundTrip_ShouldRecoverPlaintext()
+    {
+        using Bodu.Security.Cryptography.Threefish256 algorithm = Bodu.Security.Cryptography.Threefish256.Create();
+        algorithm.Mode = CipherMode.CBC;
+        algorithm.Padding = PaddingMode.PKCS7;
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+        algorithm.GenerateTweak();
+
+        byte[] plaintext = Encoding.UTF8.GetBytes("Smoke test for Threefish-256 in CBC + PKCS7.");
+
+        byte[] ciphertext;
+        using (ICryptoTransform encryptor = algorithm.CreateEncryptor())
+            ciphertext = encryptor.TransformFinalBlock(plaintext, 0, plaintext.Length);
+
+        byte[] roundTrip;
+        using (ICryptoTransform decryptor = algorithm.CreateDecryptor())
+            roundTrip = decryptor.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+
+        CollectionAssert.AreEqual(plaintext, roundTrip);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Bodu.Security.Cryptography.Skipjack" /> performs a successful
+    /// encrypt / decrypt round-trip in ECB mode with PKCS7 padding under a freshly generated key.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Skipjack_EncryptDecryptRoundTrip_ShouldRecoverPlaintext()
+    {
+        using Bodu.Security.Cryptography.Skipjack algorithm = new();
+        algorithm.Mode = CipherMode.ECB;
+        algorithm.Padding = PaddingMode.PKCS7;
+        algorithm.GenerateKey();
+        algorithm.GenerateIV();
+
+        byte[] plaintext = Encoding.UTF8.GetBytes("Skipjack smoke.");
+
+        byte[] ciphertext;
+        using (ICryptoTransform encryptor = algorithm.CreateEncryptor())
+            ciphertext = encryptor.TransformFinalBlock(plaintext, 0, plaintext.Length);
+
+        byte[] roundTrip;
+        using (ICryptoTransform decryptor = algorithm.CreateDecryptor())
+            roundTrip = decryptor.TransformFinalBlock(ciphertext, 0, ciphertext.Length);
+
+        CollectionAssert.AreEqual(plaintext, roundTrip);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Bodu.Security.Cryptography.Tiger" /> produces a 192-bit (24-byte) digest from
+    /// a non-empty input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Tiger_ComputeHash_ShouldProduce192BitDigest()
+    {
+        using Bodu.Security.Cryptography.Tiger tiger = new();
+        byte[] digest = tiger.ComputeHash(Encoding.ASCII.GetBytes("smoke"));
+
+        Assert.AreEqual(24, digest.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Bodu.Security.Cryptography.SipHash64" /> produces an 8-byte digest from a
+    /// non-empty input under a freshly generated key.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void SipHash64_ComputeHash_ShouldProduceEightByteDigest()
+    {
+        byte[] key = new byte[16];
+        for (int i = 0; i < key.Length; i++) key[i] = (byte)i;
+
+        using Bodu.Security.Cryptography.SipHash64 hash = new() { Key = key };
+        byte[] digest = hash.ComputeHash(Encoding.ASCII.GetBytes("smoke"));
+
+        Assert.AreEqual(8, digest.Length);
+    }
+}

--- a/Bodu.Test/src/Test/TestCategories.cs
+++ b/Bodu.Test/src/Test/TestCategories.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="TestCategories.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Test;
+
+/// <summary>
+/// Provides the standard <c>TestCategory</c> constants used to partition the test suite into tiered runs (smoke,
+/// BVT, regression, stress) so that build pipelines can execute a fast subset on every commit and the full set on
+/// demand.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The tiers form an inclusive hierarchy:
+/// </para>
+/// <list type="bullet">
+///   <item>
+///     <description>
+///       <see cref="Smoke" /> — the smallest possible run that exercises one primary happy-path on each public
+///       type. It is intended to detect catastrophic breakage and is run by <c>smoke.runsettings</c>.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <see cref="Regression" /> — tests omitted from the default build run because they are exhaustive,
+///       parametrised over published vectors, or otherwise duplicate coverage already provided by structural
+///       tests. The default <c>bvt.runsettings</c> filters these out; <c>regression.runsettings</c> includes
+///       everything.
+///     </description>
+///   </item>
+///   <item>
+///     <description>
+///       <see cref="Stress" /> — long-running, high-iteration tests (existing convention). Excluded from BVT;
+///       included in regression runs.
+///     </description>
+///   </item>
+/// </list>
+/// <para>
+/// A test method that carries no category attribute is treated as part of the BVT tier — the default build run
+/// executes every uncategorised test plus everything in <see cref="Smoke" />.
+/// </para>
+/// </remarks>
+public static class TestCategories
+{
+    /// <summary>
+    /// Identifies the smallest "did anything obviously break" run. Apply to one happy-path test per primary
+    /// production type so the smoke suite covers every key entry point.
+    /// </summary>
+    public const string Smoke = "Smoke";
+
+    /// <summary>
+    /// Identifies tests that are excluded from the default build/BVT run because they are exhaustive (full
+    /// known-answer vectors, full algorithm catalogues, large parameter sweeps, multi-decade calendar tables).
+    /// They run in the full regression suite.
+    /// </summary>
+    public const string Regression = "Regression";
+
+    /// <summary>
+    /// Identifies long-running stress tests that hammer a type with many iterations or large workloads. Excluded
+    /// from BVT; included in regression runs.
+    /// </summary>
+    public const string Stress = "Stress";
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,13 @@ Nullable reference types are enabled everywhere. `ImplicitUsings` is enabled for
 
 ```bash
 dotnet build Bodu.sln
-dotnet test  Bodu.sln --settings test.runsettings
-dotnet test  Bodu.Core/test/Bodu.Core.UnitTests.csproj --settings test.runsettings
+dotnet test  Bodu.sln --settings bvt.runsettings              # default build run (BVT)
+dotnet test  Bodu.sln --settings smoke.runsettings            # smoke only
+dotnet test  Bodu.sln --settings regression.runsettings       # full regression
+dotnet test  Bodu.Core/test/Bodu.Core.Test.csproj --settings bvt.runsettings
 ```
+
+See **Test Tiers** below for the category convention each runsettings file applies.
 
 `test.runsettings` enables parallel execution (`MaxCpuCount=0`) and disables AppDomains.
 
@@ -61,6 +65,33 @@ dotnet test  Bodu.Core/test/Bodu.Core.UnitTests.csproj --settings test.runsettin
 - Framework: **MSTest** (`Microsoft.VisualStudio.TestTools.UnitTesting`, `[TestClass]` / `[TestMethod]`). Do **not** introduce xUnit or NUnit.
 - Tests live in `<Project>/test/` and are organised as **partial classes** that mirror the source layout — e.g. `CircularBuffer.cs` → `CircularBufferTests.Enqueue.cs`, `CircularBufferTests.Dequeue.cs`. Extend the existing partial class when adding tests for an existing type.
 - No shared test base classes; each test is self-contained.
+
+### Test Tiers (Smoke / BVT / Regression / Stress)
+
+The suite is partitioned into tiers via `[TestCategory(...)]` so the build can run a fast subset by default and the exhaustive set on demand. Tier names are also exposed as constants on `Bodu.Test.TestCategories` for projects that reference `Bodu.Test`; either the constant or the literal string works.
+
+| Tier | Tag | Purpose |
+|---|---|---|
+| **Smoke** | `[TestCategory("Smoke")]` | One happy-path test per primary public type. Catches catastrophic breakage. |
+| **BVT** *(default)* | *(no category)* | Structural, exception, property, and contract tests. |
+| **Regression** | `[TestCategory("Regression")]` | Exhaustive vector tables, full algorithm catalogues, large parameter sweeps, multi-decade calendar tables. Excluded from BVT. |
+| **Stress** | `[TestCategory("Stress")]` | Long-running, high-iteration loops. Excluded from BVT. |
+
+Run-settings files at the repository root drive each tier:
+
+```bash
+dotnet test Bodu.sln --settings smoke.runsettings        # Smoke only
+dotnet test Bodu.sln --settings bvt.runsettings          # BVT (default build run)
+dotnet test Bodu.sln --settings regression.runsettings   # Everything
+dotnet test Bodu.sln --settings test.runsettings         # Everything (legacy alias)
+```
+
+Conventions:
+
+- Default a new test to **BVT** by leaving `TestCategory` unset.
+- Mark a test **Regression** when it is data-driven over a published vector table, an exhaustive catalogue, or a wide parameter sweep that duplicates structural coverage.
+- Mark a test **Smoke** sparingly — one per primary type, exercising the most important public method on a happy-path input.
+- Pre-existing `[TestCategory("Stress")]` tags retain their semantics.
 
 ### Test Method Naming
 

--- a/bvt.runsettings
+++ b/bvt.runsettings
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Use all available logical processors -->
+    <MaxCpuCount>0</MaxCpuCount>
+
+    <!-- Optional: Disable app domain creation to improve test performance -->
+    <DisableAppDomain>true</DisableAppDomain>
+
+    <!-- Kill the test session if it runs longer than 10 minutes per assembly -->
+    <TestSessionTimeout>600000</TestSessionTimeout>
+
+    <!--
+      Build verification (BVT): runs every test that is NOT tagged Regression or Stress. This is the default
+      build/CI run: structural, exception, property, and contract tests stay in; exhaustive known-answer
+      catalogues, multi-decade calendar tables, large parameter sweeps, and long stress loops stay out.
+      Pass this file via the dotnet test settings switch, e.g. /p:RunSettingsFilePath=bvt.runsettings.
+    -->
+    <TestCaseFilter>TestCategory!=Regression&amp;TestCategory!=Stress</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>

--- a/regression.runsettings
+++ b/regression.runsettings
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Use all available logical processors -->
+    <MaxCpuCount>0</MaxCpuCount>
+
+    <!-- Optional: Disable app domain creation to improve test performance -->
+    <DisableAppDomain>true</DisableAppDomain>
+
+    <!-- Kill the test session if it runs longer than 10 minutes per assembly -->
+    <TestSessionTimeout>600000</TestSessionTimeout>
+
+    <!--
+      Full regression: runs every test in the suite, including Smoke, BVT, Regression, and Stress tiers. This
+      is the comprehensive run executed before a release or on-demand.
+      Pass this file via the dotnet test settings switch, e.g. /p:RunSettingsFilePath=regression.runsettings.
+    -->
+  </RunConfiguration>
+</RunSettings>

--- a/smoke.runsettings
+++ b/smoke.runsettings
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!-- Use all available logical processors -->
+    <MaxCpuCount>0</MaxCpuCount>
+
+    <!-- Optional: Disable app domain creation to improve test performance -->
+    <DisableAppDomain>true</DisableAppDomain>
+
+    <!-- Kill the test session if it runs longer than 10 minutes per assembly -->
+    <TestSessionTimeout>600000</TestSessionTimeout>
+
+    <!--
+      Smoke run: only the tiny subset tagged [TestCategory("Smoke")]. Smoke covers one happy-path test per
+      primary public type so a CI gate can detect catastrophic breakage in seconds.
+      Pass this file via the dotnet test settings switch, e.g. /p:RunSettingsFilePath=smoke.runsettings.
+    -->
+    <TestCaseFilter>TestCategory=Smoke</TestCaseFilter>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
## Summary

Introduces a tiered test categorization system to partition the test suite into fast smoke runs, default BVT builds, and exhaustive regression suites. This enables CI pipelines to run a minimal "did anything obviously break" check on every commit while deferring expensive exhaustive tests to on-demand runs.

## Key Changes

- **New `TestCategories` utility class** (`Bodu.Test/src/Test/TestCategories.cs`)
  - Exposes `Smoke`, `Regression`, and `Stress` constants for test categorization
  - Provides documentation on the tier hierarchy and usage conventions

- **Run-settings files for tier filtering**
  - `smoke.runsettings` — executes only `[TestCategory("Smoke")]` tests
  - `bvt.runsettings` — executes BVT (default) and Smoke; excludes Regression and Stress
  - `regression.runsettings` — executes all tests (no filter)
  - Updated `CLAUDE.md` with tier documentation and example commands

- **Smoke test suites added across all major projects**
  - `Bodu.Core/test/Smoke/SmokeTests.cs` — one happy-path test per primary collection type
  - `Bodu.Security.Cryptography/test/Smoke/SmokeTests.cs` — cipher and hash algorithm round-trips
  - `Bodu.IO.Hashing/test/Smoke/SmokeTests.cs` — checksum and digest algorithms
  - `Bodu.Globalization.Calendar/test/Smoke/SmokeTests.cs` — Easter algorithm and notable date service

- **Regression categorization applied to existing tests**
  - Known-answer vector tests across cryptography, hashing, and calendar modules tagged `[TestCategory("Regression")]`
  - Ensures exhaustive test suites (RFC vectors, CRC catalogues, multi-decade tables) run only in full regression mode

## Implementation Details

- Smoke tests exercise one primary happy-path per public type to catch catastrophic breakage (constructor failures, null references, dispatch faults, digest sizing errors)
- BVT (default) includes structural, exception, property, and contract tests — any test without a category attribute
- Regression tier captures data-driven tests over published vectors and exhaustive parameter sweeps
- Stress tier (convention) reserved for long-running, high-iteration tests
- All run-settings files use parallel execution (`MaxCpuCount=0`) and disable AppDomains for performance

https://claude.ai/code/session_01TxyXeFwbf6kRnQpaKpgXKm