### PR TITLE
Clean up test file: remove incomplete/duplicate test code

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -33,20 +33,11 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     private static byte[] NewIv() => new byte[16] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
                                                      0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19 };
 
-    // GCM's public byte[] constructor requires a 96-bit (12-byte) nonce per NIST SP 800-38D §5.2.1.1.
-    private static byte[] NewGcmNonce() => new byte[12] { 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11,
-                                                          0x12, 0x13, 0x14, 0x15 };
-
     /// <summary>
     /// Returns a fresh AEAD transform used purely to drive the extension wrappers. CCM is selected
     /// because its public constructor accepts a block-sized IV — no nonce-length special-casing —
     /// keeping the test focus on the wrapper, not the underlying mode.
     /// </summary>
-    [TestMethod]
-    public void Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
     private static IAeadBlockCipherModeTransform NewTransform() =>
         new CcmModeTransform(new AesBlockCipher(NewKey()), NewIv());
 
@@ -59,18 +50,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void EncryptWithAad_WhenTransformIsNull_ShouldThrowArgumentNullException()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext);
-
-        byte[] recovered;
-        using (var cipher = new AesBlockCipher(key))
-            recovered = new GcmModeTransform(cipher, iv).Decrypt(cipherWithTag);
-
-        CollectionAssert.AreEqual(Plaintext, recovered);
         Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             AeadBlockCipherModeTransformExtensions.Encrypt(null!, Plaintext, AssociatedData);
@@ -129,7 +108,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         int expectedLength = Plaintext.Length + transform.TagSize;
 
         byte[] result = transform.Encrypt(Plaintext, AssociatedData);
-        byte[] result = transform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
 
         Assert.AreEqual(expectedLength, result.Length,
             "Encrypt wrapper must return a buffer of length plaintext.Length + TagSize.");
@@ -151,14 +129,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         Assert.AreEqual(Plaintext.Length, recovered.Length,
             "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
     }
-        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
-
-        using var decTransform = NewTransform();
-        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, (ReadOnlySpan<byte>)AssociatedData);
-
-    //    Assert.AreEqual(Plaintext.Length, recovered.Length,
-    //        "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
-    //}
 
     // ── Eager input-length validation ─────────────────────────────────────────────────────────
 
@@ -169,21 +139,12 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
-
-        // Flip the last bit of the tag.
-        cipherWithTag[^1] ^= 0x01;
         using var transform = NewTransform();
         byte[] tooShort = new byte[transform.TagSize - 1];
 
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            transform.Decrypt(tooShort, (ReadOnlySpan<byte>)AssociatedData);
+            transform.Decrypt(tooShort, AssociatedData);
         });
     }
 
@@ -196,12 +157,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     [TestMethod]
     public void Encrypt_NoAadOverload_ShouldEqualExplicitEmptyAad()
     {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-
-        byte[] cipherWithTag;
-        using (var cipher = new AesBlockCipher(key))
-            cipherWithTag = new GcmModeTransform(cipher, iv).Encrypt(Plaintext, AssociatedData.AsSpan().AsReadOnly());
         using var t1 = NewTransform();
         byte[] withoutAad = t1.Encrypt(Plaintext);
 
@@ -225,23 +180,6 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var decTransform = NewTransform();
         byte[] recovered = decTransform.Decrypt(ciphertextWithTag);
 
-    /// <summary>
-    /// Verifies that <see cref="AeadBlockCipherModeTransformExtensions.Decrypt(IAeadBlockCipherModeTransform, ReadOnlySpan{byte}, ReadOnlySpan{byte})" />
-    /// throws <see cref="ArgumentException" /> when the ciphertext+tag input is shorter than the tag size.
-    /// </summary>
-    [TestMethod]
-    public void Decrypt_WhenInputShorterThanTag_ShouldThrowArgumentException()
-    {
-        byte[] key = NewKey();
-        byte[] iv = NewGcmNonce();
-        using var cipher = new AesBlockCipher(key);
-        var aead = new GcmModeTransform(cipher, iv);
-
-        byte[] tooShort = new byte[aead.TagSize - 1];
-        Assert.ThrowsExactly<ArgumentException>(() =>
-        {
-            aead.Decrypt(tooShort, AssociatedData);
-        });
         CollectionAssert.AreEqual(Plaintext, recovered,
             "Decrypt without AAD must recover plaintext encrypted with the matching no-AAD overload.");
     }


### PR DESCRIPTION
## Summary
This PR removes incomplete, duplicate, and malformed test code from the `AeadBlockCipherModeTransformExtensionsTests` class. The changes focus on cleaning up the test file by eliminating code fragments that were left in an inconsistent state.

## Key Changes
- Removed the `NewGcmNonce()` helper method that was no longer being used
- Removed an incomplete `Gcm_RoundTrip_WithAssociatedData_ShouldRecoverPlaintext()` test method that was partially deleted
- Removed duplicate test logic and incomplete code fragments scattered throughout the file
- Removed redundant variable assignments and test setup code (e.g., duplicate `byte[] result` assignments)
- Cleaned up malformed test methods with incomplete implementations and commented-out assertions
- Removed GCM-specific test code that was inconsistent with the test class's focus on CCM mode transforms

## Notable Details
The test file had several instances of incomplete refactoring where code was partially removed or left in an inconsistent state. This cleanup ensures all test methods are complete and properly structured, improving code maintainability and test clarity.

https://claude.ai/code/session_016Yv2ZCQY6ou7iSjfJmdrPM