### PR TITLE
Fix CS8175: construct Span/ReadOnlySpan inline inside lambda

### DIFF
--- a/Bodu.Core/test/ThrowHelperTests.ThrowIfIndexOutOfRange.cs
+++ b/Bodu.Core/test/ThrowHelperTests.ThrowIfIndexOutOfRange.cs
@@ -64,11 +64,9 @@ public partial class ThrowHelperTests
     [DataRow(-1)]         // negative index
     public void ThrowIfIndexOutOfRange_ReadOnlySpan_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
     {
-        ReadOnlySpan<int> span = TestArray;
-
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            ThrowHelper.ThrowIfIndexOutOfRange(index, span);
+            ThrowHelper.ThrowIfIndexOutOfRange(index, new ReadOnlySpan<int>(TestArray));
         });
     }
 
@@ -98,11 +96,9 @@ public partial class ThrowHelperTests
     [DataRow(-1)]         // negative index
     public void ThrowIfIndexOutOfRange_Span_WhenIndexIsInvalid_ShouldThrowArgumentOutOfRangeException(int index)
     {
-        Span<int> span = new int[] { 1, 2, 3, 4, 5 };
-
         Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
-            ThrowHelper.ThrowIfIndexOutOfRange(index, span);
+            ThrowHelper.ThrowIfIndexOutOfRange(index, new Span<int>(new int[] { 1, 2, 3, 4, 5 }));
         });
     }
 


### PR DESCRIPTION
Span<T> and ReadOnlySpan<T> are ref structs and cannot be captured
by a lambda (CS8175). Move span construction inside the Assert.ThrowsExactly
lambda bodies so they are never captured as ref locals.

https://claude.ai/code/session_01E92rTpBcKPqzWHoQp8skHe