### PR TITLE
Fix constructor parameter ordering in NotableDateRangePipeline

### DIFF
--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -55,7 +55,6 @@ internal sealed class NotableDateRangePipeline
 		NotableDateRuleResolver ruleResolver,
 		BoduExt.CalendarWeekendDefinition weekendDefinition,
 		BoduExt.IWeekendDefinitionProvider? weekendProvider = null,
-		IAdjustmentHandlerRegistry? handlerRegistry = null)
 		IAdjustmentHandlerRegistry? handlerRegistry = null,
 		IReadOnlyList<RuleRemoval>? overrideRemovals = null)
 	{
@@ -357,7 +356,6 @@ internal sealed class NotableDateRangePipeline
 
 	/// <summary>
 	/// Builds and adds cache entries for the supplied rule, anchor year, and anchor date, expanding the rule's authored territory
-	/// list into one entry per territory that matches the request context.
 	/// list into one entry per territory that matches the request context. Entries suppressed by an override
 	/// <see cref="RuleRemoval" /> for the supplied year and territory are skipped before reaching the cache.
 	/// </summary>
@@ -366,7 +364,6 @@ internal sealed class NotableDateRangePipeline
 	/// <param name="anchorDate">The resolved anchor date.</param>
 	/// <param name="plan">The active resolution plan.</param>
 	/// <param name="cache">The shared cache being populated.</param>
-	private static void AddEntries(
 	private void AddEntries(
 		RuleStaticProfile profile,
 		int year,

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -491,7 +491,6 @@ public sealed class NotableDateService : INotableDateService
 			_resolver,
 			_weekendDefinition,
 			_weekendProvider,
-			_adjustmentHandlers);
 			_adjustmentHandlers,
 			_overrideRemovals);
 	}


### PR DESCRIPTION
## Summary
This PR corrects the parameter ordering in the `NotableDateRangePipeline` constructor and its call site to maintain consistency with the intended method signature.

## Key Changes
- **NotableDateRangePipeline.cs**: Removed duplicate `handlerRegistry` parameter declaration in the constructor signature, keeping only the correct parameter order with `handlerRegistry` followed by `overrideRemovals`
- **NotableDateService.cs**: Updated the `BuildRangePipeline()` method to pass constructor arguments in the correct order matching the fixed signature
- **NotableDateRangePipeline.cs**: Changed `AddEntries()` method from `static` to instance method to allow access to instance state required for the implementation

## Implementation Details
The constructor had a duplicate parameter declaration that was causing a syntax error. The fix ensures that:
1. The parameter list is clean with no duplicates
2. Arguments are passed in the correct order at the call site
3. The `AddEntries` method can now access instance members as needed for its implementation

https://claude.ai/code/session_01VibhdJGviwbfBDKfCcK6mp