### PR TITLE
Review and correct ThrowHelper guard methods

### DIFF
--- a/Bodu.Core/src/ResourceStrings.Designer.cs
+++ b/Bodu.Core/src/ResourceStrings.Designer.cs
@@ -167,7 +167,16 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_Invalid_CollectionIsEmpty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The collection must not be read-only..
+        /// </summary>
+        internal static string Arg_Invalid_CollectionReadOnly {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_CollectionReadOnly", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The collection contains insufficient elements. At least {0} element(s) are required..
         /// </summary>
@@ -284,7 +293,16 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_Invalid_PositiveMultipleOf", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value must be a positive power of two..
+        /// </summary>
+        internal static string Arg_Invalid_PowerOfTwo {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_PowerOfTwo", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The value is a single Unicode surrogate character, which must be written as a pair. Consider passing a character array instead..
         /// </summary>
@@ -356,13 +374,49 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_Invalid_StringNullOrEmpty", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The string length must be exactly {0} characters..
+        /// </summary>
+        internal static string Arg_Invalid_StringLength {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_StringLength", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The string length must be between {0} and {1} characters..
+        /// </summary>
+        internal static string Arg_Invalid_StringLengthRange {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_StringLengthRange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The string must not exceed {0} characters..
+        /// </summary>
+        internal static string Arg_Invalid_StringTooLong {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_StringTooLong", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The value for &apos;{0}&apos; must be {1}, but was {2}..
         /// </summary>
         internal static string Arg_Invalid_ValueForOperation {
             get {
                 return ResourceManager.GetString("Arg_Invalid_ValueForOperation", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value must equal {0}..
+        /// </summary>
+        internal static string Arg_Invalid_ValuesNotEqual {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_ValuesNotEqual", resourceCulture);
             }
         }
         
@@ -599,7 +653,25 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_OutOfRange_SequenceRangeOverflow", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Value must be a finite number (not NaN or infinity)..
+        /// </summary>
+        internal static string Arg_OutOfRange_NotFinite {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_NotFinite", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value must not equal {0}..
+        /// </summary>
+        internal static string Arg_OutOfRange_ValuesEqual {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_ValuesEqual", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Week {0} is not valid for the year {1} using culture {2}..
         /// </summary>

--- a/Bodu.Core/src/ResourceStrings.resx
+++ b/Bodu.Core/src/ResourceStrings.resx
@@ -459,4 +459,28 @@
   <data name="Arg_Invalid_CollectionIsEmpty" xml:space="preserve">
     <value>The collection is empty.</value>
   </data>
+  <data name="Arg_Invalid_CollectionReadOnly" xml:space="preserve">
+    <value>The collection must not be read-only.</value>
+  </data>
+  <data name="Arg_Invalid_PowerOfTwo" xml:space="preserve">
+    <value>The value must be a positive power of two.</value>
+  </data>
+  <data name="Arg_Invalid_StringLength" xml:space="preserve">
+    <value>The string length must be exactly {0} characters.</value>
+  </data>
+  <data name="Arg_Invalid_StringLengthRange" xml:space="preserve">
+    <value>The string length must be between {0} and {1} characters.</value>
+  </data>
+  <data name="Arg_Invalid_StringTooLong" xml:space="preserve">
+    <value>The string must not exceed {0} characters.</value>
+  </data>
+  <data name="Arg_Invalid_ValuesNotEqual" xml:space="preserve">
+    <value>The value must equal {0}.</value>
+  </data>
+  <data name="Arg_OutOfRange_NotFinite" xml:space="preserve">
+    <value>Value must be a finite number (not NaN or infinity).</value>
+  </data>
+  <data name="Arg_OutOfRange_ValuesEqual" xml:space="preserve">
+    <value>The value must not equal {0}.</value>
+  </data>
 </root>

--- a/Bodu.Core/src/ThrowHelper.CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.CallerExpression.cs
@@ -11,6 +11,7 @@
 using Bodu.Extensions;
 using System;
 using System.Collections.Generic;
+using System.Numerics;
 using System.Runtime.CompilerServices;
 
 namespace Bodu;
@@ -1165,22 +1166,53 @@ public static partial class ThrowHelper
     /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not a positive multiple
     /// of <paramref name="divisor"/>.
     /// </summary>
+    /// <typeparam name="T">A binary integer type.</typeparam>
     /// <param name="value">The value to validate.</param>
-    /// <param name="divisor">The required positive divisor.</param>
+    /// <param name="divisor">The required positive divisor. Must itself be positive.</param>
     /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="value"/> &lt;= 0 or <c>value % divisor != 0</c>.
     /// </exception>
-    /// <remarks>Useful for validating aligned buffer sizes, memory boundaries, or block-aligned lengths.</remarks>
+    /// <remarks>
+    /// Useful for validating aligned buffer sizes, memory boundaries, or block-aligned lengths. When the
+    /// required constraint is specifically a power of two, prefer <see cref="ThrowIfNotPowerOfTwo{T}"/>,
+    /// which uses a single bitwise operation.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ThrowIfNotPositiveMultipleOf(
-        int value, int divisor,
+    public static void ThrowIfNotPositiveMultipleOf<T>(
+        T value, T divisor,
         [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IBinaryInteger<T>
     {
-        if (value <= 0 || value % divisor != 0)
+        if (value <= T.Zero || value % divisor != T.Zero)
             throw new ArgumentOutOfRangeException(
                 paramName,
                 string.Format(ResourceStrings.Arg_Invalid_PositiveMultipleOf, divisor));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not a positive power of
+    /// two.
+    /// </summary>
+    /// <typeparam name="T">A binary integer type.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is not a positive integer whose binary representation contains
+    /// exactly one set bit (i.e. <c>value &lt;= 0</c> or <c>(value &amp; (value - 1)) != 0</c>).
+    /// </exception>
+    /// <remarks>
+    /// A specialisation of the positive-multiple-of family. When the divisor is itself an arbitrary positive
+    /// integer rather than a power of two, use <see cref="ThrowIfNotPositiveMultipleOf{T}"/> instead.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotPowerOfTwo<T>(
+        T value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IBinaryInteger<T>
+    {
+        if (!T.IsPow2(value))
+            throw new ArgumentOutOfRangeException(paramName, ResourceStrings.Arg_Invalid_PowerOfTwo);
     }
 
     /// <summary>
@@ -1590,6 +1622,304 @@ public static partial class ThrowHelper
 
         if (string.IsNullOrWhiteSpace(value))
             throw new ArgumentException(ResourceStrings.Arg_Invalid_StringEmptyOrWhitespace, paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException"/> if <paramref name="disposed"/> is
+    /// <see langword="true"/>.
+    /// </summary>
+    /// <param name="disposed">The disposal flag to evaluate.</param>
+    /// <param name="objectName">
+    /// The name of the disposed object included in the exception message. Supplied automatically by the
+    /// compiler via <see cref="CallerArgumentExpressionAttribute"/>.
+    /// </param>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown when <paramref name="disposed"/> is <see langword="true"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfDisposed(
+        bool disposed,
+        [CallerArgumentExpression(nameof(disposed))] string? objectName = null)
+    {
+        if (disposed)
+            throw new ObjectDisposedException(objectName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is
+    /// <see cref="double.NaN"/>, <see cref="double.PositiveInfinity"/>, or
+    /// <see cref="double.NegativeInfinity"/>.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is not a finite number.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotFinite(
+        double value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (!double.IsFinite(value))
+            throw new ArgumentOutOfRangeException(paramName, value, ResourceStrings.Arg_OutOfRange_NotFinite);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is
+    /// <see cref="float.NaN"/>, <see cref="float.PositiveInfinity"/>, or
+    /// <see cref="float.NegativeInfinity"/>.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is not a finite number.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotFinite(
+        float value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (!float.IsFinite(value))
+            throw new ArgumentOutOfRangeException(paramName, value, ResourceStrings.Arg_OutOfRange_NotFinite);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> equals
+    /// <paramref name="other"/>.
+    /// </summary>
+    /// <typeparam name="T">A type that implements <see cref="IEquatable{T}"/>.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="other">The value that <paramref name="value"/> must not equal.</param>
+    /// <param name="paramName">The name of the value parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> equals <paramref name="other"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfEqual<T>(
+        T value, T other,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IEquatable<T>
+    {
+        if (value.Equals(other))
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                string.Format(ResourceStrings.Arg_OutOfRange_ValuesEqual, other));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException"/> if <paramref name="value"/> does not equal
+    /// <paramref name="other"/>.
+    /// </summary>
+    /// <typeparam name="T">A type that implements <see cref="IEquatable{T}"/>.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="other">The value that <paramref name="value"/> must equal.</param>
+    /// <param name="paramName">The name of the value parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value"/> does not equal <paramref name="other"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotEqual<T>(
+        T value, T other,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+        where T : IEquatable<T>
+    {
+        if (!value.Equals(other))
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_ValuesNotEqual, other),
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="value"/> is <see langword="null"/>, or an
+    /// <see cref="ArgumentOutOfRangeException"/> if its length exceeds <paramref name="maxLength"/> characters.
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="maxLength">The maximum permitted length, inclusive.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <c>value.Length &gt; maxLength</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringTooLong(
+        string value, int maxLength,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
+
+        if (value.Length > maxLength)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                string.Format(ResourceStrings.Arg_Invalid_StringTooLong, maxLength));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="value"/> is <see langword="null"/>, or an
+    /// <see cref="ArgumentException"/> if its length does not equal <paramref name="expectedLength"/> characters.
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="expectedLength">The exact required length in characters.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>value.Length != expectedLength</c>.
+    /// </exception>
+    /// <remarks>
+    /// Useful for validating fixed-length identifiers such as ISIN (12 characters), CUSIP (9 characters),
+    /// or IBAN country codes (2 characters).
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringLengthIsNotEqualTo(
+        string value, int expectedLength,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
+
+        if (value.Length != expectedLength)
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_StringLength, expectedLength),
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="value"/> is <see langword="null"/>, or an
+    /// <see cref="ArgumentOutOfRangeException"/> if its length is not between <paramref name="minLength"/> and
+    /// <paramref name="maxLength"/> (inclusive).
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="minLength">The minimum permitted length, inclusive.</param>
+    /// <param name="maxLength">The maximum permitted length, inclusive. Must be &gt;= <paramref name="minLength"/>.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <c>value.Length &lt; minLength</c> or <c>value.Length &gt; maxLength</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringLengthOutOfRange(
+        string value, int minLength, int maxLength,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if (value is null)
+            throw new ArgumentNullException(paramName);
+
+        if (value.Length < minLength || value.Length > maxLength)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                string.Format(ResourceStrings.Arg_Invalid_StringLengthRange, minLength, maxLength));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="value"/> is not an ASCII
+    /// hexadecimal digit character — that is, a character in the ranges <c>'0'</c>–<c>'9'</c> (U+0030–U+0039),
+    /// <c>'A'</c>–<c>'F'</c> (U+0041–U+0046), or <c>'a'</c>–<c>'f'</c> (U+0061–U+0066) inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value"/> is not a decimal digit or a letter in <c>'A'</c>–<c>'F'</c> /
+    /// <c>'a'</c>–<c>'f'</c>.
+    /// </exception>
+    /// <remarks>
+    /// Both upper- and lowercase hex letters are accepted. Useful for validating hex-encoded cryptographic
+    /// outputs such as hash digests, key material, or initialisation vectors prior to parsing.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiHexDigit(
+        char value,
+        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    {
+        if ((uint)(value - '0') > 9u &&
+            (uint)(value - 'A') > 5u &&
+            (uint)(value - 'a') > 5u)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not a hex digit ('0'–'9', 'A'–'F', or 'a'–'f').");
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException"/> if <paramref name="collection"/> is <see langword="null"/>,
+    /// or an <see cref="ArgumentException"/> if it is read-only.
+    /// </summary>
+    /// <typeparam name="T">The element type of the collection.</typeparam>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection"/> is <see langword="null"/>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>collection.IsReadOnly</c> is <see langword="true"/>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfReadOnly<T>(
+        ICollection<T> collection,
+        [CallerArgumentExpression(nameof(collection))] string? paramName = null)
+    {
+        ThrowIfNull(collection, paramName);
+        if (collection.IsReadOnly)
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionReadOnly, paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="index"/> is outside the valid
+    /// element range of <paramref name="span"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="index">The index to validate.</param>
+    /// <param name="span">The span against which to validate the index.</param>
+    /// <param name="paramName">The name of the index parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index"/> &lt; 0 or &gt;= <c>span.Length</c>.
+    /// </exception>
+    /// <remarks>
+    /// Uses an unsigned cast to collapse the two-sided bounds check into a single comparison.
+    /// <see cref="System.ReadOnlySpan{T}"/> is a value type and cannot be <see langword="null"/>; no null guard
+    /// is required or possible.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfIndexOutOfRange<T>(
+        int index, ReadOnlySpan<T> span,
+        [CallerArgumentExpression(nameof(index))] string? paramName = null)
+    {
+        if ((uint)index >= (uint)span.Length)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                string.Format(ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException"/> if <paramref name="index"/> is outside the valid
+    /// element range of <paramref name="span"/>.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="index">The index to validate.</param>
+    /// <param name="span">The span against which to validate the index.</param>
+    /// <param name="paramName">The name of the index parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index"/> &lt; 0 or &gt;= <c>span.Length</c>.
+    /// </exception>
+    /// <remarks>
+    /// Uses an unsigned cast to collapse the two-sided bounds check into a single comparison.
+    /// <see cref="System.Span{T}"/> is a value type and cannot be <see langword="null"/>; no null guard is
+    /// required or possible.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfIndexOutOfRange<T>(
+        int index, Span<T> span,
+        [CallerArgumentExpression(nameof(index))] string? paramName = null)
+    {
+        if ((uint)index >= (uint)span.Length)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                string.Format(ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
     }
 }
 

--- a/Bodu.Core/src/ThrowHelper.CallerExpression.cs
+++ b/Bodu.Core/src/ThrowHelper.CallerExpression.cs
@@ -12,7 +12,6 @@ using Bodu.Extensions;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using static System.Runtime.InteropServices.JavaScript.JSType;
 
 namespace Bodu;
 
@@ -206,7 +205,7 @@ public static partial class ThrowHelper
     /// <paramref name="minimumLength"/> elements.
     /// </summary>
     /// <typeparam name="T">The element type of the span.</typeparam>
-    /// <param name="span">The array to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="span">The span to validate.</param>
     /// <param name="minimumLength">
     /// The minimum number of elements that <paramref name="span"/> must contain.
     /// </param>
@@ -214,16 +213,14 @@ public static partial class ThrowHelper
     /// The name of the span parameter. Supplied automatically by the compiler via
     /// <see cref="CallerArgumentExpressionAttribute"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="span"/> is <see langword="null"/>.
-    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when <c>span.Length</c> is less than <paramref name="minimumLength"/>.
     /// </exception>
     /// <remarks>
-    /// Use this overload when the caller may supply a larger span than required and the
-    /// excess elements are simply ignored — for example, a buffer that must hold at least
-    /// a full cipher block but may be larger. When the length must be exact, use
+    /// <see cref="System.Span{T}"/> is a value type and cannot be <see langword="null"/>; no null guard
+    /// is required or possible. Use this overload when the caller may supply a larger span than required
+    /// and the excess elements are simply ignored — for example, a buffer that must hold at least a full
+    /// cipher block but may be larger. When the length must be exact, use
     /// <see cref="ThrowIfSpanLengthIsNotEqualTo{T}(Span{T}, int, string)"/> instead.
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -263,7 +260,7 @@ public static partial class ThrowHelper
     /// <paramref name="minimumLength"/> elements.
     /// </summary>
     /// <typeparam name="T">The element type of the span.</typeparam>
-    /// <param name="span">The array to validate. Must not be <see langword="null"/>.</param>
+    /// <param name="span">The read-only span to validate.</param>
     /// <param name="minimumLength">
     /// The minimum number of elements that <paramref name="span"/> must contain.
     /// </param>
@@ -271,15 +268,13 @@ public static partial class ThrowHelper
     /// The name of the span parameter. Supplied automatically by the compiler via
     /// <see cref="CallerArgumentExpressionAttribute"/>.
     /// </param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="span"/> is <see langword="null"/>.
-    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when <c>span.Length</c> is less than <paramref name="minimumLength"/>.
     /// </exception>
     /// <remarks>
-    /// Use this overload when the caller may supply a larger span than required and the
-    /// excess elements are simply ignored — for example, a buffer that must hold at least
+    /// <see cref="System.ReadOnlySpan{T}"/> is a value type and cannot be <see langword="null"/>; no null
+    /// guard is required or possible. Use this overload when the caller may supply a larger span than
+    /// required and the excess elements are simply ignored — for example, a buffer that must hold at least
     /// a full cipher block but may be larger. When the length must be exact, use
     /// <see cref="ThrowIfSpanLengthIsNotEqualTo{T}(ReadOnlySpan{T}, int, string)"/> instead.
     /// </remarks>
@@ -610,6 +605,7 @@ public static partial class ThrowHelper
                     paramCountName,
                     paramSpanName));
     }
+
     /// <summary>
     /// Throws an <see cref="ArgumentNullException"/> if the array is <see langword="null"/>, or an
     /// <see cref="ArgumentException"/> if it is not assignable to <typeparamref name="TExpected"/>[].
@@ -645,9 +641,12 @@ public static partial class ThrowHelper
     /// <paramref name="minCount"/> elements.
     /// </summary>
     /// <typeparam name="T">The element type of the collection.</typeparam>
-    /// <param name="collection">The collection to validate.</param>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null"/>.</param>
     /// <param name="minCount">The minimum number of required elements.</param>
     /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when <c>collection.Count &lt; minCount</c>.
     /// </exception>
@@ -664,13 +663,16 @@ public static partial class ThrowHelper
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException"/> if the collection is  empty.
+    /// Throws an <see cref="ArgumentException"/> if the collection is empty.
     /// </summary>
     /// <typeparam name="T">The element type of the collection.</typeparam>
-    /// <param name="collection">The collection to validate.</param>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null"/>.</param>
     /// <param name="paramName">The name of the parameter. Supplied automatically by the compiler.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection"/> is <see langword="null"/>.
+    /// </exception>
     /// <exception cref="ArgumentException">
-    /// Thrown when <c>collection.Count is 0.</c>.
+    /// Thrown when <c>collection.Count == 0</c>.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ThrowIfCollectionIsEmpty<T>(
@@ -777,7 +779,7 @@ public static partial class ThrowHelper
 
         if (destination.Length < source.Length)
             throw new ArgumentException(
-                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "span", destination.Length),
+                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "array", destination.Length),
                 paramDestinationName);
     }
 
@@ -825,7 +827,7 @@ public static partial class ThrowHelper
         if (!Enum.IsDefined(typeof(TEnum), value))
             throw new ArgumentOutOfRangeException(
                 paramName,
-                string.Format(ResourceStrings.Arg_OutOfRangeException_EnumValue, value, typeof(TEnum).Name));
+                string.Format(ResourceStrings.Arg_OutOfRangeException_EnumValue, typeof(TEnum).Name, value));
     }
 
     /// <summary>

--- a/Bodu.Core/src/ThrowHelper.NetStandard.cs
+++ b/Bodu.Core/src/ThrowHelper.NetStandard.cs
@@ -71,7 +71,7 @@ public static partial class ThrowHelper
     /// Thrown when <paramref name="array" /> has a rank other than 1.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ThrowIfArrayIsNotSingleDimension(Array array)
+    public static void ThrowIfArrayMultidimensional(Array array)
     {
         if (array is null)
             throw new ArgumentNullException(nameof(array));
@@ -116,7 +116,7 @@ public static partial class ThrowHelper
     /// (e.g. 16 bytes for a cipher block, 32 bytes for a key).
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ThrowIfArrayLengthIsInsufficient(Array array, int expectedLength)
+    public static void ThrowIfArrayLengthIsNotEqualTo(Array array, int expectedLength)
     {
         if (array is null)
             throw new ArgumentNullException(nameof(array));
@@ -124,6 +124,37 @@ public static partial class ThrowHelper
         if (array.Length != expectedLength)
             throw new ArgumentException(
                 string.Format(ResourceStrings.Arg_Invalid_ArrayLength, expectedLength),
+                nameof(array));
+    }
+
+    /// <summary>
+    /// Throws an exception if the specified <paramref name="array" /> has fewer than
+    /// <paramref name="minimumLength" /> elements.
+    /// </summary>
+    /// <param name="array">The array to validate. Must not be <see langword="null" />.</param>
+    /// <param name="minimumLength">
+    /// The minimum number of elements that <paramref name="array" /> must contain.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="array" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>array.Length</c> is less than <paramref name="minimumLength" />.
+    /// </exception>
+    /// <remarks>
+    /// Use this overload when the caller may supply a larger array than required and the excess elements
+    /// are simply ignored — for example, a buffer that must hold at least a full cipher block but may be
+    /// larger. When the length must be exact, use <see cref="ThrowIfArrayLengthIsNotEqualTo" /> instead.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfArrayLengthIsInsufficient(Array array, int minimumLength)
+    {
+        if (array is null)
+            throw new ArgumentNullException(nameof(array));
+
+        if (array.Length < minimumLength)
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_ArrayTooShort, minimumLength),
                 nameof(array));
     }
 
@@ -211,42 +242,42 @@ public static partial class ThrowHelper
 
     /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if the array is <see langword="null" />, an
-    /// <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> or <paramref name="count" /> is out of
+    /// <see cref="ArgumentOutOfRangeException" /> if <paramref name="offset" /> or <paramref name="count" /> is out of
     /// range, or an <see cref="ArgumentException" /> if the segment they define exceeds the bounds of
     /// <paramref name="array" />.
     /// </summary>
     /// <param name="array">The array to validate. Must not be <see langword="null" />.</param>
-    /// <param name="index">The zero-based starting index within the array.</param>
-    /// <param name="count">The number of elements to access from <paramref name="index" />.</param>
+    /// <param name="offset">The zero-based starting index within the array.</param>
+    /// <param name="count">The number of elements to access from <paramref name="offset" />.</param>
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="array" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown when <paramref name="index" /> or <paramref name="count" /> is negative or exceeds
+    /// Thrown when <paramref name="offset" /> or <paramref name="count" /> is negative or exceeds
     /// <c>array.Length</c>.
     /// </exception>
     /// <exception cref="ArgumentException">
-    /// Thrown when <c>index + count</c> exceeds <c>array.Length</c>.
+    /// Thrown when <c>offset + count</c> exceeds <c>array.Length</c>.
     /// </exception>
-    public static void ThrowIfArrayOffsetOrCountInvalid(Array array, int index, int count)
+    public static void ThrowIfArrayOffsetOrCountInvalid(Array array, int offset, int count)
     {
         if (array is null)
             throw new ArgumentNullException(nameof(array));
 
-        if (index < 0 || index > array.Length)
+        if (offset < 0 || offset > array.Length)
             throw new ArgumentOutOfRangeException(
-                nameof(index),
-                string.Format(ResourceStrings.Arg_Invalid_ArrayOffset, nameof(array)));
+                nameof(offset),
+                string.Format(ResourceStrings.Arg_Invalid_ArrayOffset, nameof(offset)));
 
         if (count < 0 || count > array.Length)
             throw new ArgumentOutOfRangeException(
                 nameof(count),
-                string.Format(ResourceStrings.Arg_Invalid_ArrayOffset, nameof(array)));
+                string.Format(ResourceStrings.Arg_Invalid_ArrayOffset, nameof(count)));
 
-        if (count > array.Length - index)
+        if (count > array.Length - offset)
             throw new ArgumentException(
                 string.Format(ResourceStrings.Arg_Invalid_ArrayOffsetOrLength,
-                    nameof(index), nameof(count), nameof(array)));
+                    nameof(offset), nameof(count), nameof(array)));
     }
 
     /// <summary>
@@ -281,16 +312,45 @@ public static partial class ThrowHelper
     /// <paramref name="minCount" /> elements.
     /// </summary>
     /// <typeparam name="T">The element type of the collection.</typeparam>
-    /// <param name="collection">The collection to validate.</param>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null" />.</param>
     /// <param name="minCount">The minimum number of required elements.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown when <c>collection.Count &lt; minCount</c>.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ThrowIfCollectionTooSmall<T>(ICollection<T> collection, int minCount)
     {
+        if (collection is null)
+            throw new ArgumentNullException(nameof(collection));
+
         if (collection.Count < minCount)
-            throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionTooSmall, nameof(collection));
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_CollectionTooSmall, minCount),
+                nameof(collection));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> if the collection is empty.
+    /// </summary>
+    /// <typeparam name="T">The element type of the collection.</typeparam>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>collection.Count == 0</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfCollectionIsEmpty<T>(ICollection<T> collection)
+    {
+        if (collection is null)
+            throw new ArgumentNullException(nameof(collection));
+
+        if (collection.Count == 0)
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(collection));
     }
 
     /// <summary>
@@ -374,7 +434,7 @@ public static partial class ThrowHelper
 
         if (destination.Length < source.Length)
             throw new ArgumentException(
-                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "array"),
+                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "array", destination.Length),
                 nameof(destination));
     }
 
@@ -393,7 +453,7 @@ public static partial class ThrowHelper
         if (!Enum.IsDefined(typeof(TEnum), value))
             throw new ArgumentOutOfRangeException(
                 nameof(value),
-                string.Format(ResourceStrings.Arg_Invalid_EnumValue, typeof(TEnum).Name));
+                string.Format(ResourceStrings.Arg_OutOfRangeException_EnumValue, typeof(TEnum).Name, value));
     }
 
     /// <summary>
@@ -482,12 +542,18 @@ public static partial class ThrowHelper
     /// </summary>
     /// <param name="index">The index to validate.</param>
     /// <param name="array">The array against which to validate the index.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="array" /> is <see langword="null" />.
+    /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="index" /> &lt; 0 or &gt;= <c>array.LongLength</c>.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ThrowIfIndexOutOfRange(long index, Array array)
     {
+        if (array is null)
+            throw new ArgumentNullException(nameof(array));
+
         if (index < 0 || index >= array.LongLength)
             throw new ArgumentOutOfRangeException(
                 nameof(index),
@@ -963,17 +1029,44 @@ public static partial class ThrowHelper
     /// Throws an exception if the span does not have exactly <paramref name="expectedLength" /> elements.
     /// </summary>
     /// <typeparam name="T">The element type of the span.</typeparam>
-    /// <param name="span">The span to validate.</param>
+    /// <param name="span">The read-only span to validate.</param>
     /// <param name="expectedLength">The exact number of elements that <paramref name="span" /> must contain.</param>
     /// <exception cref="ArgumentException">
     /// Thrown when <c>span.Length</c> does not equal <paramref name="expectedLength" />.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ThrowIfArrayLengthIsInsufficient<T>(ReadOnlySpan<T> span, int expectedLength)
+    public static void ThrowIfSpanLengthIsNotEqualTo<T>(ReadOnlySpan<T> span, int expectedLength)
     {
         if (span.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(ResourceStrings.Arg_Invalid_ArrayLength, expectedLength),
+                string.Format(ResourceStrings.Arg_Invalid_SpanLength, expectedLength),
+                nameof(span));
+    }
+
+    /// <summary>
+    /// Throws an exception if the specified <paramref name="span" /> has fewer than
+    /// <paramref name="minimumLength" /> elements.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="span">The read-only span to validate.</param>
+    /// <param name="minimumLength">
+    /// The minimum number of elements that <paramref name="span" /> must contain.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>span.Length</c> is less than <paramref name="minimumLength" />.
+    /// </exception>
+    /// <remarks>
+    /// <see cref="System.ReadOnlySpan{T}" /> is a value type and cannot be <see langword="null" />; no null
+    /// guard is required or possible. Use this overload when the caller may supply a larger span than
+    /// required and the excess elements are simply ignored. When the length must be exact, use
+    /// <see cref="ThrowIfSpanLengthIsNotEqualTo{T}(ReadOnlySpan{T}, int)" /> instead.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfSpanLengthIsInsufficient<T>(ReadOnlySpan<T> span, int minimumLength)
+    {
+        if (span.Length < minimumLength)
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_SpanTooShort, minimumLength),
                 nameof(span));
     }
 
@@ -987,11 +1080,38 @@ public static partial class ThrowHelper
     /// Thrown when <c>span.Length</c> does not equal <paramref name="expectedLength" />.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static void ThrowIfArrayLengthIsInsufficient<T>(Span<T> span, int expectedLength)
+    public static void ThrowIfSpanLengthIsNotEqualTo<T>(Span<T> span, int expectedLength)
     {
         if (span.Length != expectedLength)
             throw new ArgumentException(
-                string.Format(ResourceStrings.Arg_Invalid_ArrayLength, expectedLength),
+                string.Format(ResourceStrings.Arg_Invalid_SpanLength, expectedLength),
+                nameof(span));
+    }
+
+    /// <summary>
+    /// Throws an exception if the specified <paramref name="span" /> has fewer than
+    /// <paramref name="minimumLength" /> elements.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="span">The span to validate.</param>
+    /// <param name="minimumLength">
+    /// The minimum number of elements that <paramref name="span" /> must contain.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>span.Length</c> is less than <paramref name="minimumLength" />.
+    /// </exception>
+    /// <remarks>
+    /// <see cref="System.Span{T}" /> is a value type and cannot be <see langword="null" />; no null guard
+    /// is required or possible. Use this overload when the caller may supply a larger span than required
+    /// and the excess elements are simply ignored. When the length must be exact, use
+    /// <see cref="ThrowIfSpanLengthIsNotEqualTo{T}(Span{T}, int)" /> instead.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfSpanLengthIsInsufficient<T>(Span<T> span, int minimumLength)
+    {
+        if (span.Length < minimumLength)
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_SpanTooShort, minimumLength),
                 nameof(span));
     }
 
@@ -1014,7 +1134,7 @@ public static partial class ThrowHelper
     {
         if (destination.Length < source.Length)
             throw new ArgumentException(
-                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "span"),
+                string.Format(ResourceStrings.Arg_Invalid_DestinationTooSmall, "span", destination.Length),
                 nameof(destination));
     }
 
@@ -1077,13 +1197,15 @@ public static partial class ThrowHelper
     public static void ThrowIfSpanLengthNotPositiveMultipleOf<T>(
         ReadOnlySpan<T> span, int divisor, bool throwIfZero = true)
     {
+        ThrowIfZeroOrNegative(divisor);
+
         if ((throwIfZero && span.Length == 0) || span.Length % divisor != 0)
             throw new ArgumentException(
                 string.Format(ResourceStrings.Arg_Invalid_SpanLengthMultipleOf, divisor),
                 nameof(span));
     }
 
-       /// <summary>
+    /// <summary>
     /// Throws an <see cref="ArgumentNullException" /> if the array is <see langword="null" />, or an
     /// <see cref="ArgumentOutOfRangeException" /> if its length is not between <paramref name="minLength" /> and
     /// <paramref name="maxLength" /> (inclusive).
@@ -1181,6 +1303,8 @@ public static partial class ThrowHelper
     public static void ThrowIfSpanLengthNotPositiveMultipleOf<T>(
         Span<T> span, int divisor, bool throwIfZero = true)
     {
+        ThrowIfZeroOrNegative(divisor);
+
         if ((throwIfZero && span.Length == 0) || span.Length % divisor != 0)
             throw new ArgumentException(
                 string.Format(ResourceStrings.Arg_Invalid_SpanLengthMultipleOf, divisor),

--- a/Bodu.Core/src/ThrowHelper.NetStandard.cs
+++ b/Bodu.Core/src/ThrowHelper.NetStandard.cs
@@ -745,11 +745,15 @@ public static partial class ThrowHelper
     /// of <paramref name="divisor" />.
     /// </summary>
     /// <param name="value">The value to validate.</param>
-    /// <param name="divisor">The required positive divisor.</param>
+    /// <param name="divisor">The required positive divisor. Must itself be positive.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="value" /> &lt;= 0 or <c>value % divisor != 0</c>.
     /// </exception>
-    /// <remarks>Useful for validating aligned buffer sizes, memory boundaries, or block-aligned lengths.</remarks>
+    /// <remarks>
+    /// Useful for validating aligned buffer sizes, memory boundaries, or block-aligned lengths. When the
+    /// required constraint is specifically a power of two, prefer <see cref="ThrowIfNotPowerOfTwo(int)" />,
+    /// which uses a single bitwise operation.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static void ThrowIfNotPositiveMultipleOf(int value, int divisor)
     {
@@ -757,6 +761,26 @@ public static partial class ThrowHelper
             throw new ArgumentOutOfRangeException(
                 nameof(value),
                 string.Format(ResourceStrings.Arg_Invalid_PositiveMultipleOf, divisor));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not a positive power
+    /// of two.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a positive integer whose binary representation contains
+    /// exactly one set bit (i.e. <c>value &lt;= 0</c> or <c>(value &amp; (value - 1)) != 0</c>).
+    /// </exception>
+    /// <remarks>
+    /// A specialisation of the positive-multiple-of family. When the divisor is itself an arbitrary positive
+    /// integer rather than a power of two, use <see cref="ThrowIfNotPositiveMultipleOf(int, int)" /> instead.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotPowerOfTwo(int value)
+    {
+        if (value <= 0 || (value & (value - 1)) != 0)
+            throw new ArgumentOutOfRangeException(nameof(value), ResourceStrings.Arg_Invalid_PowerOfTwo);
     }
 
     /// <summary>
@@ -1023,6 +1047,217 @@ public static partial class ThrowHelper
             throw new ArgumentException(ResourceStrings.Arg_Invalid_StringEmptyOrWhitespace, nameof(value));
     }
 
+    /// <summary>
+    /// Throws an <see cref="ObjectDisposedException" /> if <paramref name="disposed" /> is
+    /// <see langword="true" />.
+    /// </summary>
+    /// <param name="disposed">The disposal flag to evaluate.</param>
+    /// <param name="objectName">The name of the disposed object included in the exception message.</param>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown when <paramref name="disposed" /> is <see langword="true" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfDisposed(bool disposed, string? objectName = null)
+    {
+        if (disposed)
+            throw new ObjectDisposedException(objectName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is
+    /// <see cref="double.NaN" />, <see cref="double.PositiveInfinity" />, or
+    /// <see cref="double.NegativeInfinity" />.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a finite number.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotFinite(double value)
+    {
+        if (double.IsNaN(value) || double.IsInfinity(value))
+            throw new ArgumentOutOfRangeException(nameof(value), value, ResourceStrings.Arg_OutOfRange_NotFinite);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is
+    /// <see cref="float.NaN" />, <see cref="float.PositiveInfinity" />, or
+    /// <see cref="float.NegativeInfinity" />.
+    /// </summary>
+    /// <param name="value">The value to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a finite number.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotFinite(float value)
+    {
+        if (float.IsNaN(value) || float.IsInfinity(value))
+            throw new ArgumentOutOfRangeException(nameof(value), value, ResourceStrings.Arg_OutOfRange_NotFinite);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> equals
+    /// <paramref name="other" />.
+    /// </summary>
+    /// <typeparam name="T">A type that implements <see cref="IEquatable{T}" />.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="other">The value that <paramref name="value" /> must not equal.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> equals <paramref name="other" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfEqual<T>(T value, T other)
+        where T : IEquatable<T>
+    {
+        if (value.Equals(other))
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                string.Format(ResourceStrings.Arg_OutOfRange_ValuesEqual, other));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> if <paramref name="value" /> does not equal
+    /// <paramref name="other" />.
+    /// </summary>
+    /// <typeparam name="T">A type that implements <see cref="IEquatable{T}" />.</typeparam>
+    /// <param name="value">The value to validate.</param>
+    /// <param name="other">The value that <paramref name="value" /> must equal.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value" /> does not equal <paramref name="other" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotEqual<T>(T value, T other)
+        where T : IEquatable<T>
+    {
+        if (!value.Equals(other))
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_ValuesNotEqual, other),
+                nameof(value));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />, or an
+    /// <see cref="ArgumentOutOfRangeException" /> if its length exceeds <paramref name="maxLength" /> characters.
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null" />.</param>
+    /// <param name="maxLength">The maximum permitted length, inclusive.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <c>value.Length &gt; maxLength</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringTooLong(string value, int maxLength)
+    {
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        if (value.Length > maxLength)
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                string.Format(ResourceStrings.Arg_Invalid_StringTooLong, maxLength));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />, or an
+    /// <see cref="ArgumentException" /> if its length does not equal <paramref name="expectedLength" /> characters.
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null" />.</param>
+    /// <param name="expectedLength">The exact required length in characters.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>value.Length != expectedLength</c>.
+    /// </exception>
+    /// <remarks>
+    /// Useful for validating fixed-length identifiers such as ISIN (12 characters), CUSIP (9 characters),
+    /// or IBAN country codes (2 characters).
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringLengthIsNotEqualTo(string value, int expectedLength)
+    {
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        if (value.Length != expectedLength)
+            throw new ArgumentException(
+                string.Format(ResourceStrings.Arg_Invalid_StringLength, expectedLength),
+                nameof(value));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="value" /> is <see langword="null" />, or an
+    /// <see cref="ArgumentOutOfRangeException" /> if its length is not between <paramref name="minLength" /> and
+    /// <paramref name="maxLength" /> (inclusive).
+    /// </summary>
+    /// <param name="value">The string to validate. Must not be <see langword="null" />.</param>
+    /// <param name="minLength">The minimum permitted length, inclusive.</param>
+    /// <param name="maxLength">The maximum permitted length, inclusive. Must be &gt;= <paramref name="minLength" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <c>value.Length &lt; minLength</c> or <c>value.Length &gt; maxLength</c>.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfStringLengthOutOfRange(string value, int minLength, int maxLength)
+    {
+        if (value is null)
+            throw new ArgumentNullException(nameof(value));
+
+        if (value.Length < minLength || value.Length > maxLength)
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                string.Format(ResourceStrings.Arg_Invalid_StringLengthRange, minLength, maxLength));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="value" /> is not an ASCII
+    /// hexadecimal digit character — that is, a character in the ranges <c>'0'</c>–<c>'9'</c>, <c>'A'</c>–<c>'F'</c>,
+    /// or <c>'a'</c>–<c>'f'</c> inclusive.
+    /// </summary>
+    /// <param name="value">The character to validate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a decimal digit or a letter in <c>'A'</c>–<c>'F'</c> /
+    /// <c>'a'</c>–<c>'f'</c>.
+    /// </exception>
+    /// <remarks>Both upper- and lowercase hex letters are accepted.</remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNotAsciiHexDigit(char value)
+    {
+        if ((uint)(value - '0') > 9u &&
+            (uint)(value - 'A') > 5u &&
+            (uint)(value - 'a') > 5u)
+            throw new ArgumentOutOfRangeException(
+                nameof(value),
+                value,
+                $"Character '{value}' (U+{(int)value:X4}) is not a hex digit ('0'–'9', 'A'–'F', or 'a'–'f').");
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentNullException" /> if <paramref name="collection" /> is <see langword="null" />,
+    /// or an <see cref="ArgumentException" /> if it is read-only.
+    /// </summary>
+    /// <typeparam name="T">The element type of the collection.</typeparam>
+    /// <param name="collection">The collection to validate. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <c>collection.IsReadOnly</c> is <see langword="true" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfReadOnly<T>(ICollection<T> collection)
+    {
+        if (collection is null)
+            throw new ArgumentNullException(nameof(collection));
+
+        if (collection.IsReadOnly)
+            throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionReadOnly, nameof(collection));
+    }
+
 #if NETSTANDARD2_1_OR_GREATER
 
     /// <summary>
@@ -1232,8 +1467,6 @@ public static partial class ThrowHelper
                 string.Format(ResourceStrings.Arg_OutOfRange_RequireBetweenInclusive, minLength, maxLength));
     }
  
-    // ── INSERT inside #if NETSTANDARD2_1_OR_GREATER, after ThrowIfSpanLengthIsInsufficient overloads ──────────────
- 
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if the span length is not between
     /// <paramref name="minLength" /> and <paramref name="maxLength" /> (inclusive).
@@ -1309,6 +1542,54 @@ public static partial class ThrowHelper
             throw new ArgumentException(
                 string.Format(ResourceStrings.Arg_Invalid_SpanLengthMultipleOf, divisor),
                 nameof(span));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is outside the valid
+    /// element range of <paramref name="span" />.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="index">The index to validate.</param>
+    /// <param name="span">The span against which to validate the index.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index" /> &lt; 0 or &gt;= <c>span.Length</c>.
+    /// </exception>
+    /// <remarks>
+    /// Uses an unsigned cast to collapse the two-sided bounds check into a single comparison.
+    /// <see cref="System.ReadOnlySpan{T}" /> is a value type and cannot be <see langword="null" />; no null guard
+    /// is required or possible.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfIndexOutOfRange<T>(int index, ReadOnlySpan<T> span)
+    {
+        if ((uint)index >= (uint)span.Length)
+            throw new ArgumentOutOfRangeException(
+                nameof(index),
+                string.Format(ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is outside the valid
+    /// element range of <paramref name="span" />.
+    /// </summary>
+    /// <typeparam name="T">The element type of the span.</typeparam>
+    /// <param name="index">The index to validate.</param>
+    /// <param name="span">The span against which to validate the index.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="index" /> &lt; 0 or &gt;= <c>span.Length</c>.
+    /// </exception>
+    /// <remarks>
+    /// Uses an unsigned cast to collapse the two-sided bounds check into a single comparison.
+    /// <see cref="System.Span{T}" /> is a value type and cannot be <see langword="null" />; no null guard is
+    /// required or possible.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfIndexOutOfRange<T>(int index, Span<T> span)
+    {
+        if ((uint)index >= (uint)span.Length)
+            throw new ArgumentOutOfRangeException(
+                nameof(index),
+                string.Format(ResourceStrings.Arg_OutOfRange_IndexValidRange, span.Length));
     }
 
 #endif

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfCollectionIsEmpty.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfCollectionIsEmpty.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfCollectionIsEmpty.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfCollectionIsEmpty{T}" /> throws
+    /// <see cref="ArgumentNullException" /> when the collection is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCollectionIsEmpty_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfCollectionIsEmpty<int>(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfCollectionIsEmpty{T}" /> throws
+    /// <see cref="ArgumentException" /> when the collection has no elements.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCollectionIsEmpty_WhenCollectionIsEmpty_ShouldThrowArgumentException()
+    {
+        ICollection<int> collection = new List<int>();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfCollectionIsEmpty(collection);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfCollectionIsEmpty{T}" /> throws
+    /// <see cref="ArgumentException" /> for an empty array.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCollectionIsEmpty_WhenArrayIsEmpty_ShouldThrowArgumentException()
+    {
+        ICollection<int> collection = Array.Empty<int>();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfCollectionIsEmpty(collection);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfCollectionIsEmpty{T}" /> does not throw when the
+    /// collection contains at least one element.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCollectionIsEmpty_WhenCollectionHasElements_ShouldNotThrow()
+    {
+        ICollection<int> collection = new List<int> { 1 };
+
+        ThrowHelper.ThrowIfCollectionIsEmpty(collection);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfCollectionIsEmpty{T}" /> does not throw when the
+    /// collection contains multiple elements.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCollectionIsEmpty_WhenCollectionHasMultipleElements_ShouldNotThrow()
+    {
+        ICollection<int> collection = new[] { 1, 2, 3 };
+
+        ThrowHelper.ThrowIfCollectionIsEmpty(collection);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfDisposed.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfDisposed.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfDisposed.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfDisposed" /> throws <see cref="ObjectDisposedException" />
+    /// when the disposed flag is <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfDisposed_WhenDisposedIsTrue_ShouldThrowObjectDisposedException()
+    {
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            ThrowHelper.ThrowIfDisposed(true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfDisposed" /> includes the supplied object name in the
+    /// exception when the disposed flag is <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfDisposed_WhenDisposedIsTrueWithObjectName_ShouldIncludeNameInException()
+    {
+        ObjectDisposedException ex = Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            ThrowHelper.ThrowIfDisposed(true, "MyObject");
+        });
+
+        Assert.IsTrue(ex.Message.Contains("MyObject", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfDisposed" /> does not throw when the disposed flag is
+    /// <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfDisposed_WhenDisposedIsFalse_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfDisposed(false);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfDisposed" /> does not throw when the disposed flag is
+    /// <see langword="false" />, even when an object name is supplied.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfDisposed_WhenDisposedIsFalseWithObjectName_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfDisposed(false, "MyObject");
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfEqual.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfEqual.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfEqual{T}" /> throws <see cref="ArgumentOutOfRangeException" />
+    /// when the two integer values are equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 0)]
+    [DataRow(1, 1)]
+    [DataRow(-5, -5)]
+    [DataRow(int.MaxValue, int.MaxValue)]
+    public void ThrowIfEqual_WhenIntValuesAreEqual_ShouldThrowArgumentOutOfRangeException(int value, int other)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfEqual(value, other);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfEqual{T}" /> throws <see cref="ArgumentOutOfRangeException" />
+    /// when two string values are equal.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfEqual_WhenStringValuesAreEqual_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfEqual("hello", "hello");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfEqual{T}" /> does not throw when the two integer values
+    /// are different.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 1)]
+    [DataRow(1, 2)]
+    [DataRow(-1, 0)]
+    [DataRow(int.MinValue, int.MaxValue)]
+    public void ThrowIfEqual_WhenIntValuesAreNotEqual_ShouldNotThrow(int value, int other)
+    {
+        ThrowHelper.ThrowIfEqual(value, other);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfEqual{T}" /> does not throw when two string values
+    /// are different.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfEqual_WhenStringValuesAreNotEqual_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfEqual("hello", "world");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfEqual{T}" /> reports the correct parameter name in the
+    /// thrown exception.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfEqual_WhenValuesAreEqual_ShouldReportParamName()
+    {
+        int value = 42;
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfEqual(value, 42, "value");
+        });
+
+        Assert.AreEqual("value", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfIndexOutOfRange.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfIndexOutOfRange.cs
@@ -11,14 +11,15 @@ public partial class ThrowHelperTests
     private static readonly int[] TestArray = new[] { 1, 2, 3, 4, 5 };
 
     /// <summary>
-    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange" />, when IndexIsInvalid, throws <see cref="ArgumentOutOfRangeException" />.
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange(long, Array, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the index is out of bounds.
     /// </summary>
     [TestMethod]
-    [DataRow(5)] // index == Count
-    [DataRow(6)] // index > Count
+    [DataRow(5)]          // index == Length
+    [DataRow(6)]          // index > Length
     [DataRow(int.MaxValue)]
-    [DataRow(-1)] // negative index
-    public void ThrowIfIndexOutOfRange_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
+    [DataRow(-1)]         // negative index
+    public void ThrowIfIndexOutOfRange_Array_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
@@ -27,14 +28,96 @@ public partial class ThrowHelperTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange" />, when IndexIsWithinBounds, NotThrow.
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange(long, Array, string?)" /> throws
+    /// <see cref="ArgumentNullException" /> when the array is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfIndexOutOfRange_Array_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfIndexOutOfRange(0L, (Array)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange(long, Array, string?)" /> does not throw
+    /// when the index is within bounds.
     /// </summary>
     [TestMethod]
     [DataRow(0)]
     [DataRow(1)]
     [DataRow(4)]
-    public void ThrowIfIndexOutOfRange_WhenIndexIsWithinBounds_ShouldNotThrow(int index)
+    public void ThrowIfIndexOutOfRange_Array_WhenIndexIsWithinBounds_ShouldNotThrow(int index)
     {
         ThrowHelper.ThrowIfIndexOutOfRange(index, TestArray);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange{T}(int, ReadOnlySpan{T}, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the index is out of bounds.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5)]          // index == Length
+    [DataRow(6)]          // index > Length
+    [DataRow(int.MaxValue)]
+    [DataRow(-1)]         // negative index
+    public void ThrowIfIndexOutOfRange_ReadOnlySpan_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        ReadOnlySpan<int> span = TestArray;
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfIndexOutOfRange(index, span);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange{T}(int, ReadOnlySpan{T}, string?)" /> does
+    /// not throw when the index is within bounds.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(4)]
+    public void ThrowIfIndexOutOfRange_ReadOnlySpan_WhenIndexIsWithinBounds_ShouldNotThrow(int index)
+    {
+        ReadOnlySpan<int> span = TestArray;
+
+        ThrowHelper.ThrowIfIndexOutOfRange(index, span);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange{T}(int, Span{T}, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the index is out of bounds.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5)]          // index == Length
+    [DataRow(6)]          // index > Length
+    [DataRow(int.MaxValue)]
+    [DataRow(-1)]         // negative index
+    public void ThrowIfIndexOutOfRange_Span_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        Span<int> span = new int[] { 1, 2, 3, 4, 5 };
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfIndexOutOfRange(index, span);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfIndexOutOfRange{T}(int, Span{T}, string?)" /> does not
+    /// throw when the index is within bounds.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(4)]
+    public void ThrowIfIndexOutOfRange_Span_WhenIndexIsWithinBounds_ShouldNotThrow(int index)
+    {
+        Span<int> span = new int[] { 1, 2, 3, 4, 5 };
+
+        ThrowHelper.ThrowIfIndexOutOfRange(index, span);
     }
 }

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfNotAsciiHexDigit.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfNotAsciiHexDigit.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfNotAsciiHexDigit.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotAsciiHexDigit" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> for characters that are not valid ASCII hex digits.
+    /// </summary>
+    [TestMethod]
+    [DataRow('/')]   // char before '0' in ASCII
+    [DataRow(':')]   // char after '9' in ASCII
+    [DataRow('@')]   // char before 'A' in ASCII
+    [DataRow('G')]   // char after 'F' in ASCII
+    [DataRow('`')]   // char before 'a' in ASCII
+    [DataRow('g')]   // char after 'f' in ASCII
+    [DataRow('x')]
+    [DataRow('z')]
+    [DataRow('Z')]
+    [DataRow(' ')]
+    [DataRow('!')]
+    public void ThrowIfNotAsciiHexDigit_WhenCharIsNotHexDigit_ShouldThrowArgumentOutOfRangeException(char value)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotAsciiHexDigit(value);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotAsciiHexDigit" /> does not throw for all valid decimal
+    /// digit characters ('0'–'9').
+    /// </summary>
+    [TestMethod]
+    [DataRow('0')]
+    [DataRow('1')]
+    [DataRow('5')]
+    [DataRow('9')]
+    public void ThrowIfNotAsciiHexDigit_WhenCharIsDecimalDigit_ShouldNotThrow(char value)
+    {
+        ThrowHelper.ThrowIfNotAsciiHexDigit(value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotAsciiHexDigit" /> does not throw for all valid
+    /// uppercase hex letter characters ('A'–'F').
+    /// </summary>
+    [TestMethod]
+    [DataRow('A')]
+    [DataRow('B')]
+    [DataRow('C')]
+    [DataRow('D')]
+    [DataRow('E')]
+    [DataRow('F')]
+    public void ThrowIfNotAsciiHexDigit_WhenCharIsUppercaseHexLetter_ShouldNotThrow(char value)
+    {
+        ThrowHelper.ThrowIfNotAsciiHexDigit(value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotAsciiHexDigit" /> does not throw for all valid
+    /// lowercase hex letter characters ('a'–'f').
+    /// </summary>
+    [TestMethod]
+    [DataRow('a')]
+    [DataRow('b')]
+    [DataRow('c')]
+    [DataRow('d')]
+    [DataRow('e')]
+    [DataRow('f')]
+    public void ThrowIfNotAsciiHexDigit_WhenCharIsLowercaseHexLetter_ShouldNotThrow(char value)
+    {
+        ThrowHelper.ThrowIfNotAsciiHexDigit(value);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfNotEqual.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfNotEqual.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfNotEqual.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotEqual{T}" /> throws <see cref="ArgumentException" />
+    /// when the two integer values are not equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 1)]
+    [DataRow(1, 2)]
+    [DataRow(-1, 0)]
+    [DataRow(int.MinValue, int.MaxValue)]
+    public void ThrowIfNotEqual_WhenIntValuesAreNotEqual_ShouldThrowArgumentException(int value, int other)
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfNotEqual(value, other);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotEqual{T}" /> throws <see cref="ArgumentException" />
+    /// when two string values are not equal.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotEqual_WhenStringValuesAreNotEqual_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfNotEqual("hello", "world");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotEqual{T}" /> does not throw when the two integer values
+    /// are equal.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 0)]
+    [DataRow(1, 1)]
+    [DataRow(-5, -5)]
+    [DataRow(int.MaxValue, int.MaxValue)]
+    public void ThrowIfNotEqual_WhenIntValuesAreEqual_ShouldNotThrow(int value, int other)
+    {
+        ThrowHelper.ThrowIfNotEqual(value, other);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotEqual{T}" /> does not throw when two string values
+    /// are equal.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotEqual_WhenStringValuesAreEqual_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfNotEqual("hello", "hello");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotEqual{T}" /> reports the correct parameter name in the
+    /// thrown exception.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotEqual_WhenValuesAreNotEqual_ShouldReportParamName()
+    {
+        int value = 10;
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfNotEqual(value, 42, "value");
+        });
+
+        Assert.AreEqual("value", ex.ParamName);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfNotFinite.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfNotFinite.cs
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfNotFinite.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(double, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="double.NaN" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Double_WhenValueIsNaN_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(double.NaN);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(double, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="double.PositiveInfinity" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Double_WhenValueIsPositiveInfinity_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(double.PositiveInfinity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(double, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="double.NegativeInfinity" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Double_WhenValueIsNegativeInfinity_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(double.NegativeInfinity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(double, string?)" /> does not throw for finite
+    /// <see cref="double" /> values, including zero, negative, and boundary values.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Double_WhenValueIsFinite_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfNotFinite(0.0);
+        ThrowHelper.ThrowIfNotFinite(-0.0);
+        ThrowHelper.ThrowIfNotFinite(1.0);
+        ThrowHelper.ThrowIfNotFinite(-1.5);
+        ThrowHelper.ThrowIfNotFinite(double.MaxValue);
+        ThrowHelper.ThrowIfNotFinite(double.MinValue);
+        ThrowHelper.ThrowIfNotFinite(double.Epsilon);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(float, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="float.NaN" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Float_WhenValueIsNaN_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(float.NaN);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(float, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="float.PositiveInfinity" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Float_WhenValueIsPositiveInfinity_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(float.PositiveInfinity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(float, string?)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is <see cref="float.NegativeInfinity" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Float_WhenValueIsNegativeInfinity_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotFinite(float.NegativeInfinity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotFinite(float, string?)" /> does not throw for finite
+    /// <see cref="float" /> values, including zero, negative, and boundary values.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotFinite_Float_WhenValueIsFinite_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfNotFinite(0.0f);
+        ThrowHelper.ThrowIfNotFinite(-0.0f);
+        ThrowHelper.ThrowIfNotFinite(1.0f);
+        ThrowHelper.ThrowIfNotFinite(-1.5f);
+        ThrowHelper.ThrowIfNotFinite(float.MaxValue);
+        ThrowHelper.ThrowIfNotFinite(float.MinValue);
+        ThrowHelper.ThrowIfNotFinite(float.Epsilon);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfNotPositiveMultipleOf.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfNotPositiveMultipleOf.cs
@@ -9,31 +9,71 @@ namespace Bodu;
 public partial class ThrowHelperTests
 {
     /// <summary>
-    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf" />, when ValueIsZeroNegativeOrNotMultiple, throws <see cref="ArgumentOutOfRangeException" />.
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the integer value is zero, negative, or not a multiple
+    /// of the divisor.
     /// </summary>
     [TestMethod]
-    [DataRow(0, 2)]   // Zero is not positive
-    [DataRow(-2, 2)]  // Negative value
-    [DataRow(7, 2)]   // Not a multiple
-    [DataRow(5, 3)]   // Not a multiple
-    public void ThrowIfNotPositiveMultipleOf_WhenValueIsZeroNegativeOrNotMultiple_ShouldThrow(int value, int factor)
+    [DataRow(0, 2)]   // zero is not positive
+    [DataRow(-2, 2)]  // negative value
+    [DataRow(7, 2)]   // not a multiple
+    [DataRow(5, 3)]   // not a multiple
+    public void ThrowIfNotPositiveMultipleOf_WhenValueIsZeroNegativeOrNotMultiple_ShouldThrowArgumentOutOfRangeException(int value, int divisor)
     {
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            ThrowHelper.ThrowIfNotPositiveMultipleOf(value, factor);
+            ThrowHelper.ThrowIfNotPositiveMultipleOf(value, divisor);
         });
     }
 
     /// <summary>
-    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf" />, when ValueIsPositiveAndMultiple, NotThrow.
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf{T}" /> does not throw when the
+    /// integer value is positive and exactly divisible by the divisor.
     /// </summary>
     [TestMethod]
     [DataRow(2, 1)]
     [DataRow(4, 2)]
     [DataRow(9, 3)]
     [DataRow(10, 5)]
-    public void ThrowIfNotPositiveMultipleOf_WhenValueIsPositiveAndMultiple_ShouldNotThrow(int value, int factor)
+    public void ThrowIfNotPositiveMultipleOf_WhenValueIsPositiveAndMultiple_ShouldNotThrow(int value, int divisor)
     {
-        ThrowHelper.ThrowIfNotPositiveMultipleOf(value, factor);
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(value, divisor);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> for <see cref="long" /> values that are zero, negative, or not
+    /// a multiple of the divisor, exercising the generic <c>IBinaryInteger&lt;T&gt;</c> constraint.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotPositiveMultipleOf_WhenLongValueIsNotMultiple_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPositiveMultipleOf(0L, 4L);
+        });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPositiveMultipleOf(-8L, 4L);
+        });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPositiveMultipleOf(7L, 4L);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPositiveMultipleOf{T}" /> does not throw for <see cref="long" />
+    /// values that are positive multiples of the divisor, exercising the generic <c>IBinaryInteger&lt;T&gt;</c>
+    /// constraint.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotPositiveMultipleOf_WhenLongValueIsPositiveMultiple_ShouldNotThrow()
+    {
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(4L, 4L);
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(4294967296L, 4L); // 2^32
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(1000000000000L, 1000L);
     }
 }

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfNotPowerOfTwo.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfNotPowerOfTwo.cs
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfNotPowerOfTwo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is zero.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotPowerOfTwo_WhenValueIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPowerOfTwo(0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is negative.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-2)]
+    [DataRow(-4)]
+    [DataRow(int.MinValue)]
+    public void ThrowIfNotPowerOfTwo_WhenValueIsNegative_ShouldThrowArgumentOutOfRangeException(int value)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPowerOfTwo(value);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the value is a positive integer that is not a power of two.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3)]
+    [DataRow(5)]
+    [DataRow(6)]
+    [DataRow(7)]
+    [DataRow(9)]
+    [DataRow(10)]
+    [DataRow(100)]
+    public void ThrowIfNotPowerOfTwo_WhenValueIsNotPowerOfTwo_ShouldThrowArgumentOutOfRangeException(int value)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPowerOfTwo(value);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> does not throw when the value is a
+    /// positive power of two.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(2)]
+    [DataRow(4)]
+    [DataRow(8)]
+    [DataRow(16)]
+    [DataRow(64)]
+    [DataRow(128)]
+    [DataRow(1024)]
+    [DataRow(1073741824)] // 2^30
+    public void ThrowIfNotPowerOfTwo_WhenValueIsPowerOfTwo_ShouldNotThrow(int value)
+    {
+        ThrowHelper.ThrowIfNotPowerOfTwo(value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> works correctly with <see cref="long" />
+    /// arguments, exercising the generic <c>IBinaryInteger&lt;T&gt;</c> constraint.
+    /// </summary>
+    [TestMethod]
+    [DataRow(4294967296L)]  // 2^32 — valid power of two, exceeds int range
+    [DataRow(1099511627776L)] // 2^40
+    public void ThrowIfNotPowerOfTwo_WhenValueIsLongPowerOfTwo_ShouldNotThrow(long value)
+    {
+        ThrowHelper.ThrowIfNotPowerOfTwo(value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfNotPowerOfTwo{T}" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> for a <see cref="long" /> value that is not a power of two,
+    /// exercising the generic <c>IBinaryInteger&lt;T&gt;</c> constraint.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfNotPowerOfTwo_WhenLongValueIsNotPowerOfTwo_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfNotPowerOfTwo(4294967297L); // 2^32 + 1
+        });
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfReadOnly.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfReadOnly.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfReadOnly.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.ObjectModel;
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfReadOnly{T}" /> throws <see cref="ArgumentNullException" />
+    /// when the collection is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfReadOnly_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfReadOnly<int>(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfReadOnly{T}" /> throws <see cref="ArgumentException" />
+    /// when the collection's <c>IsReadOnly</c> property is <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfReadOnly_WhenCollectionIsReadOnly_ShouldThrowArgumentException()
+    {
+        ICollection<int> collection = new ReadOnlyCollection<int>(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfReadOnly(collection);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfReadOnly{T}" /> throws <see cref="ArgumentException" />
+    /// when an array is passed, since arrays expose a read-only <c>ICollection&lt;T&gt;</c> view.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfReadOnly_WhenCollectionIsArray_ShouldThrowArgumentException()
+    {
+        ICollection<int> array = new int[] { 1, 2, 3 };
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfReadOnly(array);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfReadOnly{T}" /> does not throw when the collection is
+    /// writable.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfReadOnly_WhenCollectionIsWritable_ShouldNotThrow()
+    {
+        ICollection<int> collection = new List<int> { 1, 2, 3 };
+
+        ThrowHelper.ThrowIfReadOnly(collection);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfReadOnly{T}" /> does not throw when the collection is
+    /// an empty writable list.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfReadOnly_WhenCollectionIsEmptyList_ShouldNotThrow()
+    {
+        ICollection<int> collection = new List<int>();
+
+        ThrowHelper.ThrowIfReadOnly(collection);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfStringLengthIsNotEqualTo.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfStringLengthIsNotEqualTo.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfStringLengthIsNotEqualTo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthIsNotEqualTo" /> throws
+    /// <see cref="ArgumentNullException" /> when the string value is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfStringLengthIsNotEqualTo_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfStringLengthIsNotEqualTo(null!, 5);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthIsNotEqualTo" /> throws
+    /// <see cref="ArgumentException" /> when the string length does not equal the expected length.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abc", 5)]    // shorter than expected
+    [DataRow("abcdef", 5)] // longer than expected
+    [DataRow("", 1)]       // empty but 1 expected
+    [DataRow("ab", 0)]     // non-empty but 0 expected
+    public void ThrowIfStringLengthIsNotEqualTo_WhenLengthDiffers_ShouldThrowArgumentException(string value, int expectedLength)
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ThrowHelper.ThrowIfStringLengthIsNotEqualTo(value, expectedLength);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthIsNotEqualTo" /> does not throw when the
+    /// string length exactly matches the expected length.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abcde", 5)]
+    [DataRow("", 0)]
+    [DataRow("x", 1)]
+    [DataRow("US", 2)]          // typical country code length
+    [DataRow("AAPLUSS00000", 12)] // ISIN-length string
+    public void ThrowIfStringLengthIsNotEqualTo_WhenLengthMatches_ShouldNotThrow(string value, int expectedLength)
+    {
+        ThrowHelper.ThrowIfStringLengthIsNotEqualTo(value, expectedLength);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfStringLengthOutOfRange.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfStringLengthOutOfRange.cs
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfStringLengthOutOfRange.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthOutOfRange" /> throws
+    /// <see cref="ArgumentNullException" /> when the string value is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfStringLengthOutOfRange_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfStringLengthOutOfRange(null!, 2, 10);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthOutOfRange" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the string length is below the minimum.
+    /// </summary>
+    [TestMethod]
+    [DataRow("a", 2, 10)]   // length 1 < min 2
+    [DataRow("", 1, 5)]     // length 0 < min 1
+    [DataRow("abc", 5, 10)] // length 3 < min 5
+    public void ThrowIfStringLengthOutOfRange_WhenLengthIsBelowMinimum_ShouldThrowArgumentOutOfRangeException(string value, int minLength, int maxLength)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfStringLengthOutOfRange(value, minLength, maxLength);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthOutOfRange" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the string length exceeds the maximum.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abcdef", 1, 5)]   // length 6 > max 5
+    [DataRow("hello!", 2, 5)]   // length 6 > max 5
+    [DataRow("abcde", 1, 4)]    // length 5 > max 4
+    public void ThrowIfStringLengthOutOfRange_WhenLengthExceedsMaximum_ShouldThrowArgumentOutOfRangeException(string value, int minLength, int maxLength)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfStringLengthOutOfRange(value, minLength, maxLength);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringLengthOutOfRange" /> does not throw when the string
+    /// length is within the specified range (inclusive on both boundaries).
+    /// </summary>
+    [TestMethod]
+    [DataRow("ab", 2, 10)]      // exactly at min
+    [DataRow("abcdefghij", 2, 10)] // exactly at max
+    [DataRow("abcde", 2, 10)]   // within range
+    [DataRow("", 0, 5)]         // min = 0, empty string valid
+    [DataRow("x", 1, 1)]        // min == max == length
+    public void ThrowIfStringLengthOutOfRange_WhenLengthIsWithinRange_ShouldNotThrow(string value, int minLength, int maxLength)
+    {
+        ThrowHelper.ThrowIfStringLengthOutOfRange(value, minLength, maxLength);
+    }
+}

--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfStringTooLong.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfStringTooLong.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThrowHelperTests.ThrowIfStringTooLong.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class ThrowHelperTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringTooLong" /> throws <see cref="ArgumentNullException" />
+    /// when the string value is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfStringTooLong_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ThrowHelper.ThrowIfStringTooLong(null!, 10);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringTooLong" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the string length exceeds the maximum.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abcdef", 5)]   // length 6 > max 5
+    [DataRow("ab", 1)]       // length 2 > max 1
+    [DataRow("x", 0)]        // length 1 > max 0
+    public void ThrowIfStringTooLong_WhenLengthExceedsMaximum_ShouldThrowArgumentOutOfRangeException(string value, int maxLength)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            ThrowHelper.ThrowIfStringTooLong(value, maxLength);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringTooLong" /> does not throw when the string length
+    /// equals the maximum (boundary condition).
+    /// </summary>
+    [TestMethod]
+    [DataRow("abcde", 5)]  // exactly at max
+    [DataRow("", 0)]        // empty string at max 0
+    public void ThrowIfStringTooLong_WhenLengthEqualsMaximum_ShouldNotThrow(string value, int maxLength)
+    {
+        ThrowHelper.ThrowIfStringTooLong(value, maxLength);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThrowHelper.ThrowIfStringTooLong" /> does not throw when the string length
+    /// is strictly less than the maximum.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abc", 10)]
+    [DataRow("", 1)]
+    [DataRow("hello world", 100)]
+    public void ThrowIfStringTooLong_WhenLengthIsBelowMaximum_ShouldNotThrow(string value, int maxLength)
+    {
+        ThrowHelper.ThrowIfStringTooLong(value, maxLength);
+    }
+}


### PR DESCRIPTION
Fixes identified across both partial files:

ThrowHelper.CallerExpression.cs
- Remove spurious `using static System.Runtime.InteropServices.JavaScript.JSType`
- ThrowIfSpanLengthIsInsufficient (Span<T> and ReadOnlySpan<T>): remove false
  <param> null-mention and spurious <exception cref="ArgumentNullException">
  — spans are value types and can never be null
- ThrowIfDestinationTooSmall (array overload): fix message arg from "span" to "array"
- ThrowIfEnumValueIsUndefined: fix reversed format args — {0} is the enum type name,
  {1} is the invalid value; was previously backwards
- ThrowIfCollectionTooSmall / ThrowIfCollectionIsEmpty: add missing
  <exception cref="ArgumentNullException"> doc; fix double-space and malformed
  <c>...</c>. punctuation in IsEmpty summary and exception description
- Add blank line separator before ThrowIfArrayTypeIsNotCompatible summary

ThrowHelper.NetStandard.cs
- Rename ThrowIfArrayIsNotSingleDimension → ThrowIfArrayMultidimensional to match
  the CallerExpression API surface (stated contract: identical public surface)
- Rename ThrowIfArrayLengthIsInsufficient(Array, int) → ThrowIfArrayLengthIsNotEqualTo
  (method was checking exact equality, not a minimum); add a correct
  ThrowIfArrayLengthIsInsufficient that checks array.Length < minimumLength
- Rename the two span exact-equality helpers inside #if NETSTANDARD2_1_OR_GREATER
  from ThrowIfArrayLengthIsInsufficient<T> → ThrowIfSpanLengthIsNotEqualTo<T>;
  change resource key from Arg_Invalid_ArrayLength to Arg_Invalid_SpanLength;
  add proper two-param ThrowIfSpanLengthIsInsufficient<T> overloads (< minimumLength)
- ThrowIfCollectionTooSmall: add null guard + ArgumentNullException doc; fix
  message construction — resource string requires string.Format with minCount arg
- Add ThrowIfCollectionIsEmpty<T> (was missing entirely from netstandard surface)
- ThrowIfIndexOutOfRange: add null guard for array + ArgumentNullException doc
- ThrowIfEnumValueIsUndefined: fix non-existent resource key Arg_Invalid_EnumValue
  → Arg_OutOfRangeException_EnumValue; fix reversed format args
- ThrowIfArrayOffsetOrCountInvalid: rename parameter index → offset to match
  CallerExpression; update doc refs and nameof() expressions accordingly
- ThrowIfDestinationTooSmall (array overload): pass missing second format arg
- ThrowIfDestinationSpanTooSmall (#if NETSTANDARD2_1): pass missing second format arg
- ThrowIfSpanLengthNotPositiveMultipleOf (both overloads): add
  ThrowIfZeroOrNegative(divisor) guard to match CallerExpression behaviour
- Fix stray leading whitespace on ThrowIfArrayLengthOutOfRange doc block

https://claude.ai/code/session_016mvuUCBFffaVvanAmYgeio