### PR TITLE
Disambiguate AEAD wrapper calls from instance Encrypt/Decrypt

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensionsTests.cs
@@ -107,7 +107,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
         using var transform = NewTransform();
         int expectedLength = Plaintext.Length + transform.TagSize;
 
-        byte[] result = transform.Encrypt(Plaintext, AssociatedData);
+        byte[] result = transform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
 
         Assert.AreEqual(expectedLength, result.Length,
             "Encrypt wrapper must return a buffer of length plaintext.Length + TagSize.");
@@ -121,10 +121,10 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
     public void Decrypt_ShouldReturnArrayOfCiphertextLengthMinusTagSize()
     {
         using var encTransform = NewTransform();
-        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, AssociatedData);
+        byte[] ciphertextWithTag = encTransform.Encrypt(Plaintext, (ReadOnlySpan<byte>)AssociatedData);
 
         using var decTransform = NewTransform();
-        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, AssociatedData);
+        byte[] recovered = decTransform.Decrypt(ciphertextWithTag, (ReadOnlySpan<byte>)AssociatedData);
 
         Assert.AreEqual(Plaintext.Length, recovered.Length,
             "Decrypt wrapper must return a buffer of length ciphertextWithTag.Length - TagSize.");
@@ -144,7 +144,7 @@ public sealed class AeadBlockCipherModeTransformExtensionsTests
 
         Assert.ThrowsExactly<ArgumentException>(() =>
         {
-            transform.Decrypt(tooShort, AssociatedData);
+            transform.Decrypt(tooShort, (ReadOnlySpan<byte>)AssociatedData);
         });
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #240. After the trimmed test file landed, three CS0029 errors appeared at the two-arg `transform.Encrypt(Plaintext, AssociatedData)` / `transform.Decrypt(ciphertextWithTag, AssociatedData)` call sites:

```
error CS0029: Cannot implicitly convert type 'int' to 'byte[]'
```

`IAeadBlockCipherModeTransform` defines `int Encrypt(ReadOnlySpan<byte>, Span<byte>)` and `int Decrypt(ReadOnlySpan<byte>, Span<byte>)`; the static extension defines `byte[] Encrypt/Decrypt(this …, ReadOnlySpan<byte>, ReadOnlySpan<byte>)`. With two `byte[]` arguments both signatures fit (`byte[]` converts to both `Span<byte>` and `ReadOnlySpan<byte>`), and C# prefers instance methods over extensions — so the call binds to the `int`-returning instance method.

Cast the AAD argument to `ReadOnlySpan<byte>` at the four wrapper call sites. `byte[] → Span<byte>` works but `ReadOnlySpan<byte> → Span<byte>` does not, so the instance overload no longer matches and resolution falls through to the extension.

The fourth site (line 147, inside `Assert.ThrowsExactly`) didn't produce CS0029 because the return value is discarded, but it was still binding to the instance method — exercising the instance method's length precondition rather than the wrapper's eager check that the test name promises.

## Test plan

- [ ] `dotnet build Bodu.sln` succeeds
- [ ] `dotnet test Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj --settings bvt.runsettings --filter "FullyQualifiedName~AeadBlockCipherModeTransformExtensionsTests"` — all 9 wrapper-contract tests pass

https://claude.ai/code/session_016Yv2ZCQY6ou7iSjfJmdrPM

---
_Generated by [Claude Code](https://claude.ai/code/session_016Yv2ZCQY6ou7iSjfJmdrPM)_