### PR TITLE
Add Multiset<T> and MultiValueDictionary<TKey,TValue> collection types

### DIFF
--- a/Bodu.Core/src/Collections.Generic/MultiValueDictionary.IEnumerable.cs
+++ b/Bodu.Core/src/Collections.Generic/MultiValueDictionary.IEnumerable.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionary.IEnumerable.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class MultiValueDictionary<TKey, TValue>
+    : System.Collections.Generic.IEnumerable<KeyValuePair<TKey, IReadOnlyList<TValue>>>
+{
+    /// <summary>
+    /// Returns an enumerator that iterates the key–value-list pairs in the
+    /// <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>An <see cref="Enumerator"/> for the dictionary.</returns>
+    /// <remarks>
+    /// The enumerator captures a structural-version token at creation. Any subsequent structural
+    /// modification — including <see cref="Add"/>, <see cref="Remove"/>, <see cref="RemoveAll"/>, or
+    /// <see cref="Clear"/> — invalidates the enumerator. The next call to
+    /// <see cref="Enumerator.MoveNext"/> or <see cref="Enumerator.Reset"/> throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public Enumerator GetEnumerator() => new Enumerator(this);
+
+    /// <inheritdoc />
+    IEnumerator<KeyValuePair<TKey, IReadOnlyList<TValue>>>
+        IEnumerable<KeyValuePair<TKey, IReadOnlyList<TValue>>>.GetEnumerator() =>
+        new Enumerator(this);
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+
+    /// <summary>
+    /// Enumerates the key–value-list pairs in a <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>Use the <see langword="foreach"/> statement to enumerate the dictionary rather than using this struct directly.</para>
+    /// <para>
+    /// The enumerator provides read-only access. Modifying the underlying dictionary after enumeration
+    /// begins invalidates the enumerator and causes <see cref="MoveNext"/> or <see cref="Reset"/> to
+    /// throw <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator : IEnumerator<KeyValuePair<TKey, IReadOnlyList<TValue>>>
+    {
+        private readonly MultiValueDictionary<TKey, TValue> _dictionary;
+        private readonly int _version;
+        private Dictionary<TKey, List<TValue>>.Enumerator _inner;
+        private KeyValuePair<TKey, IReadOnlyList<TValue>> _current;
+        private bool _beforeFirst;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Enumerator"/> struct for the specified dictionary.
+        /// </summary>
+        /// <param name="dictionary">The dictionary to enumerate.</param>
+        internal Enumerator(MultiValueDictionary<TKey, TValue> dictionary)
+        {
+            _dictionary = dictionary;
+            _version = dictionary._version;
+            _inner = dictionary._map.GetEnumerator();
+            _current = default;
+            _beforeFirst = true;
+        }
+
+        /// <summary>
+        /// Gets the key–value-list pair at the current position of the enumerator.
+        /// </summary>
+        /// <returns>The key–value-list pair at the current enumerator position.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The enumerator is positioned before the first element or after the last element.
+        /// </exception>
+        public KeyValuePair<TKey, IReadOnlyList<TValue>> Current =>
+            _beforeFirst
+                ? throw new InvalidOperationException(ResourceStrings.InvalidOperation_EnumeratorNotOnElement)
+                : _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public void Dispose() => _inner.Dispose();
+
+        /// <summary>
+        /// Advances the enumerator to the next key–value-list pair.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the enumerator was successfully advanced to the next pair;
+        /// <see langword="false"/> if the enumerator has passed the end of the collection.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">The dictionary was modified after the enumerator was created.</exception>
+        public bool MoveNext()
+        {
+            if (_version != _dictionary._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            if (!_inner.MoveNext())
+            {
+                _current = default;
+                _beforeFirst = true;
+                return false;
+            }
+
+            KeyValuePair<TKey, List<TValue>> pair = _inner.Current;
+            _current = new KeyValuePair<TKey, IReadOnlyList<TValue>>(pair.Key, pair.Value);
+            _beforeFirst = false;
+            return true;
+        }
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, before the first element in the dictionary.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The dictionary was modified after the enumerator was created.</exception>
+        public void Reset()
+        {
+            if (_version != _dictionary._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _inner.Dispose();
+            _inner = _dictionary._map.GetEnumerator();
+            _current = default;
+            _beforeFirst = true;
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/MultiValueDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/MultiValueDictionary.cs
@@ -1,0 +1,358 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionary.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Represents a mutable dictionary that maps each key to a collection of zero or more values (a multimap).
+/// Multiple values may be associated with the same key, and values are stored in insertion order per key.
+/// </summary>
+/// <typeparam name="TKey">The type of keys. Must not be <see langword="null"/>.</typeparam>
+/// <typeparam name="TValue">The type of values associated with each key.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="MultiValueDictionary{TKey, TValue}"/> fills the gap left by the BCL's
+/// <see cref="ILookup{TKey, TElement}"/> — which is read-only and produced at construction time — by
+/// providing a fully mutable one-to-many map. Keys must not be <see langword="null"/>; values may be
+/// <see langword="null"/> when <typeparamref name="TValue"/> is a reference type.
+/// </para>
+/// <para>
+/// The <see cref="Count"/> property returns the total number of key–value entries across all keys.
+/// Use <see cref="KeyCount"/> to obtain the number of distinct keys currently held. The indexer
+/// <c>this[TKey]</c> always returns an <see cref="IReadOnlyList{T}"/> — it returns an empty list rather
+/// than throwing when the key is absent, enabling safe iteration without a preceding
+/// <see cref="ContainsKey"/> check.
+/// </para>
+/// <para>
+/// Common use cases include graph adjacency lists, inverted indexes, grouping tasks by owner, and any
+/// scenario where a single key naturally maps to multiple values over the lifetime of the collection.
+/// </para>
+/// <para>
+/// <see cref="MultiValueDictionary{TKey, TValue}"/> is not thread-safe. Concurrent reads and writes
+/// require external synchronisation.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("KeyCount = {KeyCount}, Count = {Count}")]
+[DebuggerTypeProxy(typeof(MultiValueDictionaryDebugView<,>))]
+[Serializable]
+public sealed partial class MultiValueDictionary<TKey, TValue>
+    : IReadOnlyCollection<KeyValuePair<TKey, IReadOnlyList<TValue>>>
+    where TKey : notnull
+{
+    /// <summary>Shared empty list returned by the indexer and <see cref="TryGetValues"/> when a key is absent.</summary>
+    private static readonly IReadOnlyList<TValue> s_emptyValues = Array.Empty<TValue>();
+
+    /// <summary>The equality comparer used to determine key equality.</summary>
+    private readonly IEqualityComparer<TKey> _comparer;
+
+    /// <summary>The backing dictionary mapping each key to its ordered list of values.</summary>
+    private Dictionary<TKey, List<TValue>> _map;
+
+    /// <summary>The total number of value entries across all keys.</summary>
+    private int _count;
+
+    /// <summary>Incremented on every structural change; used by enumerators to detect concurrent modification.</summary>
+    private int _version;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="MultiValueDictionary{TKey, TValue}"/> class that is
+    /// empty and uses the default equality comparer for keys.
+    /// </summary>
+    public MultiValueDictionary()
+        : this((IEqualityComparer<TKey>?)null) { }
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="MultiValueDictionary{TKey, TValue}"/> class that is
+    /// empty and uses the specified equality comparer for keys.
+    /// </summary>
+    /// <param name="comparer">
+    /// The equality comparer used to compare keys. If <see langword="null"/>, the default equality
+    /// comparer for <typeparamref name="TKey"/> is used.
+    /// </param>
+    public MultiValueDictionary(IEqualityComparer<TKey>? comparer)
+    {
+        _comparer = comparer ?? EqualityComparer<TKey>.Default;
+        _map = new Dictionary<TKey, List<TValue>>(_comparer);
+    }
+
+    /// <summary>
+    /// Gets the equality comparer used to determine equality of keys in this
+    /// <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>The <see cref="IEqualityComparer{T}"/> instance used to compare keys.</returns>
+    public IEqualityComparer<TKey> Comparer => _comparer;
+
+    /// <summary>
+    /// Gets the total number of key–value entries stored across all keys.
+    /// </summary>
+    /// <returns>
+    /// The total number of values, summed across all keys. For the number of distinct keys, use <see cref="KeyCount"/>.
+    /// </returns>
+    public int Count => _count;
+
+    /// <summary>
+    /// Gets the number of distinct keys currently held in the <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>The number of distinct keys.</returns>
+    public int KeyCount => _map.Count;
+
+    /// <summary>
+    /// Gets a read-only view of all keys in the <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IReadOnlyCollection{T}"/> containing all distinct keys. The order of keys is not guaranteed.
+    /// </returns>
+    public IReadOnlyCollection<TKey> Keys => _map.Keys;
+
+    /// <summary>
+    /// Gets the values associated with <paramref name="key"/> as a read-only list.
+    /// </summary>
+    /// <param name="key">The key whose values are to be retrieved.</param>
+    /// <returns>
+    /// A read-only list of values associated with <paramref name="key"/>, in insertion order. Returns an
+    /// empty list when the key is absent — never throws <see cref="KeyNotFoundException"/>.
+    /// </returns>
+    /// <remarks>
+    /// This indexer always returns a non-null list. When the key is absent the returned list is empty, so
+    /// callers may safely iterate the result without first checking <see cref="ContainsKey"/>.
+    /// </remarks>
+    public IReadOnlyList<TValue> this[TKey key] =>
+        _map.TryGetValue(key, out List<TValue>? values) ? values : s_emptyValues;
+
+    /// <summary>
+    /// Appends <paramref name="value"/> to the list of values associated with <paramref name="key"/>.
+    /// Creates a new key entry if the key does not yet exist.
+    /// </summary>
+    /// <param name="key">The key to add the value under. Must not be <see langword="null"/>.</param>
+    /// <param name="value">The value to append.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public void Add(TKey key, TValue value)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        if (!_map.TryGetValue(key, out List<TValue>? list))
+        {
+            list = new List<TValue>();
+            _map[key] = list;
+        }
+
+        list.Add(value);
+        _count++;
+        _version++;
+    }
+
+    /// <summary>
+    /// Appends each element of <paramref name="values"/> to the list associated with <paramref name="key"/>.
+    /// Creates a new key entry if the key does not yet exist.
+    /// </summary>
+    /// <param name="key">The key to add the values under. Must not be <see langword="null"/>.</param>
+    /// <param name="values">The values to append. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key"/> is <see langword="null"/>, or <paramref name="values"/> is <see langword="null"/>.
+    /// </exception>
+    public void AddRange(TKey key, IEnumerable<TValue> values)
+    {
+        ThrowHelper.ThrowIfNull(key);
+        ThrowHelper.ThrowIfNull(values);
+
+        if (!_map.TryGetValue(key, out List<TValue>? list))
+        {
+            list = new List<TValue>();
+            _map[key] = list;
+        }
+
+        int before = list.Count;
+        list.AddRange(values);
+        int added = list.Count - before;
+
+        if (added > 0)
+        {
+            _count += added;
+            _version++;
+        }
+        else if (before == 0)
+        {
+            // Clean up a newly created empty list if values was empty.
+            _map.Remove(key);
+        }
+    }
+
+    /// <summary>
+    /// Removes all keys and their associated values from the <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    public void Clear()
+    {
+        _map.Clear();
+        _count = 0;
+        _version++;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="key"/> has at least one value in the
+    /// <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <param name="key">The key to locate. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="key"/> exists and has at least one associated value;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool ContainsKey(TKey key)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        return _map.ContainsKey(key);
+    }
+
+    /// <summary>
+    /// Determines whether the value <paramref name="value"/> is associated with <paramref name="key"/>.
+    /// </summary>
+    /// <param name="key">The key to search under. Must not be <see langword="null"/>.</param>
+    /// <param name="value">The value to locate.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="key"/> exists and one of its values equals
+    /// <paramref name="value"/> according to the default equality comparer; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool ContainsValue(TKey key, TValue value)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        return _map.TryGetValue(key, out List<TValue>? list) && list.Contains(value);
+    }
+
+    /// <summary>
+    /// Returns the values associated with <paramref name="key"/> as a read-only list.
+    /// </summary>
+    /// <param name="key">The key whose values are to be returned. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// A read-only list of values in insertion order. The list is a live view; it reflects any
+    /// subsequent additions or removals for the same key.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    /// <exception cref="KeyNotFoundException"><paramref name="key"/> does not exist in the dictionary.</exception>
+    public IReadOnlyList<TValue> GetValues(TKey key)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        if (!_map.TryGetValue(key, out List<TValue>? list))
+            throw new KeyNotFoundException($"The key '{key}' was not present in the dictionary.");
+
+        return list;
+    }
+
+    /// <summary>
+    /// Attempts to return the values associated with <paramref name="key"/> without throwing an exception.
+    /// </summary>
+    /// <param name="key">The key whose values are to be returned. Must not be <see langword="null"/>.</param>
+    /// <param name="values">
+    /// When this method returns <see langword="true"/>, contains the values associated with
+    /// <paramref name="key"/> in insertion order; otherwise, an empty list.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="key"/> exists and has at least one value;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool TryGetValues(TKey key, out IReadOnlyList<TValue> values)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        if (_map.TryGetValue(key, out List<TValue>? list))
+        {
+            values = list;
+            return true;
+        }
+
+        values = s_emptyValues;
+        return false;
+    }
+
+    /// <summary>
+    /// Removes one occurrence of <paramref name="value"/> from the list associated with
+    /// <paramref name="key"/>. Removes the key entry entirely when its value list becomes empty.
+    /// </summary>
+    /// <param name="key">The key under which to remove the value. Must not be <see langword="null"/>.</param>
+    /// <param name="value">The value to remove.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="value"/> was found under <paramref name="key"/> and
+    /// removed; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool Remove(TKey key, TValue value)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        if (!_map.TryGetValue(key, out List<TValue>? list))
+            return false;
+
+        if (!list.Remove(value))
+            return false;
+
+        _count--;
+        _version++;
+
+        if (list.Count == 0)
+            _map.Remove(key);
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes <paramref name="key"/> and all of its associated values from the
+    /// <see cref="MultiValueDictionary{TKey, TValue}"/>.
+    /// </summary>
+    /// <param name="key">The key to remove. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="key"/> was found and removed; otherwise, <see langword="false"/>.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="key"/> is <see langword="null"/>.</exception>
+    public bool RemoveAll(TKey key)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        if (!_map.TryGetValue(key, out List<TValue>? list))
+            return false;
+
+        _count -= list.Count;
+        _map.Remove(key);
+        _version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns a flat sequence of all key–value pairs, one pair per value entry across all keys.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/> in which each entry
+    /// represents one value for one key. The order of keys is not guaranteed; values within a key appear
+    /// in insertion order.
+    /// </returns>
+    /// <remarks>
+    /// The sequence is invalidated by any structural modification; iterating after a modification throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The dictionary was modified after enumeration began.</exception>
+    public IEnumerable<KeyValuePair<TKey, TValue>> Flatten()
+    {
+        int version = _version;
+        foreach (KeyValuePair<TKey, List<TValue>> entry in _map)
+        {
+            foreach (TValue value in entry.Value)
+            {
+                if (version != _version)
+                    throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+                yield return new KeyValuePair<TKey, TValue>(entry.Key, value);
+            }
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/MultiValueDictionaryDebugView.cs
+++ b/Bodu.Core/src/Collections.Generic/MultiValueDictionaryDebugView.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryDebugView.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Provides a debugger-friendly view of the <see cref="MultiValueDictionary{TKey, TValue}"/> contents,
+/// showing each key alongside its associated value list.
+/// </summary>
+/// <typeparam name="TKey">The type of keys in the dictionary.</typeparam>
+/// <typeparam name="TValue">The type of values in the dictionary.</typeparam>
+internal sealed class MultiValueDictionaryDebugView<TKey, TValue>
+    where TKey : notnull
+{
+    /// <summary>
+    /// The <see cref="MultiValueDictionary{TKey, TValue}"/> instance being debugged.
+    /// </summary>
+    private readonly MultiValueDictionary<TKey, TValue> _dictionary;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="MultiValueDictionaryDebugView{TKey, TValue}"/> class.
+    /// </summary>
+    /// <param name="dictionary">The dictionary instance to inspect. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="dictionary"/> is <see langword="null"/>.</exception>
+    public MultiValueDictionaryDebugView(MultiValueDictionary<TKey, TValue> dictionary) =>
+        _dictionary = dictionary ?? throw new ArgumentNullException(nameof(dictionary));
+
+    /// <summary>
+    /// Gets the key–value-list pairs currently held in the <see cref="MultiValueDictionary{TKey, TValue}"/>,
+    /// displayed in the debugger as root-level entries.
+    /// </summary>
+    /// <remarks>Shown in the debugger as root-level entries for quick inspection.</remarks>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public KeyValuePair<TKey, IReadOnlyList<TValue>>[] Entries =>
+        _dictionary.ToArray();
+}

--- a/Bodu.Core/src/Collections.Generic/Multiset.ICollection.cs
+++ b/Bodu.Core/src/Collections.Generic/Multiset.ICollection.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Multiset.ICollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class Multiset<T>
+    : System.Collections.ICollection
+{
+    /// <summary>Lazily initialised synchronisation root for <see cref="System.Collections.ICollection.SyncRoot"/>.</summary>
+    [NonSerialized]
+    private object? _syncRoot;
+
+    /// <summary>
+    /// Gets a value indicating whether access to the <see cref="Multiset{T}"/> is synchronised (thread-safe).
+    /// Always returns <see langword="false"/>; <see cref="Multiset{T}"/> is not thread-safe.
+    /// </summary>
+    /// <value>Always <see langword="false"/>.</value>
+    /// <returns><see langword="false"/>.</returns>
+    /// <remarks>External synchronisation is the caller's responsibility.</remarks>
+    bool ICollection.IsSynchronized => false;
+
+    /// <summary>
+    /// Gets a lazily-initialised object that can be used to synchronise access to the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <value>A non-null object suitable as a <see cref="Monitor"/> target.</value>
+    /// <returns>The synchronisation root object.</returns>
+    object ICollection.SyncRoot =>
+        _syncRoot ?? Interlocked.CompareExchange(ref _syncRoot, new object(), null) ?? _syncRoot!;
+
+    /// <summary>
+    /// Copies all elements of the <see cref="Multiset{T}"/> to a one-dimensional <see cref="Array"/>,
+    /// starting at the specified index. Each element is copied as many times as its occurrence count.
+    /// </summary>
+    /// <param name="array">The destination array. Must be a single-dimensional, zero-based array of a compatible type.</param>
+    /// <param name="index">The zero-based starting index in <paramref name="array"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="index"/> is less than zero.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="array"/> is multidimensional, not zero-based, or has an incompatible element type;
+    /// or the number of elements in the multiset exceeds the available space from <paramref name="index"/>
+    /// to the end of <paramref name="array"/>.
+    /// </exception>
+    void ICollection.CopyTo(Array array, int index)
+    {
+        ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfArrayMultidimensional(array);
+        ThrowHelper.ThrowIfArrayIsNotZeroBased(array);
+        ThrowHelper.ThrowIfLessThan(index, 0);
+        ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, index + _count);
+
+        try
+        {
+            foreach (KeyValuePair<T, int> pair in _items)
+            {
+                for (int i = 0; i < pair.Value; i++)
+                    array.SetValue(pair.Key, index++);
+            }
+        }
+        catch (InvalidCastException ex)
+        {
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_ArrayType, nameof(array), ex);
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/Multiset.IEnumerable.cs
+++ b/Bodu.Core/src/Collections.Generic/Multiset.IEnumerable.cs
@@ -1,0 +1,140 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Multiset.IEnumerable.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class Multiset<T>
+    : System.Collections.Generic.IEnumerable<T>
+{
+    /// <summary>
+    /// Returns an enumerator that iterates all elements in the <see cref="Multiset{T}"/>, yielding each
+    /// element as many times as its occurrence count.
+    /// </summary>
+    /// <returns>An <see cref="Enumerator"/> for the multiset.</returns>
+    /// <remarks>
+    /// The enumerator captures a structural-version token at creation. Any subsequent structural
+    /// modification — including <see cref="Add(T)"/>, <see cref="Remove"/>, <see cref="RemoveAll"/>,
+    /// and <see cref="Clear"/> — invalidates the enumerator. The next call to
+    /// <see cref="Enumerator.MoveNext"/> or <see cref="Enumerator.Reset"/> throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    public Enumerator GetEnumerator() => new Enumerator(this);
+
+    /// <inheritdoc />
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() => new Enumerator(this);
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() => new Enumerator(this);
+
+    /// <summary>
+    /// Enumerates the elements of a <see cref="Multiset{T}"/>, yielding each element as many times as
+    /// its occurrence count in an unspecified order.
+    /// </summary>
+    /// <remarks>
+    /// <para>Use the <see langword="foreach"/> statement to enumerate the multiset rather than using this struct directly.</para>
+    /// <para>
+    /// The enumerator provides read-only access. Modifying the underlying multiset after enumeration
+    /// begins invalidates the enumerator and causes <see cref="MoveNext"/> or <see cref="Reset"/> to
+    /// throw <see cref="InvalidOperationException"/>.
+    /// </para>
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator : IEnumerator<T>
+    {
+        private readonly Multiset<T> _multiset;
+        private readonly int _version;
+        private Dictionary<T, int>.Enumerator _inner;
+        private T _current;
+        private int _remaining;
+        private bool _beforeFirst;
+
+        /// <summary>
+        /// Initialises a new instance of the <see cref="Enumerator"/> struct for the specified multiset.
+        /// </summary>
+        /// <param name="multiset">The multiset to enumerate.</param>
+        internal Enumerator(Multiset<T> multiset)
+        {
+            _multiset = multiset;
+            _version = multiset._version;
+            _inner = multiset._items.GetEnumerator();
+            _current = default!;
+            _remaining = 0;
+            _beforeFirst = true;
+        }
+
+        /// <summary>
+        /// Gets the element at the current position of the enumerator.
+        /// </summary>
+        /// <returns>The element in the multiset at the current enumerator position.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// The enumerator is positioned before the first element or after the last element.
+        /// </exception>
+        public T Current =>
+            _beforeFirst
+                ? throw new InvalidOperationException(ResourceStrings.InvalidOperation_EnumeratorNotOnElement)
+                : _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current!;
+
+        /// <inheritdoc />
+        public void Dispose() => _inner.Dispose();
+
+        /// <summary>
+        /// Advances the enumerator to the next element in the multiset.
+        /// </summary>
+        /// <returns>
+        /// <see langword="true"/> if the enumerator was successfully advanced to the next element;
+        /// <see langword="false"/> if the enumerator has passed the end of the collection.
+        /// </returns>
+        /// <exception cref="InvalidOperationException">The multiset was modified after the enumerator was created.</exception>
+        public bool MoveNext()
+        {
+            if (_version != _multiset._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            if (_remaining > 0)
+            {
+                _remaining--;
+                _beforeFirst = false;
+                return true;
+            }
+
+            if (!_inner.MoveNext())
+            {
+                _current = default!;
+                _beforeFirst = true;
+                return false;
+            }
+
+            KeyValuePair<T, int> pair = _inner.Current;
+            _current = pair.Key;
+            _remaining = pair.Value - 1;
+            _beforeFirst = false;
+            return true;
+        }
+
+        /// <summary>
+        /// Sets the enumerator to its initial position, before the first element in the multiset.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The multiset was modified after the enumerator was created.</exception>
+        public void Reset()
+        {
+            if (_version != _multiset._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _inner.Dispose();
+            _inner = _multiset._items.GetEnumerator();
+            _current = default!;
+            _remaining = 0;
+            _beforeFirst = true;
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/Multiset.cs
+++ b/Bodu.Core/src/Collections.Generic/Multiset.cs
@@ -1,0 +1,443 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Multiset.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Represents an unordered collection that tracks the multiplicity (occurrence count) of each element.
+/// Unlike <see cref="HashSet{T}"/>, duplicate elements are permitted; unlike <see cref="List{T}"/>,
+/// element counts are tracked as integers rather than stored as repeated entries.
+/// </summary>
+/// <typeparam name="T">The type of elements in the multiset. Must not be <see langword="null"/>.</typeparam>
+/// <remarks>
+/// <para>
+/// A <see cref="Multiset{T}"/> is backed by a <see cref="Dictionary{TKey, TValue}"/> that maps each
+/// distinct element to its occurrence count. Add, remove, and lookup operations are O(1) on average,
+/// making this type well suited for frequency analysis, histogram construction, vote counting, and
+/// duplicate-aware set arithmetic.
+/// </para>
+/// <para>
+/// The <see cref="Count"/> property returns the total element count <em>including</em> multiplicity.
+/// A multiset containing <c>"a"</c> twice and <c>"b"</c> once has a <see cref="Count"/> of 3 and a
+/// <see cref="DistinctCount"/> of 2. Enumerating the multiset yields each element as many times as it
+/// appears; use <see cref="Distinct()"/> to iterate over each distinct element once, or
+/// <see cref="Frequencies()"/> to obtain element–count pairs.
+/// </para>
+/// <para>
+/// Set-theoretic operations (<see cref="Union"/>, <see cref="Intersect"/>, <see cref="Except"/>,
+/// <see cref="Sum"/>) return new <see cref="Multiset{T}"/> instances and do not mutate either operand.
+/// The semantics follow multiset algebra:
+/// </para>
+/// <list type="bullet">
+/// <item><description><see cref="Union"/> — each element appears max(a, b) times.</description></item>
+/// <item><description><see cref="Intersect"/> — each element appears min(a, b) times; elements absent from either operand are omitted.</description></item>
+/// <item><description><see cref="Except"/> — each element appears max(0, a − b) times; elements whose count reaches zero are omitted.</description></item>
+/// <item><description><see cref="Sum"/> — each element appears a + b times.</description></item>
+/// </list>
+/// <para>
+/// Set operations produce correct results only when both operands use equivalent equality comparers.
+/// The result uses this instance's comparer.
+/// </para>
+/// <para>
+/// <see cref="Multiset{T}"/> is not thread-safe. Concurrent reads and writes require external synchronisation.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("Count = {Count}, DistinctCount = {DistinctCount}")]
+[DebuggerTypeProxy(typeof(MultisetDebugView<>))]
+[Serializable]
+public sealed partial class Multiset<T>
+    : ICollection<T>, IReadOnlyCollection<T>
+    where T : notnull
+{
+    /// <summary>The equality comparer used to determine element equality.</summary>
+    private readonly IEqualityComparer<T> _comparer;
+
+    /// <summary>The backing dictionary mapping each distinct element to its occurrence count.</summary>
+    private Dictionary<T, int> _items;
+
+    /// <summary>The total number of elements, counting all occurrences.</summary>
+    private int _count;
+
+    /// <summary>Incremented on every structural change; used by enumerators to detect concurrent modification.</summary>
+    private int _version;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Multiset{T}"/> class that is empty and uses the default equality comparer.
+    /// </summary>
+    public Multiset()
+        : this((IEqualityComparer<T>?)null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Multiset{T}"/> class that is empty and uses the specified equality comparer.
+    /// </summary>
+    /// <param name="comparer">
+    /// The equality comparer used to determine element equality. If <see langword="null"/>, the default
+    /// equality comparer for <typeparamref name="T"/> is used.
+    /// </param>
+    public Multiset(IEqualityComparer<T>? comparer)
+    {
+        _comparer = comparer ?? EqualityComparer<T>.Default;
+        _items = new Dictionary<T, int>(_comparer);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Multiset{T}"/> class that contains elements copied
+    /// from the specified collection and uses the default equality comparer.
+    /// </summary>
+    /// <param name="collection">The collection from which elements are copied. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+    public Multiset(IEnumerable<T> collection)
+        : this(collection, null) { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Multiset{T}"/> class that contains elements copied
+    /// from the specified collection and uses the specified equality comparer.
+    /// </summary>
+    /// <param name="collection">The collection from which elements are copied. Must not be <see langword="null"/>.</param>
+    /// <param name="comparer">
+    /// The equality comparer used to determine element equality. If <see langword="null"/>, the default
+    /// equality comparer for <typeparamref name="T"/> is used.
+    /// </param>
+    /// <exception cref="ArgumentNullException"><paramref name="collection"/> is <see langword="null"/>.</exception>
+    public Multiset(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
+    {
+        ThrowHelper.ThrowIfNull(collection);
+
+        _comparer = comparer ?? EqualityComparer<T>.Default;
+        _items = new Dictionary<T, int>(_comparer);
+
+        foreach (T item in collection)
+            InsertCore(item, 1);
+    }
+
+    /// <summary>
+    /// Gets the equality comparer used to determine equality of elements in this <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <returns>The <see cref="IEqualityComparer{T}"/> instance used to compare elements.</returns>
+    public IEqualityComparer<T> Comparer => _comparer;
+
+    /// <summary>
+    /// Gets the total number of elements in the <see cref="Multiset{T}"/>, counting each duplicate occurrence separately.
+    /// </summary>
+    /// <returns>
+    /// The total element count including multiplicity. For the count of distinct elements, use <see cref="DistinctCount"/>.
+    /// </returns>
+    public int Count => _count;
+
+    /// <summary>
+    /// Gets the number of distinct elements in the <see cref="Multiset{T}"/>, regardless of their individual occurrence counts.
+    /// </summary>
+    /// <returns>
+    /// The number of unique elements. A multiset containing <c>"a"</c> three times and <c>"b"</c> once
+    /// has a <see cref="DistinctCount"/> of 2 and a <see cref="Count"/> of 4.
+    /// </returns>
+    public int DistinctCount => _items.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the <see cref="Multiset{T}"/> is read-only.
+    /// </summary>
+    /// <value>Always <see langword="false"/>; <see cref="Multiset{T}"/> is always mutable.</value>
+    /// <returns><see langword="false"/>.</returns>
+    bool ICollection<T>.IsReadOnly => false;
+
+    /// <summary>
+    /// Adds one occurrence of <paramref name="item"/> to the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <param name="item">The element to add.</param>
+    public void Add(T item)
+    {
+        InsertCore(item, 1);
+        _version++;
+    }
+
+    /// <summary>
+    /// Adds <paramref name="count"/> occurrences of <paramref name="item"/> to the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <param name="item">The element to add.</param>
+    /// <param name="count">The number of occurrences to add. Must be greater than zero.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="count"/> is less than or equal to zero.</exception>
+    public void Add(T item, int count)
+    {
+        ThrowHelper.ThrowIfZeroOrNegative(count);
+
+        InsertCore(item, count);
+        _version++;
+    }
+
+    /// <summary>
+    /// Removes all elements from the <see cref="Multiset{T}"/>.
+    /// </summary>
+    public void Clear()
+    {
+        _items.Clear();
+        _count = 0;
+        _version++;
+    }
+
+    /// <summary>
+    /// Determines whether the <see cref="Multiset{T}"/> contains at least one occurrence of <paramref name="item"/>.
+    /// </summary>
+    /// <param name="item">The element to locate.</param>
+    /// <returns>
+    /// <see langword="true"/> if <paramref name="item"/> occurs one or more times in the multiset;
+    /// otherwise, <see langword="false"/>.
+    /// </returns>
+    public bool Contains(T item) =>
+        _items.ContainsKey(item);
+
+    /// <summary>
+    /// Returns the number of times <paramref name="item"/> appears in the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <param name="item">The element whose occurrence count is to be returned.</param>
+    /// <returns>
+    /// The number of times <paramref name="item"/> appears in the multiset, or <c>0</c> if the element is absent.
+    /// </returns>
+    public int CountOf(T item) =>
+        _items.TryGetValue(item, out int count) ? count : 0;
+
+    /// <summary>
+    /// Copies all elements of the <see cref="Multiset{T}"/> to a one-dimensional array, starting at the
+    /// specified array index. Each element is copied as many times as its occurrence count.
+    /// </summary>
+    /// <param name="array">The destination array. Must not be <see langword="null"/>.</param>
+    /// <param name="arrayIndex">The zero-based starting index in <paramref name="array"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="array"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="arrayIndex"/> is less than zero.</exception>
+    /// <exception cref="ArgumentException">
+    /// The number of elements in the multiset exceeds the available space from <paramref name="arrayIndex"/>
+    /// to the end of <paramref name="array"/>.
+    /// </exception>
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfNegative(arrayIndex);
+        ThrowHelper.ThrowIfArrayLengthIsInsufficient(array, arrayIndex + _count);
+
+        foreach (KeyValuePair<T, int> pair in _items)
+        {
+            for (int i = 0; i < pair.Value; i++)
+                array[arrayIndex++] = pair.Key;
+        }
+    }
+
+    /// <summary>
+    /// Removes one occurrence of <paramref name="item"/> from the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <param name="item">The element to remove one occurrence of.</param>
+    /// <returns>
+    /// <see langword="true"/> if an occurrence of <paramref name="item"/> was found and removed;
+    /// <see langword="false"/> if the element does not appear in the multiset.
+    /// </returns>
+    public bool Remove(T item)
+    {
+        if (!_items.TryGetValue(item, out int count))
+            return false;
+
+        if (count == 1)
+            _items.Remove(item);
+        else
+            _items[item] = count - 1;
+
+        _count--;
+        _version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Removes all occurrences of <paramref name="item"/> from the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <param name="item">The element whose occurrences are to be removed.</param>
+    /// <returns>
+    /// <see langword="true"/> if one or more occurrences of <paramref name="item"/> were removed;
+    /// <see langword="false"/> if the element does not appear in the multiset.
+    /// </returns>
+    public bool RemoveAll(T item)
+    {
+        if (!_items.TryGetValue(item, out int count))
+            return false;
+
+        _items.Remove(item);
+        _count -= count;
+        _version++;
+        return true;
+    }
+
+    /// <summary>
+    /// Returns an enumerable sequence that yields each distinct element in the <see cref="Multiset{T}"/>
+    /// exactly once, regardless of its occurrence count.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> that yields each distinct element once. The order of elements is
+    /// not guaranteed.
+    /// </returns>
+    /// <remarks>
+    /// This method enumerates only the distinct elements in O(<see cref="DistinctCount"/>) time, avoiding
+    /// the O(<see cref="Count"/>) cost of iterating the full multiset then de-duplicating. The sequence
+    /// is invalidated by any structural modification; iterating after a modification throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The multiset was modified after enumeration began.</exception>
+    public IEnumerable<T> Distinct()
+    {
+        int version = _version;
+        foreach (T key in _items.Keys)
+        {
+            if (version != _version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            yield return key;
+        }
+    }
+
+    /// <summary>
+    /// Returns an enumerable sequence of element–count pairs for each distinct element in the <see cref="Multiset{T}"/>.
+    /// </summary>
+    /// <returns>
+    /// An <see cref="IEnumerable{T}"/> of <see cref="KeyValuePair{TKey, TValue}"/> where each key is a
+    /// distinct element and each value is that element's occurrence count. The order of pairs is not guaranteed.
+    /// </returns>
+    /// <remarks>
+    /// The sequence is invalidated by any structural modification; iterating after a modification throws
+    /// <see cref="InvalidOperationException"/>.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">The multiset was modified after enumeration began.</exception>
+    public IEnumerable<KeyValuePair<T, int>> Frequencies()
+    {
+        int version = _version;
+        foreach (KeyValuePair<T, int> pair in _items)
+        {
+            if (version != _version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            yield return pair;
+        }
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="Multiset{T}"/> containing the multiset union of this instance and
+    /// <paramref name="other"/>. Each element appears as many times as the maximum of its counts in either operand.
+    /// </summary>
+    /// <param name="other">The multiset to compute the union with. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// A new <see cref="Multiset{T}"/> using this instance's comparer in which each element <c>x</c>
+    /// has count max(CountOf(x), other.CountOf(x)).
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="other"/> is <see langword="null"/>.</exception>
+    public Multiset<T> Union(Multiset<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        Multiset<T> result = new Multiset<T>(_comparer);
+        foreach (KeyValuePair<T, int> pair in _items)
+            result.InsertCore(pair.Key, pair.Value);
+
+        foreach (KeyValuePair<T, int> pair in other._items)
+        {
+            result._items.TryGetValue(pair.Key, out int existing);
+            if (pair.Value > existing)
+            {
+                result._items[pair.Key] = pair.Value;
+                result._count += pair.Value - existing;
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="Multiset{T}"/> containing the multiset intersection of this instance and
+    /// <paramref name="other"/>. Each element appears as many times as the minimum of its counts in both
+    /// operands; elements absent from either operand are omitted.
+    /// </summary>
+    /// <param name="other">The multiset to compute the intersection with. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// A new <see cref="Multiset{T}"/> using this instance's comparer in which each element <c>x</c>
+    /// has count min(CountOf(x), other.CountOf(x)), with elements at zero count omitted.
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="other"/> is <see langword="null"/>.</exception>
+    public Multiset<T> Intersect(Multiset<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        Multiset<T> result = new Multiset<T>(_comparer);
+        foreach (KeyValuePair<T, int> pair in _items)
+        {
+            int count = Math.Min(pair.Value, other.CountOf(pair.Key));
+            if (count > 0)
+                result.InsertCore(pair.Key, count);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="Multiset{T}"/> containing the multiset difference of this instance minus
+    /// <paramref name="other"/>. Each element appears max(0, CountOf(x) − other.CountOf(x)) times;
+    /// elements whose resulting count is zero are omitted.
+    /// </summary>
+    /// <param name="other">The multiset to subtract. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// A new <see cref="Multiset{T}"/> using this instance's comparer in which each element <c>x</c>
+    /// has count max(0, CountOf(x) − other.CountOf(x)).
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="other"/> is <see langword="null"/>.</exception>
+    public Multiset<T> Except(Multiset<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        Multiset<T> result = new Multiset<T>(_comparer);
+        foreach (KeyValuePair<T, int> pair in _items)
+        {
+            int count = Math.Max(0, pair.Value - other.CountOf(pair.Key));
+            if (count > 0)
+                result.InsertCore(pair.Key, count);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="Multiset{T}"/> containing the multiset sum of this instance and
+    /// <paramref name="other"/>. Each element appears CountOf(x) + other.CountOf(x) times.
+    /// </summary>
+    /// <param name="other">The multiset to sum with. Must not be <see langword="null"/>.</param>
+    /// <returns>
+    /// A new <see cref="Multiset{T}"/> using this instance's comparer in which each element <c>x</c>
+    /// has count CountOf(x) + other.CountOf(x).
+    /// </returns>
+    /// <exception cref="ArgumentNullException"><paramref name="other"/> is <see langword="null"/>.</exception>
+    public Multiset<T> Sum(Multiset<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        Multiset<T> result = new Multiset<T>(_comparer);
+        foreach (KeyValuePair<T, int> pair in _items)
+            result.InsertCore(pair.Key, pair.Value);
+
+        foreach (KeyValuePair<T, int> pair in other._items)
+            result.InsertCore(pair.Key, pair.Value);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="count"/> occurrences of <paramref name="item"/> into the backing dictionary
+    /// without incrementing <see cref="_version"/>. Used by constructors and set-operation builders where
+    /// no enumerators exist for the target instance.
+    /// </summary>
+    /// <param name="item">The element to insert.</param>
+    /// <param name="count">The number of occurrences to add.</param>
+    private void InsertCore(T item, int count)
+    {
+        _items[item] = _items.TryGetValue(item, out int existing) ? existing + count : count;
+        _count += count;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/MultisetDebugView.cs
+++ b/Bodu.Core/src/Collections.Generic/MultisetDebugView.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetDebugView.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Provides a debugger-friendly view of the <see cref="Multiset{T}"/> contents, showing each distinct
+/// element alongside its occurrence count.
+/// </summary>
+/// <typeparam name="T">Specifies the type of elements in the multiset.</typeparam>
+internal sealed class MultisetDebugView<T>
+    where T : notnull
+{
+    /// <summary>
+    /// The <see cref="Multiset{T}"/> instance being debugged.
+    /// </summary>
+    private readonly Multiset<T> _multiset;
+
+    /// <summary>
+    /// Initialises a new instance of the <see cref="MultisetDebugView{T}"/> class.
+    /// </summary>
+    /// <param name="multiset">The multiset instance to inspect. Must not be <see langword="null"/>.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="multiset"/> is <see langword="null"/>.</exception>
+    public MultisetDebugView(Multiset<T> multiset) =>
+        _multiset = multiset ?? throw new ArgumentNullException(nameof(multiset));
+
+    /// <summary>
+    /// Gets the element–count pairs currently held in the <see cref="Multiset{T}"/>, displayed in the
+    /// debugger as root-level entries.
+    /// </summary>
+    /// <remarks>Shown in the debugger as root-level entries for quick inspection.</remarks>
+    [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+    public KeyValuePair<T, int>[] Frequencies =>
+        _multiset.Frequencies().ToArray();
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Add.cs
@@ -142,4 +142,52 @@ public partial class MultiValueDictionaryTests
         Assert.AreEqual(3, sut.Count);
         Assert.AreEqual(1, sut.KeyCount);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> does not create a key entry when the values sequence is empty and the key is new.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenEmptySequenceForNewKey_ShouldNotCreateKey()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.AddRange("k", Array.Empty<int>());
+
+        Assert.AreEqual(0, sut.KeyCount);
+        Assert.AreEqual(0, sut.Count);
+        Assert.IsFalse(sut.ContainsKey("k"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> does not modify the count when the values sequence is empty and the key already exists.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenEmptySequenceForExistingKey_ShouldNotModifyCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+        int countBefore = sut.Count;
+
+        sut.AddRange("k", Array.Empty<int>());
+
+        Assert.AreEqual(countBefore, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Add"/> correctly maintains <see cref="MultiValueDictionary{TKey,TValue}.Count"/> across multiple keys.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenMultipleKeysUsed_ShouldMaintainTotalCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+        sut.Add("c", 3);
+        sut.Add("a", 4);
+
+        Assert.AreEqual(4, sut.Count);
+        Assert.AreEqual(3, sut.KeyCount);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Add.cs
@@ -1,0 +1,145 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.Add.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Add(TKey, TValue)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Add(TKey,TValue)"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.Add(null!, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Add(TKey,TValue)"/> creates a new key entry when the key is new.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenKeyIsNew_ShouldCreateEntryAndIncrementKeyCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.Add("a", 1);
+
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsTrue(sut.ContainsKey("a"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Add(TKey,TValue)"/> appends to an existing key without duplicating the key.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenKeyExists_ShouldAppendValueWithoutDuplicatingKey()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("a", 3);
+
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(3, sut["a"].Count);
+    }
+
+    /// <summary>
+    /// Verifies that values are stored in insertion order for each key.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenValuesAddedForSameKey_ShouldPreserveInsertionOrder()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.Add("k", 30);
+        sut.Add("k", 10);
+        sut.Add("k", 20);
+
+        IReadOnlyList<int> values = sut["k"];
+
+        Assert.AreEqual(30, values[0]);
+        Assert.AreEqual(10, values[1]);
+        Assert.AreEqual(20, values[2]);
+    }
+
+    // --------------------------------------------------------
+    // AddRange(TKey, IEnumerable<TValue>)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.AddRange(null!, new[] { 1, 2 });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> throws <see cref="ArgumentNullException"/> for a null values sequence.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenValuesIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.AddRange("a", null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> appends all values to an existing key.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCalled_ShouldAppendAllValuesInOrder()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+
+        sut.AddRange("k", new[] { 2, 3, 4 });
+
+        Assert.AreEqual(4, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 4 }, sut["k"].ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> correctly counts items from a new key.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenKeyIsNew_ShouldCreateKeyAndSetCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.AddRange("new", new[] { 10, 20, 30 });
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.DataDriven.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.DataDriven.cs
@@ -1,0 +1,144 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.DataDriven.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Add — parameterised value counts per key
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Add"/> correctly accumulates any number
+    /// of values under a single key, across a range of value counts.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(5)]
+    [DataRow(10)]
+    [DataRow(100)]
+    public void Add_WhenValuesAccumulatedForOneKey_ShouldTrackCountExactly(int valueCount)
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        for (int i = 0; i < valueCount; i++)
+            sut.Add("k", i);
+
+        Assert.AreEqual(valueCount, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(valueCount, sut["k"].Count);
+    }
+
+    // --------------------------------------------------------
+    // RemoveAll — parameterised value counts
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> removes all values for a
+    /// key regardless of how many values were stored, across a range of value counts.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(5)]
+    [DataRow(10)]
+    public void RemoveAll_WhenKeyHasVariousValueCounts_ShouldRemoveAllAndUpdateCount(int valueCount)
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        for (int i = 0; i < valueCount; i++)
+            sut.Add("k", i);
+        sut.Add("other", 99);
+
+        bool result = sut.RemoveAll("k");
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey("k"));
+    }
+
+    // --------------------------------------------------------
+    // AddRange — parameterised value counts
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.AddRange"/> appends all elements in the
+    /// supplied sequence in insertion order, for a range of sequence lengths.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(3)]
+    [DataRow(10)]
+    [DataRow(50)]
+    public void AddRange_WhenSequenceHasVaryingLength_ShouldAppendAllInOrder(int length)
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        int[] values = Enumerable.Range(0, length).ToArray();
+
+        sut.AddRange("k", values);
+
+        Assert.AreEqual(length, sut.Count);
+        CollectionAssert.AreEqual(values, sut["k"].ToList());
+    }
+
+    // --------------------------------------------------------
+    // Remove — value at various positions in the list
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> can remove the
+    /// value at any position (by value index) within a key's list, for a range of list sizes.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 0)]
+    [DataRow(3, 1)]
+    [DataRow(3, 2)]
+    [DataRow(5, 0)]
+    [DataRow(5, 4)]
+    public void Remove_WhenValueIsAtVariousPositions_ShouldRemoveExactlyOne(int listSize, int positionToRemove)
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        for (int i = 0; i < listSize; i++)
+            sut.Add("k", i * 10);
+
+        int valueToRemove = positionToRemove * 10;
+        bool result = sut.Remove("k", valueToRemove);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(listSize - 1, sut.Count);
+        Assert.IsFalse(sut["k"].Contains(valueToRemove));
+    }
+
+    // --------------------------------------------------------
+    // GetValues — insertion-order guarantee
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.GetValues"/> always returns values in
+    /// insertion order, for a range of value counts.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(5)]
+    [DataRow(20)]
+    public void GetValues_WhenRetrieved_ShouldPreserveInsertionOrder(int valueCount)
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        int[] expected = Enumerable.Range(0, valueCount).Select(i => i * 7).ToArray();
+        foreach (int v in expected)
+            sut.Add("k", v);
+
+        System.Collections.Generic.IReadOnlyList<int> actual = sut.GetValues("k");
+
+        CollectionAssert.AreEqual(expected, actual.ToList());
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Enumeration.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Enumeration.cs
@@ -103,6 +103,206 @@ public partial class MultiValueDictionaryTests
     }
 
     // --------------------------------------------------------
+    // Enumerator — Current before MoveNext
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that accessing <see cref="MultiValueDictionary{TKey,TValue}.Enumerator.Current"/> before the first call to
+    /// <see cref="MultiValueDictionary{TKey,TValue}.Enumerator.MoveNext"/> throws <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_CurrentBeforeMoveNext_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        MultiValueDictionary<string, int>.Enumerator en = sut.GetEnumerator();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = en.Current;
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — Current after exhaustion
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that accessing <see cref="MultiValueDictionary{TKey,TValue}.Enumerator.Current"/> after the enumerator is exhausted throws <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_AfterExhaustion_CurrentShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        MultiValueDictionary<string, int>.Enumerator en = sut.GetEnumerator();
+        while (en.MoveNext()) { }
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = en.Current;
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — Reset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Enumerator.Reset"/> repositions the enumerator to before the first element,
+    /// allowing the dictionary to be enumerated again from the beginning.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenReset_ShouldAllowReEnumeration()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        MultiValueDictionary<string, int>.Enumerator en = sut.GetEnumerator();
+        List<string> firstPass = new List<string>();
+        while (en.MoveNext())
+            firstPass.Add(en.Current.Key);
+
+        en.Reset();
+
+        List<string> secondPass = new List<string>();
+        while (en.MoveNext())
+            secondPass.Add(en.Current.Key);
+
+        firstPass.Sort();
+        secondPass.Sort();
+        CollectionAssert.AreEqual(firstPass, secondPass);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Enumerator.Reset"/> throws <see cref="InvalidOperationException"/> when the dictionary was modified after the enumerator was created.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetAfterModification_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        MultiValueDictionary<string, int>.Enumerator en = sut.GetEnumerator();
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            en.Reset();
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — additional mutation invalidation paths
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the dictionary is modified via <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedViaRemoveAll_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, IReadOnlyList<int>> _ in sut)
+                sut.RemoveAll("a");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the dictionary is cleared during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedViaClear_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, IReadOnlyList<int>> _ in sut)
+                sut.Clear();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when a single value is removed from an existing key during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedViaRemove_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, IReadOnlyList<int>> _ in sut)
+                sut.Remove("a", 1);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Flatten — additional mutation invalidation paths
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> throws <see cref="InvalidOperationException"/> when the dictionary is modified via <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenModifiedViaRemoveAll_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, int> _ in sut.Flatten())
+                sut.RemoveAll("a");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> throws <see cref="InvalidOperationException"/> when the dictionary is cleared during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenModifiedViaClear_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, int> _ in sut.Flatten())
+                sut.Clear();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> throws <see cref="InvalidOperationException"/> when a value is removed during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenModifiedViaRemove_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, int> _ in sut.Flatten())
+                sut.Remove("a", 1);
+        });
+    }
+
+    // --------------------------------------------------------
     // Regression: round-trip fidelity
     // --------------------------------------------------------
 

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Enumeration.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Enumeration.cs
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.Enumeration.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Flatten()
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> produces one pair per value entry.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenCalled_ShouldYieldOnePairPerValueEntry()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("b", 3);
+
+        List<KeyValuePair<string, int>> flat = sut.Flatten().ToList();
+
+        Assert.AreEqual(3, flat.Count);
+
+        List<KeyValuePair<string, int>> sorted = flat.OrderBy(p => p.Key).ThenBy(p => p.Value).ToList();
+        Assert.AreEqual(new KeyValuePair<string, int>("a", 1), sorted[0]);
+        Assert.AreEqual(new KeyValuePair<string, int>("a", 2), sorted[1]);
+        Assert.AreEqual(new KeyValuePair<string, int>("b", 3), sorted[2]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> returns no pairs when the dictionary is empty.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenEmpty_ShouldReturnNoPairs()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.AreEqual(0, sut.Flatten().Count());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Flatten"/> throws <see cref="InvalidOperationException"/> when modified during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Flatten_WhenModifiedDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, int> _ in sut.Flatten())
+                sut.Add("c", 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // GetEnumerator / foreach
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that enumerating the dictionary yields one key–value-list pair per distinct key.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenEnumerated_ShouldYieldOneEntryPerKey()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("b", 3);
+
+        List<KeyValuePair<string, IReadOnlyList<int>>> entries = sut.ToList();
+
+        Assert.AreEqual(2, entries.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the dictionary is modified during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<string, IReadOnlyList<int>> _ in sut)
+                sut.Add("b", 2);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Regression: round-trip fidelity
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a large number of keys and values are stored and retrieved correctly.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Add_WhenManyKeysAndValuesAdded_ShouldRetrieveAllCorrectly()
+    {
+        MultiValueDictionary<int, int> sut = new MultiValueDictionary<int, int>();
+        int keyCount = 200;
+        int valuesPerKey = 10;
+
+        for (int k = 0; k < keyCount; k++)
+        {
+            for (int v = 0; v < valuesPerKey; v++)
+                sut.Add(k, v);
+        }
+
+        Assert.AreEqual(keyCount * valuesPerKey, sut.Count);
+        Assert.AreEqual(keyCount, sut.KeyCount);
+
+        for (int k = 0; k < keyCount; k++)
+        {
+            IReadOnlyList<int> values = sut[k];
+            Assert.AreEqual(valuesPerKey, values.Count);
+            for (int v = 0; v < valuesPerKey; v++)
+                Assert.AreEqual(v, values[v]);
+        }
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Query.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Query.cs
@@ -1,0 +1,165 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.Query.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // GetValues(TKey)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.GetValues"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void GetValues_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.GetValues(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.GetValues"/> throws <see cref="KeyNotFoundException"/> when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void GetValues_WhenKeyAbsent_ShouldThrowKeyNotFoundException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<KeyNotFoundException>(() =>
+        {
+            _ = sut.GetValues("missing");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.GetValues"/> returns the values for an existing key.
+    /// </summary>
+    [TestMethod]
+    public void GetValues_WhenKeyPresent_ShouldReturnAssociatedValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 100);
+        sut.Add("k", 200);
+
+        IReadOnlyList<int> result = sut.GetValues("k");
+
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual(100, result[0]);
+        Assert.AreEqual(200, result[1]);
+    }
+
+    // --------------------------------------------------------
+    // TryGetValues(TKey, out IReadOnlyList<TValue>)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.TryGetValues"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void TryGetValues_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.TryGetValues(null!, out _);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.TryGetValues"/> returns <see langword="false"/> and an empty list when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void TryGetValues_WhenKeyAbsent_ShouldReturnFalseAndEmptyList()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        bool found = sut.TryGetValues("missing", out IReadOnlyList<int> values);
+
+        Assert.IsFalse(found);
+        Assert.IsNotNull(values);
+        Assert.AreEqual(0, values.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.TryGetValues"/> returns <see langword="true"/> and the correct values when the key is present.
+    /// </summary>
+    [TestMethod]
+    public void TryGetValues_WhenKeyPresent_ShouldReturnTrueAndValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 5);
+        sut.Add("k", 10);
+
+        bool found = sut.TryGetValues("k", out IReadOnlyList<int> values);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(2, values.Count);
+    }
+
+    // --------------------------------------------------------
+    // ContainsValue(TKey, TValue)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.ContainsValue(null!, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> returns <see langword="false"/> when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenKeyAbsent_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.IsFalse(sut.ContainsValue("k", 1));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> returns <see langword="false"/> when the key exists but the value is absent.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenKeyPresentButValueAbsent_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+
+        Assert.IsFalse(sut.ContainsValue("k", 99));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> returns <see langword="true"/> when both key and value are present.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenKeyAndValuePresent_ShouldReturnTrue()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 42);
+
+        Assert.IsTrue(sut.ContainsValue("k", 42));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Query.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Query.cs
@@ -162,4 +162,113 @@ public partial class MultiValueDictionaryTests
 
         Assert.IsTrue(sut.ContainsValue("k", 42));
     }
+
+    // --------------------------------------------------------
+    // GetValues — live view
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the list returned by <see cref="MultiValueDictionary{TKey,TValue}.GetValues"/> reflects values added to the same key after the call.
+    /// </summary>
+    [TestMethod]
+    public void GetValues_WhenReturned_ShouldReflectSubsequentAdditions()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+
+        IReadOnlyList<int> view = sut.GetValues("k");
+        sut.Add("k", 2);
+
+        Assert.AreEqual(2, view.Count);
+        Assert.AreEqual(2, view[1]);
+    }
+
+    // --------------------------------------------------------
+    // TryGetValues — live view
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the list returned by <see cref="MultiValueDictionary{TKey,TValue}.TryGetValues"/> reflects values added to the same key after the call.
+    /// </summary>
+    [TestMethod]
+    public void TryGetValues_WhenReturned_ShouldReflectSubsequentAdditions()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 10);
+
+        bool found = sut.TryGetValues("k", out IReadOnlyList<int> view);
+        Assert.IsTrue(found);
+
+        sut.Add("k", 20);
+
+        Assert.AreEqual(2, view.Count);
+        Assert.AreEqual(20, view[1]);
+    }
+
+    // --------------------------------------------------------
+    // Indexer — live view
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the list returned by the indexer reflects values added to the same key after the call.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenKeyPresent_ShouldReflectSubsequentAdditions()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 100);
+
+        IReadOnlyList<int> view = sut["k"];
+        sut.Add("k", 200);
+
+        Assert.AreEqual(2, view.Count);
+        Assert.AreEqual(200, view[1]);
+    }
+
+    // --------------------------------------------------------
+    // Null values
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a <see langword="null"/> value can be stored and retrieved under a key.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenValueIsNull_ShouldStoreAndRetrieveNull()
+    {
+        MultiValueDictionary<string, string?> sut = new MultiValueDictionary<string, string?>();
+
+        sut.Add("k", null);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsNull(sut["k"][0]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> returns <see langword="true"/> when the stored value is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenValueIsNull_ShouldReturnTrue()
+    {
+        MultiValueDictionary<string, string?> sut = new MultiValueDictionary<string, string?>();
+        sut.Add("k", null);
+
+        Assert.IsTrue(sut.ContainsValue("k", null));
+    }
+
+    /// <summary>
+    /// Verifies that a <see langword="null"/> value can be removed from a key's value list.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueIsNull_ShouldRemoveNullEntry()
+    {
+        MultiValueDictionary<string, string?> sut = new MultiValueDictionary<string, string?>();
+        sut.Add("k", null);
+        sut.Add("k", "other");
+
+        bool removed = sut.Remove("k", null);
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, sut.Count);
+        CollectionAssert.AreEqual(new[] { "other" }, sut["k"].ToList());
+    }
 }

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Remove.cs
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Remove(TKey, TValue)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Remove(null!, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> returns <see langword="false"/> when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenKeyAbsent_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        bool result = sut.Remove("missing", 1);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> returns <see langword="false"/> when the value is absent for an existing key.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueAbsentForExistingKey_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+
+        bool result = sut.Remove("k", 99);
+
+        Assert.IsFalse(result);
+        Assert.AreEqual(1, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes one value and returns <see langword="true"/>.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValuePresent_ShouldReturnTrueAndDecrementCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+        sut.Add("k", 2);
+        sut.Add("k", 3);
+
+        bool result = sut.Remove("k", 2);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        CollectionAssert.AreEqual(new[] { 1, 3 }, sut["k"].ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes the key entry when its last value is removed.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenLastValueRemoved_ShouldRemoveKeyEntry()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 42);
+
+        sut.Remove("k", 42);
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey("k"));
+    }
+
+    // --------------------------------------------------------
+    // RemoveAll(TKey)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.RemoveAll(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> returns <see langword="false"/> when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenKeyAbsent_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        bool result = sut.RemoveAll("missing");
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> removes the key and all its values.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenKeyPresent_ShouldReturnTrueAndRemoveAllValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("x", 1);
+        sut.Add("x", 2);
+        sut.Add("x", 3);
+        sut.Add("y", 4);
+
+        bool result = sut.RemoveAll("x");
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey("x"));
+        Assert.IsTrue(sut.ContainsKey("y"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.Remove.cs
@@ -92,6 +92,60 @@ public partial class MultiValueDictionaryTests
         Assert.IsFalse(sut.ContainsKey("k"));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes the first occurrence and preserves remaining values when the value appears at the first position.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueIsFirstInList_ShouldPreserveRemaining()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 10);
+        sut.Add("k", 20);
+        sut.Add("k", 30);
+
+        bool result = sut.Remove("k", 10);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, sut.Count);
+        CollectionAssert.AreEqual(new[] { 20, 30 }, sut["k"].ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes the value and preserves remaining when the value appears at the last position.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueIsLastInList_ShouldPreserveRemaining()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 10);
+        sut.Add("k", 20);
+        sut.Add("k", 30);
+
+        bool result = sut.Remove("k", 30);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, sut.Count);
+        CollectionAssert.AreEqual(new[] { 10, 20 }, sut["k"].ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes only one occurrence when the same value appears multiple times under a key.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueAppearsMultipleTimes_ShouldRemoveOnlyOneOccurrence()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 5);
+        sut.Add("k", 5);
+        sut.Add("k", 5);
+
+        bool result = sut.Remove("k", 5);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(2, sut["k"].Count);
+    }
+
     // --------------------------------------------------------
     // RemoveAll(TKey)
     // --------------------------------------------------------

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.TypeCoverage.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.TypeCoverage.cs
@@ -1,0 +1,254 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.TypeCoverage.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Private helper types
+    // --------------------------------------------------------
+
+    /// <summary>Value-type key with structural (value-based) equality via record struct.</summary>
+    private readonly record struct Coord(int Row, int Col);
+
+    /// <summary>Reference-type value with no overridden equality — uses reference identity.</summary>
+    private sealed class Label
+    {
+        public string Text { get; }
+
+        public Label(string text) { Text = text; }
+    }
+
+    // --------------------------------------------------------
+    // Value-type struct as TKey
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a struct key with the same field values is treated as the same key regardless of
+    /// which instance is used, confirming value-type equality semantics for dictionary lookup.
+    /// </summary>
+    [TestMethod]
+    public void MultiValueDictionary_WhenKeyIsValueTypeStruct_ShouldMatchByValue()
+    {
+        MultiValueDictionary<Coord, string> sut = new MultiValueDictionary<Coord, string>();
+        Coord key = new Coord(1, 2);
+
+        sut.Add(key, "alpha");
+        sut.Add(new Coord(1, 2), "beta");
+
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(2, sut[new Coord(1, 2)].Count);
+    }
+
+    /// <summary>
+    /// Verifies that two struct keys with different field values are treated as distinct keys.
+    /// </summary>
+    [TestMethod]
+    public void MultiValueDictionary_WhenKeyIsValueTypeStructWithDifferentFields_ShouldStoreSeparately()
+    {
+        MultiValueDictionary<Coord, string> sut = new MultiValueDictionary<Coord, string>();
+
+        sut.Add(new Coord(1, 2), "a");
+        sut.Add(new Coord(3, 4), "b");
+
+        Assert.AreEqual(2, sut.KeyCount);
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual("a", sut[new Coord(1, 2)][0]);
+        Assert.AreEqual("b", sut[new Coord(3, 4)][0]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> matches a struct key by
+    /// value, not by instance identity.
+    /// </summary>
+    [TestMethod]
+    public void ContainsKey_WhenKeyIsValueTypeStruct_ShouldMatchByValue()
+    {
+        MultiValueDictionary<Coord, string> sut = new MultiValueDictionary<Coord, string>();
+        sut.Add(new Coord(7, 8), "x");
+
+        Assert.IsTrue(sut.ContainsKey(new Coord(7, 8)));
+        Assert.IsFalse(sut.ContainsKey(new Coord(7, 9)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/> removes the correct entry
+    /// when the key is a value-type struct, located by value equality.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenKeyIsValueTypeStruct_ShouldRemoveByValue()
+    {
+        MultiValueDictionary<Coord, string> sut = new MultiValueDictionary<Coord, string>();
+        sut.Add(new Coord(1, 2), "a");
+        sut.Add(new Coord(3, 4), "b");
+
+        bool removed = sut.RemoveAll(new Coord(1, 2));
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey(new Coord(1, 2)));
+        Assert.IsTrue(sut.ContainsKey(new Coord(3, 4)));
+    }
+
+    // --------------------------------------------------------
+    // Value-type struct as TValue
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that struct values are stored and retrieved by value, and that insertion order is preserved.
+    /// </summary>
+    [TestMethod]
+    public void MultiValueDictionary_WhenValueIsValueTypeStruct_ShouldStoreAndRetrieveByValue()
+    {
+        MultiValueDictionary<string, Coord> sut = new MultiValueDictionary<string, Coord>();
+        sut.Add("grid", new Coord(1, 2));
+        sut.Add("grid", new Coord(3, 4));
+
+        IReadOnlyList<Coord> values = sut["grid"];
+
+        Assert.AreEqual(2, values.Count);
+        Assert.AreEqual(new Coord(1, 2), values[0]);
+        Assert.AreEqual(new Coord(3, 4), values[1]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> locates a struct value
+    /// by value equality, not by reference.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenValueIsValueTypeStruct_ShouldMatchByValue()
+    {
+        MultiValueDictionary<string, Coord> sut = new MultiValueDictionary<string, Coord>();
+        sut.Add("k", new Coord(5, 6));
+
+        Assert.IsTrue(sut.ContainsValue("k", new Coord(5, 6)));
+        Assert.IsFalse(sut.ContainsValue("k", new Coord(5, 7)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes a struct
+    /// value by value equality.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueIsValueTypeStruct_ShouldRemoveByValue()
+    {
+        MultiValueDictionary<string, Coord> sut = new MultiValueDictionary<string, Coord>();
+        sut.Add("k", new Coord(1, 2));
+        sut.Add("k", new Coord(3, 4));
+
+        bool removed = sut.Remove("k", new Coord(1, 2));
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsFalse(sut.ContainsValue("k", new Coord(1, 2)));
+        Assert.IsTrue(sut.ContainsValue("k", new Coord(3, 4)));
+    }
+
+    // --------------------------------------------------------
+    // Reference-type class as TValue (reference identity)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that two distinct <see cref="Label"/> instances with the same text are stored as separate
+    /// values, because <see cref="Label"/> uses reference identity.
+    /// </summary>
+    [TestMethod]
+    public void MultiValueDictionary_WhenValueIsReferenceType_ShouldStoreBothInstances()
+    {
+        Label l1 = new Label("hello");
+        Label l2 = new Label("hello");
+
+        MultiValueDictionary<string, Label> sut = new MultiValueDictionary<string, Label>();
+        sut.Add("k", l1);
+        sut.Add("k", l2);
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(2, sut["k"].Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsValue"/> uses reference equality
+    /// for reference-type values with no overridden <see cref="object.Equals(object)"/>.
+    /// </summary>
+    [TestMethod]
+    public void ContainsValue_WhenValueIsReferenceTypeAndSameInstance_ShouldReturnTrue()
+    {
+        Label l1 = new Label("hello");
+        Label l2 = new Label("hello");
+
+        MultiValueDictionary<string, Label> sut = new MultiValueDictionary<string, Label>();
+        sut.Add("k", l1);
+
+        Assert.IsTrue(sut.ContainsValue("k", l1));
+        Assert.IsFalse(sut.ContainsValue("k", l2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Remove(TKey,TValue)"/> removes only the
+    /// specific <see cref="Label"/> instance that was requested, leaving other instances untouched.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenValueIsReferenceType_ShouldRemoveOnlyRequestedInstance()
+    {
+        Label l1 = new Label("hello");
+        Label l2 = new Label("hello");
+
+        MultiValueDictionary<string, Label> sut = new MultiValueDictionary<string, Label>();
+        sut.Add("k", l1);
+        sut.Add("k", l2);
+
+        bool removed = sut.Remove("k", l1);
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsTrue(sut.ContainsValue("k", l2));
+        Assert.IsFalse(sut.ContainsValue("k", l1));
+    }
+
+    // --------------------------------------------------------
+    // Custom comparer for TKey
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a custom key comparer causes case-insensitively equal string keys to be merged into a
+    /// single entry, accumulating their values together.
+    /// </summary>
+    [TestMethod]
+    public void MultiValueDictionary_WhenCustomComparerUsed_ShouldMergeEquivalentKeys()
+    {
+        MultiValueDictionary<string, int> sut =
+            new MultiValueDictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+
+        sut.Add("Alpha", 1);
+        sut.Add("ALPHA", 2);
+        sut.Add("alpha", 3);
+
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(3, sut["Alpha"].Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> honours the custom key
+    /// comparer, returning <see langword="true"/> for a key that differs only in case.
+    /// </summary>
+    [TestMethod]
+    public void ContainsKey_WhenCustomComparerUsed_ShouldMatchCaseInsensitively()
+    {
+        MultiValueDictionary<string, int> sut =
+            new MultiValueDictionary<string, int>(System.StringComparer.OrdinalIgnoreCase);
+        sut.Add("FOO", 1);
+
+        Assert.IsTrue(sut.ContainsKey("foo"));
+        Assert.IsTrue(sut.ContainsKey("FOO"));
+        Assert.IsTrue(sut.ContainsKey("Foo"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.cs
@@ -178,6 +178,18 @@ public partial class MultiValueDictionaryTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> returns <see langword="true"/> when the key is present.
+    /// </summary>
+    [TestMethod]
+    public void ContainsKey_WhenKeyPresent_ShouldReturnTrue()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 1);
+
+        Assert.IsTrue(sut.ContainsKey("k"));
+    }
+
+    /// <summary>
     /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> throws <see cref="ArgumentNullException"/> for a null key.
     /// </summary>
     [TestMethod]
@@ -192,7 +204,88 @@ public partial class MultiValueDictionaryTests
     }
 
     // --------------------------------------------------------
-    // Clear
+    // Count — edge cases
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Count"/> decrements when the last value is removed from a key, eliminating the key entry.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenLastValueRemovedFromKey_ShouldDecrementByOne()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 42);
+
+        sut.Remove("k", 42);
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.KeyCount"/> decrements to zero after the last value is removed from the only key.
+    /// </summary>
+    [TestMethod]
+    public void KeyCount_WhenLastValueRemovedFromKey_ShouldDecrementToZero()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("k", 42);
+
+        sut.Remove("k", 42);
+
+        Assert.AreEqual(0, sut.KeyCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Count"/> is correctly decremented after <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/>.
+    /// </summary>
+    [TestMethod]
+    public void Count_AfterRemoveAll_ShouldReflectRemovedValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("a", 3);
+        sut.Add("b", 4);
+
+        sut.RemoveAll("a");
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+    }
+
+    // --------------------------------------------------------
+    // Keys — edge cases
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Keys"/> is empty when the dictionary contains no entries.
+    /// </summary>
+    [TestMethod]
+    public void Keys_WhenEmpty_ShouldBeEmpty()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.AreEqual(0, sut.Keys.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Keys"/> no longer contains a key after all its values are removed via <see cref="MultiValueDictionary{TKey,TValue}.RemoveAll"/>.
+    /// </summary>
+    [TestMethod]
+    public void Keys_AfterRemoveAll_ShouldNotContainRemovedKey()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("x", 1);
+        sut.Add("y", 2);
+
+        sut.RemoveAll("x");
+
+        CollectionAssert.DoesNotContain(sut.Keys.ToList(), "x");
+        CollectionAssert.Contains(sut.Keys.ToList(), "y");
+    }
+
+    // --------------------------------------------------------
+    // Clear — edge cases
     // --------------------------------------------------------
 
     /// <summary>
@@ -210,5 +303,38 @@ public partial class MultiValueDictionaryTests
         Assert.AreEqual(0, sut.Count);
         Assert.AreEqual(0, sut.KeyCount);
         Assert.IsFalse(sut.ContainsKey("a"));
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="MultiValueDictionary{TKey,TValue}.Clear"/> on an already-empty dictionary leaves it in a valid empty state.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenAlreadyEmpty_ShouldRemainEmpty()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.KeyCount);
+    }
+
+    /// <summary>
+    /// Verifies that entries added after <see cref="MultiValueDictionary{TKey,TValue}.Clear"/> are tracked correctly.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalledThenItemsReAdded_ShouldTrackNewItems()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("old", 1);
+        sut.Clear();
+
+        sut.Add("new", 10);
+        sut.Add("new", 20);
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey("old"));
+        Assert.IsTrue(sut.ContainsKey("new"));
     }
 }

--- a/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.cs
+++ b/Bodu.Core/test/Collections.Generic/MultiValueDictionaryTests.cs
@@ -1,0 +1,214 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultiValueDictionaryTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Unit tests for <see cref="MultiValueDictionary{TKey, TValue}"/>.
+/// </summary>
+[TestClass]
+public partial class MultiValueDictionaryTests
+{
+    // --------------------------------------------------------
+    // Constructor — default
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the default constructor produces an empty dictionary with zero counts.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Ctor_WhenDefault_ShouldBeEmpty()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.KeyCount);
+    }
+
+    /// <summary>
+    /// Verifies that the default constructor uses the default equality comparer for keys.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenDefault_ShouldUseDefaultComparer()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.AreEqual(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Constructor — with comparer
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that passing a null comparer to the comparer constructor defaults to the default equality comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsNull_ShouldUseDefaultComparer()
+    {
+        MultiValueDictionary<string, int> sut =
+            new MultiValueDictionary<string, int>((IEqualityComparer<string>?)null);
+
+        Assert.AreEqual(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that a custom comparer is used for key equality.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldUseSpecifiedComparer()
+    {
+        MultiValueDictionary<string, int> sut =
+            new MultiValueDictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+
+        sut.Add("KEY", 1);
+        sut.Add("key", 2);
+
+        Assert.AreEqual(1, sut.KeyCount);
+        Assert.AreEqual(2, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // Count and KeyCount
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Count"/> reflects the total value entries.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenItemsAdded_ShouldReflectTotalValueEntries()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("b", 3);
+
+        Assert.AreEqual(3, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.KeyCount"/> reflects only the number of distinct keys.
+    /// </summary>
+    [TestMethod]
+    public void KeyCount_WhenItemsAdded_ShouldReflectDistinctKeyCount()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("a", 2);
+        sut.Add("b", 3);
+
+        Assert.AreEqual(2, sut.KeyCount);
+    }
+
+    // --------------------------------------------------------
+    // Keys
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Keys"/> contains all distinct keys.
+    /// </summary>
+    [TestMethod]
+    public void Keys_WhenItemsAdded_ShouldContainAllDistinctKeys()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("x", 1);
+        sut.Add("y", 2);
+        sut.Add("x", 3);
+
+        CollectionAssert.Contains(sut.Keys.ToList(), "x");
+        CollectionAssert.Contains(sut.Keys.ToList(), "y");
+        Assert.AreEqual(2, sut.Keys.Count);
+    }
+
+    // --------------------------------------------------------
+    // Indexer
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the indexer returns an empty list for an absent key rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenKeyAbsent_ShouldReturnEmptyList()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        IReadOnlyList<int> result = sut["missing"];
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the indexer returns the values for an existing key.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenKeyPresent_ShouldReturnAssociatedValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 10);
+        sut.Add("a", 20);
+
+        IReadOnlyList<int> result = sut["a"];
+
+        Assert.AreEqual(2, result.Count);
+        CollectionAssert.AreEqual(new[] { 10, 20 }, result.ToList());
+    }
+
+    // --------------------------------------------------------
+    // ContainsKey
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> returns <see langword="false"/> for an absent key.
+    /// </summary>
+    [TestMethod]
+    public void ContainsKey_WhenKeyAbsent_ShouldReturnFalse()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.IsFalse(sut.ContainsKey("missing"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.ContainsKey"/> throws <see cref="ArgumentNullException"/> for a null key.
+    /// </summary>
+    [TestMethod]
+    public void ContainsKey_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.ContainsKey(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Clear
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="MultiValueDictionary{TKey,TValue}.Clear"/> removes all entries.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalled_ShouldRemoveAllKeysAndValues()
+    {
+        MultiValueDictionary<string, int> sut = new MultiValueDictionary<string, int>();
+        sut.Add("a", 1);
+        sut.Add("b", 2);
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.KeyCount);
+        Assert.IsFalse(sut.ContainsKey("a"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.Add.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.Add.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Add(T item)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T)"/> increments <see cref="Multiset{T}.Count"/> by one.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemAdded_ShouldIncrementCount()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        sut.Add(1);
+
+        Assert.AreEqual(1, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T)"/> increments the multiplicity of an existing element.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenSameItemAddedTwice_ShouldIncrementCountOf()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        sut.Add(7);
+        sut.Add(7);
+
+        Assert.AreEqual(2, sut.CountOf(7));
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T)"/> increases <see cref="Multiset{T}.DistinctCount"/> only for new elements.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDistinctItemsAdded_ShouldIncrementDistinctCount()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        sut.Add("a");
+        sut.Add("b");
+        sut.Add("a");
+
+        Assert.AreEqual(2, sut.DistinctCount);
+    }
+
+    // --------------------------------------------------------
+    // Add(T item, int count)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T, int)"/> throws <see cref="ArgumentOutOfRangeException"/> when count is zero.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCountIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Add(1, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T, int)"/> throws <see cref="ArgumentOutOfRangeException"/> when count is negative.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCountIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Add(1, -3);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T, int)"/> adds the correct number of occurrences at once.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCountIsPositive_ShouldAddMultipleOccurrences()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        sut.Add(42, 5);
+
+        Assert.AreEqual(5, sut.CountOf(42));
+        Assert.AreEqual(5, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T, int)"/> accumulates counts when called multiple times for the same element.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCalledMultipleTimesForSameElement_ShouldAccumulateCounts()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        sut.Add("x", 3);
+        sut.Add("x", 4);
+
+        Assert.AreEqual(7, sut.CountOf("x"));
+        Assert.AreEqual(7, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that adding a large number of items maintains accurate count tracking.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Add_WhenManyDistinctItemsAdded_ShouldTrackAllCountsAccurately()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        int expectedTotal = 0;
+
+        for (int i = 0; i < 1000; i++)
+        {
+            int count = (i % 5) + 1;
+            sut.Add(i, count);
+            expectedTotal += count;
+        }
+
+        Assert.AreEqual(expectedTotal, sut.Count);
+        Assert.AreEqual(1000, sut.DistinctCount);
+
+        for (int i = 0; i < 1000; i++)
+            Assert.AreEqual((i % 5) + 1, sut.CountOf(i));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.DataDriven.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.DataDriven.cs
@@ -1,0 +1,196 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.DataDriven.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Add(T, int) — parameterised count
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Add(T, int)"/> adds exactly the specified number of occurrences
+    /// for a range of count values.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(5)]
+    [DataRow(10)]
+    [DataRow(1000)]
+    public void Add_WhenCountProvided_ShouldSetCountOfExactly(int count)
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        sut.Add(99, count);
+
+        Assert.AreEqual(count, sut.CountOf(99));
+        Assert.AreEqual(count, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+    }
+
+    // --------------------------------------------------------
+    // Remove — decrements from various initial counts
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> decrements the occurrence count by exactly one,
+    /// across a range of initial counts.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, 0)]
+    [DataRow(2, 1)]
+    [DataRow(5, 4)]
+    [DataRow(10, 9)]
+    public void Remove_WhenElementHasMultipleOccurrences_ShouldDecrementCountOf(int initialCount, int expectedAfter)
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(42, initialCount);
+
+        sut.Remove(42);
+
+        Assert.AreEqual(expectedAfter, sut.CountOf(42));
+        Assert.AreEqual(expectedAfter, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // Union — various left/right count combinations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> returns the maximum of the two operand counts for a
+    /// single shared element, across a range of count combinations.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 1, 3)]
+    [DataRow(1, 3, 3)]
+    [DataRow(2, 2, 2)]
+    [DataRow(0, 5, 5)]
+    [DataRow(5, 0, 5)]
+    [DataRow(4, 4, 4)]
+    public void Union_WhenCountsVary_ShouldReturnMaxCount(int leftCount, int rightCount, int expectedCount)
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+        if (leftCount > 0) a.Add(1, leftCount);
+        if (rightCount > 0) b.Add(1, rightCount);
+
+        Multiset<int> result = a.Union(b);
+
+        Assert.AreEqual(expectedCount, result.CountOf(1));
+    }
+
+    // --------------------------------------------------------
+    // Intersect — various left/right count combinations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns the minimum of the two operand counts for a
+    /// shared element, across a range of count combinations.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 1, 1)]
+    [DataRow(1, 3, 1)]
+    [DataRow(4, 4, 4)]
+    [DataRow(0, 5, 0)]
+    [DataRow(5, 0, 0)]
+    public void Intersect_WhenCountsVary_ShouldReturnMinCount(int leftCount, int rightCount, int expectedCount)
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+        if (leftCount > 0) a.Add(1, leftCount);
+        if (rightCount > 0) b.Add(1, rightCount);
+
+        Multiset<int> result = a.Intersect(b);
+
+        Assert.AreEqual(expectedCount, result.CountOf(1));
+    }
+
+    // --------------------------------------------------------
+    // Except — various left/right count combinations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> returns max(0, left − right) for a single element,
+    /// across a range of count combinations.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 1, 2)]
+    [DataRow(1, 3, 0)]
+    [DataRow(2, 2, 0)]
+    [DataRow(5, 0, 5)]
+    [DataRow(0, 5, 0)]
+    [DataRow(3, 3, 0)]
+    public void Except_WhenCountsVary_ShouldReturnClampedDifference(int leftCount, int rightCount, int expectedCount)
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+        if (leftCount > 0) a.Add(1, leftCount);
+        if (rightCount > 0) b.Add(1, rightCount);
+
+        Multiset<int> result = a.Except(b);
+
+        Assert.AreEqual(expectedCount, result.CountOf(1));
+    }
+
+    // --------------------------------------------------------
+    // Sum — various left/right count combinations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> returns the sum of the two operand counts for a single
+    /// element, across a range of count combinations.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 1, 4)]
+    [DataRow(1, 3, 4)]
+    [DataRow(2, 2, 4)]
+    [DataRow(0, 5, 5)]
+    [DataRow(5, 0, 5)]
+    [DataRow(4, 4, 8)]
+    public void Sum_WhenCountsVary_ShouldReturnSumOfCounts(int leftCount, int rightCount, int expectedCount)
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+        if (leftCount > 0) a.Add(1, leftCount);
+        if (rightCount > 0) b.Add(1, rightCount);
+
+        Multiset<int> result = a.Sum(b);
+
+        Assert.AreEqual(expectedCount, result.CountOf(1));
+    }
+
+    // --------------------------------------------------------
+    // CopyTo — parameterised array size and offset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> fills the destination array starting at the
+    /// specified index, leaving preceding slots untouched, for a range of offsets.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(3)]
+    [DataRow(5)]
+    public void CopyTo_WhenOffsetVaries_ShouldFillFromOffsetOnly(int offset)
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(7, 2);
+        int[] dest = new int[offset + 2];
+
+        sut.CopyTo(dest, offset);
+
+        for (int i = 0; i < offset; i++)
+            Assert.AreEqual(0, dest[i], $"Slot {i} before offset should be untouched.");
+
+        Assert.AreEqual(7, dest[offset]);
+        Assert.AreEqual(7, dest[offset + 1]);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.Enumeration.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.Enumeration.cs
@@ -175,4 +175,201 @@ public partial class MultisetTests
         int[] values = dest.Cast<int>().OrderBy(x => x).ToArray();
         CollectionAssert.AreEqual(new[] { 5, 5, 6 }, values);
     }
+
+    // --------------------------------------------------------
+    // Enumerator — Current before MoveNext
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that accessing <see cref="Multiset{T}.Enumerator.Current"/> before the first call to
+    /// <see cref="Multiset{T}.Enumerator.MoveNext"/> throws <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_CurrentBeforeMoveNext_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        Multiset<int>.Enumerator en = sut.GetEnumerator();
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = en.Current;
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — Current after exhaustion
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that accessing <see cref="Multiset{T}.Enumerator.Current"/> after the enumerator is exhausted throws <see cref="InvalidOperationException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_AfterExhaustion_CurrentShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(42);
+        Multiset<int>.Enumerator en = sut.GetEnumerator();
+        while (en.MoveNext()) { }
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = en.Current;
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — Reset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Enumerator.Reset"/> repositions the enumerator to before the first element,
+    /// allowing the multiset to be enumerated again from the beginning.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenReset_ShouldAllowReEnumeration()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1, 2);
+        sut.Add(2, 1);
+
+        Multiset<int>.Enumerator en = sut.GetEnumerator();
+        List<int> firstPass = new List<int>();
+        while (en.MoveNext())
+            firstPass.Add(en.Current);
+
+        en.Reset();
+
+        List<int> secondPass = new List<int>();
+        while (en.MoveNext())
+            secondPass.Add(en.Current);
+
+        firstPass.Sort();
+        secondPass.Sort();
+        CollectionAssert.AreEqual(firstPass, secondPass);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Enumerator.Reset"/> throws <see cref="InvalidOperationException"/>
+    /// when the multiset has been modified after the enumerator was created.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetAfterModification_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        Multiset<int>.Enumerator en = sut.GetEnumerator();
+        sut.Add(2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            en.Reset();
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — RemoveAll invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the multiset is modified via <see cref="Multiset{T}.RemoveAll"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedDuringEnumerationViaRemoveAll_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut)
+                sut.RemoveAll(1);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Enumerator — Add(T, int) invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the multiset is modified via <see cref="Multiset{T}.Add(T, int)"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedDuringEnumerationViaAddWithCount_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut)
+                sut.Add(99, 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Distinct — empty multiset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Distinct()"/> yields no elements when the multiset is empty.
+    /// </summary>
+    [TestMethod]
+    public void Distinct_WhenEmpty_ShouldYieldNoElements()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.AreEqual(0, sut.Distinct().Count());
+    }
+
+    // --------------------------------------------------------
+    // Frequencies — empty multiset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Frequencies()"/> yields no pairs when the multiset is empty.
+    /// </summary>
+    [TestMethod]
+    public void Frequencies_WhenEmpty_ShouldYieldNoPairs()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.AreEqual(0, sut.Frequencies().Count());
+    }
+
+    // --------------------------------------------------------
+    // Distinct — RemoveAll invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Distinct()"/> throws <see cref="InvalidOperationException"/> when the multiset is modified via <see cref="Multiset{T}.RemoveAll"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Distinct_WhenModifiedViaRemoveAllDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut.Distinct())
+                sut.RemoveAll(1);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Frequencies — RemoveAll invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Frequencies()"/> throws <see cref="InvalidOperationException"/> when the multiset is modified via <see cref="Multiset{T}.RemoveAll"/> during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Frequencies_WhenModifiedViaRemoveAllDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<int, int> _ in sut.Frequencies())
+                sut.RemoveAll(1);
+        });
+    }
 }

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.Enumeration.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.Enumeration.cs
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.Enumeration.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // GetEnumerator / foreach
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that enumerating the multiset yields each element as many times as its occurrence count.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenEnumerated_ShouldYieldElementsWithMultiplicity()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1, 3);
+        sut.Add(2, 2);
+
+        List<int> result = sut.ToList();
+        result.Sort();
+
+        CollectionAssert.AreEqual(new[] { 1, 1, 1, 2, 2 }, result);
+    }
+
+    /// <summary>
+    /// Verifies that enumerating an empty multiset produces no elements.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenEmpty_ShouldProduceNoElements()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.AreEqual(0, sut.Count());
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the multiset is modified during enumeration via Add.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedDuringEnumerationViaAdd_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut)
+                sut.Add(99);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the multiset is modified during enumeration via Remove.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenModifiedDuringEnumerationViaRemove_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut)
+                sut.Remove(1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator throws <see cref="InvalidOperationException"/> when the multiset is cleared during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenClearedDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut)
+                sut.Clear();
+        });
+    }
+
+    // --------------------------------------------------------
+    // Distinct()
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Distinct()"/> yields each element exactly once.
+    /// </summary>
+    [TestMethod]
+    public void Distinct_WhenCalled_ShouldYieldEachDistinctElementOnce()
+    {
+        Multiset<string> sut = new Multiset<string>(["a", "a", "b", "c", "c", "c"]);
+
+        List<string> distinct = sut.Distinct().OrderBy(x => x).ToList();
+
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, distinct);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Distinct()"/> throws <see cref="InvalidOperationException"/> when modified during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Distinct_WhenModifiedDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (int _ in sut.Distinct())
+                sut.Add(99);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Frequencies()
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Frequencies()"/> returns correct element–count pairs.
+    /// </summary>
+    [TestMethod]
+    public void Frequencies_WhenCalled_ShouldReturnCorrectPairs()
+    {
+        Multiset<string> sut = new Multiset<string>(["a", "a", "b"]);
+
+        Dictionary<string, int> freqs = sut.Frequencies().ToDictionary(p => p.Key, p => p.Value);
+
+        Assert.AreEqual(2, freqs["a"]);
+        Assert.AreEqual(1, freqs["b"]);
+        Assert.AreEqual(2, freqs.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Frequencies()"/> throws <see cref="InvalidOperationException"/> when modified during enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Frequencies_WhenModifiedDuringEnumeration_ShouldThrowInvalidOperationException()
+    {
+        Multiset<int> sut = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            foreach (KeyValuePair<int, int> _ in sut.Frequencies())
+                sut.Add(99);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection explicit (non-generic)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> copies all elements with multiplicity into an object array.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenCalled_ShouldCopyAllElementsWithMultiplicity()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(5, 2);
+        sut.Add(6, 1);
+
+        object[] dest = new object[3];
+        ((System.Collections.ICollection)sut).CopyTo(dest, 0);
+
+        int[] values = dest.Cast<int>().OrderBy(x => x).ToArray();
+        CollectionAssert.AreEqual(new[] { 5, 5, 6 }, values);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.ICollection.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.ICollection.cs
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.ICollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // ICollection.IsSynchronized
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="System.Collections.ICollection.IsSynchronized"/> always returns <see langword="false"/>.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionIsSynchronized_ShouldReturnFalse()
+    {
+        ICollection sut = new Multiset<int>();
+
+        Assert.IsFalse(sut.IsSynchronized);
+    }
+
+    // --------------------------------------------------------
+    // ICollection.SyncRoot
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="System.Collections.ICollection.SyncRoot"/> returns a non-null object.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionSyncRoot_ShouldReturnNonNull()
+    {
+        ICollection sut = new Multiset<int>();
+
+        Assert.IsNotNull(sut.SyncRoot);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="System.Collections.ICollection.SyncRoot"/> returns the same instance on successive calls.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionSyncRoot_WhenCalledMultipleTimes_ShouldReturnSameInstance()
+    {
+        ICollection sut = new Multiset<int>();
+
+        object first = sut.SyncRoot;
+        object second = sut.SyncRoot;
+
+        Assert.AreSame(first, second);
+    }
+
+    // --------------------------------------------------------
+    // ICollection<T>.IsReadOnly
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ICollection{T}.IsReadOnly"/> returns <see langword="false"/> for a mutable multiset.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionIsReadOnly_ShouldReturnFalse()
+    {
+        ICollection<int> sut = new Multiset<int>();
+
+        Assert.IsFalse(sut.IsReadOnly);
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — null array
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> throws <see cref="ArgumentNullException"/> when the array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        ICollection sut = new Multiset<int>();
+        ((Multiset<int>)sut).Add(1);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.CopyTo(null!, 0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — negative index
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> throws <see cref="ArgumentOutOfRangeException"/> when the index is negative.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        ICollection sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.CopyTo(new object[5], -1);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — array too small
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> throws <see cref="ArgumentException"/> when the destination array is too small.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenArrayIsTooSmall_ShouldThrowArgumentException()
+    {
+        Multiset<int> multiset = new Multiset<int>();
+        multiset.Add(1);
+        multiset.Add(2);
+        multiset.Add(3);
+        ICollection sut = multiset;
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new object[2], 0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — multidimensional array
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> throws <see cref="ArgumentException"/> when the array is multidimensional.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenArrayIsMultidimensional_ShouldThrowArgumentException()
+    {
+        ICollection sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new object[2, 2], 0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — incompatible element type
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> throws <see cref="ArgumentException"/> when the destination array has an incompatible element type.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenElementTypeIsIncompatible_ShouldThrowArgumentException()
+    {
+        Multiset<string> multiset = new Multiset<string>();
+        multiset.Add("hello");
+        ICollection sut = multiset;
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[1], 0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — empty multiset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> does not modify the destination array when the multiset is empty.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenMultisetIsEmpty_ShouldNotModifyArray()
+    {
+        ICollection sut = new Multiset<int>();
+        object[] dest = new object[] { 99 };
+
+        sut.CopyTo(dest, 0);
+
+        Assert.AreEqual(99, dest[0]);
+    }
+
+    // --------------------------------------------------------
+    // ICollection.CopyTo — with offset
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the non-generic <c>ICollection.CopyTo</c> copies elements starting at the specified index offset.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionCopyTo_WhenOffsetSpecified_ShouldCopyAtCorrectPosition()
+    {
+        Multiset<int> multiset = new Multiset<int>();
+        multiset.Add(7, 2);
+        ICollection sut = multiset;
+        object[] dest = new object[4];
+
+        sut.CopyTo(dest, 2);
+
+        Assert.IsNull(dest[0]);
+        Assert.IsNull(dest[1]);
+        Assert.AreEqual(7, (int)dest[2]);
+        Assert.AreEqual(7, (int)dest[3]);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.Remove.cs
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Remove(T item)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> returns <see langword="false"/> when the element is absent.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementAbsent_ShouldReturnFalse()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        bool result = sut.Remove(99);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> returns <see langword="true"/> and decrements the count for an existing element.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenElementPresent_ShouldReturnTrueAndDecrementCount()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1, 3);
+
+        bool result = sut.Remove(1);
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(2, sut.CountOf(1));
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> removes the element from the multiset when its last occurrence is removed.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenLastOccurrenceRemoved_ShouldEliminateElement()
+    {
+        Multiset<string> sut = new Multiset<string>();
+        sut.Add("only");
+
+        sut.Remove("only");
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.DistinctCount);
+        Assert.IsFalse(sut.Contains("only"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> does not affect other elements when called for one element.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenOneElementRemoved_ShouldNotAffectOtherElements()
+    {
+        Multiset<string> sut = new Multiset<string>(["a", "a", "b", "b", "b"]);
+
+        sut.Remove("a");
+
+        Assert.AreEqual(1, sut.CountOf("a"));
+        Assert.AreEqual(3, sut.CountOf("b"));
+        Assert.AreEqual(4, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // RemoveAll(T item)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.RemoveAll"/> returns <see langword="false"/> when the element is absent.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenElementAbsent_ShouldReturnFalse()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        bool result = sut.RemoveAll(42);
+
+        Assert.IsFalse(result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.RemoveAll"/> returns <see langword="true"/> and removes all occurrences.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenElementPresent_ShouldReturnTrueAndRemoveAllOccurrences()
+    {
+        Multiset<string> sut = new Multiset<string>(["x", "x", "x", "y"]);
+
+        bool result = sut.RemoveAll("x");
+
+        Assert.IsTrue(result);
+        Assert.AreEqual(0, sut.CountOf("x"));
+        Assert.IsFalse(sut.Contains("x"));
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.RemoveAll"/> does not affect other elements.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAll_WhenCalled_ShouldNotAffectOtherElements()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1, 5);
+        sut.Add(2, 3);
+
+        sut.RemoveAll(1);
+
+        Assert.AreEqual(3, sut.CountOf(2));
+        Assert.AreEqual(3, sut.Count);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.SetOperations.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.SetOperations.cs
@@ -204,4 +204,258 @@ public partial class MultisetTests
         Assert.AreEqual(2, a.Count);
         Assert.AreEqual(2, b.Count);
     }
+
+    // --------------------------------------------------------
+    // Union — empty operands
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> returns an empty multiset when both operands are empty.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenBothEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Union(b);
+
+        Assert.AreEqual(0, result.Count);
+        Assert.AreEqual(0, result.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> returns a copy of the right operand when the left operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenLeftIsEmpty_ShouldReturnCopyOfRight()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>(new[] { 1, 1, 2 });
+
+        Multiset<int> result = a.Union(b);
+
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(2, result.CountOf(1));
+        Assert.AreEqual(1, result.CountOf(2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> returns a copy of the left operand when the right operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenRightIsEmpty_ShouldReturnCopyOfLeft()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 2 });
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Union(b);
+
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(2, result.CountOf(1));
+        Assert.AreEqual(1, result.CountOf(2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> with itself returns a multiset with the same element counts.
+    /// </summary>
+    [TestMethod]
+    public void Union_WithSelf_ShouldReturnSameCounts()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 1, 2, 2 });
+
+        Multiset<int> result = a.Union(a);
+
+        Assert.AreEqual(3, result.CountOf(1));
+        Assert.AreEqual(2, result.CountOf(2));
+        Assert.AreEqual(5, result.Count);
+    }
+
+    // --------------------------------------------------------
+    // Intersect — empty operands
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns an empty multiset when both operands are empty.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenBothEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Intersect(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns an empty multiset when the left operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenLeftIsEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Multiset<int> result = a.Intersect(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns an empty multiset when the right operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenRightIsEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 2, 3 });
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Intersect(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> with itself returns a multiset with the same element counts.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WithSelf_ShouldReturnSameCounts()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 1, 2, 2 });
+
+        Multiset<int> result = a.Intersect(a);
+
+        Assert.AreEqual(3, result.CountOf(1));
+        Assert.AreEqual(2, result.CountOf(2));
+        Assert.AreEqual(5, result.Count);
+    }
+
+    // --------------------------------------------------------
+    // Except — empty operands
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> returns an empty multiset when both operands are empty.
+    /// </summary>
+    [TestMethod]
+    public void Except_WhenBothEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Except(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> returns an empty multiset when the left operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Except_WhenLeftIsEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>(new[] { 1, 2, 3 });
+
+        Multiset<int> result = a.Except(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> returns a copy of the left operand when the right operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Except_WhenRightIsEmpty_ShouldReturnCopyOfLeft()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 2 });
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Except(b);
+
+        Assert.AreEqual(2, result.CountOf(1));
+        Assert.AreEqual(1, result.CountOf(2));
+        Assert.AreEqual(3, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> with itself returns an empty multiset.
+    /// </summary>
+    [TestMethod]
+    public void Except_WithSelf_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 1, 2, 2 });
+
+        Multiset<int> result = a.Except(a);
+
+        Assert.AreEqual(0, result.Count);
+        Assert.AreEqual(0, result.DistinctCount);
+    }
+
+    // --------------------------------------------------------
+    // Sum — empty operands
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> returns an empty multiset when both operands are empty.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WhenBothEmpty_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Sum(b);
+
+        Assert.AreEqual(0, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> returns a copy of the right operand when the left operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WhenLeftIsEmpty_ShouldReturnCopyOfRight()
+    {
+        Multiset<int> a = new Multiset<int>();
+        Multiset<int> b = new Multiset<int>(new[] { 1, 1, 2 });
+
+        Multiset<int> result = a.Sum(b);
+
+        Assert.AreEqual(2, result.CountOf(1));
+        Assert.AreEqual(1, result.CountOf(2));
+        Assert.AreEqual(3, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> returns a copy of the left operand when the right operand is empty.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WhenRightIsEmpty_ShouldReturnCopyOfLeft()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 2 });
+        Multiset<int> b = new Multiset<int>();
+
+        Multiset<int> result = a.Sum(b);
+
+        Assert.AreEqual(2, result.CountOf(1));
+        Assert.AreEqual(1, result.CountOf(2));
+        Assert.AreEqual(3, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> with itself returns a multiset with doubled element counts.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WithSelf_ShouldReturnDoubledCounts()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 1, 2, 2 });
+
+        Multiset<int> result = a.Sum(a);
+
+        Assert.AreEqual(6, result.CountOf(1));
+        Assert.AreEqual(4, result.CountOf(2));
+        Assert.AreEqual(10, result.Count);
+    }
 }

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.SetOperations.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.SetOperations.cs
@@ -1,0 +1,207 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.SetOperations.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Union
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> throws <see cref="ArgumentNullException"/> when other is null.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Union(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> returns max count for each element.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenCalled_ShouldReturnMaxCountForEachElement()
+    {
+        Multiset<string> a = new Multiset<string>(["x", "x", "y"]);
+        Multiset<string> b = new Multiset<string>(["x", "y", "y", "z"]);
+
+        Multiset<string> result = a.Union(b);
+
+        Assert.AreEqual(2, result.CountOf("x"));
+        Assert.AreEqual(2, result.CountOf("y"));
+        Assert.AreEqual(1, result.CountOf("z"));
+        Assert.AreEqual(5, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Union"/> does not mutate either operand.
+    /// </summary>
+    [TestMethod]
+    public void Union_WhenCalled_ShouldNotMutateOperands()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 1, 2 });
+        Multiset<int> b = new Multiset<int>(new[] { 2, 3 });
+
+        _ = a.Union(b);
+
+        Assert.AreEqual(3, a.Count);
+        Assert.AreEqual(2, b.Count);
+    }
+
+    // --------------------------------------------------------
+    // Intersect
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> throws <see cref="ArgumentNullException"/> when other is null.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Intersect(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns min count for each shared element.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenCalled_ShouldReturnMinCountForSharedElements()
+    {
+        Multiset<string> a = new Multiset<string>(["x", "x", "y"]);
+        Multiset<string> b = new Multiset<string>(["x", "y", "y", "z"]);
+
+        Multiset<string> result = a.Intersect(b);
+
+        Assert.AreEqual(1, result.CountOf("x"));
+        Assert.AreEqual(1, result.CountOf("y"));
+        Assert.AreEqual(0, result.CountOf("z"));
+        Assert.AreEqual(2, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Intersect"/> returns an empty multiset when no elements are shared.
+    /// </summary>
+    [TestMethod]
+    public void Intersect_WhenNoSharedElements_ShouldReturnEmpty()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 2 });
+        Multiset<int> b = new Multiset<int>(new[] { 3, 4 });
+
+        Multiset<int> result = a.Intersect(b);
+
+        Assert.AreEqual(0, result.Count);
+        Assert.AreEqual(0, result.DistinctCount);
+    }
+
+    // --------------------------------------------------------
+    // Except
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> throws <see cref="ArgumentNullException"/> when other is null.
+    /// </summary>
+    [TestMethod]
+    public void Except_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Except(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Except"/> subtracts counts, flooring at zero.
+    /// </summary>
+    [TestMethod]
+    public void Except_WhenCalled_ShouldSubtractCountsFlooringAtZero()
+    {
+        Multiset<string> a = new Multiset<string>(["x", "x", "x", "y", "y"]);
+        Multiset<string> b = new Multiset<string>(["x", "x", "y", "y", "y", "z"]);
+
+        Multiset<string> result = a.Except(b);
+
+        Assert.AreEqual(1, result.CountOf("x"));
+        Assert.AreEqual(0, result.CountOf("y"));
+        Assert.AreEqual(0, result.CountOf("z"));
+        Assert.AreEqual(1, result.Count);
+    }
+
+    // --------------------------------------------------------
+    // Sum
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> throws <see cref="ArgumentNullException"/> when other is null.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Sum(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Sum"/> returns the combined count for each element.
+    /// </summary>
+    [TestMethod]
+    public void Sum_WhenCalled_ShouldReturnSummedCountsForEachElement()
+    {
+        Multiset<string> a = new Multiset<string>(["x", "x", "y"]);
+        Multiset<string> b = new Multiset<string>(["x", "y", "z"]);
+
+        Multiset<string> result = a.Sum(b);
+
+        Assert.AreEqual(3, result.CountOf("x"));
+        Assert.AreEqual(2, result.CountOf("y"));
+        Assert.AreEqual(1, result.CountOf("z"));
+        Assert.AreEqual(6, result.Count);
+    }
+
+    /// <summary>
+    /// Verifies that set-operation results do not share state with either operand.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void SetOperations_WhenResultMutated_ShouldNotAffectOperands()
+    {
+        Multiset<int> a = new Multiset<int>(new[] { 1, 2 });
+        Multiset<int> b = new Multiset<int>(new[] { 2, 3 });
+
+        Multiset<int> union = a.Union(b);
+        Multiset<int> intersect = a.Intersect(b);
+        Multiset<int> except = a.Except(b);
+        Multiset<int> sum = a.Sum(b);
+
+        union.Add(99);
+        intersect.Add(99);
+        except.Add(99);
+        sum.Add(99);
+
+        Assert.AreEqual(2, a.Count);
+        Assert.AreEqual(2, b.Count);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.TypeCoverage.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.TypeCoverage.cs
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.TypeCoverage.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Private helper types
+    // --------------------------------------------------------
+
+    /// <summary>Value-type element with structural (value-based) equality via record struct.</summary>
+    private readonly record struct Point(int X, int Y);
+
+    /// <summary>Reference-type element with no overridden equality — uses reference identity.</summary>
+    private sealed class Widget
+    {
+        public int Id { get; }
+
+        public Widget(int id) { Id = id; }
+    }
+
+    /// <summary>Equality comparer that considers two <see cref="Point"/> values equal when their X coordinates match.</summary>
+    private sealed class XOnlyComparer : IEqualityComparer<Point>
+    {
+        public bool Equals(Point x, Point y) => x.X == y.X;
+
+        public int GetHashCode(Point obj) => obj.X.GetHashCode();
+    }
+
+    // --------------------------------------------------------
+    // Value-type struct elements
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that two distinct <see cref="Point"/> instances with the same field values are treated as
+    /// the same element, confirming value-type equality semantics.
+    /// </summary>
+    [TestMethod]
+    public void Multiset_WithValueTypeStruct_ShouldTrackByValue()
+    {
+        Multiset<Point> sut = new Multiset<Point>();
+        sut.Add(new Point(1, 2));
+        sut.Add(new Point(1, 2));
+        sut.Add(new Point(3, 4));
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(2, sut.DistinctCount);
+        Assert.AreEqual(2, sut.CountOf(new Point(1, 2)));
+        Assert.AreEqual(1, sut.CountOf(new Point(3, 4)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="true"/> for a value-type
+    /// element that is equal by value but is a distinct instance.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WithValueTypeStruct_ShouldMatchByValue()
+    {
+        Multiset<Point> sut = new Multiset<Point>();
+        sut.Add(new Point(5, 10));
+
+        Assert.IsTrue(sut.Contains(new Point(5, 10)));
+        Assert.IsFalse(sut.Contains(new Point(5, 99)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> removes a value-type element by value equality,
+    /// not by reference identity.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WithValueTypeStruct_ShouldRemoveByValue()
+    {
+        Multiset<Point> sut = new Multiset<Point>();
+        sut.Add(new Point(1, 2), 3);
+
+        bool removed = sut.Remove(new Point(1, 2));
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(2, sut.CountOf(new Point(1, 2)));
+    }
+
+    /// <summary>
+    /// Verifies that set operations on a <see cref="Multiset{T}"/> of value-type elements produce the
+    /// correct element counts based on value equality.
+    /// </summary>
+    [TestMethod]
+    public void SetOperations_WithValueTypeStruct_ShouldApplyValueEquality()
+    {
+        Multiset<Point> a = new Multiset<Point>();
+        a.Add(new Point(1, 2), 3);
+        a.Add(new Point(3, 4), 1);
+
+        Multiset<Point> b = new Multiset<Point>();
+        b.Add(new Point(1, 2), 1);
+        b.Add(new Point(5, 6), 2);
+
+        Multiset<Point> union = a.Union(b);
+        Multiset<Point> intersect = a.Intersect(b);
+        Multiset<Point> except = a.Except(b);
+        Multiset<Point> sum = a.Sum(b);
+
+        Assert.AreEqual(3, union.CountOf(new Point(1, 2)));
+        Assert.AreEqual(1, intersect.CountOf(new Point(1, 2)));
+        Assert.AreEqual(2, except.CountOf(new Point(1, 2)));
+        Assert.AreEqual(4, sum.CountOf(new Point(1, 2)));
+    }
+
+    // --------------------------------------------------------
+    // Reference-type class elements (reference identity)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that two distinct <see cref="Widget"/> instances with the same field values are treated as
+    /// separate elements because <see cref="Widget"/> uses reference identity.
+    /// </summary>
+    [TestMethod]
+    public void Multiset_WithReferenceTypeElements_ShouldTrackByReferenceByDefault()
+    {
+        Widget w1 = new Widget(1);
+        Widget w2 = new Widget(1);
+
+        Multiset<Widget> sut = new Multiset<Widget>();
+        sut.Add(w1);
+        sut.Add(w2);
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(2, sut.DistinctCount);
+        Assert.AreEqual(1, sut.CountOf(w1));
+        Assert.AreEqual(1, sut.CountOf(w2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> with a reference-type element removes only the
+    /// specific object instance, leaving a distinct instance with the same field values untouched.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WithReferenceTypeElement_ShouldRemoveSpecificInstance()
+    {
+        Widget w1 = new Widget(99);
+        Widget w2 = new Widget(99);
+
+        Multiset<Widget> sut = new Multiset<Widget>();
+        sut.Add(w1);
+        sut.Add(w2);
+
+        sut.Remove(w1);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsFalse(sut.Contains(w1));
+        Assert.IsTrue(sut.Contains(w2));
+    }
+
+    // --------------------------------------------------------
+    // Custom equality comparer
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a <see cref="Multiset{T}"/> constructed with a custom equality comparer uses that
+    /// comparer to determine element equality, merging elements that the comparer considers equivalent.
+    /// </summary>
+    [TestMethod]
+    public void Multiset_WithCustomEqualityComparer_ShouldUseComparerForElementEquality()
+    {
+        Multiset<Point> sut = new Multiset<Point>(new XOnlyComparer());
+        sut.Add(new Point(1, 10));
+        sut.Add(new Point(1, 99));
+        sut.Add(new Point(2, 50));
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(2, sut.DistinctCount);
+        Assert.AreEqual(2, sut.CountOf(new Point(1, 0)));
+        Assert.AreEqual(1, sut.CountOf(new Point(2, 0)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Remove"/> honours the custom equality comparer when locating
+    /// the element to remove.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WithCustomEqualityComparer_ShouldLocateElementViaComparer()
+    {
+        Multiset<Point> sut = new Multiset<Point>(new XOnlyComparer());
+        sut.Add(new Point(7, 100));
+        sut.Add(new Point(7, 200));
+
+        bool removed = sut.Remove(new Point(7, 999));
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, sut.CountOf(new Point(7, 0)));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.cs
@@ -106,6 +106,34 @@ public partial class MultisetTests
         Assert.AreEqual(1, sut.CountOf("c"));
     }
 
+    /// <summary>
+    /// Verifies that constructing from an empty collection produces an empty multiset.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenEmptyCollectionProvided_ShouldBeEmpty()
+    {
+        Multiset<string> sut = new Multiset<string>(Array.Empty<string>());
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that constructing from a collection with a custom comparer uses the specified comparer for element equality.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionAndComparerProvided_ShouldUseSpecifiedComparer()
+    {
+        Multiset<string> sut = new Multiset<string>(
+            new[] { "A", "a", "B" },
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(2, sut.DistinctCount);
+        Assert.AreEqual(2, sut.CountOf("a"));
+        Assert.AreEqual(1, sut.CountOf("b"));
+    }
+
     // --------------------------------------------------------
     // Count and DistinctCount
     // --------------------------------------------------------
@@ -177,6 +205,33 @@ public partial class MultisetTests
         Assert.IsFalse(sut.Contains("world"));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="false"/> after all occurrences of an element have been removed.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenAllOccurrencesRemoved_ShouldReturnFalse()
+    {
+        Multiset<string> sut = new Multiset<string>();
+        sut.Add("x", 3);
+        sut.RemoveAll("x");
+
+        Assert.IsFalse(sut.Contains("x"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="true"/> after an element is re-added following removal.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementReaddedAfterRemoval_ShouldReturnTrue()
+    {
+        Multiset<string> sut = new Multiset<string>();
+        sut.Add("y");
+        sut.Remove("y");
+        sut.Add("y");
+
+        Assert.IsTrue(sut.Contains("y"));
+    }
+
     // --------------------------------------------------------
     // CountOf
     // --------------------------------------------------------
@@ -206,6 +261,19 @@ public partial class MultisetTests
         Assert.AreEqual(3, sut.CountOf(5));
     }
 
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CountOf"/> returns the decremented multiplicity after one occurrence is removed.
+    /// </summary>
+    [TestMethod]
+    public void CountOf_WhenOneOccurrenceRemovedFromMultiple_ShouldReturnDecremented()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(3, 4);
+        sut.Remove(3);
+
+        Assert.AreEqual(3, sut.CountOf(3));
+    }
+
     // --------------------------------------------------------
     // Clear
     // --------------------------------------------------------
@@ -223,6 +291,36 @@ public partial class MultisetTests
         Assert.AreEqual(0, sut.Count);
         Assert.AreEqual(0, sut.DistinctCount);
         Assert.IsFalse(sut.Contains("a"));
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="Multiset{T}.Clear"/> on an already-empty multiset leaves it in a valid empty state.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenAlreadyEmpty_ShouldRemainEmpty()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that items added after <see cref="Multiset{T}.Clear"/> are tracked correctly.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalledThenItemsReAdded_ShouldTrackNewItems()
+    {
+        Multiset<string> sut = new Multiset<string>(["old", "old"]);
+        sut.Clear();
+        sut.Add("new", 3);
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+        Assert.AreEqual(3, sut.CountOf("new"));
+        Assert.IsFalse(sut.Contains("old"));
     }
 
     // --------------------------------------------------------
@@ -290,5 +388,56 @@ public partial class MultisetTests
         {
             sut.CopyTo(new int[2], 0);
         });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> throws <see cref="ArgumentException"/> when the remaining space after the offset is insufficient.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenRemainingSpaceAfterOffsetIsInsufficient_ShouldThrowArgumentException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[5], 3);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> does not modify the destination array when the multiset is empty.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenMultisetIsEmpty_ShouldNotModifyArray()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        int[] dest = new int[] { 99, 88 };
+
+        sut.CopyTo(dest, 0);
+
+        Assert.AreEqual(99, dest[0]);
+        Assert.AreEqual(88, dest[1]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> copies elements starting at the specified array index.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenOffsetSpecified_ShouldCopyAtCorrectPosition()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(42, 2);
+        int[] dest = new int[5];
+
+        sut.CopyTo(dest, 2);
+
+        Assert.AreEqual(0, dest[0]);
+        Assert.AreEqual(0, dest[1]);
+        Assert.AreEqual(42, dest[2]);
+        Assert.AreEqual(42, dest[3]);
+        Assert.AreEqual(0, dest[4]);
     }
 }

--- a/Bodu.Core/test/Collections.Generic/MultisetTests.cs
+++ b/Bodu.Core/test/Collections.Generic/MultisetTests.cs
@@ -1,0 +1,294 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MultisetTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Unit tests for <see cref="Multiset{T}"/>.
+/// </summary>
+[TestClass]
+public partial class MultisetTests
+{
+    // --------------------------------------------------------
+    // Constructor — default
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the default constructor produces an empty multiset with zero count.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Ctor_WhenDefault_ShouldBeEmpty()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.DistinctCount);
+    }
+
+    /// <summary>
+    /// Verifies that the default constructor uses the default equality comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenDefault_ShouldUseDefaultComparer()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.AreEqual(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Constructor — with comparer
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that passing a null comparer to the comparer constructor defaults to the default equality comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsNull_ShouldUseDefaultComparer()
+    {
+        Multiset<string> sut = new Multiset<string>((IEqualityComparer<string>?)null);
+
+        Assert.AreEqual(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that a custom comparer is stored and used for element equality.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldUseSpecifiedComparer()
+    {
+        Multiset<string> sut = new Multiset<string>(StringComparer.OrdinalIgnoreCase);
+
+        sut.Add("A");
+        sut.Add("a");
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual(1, sut.DistinctCount);
+        Assert.AreEqual(2, sut.CountOf("A"));
+    }
+
+    // --------------------------------------------------------
+    // Constructor — from collection
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that constructing from a null collection throws <see cref="ArgumentNullException"/>.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new Multiset<string>((IEnumerable<string>)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing from a collection correctly tracks element counts.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionHasDuplicates_ShouldTrackMultiplicity()
+    {
+        Multiset<string> sut = new Multiset<string>(["a", "b", "a", "c", "a"]);
+
+        Assert.AreEqual(5, sut.Count);
+        Assert.AreEqual(3, sut.DistinctCount);
+        Assert.AreEqual(3, sut.CountOf("a"));
+        Assert.AreEqual(1, sut.CountOf("b"));
+        Assert.AreEqual(1, sut.CountOf("c"));
+    }
+
+    // --------------------------------------------------------
+    // Count and DistinctCount
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Count"/> reflects the total element count including multiplicity.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenItemsAdded_ShouldReflectTotalWithMultiplicity()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        sut.Add(1);
+        sut.Add(2);
+
+        Assert.AreEqual(3, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.DistinctCount"/> reflects only the number of unique elements.
+    /// </summary>
+    [TestMethod]
+    public void DistinctCount_WhenItemsAdded_ShouldReflectUniqueElementCount()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        sut.Add(1);
+        sut.Add(2);
+
+        Assert.AreEqual(2, sut.DistinctCount);
+    }
+
+    // --------------------------------------------------------
+    // Contains
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="false"/> for an empty multiset.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenEmpty_ShouldReturnFalse()
+    {
+        Multiset<string> sut = new Multiset<string>();
+
+        Assert.IsFalse(sut.Contains("x"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="true"/> for a present element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementPresent_ShouldReturnTrue()
+    {
+        Multiset<string> sut = new Multiset<string>();
+        sut.Add("hello");
+
+        Assert.IsTrue(sut.Contains("hello"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Contains"/> returns <see langword="false"/> for a missing element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenElementAbsent_ShouldReturnFalse()
+    {
+        Multiset<string> sut = new Multiset<string>();
+        sut.Add("hello");
+
+        Assert.IsFalse(sut.Contains("world"));
+    }
+
+    // --------------------------------------------------------
+    // CountOf
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CountOf"/> returns zero for an element not in the multiset.
+    /// </summary>
+    [TestMethod]
+    public void CountOf_WhenElementAbsent_ShouldReturnZero()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.AreEqual(0, sut.CountOf(42));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CountOf"/> returns the correct multiplicity after multiple additions.
+    /// </summary>
+    [TestMethod]
+    public void CountOf_WhenElementAddedMultipleTimes_ShouldReturnMultiplicity()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(5);
+        sut.Add(5);
+        sut.Add(5);
+
+        Assert.AreEqual(3, sut.CountOf(5));
+    }
+
+    // --------------------------------------------------------
+    // Clear
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.Clear"/> resets count and distinct count to zero.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalled_ShouldRemoveAllElements()
+    {
+        Multiset<string> sut = new Multiset<string>(["a", "a", "b"]);
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.DistinctCount);
+        Assert.IsFalse(sut.Contains("a"));
+    }
+
+    // --------------------------------------------------------
+    // CopyTo
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> throws <see cref="ArgumentNullException"/> when the array is null.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.CopyTo(null!, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> throws <see cref="ArgumentOutOfRangeException"/> when the index is negative.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.CopyTo(new int[5], -1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> copies all elements with correct multiplicity.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenCalled_ShouldCopyAllElementsWithMultiplicity()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(10, 3);
+        sut.Add(20, 2);
+
+        int[] dest = new int[5];
+        sut.CopyTo(dest, 0);
+
+        int[] sorted = (int[])dest.Clone();
+        System.Array.Sort(sorted);
+        CollectionAssert.AreEqual(new[] { 10, 10, 10, 20, 20 }, sorted);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Multiset{T}.CopyTo"/> throws <see cref="ArgumentException"/> when the destination array is too small.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsTooSmall_ShouldThrowArgumentException()
+    {
+        Multiset<int> sut = new Multiset<int>();
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[2], 0);
+        });
+    }
+}


### PR DESCRIPTION
Introduces two generic collection types absent from the BCL:

- Multiset<T>: unordered hash-backed bag that tracks element multiplicity.
  Provides O(1) Add/Remove/CountOf, set algebra (Union, Intersect, Except, Sum),
  Distinct() and Frequencies() projections, and a version-checked Enumerator.

- MultiValueDictionary<TKey,TValue>: mutable one-to-many map (multimap).
  Fills the gap left by the read-only ILookup/Lookup. Supports Add, AddRange,
  Remove(key,value), RemoveAll, GetValues, TryGetValues, a safe no-throw indexer,
  and Flatten() enumeration. Keys auto-evict when their value list empties.

Both types follow established Bodu.Core conventions: ICollection<T> /
IReadOnlyCollection<T> implementation, [DebuggerDisplay] / [DebuggerTypeProxy],
[Serializable], version-tracking enumerators, ThrowHelper validation, and
full XML documentation on every member.

Smoke, BVT, and Regression tests added for both types.

https://claude.ai/code/session_01N3GeUPWvtdNRozGFEP85MP