### PR TITLE
Refactor OrderedSet and IndexedSet to use shared OrderedSetStorage

### DIFF
--- a/Bodu.Core/src/Collections.Generic/IndexedSet.Enumerator.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedSet.Enumerator.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSet.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSet<T>
+{
+    /// <inheritdoc />
+    IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <summary>
+    /// Enumerates the elements of an <see cref="IndexedSet{T}" /> in insertion order without allocating.
+    /// </summary>
+    /// <remarks>
+    /// The enumerator captures the set's version on construction. Any structural mutation invalidates the
+    /// enumerator and causes <see cref="MoveNext" /> or <see cref="Reset" /> to throw
+    /// <see cref="InvalidOperationException" />.
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator : IEnumerator<T>
+    {
+        /// <summary>
+        /// The set being enumerated.
+        /// </summary>
+        private readonly IndexedSet<T> _owner;
+
+        /// <summary>
+        /// The version captured from <see cref="_owner" /> at construction.
+        /// </summary>
+        private readonly int _version;
+
+        /// <summary>
+        /// The index of the next item to yield.
+        /// </summary>
+        private int _index;
+
+        /// <summary>
+        /// The item returned by <see cref="Current" /> for the current position.
+        /// </summary>
+        private T _current;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Enumerator" /> struct over the specified set.
+        /// </summary>
+        /// <param name="owner">The set to enumerate.</param>
+        internal Enumerator(IndexedSet<T> owner)
+        {
+            _owner = owner;
+            _version = owner._version;
+            _index = 0;
+            _current = default!;
+        }
+
+        /// <inheritdoc />
+        public T Current => _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            if (_index >= _owner._count)
+                return false;
+
+            _current = _owner._items[_index];
+            _index++;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _index = 0;
+            _current = default!;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/IndexedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedSet.cs
@@ -11,21 +11,22 @@ using System.Diagnostics;
 namespace Bodu.Collections.Generic;
 
 /// <summary>
-/// Represents an insertion-ordered set with index-based access.
+/// Represents an index-addressable unique list — an insertion-ordered collection of unique elements that
+/// exposes the full <see cref="IList{T}" /> contract.
 /// </summary>
 /// <typeparam name="T">The type of elements in the set. Elements must not be <see langword="null" />.</typeparam>
 /// <remarks>
 /// <para>
-/// <see cref="IndexedSet{T}" /> stores elements in a compact contiguous array for deterministic index order
-/// and maintains a custom open-addressing bucket table over those array slots for fast uniqueness checks.
-/// The hash table is not a BCL <see cref="System.Collections.Generic.HashSet{T}" /> or
-/// <see cref="System.Collections.Generic.Dictionary{TKey, TValue}" /> wrapper; it is implemented directly with
-/// two parallel <see cref="int" /> arrays — one of bucket heads, one of chain links — sized as power-of-two
-/// capacities and rehashed when the load factor exceeds three quarters.
+/// <see cref="IndexedSet{T}" /> shares its backing storage with <see cref="OrderedSet{T}" /> via the
+/// internal <see cref="OrderedSetStorage{T}" /> engine: a contiguous element array for deterministic index
+/// order plus an open-addressing hash table for O(1) <see cref="Contains" /> and <see cref="IndexOf" />.
+/// No BCL collection types are used as backing storage.
 /// </para>
 /// <para>
-/// Adding an item appends it to the end of the logical order. Insertions, removals, moves, and indexed
-/// replacement preserve uniqueness and update the hash table.
+/// Use <see cref="IndexedSet{T}" /> when callers need positional mutation — <see cref="Insert" />,
+/// <see cref="RemoveAt" />, <see cref="Move" />, or the indexer setter. Use <see cref="OrderedSet{T}" />
+/// when the public surface is conceptually a set and indices exist only as a read-only view onto insertion
+/// order.
 /// </para>
 /// <para>
 /// This type is not thread-safe.
@@ -33,19 +34,10 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [Serializable]
-public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
+public sealed partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     where T : notnull
 {
-    private const int DefaultCapacity = 4;
-    private const int MaxLoadFactorNumerator = 3;
-    private const int MaxLoadFactorDenominator = 4;
-
-    private readonly IEqualityComparer<T> _comparer;
-    private int[] _buckets;
-    private int[] _next;
-    private T[] _items;
-    private int _count;
-    private int _version;
+    private readonly OrderedSetStorage<T> _storage;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class using the default capacity and comparer.
@@ -86,19 +78,11 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </exception>
     public IndexedSet(int capacity, IEqualityComparer<T>? comparer)
     {
-        ThrowHelper.ThrowIfNegative(capacity);
-
-        _comparer = comparer ?? EqualityComparer<T>.Default;
-        _items = capacity == 0 ? Array.Empty<T>() : new T[capacity];
-        _next = capacity == 0 ? Array.Empty<int>() : new int[capacity];
-        _buckets = Array.Empty<int>();
-
-        if (capacity > 0)
-            ResizeBuckets(CalculateBucketCapacity(capacity));
+        _storage = new OrderedSetStorage<T>(capacity, comparer);
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from <paramref name="collection" />.
     /// </summary>
     /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <exception cref="ArgumentNullException">
@@ -110,7 +94,7 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from <paramref name="collection" />.
     /// </summary>
     /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
@@ -123,26 +107,26 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
         ThrowHelper.ThrowIfNull(collection);
 
         foreach (T item in collection)
-            Add(item);
+            _storage.Add(item);
     }
 
     /// <summary>
     /// Gets the equality comparer used to compare elements.
     /// </summary>
     /// <returns>The active equality comparer.</returns>
-    public IEqualityComparer<T> Comparer => _comparer;
+    public IEqualityComparer<T> Comparer => _storage.Comparer;
 
     /// <summary>
     /// Gets the number of elements in the set.
     /// </summary>
     /// <returns>The number of elements currently stored in the set.</returns>
-    public int Count => _count;
+    public int Count => _storage.Count;
 
     /// <summary>
     /// Gets the allocated element capacity.
     /// </summary>
     /// <returns>The current allocated capacity of the underlying element storage.</returns>
-    public int Capacity => _items.Length;
+    public int Capacity => _storage.Capacity;
 
     /// <summary>
     /// Gets a value indicating whether the set is read-only.
@@ -151,7 +135,7 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     public bool IsReadOnly => false;
 
     /// <summary>
-    /// Gets or replaces the element at the specified index.
+    /// Gets or replaces the element at the specified zero-based index.
     /// </summary>
     /// <param name="index">The zero-based index of the element to access.</param>
     /// <returns>The element at <paramref name="index" />.</returns>
@@ -166,28 +150,8 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </exception>
     public T this[int index]
     {
-        get
-        {
-            ValidateIndex(index);
-            return _items[index];
-        }
-
-        set
-        {
-            ThrowHelper.ThrowIfNull(value);
-            ValidateIndex(index);
-
-            int existingIndex = IndexOf(value);
-            if (existingIndex >= 0 && existingIndex != index)
-                throw new ArgumentException("The set already contains the specified value.", nameof(value));
-
-            if (existingIndex == index)
-                return;
-
-            _items[index] = value;
-            RebuildHashTable();
-            _version++;
-        }
+        get => _storage.GetAt(index);
+        set => _storage.ReplaceAt(index, value);
     }
 
     /// <summary>
@@ -195,59 +159,32 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </summary>
     /// <param name="item">The item to add. Must not be <see langword="null" />.</param>
     /// <returns>
-    /// <see langword="true" /> if the item was added; otherwise, <see langword="false" /> if the set already contained it.
+    /// <see langword="true" /> if the item was added; otherwise, <see langword="false" /> when the set already contained it.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="item" /> is <see langword="null" />.
     /// </exception>
-    public bool Add(T item)
-    {
-        ThrowHelper.ThrowIfNull(item);
-
-        if (IndexOf(item) >= 0)
-            return false;
-
-        EnsureCapacity(_count + 1);
-        EnsureHashCapacity(_count + 1);
-
-        _items[_count] = item;
-        AddToHashTable(item, _count);
-        _count++;
-        _version++;
-
-        return true;
-    }
+    public bool Add(T item) =>
+        _storage.Add(item);
 
     /// <summary>
-    /// Adds each unique item from the specified collection.
+    /// Adds each unique item from <paramref name="collection" />.
     /// </summary>
     /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <returns>The number of items added.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="collection" /> is <see langword="null" />.
     /// </exception>
-    public int AddRange(IEnumerable<T> collection)
-    {
-        ThrowHelper.ThrowIfNull(collection);
-
-        int added = 0;
-
-        foreach (T item in collection)
-        {
-            if (Add(item))
-                added++;
-        }
-
-        return added;
-    }
+    public int AddRange(IEnumerable<T> collection) =>
+        _storage.AddRange(collection);
 
     /// <summary>
-    /// Attempts to insert the specified item at the specified index.
+    /// Attempts to insert the specified item at the specified position.
     /// </summary>
     /// <param name="index">The insertion index in the range <c>[0, <see cref="Count" />]</c>.</param>
     /// <param name="item">The item to insert. Must not be <see langword="null" />.</param>
     /// <returns>
-    /// <see langword="true" /> if the item was inserted; otherwise, <see langword="false" /> if the set already contained it.
+    /// <see langword="true" /> if the item was inserted; otherwise, <see langword="false" /> when the set already contained it.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="item" /> is <see langword="null" />.
@@ -255,30 +192,11 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="index" /> is negative or greater than <see cref="Count" />.
     /// </exception>
-    public bool TryInsert(int index, T item)
-    {
-        ValidateInsertionIndex(index);
-        ThrowHelper.ThrowIfNull(item);
-
-        if (IndexOf(item) >= 0)
-            return false;
-
-        EnsureCapacity(_count + 1);
-        EnsureHashCapacity(_count + 1);
-
-        if (index < _count)
-            Array.Copy(_items, index, _items, index + 1, _count - index);
-
-        _items[index] = item;
-        _count++;
-        RebuildHashTable();
-        _version++;
-
-        return true;
-    }
+    public bool TryInsert(int index, T item) =>
+        _storage.TryInsert(index, item);
 
     /// <summary>
-    /// Inserts the specified item at the specified index.
+    /// Inserts the specified item at the specified position.
     /// </summary>
     /// <param name="index">The insertion index in the range <c>[0, <see cref="Count" />]</c>.</param>
     /// <param name="item">The item to insert. Must not be <see langword="null" />.</param>
@@ -291,7 +209,7 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <exception cref="ArgumentException">The item already exists in the set.</exception>
     public void Insert(int index, T item)
     {
-        if (!TryInsert(index, item))
+        if (!_storage.TryInsert(index, item))
             throw new ArgumentException("The set already contains the specified value.", nameof(item));
     }
 
@@ -305,84 +223,35 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="item" /> is <see langword="null" />.
     /// </exception>
-    public bool Remove(T item)
-    {
-        ThrowHelper.ThrowIfNull(item);
-
-        int index = IndexOf(item);
-        if (index < 0)
-            return false;
-
-        RemoveAt(index);
-        return true;
-    }
+    public bool Remove(T item) =>
+        _storage.Remove(item);
 
     /// <summary>
-    /// Removes the item at the specified index.
+    /// Removes the element at the specified index.
     /// </summary>
     /// <param name="index">The zero-based index to remove.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
     /// </exception>
-    public void RemoveAt(int index)
-    {
-        ValidateIndex(index);
-
-        int moveCount = _count - index - 1;
-
-        if (moveCount > 0)
-            Array.Copy(_items, index + 1, _items, index, moveCount);
-
-        _count--;
-        _items[_count] = default!;
-
-        RebuildHashTable();
-        _version++;
-    }
+    public void RemoveAt(int index) =>
+        _storage.RemoveAt(index);
 
     /// <summary>
-    /// Moves an existing item from one index to another.
+    /// Moves an existing element from one index to another.
     /// </summary>
-    /// <param name="oldIndex">The current index.</param>
-    /// <param name="newIndex">The target index.</param>
+    /// <param name="oldIndex">The current zero-based index.</param>
+    /// <param name="newIndex">The target zero-based index.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="oldIndex" /> or <paramref name="newIndex" /> is negative or greater than or equal to <see cref="Count" />.
     /// </exception>
-    public void Move(int oldIndex, int newIndex)
-    {
-        ValidateIndex(oldIndex);
-        ValidateIndex(newIndex);
-
-        if (oldIndex == newIndex)
-            return;
-
-        T item = _items[oldIndex];
-
-        if (oldIndex < newIndex)
-            Array.Copy(_items, oldIndex + 1, _items, oldIndex, newIndex - oldIndex);
-        else
-            Array.Copy(_items, newIndex, _items, newIndex + 1, oldIndex - newIndex);
-
-        _items[newIndex] = item;
-        RebuildHashTable();
-        _version++;
-    }
+    public void Move(int oldIndex, int newIndex) =>
+        _storage.Move(oldIndex, newIndex);
 
     /// <summary>
-    /// Removes all items from the set.
+    /// Removes all elements from the set.
     /// </summary>
-    public void Clear()
-    {
-        if (_count == 0)
-            return;
-
-        Array.Clear(_items, 0, _count);
-        Array.Clear(_next, 0, _next.Length);
-        Array.Clear(_buckets, 0, _buckets.Length);
-
-        _count = 0;
-        _version++;
-    }
+    public void Clear() =>
+        _storage.Clear();
 
     /// <summary>
     /// Determines whether the set contains the specified item.
@@ -394,40 +263,22 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="item" /> is <see langword="null" />.
     /// </exception>
-    public bool Contains(T item)
-    {
-        ThrowHelper.ThrowIfNull(item);
-        return IndexOf(item) >= 0;
-    }
+    public bool Contains(T item) =>
+        _storage.Contains(item);
 
     /// <summary>
-    /// Returns the index of the specified item.
+    /// Returns the zero-based index of the specified item.
     /// </summary>
     /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
-    /// <returns>The zero-based index, or <c>-1</c> if the item is not present.</returns>
+    /// <returns>The zero-based index of the item, or <c>-1</c> if it is not present.</returns>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="item" /> is <see langword="null" />.
     /// </exception>
-    public int IndexOf(T item)
-    {
-        ThrowHelper.ThrowIfNull(item);
-
-        if (_count == 0 || _buckets.Length == 0)
-            return -1;
-
-        int bucket = GetBucket(item, _buckets.Length);
-
-        for (int index = _buckets[bucket] - 1; index >= 0; index = _next[index] - 1)
-        {
-            if (_comparer.Equals(_items[index], item))
-                return index;
-        }
-
-        return -1;
-    }
+    public int IndexOf(T item) =>
+        _storage.IndexOf(item);
 
     /// <summary>
-    /// Copies the set items to the specified array.
+    /// Copies the elements to the specified array starting at <paramref name="arrayIndex" />.
     /// </summary>
     /// <param name="array">The destination array. Must not be <see langword="null" />.</param>
     /// <param name="arrayIndex">The destination start index.</param>
@@ -438,77 +289,39 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <paramref name="arrayIndex" /> is negative.
     /// </exception>
     /// <exception cref="ArgumentException">
-    /// <paramref name="array" /> does not have enough space starting at <paramref name="arrayIndex" /> to hold the set.
+    /// <paramref name="array" /> does not have enough space starting at <paramref name="arrayIndex" />.
     /// </exception>
-    public void CopyTo(T[] array, int arrayIndex)
-    {
-        ThrowHelper.ThrowIfNull(array);
-        ThrowHelper.ThrowIfNegative(arrayIndex);
-
-        if (array.Length - arrayIndex < _count)
-            throw new ArgumentException("The destination array does not have sufficient space.", nameof(array));
-
-        Array.Copy(_items, 0, array, arrayIndex, _count);
-    }
+    public void CopyTo(T[] array, int arrayIndex) =>
+        _storage.CopyTo(array, arrayIndex);
 
     /// <summary>
-    /// Ensures that the set can hold at least the specified number of items without reallocating item storage.
+    /// Ensures that the set can hold at least the specified number of items without reallocating storage.
     /// </summary>
     /// <param name="capacity">The desired item capacity.</param>
-    /// <returns>The current item capacity.</returns>
+    /// <returns>The resulting item capacity.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="capacity" /> is negative.
     /// </exception>
-    public int EnsureCapacity(int capacity)
-    {
-        ThrowHelper.ThrowIfNegative(capacity);
-
-        if (_items.Length < capacity)
-            ResizeItemStorage(GrowCapacity(capacity));
-
-        EnsureHashCapacity(capacity);
-
-        return _items.Length;
-    }
+    public int EnsureCapacity(int capacity) =>
+        _storage.EnsureCapacity(capacity);
 
     /// <summary>
-    /// Shrinks the internal item storage to the current count.
+    /// Shrinks the underlying storage to the current element count.
     /// </summary>
-    public void TrimExcess()
-    {
-        if (_count == 0)
-        {
-            _items = Array.Empty<T>();
-            _next = Array.Empty<int>();
-            _buckets = Array.Empty<int>();
-            _version++;
-            return;
-        }
-
-        if (_items.Length == _count)
-            return;
-
-        ResizeItemStorage(_count);
-        ResizeBuckets(CalculateBucketCapacity(_count));
-        RebuildHashTable();
-        _version++;
-    }
+    public void TrimExcess() =>
+        _storage.TrimExcess();
 
     /// <summary>
-    /// Copies the items to a new array in indexed order.
+    /// Copies the elements to a new array in insertion order.
     /// </summary>
-    /// <returns>A new array containing the set items.</returns>
-    public T[] ToArray()
-    {
-        T[] result = new T[_count];
-        Array.Copy(_items, 0, result, 0, _count);
-        return result;
-    }
+    /// <returns>A new array containing the set elements.</returns>
+    public T[] ToArray() =>
+        _storage.ToArray();
 
     /// <summary>
-    /// Returns an enumerator that iterates through the set in indexed order.
+    /// Returns an enumerator that iterates through the set in insertion order.
     /// </summary>
-    /// <returns>An <see cref="Enumerator" /> over the set items.</returns>
+    /// <returns>An <see cref="Enumerator" /> over the set elements.</returns>
     public Enumerator GetEnumerator() =>
         new(this);
 
@@ -517,156 +330,15 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </summary>
     /// <param name="item">The item to add.</param>
     /// <remarks>
-    /// Discards the boolean result of <see cref="Add(T)" />; callers that need to detect a duplicate-add should
-    /// invoke the typed <see cref="Add(T)" /> overload directly.
+    /// Discards the boolean result of <see cref="Add(T)" />; callers that need to detect a duplicate-add
+    /// should invoke the typed <see cref="Add(T)" /> overload directly.
     /// </remarks>
     void ICollection<T>.Add(T item) =>
-        Add(item);
+        _storage.Add(item);
 
     /// <summary>
-    /// Appends the specified item to the open-addressing hash table.
-    /// </summary>
-    /// <param name="item">The item to add.</param>
-    /// <param name="itemIndex">The index of the item in the contiguous item storage.</param>
-    private void AddToHashTable(T item, int itemIndex)
-    {
-        int bucket = GetBucket(item, _buckets.Length);
-
-        _next[itemIndex] = _buckets[bucket];
-        _buckets[bucket] = itemIndex + 1;
-    }
-
-    /// <summary>
-    /// Rebuilds the hash table from the contiguous item storage. Used after operations that change the
-    /// logical order of items (insertion at a non-tail index, removal, move, replace).
-    /// </summary>
-    private void RebuildHashTable()
-    {
-        if (_count == 0)
-        {
-            Array.Clear(_buckets, 0, _buckets.Length);
-            Array.Clear(_next, 0, _next.Length);
-            return;
-        }
-
-        EnsureHashCapacity(_count);
-
-        Array.Clear(_buckets, 0, _buckets.Length);
-        Array.Clear(_next, 0, _count);
-
-        for (int i = 0; i < _count; i++)
-            AddToHashTable(_items[i], i);
-    }
-
-    /// <summary>
-    /// Grows the bucket array if the load factor would exceed three quarters at <paramref name="itemCount" />,
-    /// and rebuilds the chain links.
-    /// </summary>
-    /// <param name="itemCount">The intended item count after the pending operation.</param>
-    private void EnsureHashCapacity(int itemCount)
-    {
-        if (itemCount == 0)
-            return;
-
-        if (_buckets.Length == 0 ||
-            itemCount * MaxLoadFactorDenominator > _buckets.Length * MaxLoadFactorNumerator)
-        {
-            ResizeBuckets(CalculateBucketCapacity(itemCount));
-            RebuildHashTable();
-        }
-    }
-
-    /// <summary>
-    /// Reallocates the bucket array to the specified power-of-two capacity. Existing chain links are
-    /// discarded; the caller is expected to follow with <see cref="RebuildHashTable" /> when items are present.
-    /// </summary>
-    /// <param name="capacity">The new bucket count.</param>
-    private void ResizeBuckets(int capacity)
-    {
-        _buckets = new int[capacity];
-    }
-
-    /// <summary>
-    /// Resizes the parallel item and chain-link arrays to the specified capacity.
-    /// </summary>
-    /// <param name="capacity">The new element capacity.</param>
-    private void ResizeItemStorage(int capacity)
-    {
-        Array.Resize(ref _items, capacity);
-        Array.Resize(ref _next, capacity);
-    }
-
-    /// <summary>
-    /// Returns a power-of-two bucket count that keeps the table within the configured load factor for
-    /// <paramref name="itemCapacity" /> items.
-    /// </summary>
-    /// <param name="itemCapacity">The intended item capacity.</param>
-    /// <returns>The bucket array length to allocate.</returns>
-    private int CalculateBucketCapacity(int itemCapacity)
-    {
-        int minimum = Math.Max(DefaultCapacity, (itemCapacity * MaxLoadFactorDenominator / MaxLoadFactorNumerator) + 1);
-        return RoundUpToPowerOfTwo(minimum);
-    }
-
-    /// <summary>
-    /// Computes the next item capacity by doubling the current size, with a clamp at
-    /// <see cref="Array.MaxLength" /> and a floor at <paramref name="minimum" />.
-    /// </summary>
-    /// <param name="minimum">The minimum acceptable capacity.</param>
-    /// <returns>The chosen capacity.</returns>
-    private int GrowCapacity(int minimum)
-    {
-        int capacity = _items.Length == 0 ? DefaultCapacity : _items.Length * 2;
-
-        if ((uint)capacity > Array.MaxLength)
-            capacity = Array.MaxLength;
-
-        if (capacity < minimum)
-            capacity = minimum;
-
-        return capacity;
-    }
-
-    /// <summary>
-    /// Computes the bucket index for the specified item, masked into the power-of-two bucket array length.
-    /// </summary>
-    /// <param name="item">The item whose hash is to be bucketed.</param>
-    /// <param name="bucketCount">The current bucket array length; must be a power of two.</param>
-    /// <returns>The bucket index in the range <c>[0, bucketCount)</c>.</returns>
-    private int GetBucket(T item, int bucketCount)
-    {
-        int hash = _comparer.GetHashCode(item) & 0x7fffffff;
-        return hash & (bucketCount - 1);
-    }
-
-    /// <summary>
-    /// Rounds <paramref name="value" /> up to the next power of two, clamped between <c>1</c> and
-    /// <c>2^30</c>.
-    /// </summary>
-    /// <param name="value">The value to round.</param>
-    /// <returns>The smallest power of two greater than or equal to <paramref name="value" />.</returns>
-    private static int RoundUpToPowerOfTwo(int value)
-    {
-        if (value <= 1)
-            return 1;
-
-        if (value >= 1 << 30)
-            return 1 << 30;
-
-        value--;
-        value |= value >> 1;
-        value |= value >> 2;
-        value |= value >> 4;
-        value |= value >> 8;
-        value |= value >> 16;
-        value++;
-
-        return value;
-    }
-
-    /// <summary>
-    /// Returns a capacity hint suitable for sizing storage from an enumerable, preferring the fast paths
-    /// exposed by <see cref="ICollection{T}" /> and <see cref="IReadOnlyCollection{T}" />.
+    /// Returns a capacity hint suitable for sizing storage from <paramref name="collection" />, preferring
+    /// the fast paths exposed by <see cref="ICollection{T}" /> and <see cref="IReadOnlyCollection{T}" />.
     /// </summary>
     /// <param name="collection">The source enumerable, which may be <see langword="null" />.</param>
     /// <returns>The hinted capacity, or <c>0</c> when the count cannot be determined cheaply.</returns>
@@ -680,25 +352,5 @@ public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
             : collection is IReadOnlyCollection<T> readOnlyCollection
                 ? readOnlyCollection.Count
                 : 0;
-    }
-
-    /// <summary>
-    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
-    /// <c>[0, <see cref="Count" />)</c>.
-    /// </summary>
-    /// <param name="index">The index to validate.</param>
-    private void ValidateIndex(int index)
-    {
-        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
-    }
-
-    /// <summary>
-    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
-    /// <c>[0, <see cref="Count" />]</c>.
-    /// </summary>
-    /// <param name="index">The insertion index to validate.</param>
-    private void ValidateInsertionIndex(int index)
-    {
-        if ((uint)index > (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
     }
 }

--- a/Bodu.Core/src/Collections.Generic/IndexedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedSet.cs
@@ -1,11 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="IndexedSet.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,8 +16,12 @@ namespace Bodu.Collections.Generic;
 /// <typeparam name="T">The type of elements in the set. Elements must not be <see langword="null" />.</typeparam>
 /// <remarks>
 /// <para>
-/// <see cref="IndexedSet{T}" /> stores elements in a compact contiguous array for deterministic index order,
-/// and maintains a custom open bucket table over those array slots for fast uniqueness checks.
+/// <see cref="IndexedSet{T}" /> stores elements in a compact contiguous array for deterministic index order
+/// and maintains a custom open-addressing bucket table over those array slots for fast uniqueness checks.
+/// The hash table is not a BCL <see cref="System.Collections.Generic.HashSet{T}" /> or
+/// <see cref="System.Collections.Generic.Dictionary{TKey, TValue}" /> wrapper; it is implemented directly with
+/// two parallel <see cref="int" /> arrays — one of bucket heads, one of chain links — sized as power-of-two
+/// capacities and rehashed when the load factor exceeds three quarters.
 /// </para>
 /// <para>
 /// Adding an item appends it to the end of the logical order. Insertions, removals, moves, and indexed
@@ -30,7 +33,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [Serializable]
-public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
+public partial class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     where T : notnull
 {
     private const int DefaultCapacity = 4;
@@ -45,7 +48,7 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     private int _version;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class.
+    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class using the default capacity and comparer.
     /// </summary>
     public IndexedSet()
         : this(0, null)
@@ -65,6 +68,9 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class with the specified initial capacity.
     /// </summary>
     /// <param name="capacity">The initial element capacity.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public IndexedSet(int capacity)
         : this(capacity, null)
     {
@@ -75,10 +81,12 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </summary>
     /// <param name="capacity">The initial element capacity.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public IndexedSet(int capacity, IEqualityComparer<T>? comparer)
     {
-        if (capacity < 0)
-            throw new ArgumentOutOfRangeException(nameof(capacity));
+        ThrowHelper.ThrowIfNegative(capacity);
 
         _comparer = comparer ?? EqualityComparer<T>.Default;
         _items = capacity == 0 ? Array.Empty<T>() : new T[capacity];
@@ -90,24 +98,29 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from the specified collection.
     /// </summary>
-    /// <param name="collection">The source collection.</param>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     public IndexedSet(IEnumerable<T> collection)
         : this(collection, null)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="IndexedSet{T}" /> class containing the unique elements from the specified collection.
     /// </summary>
-    /// <param name="collection">The source collection.</param>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     public IndexedSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
         : this(GetCapacityHint(collection), comparer)
     {
-        if (collection is null)
-            throw new ArgumentNullException(nameof(collection));
+        ThrowHelper.ThrowIfNull(collection);
 
         foreach (T item in collection)
             Add(item);
@@ -116,28 +129,38 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Gets the equality comparer used to compare elements.
     /// </summary>
+    /// <returns>The active equality comparer.</returns>
     public IEqualityComparer<T> Comparer => _comparer;
 
     /// <summary>
     /// Gets the number of elements in the set.
     /// </summary>
+    /// <returns>The number of elements currently stored in the set.</returns>
     public int Count => _count;
 
     /// <summary>
     /// Gets the allocated element capacity.
     /// </summary>
+    /// <returns>The current allocated capacity of the underlying element storage.</returns>
     public int Capacity => _items.Length;
 
     /// <summary>
     /// Gets a value indicating whether the set is read-only.
     /// </summary>
+    /// <returns>Always <see langword="false" />.</returns>
     public bool IsReadOnly => false;
 
     /// <summary>
-    /// Gets or replaces the item at the specified index.
+    /// Gets or replaces the element at the specified index.
     /// </summary>
-    /// <param name="index">The zero-based index.</param>
-    /// <returns>The item at <paramref name="index" />.</returns>
+    /// <param name="index">The zero-based index of the element to access.</param>
+    /// <returns>The element at <paramref name="index" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// The replacement value is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// The replacement value already exists at another index.
     /// </exception>
@@ -151,7 +174,7 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
 
         set
         {
-            ValidateItem(value, nameof(value));
+            ThrowHelper.ThrowIfNull(value);
             ValidateIndex(index);
 
             int existingIndex = IndexOf(value);
@@ -170,13 +193,16 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Adds the specified item to the end of the set.
     /// </summary>
-    /// <param name="item">The item to add.</param>
+    /// <param name="item">The item to add. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if the item was added; otherwise, <see langword="false" /> if the set already contained it.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
     public bool Add(T item)
     {
-        ValidateItem(item, nameof(item));
+        ThrowHelper.ThrowIfNull(item);
 
         if (IndexOf(item) >= 0)
             return false;
@@ -195,12 +221,14 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Adds each unique item from the specified collection.
     /// </summary>
-    /// <param name="collection">The source collection.</param>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <returns>The number of items added.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     public int AddRange(IEnumerable<T> collection)
     {
-        if (collection is null)
-            throw new ArgumentNullException(nameof(collection));
+        ThrowHelper.ThrowIfNull(collection);
 
         int added = 0;
 
@@ -216,15 +244,21 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Attempts to insert the specified item at the specified index.
     /// </summary>
-    /// <param name="index">The insertion index.</param>
-    /// <param name="item">The item to insert.</param>
+    /// <param name="index">The insertion index in the range <c>[0, <see cref="Count" />]</c>.</param>
+    /// <param name="item">The item to insert. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if the item was inserted; otherwise, <see langword="false" /> if the set already contained it.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than <see cref="Count" />.
+    /// </exception>
     public bool TryInsert(int index, T item)
     {
         ValidateInsertionIndex(index);
-        ValidateItem(item, nameof(item));
+        ThrowHelper.ThrowIfNull(item);
 
         if (IndexOf(item) >= 0)
             return false;
@@ -246,8 +280,14 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Inserts the specified item at the specified index.
     /// </summary>
-    /// <param name="index">The insertion index.</param>
-    /// <param name="item">The item to insert.</param>
+    /// <param name="index">The insertion index in the range <c>[0, <see cref="Count" />]</c>.</param>
+    /// <param name="item">The item to insert. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than <see cref="Count" />.
+    /// </exception>
     /// <exception cref="ArgumentException">The item already exists in the set.</exception>
     public void Insert(int index, T item)
     {
@@ -258,13 +298,16 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Removes the specified item from the set.
     /// </summary>
-    /// <param name="item">The item to remove.</param>
+    /// <param name="item">The item to remove. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if the item was removed; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
     public bool Remove(T item)
     {
-        ValidateItem(item, nameof(item));
+        ThrowHelper.ThrowIfNull(item);
 
         int index = IndexOf(item);
         if (index < 0)
@@ -278,6 +321,9 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// Removes the item at the specified index.
     /// </summary>
     /// <param name="index">The zero-based index to remove.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
     public void RemoveAt(int index)
     {
         ValidateIndex(index);
@@ -299,6 +345,9 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </summary>
     /// <param name="oldIndex">The current index.</param>
     /// <param name="newIndex">The target index.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="oldIndex" /> or <paramref name="newIndex" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
     public void Move(int oldIndex, int newIndex)
     {
         ValidateIndex(oldIndex);
@@ -338,24 +387,30 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Determines whether the set contains the specified item.
     /// </summary>
-    /// <param name="item">The item to locate.</param>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if the item exists; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
     public bool Contains(T item)
     {
-        ValidateItem(item, nameof(item));
+        ThrowHelper.ThrowIfNull(item);
         return IndexOf(item) >= 0;
     }
 
     /// <summary>
     /// Returns the index of the specified item.
     /// </summary>
-    /// <param name="item">The item to locate.</param>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
     /// <returns>The zero-based index, or <c>-1</c> if the item is not present.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
     public int IndexOf(T item)
     {
-        ValidateItem(item, nameof(item));
+        ThrowHelper.ThrowIfNull(item);
 
         if (_count == 0 || _buckets.Length == 0)
             return -1;
@@ -374,15 +429,21 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Copies the set items to the specified array.
     /// </summary>
-    /// <param name="array">The destination array.</param>
+    /// <param name="array">The destination array. Must not be <see langword="null" />.</param>
     /// <param name="arrayIndex">The destination start index.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="array" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="arrayIndex" /> is negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="array" /> does not have enough space starting at <paramref name="arrayIndex" /> to hold the set.
+    /// </exception>
     public void CopyTo(T[] array, int arrayIndex)
     {
-        if (array is null)
-            throw new ArgumentNullException(nameof(array));
-
-        if (arrayIndex < 0)
-            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+        ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfNegative(arrayIndex);
 
         if (array.Length - arrayIndex < _count)
             throw new ArgumentException("The destination array does not have sufficient space.", nameof(array));
@@ -395,10 +456,12 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// </summary>
     /// <param name="capacity">The desired item capacity.</param>
     /// <returns>The current item capacity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public int EnsureCapacity(int capacity)
     {
-        if (capacity < 0)
-            throw new ArgumentOutOfRangeException(nameof(capacity));
+        ThrowHelper.ThrowIfNegative(capacity);
 
         if (_items.Length < capacity)
             ResizeItemStorage(GrowCapacity(capacity));
@@ -437,7 +500,7 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <returns>A new array containing the set items.</returns>
     public T[] ToArray()
     {
-        var result = new T[_count];
+        T[] result = new T[_count];
         Array.Copy(_items, 0, result, 0, _count);
         return result;
     }
@@ -445,21 +508,26 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
     /// <summary>
     /// Returns an enumerator that iterates through the set in indexed order.
     /// </summary>
-    /// <returns>The enumerator.</returns>
+    /// <returns>An <see cref="Enumerator" /> over the set items.</returns>
     public Enumerator GetEnumerator() =>
         new(this);
 
-    /// <inheritdoc />
-    IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
-        GetEnumerator();
-
-    /// <inheritdoc />
-    IEnumerator IEnumerable.GetEnumerator() =>
-        GetEnumerator();
-
+    /// <summary>
+    /// Adds <paramref name="item" /> via the <see cref="ICollection{T}.Add(T)" /> contract.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <remarks>
+    /// Discards the boolean result of <see cref="Add(T)" />; callers that need to detect a duplicate-add should
+    /// invoke the typed <see cref="Add(T)" /> overload directly.
+    /// </remarks>
     void ICollection<T>.Add(T item) =>
         Add(item);
 
+    /// <summary>
+    /// Appends the specified item to the open-addressing hash table.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <param name="itemIndex">The index of the item in the contiguous item storage.</param>
     private void AddToHashTable(T item, int itemIndex)
     {
         int bucket = GetBucket(item, _buckets.Length);
@@ -468,6 +536,10 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
         _buckets[bucket] = itemIndex + 1;
     }
 
+    /// <summary>
+    /// Rebuilds the hash table from the contiguous item storage. Used after operations that change the
+    /// logical order of items (insertion at a non-tail index, removal, move, replace).
+    /// </summary>
     private void RebuildHashTable()
     {
         if (_count == 0)
@@ -486,6 +558,11 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
             AddToHashTable(_items[i], i);
     }
 
+    /// <summary>
+    /// Grows the bucket array if the load factor would exceed three quarters at <paramref name="itemCount" />,
+    /// and rebuilds the chain links.
+    /// </summary>
+    /// <param name="itemCount">The intended item count after the pending operation.</param>
     private void EnsureHashCapacity(int itemCount)
     {
         if (itemCount == 0)
@@ -499,23 +576,44 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
         }
     }
 
+    /// <summary>
+    /// Reallocates the bucket array to the specified power-of-two capacity. Existing chain links are
+    /// discarded; the caller is expected to follow with <see cref="RebuildHashTable" /> when items are present.
+    /// </summary>
+    /// <param name="capacity">The new bucket count.</param>
     private void ResizeBuckets(int capacity)
     {
         _buckets = new int[capacity];
     }
 
+    /// <summary>
+    /// Resizes the parallel item and chain-link arrays to the specified capacity.
+    /// </summary>
+    /// <param name="capacity">The new element capacity.</param>
     private void ResizeItemStorage(int capacity)
     {
         Array.Resize(ref _items, capacity);
         Array.Resize(ref _next, capacity);
     }
 
+    /// <summary>
+    /// Returns a power-of-two bucket count that keeps the table within the configured load factor for
+    /// <paramref name="itemCapacity" /> items.
+    /// </summary>
+    /// <param name="itemCapacity">The intended item capacity.</param>
+    /// <returns>The bucket array length to allocate.</returns>
     private int CalculateBucketCapacity(int itemCapacity)
     {
         int minimum = Math.Max(DefaultCapacity, (itemCapacity * MaxLoadFactorDenominator / MaxLoadFactorNumerator) + 1);
         return RoundUpToPowerOfTwo(minimum);
     }
 
+    /// <summary>
+    /// Computes the next item capacity by doubling the current size, with a clamp at
+    /// <see cref="Array.MaxLength" /> and a floor at <paramref name="minimum" />.
+    /// </summary>
+    /// <param name="minimum">The minimum acceptable capacity.</param>
+    /// <returns>The chosen capacity.</returns>
     private int GrowCapacity(int minimum)
     {
         int capacity = _items.Length == 0 ? DefaultCapacity : _items.Length * 2;
@@ -529,12 +627,24 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
         return capacity;
     }
 
+    /// <summary>
+    /// Computes the bucket index for the specified item, masked into the power-of-two bucket array length.
+    /// </summary>
+    /// <param name="item">The item whose hash is to be bucketed.</param>
+    /// <param name="bucketCount">The current bucket array length; must be a power of two.</param>
+    /// <returns>The bucket index in the range <c>[0, bucketCount)</c>.</returns>
     private int GetBucket(T item, int bucketCount)
     {
         int hash = _comparer.GetHashCode(item) & 0x7fffffff;
         return hash & (bucketCount - 1);
     }
 
+    /// <summary>
+    /// Rounds <paramref name="value" /> up to the next power of two, clamped between <c>1</c> and
+    /// <c>2^30</c>.
+    /// </summary>
+    /// <param name="value">The value to round.</param>
+    /// <returns>The smallest power of two greater than or equal to <paramref name="value" />.</returns>
     private static int RoundUpToPowerOfTwo(int value)
     {
         if (value <= 1)
@@ -554,6 +664,12 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
         return value;
     }
 
+    /// <summary>
+    /// Returns a capacity hint suitable for sizing storage from an enumerable, preferring the fast paths
+    /// exposed by <see cref="ICollection{T}" /> and <see cref="IReadOnlyCollection{T}" />.
+    /// </summary>
+    /// <param name="collection">The source enumerable, which may be <see langword="null" />.</param>
+    /// <returns>The hinted capacity, or <c>0</c> when the count cannot be determined cheaply.</returns>
     private static int GetCapacityHint(IEnumerable<T>? collection)
     {
         if (collection is null)
@@ -566,75 +682,23 @@ public class IndexedSet<T> : IList<T>, IReadOnlyList<T>
                 : 0;
     }
 
-    private static void ValidateItem(T item, string paramName)
-    {
-        if (item is null)
-            throw new ArgumentNullException(paramName);
-    }
-
+    /// <summary>
+    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
+    /// <c>[0, <see cref="Count" />)</c>.
+    /// </summary>
+    /// <param name="index">The index to validate.</param>
     private void ValidateIndex(int index)
     {
-        if ((uint)index >= (uint)_count)
-            throw new ArgumentOutOfRangeException(nameof(index));
-    }
-
-    private void ValidateInsertionIndex(int index)
-    {
-        if ((uint)index > (uint)_count)
-            throw new ArgumentOutOfRangeException(nameof(index));
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
     }
 
     /// <summary>
-    /// Enumerates an <see cref="IndexedSet{T}" /> without allocating.
+    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
+    /// <c>[0, <see cref="Count" />]</c>.
     /// </summary>
-    public struct Enumerator : IEnumerator<T>
+    /// <param name="index">The insertion index to validate.</param>
+    private void ValidateInsertionIndex(int index)
     {
-        private readonly IndexedSet<T> _owner;
-        private readonly int _version;
-        private int _index;
-        private T _current;
-
-        internal Enumerator(IndexedSet<T> owner)
-        {
-            _owner = owner;
-            _version = owner._version;
-            _index = 0;
-            _current = default!;
-        }
-
-        /// <inheritdoc />
-        public T Current => _current;
-
-        /// <inheritdoc />
-        object IEnumerator.Current => Current;
-
-        /// <inheritdoc />
-        public bool MoveNext()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            if (_index >= _owner._count)
-                return false;
-
-            _current = _owner._items[_index];
-            _index++;
-            return true;
-        }
-
-        /// <inheritdoc />
-        public void Reset()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            _index = 0;
-            _current = default!;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-        }
+        if ((uint)index > (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
     }
 }

--- a/Bodu.Core/src/Collections.Generic/OrderedSet.Enumerator.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSet.Enumerator.cs
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------------------------------------------
-// <copyright file="IndexedSet.Enumerator.cs" company="PlaceholderCompany">
+// <copyright file="OrderedSet.Enumerator.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 
 namespace Bodu.Collections.Generic;
 
-public sealed partial class IndexedSet<T>
+public sealed partial class OrderedSet<T>
 {
     /// <inheritdoc />
     IEnumerator<T> IEnumerable<T>.GetEnumerator() =>
@@ -21,7 +21,7 @@ public sealed partial class IndexedSet<T>
         GetEnumerator();
 
     /// <summary>
-    /// Enumerates the elements of an <see cref="IndexedSet{T}" /> in insertion order without allocating.
+    /// Enumerates the elements of an <see cref="OrderedSet{T}" /> in insertion order without allocating.
     /// </summary>
     /// <remarks>
     /// The enumerator captures the underlying storage version on construction. Any structural mutation
@@ -55,7 +55,7 @@ public sealed partial class IndexedSet<T>
         /// Initializes a new instance of the <see cref="Enumerator" /> struct over the specified set.
         /// </summary>
         /// <param name="owner">The set to enumerate.</param>
-        internal Enumerator(IndexedSet<T> owner)
+        internal Enumerator(OrderedSet<T> owner)
         {
             _storage = owner._storage;
             _version = _storage._version;

--- a/Bodu.Core/src/Collections.Generic/OrderedSet.ISet.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSet.ISet.cs
@@ -1,0 +1,297 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSet.ISet.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class OrderedSet<T>
+{
+    /// <summary>
+    /// Adds <paramref name="item" /> via the <see cref="ICollection{T}.Add(T)" /> contract.
+    /// </summary>
+    /// <param name="item">The item to add.</param>
+    /// <remarks>
+    /// Discards the boolean result of <see cref="Add(T)" />; callers that need to detect a duplicate-add
+    /// should invoke the typed <see cref="Add(T)" /> overload directly.
+    /// </remarks>
+    void ICollection<T>.Add(T item) =>
+        _storage.Add(item);
+
+    /// <summary>
+    /// Modifies the current set so that it contains every element that is present in either this set or
+    /// <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to union with. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public void UnionWith(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        foreach (T item in other)
+            _storage.Add(item);
+    }
+
+    /// <summary>
+    /// Modifies the current set so that it contains only elements that are also present in <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to intersect with. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public void IntersectWith(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        if (_storage.Count == 0)
+            return;
+
+        if (ReferenceEquals(other, this))
+            return;
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+        _storage.RemoveWhere(item => !projection.Contains(item));
+    }
+
+    /// <summary>
+    /// Modifies the current set so that it contains only elements that are not present in <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to subtract. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public void ExceptWith(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        if (_storage.Count == 0)
+            return;
+
+        if (ReferenceEquals(other, this))
+        {
+            _storage.Clear();
+            return;
+        }
+
+        foreach (T item in other)
+            _storage.Remove(item);
+    }
+
+    /// <summary>
+    /// Modifies the current set so that it contains only elements that are present either in the current
+    /// set or in <paramref name="other" />, but not in both.
+    /// </summary>
+    /// <param name="other">The collection to apply symmetric difference with. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public void SymmetricExceptWith(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        if (ReferenceEquals(other, this))
+        {
+            _storage.Clear();
+            return;
+        }
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+
+        for (int i = 0; i < projection.Count; i++)
+        {
+            T item = projection._items[i];
+            if (!_storage.Add(item))
+                _storage.Remove(item);
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the current set is a subset of <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to test against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if every element of the current set is also in <paramref name="other" />; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool IsSubsetOf(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        if (_storage.Count == 0)
+            return true;
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+
+        if (_storage.Count > projection.Count)
+            return false;
+
+        for (int i = 0; i < _storage._count; i++)
+        {
+            if (!projection.Contains(_storage._items[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the current set is a superset of <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to test against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if every element of <paramref name="other" /> is also in the current set; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool IsSupersetOf(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        foreach (T item in other)
+        {
+            if (!_storage.Contains(item))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the current set is a proper (strict) subset of <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to test against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the current set is a subset of <paramref name="other" /> and the two are not equal; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool IsProperSubsetOf(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+
+        if (_storage.Count >= projection.Count)
+            return false;
+
+        for (int i = 0; i < _storage._count; i++)
+        {
+            if (!projection.Contains(_storage._items[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the current set is a proper (strict) superset of <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to test against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the current set is a superset of <paramref name="other" /> and the two are not equal; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool IsProperSupersetOf(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+
+        if (_storage.Count <= projection.Count)
+            return false;
+
+        for (int i = 0; i < projection._count; i++)
+        {
+            if (!_storage.Contains(projection._items[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Determines whether the current set and <paramref name="other" /> share any elements.
+    /// </summary>
+    /// <param name="other">The collection to test against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the two collections share at least one element; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool Overlaps(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        if (_storage.Count == 0)
+            return false;
+
+        foreach (T item in other)
+        {
+            if (_storage.Contains(item))
+                return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the current set contains exactly the same elements as <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The collection to compare against. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the two collections contain the same elements (ignoring duplicates and order); otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
+    public bool SetEquals(IEnumerable<T> other)
+    {
+        ThrowHelper.ThrowIfNull(other);
+
+        OrderedSetStorage<T> projection = BuildProjection(other);
+
+        if (_storage.Count != projection.Count)
+            return false;
+
+        for (int i = 0; i < _storage._count; i++)
+        {
+            if (!projection.Contains(_storage._items[i]))
+                return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a temporary <see cref="OrderedSetStorage{T}" /> projection of <paramref name="other" /> for
+    /// O(1) membership tests, deduplicating along the way.
+    /// </summary>
+    /// <param name="other">The source enumerable.</param>
+    /// <returns>A new storage instance containing each distinct element of <paramref name="other" />.</returns>
+    private OrderedSetStorage<T> BuildProjection(IEnumerable<T> other)
+    {
+        int hint = other is ICollection<T> col ? col.Count
+                 : other is IReadOnlyCollection<T> rc ? rc.Count
+                 : 0;
+
+        OrderedSetStorage<T> projection = new(hint, _storage.Comparer);
+
+        foreach (T item in other)
+            projection.Add(item);
+
+        return projection;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/OrderedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSet.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="OrderedSet.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -16,8 +16,8 @@ namespace Bodu.Collections.Generic;
 /// <typeparam name="T">The type of elements in the set. Elements must not be <see langword="null" />.</typeparam>
 /// <remarks>
 /// <para>
-/// <see cref="OrderedSet{T}" /> is a semantic alias over <see cref="IndexedSet{T}" />. It preserves insertion order,
-/// rejects duplicate values, and supports index-based access.
+/// <see cref="OrderedSet{T}" /> is a sealed semantic alias over <see cref="IndexedSet{T}" />. It preserves
+/// insertion order, rejects duplicate values, and inherits index-based access.
 /// </para>
 /// <para>
 /// Use <see cref="IndexedSet{T}" /> when the index-addressable behaviour is the primary concept. Use
@@ -30,7 +30,7 @@ public sealed class OrderedSet<T> : IndexedSet<T>
     where T : notnull
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class.
+    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class using the default capacity and comparer.
     /// </summary>
     public OrderedSet()
     {
@@ -49,6 +49,9 @@ public sealed class OrderedSet<T> : IndexedSet<T>
     /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class with the specified initial capacity.
     /// </summary>
     /// <param name="capacity">The initial item capacity.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public OrderedSet(int capacity)
         : base(capacity)
     {
@@ -59,25 +62,34 @@ public sealed class OrderedSet<T> : IndexedSet<T>
     /// </summary>
     /// <param name="capacity">The initial item capacity.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public OrderedSet(int capacity, IEqualityComparer<T>? comparer)
         : base(capacity, comparer)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from the specified collection.
     /// </summary>
-    /// <param name="collection">The source collection.</param>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     public OrderedSet(IEnumerable<T> collection)
         : base(collection)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from the specified collection.
     /// </summary>
-    /// <param name="collection">The source collection.</param>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
     public OrderedSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
         : base(collection, comparer)
     {

--- a/Bodu.Core/src/Collections.Generic/OrderedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSet.cs
@@ -11,28 +11,40 @@ using System.Diagnostics;
 namespace Bodu.Collections.Generic;
 
 /// <summary>
-/// Represents an insertion-ordered set.
+/// Represents an insertion-ordered set — a <see cref="ISet{T}" /> that preserves the order in which
+/// elements were first added and exposes that order through <see cref="IReadOnlyList{T}" />.
 /// </summary>
 /// <typeparam name="T">The type of elements in the set. Elements must not be <see langword="null" />.</typeparam>
 /// <remarks>
 /// <para>
-/// <see cref="OrderedSet{T}" /> is a sealed semantic alias over <see cref="IndexedSet{T}" />. It preserves
-/// insertion order, rejects duplicate values, and inherits index-based access.
+/// <see cref="OrderedSet{T}" /> shares its backing storage with <see cref="IndexedSet{T}" /> via the
+/// internal <see cref="OrderedSetStorage{T}" /> engine: a contiguous element array for deterministic
+/// insertion order plus an open-addressing hash table for O(1) <see cref="Contains" />. No BCL collection
+/// types are used as backing storage.
 /// </para>
 /// <para>
-/// Use <see cref="IndexedSet{T}" /> when the index-addressable behaviour is the primary concept. Use
-/// <see cref="OrderedSet{T}" /> when the order-preserving set behaviour is the primary concept.
+/// The contract is strictly set-shaped: <see cref="ISet{T}" /> for mutation and set algebra,
+/// <see cref="IReadOnlyList{T}" /> for ordered iteration and positional read access. Positional mutation
+/// (<c>Insert</c>, <c>RemoveAt</c>, <c>Move</c>, indexer setter) is intentionally not exposed — use
+/// <see cref="IndexedSet{T}" /> when those operations are required.
+/// </para>
+/// <para>
+/// This type is not thread-safe.
 /// </para>
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [Serializable]
-public sealed class OrderedSet<T> : IndexedSet<T>
+public sealed partial class OrderedSet<T>
+    : ISet<T>, IReadOnlyList<T>
     where T : notnull
 {
+    private readonly OrderedSetStorage<T> _storage;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class using the default capacity and comparer.
     /// </summary>
     public OrderedSet()
+        : this(0, null)
     {
     }
 
@@ -41,49 +53,49 @@ public sealed class OrderedSet<T> : IndexedSet<T>
     /// </summary>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
     public OrderedSet(IEqualityComparer<T>? comparer)
-        : base(comparer)
+        : this(0, comparer)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class with the specified initial capacity.
     /// </summary>
-    /// <param name="capacity">The initial item capacity.</param>
+    /// <param name="capacity">The initial element capacity.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="capacity" /> is negative.
     /// </exception>
     public OrderedSet(int capacity)
-        : base(capacity)
+        : this(capacity, null)
     {
     }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class with the specified initial capacity and comparer.
     /// </summary>
-    /// <param name="capacity">The initial item capacity.</param>
+    /// <param name="capacity">The initial element capacity.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="capacity" /> is negative.
     /// </exception>
     public OrderedSet(int capacity, IEqualityComparer<T>? comparer)
-        : base(capacity, comparer)
     {
+        _storage = new OrderedSetStorage<T>(capacity, comparer);
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from <paramref name="collection" />.
     /// </summary>
     /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="collection" /> is <see langword="null" />.
     /// </exception>
     public OrderedSet(IEnumerable<T> collection)
-        : base(collection)
+        : this(collection, null)
     {
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from the specified collection.
+    /// Initializes a new instance of the <see cref="OrderedSet{T}" /> class containing the unique elements from <paramref name="collection" />.
     /// </summary>
     /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
     /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
@@ -91,7 +103,178 @@ public sealed class OrderedSet<T> : IndexedSet<T>
     /// <paramref name="collection" /> is <see langword="null" />.
     /// </exception>
     public OrderedSet(IEnumerable<T> collection, IEqualityComparer<T>? comparer)
-        : base(collection, comparer)
+        : this(GetCapacityHint(collection), comparer)
     {
+        ThrowHelper.ThrowIfNull(collection);
+
+        foreach (T item in collection)
+            _storage.Add(item);
+    }
+
+    /// <summary>
+    /// Gets the equality comparer used to compare elements.
+    /// </summary>
+    /// <returns>The active equality comparer.</returns>
+    public IEqualityComparer<T> Comparer => _storage.Comparer;
+
+    /// <summary>
+    /// Gets the number of elements in the set.
+    /// </summary>
+    /// <returns>The number of elements currently stored in the set.</returns>
+    public int Count => _storage.Count;
+
+    /// <summary>
+    /// Gets the allocated element capacity.
+    /// </summary>
+    /// <returns>The current allocated capacity of the underlying element storage.</returns>
+    public int Capacity => _storage.Capacity;
+
+    /// <summary>
+    /// Gets a value indicating whether the set is read-only.
+    /// </summary>
+    /// <returns>Always <see langword="false" />.</returns>
+    public bool IsReadOnly => false;
+
+    /// <summary>
+    /// Gets the element at the specified zero-based index in insertion order.
+    /// </summary>
+    /// <param name="index">The zero-based index of the element to access.</param>
+    /// <returns>The element at <paramref name="index" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    public T this[int index] => _storage.GetAt(index);
+
+    /// <summary>
+    /// Adds the specified item to the set.
+    /// </summary>
+    /// <param name="item">The item to add. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item was added; otherwise, <see langword="false" /> when the set already contained it.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    public bool Add(T item) =>
+        _storage.Add(item);
+
+    /// <summary>
+    /// Adds each unique item from <paramref name="collection" />.
+    /// </summary>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
+    /// <returns>The number of items added.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
+    public int AddRange(IEnumerable<T> collection) =>
+        _storage.AddRange(collection);
+
+    /// <summary>
+    /// Removes the specified item from the set.
+    /// </summary>
+    /// <param name="item">The item to remove. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item was removed; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    public bool Remove(T item) =>
+        _storage.Remove(item);
+
+    /// <summary>
+    /// Removes all elements from the set.
+    /// </summary>
+    public void Clear() =>
+        _storage.Clear();
+
+    /// <summary>
+    /// Determines whether the set contains the specified item.
+    /// </summary>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item exists; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    public bool Contains(T item) =>
+        _storage.Contains(item);
+
+    /// <summary>
+    /// Returns the zero-based index of <paramref name="item" /> in insertion order.
+    /// </summary>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
+    /// <returns>The zero-based index of the item, or <c>-1</c> if it is not present.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    public int IndexOf(T item) =>
+        _storage.IndexOf(item);
+
+    /// <summary>
+    /// Copies the elements to the specified array starting at <paramref name="arrayIndex" />.
+    /// </summary>
+    /// <param name="array">The destination array. Must not be <see langword="null" />.</param>
+    /// <param name="arrayIndex">The destination start index.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="array" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="arrayIndex" /> is negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="array" /> does not have enough space starting at <paramref name="arrayIndex" />.
+    /// </exception>
+    public void CopyTo(T[] array, int arrayIndex) =>
+        _storage.CopyTo(array, arrayIndex);
+
+    /// <summary>
+    /// Ensures that the set can hold at least the specified number of items without reallocating storage.
+    /// </summary>
+    /// <param name="capacity">The desired item capacity.</param>
+    /// <returns>The resulting item capacity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
+    public int EnsureCapacity(int capacity) =>
+        _storage.EnsureCapacity(capacity);
+
+    /// <summary>
+    /// Shrinks the underlying storage to the current element count.
+    /// </summary>
+    public void TrimExcess() =>
+        _storage.TrimExcess();
+
+    /// <summary>
+    /// Copies the elements to a new array in insertion order.
+    /// </summary>
+    /// <returns>A new array containing the set elements.</returns>
+    public T[] ToArray() =>
+        _storage.ToArray();
+
+    /// <summary>
+    /// Returns an enumerator that iterates through the set in insertion order.
+    /// </summary>
+    /// <returns>An <see cref="Enumerator" /> over the set elements.</returns>
+    public Enumerator GetEnumerator() =>
+        new(this);
+
+    /// <summary>
+    /// Returns a capacity hint suitable for sizing storage from <paramref name="collection" />, preferring
+    /// the fast paths exposed by <see cref="ICollection{T}" /> and <see cref="IReadOnlyCollection{T}" />.
+    /// </summary>
+    /// <param name="collection">The source enumerable, which may be <see langword="null" />.</param>
+    /// <returns>The hinted capacity, or <c>0</c> when the count cannot be determined cheaply.</returns>
+    private static int GetCapacityHint(IEnumerable<T>? collection)
+    {
+        if (collection is null)
+            return 0;
+
+        return collection is ICollection<T> genericCollection
+            ? genericCollection.Count
+            : collection is IReadOnlyCollection<T> readOnlyCollection
+                ? readOnlyCollection.Count
+                : 0;
     }
 }

--- a/Bodu.Core/src/Collections.Generic/OrderedSetStorage.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSetStorage.cs
@@ -1,0 +1,623 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorage.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Provides the shared ordered-uniqueness storage engine used by <see cref="OrderedSet{T}" /> and
+/// <see cref="IndexedSet{T}" />.
+/// </summary>
+/// <typeparam name="T">The element type. Elements must not be <see langword="null" />.</typeparam>
+/// <remarks>
+/// <para>
+/// Elements live in a contiguous <see cref="Array" /> for deterministic insertion order. A hand-rolled
+/// open-addressing hash table over two parallel <see cref="int" /> arrays — one of bucket heads, one of
+/// chain links — provides O(1) average-case <see cref="Contains" /> and <see cref="IndexOf" />. The bucket
+/// count is always a power of two and the table is rehashed when the load factor exceeds three quarters.
+/// </para>
+/// <para>
+/// No BCL collection types back this storage; it is sized and laid out specifically for the ordered-set
+/// surface exposed by its consumers.
+/// </para>
+/// <para>
+/// This type is internal and is not thread-safe. Consumers are responsible for boundary semantics, choosing
+/// which operations to expose, and synchronising external mutators.
+/// </para>
+/// </remarks>
+[Serializable]
+internal sealed class OrderedSetStorage<T>
+    where T : notnull
+{
+    private const int DefaultCapacity = 4;
+    private const int MaxLoadFactorNumerator = 3;
+    private const int MaxLoadFactorDenominator = 4;
+
+    internal readonly IEqualityComparer<T> _comparer;
+    internal int[] _buckets;
+    internal int[] _next;
+    internal T[] _items;
+    internal int _count;
+    internal int _version;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="OrderedSetStorage{T}" /> class with the specified capacity and comparer.
+    /// </summary>
+    /// <param name="capacity">The initial element capacity.</param>
+    /// <param name="comparer">The equality comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
+    internal OrderedSetStorage(int capacity, IEqualityComparer<T>? comparer)
+    {
+        ThrowHelper.ThrowIfNegative(capacity);
+
+        _comparer = comparer ?? EqualityComparer<T>.Default;
+        _items = capacity == 0 ? Array.Empty<T>() : new T[capacity];
+        _next = capacity == 0 ? Array.Empty<int>() : new int[capacity];
+        _buckets = Array.Empty<int>();
+
+        if (capacity > 0)
+            ResizeBuckets(CalculateBucketCapacity(capacity));
+    }
+
+    /// <summary>
+    /// Gets the equality comparer used to compare elements.
+    /// </summary>
+    /// <returns>The active equality comparer.</returns>
+    internal IEqualityComparer<T> Comparer => _comparer;
+
+    /// <summary>
+    /// Gets the number of elements currently stored.
+    /// </summary>
+    /// <returns>The number of elements currently stored.</returns>
+    internal int Count => _count;
+
+    /// <summary>
+    /// Gets the allocated element capacity.
+    /// </summary>
+    /// <returns>The current allocated capacity of the underlying element storage.</returns>
+    internal int Capacity => _items.Length;
+
+    /// <summary>
+    /// Returns the element at the specified zero-based index.
+    /// </summary>
+    /// <param name="index">The zero-based index.</param>
+    /// <returns>The element at <paramref name="index" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    internal T GetAt(int index)
+    {
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+        return _items[index];
+    }
+
+    /// <summary>
+    /// Appends the specified item to the end of the order if it is not already present.
+    /// </summary>
+    /// <param name="item">The item to add. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item was added; otherwise, <see langword="false" /> when the item was already present.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    internal bool Add(T item)
+    {
+        ThrowHelper.ThrowIfNull(item);
+
+        if (FindIndex(item) >= 0)
+            return false;
+
+        EnsureItemCapacity(_count + 1);
+        EnsureHashCapacity(_count + 1);
+
+        _items[_count] = item;
+        AddToHashTable(item, _count);
+        _count++;
+        _version++;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Appends each unique item from <paramref name="collection" />.
+    /// </summary>
+    /// <param name="collection">The source collection. Must not be <see langword="null" />.</param>
+    /// <returns>The number of items added.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="collection" /> is <see langword="null" />.
+    /// </exception>
+    internal int AddRange(IEnumerable<T> collection)
+    {
+        ThrowHelper.ThrowIfNull(collection);
+
+        int added = 0;
+
+        foreach (T item in collection)
+        {
+            if (Add(item))
+                added++;
+        }
+
+        return added;
+    }
+
+    /// <summary>
+    /// Attempts to insert the specified item at the specified position.
+    /// </summary>
+    /// <param name="index">The insertion index in the range <c>[0, <see cref="Count" />]</c>.</param>
+    /// <param name="item">The item to insert. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item was inserted; otherwise, <see langword="false" /> when the item was already present.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than <see cref="Count" />.
+    /// </exception>
+    internal bool TryInsert(int index, T item)
+    {
+        if ((uint)index > (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+        ThrowHelper.ThrowIfNull(item);
+
+        if (FindIndex(item) >= 0)
+            return false;
+
+        EnsureItemCapacity(_count + 1);
+        EnsureHashCapacity(_count + 1);
+
+        if (index < _count)
+            Array.Copy(_items, index, _items, index + 1, _count - index);
+
+        _items[index] = item;
+        _count++;
+        RebuildHashTable();
+        _version++;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the specified item if present.
+    /// </summary>
+    /// <param name="item">The item to remove. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item was removed; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    internal bool Remove(T item)
+    {
+        ThrowHelper.ThrowIfNull(item);
+
+        int index = FindIndex(item);
+        if (index < 0)
+            return false;
+
+        RemoveCore(index);
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the element at the specified index.
+    /// </summary>
+    /// <param name="index">The zero-based index to remove.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    internal void RemoveAt(int index)
+    {
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+        RemoveCore(index);
+    }
+
+    /// <summary>
+    /// Moves an existing element from one index to another.
+    /// </summary>
+    /// <param name="oldIndex">The current zero-based index.</param>
+    /// <param name="newIndex">The target zero-based index.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="oldIndex" /> or <paramref name="newIndex" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    internal void Move(int oldIndex, int newIndex)
+    {
+        if ((uint)oldIndex >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(oldIndex));
+        if ((uint)newIndex >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(newIndex));
+
+        if (oldIndex == newIndex)
+            return;
+
+        T item = _items[oldIndex];
+
+        if (oldIndex < newIndex)
+            Array.Copy(_items, oldIndex + 1, _items, oldIndex, newIndex - oldIndex);
+        else
+            Array.Copy(_items, newIndex, _items, newIndex + 1, oldIndex - newIndex);
+
+        _items[newIndex] = item;
+        RebuildHashTable();
+        _version++;
+    }
+
+    /// <summary>
+    /// Replaces the element at the specified index with the specified value.
+    /// </summary>
+    /// <param name="index">The zero-based index to replace.</param>
+    /// <param name="value">The replacement value. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="value" /> already exists at another index.
+    /// </exception>
+    internal void ReplaceAt(int index, T value)
+    {
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
+        ThrowHelper.ThrowIfNull(value);
+
+        int existingIndex = FindIndex(value);
+        if (existingIndex >= 0 && existingIndex != index)
+            throw new ArgumentException("The set already contains the specified value.", nameof(value));
+
+        if (existingIndex == index)
+            return;
+
+        _items[index] = value;
+        RebuildHashTable();
+        _version++;
+    }
+
+    /// <summary>
+    /// Removes every element for which <paramref name="match" /> returns <see langword="true" />.
+    /// </summary>
+    /// <param name="match">The predicate that selects elements to remove.</param>
+    /// <returns>The number of elements removed.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="match" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Compacts surviving elements in a single pass and then rebuilds the hash table once, which is faster
+    /// than calling <see cref="Remove" /> repeatedly when many removals are anticipated.
+    /// </remarks>
+    internal int RemoveWhere(Predicate<T> match)
+    {
+        ThrowHelper.ThrowIfNull(match);
+
+        int kept = 0;
+        for (int i = 0; i < _count; i++)
+        {
+            T item = _items[i];
+            if (!match(item))
+            {
+                if (kept != i)
+                    _items[kept] = item;
+                kept++;
+            }
+        }
+
+        int removed = _count - kept;
+        if (removed > 0)
+        {
+            Array.Clear(_items, kept, removed);
+            _count = kept;
+            RebuildHashTable();
+            _version++;
+        }
+
+        return removed;
+    }
+
+    /// <summary>
+    /// Removes all elements.
+    /// </summary>
+    internal void Clear()
+    {
+        if (_count == 0)
+            return;
+
+        Array.Clear(_items, 0, _count);
+        Array.Clear(_next, 0, _next.Length);
+        Array.Clear(_buckets, 0, _buckets.Length);
+
+        _count = 0;
+        _version++;
+    }
+
+    /// <summary>
+    /// Determines whether the storage contains <paramref name="item" />.
+    /// </summary>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if the item exists; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    internal bool Contains(T item)
+    {
+        ThrowHelper.ThrowIfNull(item);
+        return FindIndex(item) >= 0;
+    }
+
+    /// <summary>
+    /// Returns the zero-based index of <paramref name="item" />, or <c>-1</c> if not present.
+    /// </summary>
+    /// <param name="item">The item to locate. Must not be <see langword="null" />.</param>
+    /// <returns>The zero-based index of the item, or <c>-1</c> if it is not present.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="item" /> is <see langword="null" />.
+    /// </exception>
+    internal int IndexOf(T item)
+    {
+        ThrowHelper.ThrowIfNull(item);
+        return FindIndex(item);
+    }
+
+    /// <summary>
+    /// Copies the elements to <paramref name="array" /> starting at <paramref name="arrayIndex" />.
+    /// </summary>
+    /// <param name="array">The destination array. Must not be <see langword="null" />.</param>
+    /// <param name="arrayIndex">The destination start index.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="array" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="arrayIndex" /> is negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="array" /> does not have enough space starting at <paramref name="arrayIndex" />.
+    /// </exception>
+    internal void CopyTo(T[] array, int arrayIndex)
+    {
+        ThrowHelper.ThrowIfNull(array);
+        ThrowHelper.ThrowIfNegative(arrayIndex);
+
+        if (array.Length - arrayIndex < _count)
+            throw new ArgumentException("The destination array does not have sufficient space.", nameof(array));
+
+        Array.Copy(_items, 0, array, arrayIndex, _count);
+    }
+
+    /// <summary>
+    /// Ensures that the storage can hold at least <paramref name="capacity" /> elements without reallocating.
+    /// </summary>
+    /// <param name="capacity">The desired capacity.</param>
+    /// <returns>The resulting element capacity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
+    internal int EnsureCapacity(int capacity)
+    {
+        ThrowHelper.ThrowIfNegative(capacity);
+
+        EnsureItemCapacity(capacity);
+        EnsureHashCapacity(capacity);
+
+        return _items.Length;
+    }
+
+    /// <summary>
+    /// Shrinks the underlying storage to the current element count.
+    /// </summary>
+    internal void TrimExcess()
+    {
+        if (_count == 0)
+        {
+            _items = Array.Empty<T>();
+            _next = Array.Empty<int>();
+            _buckets = Array.Empty<int>();
+            _version++;
+            return;
+        }
+
+        if (_items.Length == _count)
+            return;
+
+        Array.Resize(ref _items, _count);
+        Array.Resize(ref _next, _count);
+        ResizeBuckets(CalculateBucketCapacity(_count));
+        RebuildHashTable();
+        _version++;
+    }
+
+    /// <summary>
+    /// Copies the elements to a new array in insertion order.
+    /// </summary>
+    /// <returns>A new array containing the elements.</returns>
+    internal T[] ToArray()
+    {
+        T[] result = new T[_count];
+        Array.Copy(_items, 0, result, 0, _count);
+        return result;
+    }
+
+    /// <summary>
+    /// Looks up the index of <paramref name="item" /> through the hash table without validating arguments.
+    /// </summary>
+    /// <param name="item">The item to locate.</param>
+    /// <returns>The zero-based index of the item, or <c>-1</c> if it is not present.</returns>
+    private int FindIndex(T item)
+    {
+        if (_count == 0 || _buckets.Length == 0)
+            return -1;
+
+        int bucket = GetBucket(item, _buckets.Length);
+
+        for (int index = _buckets[bucket] - 1; index >= 0; index = _next[index] - 1)
+        {
+            if (_comparer.Equals(_items[index], item))
+                return index;
+        }
+
+        return -1;
+    }
+
+    /// <summary>
+    /// Removes the element at the specified index without validating the argument.
+    /// </summary>
+    /// <param name="index">The zero-based index to remove.</param>
+    private void RemoveCore(int index)
+    {
+        int moveCount = _count - index - 1;
+
+        if (moveCount > 0)
+            Array.Copy(_items, index + 1, _items, index, moveCount);
+
+        _count--;
+        _items[_count] = default!;
+
+        RebuildHashTable();
+        _version++;
+    }
+
+    /// <summary>
+    /// Grows the contiguous element storage if it is smaller than <paramref name="capacity" />.
+    /// </summary>
+    /// <param name="capacity">The required capacity.</param>
+    private void EnsureItemCapacity(int capacity)
+    {
+        if (_items.Length >= capacity)
+            return;
+
+        int newCapacity = GrowCapacity(capacity);
+        Array.Resize(ref _items, newCapacity);
+        Array.Resize(ref _next, newCapacity);
+    }
+
+    /// <summary>
+    /// Adds an item index to the open-addressing hash table.
+    /// </summary>
+    /// <param name="item">The item whose bucket is being populated.</param>
+    /// <param name="itemIndex">The index of the item in the contiguous storage.</param>
+    private void AddToHashTable(T item, int itemIndex)
+    {
+        int bucket = GetBucket(item, _buckets.Length);
+
+        _next[itemIndex] = _buckets[bucket];
+        _buckets[bucket] = itemIndex + 1;
+    }
+
+    /// <summary>
+    /// Rebuilds the hash table from the contiguous element storage.
+    /// </summary>
+    private void RebuildHashTable()
+    {
+        if (_count == 0)
+        {
+            Array.Clear(_buckets, 0, _buckets.Length);
+            Array.Clear(_next, 0, _next.Length);
+            return;
+        }
+
+        EnsureHashCapacity(_count);
+
+        Array.Clear(_buckets, 0, _buckets.Length);
+        Array.Clear(_next, 0, _count);
+
+        for (int i = 0; i < _count; i++)
+            AddToHashTable(_items[i], i);
+    }
+
+    /// <summary>
+    /// Grows the bucket array if the load factor would exceed three quarters at <paramref name="itemCount" />.
+    /// </summary>
+    /// <param name="itemCount">The intended item count.</param>
+    private void EnsureHashCapacity(int itemCount)
+    {
+        if (itemCount == 0)
+            return;
+
+        if (_buckets.Length == 0 ||
+            itemCount * MaxLoadFactorDenominator > _buckets.Length * MaxLoadFactorNumerator)
+        {
+            ResizeBuckets(CalculateBucketCapacity(itemCount));
+            RebuildHashTable();
+        }
+    }
+
+    /// <summary>
+    /// Reallocates the bucket array to <paramref name="capacity" /> entries.
+    /// </summary>
+    /// <param name="capacity">The new bucket count; must be a power of two.</param>
+    private void ResizeBuckets(int capacity) =>
+        _buckets = new int[capacity];
+
+    /// <summary>
+    /// Returns a power-of-two bucket count that keeps the table within the configured load factor for
+    /// <paramref name="itemCapacity" /> items.
+    /// </summary>
+    /// <param name="itemCapacity">The intended item capacity.</param>
+    /// <returns>The bucket array length to allocate.</returns>
+    private int CalculateBucketCapacity(int itemCapacity)
+    {
+        int minimum = Math.Max(DefaultCapacity, (itemCapacity * MaxLoadFactorDenominator / MaxLoadFactorNumerator) + 1);
+        return RoundUpToPowerOfTwo(minimum);
+    }
+
+    /// <summary>
+    /// Computes the next element capacity by doubling, clamped to <see cref="Array.MaxLength" /> and floored
+    /// at <paramref name="minimum" />.
+    /// </summary>
+    /// <param name="minimum">The minimum required capacity.</param>
+    /// <returns>The chosen capacity.</returns>
+    private int GrowCapacity(int minimum)
+    {
+        int capacity = _items.Length == 0 ? DefaultCapacity : _items.Length * 2;
+
+        if ((uint)capacity > Array.MaxLength)
+            capacity = Array.MaxLength;
+
+        if (capacity < minimum)
+            capacity = minimum;
+
+        return capacity;
+    }
+
+    /// <summary>
+    /// Computes the bucket index for <paramref name="item" />.
+    /// </summary>
+    /// <param name="item">The item to hash.</param>
+    /// <param name="bucketCount">The bucket count; must be a power of two.</param>
+    /// <returns>The bucket index in <c>[0, bucketCount)</c>.</returns>
+    private int GetBucket(T item, int bucketCount)
+    {
+        int hash = _comparer.GetHashCode(item) & 0x7fffffff;
+        return hash & (bucketCount - 1);
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="value" /> up to the next power of two, clamped to <c>[1, 2^30]</c>.
+    /// </summary>
+    /// <param name="value">The value to round.</param>
+    /// <returns>The smallest power of two greater than or equal to <paramref name="value" />.</returns>
+    private static int RoundUpToPowerOfTwo(int value)
+    {
+        if (value <= 1)
+            return 1;
+
+        if (value >= 1 << 30)
+            return 1 << 30;
+
+        value--;
+        value |= value >> 1;
+        value |= value >> 2;
+        value |= value >> 4;
+        value |= value >> 8;
+        value |= value >> 16;
+        value++;
+
+        return value;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/Range.cs
+++ b/Bodu.Core/src/Collections.Generic/Range.cs
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Range.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Represents a half-open range, where <see cref="StartInclusive" /> is included and
+/// <see cref="EndExclusive" /> is excluded.
+/// </summary>
+/// <typeparam name="T">The comparable endpoint type.</typeparam>
+/// <remarks>
+/// <para>
+/// <see cref="Range{T}" /> is an immutable value type used as the element of <see cref="RangeSet{T}" /> and as a
+/// shared building block for the <see cref="RangeDictionary{TKey, TValue}" /> family. Validation rejects ranges
+/// where the start is not strictly less than the end.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("[{StartInclusive}, {EndExclusive})")]
+public readonly struct Range<T>
+    : IEquatable<Range<T>>
+    where T : IComparable<T>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Range{T}" /> struct.
+    /// </summary>
+    /// <param name="startInclusive">The inclusive start of the range.</param>
+    /// <param name="endExclusive">The exclusive end of the range.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
+    public Range(T startInclusive, T endExclusive)
+    {
+        ValidateRange(startInclusive, endExclusive, Comparer<T>.Default);
+
+        StartInclusive = startInclusive;
+        EndExclusive = endExclusive;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    /// <returns>The inclusive lower bound of the range.</returns>
+    public T StartInclusive { get; }
+
+    /// <summary>
+    /// Gets the exclusive end of the range.
+    /// </summary>
+    /// <returns>The exclusive upper bound of the range.</returns>
+    public T EndExclusive { get; }
+
+    /// <summary>
+    /// Determines whether the specified value falls inside this range.
+    /// </summary>
+    /// <param name="value">The value to test. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="value" /> is inside the range; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    public bool Contains(T value)
+    {
+        ThrowHelper.ThrowIfNull(value);
+
+        IComparer<T> comparer = Comparer<T>.Default;
+        return comparer.Compare(StartInclusive, value) <= 0 &&
+               comparer.Compare(value, EndExclusive) < 0;
+    }
+
+    /// <summary>
+    /// Determines whether two ranges have identical endpoints.
+    /// </summary>
+    /// <param name="other">The range to compare with this instance.</param>
+    /// <returns>
+    /// <see langword="true" /> if the ranges share the same start and end; otherwise, <see langword="false" />.
+    /// </returns>
+    public bool Equals(Range<T> other) =>
+        Comparer<T>.Default.Compare(StartInclusive, other.StartInclusive) == 0 &&
+        Comparer<T>.Default.Compare(EndExclusive, other.EndExclusive) == 0;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is Range<T> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        HashCode.Combine(StartInclusive, EndExclusive);
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        $"[{StartInclusive}, {EndExclusive})";
+
+    /// <summary>
+    /// Returns a value indicating whether two ranges have identical endpoints.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>
+    /// <see langword="true" /> if the operands are equal; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool operator ==(Range<T> left, Range<T> right) => left.Equals(right);
+
+    /// <summary>
+    /// Returns a value indicating whether two ranges have differing endpoints.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>
+    /// <see langword="true" /> if the operands are not equal; otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool operator !=(Range<T> left, Range<T> right) => !left.Equals(right);
+
+    /// <summary>
+    /// Validates that the specified endpoints describe a non-empty half-open range under <paramref name="comparer" />.
+    /// </summary>
+    /// <param name="startInclusive">The inclusive start.</param>
+    /// <param name="endExclusive">The exclusive end.</param>
+    /// <param name="comparer">The comparer used to order endpoints. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" /> per <paramref name="comparer" />.
+    /// </exception>
+    internal static void ValidateRange(T startInclusive, T endExclusive, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(startInclusive);
+        ThrowHelper.ThrowIfNull(endExclusive);
+
+        if (comparer.Compare(startInclusive, endExclusive) >= 0)
+            throw new ArgumentException("The range start must be less than the range end.", nameof(startInclusive));
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/RangeDictionary.Enumerator.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeDictionary.Enumerator.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RangeDictionary.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class RangeDictionary<TKey, TValue>
+{
+    /// <inheritdoc />
+    IEnumerator<ValueRange<TKey, TValue>> IEnumerable<ValueRange<TKey, TValue>>.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <summary>
+    /// Enumerates the entries of a <see cref="RangeDictionary{TKey, TValue}" /> in ascending start order
+    /// without allocating.
+    /// </summary>
+    /// <remarks>
+    /// The enumerator captures the dictionary's version on construction. Any structural mutation invalidates
+    /// the enumerator and causes <see cref="MoveNext" /> or <see cref="Reset" /> to throw
+    /// <see cref="InvalidOperationException" />.
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator : IEnumerator<ValueRange<TKey, TValue>>
+    {
+        /// <summary>
+        /// The dictionary being enumerated.
+        /// </summary>
+        private readonly RangeDictionary<TKey, TValue> _owner;
+
+        /// <summary>
+        /// The version captured from <paramref name="owner" /> at construction.
+        /// </summary>
+        private readonly int _version;
+
+        /// <summary>
+        /// The index of the next entry to yield.
+        /// </summary>
+        private int _index;
+
+        /// <summary>
+        /// The entry returned by <see cref="Current" /> for the current position.
+        /// </summary>
+        private ValueRange<TKey, TValue> _current;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Enumerator" /> struct over the specified dictionary.
+        /// </summary>
+        /// <param name="owner">The dictionary to enumerate.</param>
+        internal Enumerator(RangeDictionary<TKey, TValue> owner)
+        {
+            _owner = owner;
+            _version = owner._version;
+            _index = 0;
+            _current = default;
+        }
+
+        /// <inheritdoc />
+        public ValueRange<TKey, TValue> Current => _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            if (_index >= _owner._count)
+                return false;
+
+            _current = new ValueRange<TKey, TValue>(
+                _owner._starts[_index],
+                _owner._ends[_index],
+                _owner._values[_index],
+                skipValidation: true);
+
+            _index++;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _index = 0;
+            _current = default;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/RangeDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeDictionary.cs
@@ -1,155 +1,14 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="RangeDictionary.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
 namespace Bodu.Collections.Generic;
-
-/// <summary>
-/// Represents a half-open range, where <see cref="StartInclusive" /> is included and
-/// <see cref="EndExclusive" /> is excluded.
-/// </summary>
-/// <typeparam name="T">The comparable endpoint type.</typeparam>
-[DebuggerDisplay("[{StartInclusive}, {EndExclusive})")]
-public readonly struct RangeDictionary<T>
-    where T : IComparable<T>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="RangeDictionary{T}" /> struct.
-    /// </summary>
-    /// <param name="startInclusive">The inclusive start of the range.</param>
-    /// <param name="endExclusive">The exclusive end of the range.</param>
-    /// <exception cref="ArgumentNullException">
-    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
-    /// </exception>
-    public RangeDictionary(T startInclusive, T endExclusive)
-    {
-        ValidateRange(startInclusive, endExclusive, Comparer<T>.Default);
-
-        StartInclusive = startInclusive;
-        EndExclusive = endExclusive;
-    }
-
-    /// <summary>
-    /// Gets the inclusive start of the range.
-    /// </summary>
-    public T StartInclusive { get; }
-
-    /// <summary>
-    /// Gets the exclusive end of the range.
-    /// </summary>
-    public T EndExclusive { get; }
-
-    /// <summary>
-    /// Determines whether the specified value falls inside this range.
-    /// </summary>
-    /// <param name="value">The value to test.</param>
-    /// <returns>
-    /// <see langword="true" /> if <paramref name="value" /> is inside the range; otherwise, <see langword="false" />.
-    /// </returns>
-    public bool Contains(T value)
-    {
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
-
-        var comparer = Comparer<T>.Default;
-        return comparer.Compare(StartInclusive, value) <= 0 &&
-               comparer.Compare(value, EndExclusive) < 0;
-    }
-
-    /// <inheritdoc />
-    public override string ToString() =>
-        $"[{StartInclusive}, {EndExclusive})";
-
-    internal static void ValidateRange(T startInclusive, T endExclusive, IComparer<T> comparer)
-    {
-        if (startInclusive is null)
-            throw new ArgumentNullException(nameof(startInclusive));
-
-        if (endExclusive is null)
-            throw new ArgumentNullException(nameof(endExclusive));
-
-        if (comparer.Compare(startInclusive, endExclusive) >= 0)
-            throw new ArgumentException("The range start must be less than the range end.");
-    }
-}
-
-/// <summary>
-/// Represents a half-open range mapped to a value.
-/// </summary>
-/// <typeparam name="TKey">The comparable endpoint type.</typeparam>
-/// <typeparam name="TValue">The value type.</typeparam>
-[DebuggerDisplay("[{StartInclusive}, {EndExclusive}) = {Value}")]
-public readonly struct ValueRange<TKey, TValue>
-    where TKey : IComparable<TKey>
-{
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ValueRange{TKey, TValue}" /> struct.
-    /// </summary>
-    /// <param name="startInclusive">The inclusive start of the range.</param>
-    /// <param name="endExclusive">The exclusive end of the range.</param>
-    /// <param name="value">The value mapped to the range.</param>
-    public ValueRange(TKey startInclusive, TKey endExclusive, TValue value)
-    {
-        RangeDictionary<TKey>.ValidateRange(startInclusive, endExclusive, Comparer<TKey>.Default);
-
-        StartInclusive = startInclusive;
-        EndExclusive = endExclusive;
-        Value = value;
-    }
-
-    internal ValueRange(TKey startInclusive, TKey endExclusive, TValue value, bool skipValidation)
-    {
-        StartInclusive = startInclusive;
-        EndExclusive = endExclusive;
-        Value = value;
-    }
-
-    /// <summary>
-    /// Gets the inclusive start of the range.
-    /// </summary>
-    public TKey StartInclusive { get; }
-
-    /// <summary>
-    /// Gets the exclusive end of the range.
-    /// </summary>
-    public TKey EndExclusive { get; }
-
-    /// <summary>
-    /// Gets the value associated with the range.
-    /// </summary>
-    public TValue Value { get; }
-
-    /// <summary>
-    /// Determines whether the specified key falls inside this range.
-    /// </summary>
-    /// <param name="key">The key to test.</param>
-    /// <returns>
-    /// <see langword="true" /> if <paramref name="key" /> is inside the range; otherwise, <see langword="false" />.
-    /// </returns>
-    public bool Contains(TKey key)
-    {
-        if (key is null)
-            throw new ArgumentNullException(nameof(key));
-
-        var comparer = Comparer<TKey>.Default;
-        return comparer.Compare(StartInclusive, key) <= 0 &&
-               comparer.Compare(key, EndExclusive) < 0;
-    }
-
-    /// <inheritdoc />
-    public override string ToString() =>
-        $"[{StartInclusive}, {EndExclusive}) = {Value}";
-}
 
 /// <summary>
 /// Represents a sorted dictionary that maps non-overlapping half-open ranges to values.
@@ -158,17 +17,21 @@ public readonly struct ValueRange<TKey, TValue>
 /// <typeparam name="TValue">The value type.</typeparam>
 /// <remarks>
 /// <para>
-/// Ranges are stored in sorted parallel arrays. Lookups use binary search over range starts and then a single
-/// end-boundary check.
+/// Entries are stored in three parallel arrays — one for the inclusive start of each range, one for the
+/// exclusive end, and one for the associated value. Lookups use binary search across the start endpoints,
+/// followed by a single end-boundary check. Insertions and removals shift the affected suffix of each array.
 /// </para>
 /// <para>
-/// Ranges use half-open semantics: <c>[startInclusive, endExclusive)</c>. Adjacent ranges are allowed; overlapping
-/// ranges are rejected.
+/// Ranges use half-open semantics: <c>[startInclusive, endExclusive)</c>. Adjacent ranges are allowed;
+/// overlapping ranges are rejected with <see cref="ArgumentException" />.
+/// </para>
+/// <para>
+/// This type is not thread-safe.
 /// </para>
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [Serializable]
-public sealed class RangeDictionary<TKey, TValue> 
+public sealed partial class RangeDictionary<TKey, TValue>
     : IReadOnlyCollection<ValueRange<TKey, TValue>>
     where TKey : IComparable<TKey>
 {
@@ -182,7 +45,7 @@ public sealed class RangeDictionary<TKey, TValue>
     private int _version;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RangeDictionary{TKey, TValue}" /> class.
+    /// Initializes a new instance of the <see cref="RangeDictionary{TKey, TValue}" /> class using the default endpoint comparer.
     /// </summary>
     public RangeDictionary()
         : this(null)
@@ -190,9 +53,9 @@ public sealed class RangeDictionary<TKey, TValue>
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RangeDictionary{TKey, TValue}" /> class.
+    /// Initializes a new instance of the <see cref="RangeDictionary{TKey, TValue}" /> class using the specified comparer.
     /// </summary>
-    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use <see cref="Comparer{TKey}.Default" />.</param>
     public RangeDictionary(IComparer<TKey>? comparer)
     {
         _comparer = comparer ?? Comparer<TKey>.Default;
@@ -204,23 +67,29 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <summary>
     /// Gets the comparer used to order range endpoints.
     /// </summary>
+    /// <returns>The active endpoint comparer.</returns>
     public IComparer<TKey> Comparer => _comparer;
 
     /// <summary>
     /// Gets the number of stored ranges.
     /// </summary>
+    /// <returns>The number of ranges currently stored in the dictionary.</returns>
     public int Count => _count;
 
     /// <summary>
     /// Gets the allocated range capacity.
     /// </summary>
+    /// <returns>The current allocated capacity of the underlying storage.</returns>
     public int Capacity => _starts.Length;
 
     /// <summary>
     /// Gets the value associated with the range containing the specified key.
     /// </summary>
-    /// <param name="key">The key to locate.</param>
+    /// <param name="key">The key to locate. Must not be <see langword="null" />.</param>
     /// <returns>The value associated with the containing range.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
     /// <exception cref="KeyNotFoundException">No range contains <paramref name="key" />.</exception>
     public TValue this[TKey key]
     {
@@ -238,6 +107,9 @@ public sealed class RangeDictionary<TKey, TValue>
     /// </summary>
     /// <param name="index">The zero-based range index.</param>
     /// <returns>The range entry at <paramref name="index" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
     public ValueRange<TKey, TValue> GetEntryAt(int index)
     {
         ValidateIndex(index);
@@ -250,18 +122,24 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <param name="startInclusive">The inclusive start.</param>
     /// <param name="endExclusive">The exclusive end.</param>
     /// <param name="value">The value to associate with the range.</param>
-    /// <exception cref="ArgumentException">The range overlaps an existing range.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />, or the
+    /// range overlaps an existing range.
+    /// </exception>
     public void Add(TKey startInclusive, TKey endExclusive, TValue value)
     {
-        RangeDictionary<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         int index = LowerBound(startInclusive);
 
         if (index > 0 && _comparer.Compare(_ends[index - 1], startInclusive) > 0)
-            throw new ArgumentException("The specified range overlaps an existing range.");
+            throw new ArgumentException("The specified range overlaps an existing range.", nameof(startInclusive));
 
         if (index < _count && _comparer.Compare(_starts[index], endExclusive) < 0)
-            throw new ArgumentException("The specified range overlaps an existing range.");
+            throw new ArgumentException("The specified range overlaps an existing range.", nameof(endExclusive));
 
         InsertAt(index, startInclusive, endExclusive, value);
     }
@@ -270,6 +148,7 @@ public sealed class RangeDictionary<TKey, TValue>
     /// Adds the specified range entry.
     /// </summary>
     /// <param name="entry">The entry to add.</param>
+    /// <exception cref="ArgumentException">The entry overlaps an existing range.</exception>
     public void Add(ValueRange<TKey, TValue> entry) =>
         Add(entry.StartInclusive, entry.EndExclusive, entry.Value);
 
@@ -281,9 +160,15 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <returns>
     /// <see langword="true" /> if the exact range was removed; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public bool Remove(TKey startInclusive, TKey endExclusive)
     {
-        RangeDictionary<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         int index = LowerBound(startInclusive);
 
@@ -316,21 +201,27 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <summary>
     /// Determines whether any stored range contains the specified key.
     /// </summary>
-    /// <param name="key">The key to locate.</param>
+    /// <param name="key">The key to locate. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if a range contains the key; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
     public bool ContainsKey(TKey key) =>
         FindContainingIndex(key) >= 0;
 
     /// <summary>
     /// Attempts to get the value associated with the range containing the specified key.
     /// </summary>
-    /// <param name="key">The key to locate.</param>
+    /// <param name="key">The key to locate. Must not be <see langword="null" />.</param>
     /// <param name="value">The value associated with the containing range, if found.</param>
     /// <returns>
     /// <see langword="true" /> if a range contains the key; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
     public bool TryGetValue(TKey key, out TValue value)
     {
         int index = FindContainingIndex(key);
@@ -348,11 +239,14 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <summary>
     /// Attempts to get the range entry containing the specified key.
     /// </summary>
-    /// <param name="key">The key to locate.</param>
+    /// <param name="key">The key to locate. Must not be <see langword="null" />.</param>
     /// <param name="entry">The containing range entry, if found.</param>
     /// <returns>
     /// <see langword="true" /> if a range contains the key; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
     public bool TryGetEntry(TKey key, out ValueRange<TKey, TValue> entry)
     {
         int index = FindContainingIndex(key);
@@ -375,9 +269,15 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <returns>
     /// <see langword="true" /> if the range overlaps an existing range; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public bool Overlaps(TKey startInclusive, TKey endExclusive)
     {
-        RangeDictionary<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<TKey>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         int index = LowerBound(startInclusive);
 
@@ -392,10 +292,12 @@ public sealed class RangeDictionary<TKey, TValue>
     /// </summary>
     /// <param name="capacity">The desired capacity.</param>
     /// <returns>The current capacity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public int EnsureCapacity(int capacity)
     {
-        if (capacity < 0)
-            throw new ArgumentOutOfRangeException(nameof(capacity));
+        ThrowHelper.ThrowIfNegative(capacity);
 
         if (_starts.Length < capacity)
             ResizeStorage(GrowCapacity(capacity));
@@ -404,12 +306,12 @@ public sealed class RangeDictionary<TKey, TValue>
     }
 
     /// <summary>
-    /// Copies the stored range entries to a new array.
+    /// Copies the stored range entries to a new array in ascending sorted order.
     /// </summary>
     /// <returns>A new array containing the stored entries.</returns>
     public ValueRange<TKey, TValue>[] ToArray()
     {
-        var result = new ValueRange<TKey, TValue>[_count];
+        ValueRange<TKey, TValue>[] result = new ValueRange<TKey, TValue>[_count];
 
         for (int i = 0; i < _count; i++)
             result[i] = new ValueRange<TKey, TValue>(_starts[i], _ends[i], _values[i], skipValidation: true);
@@ -420,22 +322,21 @@ public sealed class RangeDictionary<TKey, TValue>
     /// <summary>
     /// Returns an enumerator that iterates through the stored range entries in ascending order.
     /// </summary>
-    /// <returns>The enumerator.</returns>
+    /// <returns>An <see cref="Enumerator" /> over the dictionary entries.</returns>
     public Enumerator GetEnumerator() =>
         new(this);
 
-    /// <inheritdoc />
-    IEnumerator<ValueRange<TKey, TValue>> IEnumerable<ValueRange<TKey, TValue>>.GetEnumerator() =>
-        GetEnumerator();
-
-    /// <inheritdoc />
-    IEnumerator IEnumerable.GetEnumerator() =>
-        GetEnumerator();
-
+    /// <summary>
+    /// Locates the index of the range that contains the specified key, if any.
+    /// </summary>
+    /// <param name="key">The key to locate.</param>
+    /// <returns>The index of the containing range, or <c>-1</c> if no range contains the key.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
     private int FindContainingIndex(TKey key)
     {
-        if (key is null)
-            throw new ArgumentNullException(nameof(key));
+        ThrowHelper.ThrowIfNull(key);
 
         int index = UpperBound(key) - 1;
 
@@ -445,6 +346,13 @@ public sealed class RangeDictionary<TKey, TValue>
         return _comparer.Compare(key, _ends[index]) < 0 ? index : -1;
     }
 
+    /// <summary>
+    /// Inserts an entry at the specified position, growing storage as needed and shifting trailing entries.
+    /// </summary>
+    /// <param name="index">The insertion index.</param>
+    /// <param name="startInclusive">The inclusive start.</param>
+    /// <param name="endExclusive">The exclusive end.</param>
+    /// <param name="value">The value associated with the entry.</param>
     private void InsertAt(int index, TKey startInclusive, TKey endExclusive, TValue value)
     {
         EnsureCapacity(_count + 1);
@@ -463,6 +371,10 @@ public sealed class RangeDictionary<TKey, TValue>
         _version++;
     }
 
+    /// <summary>
+    /// Removes the entry at the specified index and shifts trailing entries left to keep storage contiguous.
+    /// </summary>
+    /// <param name="index">The index of the entry to remove.</param>
     private void RemoveAt(int index)
     {
         int moveCount = _count - index - 1;
@@ -481,6 +393,11 @@ public sealed class RangeDictionary<TKey, TValue>
         _version++;
     }
 
+    /// <summary>
+    /// Returns the lowest index whose start endpoint is not less than <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The endpoint to locate.</param>
+    /// <returns>The lower-bound index for <paramref name="value" />.</returns>
     private int LowerBound(TKey value)
     {
         int low = 0;
@@ -499,6 +416,11 @@ public sealed class RangeDictionary<TKey, TValue>
         return low;
     }
 
+    /// <summary>
+    /// Returns the lowest index whose start endpoint is greater than <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The endpoint to locate.</param>
+    /// <returns>The upper-bound index for <paramref name="value" />.</returns>
     private int UpperBound(TKey value)
     {
         int low = 0;
@@ -517,12 +439,20 @@ public sealed class RangeDictionary<TKey, TValue>
         return low;
     }
 
+    /// <summary>
+    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
+    /// <c>[0, <see cref="Count" />)</c>.
+    /// </summary>
+    /// <param name="index">The index to validate.</param>
     private void ValidateIndex(int index)
     {
-        if ((uint)index >= (uint)_count)
-            throw new ArgumentOutOfRangeException(nameof(index));
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
     }
 
+    /// <summary>
+    /// Reallocates the parallel storage arrays to the specified capacity.
+    /// </summary>
+    /// <param name="capacity">The new capacity.</param>
     private void ResizeStorage(int capacity)
     {
         Array.Resize(ref _starts, capacity);
@@ -530,6 +460,12 @@ public sealed class RangeDictionary<TKey, TValue>
         Array.Resize(ref _values, capacity);
     }
 
+    /// <summary>
+    /// Computes the next capacity by doubling the current size, with a clamp at <see cref="Array.MaxLength" />
+    /// and a floor at <paramref name="minimum" />.
+    /// </summary>
+    /// <param name="minimum">The minimum acceptable capacity.</param>
+    /// <returns>The chosen capacity.</returns>
     private int GrowCapacity(int minimum)
     {
         int capacity = _starts.Length == 0 ? DefaultCapacity : _starts.Length * 2;
@@ -541,64 +477,5 @@ public sealed class RangeDictionary<TKey, TValue>
             capacity = minimum;
 
         return capacity;
-    }
-
-    /// <summary>
-    /// Enumerates a <see cref="RangeDictionary{TKey, TValue}" /> without allocating.
-    /// </summary>
-    public struct Enumerator : IEnumerator<ValueRange<TKey, TValue>>
-    {
-        private readonly RangeDictionary<TKey, TValue> _owner;
-        private readonly int _version;
-        private int _index;
-        private ValueRange<TKey, TValue> _current;
-
-        internal Enumerator(RangeDictionary<TKey, TValue> owner)
-        {
-            _owner = owner;
-            _version = owner._version;
-            _index = 0;
-            _current = default;
-        }
-
-        /// <inheritdoc />
-        public ValueRange<TKey, TValue> Current => _current;
-
-        /// <inheritdoc />
-        object IEnumerator.Current => Current;
-
-        /// <inheritdoc />
-        public bool MoveNext()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            if (_index >= _owner._count)
-                return false;
-
-            _current = new ValueRange<TKey, TValue>(
-                _owner._starts[_index],
-                _owner._ends[_index],
-                _owner._values[_index],
-                skipValidation: true);
-
-            _index++;
-            return true;
-        }
-
-        /// <inheritdoc />
-        public void Reset()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            _index = 0;
-            _current = default;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-        }
     }
 }

--- a/Bodu.Core/src/Collections.Generic/RangeSet.Enumerator.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeSet.Enumerator.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RangeSet.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Bodu.Collections.Generic;
+
+public sealed partial class RangeSet<T>
+{
+    /// <inheritdoc />
+    IEnumerator<Range<T>> IEnumerable<Range<T>>.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator() =>
+        GetEnumerator();
+
+    /// <summary>
+    /// Enumerates the ranges of a <see cref="RangeSet{T}" /> in ascending start order without allocating.
+    /// </summary>
+    /// <remarks>
+    /// The enumerator captures the set's version on construction. Any structural mutation invalidates the
+    /// enumerator and causes <see cref="MoveNext" /> or <see cref="Reset" /> to throw
+    /// <see cref="InvalidOperationException" />.
+    /// </remarks>
+    [Serializable]
+    public struct Enumerator : IEnumerator<Range<T>>
+    {
+        /// <summary>
+        /// The set being enumerated.
+        /// </summary>
+        private readonly RangeSet<T> _owner;
+
+        /// <summary>
+        /// The version captured from <see cref="_owner" /> at construction.
+        /// </summary>
+        private readonly int _version;
+
+        /// <summary>
+        /// The index of the next range to yield.
+        /// </summary>
+        private int _index;
+
+        /// <summary>
+        /// The range returned by <see cref="Current" /> for the current position.
+        /// </summary>
+        private Range<T> _current;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Enumerator" /> struct over the specified set.
+        /// </summary>
+        /// <param name="owner">The set to enumerate.</param>
+        internal Enumerator(RangeSet<T> owner)
+        {
+            _owner = owner;
+            _version = owner._version;
+            _index = 0;
+            _current = default;
+        }
+
+        /// <inheritdoc />
+        public Range<T> Current => _current;
+
+        /// <inheritdoc />
+        object IEnumerator.Current => Current;
+
+        /// <inheritdoc />
+        public bool MoveNext()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            if (_index >= _owner._count)
+                return false;
+
+            _current = new Range<T>(_owner._starts[_index], _owner._ends[_index]);
+            _index++;
+            return true;
+        }
+
+        /// <inheritdoc />
+        public void Reset()
+        {
+            if (_version != _owner._version)
+                throw new InvalidOperationException(ResourceStrings.InvalidOperation_CollectionModified);
+
+            _index = 0;
+            _current = default;
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+        }
+    }
+}

--- a/Bodu.Core/src/Collections.Generic/RangeSet.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeSet.cs
@@ -1,11 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="RangeSet.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 
@@ -17,17 +16,21 @@ namespace Bodu.Collections.Generic;
 /// <typeparam name="T">The comparable endpoint type.</typeparam>
 /// <remarks>
 /// <para>
-/// Ranges are stored in two compact parallel arrays: one for starts and one for ends. The arrays are kept
-/// sorted by start value and adjacent or overlapping ranges are merged on insertion.
+/// Ranges are stored in two compact parallel arrays — one for the inclusive start of each range and one for
+/// the exclusive end. The arrays are kept sorted by start endpoint, and adjacent or overlapping ranges are
+/// merged on insertion.
 /// </para>
 /// <para>
 /// Ranges use half-open semantics: <c>[startInclusive, endExclusive)</c>.
 /// </para>
+/// <para>
+/// This type is not thread-safe.
+/// </para>
 /// </remarks>
 [DebuggerDisplay("Count = {Count}")]
 [Serializable]
-public sealed class RangeSet<T> 
-    : IReadOnlyCollection<RangeDictionary<T>>
+public sealed partial class RangeSet<T>
+    : IReadOnlyCollection<Range<T>>
     where T : IComparable<T>
 {
     private const int DefaultCapacity = 4;
@@ -39,7 +42,7 @@ public sealed class RangeSet<T>
     private int _version;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="RangeSet{T}" /> class.
+    /// Initializes a new instance of the <see cref="RangeSet{T}" /> class using the default comparer.
     /// </summary>
     public RangeSet()
         : this(null)
@@ -49,7 +52,7 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="RangeSet{T}" /> class using the specified comparer.
     /// </summary>
-    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use the default comparer.</param>
+    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use <see cref="Comparer{T}.Default" />.</param>
     public RangeSet(IComparer<T>? comparer)
     {
         _comparer = comparer ?? Comparer<T>.Default;
@@ -60,31 +63,36 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Initializes a new instance of the <see cref="RangeSet{T}" /> class containing the specified ranges.
     /// </summary>
-    /// <param name="ranges">The ranges to add.</param>
-    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use the default comparer.</param>
-    public RangeSet(IEnumerable<RangeDictionary<T>> ranges, IComparer<T>? comparer = null)
+    /// <param name="ranges">The ranges to add. Must not be <see langword="null" />.</param>
+    /// <param name="comparer">The endpoint comparer, or <see langword="null" /> to use <see cref="Comparer{T}.Default" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="ranges" /> is <see langword="null" />.
+    /// </exception>
+    public RangeSet(IEnumerable<Range<T>> ranges, IComparer<T>? comparer = null)
         : this(comparer)
     {
-        if (ranges is null)
-            throw new ArgumentNullException(nameof(ranges));
+        ThrowHelper.ThrowIfNull(ranges);
 
-        foreach (RangeDictionary<T> range in ranges)
+        foreach (Range<T> range in ranges)
             Add(range.StartInclusive, range.EndExclusive);
     }
 
     /// <summary>
     /// Gets the comparer used to order range endpoints.
     /// </summary>
+    /// <returns>The active endpoint comparer.</returns>
     public IComparer<T> Comparer => _comparer;
 
     /// <summary>
     /// Gets the number of stored ranges.
     /// </summary>
+    /// <returns>The number of ranges currently stored in the set.</returns>
     public int Count => _count;
 
     /// <summary>
     /// Gets the allocated range capacity.
     /// </summary>
+    /// <returns>The current allocated capacity of the underlying storage.</returns>
     public int Capacity => _starts.Length;
 
     /// <summary>
@@ -92,12 +100,15 @@ public sealed class RangeSet<T>
     /// </summary>
     /// <param name="index">The zero-based range index.</param>
     /// <returns>The range at <paramref name="index" />.</returns>
-    public RangeDictionary<T> this[int index]
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is negative or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    public Range<T> this[int index]
     {
         get
         {
             ValidateIndex(index);
-            return new RangeDictionary<T>(_starts[index], _ends[index]);
+            return new Range<T>(_starts[index], _ends[index]);
         }
     }
 
@@ -106,9 +117,15 @@ public sealed class RangeSet<T>
     /// </summary>
     /// <param name="startInclusive">The inclusive start.</param>
     /// <param name="endExclusive">The exclusive end.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public void Add(T startInclusive, T endExclusive)
     {
-        RangeDictionary<T>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<T>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         if (_count == 0)
         {
@@ -152,23 +169,29 @@ public sealed class RangeSet<T>
     }
 
     /// <summary>
-    /// Adds the specified range.
+    /// Adds the specified range to the set, merging any overlapping or adjacent ranges.
     /// </summary>
     /// <param name="range">The range to add.</param>
-    public void Add(RangeDictionary<T> range) =>
+    public void Add(Range<T> range) =>
         Add(range.StartInclusive, range.EndExclusive);
 
     /// <summary>
-    /// Removes the specified half-open range from the set.
+    /// Removes the specified half-open range from the set, trimming or splitting overlapping ranges as needed.
     /// </summary>
     /// <param name="startInclusive">The inclusive start.</param>
     /// <param name="endExclusive">The exclusive end.</param>
     /// <returns>
     /// <see langword="true" /> if the set was changed; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public bool Remove(T startInclusive, T endExclusive)
     {
-        RangeDictionary<T>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<T>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         if (_count == 0)
             return false;
@@ -217,7 +240,8 @@ public sealed class RangeSet<T>
                 continue;
             }
 
-            // Split one range into two ranges.
+            // Split one range into two ranges: the prefix [rangeStart, startInclusive) is retained in
+            // place, and the suffix [endExclusive, rangeEnd) is inserted immediately after.
             _ends[index] = startInclusive;
             InsertAt(index + 1, endExclusive, rangeEnd);
             changed = true;
@@ -234,7 +258,7 @@ public sealed class RangeSet<T>
     /// <returns>
     /// <see langword="true" /> if the set was changed; otherwise, <see langword="false" />.
     /// </returns>
-    public bool Remove(RangeDictionary<T> range) =>
+    public bool Remove(Range<T> range) =>
         Remove(range.StartInclusive, range.EndExclusive);
 
     /// <summary>
@@ -254,10 +278,13 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Determines whether the specified value falls inside any stored range.
     /// </summary>
-    /// <param name="value">The value to test.</param>
+    /// <param name="value">The value to test. Must not be <see langword="null" />.</param>
     /// <returns>
     /// <see langword="true" /> if the value is contained; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
     public bool Contains(T value) =>
         FindContainingIndex(value) >= 0;
 
@@ -269,9 +296,15 @@ public sealed class RangeSet<T>
     /// <returns>
     /// <see langword="true" /> if the range is fully contained; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public bool Contains(T startInclusive, T endExclusive)
     {
-        RangeDictionary<T>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<T>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         int index = FindContainingIndex(startInclusive);
         return index >= 0 && _comparer.Compare(endExclusive, _ends[index]) <= 0;
@@ -285,9 +318,15 @@ public sealed class RangeSet<T>
     /// <returns>
     /// <see langword="true" /> if the range overlaps a stored range; otherwise, <see langword="false" />.
     /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
     public bool Overlaps(T startInclusive, T endExclusive)
     {
-        RangeDictionary<T>.ValidateRange(startInclusive, endExclusive, _comparer);
+        Range<T>.ValidateRange(startInclusive, endExclusive, _comparer);
 
         int index = Math.Max(0, UpperBound(startInclusive) - 1);
 
@@ -305,14 +344,16 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Returns a new set containing the union of this set and another set.
     /// </summary>
-    /// <param name="other">The other set.</param>
-    /// <returns>The union set.</returns>
+    /// <param name="other">The other set. Must not be <see langword="null" />.</param>
+    /// <returns>A new <see cref="RangeSet{T}" /> containing the union.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
     public RangeSet<T> Union(RangeSet<T> other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
+        ThrowHelper.ThrowIfNull(other);
 
-        var result = new RangeSet<T>(_comparer);
+        RangeSet<T> result = new(_comparer);
         result.EnsureCapacity(_count + other._count);
 
         for (int i = 0; i < _count; i++)
@@ -327,14 +368,16 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Returns a new set containing the intersection of this set and another set.
     /// </summary>
-    /// <param name="other">The other set.</param>
-    /// <returns>The intersection set.</returns>
+    /// <param name="other">The other set. Must not be <see langword="null" />.</param>
+    /// <returns>A new <see cref="RangeSet{T}" /> containing the intersection.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
     public RangeSet<T> Intersect(RangeSet<T> other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
+        ThrowHelper.ThrowIfNull(other);
 
-        var result = new RangeSet<T>(_comparer);
+        RangeSet<T> result = new(_comparer);
 
         int left = 0;
         int right = 0;
@@ -359,14 +402,16 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Returns a new set containing the ranges in this set except those covered by another set.
     /// </summary>
-    /// <param name="other">The other set.</param>
-    /// <returns>The difference set.</returns>
+    /// <param name="other">The other set. Must not be <see langword="null" />.</param>
+    /// <returns>A new <see cref="RangeSet{T}" /> containing the difference.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="other" /> is <see langword="null" />.
+    /// </exception>
     public RangeSet<T> Except(RangeSet<T> other)
     {
-        if (other is null)
-            throw new ArgumentNullException(nameof(other));
+        ThrowHelper.ThrowIfNull(other);
 
-        var result = new RangeSet<T>(_comparer);
+        RangeSet<T> result = new(_comparer);
         result.EnsureCapacity(_count);
 
         for (int i = 0; i < _count; i++)
@@ -383,10 +428,12 @@ public sealed class RangeSet<T>
     /// </summary>
     /// <param name="capacity">The desired capacity.</param>
     /// <returns>The current capacity.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="capacity" /> is negative.
+    /// </exception>
     public int EnsureCapacity(int capacity)
     {
-        if (capacity < 0)
-            throw new ArgumentOutOfRangeException(nameof(capacity));
+        ThrowHelper.ThrowIfNegative(capacity);
 
         if (_starts.Length < capacity)
             ResizeStorage(GrowCapacity(capacity));
@@ -395,15 +442,15 @@ public sealed class RangeSet<T>
     }
 
     /// <summary>
-    /// Copies the stored ranges to a new array.
+    /// Copies the stored ranges to a new array in ascending sorted order.
     /// </summary>
     /// <returns>A new array containing the stored ranges.</returns>
-    public RangeDictionary<T>[] ToArray()
+    public Range<T>[] ToArray()
     {
-        var result = new RangeDictionary<T>[_count];
+        Range<T>[] result = new Range<T>[_count];
 
         for (int i = 0; i < _count; i++)
-            result[i] = new RangeDictionary<T>(_starts[i], _ends[i]);
+            result[i] = new Range<T>(_starts[i], _ends[i]);
 
         return result;
     }
@@ -411,22 +458,21 @@ public sealed class RangeSet<T>
     /// <summary>
     /// Returns an enumerator that iterates through the stored ranges in ascending order.
     /// </summary>
-    /// <returns>The enumerator.</returns>
+    /// <returns>An <see cref="Enumerator" /> over the stored ranges.</returns>
     public Enumerator GetEnumerator() =>
         new(this);
 
-    /// <inheritdoc />
-    IEnumerator<RangeDictionary<T>> IEnumerable<RangeDictionary<T>>.GetEnumerator() =>
-        GetEnumerator();
-
-    /// <inheritdoc />
-    IEnumerator IEnumerable.GetEnumerator() =>
-        GetEnumerator();
-
+    /// <summary>
+    /// Locates the index of the range that contains <paramref name="value" />, if any.
+    /// </summary>
+    /// <param name="value">The value to locate. Must not be <see langword="null" />.</param>
+    /// <returns>The index of the containing range, or <c>-1</c> if no range contains the value.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
     private int FindContainingIndex(T value)
     {
-        if (value is null)
-            throw new ArgumentNullException(nameof(value));
+        ThrowHelper.ThrowIfNull(value);
 
         int index = UpperBound(value) - 1;
 
@@ -436,6 +482,12 @@ public sealed class RangeSet<T>
         return _comparer.Compare(value, _ends[index]) < 0 ? index : -1;
     }
 
+    /// <summary>
+    /// Inserts a range at the specified position, growing storage as needed and shifting trailing entries.
+    /// </summary>
+    /// <param name="index">The insertion index.</param>
+    /// <param name="startInclusive">The inclusive start.</param>
+    /// <param name="endExclusive">The exclusive end.</param>
     private void InsertAt(int index, T startInclusive, T endExclusive)
     {
         EnsureCapacity(_count + 1);
@@ -452,6 +504,10 @@ public sealed class RangeSet<T>
         _version++;
     }
 
+    /// <summary>
+    /// Removes the range at the specified index and shifts trailing ranges left to keep storage contiguous.
+    /// </summary>
+    /// <param name="index">The index of the range to remove.</param>
     private void RemoveAt(int index)
     {
         int moveCount = _count - index - 1;
@@ -468,6 +524,12 @@ public sealed class RangeSet<T>
         _version++;
     }
 
+    /// <summary>
+    /// Removes <paramref name="count" /> consecutive ranges starting at <paramref name="index" /> and shifts
+    /// any trailing ranges left to keep storage contiguous.
+    /// </summary>
+    /// <param name="index">The index of the first range to remove.</param>
+    /// <param name="count">The number of ranges to remove.</param>
     private void RemoveRange(int index, int count)
     {
         if (count <= 0)
@@ -488,6 +550,11 @@ public sealed class RangeSet<T>
         _version++;
     }
 
+    /// <summary>
+    /// Returns the lowest index whose start endpoint is not less than <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The endpoint to locate.</param>
+    /// <returns>The lower-bound index for <paramref name="value" />.</returns>
     private int LowerBound(T value)
     {
         int low = 0;
@@ -506,6 +573,11 @@ public sealed class RangeSet<T>
         return low;
     }
 
+    /// <summary>
+    /// Returns the lowest index whose start endpoint is greater than <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The endpoint to locate.</param>
+    /// <returns>The upper-bound index for <paramref name="value" />.</returns>
     private int UpperBound(T value)
     {
         int low = 0;
@@ -524,24 +596,50 @@ public sealed class RangeSet<T>
         return low;
     }
 
+    /// <summary>
+    /// Returns the lesser of two values per the configured comparer.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>The lesser of the two operands.</returns>
     private T Min(T left, T right) =>
         _comparer.Compare(left, right) <= 0 ? left : right;
 
+    /// <summary>
+    /// Returns the greater of two values per the configured comparer.
+    /// </summary>
+    /// <param name="left">The left operand.</param>
+    /// <param name="right">The right operand.</param>
+    /// <returns>The greater of the two operands.</returns>
     private T Max(T left, T right) =>
         _comparer.Compare(left, right) >= 0 ? left : right;
 
+    /// <summary>
+    /// Throws <see cref="ArgumentOutOfRangeException" /> if <paramref name="index" /> is not within
+    /// <c>[0, <see cref="Count" />)</c>.
+    /// </summary>
+    /// <param name="index">The index to validate.</param>
     private void ValidateIndex(int index)
     {
-        if ((uint)index >= (uint)_count)
-            throw new ArgumentOutOfRangeException(nameof(index));
+        if ((uint)index >= (uint)_count) throw new ArgumentOutOfRangeException(nameof(index));
     }
 
+    /// <summary>
+    /// Reallocates the parallel storage arrays to the specified capacity.
+    /// </summary>
+    /// <param name="capacity">The new capacity.</param>
     private void ResizeStorage(int capacity)
     {
         Array.Resize(ref _starts, capacity);
         Array.Resize(ref _ends, capacity);
     }
 
+    /// <summary>
+    /// Computes the next capacity by doubling the current size, with a clamp at <see cref="Array.MaxLength" />
+    /// and a floor at <paramref name="minimum" />.
+    /// </summary>
+    /// <param name="minimum">The minimum acceptable capacity.</param>
+    /// <returns>The chosen capacity.</returns>
     private int GrowCapacity(int minimum)
     {
         int capacity = _starts.Length == 0 ? DefaultCapacity : _starts.Length * 2;
@@ -554,59 +652,4 @@ public sealed class RangeSet<T>
 
         return capacity;
     }
-
-    /// <summary>
-    /// Enumerates a <see cref="RangeSet{T}" /> without allocating.
-    /// </summary>
-    public struct Enumerator : IEnumerator<RangeDictionary<T>>
-    {
-        private readonly RangeSet<T> _owner;
-        private readonly int _version;
-        private int _index;
-        private RangeDictionary<T> _current;
-
-        internal Enumerator(RangeSet<T> owner)
-        {
-            _owner = owner;
-            _version = owner._version;
-            _index = 0;
-            _current = default;
-        }
-
-        /// <inheritdoc />
-        public RangeDictionary<T> Current => _current;
-
-        /// <inheritdoc />
-        object IEnumerator.Current => Current;
-
-        /// <inheritdoc />
-        public bool MoveNext()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            if (_index >= _owner._count)
-                return false;
-
-            _current = new RangeDictionary<T>(_owner._starts[_index], _owner._ends[_index]);
-            _index++;
-            return true;
-        }
-
-        /// <inheritdoc />
-        public void Reset()
-        {
-            if (_version != _owner._version)
-                throw new InvalidOperationException("The collection was modified during enumeration.");
-
-            _index = 0;
-            _current = default;
-        }
-
-        /// <inheritdoc />
-        public void Dispose()
-        {
-        }
-    }
 }
-

--- a/Bodu.Core/src/Collections.Generic/ValueRange.cs
+++ b/Bodu.Core/src/Collections.Generic/ValueRange.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ValueRange.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Represents a half-open range mapped to a value.
+/// </summary>
+/// <typeparam name="TKey">The comparable endpoint type.</typeparam>
+/// <typeparam name="TValue">The value type.</typeparam>
+/// <remarks>
+/// <see cref="ValueRange{TKey, TValue}" /> is the entry type yielded by <see cref="RangeDictionary{TKey, TValue}" />.
+/// It pairs a half-open range with an associated value, in the spirit of
+/// <see cref="KeyValuePair{TKey, TValue}" /> for keyed dictionaries.
+/// </remarks>
+[DebuggerDisplay("[{StartInclusive}, {EndExclusive}) = {Value}")]
+public readonly struct ValueRange<TKey, TValue>
+    where TKey : IComparable<TKey>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueRange{TKey, TValue}" /> struct.
+    /// </summary>
+    /// <param name="startInclusive">The inclusive start of the range.</param>
+    /// <param name="endExclusive">The exclusive end of the range.</param>
+    /// <param name="value">The value mapped to the range.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="startInclusive" /> or <paramref name="endExclusive" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="startInclusive" /> is greater than or equal to <paramref name="endExclusive" />.
+    /// </exception>
+    public ValueRange(TKey startInclusive, TKey endExclusive, TValue value)
+    {
+        Range<TKey>.ValidateRange(startInclusive, endExclusive, Comparer<TKey>.Default);
+
+        StartInclusive = startInclusive;
+        EndExclusive = endExclusive;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ValueRange{TKey, TValue}" /> struct without validating endpoints.
+    /// </summary>
+    /// <param name="startInclusive">The inclusive start of the range.</param>
+    /// <param name="endExclusive">The exclusive end of the range.</param>
+    /// <param name="value">The value mapped to the range.</param>
+    /// <param name="skipValidation">Always <see langword="true" />; selects the unchecked overload.</param>
+    /// <remarks>
+    /// Used by <see cref="RangeDictionary{TKey, TValue}" /> when the endpoints have already been validated by the
+    /// owning collection, to avoid revalidation overhead during enumeration and entry projection.
+    /// </remarks>
+    internal ValueRange(TKey startInclusive, TKey endExclusive, TValue value, bool skipValidation)
+    {
+        _ = skipValidation;
+
+        StartInclusive = startInclusive;
+        EndExclusive = endExclusive;
+        Value = value;
+    }
+
+    /// <summary>
+    /// Gets the inclusive start of the range.
+    /// </summary>
+    /// <returns>The inclusive lower bound of the range.</returns>
+    public TKey StartInclusive { get; }
+
+    /// <summary>
+    /// Gets the exclusive end of the range.
+    /// </summary>
+    /// <returns>The exclusive upper bound of the range.</returns>
+    public TKey EndExclusive { get; }
+
+    /// <summary>
+    /// Gets the value associated with the range.
+    /// </summary>
+    /// <returns>The value mapped to this range.</returns>
+    public TValue Value { get; }
+
+    /// <summary>
+    /// Determines whether the specified key falls inside this range.
+    /// </summary>
+    /// <param name="key">The key to test. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="key" /> is inside the range; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="key" /> is <see langword="null" />.
+    /// </exception>
+    public bool Contains(TKey key)
+    {
+        ThrowHelper.ThrowIfNull(key);
+
+        IComparer<TKey> comparer = Comparer<TKey>.Default;
+        return comparer.Compare(StartInclusive, key) <= 0 &&
+               comparer.Compare(key, EndExclusive) < 0;
+    }
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        $"[{StartInclusive}, {EndExclusive}) = {Value}";
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Add.cs
@@ -1,0 +1,197 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Add.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // Add — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Add(T)" /> rejects a <see langword="null" /> reference.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Add(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Add — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a new item is appended and the return value is <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsUnique_ShouldAppendAndReturnTrue()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        bool added = sut.Add(99);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(99, sut[0]);
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate add returns <see langword="false" /> and does not change order or count.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsDuplicate_ShouldReturnFalseAndPreserveOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool added = sut.Add(2);
+
+        Assert.IsFalse(added);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that adding many items grows the storage to hold them and preserves insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenManyItemsAdded_ShouldGrowAndPreserveOrder()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        for (int i = 0; i < 1000; i++)
+            Assert.IsTrue(sut.Add(i));
+
+        Assert.AreEqual(1000, sut.Count);
+        for (int i = 0; i < 1000; i++)
+            Assert.AreEqual(i, sut[i]);
+    }
+
+    /// <summary>
+    /// Verifies that a custom comparer is honoured when detecting duplicates.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCustomComparerProvided_ShouldDeduplicateAccordingly()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Add("Hello"));
+        Assert.IsFalse(sut.Add("HELLO"));
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual("Hello", sut[0]);
+    }
+
+    // --------------------------------------------------------
+    // AddRange — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.AddRange(IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.AddRange(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.AddRange(IEnumerable{T})" /> rejects a source that yields a
+    /// <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.AddRange(new[] { "a", null!, "b" });
+        });
+    }
+
+    // --------------------------------------------------------
+    // AddRange — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.AddRange(IEnumerable{T})" /> returns the count of new items added
+    /// while preserving insertion order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsDuplicatesAndNewItems_ShouldReturnNewItemCount()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        int added = sut.AddRange(new[] { 2, 3, 4, 4, 5 });
+
+        Assert.AreEqual(3, added);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source returns zero and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsEmpty_ShouldReturnZero()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        int added = sut.AddRange(Array.Empty<int>());
+
+        Assert.AreEqual(0, added);
+        CollectionAssert.AreEqual(new[] { 1, 2 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // ICollection<T>.Add — explicit implementation (from IList<T>)
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the inherited <see cref="ICollection{T}.Add(T)" /> appends a new item.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionAdd_WhenItemIsNew_ShouldAppendItem()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+        ICollection<int> typed = sut;
+
+        typed.Add(42);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(42, sut[0]);
+    }
+
+    /// <summary>
+    /// Verifies that the inherited <see cref="ICollection{T}.Add(T)" /> discards the duplicate outcome and
+    /// leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionAdd_WhenItemIsDuplicate_ShouldLeaveSetUnchanged()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        ICollection<int> typed = sut;
+
+        typed.Add(2);
+
+        Assert.AreEqual(3, sut.Count);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Capacity.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Capacity.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Capacity.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // EnsureCapacity
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.EnsureCapacity(int)" /> rejects a negative capacity.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void EnsureCapacity_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.EnsureCapacity(capacity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.EnsureCapacity(int)" /> grows to at least the requested capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenLargerCapacityRequested_ShouldGrow()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        int reported = sut.EnsureCapacity(128);
+
+        Assert.IsTrue(reported >= 128);
+        Assert.IsTrue(sut.Capacity >= 128);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.EnsureCapacity(int)" /> does not shrink when the requested
+    /// capacity is below the current capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenSmallerCapacityRequested_ShouldNotShrink()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(64);
+        int capacityBefore = sut.Capacity;
+
+        int reported = sut.EnsureCapacity(4);
+
+        Assert.AreEqual(capacityBefore, sut.Capacity);
+        Assert.AreEqual(capacityBefore, reported);
+    }
+
+    /// <summary>
+    /// Verifies that growth preserves the existing contents.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenGrown_ShouldPreserveContents()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.EnsureCapacity(128);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // TrimExcess
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.TrimExcess" /> on an empty set releases the backing arrays.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenSetIsEmpty_ShouldResetCapacityToZero()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(16);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(0, sut.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.TrimExcess" /> shrinks capacity to <see cref="IndexedSet{T}.Count" />
+    /// and preserves contents.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCapacityExceedsCount_ShouldShrinkAndPreserveContents()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(128);
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(3, sut.Capacity);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that items remain locatable after <see cref="IndexedSet{T}.TrimExcess" />.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCalled_ShouldKeepItemsLocatable()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(128);
+        sut.Add(10);
+        sut.Add(20);
+        sut.Add(30);
+
+        sut.TrimExcess();
+
+        Assert.IsTrue(sut.Contains(20));
+        Assert.AreEqual(2, sut.IndexOf(30));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Contains.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Contains.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Contains.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Contains(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Contains(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Contains(T)" /> on an empty set returns <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenSetIsEmpty_ShouldReturnFalse()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.IsFalse(sut.Contains(99));
+    }
+
+    /// <summary>
+    /// Verifies the membership outcome across a range of inputs.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, true)]
+    [DataRow(2, true)]
+    [DataRow(3, true)]
+    [DataRow(0, false)]
+    [DataRow(4, false)]
+    public void Contains_WhenItemPresenceVaries_ShouldReturnExpected(int item, bool expected)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.AreEqual(expected, sut.Contains(item));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Contains(T)" /> uses the configured comparer for equality.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenCustomComparerProvided_ShouldUseComparerForEquality()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "Hello" }, StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Contains("HELLO"));
+        Assert.IsTrue(sut.Contains("hello"));
+        Assert.IsFalse(sut.Contains("world"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.CopyTo.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.CopyTo.cs
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.CopyTo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // CopyTo — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> rejects a <see langword="null" /> array.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.CopyTo(null!, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> rejects a negative offset.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void CopyTo_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException(int arrayIndex)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.CopyTo(new int[10], arrayIndex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when the array is too small.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsTooSmall_ShouldThrowArgumentException()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[2], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when the remaining space after the offset is insufficient.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenRemainingSpaceAfterOffsetIsInsufficient_ShouldThrowArgumentException()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[5], 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // CopyTo — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> copies elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsZero_ShouldCopyInInsertionOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        int[] target = new int[3];
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.CopyTo(T[], int)" /> starts copying at the supplied offset.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsNonZero_ShouldCopyAtCorrectPosition()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20 });
+        int[] target = new int[] { 99, 99, 99, 99 };
+
+        sut.CopyTo(target, 1);
+
+        CollectionAssert.AreEqual(new[] { 99, 10, 20, 99 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that copying an empty set does not modify the destination array.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenSetIsEmpty_ShouldNotModifyArray()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+        int[] target = new int[] { 99, 88 };
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 99, 88 }, target);
+    }
+
+    // --------------------------------------------------------
+    // ToArray
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.ToArray" /> on an empty set returns an empty array.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenSetIsEmpty_ShouldReturnEmptyArray()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        int[] array = sut.ToArray();
+
+        Assert.AreEqual(0, array.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.ToArray" /> returns the elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenSetPopulated_ShouldReturnInsertionOrderedArray()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        int[] array = sut.ToArray();
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, array);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.ToArray" /> returns a disconnected snapshot.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenCalled_ShouldReturnDisconnectedSnapshot()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        int[] snapshot = sut.ToArray();
+
+        sut.Add(4);
+        sut.Remove(1);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, snapshot);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Ctor.cs
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Ctor.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // Default constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the default constructor creates an empty set with the default comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenDefault_ShouldBeEmptyWithDefaultComparer()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.Capacity);
+        Assert.AreSame(EqualityComparer<int>.Default, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Comparer-only constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the comparer-only constructor defaults to the default comparer when supplied
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsNull_ShouldUseDefaultComparer()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>((IEqualityComparer<string>?)null);
+
+        Assert.AreSame(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that the comparer-only constructor stores and uses the supplied comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldUseSpecifiedComparer()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreSame(StringComparer.OrdinalIgnoreCase, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Capacity constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a negative capacity is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-100)]
+    [DataRow(int.MinValue)]
+    public void Ctor_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new IndexedSet<int>(capacity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the capacity constructor accepts non-negative values and pre-allocates the requested
+    /// capacity.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(16)]
+    [DataRow(1024)]
+    public void Ctor_WhenCapacityIsValid_ShouldAllocateRequestedCapacity(int capacity)
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(capacity);
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(capacity, sut.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that the capacity-and-comparer constructor combines both arguments.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCapacityAndComparerProvided_ShouldUseBoth()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>(8, StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(8, sut.Capacity);
+        Assert.AreSame(StringComparer.OrdinalIgnoreCase, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Collection constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the collection constructor rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new IndexedSet<int>((IEnumerable<int>)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the collection constructor rejects a source that yields a <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionContainsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new IndexedSet<string>(new[] { "a", null!, "b" });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the collection constructor preserves first-occurrence order while deduplicating.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionContainsDuplicates_ShouldPreserveFirstOccurrenceOrder()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(new[] { 1, 2, 2, 3, 1, 4 });
+
+        Assert.AreEqual(4, sut.Count);
+        Assert.AreEqual(1, sut[0]);
+        Assert.AreEqual(2, sut[1]);
+        Assert.AreEqual(3, sut[2]);
+        Assert.AreEqual(4, sut[3]);
+    }
+
+    /// <summary>
+    /// Verifies that an empty source collection produces an empty set.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionIsEmpty_ShouldBeEmpty()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>(Array.Empty<int>());
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the collection-and-comparer constructor uses the supplied comparer for deduplication.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionAndComparerProvided_ShouldUseSpecifiedComparer()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>(
+            new[] { "A", "a", "B", "b" },
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual("A", sut[0]);
+        Assert.AreEqual("B", sut[1]);
+    }
+
+    /// <summary>
+    /// Verifies that the collection-and-comparer constructor preallocates capacity from an
+    /// <see cref="ICollection{T}" /> hint.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionHasCountHint_ShouldPreallocateCapacity()
+    {
+        List<int> source = new List<int> { 1, 2, 3, 4, 5 };
+
+        IndexedSet<int> sut = new IndexedSet<int>(source);
+
+        Assert.AreEqual(5, sut.Count);
+        Assert.IsTrue(sut.Capacity >= 5);
+    }
+
+    // --------------------------------------------------------
+    // IsReadOnly
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IsReadOnly" /> is always <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void IsReadOnly_WhenInspected_ShouldReturnFalse()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.IsFalse(sut.IsReadOnly);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Enumerator.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Enumerator.cs
@@ -1,0 +1,193 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // GetEnumerator — typed struct
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.GetEnumerator" /> yields elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenSetPopulated_ShouldYieldAllItemsInOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        List<int> seen = new List<int>();
+
+        foreach (int item in sut)
+            seen.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator on an empty set yields no elements.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenSetIsEmpty_ShouldYieldNoElements()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Enumerator.MoveNext" /> returns <see langword="false" /> once
+    /// every element has been yielded.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenEndReached_ShouldReturnFalseFromMoveNext()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.IsFalse(enumerator.MoveNext());
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Enumerator.Reset" /> restarts iteration from the first element.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetCalled_ShouldRestartIteration()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.AreEqual(1, enumerator.Current);
+
+        enumerator.Reset();
+
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.AreEqual(1, enumerator.Current);
+    }
+
+    // --------------------------------------------------------
+    // Versioning / invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that mutating the set after creating an enumerator causes subsequent
+    /// <see cref="IndexedSet{T}.Enumerator.MoveNext" /> calls to throw <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenSetMutatedAfterCreation_ShouldThrowOnMoveNext()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut.Add(99);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.MoveNext();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that mutating the set after creating an enumerator causes
+    /// <see cref="IndexedSet{T}.Enumerator.Reset" /> to throw <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenSetMutatedAfterCreation_ShouldThrowOnReset()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut.RemoveAt(1);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            enumerator.Reset();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that positional mutation (<see cref="IndexedSet{T}.Move(int, int)" />) invalidates an enumerator.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenMoveCalledAfterCreation_ShouldThrowOnMoveNext()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut.Move(0, 2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.MoveNext();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that replacing an element via the indexer setter invalidates an enumerator.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenIndexerSetterCalledAfterCreation_ShouldThrowOnMoveNext()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IndexedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut[0] = 99;
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.MoveNext();
+        });
+    }
+
+    // --------------------------------------------------------
+    // Explicit interface implementations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the explicit <see cref="IEnumerable{T}.GetEnumerator" /> implementation yields elements
+    /// in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void IEnumerableT_WhenIterated_ShouldYieldAllItemsInOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        IEnumerable<int> typed = sut;
+        List<int> seen = new List<int>();
+
+        foreach (int item in typed)
+            seen.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+
+    /// <summary>
+    /// Verifies that the explicit non-generic <see cref="IEnumerable.GetEnumerator" /> implementation yields
+    /// elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void IEnumerable_WhenIterated_ShouldYieldAllItemsInOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        IEnumerable untyped = sut;
+        List<int> seen = new List<int>();
+
+        foreach (object item in untyped)
+            seen.Add((int)item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.IList.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.IList.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.IList.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // IList<T> contract — typed surface
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}" /> can be assigned to <see cref="IList{T}" /> and exposes the
+    /// expected indexer, count, and read/write surface.
+    /// </summary>
+    [TestMethod]
+    public void IListT_WhenAssignedToInterface_ShouldExposeFullContract()
+    {
+        IList<int> typed = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(3, typed.Count);
+        Assert.AreEqual(10, typed[0]);
+        Assert.AreEqual(0, typed.IndexOf(10));
+        Assert.IsTrue(typed.Contains(20));
+        Assert.IsFalse(typed.IsReadOnly);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IList{T}.Insert(int, T)" /> contract reaches the underlying
+    /// <see cref="IndexedSet{T}.Insert(int, T)" /> implementation.
+    /// </summary>
+    [TestMethod]
+    public void IListT_Insert_WhenCalled_ShouldDelegateToInsert()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IList<int> typed = sut;
+
+        typed.Insert(1, 99);
+
+        CollectionAssert.AreEqual(new[] { 1, 99, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IList{T}.RemoveAt(int)" /> contract reaches the underlying
+    /// <see cref="IndexedSet{T}.RemoveAt(int)" /> implementation.
+    /// </summary>
+    [TestMethod]
+    public void IListT_RemoveAt_WhenCalled_ShouldDelegateToRemoveAt()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IList<int> typed = sut;
+
+        typed.RemoveAt(0);
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IList{T}" /> indexer setter reaches the underlying replace path.
+    /// </summary>
+    [TestMethod]
+    public void IListT_Indexer_Set_WhenCalled_ShouldReplaceElement()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        IList<int> typed = sut;
+
+        typed[1] = 99;
+
+        CollectionAssert.AreEqual(new[] { 1, 99, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}" /> can be assigned to <see cref="IReadOnlyList{T}" /> and
+    /// exposes the expected read surface.
+    /// </summary>
+    [TestMethod]
+    public void IReadOnlyListT_WhenAssignedToInterface_ShouldExposeReadSurface()
+    {
+        IReadOnlyList<int> typed = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(3, typed.Count);
+        Assert.AreEqual(10, typed[0]);
+        Assert.AreEqual(20, typed[1]);
+        Assert.AreEqual(30, typed[2]);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.IndexOf.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.IndexOf.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.IndexOf.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IndexOf(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = new IndexedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IndexOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IndexOf(T)" /> returns <c>-1</c> on an empty set.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenSetIsEmpty_ShouldReturnMinusOne()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.AreEqual(-1, sut.IndexOf(99));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IndexOf(T)" /> returns the insertion-order index for each item.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 0)]
+    [DataRow(20, 1)]
+    [DataRow(30, 2)]
+    [DataRow(99, -1)]
+    public void IndexOf_WhenSetPopulated_ShouldReturnExpectedIndex(int item, int expected)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(expected, sut.IndexOf(item));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IndexOf(T)" /> uses the configured comparer when locating items.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenCustomComparerProvided_ShouldUseComparerForEquality()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "Alpha", "Beta" }, StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(0, sut.IndexOf("ALPHA"));
+        Assert.AreEqual(1, sut.IndexOf("beta"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.IndexOf(T)" /> reflects index shifts after a removal.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemRemovedFromMiddle_ShouldUpdateLaterIndices()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30, 40 });
+
+        sut.Remove(20);
+
+        Assert.AreEqual(0, sut.IndexOf(10));
+        Assert.AreEqual(1, sut.IndexOf(30));
+        Assert.AreEqual(2, sut.IndexOf(40));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Indexer.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Indexer.cs
@@ -1,0 +1,134 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Indexer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // Indexer get — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that getting the indexer with an out-of-range index throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MaxValue)]
+    [DataRow(int.MinValue)]
+    public void Indexer_Get_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut[index];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer returns elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Get_WhenSetPopulated_ShouldReturnElementInInsertionOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(10, sut[0]);
+        Assert.AreEqual(20, sut[1]);
+        Assert.AreEqual(30, sut[2]);
+    }
+
+    // --------------------------------------------------------
+    // Indexer set — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that assigning to the indexer with an out-of-range index throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MaxValue)]
+    public void Indexer_Set_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut[index] = 99;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning a <see langword="null" /> reference through the indexer throws
+    /// <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "a", "b" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut[0] = null!;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that assigning a value that already exists at a different index throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenValueExistsAtAnotherIndex_ShouldThrowArgumentException()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut[0] = 3;
+        });
+    }
+
+    // --------------------------------------------------------
+    // Indexer set — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that assigning a new value through the indexer replaces the element at that index and updates
+    /// the hash table.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenValueIsNew_ShouldReplaceAtPositionAndUpdateLookup()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut[1] = 99;
+
+        CollectionAssert.AreEqual(new[] { 1, 99, 3 }, SnapshotByIndexer(sut));
+        Assert.IsTrue(sut.Contains(99));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.AreEqual(1, sut.IndexOf(99));
+    }
+
+    /// <summary>
+    /// Verifies that assigning a value equal to the one already at that index is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenValueIsAlreadyAtIndex_ShouldBeNoOp()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut[1] = 2;
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+        Assert.IsTrue(sut.Contains(2));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Insert.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Insert.cs
@@ -1,0 +1,184 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Insert.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // TryInsert — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.TryInsert(int, T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "a", "b" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.TryInsert(0, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.TryInsert(int, T)" /> rejects an out-of-range index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void TryInsert_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.TryInsert(index, 99);
+        });
+    }
+
+    // --------------------------------------------------------
+    // TryInsert — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a duplicate insertion returns <see langword="false" /> and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemIsDuplicate_ShouldReturnFalseAndPreserveOrder()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool inserted = sut.TryInsert(0, 2);
+
+        Assert.IsFalse(inserted);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.TryInsert(int, T)" /> appends, prepends, or inserts the value
+    /// at the requested position depending on the index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, new[] { 99, 1, 2, 3 })]
+    [DataRow(1, new[] { 1, 99, 2, 3 })]
+    [DataRow(2, new[] { 1, 2, 99, 3 })]
+    [DataRow(3, new[] { 1, 2, 3, 99 })]
+    public void TryInsert_WhenIndexIsValid_ShouldPlaceItemAtPosition(int index, int[] expected)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.TryInsert(index, 99));
+
+        CollectionAssert.AreEqual(expected, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an inserted item becomes locatable through <see cref="IndexedSet{T}.IndexOf(T)" />.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemInserted_ShouldUpdateIndexOf()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.TryInsert(1, 99);
+
+        Assert.AreEqual(1, sut.IndexOf(99));
+        Assert.AreEqual(2, sut.IndexOf(2));
+        Assert.AreEqual(3, sut.IndexOf(3));
+    }
+
+    // --------------------------------------------------------
+    // Insert — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Insert(int, T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Insert_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "a", "b" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.Insert(0, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Insert(int, T)" /> rejects an out-of-range index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MinValue)]
+    public void Insert_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Insert(index, 99);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Insert(int, T)" /> throws <see cref="ArgumentException" /> when
+    /// the item is already in the set.
+    /// </summary>
+    [TestMethod]
+    public void Insert_WhenItemIsDuplicate_ShouldThrowArgumentException()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.Insert(0, 2);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Insert — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Insert(int, T)" /> places the item at the requested index and
+    /// shifts later elements rightwards.
+    /// </summary>
+    [TestMethod]
+    public void Insert_WhenItemAndIndexAreValid_ShouldPlaceItemAtPosition()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        sut.Insert(1, 99);
+
+        CollectionAssert.AreEqual(new[] { 10, 99, 20, 30 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IndexedSet{T}.Insert(int, T)" /> entry point implements the
+    /// <see cref="System.Collections.Generic.IList{T}.Insert(int, T)" /> contract correctly when invoked via
+    /// the typed interface.
+    /// </summary>
+    [TestMethod]
+    public void IListInsert_WhenCalledThroughInterface_ShouldDelegateToInsert()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        System.Collections.Generic.IList<int> typed = sut;
+
+        typed.Insert(0, 99);
+
+        CollectionAssert.AreEqual(new[] { 99, 10, 20, 30 }, SnapshotByIndexer(sut));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Move.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Move.cs
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Move.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // Move — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Move(int, int)" /> rejects an out-of-range <c>oldIndex</c>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1, 0)]
+    [DataRow(3, 0)]
+    [DataRow(int.MaxValue, 0)]
+    public void Move_WhenOldIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int oldIndex, int newIndex)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Move(oldIndex, newIndex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Move(int, int)" /> rejects an out-of-range <c>newIndex</c>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, -1)]
+    [DataRow(0, 3)]
+    [DataRow(0, int.MaxValue)]
+    public void Move_WhenNewIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int oldIndex, int newIndex)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Move(oldIndex, newIndex);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Move — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Move(int, int)" /> with identical indices is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenSourceAndDestinationAreEqual_ShouldLeaveSetUnchanged()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.Move(1, 1);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving an element forward shifts intervening elements leftwards.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingForward_ShouldShiftInterveningLeft()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3, 4, 5 });
+
+        sut.Move(1, 3);
+
+        CollectionAssert.AreEqual(new[] { 1, 3, 4, 2, 5 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving an element backward shifts intervening elements rightwards.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingBackward_ShouldShiftInterveningRight()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3, 4, 5 });
+
+        sut.Move(3, 1);
+
+        CollectionAssert.AreEqual(new[] { 1, 4, 2, 3, 5 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moved elements remain locatable through <see cref="IndexedSet{T}.IndexOf(T)" /> at
+    /// their new positions.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenItemRelocated_ShouldUpdateIndexOf()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30, 40 });
+
+        sut.Move(0, 2);
+
+        Assert.AreEqual(2, sut.IndexOf(10));
+        Assert.AreEqual(0, sut.IndexOf(20));
+        Assert.AreEqual(1, sut.IndexOf(30));
+        Assert.AreEqual(3, sut.IndexOf(40));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.Remove.cs
@@ -1,0 +1,171 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class IndexedSetTests
+{
+    // --------------------------------------------------------
+    // Remove — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Remove(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        IndexedSet<string> sut = CreateSet(new[] { "a" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Remove(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Remove — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that removing an absent item returns <see langword="false" /> and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsAbsent_ShouldReturnFalseAndLeaveSetUnchanged()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool removed = sut.Remove(99);
+
+        Assert.IsFalse(removed);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing a present item returns <see langword="true" /> and compacts the order.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, new[] { 2, 3 })]
+    [DataRow(2, new[] { 1, 3 })]
+    [DataRow(3, new[] { 1, 2 })]
+    public void Remove_WhenItemIsPresent_ShouldReturnTrueAndCompactOrder(int target, int[] expected)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool removed = sut.Remove(target);
+
+        Assert.IsTrue(removed);
+        CollectionAssert.AreEqual(expected, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // RemoveAt — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.RemoveAt(int)" /> rejects an out-of-range index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MaxValue)]
+    [DataRow(int.MinValue)]
+    public void RemoveAt_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.RemoveAt(index);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.RemoveAt(int)" /> on an empty set throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenSetIsEmpty_ShouldThrowArgumentOutOfRangeException()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.RemoveAt(0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // RemoveAt — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.RemoveAt(int)" /> removes the element at the given index and
+    /// shifts later elements left.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, new[] { 20, 30, 40 })]
+    [DataRow(1, new[] { 10, 30, 40 })]
+    [DataRow(2, new[] { 10, 20, 40 })]
+    [DataRow(3, new[] { 10, 20, 30 })]
+    public void RemoveAt_WhenIndexIsValid_ShouldRemoveElementAtPosition(int index, int[] expected)
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 10, 20, 30, 40 });
+
+        sut.RemoveAt(index);
+
+        CollectionAssert.AreEqual(expected, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an item removed via <see cref="IndexedSet{T}.RemoveAt(int)" /> is no longer reported as
+    /// present.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenItemRemoved_ShouldNoLongerBeContained()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.RemoveAt(1);
+
+        Assert.IsFalse(sut.Contains(2));
+        Assert.AreEqual(-1, sut.IndexOf(2));
+    }
+
+    // --------------------------------------------------------
+    // Clear
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="IndexedSet{T}.Clear" /> empties the set.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalled_ShouldRemoveAllElements()
+    {
+        IndexedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.IsFalse(sut.Contains(1));
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IndexedSet{T}.Clear" /> on an already-empty set leaves it empty.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenAlreadyEmpty_ShouldRemainEmpty()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/IndexedSetTests.cs
+++ b/Bodu.Core/test/Collections.Generic/IndexedSetTests.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IndexedSetTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Unit tests for <see cref="IndexedSet{T}" />.
+/// </summary>
+[TestClass]
+public partial class IndexedSetTests
+{
+    /// <summary>
+    /// Verifies the happy-path smoke check: items added in sequence are accessible at their insertion indices.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Add_WhenItemsAreUnique_ShouldBeIndexAddressable()
+    {
+        IndexedSet<int> sut = new IndexedSet<int>();
+
+        Assert.IsTrue(sut.Add(10));
+        Assert.IsTrue(sut.Add(20));
+        Assert.IsTrue(sut.Add(30));
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(10, sut[0]);
+        Assert.AreEqual(20, sut[1]);
+        Assert.AreEqual(30, sut[2]);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="IndexedSet{T}" /> seeded with the specified items.
+    /// </summary>
+    /// <param name="items">The items to seed.</param>
+    /// <param name="comparer">An optional comparer.</param>
+    /// <returns>The populated set.</returns>
+    private static IndexedSet<T> CreateSet<T>(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        where T : notnull
+    {
+        IndexedSet<T> set = new IndexedSet<T>(comparer);
+        foreach (T item in items)
+            set.Add(item);
+
+        return set;
+    }
+
+    /// <summary>
+    /// Materialises the elements of <paramref name="set" /> using the public indexer.
+    /// </summary>
+    /// <param name="set">The set to snapshot.</param>
+    /// <returns>An array containing the elements in insertion order.</returns>
+    private static T[] SnapshotByIndexer<T>(IndexedSet<T> set)
+        where T : notnull
+    {
+        T[] result = new T[set.Count];
+        for (int i = 0; i < set.Count; i++)
+            result[i] = set[i];
+
+        return result;
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Add.cs
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Add.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Add — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that adding a <see langword="null" /> reference is rejected with <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, null);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.Add(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Add — single-item behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that adding a previously unseen item appends it to the end of the order and returns
+    /// <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsUnique_ShouldAppendAndReturnTrue()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        bool added = sut.Add(7);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(7, sut.GetAt(0));
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate add is a no-op that returns <see langword="false" /> and does not change
+    /// element ordering.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsDuplicate_ShouldReturnFalseAndNotChangeOrder()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        bool added = sut.Add(2);
+
+        Assert.IsFalse(added);
+        Assert.AreEqual(3, sut.Count);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // Add — sequential behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that multiple successive adds maintain insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemsAreSequential_ShouldPreserveInsertionOrder()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        for (int i = 10; i < 20; i++)
+            Assert.IsTrue(sut.Add(i));
+
+        Assert.AreEqual(10, sut.Count);
+        for (int i = 0; i < 10; i++)
+            Assert.AreEqual(10 + i, sut.GetAt(i));
+    }
+
+    /// <summary>
+    /// Verifies that adding items into a zero-capacity storage triggers element-array growth.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenStorageGrowsFromZeroCapacity_ShouldGrowToHoldAllItems()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        for (int i = 0; i < 100; i++)
+            Assert.IsTrue(sut.Add(i));
+
+        Assert.AreEqual(100, sut.Count);
+        Assert.IsTrue(sut.Capacity >= 100);
+    }
+
+    // --------------------------------------------------------
+    // Add — reference-type semantics
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the default comparer treats two distinct reference instances with equal value as the
+    /// same element by overriding <see cref="object.Equals(object)" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenValueTypeEqualityIsSatisfied_ShouldDeduplicate()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, null);
+
+        Assert.IsTrue(sut.Add("alpha"));
+        Assert.IsFalse(sut.Add(new string("alpha".ToCharArray())));
+        Assert.AreEqual(1, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that hash collisions are handled correctly when many items share the same bucket.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemsHashCollide_ShouldKeepUniqueByReferenceIdentity()
+    {
+        OrderedSetStorage<HashCollider> sut = new OrderedSetStorage<HashCollider>(0, null);
+        HashCollider a = new HashCollider("a");
+        HashCollider b = new HashCollider("b");
+        HashCollider c = new HashCollider("c");
+
+        Assert.IsTrue(sut.Add(a));
+        Assert.IsTrue(sut.Add(b));
+        Assert.IsTrue(sut.Add(c));
+        Assert.IsFalse(sut.Add(a));
+        Assert.IsFalse(sut.Add(b));
+        Assert.IsFalse(sut.Add(c));
+
+        Assert.AreEqual(3, sut.Count);
+        CollectionAssert.AreEqual(new[] { a, b, c }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // AddRange — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.AddRange(IEnumerable{T})" /> rejects a <see langword="null" /> collection.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.AddRange(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.AddRange(IEnumerable{T})" /> rejects a collection
+    /// that yields a <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, null);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.AddRange(new[] { "ok", null!, "later" });
+        });
+    }
+
+    // --------------------------------------------------------
+    // AddRange — counting behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.AddRange(IEnumerable{T})" /> returns the number of new
+    /// elements added, ignoring duplicates relative to the existing contents and within the source.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsDuplicatesAndNewItems_ShouldReturnNewItemCount()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        int added = sut.AddRange(new[] { 2, 3, 4, 5, 5 });
+
+        Assert.AreEqual(2, added);
+        Assert.AreEqual(5, sut.Count);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source collection results in zero additions and no version bump.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsEmpty_ShouldReturnZero()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+        int versionBefore = sut._version;
+
+        int added = sut.AddRange(Array.Empty<int>());
+
+        Assert.AreEqual(0, added);
+        Assert.AreEqual(versionBefore, sut._version);
+        Assert.AreEqual(2, sut.Count);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Capacity.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Capacity.cs
@@ -1,0 +1,187 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Capacity.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Count
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Count" /> is zero immediately after construction.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenStorageIsNewlyConstructed_ShouldBeZero()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Count" /> reflects the number of currently-stored
+    /// elements across additions and removals.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenItemsAddedAndRemoved_ShouldReflectCurrentSize()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+        sut.Remove(2);
+
+        Assert.AreEqual(2, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // EnsureCapacity — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a negative capacity is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void EnsureCapacity_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.EnsureCapacity(capacity);
+        });
+    }
+
+    // --------------------------------------------------------
+    // EnsureCapacity — growth behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.EnsureCapacity(int)" /> grows the element array when the
+    /// requested capacity exceeds the current capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenRequestedCapacityExceedsCurrent_ShouldGrow()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        int newCapacity = sut.EnsureCapacity(128);
+
+        Assert.IsTrue(newCapacity >= 128);
+        Assert.IsTrue(sut.Capacity >= 128);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.EnsureCapacity(int)" /> is a no-op when the requested
+    /// capacity does not exceed the current capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenRequestedCapacityDoesNotExceedCurrent_ShouldNotShrink()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(16, null);
+
+        int newCapacity = sut.EnsureCapacity(4);
+
+        Assert.AreEqual(16, sut.Capacity);
+        Assert.AreEqual(16, newCapacity);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.EnsureCapacity(int)" /> preserves existing elements.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenGrown_ShouldPreserveContents()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.EnsureCapacity(128);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+        Assert.IsTrue(sut.Capacity >= 128);
+    }
+
+    // --------------------------------------------------------
+    // TrimExcess
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.TrimExcess" /> on an empty storage resets internal
+    /// arrays to length zero.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenStorageIsEmpty_ShouldResetCapacityToZero()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(16, null);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(0, sut.Capacity);
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.TrimExcess" /> on a storage where capacity matches count
+    /// is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCapacityEqualsCount_ShouldBeNoOp()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+        sut.Add(1);
+        sut.Add(2);
+        sut.TrimExcess();
+        int capacityBefore = sut.Capacity;
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(capacityBefore, sut.Capacity);
+        CollectionAssert.AreEqual(new[] { 1, 2 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.TrimExcess" /> on a partially-filled storage shrinks
+    /// capacity down to <see cref="OrderedSetStorage{T}.Count" /> and preserves contents.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCapacityExceedsCount_ShouldShrinkAndPreserveContents()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(128, null);
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(3, sut.Capacity);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that elements remain findable through the hash table after <see cref="OrderedSetStorage{T}.TrimExcess" />.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCalled_ShouldKeepItemsFindable()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(128, null);
+        sut.Add(10);
+        sut.Add(20);
+        sut.Add(30);
+
+        sut.TrimExcess();
+
+        Assert.IsTrue(sut.Contains(10));
+        Assert.AreEqual(1, sut.IndexOf(20));
+        Assert.AreEqual(2, sut.IndexOf(30));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Copy.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Copy.cs
@@ -1,0 +1,172 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Copy.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // CopyTo — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> rejects a <see langword="null" /> array.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.CopyTo(null!, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> rejects a negative offset.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void CopyTo_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException(int arrayIndex)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.CopyTo(new int[10], arrayIndex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when the array is too small to hold the storage.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsTooSmall_ShouldThrowArgumentException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[2], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when there is insufficient space after the supplied offset.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenRemainingSpaceAfterOffsetIsInsufficient_ShouldThrowArgumentException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[5], 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // CopyTo — successful copy behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> copies the elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsZero_ShouldCopyInInsertionOrder()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30 });
+        int[] target = new int[3];
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.CopyTo(T[], int)" /> copies the elements starting at the
+    /// specified offset, leaving earlier slots untouched.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsNonZero_ShouldCopyStartingAtOffset()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20 });
+        int[] target = new int[] { 99, 99, 99, 99 };
+
+        sut.CopyTo(target, 1);
+
+        CollectionAssert.AreEqual(new[] { 99, 10, 20, 99 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that copying from an empty storage does not modify the destination.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenStorageIsEmpty_ShouldNotModifyArray()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+        int[] target = new int[] { 99, 88 };
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 99, 88 }, target);
+    }
+
+    // --------------------------------------------------------
+    // ToArray
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ToArray" /> on an empty storage returns an empty array.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenStorageIsEmpty_ShouldReturnEmptyArray()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        int[] array = sut.ToArray();
+
+        Assert.AreEqual(0, array.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ToArray" /> returns a snapshot of insertion order with
+    /// matching length and contents.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenStoragePopulated_ShouldReturnInsertionOrderedArray()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30 });
+
+        int[] array = sut.ToArray();
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, array);
+        Assert.AreEqual(sut.Count, array.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ToArray" /> returns a fresh array that is independent of
+    /// subsequent storage mutations.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenCalled_ShouldReturnDisconnectedSnapshot()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int[] snapshot = sut.ToArray();
+
+        sut.Add(4);
+
+        Assert.AreEqual(3, snapshot.Length);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, snapshot);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Ctor.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Ctor.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Constructor — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a negative capacity is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-100)]
+    [DataRow(int.MinValue)]
+    public void Ctor_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new OrderedSetStorage<int>(capacity, null);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Constructor — capacity handling
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a zero capacity initialises empty backing arrays.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCapacityIsZero_ShouldHaveZeroCapacity()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that a positive capacity is preserved on the underlying element array.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(4)]
+    [DataRow(16)]
+    [DataRow(1024)]
+    public void Ctor_WhenCapacityIsPositive_ShouldAllocateRequestedCapacity(int capacity)
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(capacity, null);
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(capacity, sut.Capacity);
+    }
+
+    // --------------------------------------------------------
+    // Constructor — comparer handling
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a <see langword="null" /> comparer is replaced with the default equality comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsNull_ShouldUseDefaultComparer()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, null);
+
+        Assert.AreSame(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that a non-<see langword="null" /> comparer is stored verbatim.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldUseSpecifiedComparer()
+    {
+        IEqualityComparer<string> comparer = StringComparer.OrdinalIgnoreCase;
+
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, comparer);
+
+        Assert.AreSame(comparer, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that the provided comparer is used to determine element equality during subsequent operations.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldGovernEquality()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Add("HELLO"));
+        Assert.IsFalse(sut.Add("hello"));
+        Assert.AreEqual(1, sut.Count);
+        Assert.IsTrue(sut.Contains("Hello"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.HashTable.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.HashTable.cs
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.HashTable.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Rehashing
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that filling the storage past the configured load factor triggers a rehash while preserving
+    /// every element's index.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow(8)]
+    [DataRow(64)]
+    [DataRow(512)]
+    [DataRow(4096)]
+    public void HashTable_WhenLoadFactorExceeded_ShouldRehashAndPreserveOrder(int size)
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        for (int i = 0; i < size; i++)
+            Assert.IsTrue(sut.Add(i));
+
+        Assert.AreEqual(size, sut.Count);
+        for (int i = 0; i < size; i++)
+        {
+            Assert.AreEqual(i, sut.GetAt(i));
+            Assert.AreEqual(i, sut.IndexOf(i));
+            Assert.IsTrue(sut.Contains(i));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that interleaved add/remove operations leave the hash table in a consistent state where every
+    /// surviving element is locatable at its current insertion index.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void HashTable_WhenAddingAndRemovingInterleaved_ShouldRemainConsistent()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        for (int i = 0; i < 1000; i++)
+            sut.Add(i);
+
+        for (int i = 0; i < 1000; i += 2)
+            Assert.IsTrue(sut.Remove(i));
+
+        Assert.AreEqual(500, sut.Count);
+        for (int i = 0; i < sut.Count; i++)
+        {
+            int item = sut.GetAt(i);
+            Assert.AreEqual(i, sut.IndexOf(item));
+            Assert.IsTrue(sut.Contains(item));
+        }
+    }
+
+    // --------------------------------------------------------
+    // Collision handling
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a long chain of hash-colliding items is fully traversed by lookups.
+    /// </summary>
+    [TestMethod]
+    public void HashTable_WhenManyItemsCollide_ShouldResolveEachThroughChain()
+    {
+        OrderedSetStorage<HashCollider> sut = new OrderedSetStorage<HashCollider>(0, null);
+        HashCollider[] items = new HashCollider[32];
+
+        for (int i = 0; i < items.Length; i++)
+        {
+            items[i] = new HashCollider("c" + i);
+            Assert.IsTrue(sut.Add(items[i]));
+        }
+
+        for (int i = 0; i < items.Length; i++)
+        {
+            Assert.IsTrue(sut.Contains(items[i]));
+            Assert.AreEqual(i, sut.IndexOf(items[i]));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that removing colliding items still resolves the remaining chain correctly.
+    /// </summary>
+    [TestMethod]
+    public void HashTable_WhenColliderItemsRemoved_ShouldStillResolveRemaining()
+    {
+        OrderedSetStorage<HashCollider> sut = new OrderedSetStorage<HashCollider>(0, null);
+        HashCollider a = new HashCollider("a");
+        HashCollider b = new HashCollider("b");
+        HashCollider c = new HashCollider("c");
+        HashCollider d = new HashCollider("d");
+
+        sut.Add(a);
+        sut.Add(b);
+        sut.Add(c);
+        sut.Add(d);
+
+        sut.Remove(b);
+        sut.Remove(c);
+
+        Assert.IsTrue(sut.Contains(a));
+        Assert.IsFalse(sut.Contains(b));
+        Assert.IsFalse(sut.Contains(c));
+        Assert.IsTrue(sut.Contains(d));
+        Assert.AreEqual(0, sut.IndexOf(a));
+        Assert.AreEqual(1, sut.IndexOf(d));
+    }
+
+    // --------------------------------------------------------
+    // Comparer interaction
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a custom comparer governs lookups across the full add/contains/index/remove cycle.
+    /// </summary>
+    [TestMethod]
+    public void HashTable_WhenCustomComparerProvided_ShouldGovernAllLookups()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Add("Alpha"));
+        Assert.IsFalse(sut.Add("ALPHA"));
+        Assert.IsTrue(sut.Add("Beta"));
+
+        Assert.IsTrue(sut.Contains("alpha"));
+        Assert.AreEqual(0, sut.IndexOf("ALPHA"));
+        Assert.IsTrue(sut.Remove("alpha"));
+        Assert.IsFalse(sut.Contains("alpha"));
+        Assert.AreEqual(1, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that supplying a comparer with consistent <see cref="IEqualityComparer{T}.GetHashCode" /> and
+    /// <see cref="IEqualityComparer{T}.Equals" /> is respected even when many items share the same hash.
+    /// </summary>
+    [TestMethod]
+    public void HashTable_WhenComparerForcesIdenticalHashes_ShouldStillDistinguishByEquals()
+    {
+        OrderedSetStorage<string> sut = new OrderedSetStorage<string>(0, new FixedHashStringComparer());
+
+        Assert.IsTrue(sut.Add("alpha"));
+        Assert.IsTrue(sut.Add("beta"));
+        Assert.IsTrue(sut.Add("gamma"));
+        Assert.IsFalse(sut.Add("alpha"));
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.IsTrue(sut.Contains("beta"));
+        Assert.AreEqual(1, sut.IndexOf("beta"));
+    }
+
+    /// <summary>
+    /// An <see cref="IEqualityComparer{T}" /> for <see cref="string" /> that delegates equality to ordinal
+    /// comparison but forces every hash code to zero in order to exercise collision handling.
+    /// </summary>
+    private sealed class FixedHashStringComparer : IEqualityComparer<string>
+    {
+        /// <inheritdoc />
+        public bool Equals(string? x, string? y) => string.Equals(x, y, StringComparison.Ordinal);
+
+        /// <inheritdoc />
+        public int GetHashCode(string obj) => 0;
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Insert.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Insert.cs
@@ -1,0 +1,366 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Insert.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // TryInsert — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.TryInsert(int, T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = CreateStorage(new[] { "a", "b" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.TryInsert(0, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an out-of-range index is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-100)]
+    [DataRow(int.MinValue)]
+    public void TryInsert_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.TryInsert(index, 99);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an index strictly greater than <see cref="OrderedSetStorage{T}.Count" /> is rejected.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenIndexExceedsCount_ShouldThrowArgumentOutOfRangeException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.TryInsert(3, 99);
+        });
+    }
+
+    // --------------------------------------------------------
+    // TryInsert — duplicates
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that attempting to insert a duplicate returns <see langword="false" /> and does not change
+    /// element order, count, or version.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemIsDuplicate_ShouldReturnFalseAndPreserveState()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        bool inserted = sut.TryInsert(0, 2);
+
+        Assert.IsFalse(inserted);
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(versionBefore, sut._version);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // TryInsert — positional behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that inserting at the start prepends the item.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenIndexIsZero_ShouldPrepend()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.TryInsert(0, 99));
+
+        CollectionAssert.AreEqual(new[] { 99, 1, 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that inserting at an interior index shifts later elements rightwards.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenIndexIsInterior_ShouldShiftLaterElementsRight()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.TryInsert(1, 99));
+
+        CollectionAssert.AreEqual(new[] { 1, 99, 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that inserting at <see cref="OrderedSetStorage{T}.Count" /> appends the item.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenIndexEqualsCount_ShouldAppend()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.TryInsert(3, 99));
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 99 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that inserting into an empty storage at index zero adds the only element.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenStorageIsEmpty_ShouldAddFirstElement()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.IsTrue(sut.TryInsert(0, 42));
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(42, sut.GetAt(0));
+    }
+
+    /// <summary>
+    /// Verifies that an inserted item is locatable through the hash table afterwards.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenInserted_ShouldBeFindable()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30 });
+
+        Assert.IsTrue(sut.TryInsert(1, 99));
+
+        Assert.IsTrue(sut.Contains(99));
+        Assert.AreEqual(1, sut.IndexOf(99));
+    }
+
+    // --------------------------------------------------------
+    // ReplaceAt — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ReplaceAt(int, T)" /> rejects a <see langword="null" /> value.
+    /// </summary>
+    [TestMethod]
+    public void ReplaceAt_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = CreateStorage(new[] { "a", "b" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.ReplaceAt(0, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an out-of-range index is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(2)]
+    [DataRow(int.MinValue)]
+    public void ReplaceAt_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.ReplaceAt(index, 99);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that replacing an element with a value that already exists at a different index throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void ReplaceAt_WhenValueExistsAtAnotherIndex_ShouldThrowArgumentException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.ReplaceAt(0, 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // ReplaceAt — mutation behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that replacing an index with a new value updates the element and keeps it locatable
+    /// through the hash table.
+    /// </summary>
+    [TestMethod]
+    public void ReplaceAt_WhenValueIsNew_ShouldReplaceAndRehash()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.ReplaceAt(1, 99);
+
+        CollectionAssert.AreEqual(new[] { 1, 99, 3 }, Snapshot(sut));
+        Assert.IsTrue(sut.Contains(99));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.AreEqual(1, sut.IndexOf(99));
+    }
+
+    /// <summary>
+    /// Verifies that replacing an index with the value it already holds is a no-op and does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void ReplaceAt_WhenValueIsAlreadyAtIndex_ShouldBeNoOp()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        sut.ReplaceAt(1, 2);
+
+        Assert.AreEqual(versionBefore, sut._version);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // Move — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that an out-of-range <c>oldIndex</c> is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1, 0)]
+    [DataRow(3, 0)]
+    [DataRow(int.MaxValue, 0)]
+    public void Move_WhenOldIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int oldIndex, int newIndex)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Move(oldIndex, newIndex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an out-of-range <c>newIndex</c> is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, -1)]
+    [DataRow(0, 3)]
+    [DataRow(0, int.MaxValue)]
+    public void Move_WhenNewIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int oldIndex, int newIndex)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.Move(oldIndex, newIndex);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Move — positional behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that moving an element to the same index is a no-op and does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenSourceAndDestinationAreEqual_ShouldBeNoOp()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        sut.Move(1, 1);
+
+        Assert.AreEqual(versionBefore, sut._version);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving an element forward shifts the intervening elements leftwards.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingForward_ShouldShiftInterveningLeft()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4, 5 });
+
+        sut.Move(1, 3);
+
+        CollectionAssert.AreEqual(new[] { 1, 3, 4, 2, 5 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving an element backward shifts the intervening elements rightwards.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingBackward_ShouldShiftInterveningRight()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4, 5 });
+
+        sut.Move(3, 1);
+
+        CollectionAssert.AreEqual(new[] { 1, 4, 2, 3, 5 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving the first element to the last position cycles all other elements forward by one.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingFirstToLast_ShouldRotateLeftByOne()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4 });
+
+        sut.Move(0, 3);
+
+        CollectionAssert.AreEqual(new[] { 2, 3, 4, 1 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moving the last element to the first position cycles all other elements backward by one.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenMovingLastToFirst_ShouldRotateRightByOne()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4 });
+
+        sut.Move(3, 0);
+
+        CollectionAssert.AreEqual(new[] { 4, 1, 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that moved elements remain locatable through the hash table at their new indices.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenItemRelocated_ShouldUpdateIndexOf()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30, 40 });
+
+        sut.Move(0, 2);
+
+        Assert.AreEqual(2, sut.IndexOf(10));
+        Assert.AreEqual(0, sut.IndexOf(20));
+        Assert.AreEqual(1, sut.IndexOf(30));
+        Assert.AreEqual(3, sut.IndexOf(40));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Lookup.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Lookup.cs
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Lookup.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // GetAt
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.GetAt(int)" /> rejects an out-of-range index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MinValue)]
+    [DataRow(int.MaxValue)]
+    public void GetAt_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.GetAt(index);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.GetAt(int)" /> on an empty storage with index zero
+    /// throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void GetAt_WhenStorageIsEmpty_ShouldThrowArgumentOutOfRangeException()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.GetAt(0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.GetAt(int)" /> returns the element at the requested
+    /// insertion-order index.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 10)]
+    [DataRow(1, 20)]
+    [DataRow(2, 30)]
+    public void GetAt_WhenIndexIsValid_ShouldReturnElementAtIndex(int index, int expected)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(expected, sut.GetAt(index));
+    }
+
+    // --------------------------------------------------------
+    // Contains — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Contains(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = CreateStorage(new[] { "a" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Contains(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Contains — basic behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Contains(T)" /> returns <see langword="false" /> on an
+    /// empty storage.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenStorageIsEmpty_ShouldReturnFalse()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.IsFalse(sut.Contains(99));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Contains(T)" /> returns <see langword="true" /> for a
+    /// present element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemIsPresent_ShouldReturnTrue()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.Contains(2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Contains(T)" /> returns <see langword="false" /> for an
+    /// absent element.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemIsAbsent_ShouldReturnFalse()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsFalse(sut.Contains(99));
+    }
+
+    /// <summary>
+    /// Verifies that hash collisions still resolve to the correct membership answer.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemsHashCollide_ShouldResolveCorrectly()
+    {
+        OrderedSetStorage<HashCollider> sut = new OrderedSetStorage<HashCollider>(0, null);
+        HashCollider a = new HashCollider("a");
+        HashCollider b = new HashCollider("b");
+        HashCollider c = new HashCollider("c");
+
+        sut.Add(a);
+        sut.Add(b);
+
+        Assert.IsTrue(sut.Contains(a));
+        Assert.IsTrue(sut.Contains(b));
+        Assert.IsFalse(sut.Contains(c));
+    }
+
+    // --------------------------------------------------------
+    // IndexOf — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.IndexOf(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = CreateStorage(new[] { "a" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IndexOf(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // IndexOf — basic behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.IndexOf(T)" /> returns <c>-1</c> on an empty storage.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenStorageIsEmpty_ShouldReturnMinusOne()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.AreEqual(-1, sut.IndexOf(99));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.IndexOf(T)" /> returns the insertion-order index of a
+    /// present element.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 0)]
+    [DataRow(20, 1)]
+    [DataRow(30, 2)]
+    [DataRow(99, -1)]
+    public void IndexOf_WhenStoragePopulated_ShouldReturnExpectedIndex(int item, int expected)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(expected, sut.IndexOf(item));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.IndexOf(T)" /> correctly resolves indices for
+    /// hash-colliding items.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemsHashCollide_ShouldReturnCorrectIndex()
+    {
+        OrderedSetStorage<HashCollider> sut = new OrderedSetStorage<HashCollider>(0, null);
+        HashCollider a = new HashCollider("a");
+        HashCollider b = new HashCollider("b");
+        HashCollider c = new HashCollider("c");
+
+        sut.Add(a);
+        sut.Add(b);
+        sut.Add(c);
+
+        Assert.AreEqual(0, sut.IndexOf(a));
+        Assert.AreEqual(1, sut.IndexOf(b));
+        Assert.AreEqual(2, sut.IndexOf(c));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Remove.cs
@@ -1,0 +1,324 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Remove — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Remove(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<string> sut = CreateStorage(new[] { "a" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.Remove(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Remove — single-item behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that removing an absent item returns <see langword="false" /> and does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsAbsent_ShouldReturnFalseAndNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        bool removed = sut.Remove(99);
+
+        Assert.IsFalse(removed);
+        Assert.AreEqual(versionBefore, sut._version);
+        Assert.AreEqual(3, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that removing the first element shifts later elements left and returns <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsFirst_ShouldShiftRemainingLeft()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.Remove(1));
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing an interior element shifts later elements left.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsInterior_ShouldShiftRemainingLeft()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4 });
+
+        Assert.IsTrue(sut.Remove(2));
+
+        CollectionAssert.AreEqual(new[] { 1, 3, 4 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing the last element trims the order with no shifts.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsLast_ShouldTrimOrder()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.Remove(3));
+
+        CollectionAssert.AreEqual(new[] { 1, 2 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing an item also clears it from the hash table.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenCalled_ShouldEvictFromHashTable()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.Remove(2);
+
+        Assert.IsFalse(sut.Contains(2));
+        Assert.AreEqual(-1, sut.IndexOf(2));
+    }
+
+    /// <summary>
+    /// Verifies that re-adding a previously removed item appends it at the end of the order.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemReAddedAfterRemoval_ShouldAppendAtEnd()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.Remove(2);
+        sut.Add(2);
+
+        CollectionAssert.AreEqual(new[] { 1, 3, 2 }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // RemoveAt — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that an out-of-range index is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MaxValue)]
+    [DataRow(int.MinValue)]
+    public void RemoveAt_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.RemoveAt(index);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="OrderedSetStorage{T}.RemoveAt" /> on an empty storage with index zero
+    /// throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenStorageIsEmpty_ShouldThrowArgumentOutOfRangeException()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.RemoveAt(0);
+        });
+    }
+
+    // --------------------------------------------------------
+    // RemoveAt — positional behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that removing at index zero shifts later elements left and decrements <see cref="OrderedSetStorage{T}.Count" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenIndexIsZero_ShouldShiftRemainingLeft()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.RemoveAt(0);
+
+        CollectionAssert.AreEqual(new[] { 2, 3 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing at the last index trims the order.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenIndexIsLast_ShouldTrimOrder()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.RemoveAt(2);
+
+        CollectionAssert.AreEqual(new[] { 1, 2 }, Snapshot(sut));
+    }
+
+    // --------------------------------------------------------
+    // RemoveWhere — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.RemoveWhere(System.Predicate{T})" /> rejects a <see langword="null" /> predicate.
+    /// </summary>
+    [TestMethod]
+    public void RemoveWhere_WhenMatchIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.RemoveWhere(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // RemoveWhere — predicate behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.RemoveWhere(System.Predicate{T})" /> returns the number
+    /// of removed elements and compacts the remainder in original order.
+    /// </summary>
+    [TestMethod]
+    public void RemoveWhere_WhenSomeElementsMatch_ShouldRemoveMatchingAndKeepOrder()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4, 5, 6 });
+
+        int removed = sut.RemoveWhere(x => x % 2 == 0);
+
+        Assert.AreEqual(3, removed);
+        CollectionAssert.AreEqual(new[] { 1, 3, 5 }, Snapshot(sut));
+    }
+
+    /// <summary>
+    /// Verifies that when no element matches, <see cref="OrderedSetStorage{T}.RemoveWhere(System.Predicate{T})" />
+    /// returns zero and does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void RemoveWhere_WhenNothingMatches_ShouldReturnZeroAndNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        int removed = sut.RemoveWhere(_ => false);
+
+        Assert.AreEqual(0, removed);
+        Assert.AreEqual(versionBefore, sut._version);
+        Assert.AreEqual(3, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that when every element matches, the storage is emptied.
+    /// </summary>
+    [TestMethod]
+    public void RemoveWhere_WhenAllMatch_ShouldEmptyStorage()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        int removed = sut.RemoveWhere(_ => true);
+
+        Assert.AreEqual(3, removed);
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that after <see cref="OrderedSetStorage{T}.RemoveWhere(System.Predicate{T})" />, surviving
+    /// elements are still findable through the hash table.
+    /// </summary>
+    [TestMethod]
+    public void RemoveWhere_WhenSomeElementsMatch_ShouldRehashSurvivors()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3, 4 });
+
+        sut.RemoveWhere(x => x == 2);
+
+        Assert.IsTrue(sut.Contains(1));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.IsTrue(sut.Contains(3));
+        Assert.IsTrue(sut.Contains(4));
+        Assert.AreEqual(0, sut.IndexOf(1));
+        Assert.AreEqual(1, sut.IndexOf(3));
+        Assert.AreEqual(2, sut.IndexOf(4));
+    }
+
+    // --------------------------------------------------------
+    // Clear
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Clear" /> empties the storage and bumps the version.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenStorageHasItems_ShouldEmptyStorage()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int versionBefore = sut._version;
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreNotEqual(versionBefore, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Clear" /> on an already-empty storage is a no-op and
+    /// does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenStorageIsEmpty_ShouldBeNoOp()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+        int versionBefore = sut._version;
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(versionBefore, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that items re-added after <see cref="OrderedSetStorage{T}.Clear" /> are tracked correctly.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenItemsReAddedAfterClear_ShouldTrackNewItems()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+
+        sut.Clear();
+        sut.Add(99);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(99, sut.GetAt(0));
+        Assert.IsTrue(sut.Contains(99));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Versioning.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.Versioning.cs
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.Versioning.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetStorageTests
+{
+    // --------------------------------------------------------
+    // Version is bumped on mutating operations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Add(T)" /> bumps the version when the item is new.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsNew_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+        int before = sut._version;
+
+        sut.Add(1);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Add(T)" /> does not bump the version when the item is a duplicate.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsDuplicate_ShouldNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        sut.Add(2);
+
+        Assert.AreEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Remove(T)" /> bumps the version when an item is removed.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemPresent_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+        int before = sut._version;
+
+        sut.Remove(1);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.RemoveAt(int)" /> bumps the version when called.
+    /// </summary>
+    [TestMethod]
+    public void RemoveAt_WhenCalled_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+        int before = sut._version;
+
+        sut.RemoveAt(0);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.TryInsert(int, T)" /> bumps the version when the item is new.
+    /// </summary>
+    [TestMethod]
+    public void TryInsert_WhenItemIsNew_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2 });
+        int before = sut._version;
+
+        sut.TryInsert(1, 99);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Move(int, int)" /> bumps the version when the indices differ.
+    /// </summary>
+    [TestMethod]
+    public void Move_WhenIndicesDiffer_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        sut.Move(0, 2);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ReplaceAt(int, T)" /> bumps the version when the value
+    /// at the index actually changes.
+    /// </summary>
+    [TestMethod]
+    public void ReplaceAt_WhenValueChanges_ShouldBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        sut.ReplaceAt(0, 99);
+
+        Assert.AreNotEqual(before, sut._version);
+    }
+
+    // --------------------------------------------------------
+    // Version is not bumped on read-only operations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.Contains(T)" /> does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenCalled_ShouldNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        _ = sut.Contains(2);
+        _ = sut.Contains(99);
+
+        Assert.AreEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.IndexOf(T)" /> does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenCalled_ShouldNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        _ = sut.IndexOf(2);
+        _ = sut.IndexOf(99);
+
+        Assert.AreEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.GetAt(int)" /> does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void GetAt_WhenCalled_ShouldNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        _ = sut.GetAt(0);
+
+        Assert.AreEqual(before, sut._version);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSetStorage{T}.ToArray" /> does not bump the version.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenCalled_ShouldNotBumpVersion()
+    {
+        OrderedSetStorage<int> sut = CreateStorage(new[] { 1, 2, 3 });
+        int before = sut._version;
+
+        _ = sut.ToArray();
+
+        Assert.AreEqual(before, sut._version);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetStorageTests.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetStorageTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Unit tests for the internal <see cref="OrderedSetStorage{T}" /> engine that backs
+/// <see cref="OrderedSet{T}" /> and <see cref="IndexedSet{T}" />.
+/// </summary>
+[TestClass]
+public partial class OrderedSetStorageTests
+{
+    /// <summary>
+    /// Verifies the happy path for <see cref="OrderedSetStorage{T}.Add(T)" /> on an empty storage —
+    /// the canonical smoke check for the engine.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Add_WhenItemIsNew_ShouldAppendAndReturnTrue()
+    {
+        OrderedSetStorage<int> sut = new OrderedSetStorage<int>(0, null);
+
+        bool added = sut.Add(42);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(42, sut.GetAt(0));
+    }
+
+    /// <summary>
+    /// Creates a populated storage seeded with the specified items in order.
+    /// </summary>
+    /// <param name="items">The items to seed.</param>
+    /// <param name="comparer">An optional comparer.</param>
+    /// <returns>The populated storage.</returns>
+    private static OrderedSetStorage<T> CreateStorage<T>(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        where T : notnull
+    {
+        OrderedSetStorage<T> storage = new OrderedSetStorage<T>(0, comparer);
+        foreach (T item in items)
+            storage.Add(item);
+
+        return storage;
+    }
+
+    /// <summary>
+    /// Returns the contents of <paramref name="storage" /> as a snapshot array in insertion order.
+    /// </summary>
+    /// <param name="storage">The storage to snapshot.</param>
+    /// <returns>An array containing the elements in insertion order.</returns>
+    private static T[] Snapshot<T>(OrderedSetStorage<T> storage)
+        where T : notnull
+    {
+        T[] result = new T[storage.Count];
+        for (int i = 0; i < storage.Count; i++)
+            result[i] = storage.GetAt(i);
+
+        return result;
+    }
+
+    /// <summary>
+    /// A reference-type helper whose <see cref="GetHashCode" /> deliberately collides for every instance,
+    /// allowing tests to exercise hash-table chain traversal and collision handling. Equality is identity-based.
+    /// </summary>
+    private sealed class HashCollider
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="HashCollider" /> class with the specified label.
+        /// </summary>
+        /// <param name="label">A label used for diagnostics; not part of equality.</param>
+        public HashCollider(string label)
+        {
+            this.Label = label;
+        }
+
+        /// <summary>
+        /// Gets the diagnostic label.
+        /// </summary>
+        /// <returns>The diagnostic label.</returns>
+        public string Label { get; }
+
+        /// <inheritdoc />
+        public override int GetHashCode() => 0;
+
+        /// <inheritdoc />
+        public override bool Equals(object? obj) => ReferenceEquals(this, obj);
+
+        /// <inheritdoc />
+        public override string ToString() => this.Label;
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Add.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Add.cs
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Add.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // Add(T) — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Add(T)" /> rejects a <see langword="null" /> reference.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Add(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Add(T) — single-item behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a new item is appended and the return value is <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsUnique_ShouldAppendAndReturnTrue()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        bool added = sut.Add(99);
+
+        Assert.IsTrue(added);
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(99, sut[0]);
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate add returns <see langword="false" /> and does not change order or count.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenItemIsDuplicate_ShouldReturnFalseAndPreserveOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool added = sut.Add(2);
+
+        Assert.IsFalse(added);
+        Assert.AreEqual(3, sut.Count);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that adding many items grows the storage to hold them and preserves insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenManyItemsAdded_ShouldGrowAndPreserveOrder()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        for (int i = 0; i < 1000; i++)
+            Assert.IsTrue(sut.Add(i));
+
+        Assert.AreEqual(1000, sut.Count);
+        for (int i = 0; i < 1000; i++)
+            Assert.AreEqual(i, sut[i]);
+    }
+
+    // --------------------------------------------------------
+    // Add(T) — comparer interaction
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a custom comparer is honoured when detecting duplicates on <see cref="OrderedSet{T}.Add(T)" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenCustomComparerProvided_ShouldDeduplicateAccordingly()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Add("Hello"));
+        Assert.IsFalse(sut.Add("HELLO"));
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual("Hello", sut[0]);
+    }
+
+    // --------------------------------------------------------
+    // AddRange — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.AddRange(IEnumerable{T})" /> rejects a <see langword="null" />
+    /// collection.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.AddRange(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.AddRange(IEnumerable{T})" /> rejects a source that yields a
+    /// <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.AddRange(new[] { "a", null!, "b" });
+        });
+    }
+
+    // --------------------------------------------------------
+    // AddRange — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.AddRange(IEnumerable{T})" /> returns the number of newly-added
+    /// elements and preserves insertion order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionContainsDuplicatesAndNewItems_ShouldReturnNewItemCount()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        int added = sut.AddRange(new[] { 2, 3, 4, 4, 5 });
+
+        Assert.AreEqual(3, added);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 4, 5 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.AddRange(IEnumerable{T})" /> with an empty source returns zero
+    /// and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenCollectionIsEmpty_ShouldReturnZero()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        int added = sut.AddRange(Array.Empty<int>());
+
+        Assert.AreEqual(0, added);
+        CollectionAssert.AreEqual(new[] { 1, 2 }, SnapshotByIndexer(sut));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Capacity.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Capacity.cs
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Capacity.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // EnsureCapacity
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.EnsureCapacity(int)" /> rejects a negative capacity.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void EnsureCapacity_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.EnsureCapacity(capacity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.EnsureCapacity(int)" /> grows to at least the requested
+    /// capacity and reports it.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenLargerCapacityRequested_ShouldGrow()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        int reported = sut.EnsureCapacity(128);
+
+        Assert.IsTrue(reported >= 128);
+        Assert.IsTrue(sut.Capacity >= 128);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.EnsureCapacity(int)" /> is a no-op when the requested capacity
+    /// does not exceed the current capacity.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenSmallerCapacityRequested_ShouldNotShrink()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(64);
+        int capacityBefore = sut.Capacity;
+
+        int reported = sut.EnsureCapacity(4);
+
+        Assert.AreEqual(capacityBefore, sut.Capacity);
+        Assert.AreEqual(capacityBefore, reported);
+    }
+
+    /// <summary>
+    /// Verifies that growth preserves the existing contents.
+    /// </summary>
+    [TestMethod]
+    public void EnsureCapacity_WhenGrown_ShouldPreserveContents()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.EnsureCapacity(128);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // TrimExcess
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.TrimExcess" /> on an empty set releases the backing arrays.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenSetIsEmpty_ShouldResetCapacityToZero()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(16);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(0, sut.Capacity);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.TrimExcess" /> on a partially-filled set shrinks capacity to
+    /// <see cref="OrderedSet{T}.Count" /> and preserves contents.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCapacityExceedsCount_ShouldShrinkAndPreserveContents()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(128);
+        sut.Add(1);
+        sut.Add(2);
+        sut.Add(3);
+
+        sut.TrimExcess();
+
+        Assert.AreEqual(3, sut.Capacity);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that items remain locatable after <see cref="OrderedSet{T}.TrimExcess" />.
+    /// </summary>
+    [TestMethod]
+    public void TrimExcess_WhenCalled_ShouldKeepItemsLocatable()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(128);
+        sut.Add(10);
+        sut.Add(20);
+        sut.Add(30);
+
+        sut.TrimExcess();
+
+        Assert.IsTrue(sut.Contains(20));
+        Assert.AreEqual(2, sut.IndexOf(30));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Contains.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Contains.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Contains.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Contains(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Contains(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Contains(T)" /> returns <see langword="false" /> on an empty set.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenSetIsEmpty_ShouldReturnFalse()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsFalse(sut.Contains(99));
+    }
+
+    /// <summary>
+    /// Verifies the membership outcome across a range of inputs.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, true)]
+    [DataRow(2, true)]
+    [DataRow(3, true)]
+    [DataRow(0, false)]
+    [DataRow(4, false)]
+    [DataRow(int.MaxValue, false)]
+    public void Contains_WhenItemPresenceVaries_ShouldReturnExpected(int item, bool expected)
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.AreEqual(expected, sut.Contains(item));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Contains(T)" /> uses the configured comparer for equality.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenCustomComparerProvided_ShouldUseComparerForEquality()
+    {
+        OrderedSet<string> sut = CreateSet(new[] { "Hello" }, StringComparer.OrdinalIgnoreCase);
+
+        Assert.IsTrue(sut.Contains("HELLO"));
+        Assert.IsTrue(sut.Contains("hello"));
+        Assert.IsFalse(sut.Contains("world"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.CopyTo.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.CopyTo.cs
@@ -1,0 +1,169 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.CopyTo.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // CopyTo — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> rejects a <see langword="null" /> array.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.CopyTo(null!, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> rejects a negative offset.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void CopyTo_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException(int arrayIndex)
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            sut.CopyTo(new int[10], arrayIndex);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when the array is too small.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenArrayIsTooSmall_ShouldThrowArgumentException()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[2], 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> throws <see cref="ArgumentException" />
+    /// when the remaining space after the offset is insufficient.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenRemainingSpaceAfterOffsetIsInsufficient_ShouldThrowArgumentException()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            sut.CopyTo(new int[5], 3);
+        });
+    }
+
+    // --------------------------------------------------------
+    // CopyTo — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> copies elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsZero_ShouldCopyInInsertionOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        int[] target = new int[3];
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.CopyTo(T[], int)" /> copies starting at the offset, leaving
+    /// earlier and later slots untouched.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenIndexIsNonZero_ShouldCopyAtCorrectPosition()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20 });
+        int[] target = new int[] { 99, 99, 99, 99 };
+
+        sut.CopyTo(target, 1);
+
+        CollectionAssert.AreEqual(new[] { 99, 10, 20, 99 }, target);
+    }
+
+    /// <summary>
+    /// Verifies that copying an empty set does not modify the destination array.
+    /// </summary>
+    [TestMethod]
+    public void CopyTo_WhenSetIsEmpty_ShouldNotModifyArray()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+        int[] target = new int[] { 99, 88 };
+
+        sut.CopyTo(target, 0);
+
+        CollectionAssert.AreEqual(new[] { 99, 88 }, target);
+    }
+
+    // --------------------------------------------------------
+    // ToArray
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ToArray" /> on an empty set returns an empty array.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenSetIsEmpty_ShouldReturnEmptyArray()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        int[] array = sut.ToArray();
+
+        Assert.AreEqual(0, array.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ToArray" /> returns a fresh array in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenSetPopulated_ShouldReturnInsertionOrderedArray()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        int[] array = sut.ToArray();
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, array);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ToArray" /> returns a disconnected snapshot.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenCalled_ShouldReturnDisconnectedSnapshot()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        int[] snapshot = sut.ToArray();
+
+        sut.Add(4);
+        sut.Remove(1);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, snapshot);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Ctor.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Ctor.cs
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Ctor.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // Default constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the default constructor creates an empty set with the default comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenDefault_ShouldBeEmptyWithDefaultComparer()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(0, sut.Capacity);
+        Assert.AreSame(EqualityComparer<int>.Default, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Comparer-only constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the comparer-only constructor defaults to the default comparer when supplied
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsNull_ShouldUseDefaultComparer()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>((IEqualityComparer<string>?)null);
+
+        Assert.AreSame(EqualityComparer<string>.Default, sut.Comparer);
+    }
+
+    /// <summary>
+    /// Verifies that the comparer-only constructor stores and uses the supplied comparer.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenComparerIsProvided_ShouldUseSpecifiedComparer()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreSame(StringComparer.OrdinalIgnoreCase, sut.Comparer);
+
+        sut.Add("alpha");
+        Assert.IsTrue(sut.Contains("ALPHA"));
+    }
+
+    // --------------------------------------------------------
+    // Capacity constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that a negative capacity is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(-100)]
+    [DataRow(int.MinValue)]
+    public void Ctor_WhenCapacityIsNegative_ShouldThrowArgumentOutOfRangeException(int capacity)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new OrderedSet<int>(capacity);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the capacity constructor accepts non-negative values and pre-allocates the requested
+    /// capacity.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(1)]
+    [DataRow(16)]
+    [DataRow(1024)]
+    public void Ctor_WhenCapacityIsValid_ShouldAllocateRequestedCapacity(int capacity)
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(capacity);
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.AreEqual(capacity, sut.Capacity);
+    }
+
+    // --------------------------------------------------------
+    // Capacity + comparer constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the capacity-and-comparer constructor combines both arguments correctly.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCapacityAndComparerProvided_ShouldUseBoth()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>(8, StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(8, sut.Capacity);
+        Assert.AreSame(StringComparer.OrdinalIgnoreCase, sut.Comparer);
+    }
+
+    // --------------------------------------------------------
+    // Collection constructor
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the collection constructor rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new OrderedSet<int>((IEnumerable<int>)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the collection constructor rejects a source that yields a <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionContainsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new OrderedSet<string>(new[] { "a", null!, "b" });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the collection constructor preserves insertion order while deduplicating.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionContainsDuplicates_ShouldPreserveFirstOccurrenceOrder()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(new[] { 1, 2, 2, 3, 1, 4 });
+
+        Assert.AreEqual(4, sut.Count);
+        Assert.AreEqual(1, sut[0]);
+        Assert.AreEqual(2, sut[1]);
+        Assert.AreEqual(3, sut[2]);
+        Assert.AreEqual(4, sut[3]);
+    }
+
+    /// <summary>
+    /// Verifies that an empty source collection produces an empty set.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionIsEmpty_ShouldBeEmpty()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>(Array.Empty<int>());
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the collection-and-comparer constructor uses the supplied comparer for deduplication.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionAndComparerProvided_ShouldUseSpecifiedComparer()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>(
+            new[] { "A", "a", "B", "b" },
+            StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(2, sut.Count);
+        Assert.AreEqual("A", sut[0]);
+        Assert.AreEqual("B", sut[1]);
+    }
+
+    /// <summary>
+    /// Verifies that the collection-and-comparer constructor preallocates capacity from an
+    /// <see cref="ICollection{T}" /> hint.
+    /// </summary>
+    [TestMethod]
+    public void Ctor_WhenCollectionHasCountHint_ShouldPreallocateCapacity()
+    {
+        List<int> source = new List<int> { 1, 2, 3, 4, 5 };
+
+        OrderedSet<int> sut = new OrderedSet<int>(source);
+
+        Assert.AreEqual(5, sut.Count);
+        Assert.IsTrue(sut.Capacity >= 5);
+    }
+
+    // --------------------------------------------------------
+    // IsReadOnly
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IsReadOnly" /> is always <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void IsReadOnly_WhenInspected_ShouldReturnFalse()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsFalse(sut.IsReadOnly);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Enumerator.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Enumerator.cs
@@ -1,0 +1,159 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Enumerator.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // GetEnumerator — typed struct
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the public <see cref="OrderedSet{T}.GetEnumerator" /> yields all elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenSetPopulated_ShouldYieldAllItemsInOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        List<int> seen = new List<int>();
+
+        foreach (int item in sut)
+            seen.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+
+    /// <summary>
+    /// Verifies that the enumerator on an empty set yields no elements.
+    /// </summary>
+    [TestMethod]
+    public void GetEnumerator_WhenSetIsEmpty_ShouldYieldNoElements()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        OrderedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Enumerator.MoveNext" /> returns <see langword="false" /> once
+    /// every element has been yielded.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenEndReached_ShouldReturnFalseFromMoveNext()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        OrderedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.IsFalse(enumerator.MoveNext());
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Enumerator.Reset" /> restarts iteration from the first element.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenResetCalled_ShouldRestartIteration()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        OrderedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.AreEqual(1, enumerator.Current);
+
+        enumerator.Reset();
+
+        Assert.IsTrue(enumerator.MoveNext());
+        Assert.AreEqual(1, enumerator.Current);
+    }
+
+    // --------------------------------------------------------
+    // Versioning / invalidation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that mutating the set after creating an enumerator causes subsequent
+    /// <see cref="OrderedSet{T}.Enumerator.MoveNext" /> calls to throw <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenSetMutatedAfterCreation_ShouldThrowOnMoveNext()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        OrderedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut.Add(99);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = enumerator.MoveNext();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that mutating the set after creating an enumerator causes
+    /// <see cref="OrderedSet{T}.Enumerator.Reset" /> to throw <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_WhenSetMutatedAfterCreation_ShouldThrowOnReset()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        OrderedSet<int>.Enumerator enumerator = sut.GetEnumerator();
+
+        sut.Remove(2);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            enumerator.Reset();
+        });
+    }
+
+    // --------------------------------------------------------
+    // Explicit interface implementations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that the explicit <see cref="IEnumerable{T}.GetEnumerator" /> implementation yields elements
+    /// in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void IEnumerableT_WhenIterated_ShouldYieldAllItemsInOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        IEnumerable<int> typed = sut;
+        List<int> seen = new List<int>();
+
+        foreach (int item in typed)
+            seen.Add(item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+
+    /// <summary>
+    /// Verifies that the explicit non-generic <see cref="IEnumerable.GetEnumerator" /> implementation yields
+    /// elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void IEnumerable_WhenIterated_ShouldYieldAllItemsInOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+        IEnumerable untyped = sut;
+        List<int> seen = new List<int>();
+
+        foreach (object item in untyped)
+            seen.Add((int)item);
+
+        CollectionAssert.AreEqual(new[] { 10, 20, 30 }, seen);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.ICollection.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.ICollection.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.ICollection.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    /// <summary>
+    /// Verifies that the explicit <see cref="ICollection{T}.Add(T)" /> implementation appends a new item.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionAdd_WhenItemIsNew_ShouldAppendItem()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+        ICollection<int> typed = sut;
+
+        typed.Add(42);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(42, sut[0]);
+    }
+
+    /// <summary>
+    /// Verifies that the explicit <see cref="ICollection{T}.Add(T)" /> implementation discards the duplicate
+    /// outcome and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionAdd_WhenItemIsDuplicate_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+        ICollection<int> typed = sut;
+
+        typed.Add(2);
+
+        Assert.AreEqual(3, sut.Count);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that the explicit <see cref="ICollection{T}.Add(T)" /> implementation rejects a
+    /// <see langword="null" /> reference.
+    /// </summary>
+    [TestMethod]
+    public void ICollectionAdd_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>();
+        ICollection<string> typed = sut;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            typed.Add(null!);
+        });
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.IndexOf.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.IndexOf.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.IndexOf.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IndexOf(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = new OrderedSet<string>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IndexOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IndexOf(T)" /> returns <c>-1</c> on an empty set.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenSetIsEmpty_ShouldReturnMinusOne()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.AreEqual(-1, sut.IndexOf(99));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IndexOf(T)" /> reports the insertion-order index for each item.
+    /// </summary>
+    [TestMethod]
+    [DataRow(10, 0)]
+    [DataRow(20, 1)]
+    [DataRow(30, 2)]
+    [DataRow(99, -1)]
+    public void IndexOf_WhenSetPopulated_ShouldReturnExpectedIndex(int item, int expected)
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(expected, sut.IndexOf(item));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IndexOf(T)" /> uses the configured comparer when locating items.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenCustomComparerProvided_ShouldUseComparerForEquality()
+    {
+        OrderedSet<string> sut = CreateSet(new[] { "Alpha", "Beta" }, StringComparer.OrdinalIgnoreCase);
+
+        Assert.AreEqual(0, sut.IndexOf("ALPHA"));
+        Assert.AreEqual(1, sut.IndexOf("beta"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IndexOf(T)" /> reflects index shifts after a removal.
+    /// </summary>
+    [TestMethod]
+    public void IndexOf_WhenItemRemovedFromMiddle_ShouldUpdateLaterIndices()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30, 40 });
+
+        sut.Remove(20);
+
+        Assert.AreEqual(0, sut.IndexOf(10));
+        Assert.AreEqual(1, sut.IndexOf(30));
+        Assert.AreEqual(2, sut.IndexOf(40));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Indexer.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Indexer.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Indexer.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    /// <summary>
+    /// Verifies that the indexer rejects out-of-range indices.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(3)]
+    [DataRow(int.MaxValue)]
+    [DataRow(int.MinValue)]
+    public void Indexer_WhenIndexIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int index)
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut[index];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer on an empty set throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenSetIsEmpty_ShouldThrowArgumentOutOfRangeException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut[0];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer returns elements in insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenSetPopulated_ShouldReturnElementInInsertionOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30 });
+
+        Assert.AreEqual(10, sut[0]);
+        Assert.AreEqual(20, sut[1]);
+        Assert.AreEqual(30, sut[2]);
+    }
+
+    /// <summary>
+    /// Verifies that the indexer reflects removals — every surviving element shifts to the slot it would
+    /// occupy in a newly-built set with the same insertion sequence.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenItemRemoved_ShouldReflectShiftedIndices()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 10, 20, 30, 40 });
+
+        sut.Remove(20);
+
+        Assert.AreEqual(10, sut[0]);
+        Assert.AreEqual(30, sut[1]);
+        Assert.AreEqual(40, sut[2]);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.Remove.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.Remove.cs
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.Remove.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // Remove — argument validation
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Remove(T)" /> rejects a <see langword="null" /> item.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<string> sut = CreateSet(new[] { "a" });
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Remove(null!);
+        });
+    }
+
+    // --------------------------------------------------------
+    // Remove — behaviour
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that removing an absent item returns <see langword="false" /> and leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemIsAbsent_ShouldReturnFalseAndLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool removed = sut.Remove(99);
+
+        Assert.IsFalse(removed);
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that removing a present item returns <see langword="true" /> and compacts the remaining order.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, new[] { 2, 3 })]
+    [DataRow(2, new[] { 1, 3 })]
+    [DataRow(3, new[] { 1, 2 })]
+    public void Remove_WhenItemIsPresent_ShouldReturnTrueAndCompactOrder(int target, int[] expected)
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        bool removed = sut.Remove(target);
+
+        Assert.IsTrue(removed);
+        CollectionAssert.AreEqual(expected, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that a removed item is no longer reported by <see cref="OrderedSet{T}.Contains(T)" /> or
+    /// <see cref="OrderedSet{T}.IndexOf(T)" />.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemRemoved_ShouldNoLongerBeReportedPresent()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.Remove(2);
+
+        Assert.IsFalse(sut.Contains(2));
+        Assert.AreEqual(-1, sut.IndexOf(2));
+    }
+
+    /// <summary>
+    /// Verifies that re-adding a previously removed item appends it to the end.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenItemReAddedAfterRemoval_ShouldAppendAtEnd()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.Remove(2);
+        sut.Add(2);
+
+        CollectionAssert.AreEqual(new[] { 1, 3, 2 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // Clear
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Clear" /> removes every element and resets <see cref="OrderedSet{T}.Count" />.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenCalled_ShouldRemoveAllElements()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+        Assert.IsFalse(sut.Contains(1));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.IsFalse(sut.Contains(3));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Clear" /> on an already-empty set remains empty.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenAlreadyEmpty_ShouldRemainEmpty()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        sut.Clear();
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that items added after <see cref="OrderedSet{T}.Clear" /> are tracked normally.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenItemsReAddedAfterClear_ShouldTrackNewItems()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        sut.Clear();
+        sut.Add(99);
+
+        Assert.AreEqual(1, sut.Count);
+        Assert.AreEqual(99, sut[0]);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.SetOperations.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.SetOperations.cs
@@ -1,0 +1,315 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.SetOperations.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // UnionWith
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.UnionWith(IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void UnionWith_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.UnionWith(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.UnionWith(IEnumerable{T})" /> appends new items in source order
+    /// after the existing contents.
+    /// </summary>
+    [TestMethod]
+    public void UnionWith_WhenOtherHasNewItems_ShouldAppendInSourceOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        sut.UnionWith(new[] { 2, 3, 4 });
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3, 4 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void UnionWith_WhenOtherIsEmpty_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.UnionWith(Array.Empty<int>());
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.UnionWith(IEnumerable{T})" /> with the set itself is a no-op
+    /// because every element is already present.
+    /// </summary>
+    [TestMethod]
+    public void UnionWith_WhenOtherIsSelf_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.UnionWith(sut);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // IntersectWith
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IntersectWith(IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void IntersectWith_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.IntersectWith(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IntersectWith(IEnumerable{T})" /> keeps only the elements that
+    /// are also in the source, preserving original insertion order.
+    /// </summary>
+    [TestMethod]
+    public void IntersectWith_WhenOtherHasOverlap_ShouldRetainOnlyCommonInOriginalOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3, 4 });
+
+        sut.IntersectWith(new[] { 4, 2, 5 });
+
+        CollectionAssert.AreEqual(new[] { 2, 4 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source clears the set.
+    /// </summary>
+    [TestMethod]
+    public void IntersectWith_WhenOtherIsEmpty_ShouldClearSet()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.IntersectWith(Array.Empty<int>());
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that intersecting an empty set with a non-empty source is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void IntersectWith_WhenSetIsEmpty_ShouldRemainEmpty()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        sut.IntersectWith(new[] { 1, 2, 3 });
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that intersecting the set with itself leaves it unchanged via the reference-identity fast path.
+    /// </summary>
+    [TestMethod]
+    public void IntersectWith_WhenOtherIsSelf_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.IntersectWith(sut);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    // --------------------------------------------------------
+    // ExceptWith
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ExceptWith(IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void ExceptWith_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.ExceptWith(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ExceptWith(IEnumerable{T})" /> removes elements that are present
+    /// in the source while preserving original order.
+    /// </summary>
+    [TestMethod]
+    public void ExceptWith_WhenOtherHasItemsInCommon_ShouldRemoveThemInOriginalOrder()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3, 4 });
+
+        sut.ExceptWith(new[] { 2, 4, 99 });
+
+        CollectionAssert.AreEqual(new[] { 1, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void ExceptWith_WhenOtherIsEmpty_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.ExceptWith(Array.Empty<int>());
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ExceptWith(IEnumerable{T})" /> with the set itself clears the set.
+    /// </summary>
+    [TestMethod]
+    public void ExceptWith_WhenOtherIsSelf_ShouldClearSet()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.ExceptWith(sut);
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.ExceptWith(IEnumerable{T})" /> on an empty set is a no-op.
+    /// </summary>
+    [TestMethod]
+    public void ExceptWith_WhenSetIsEmpty_ShouldRemainEmpty()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        sut.ExceptWith(new[] { 1, 2, 3 });
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // SymmetricExceptWith
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.SymmetricExceptWith(IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void SymmetricExceptWith_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            sut.SymmetricExceptWith(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.SymmetricExceptWith(IEnumerable{T})" /> retains the elements
+    /// exclusive to either side and removes the shared elements.
+    /// </summary>
+    [TestMethod]
+    public void SymmetricExceptWith_WhenOtherOverlaps_ShouldKeepExclusiveElements()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.SymmetricExceptWith(new[] { 2, 3, 4, 5 });
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.IsTrue(sut.Contains(1));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.IsFalse(sut.Contains(3));
+        Assert.IsTrue(sut.Contains(4));
+        Assert.IsTrue(sut.Contains(5));
+    }
+
+    /// <summary>
+    /// Verifies that an empty source leaves the set unchanged.
+    /// </summary>
+    [TestMethod]
+    public void SymmetricExceptWith_WhenOtherIsEmpty_ShouldLeaveSetUnchanged()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.SymmetricExceptWith(Array.Empty<int>());
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, SnapshotByIndexer(sut));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.SymmetricExceptWith(IEnumerable{T})" /> with the set itself
+    /// clears the set.
+    /// </summary>
+    [TestMethod]
+    public void SymmetricExceptWith_WhenOtherIsSelf_ShouldClearSet()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        sut.SymmetricExceptWith(sut);
+
+        Assert.AreEqual(0, sut.Count);
+    }
+
+    /// <summary>
+    /// Verifies that a source containing duplicates is deduplicated before applying symmetric difference.
+    /// </summary>
+    [TestMethod]
+    public void SymmetricExceptWith_WhenOtherHasDuplicates_ShouldDeduplicateBeforeApplying()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        sut.SymmetricExceptWith(new[] { 2, 2, 3, 3 });
+
+        Assert.IsTrue(sut.Contains(1));
+        Assert.IsFalse(sut.Contains(2));
+        Assert.IsTrue(sut.Contains(3));
+        Assert.AreEqual(2, sut.Count);
+    }
+
+    // --------------------------------------------------------
+    // Comparer-aware set operations
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that set operations honour the configured comparer when matching elements against the source.
+    /// </summary>
+    [TestMethod]
+    public void SetOperations_WhenCustomComparerProvided_ShouldHonourComparer()
+    {
+        OrderedSet<string> sut = CreateSet(new[] { "Alpha", "Beta" }, StringComparer.OrdinalIgnoreCase);
+
+        sut.UnionWith(new[] { "ALPHA", "Gamma" });
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.IsTrue(sut.Contains("alpha"));
+        Assert.IsTrue(sut.Contains("BETA"));
+        Assert.IsTrue(sut.Contains("Gamma"));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.SetRelations.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.SetRelations.cs
@@ -1,0 +1,286 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.SetRelations.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+public partial class OrderedSetTests
+{
+    // --------------------------------------------------------
+    // IsSubsetOf
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IsSubsetOf(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void IsSubsetOf_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IsSubsetOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an empty set is a subset of every collection, including the empty collection.
+    /// </summary>
+    [TestMethod]
+    public void IsSubsetOf_WhenSetIsEmpty_ShouldReturnTrue()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsTrue(sut.IsSubsetOf(Array.Empty<int>()));
+        Assert.IsTrue(sut.IsSubsetOf(new[] { 1, 2, 3 }));
+    }
+
+    /// <summary>
+    /// Verifies the boundary outcomes for <see cref="OrderedSet{T}.IsSubsetOf(System.Collections.Generic.IEnumerable{T})" />.
+    /// </summary>
+    [TestMethod]
+    public void IsSubsetOf_WhenComparisonsVary_ShouldReturnExpected()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.IsTrue(sut.IsSubsetOf(new[] { 1, 2, 3 }));
+        Assert.IsTrue(sut.IsSubsetOf(new[] { 1, 2 }));
+        Assert.IsFalse(sut.IsSubsetOf(new[] { 1, 3 }));
+        Assert.IsFalse(sut.IsSubsetOf(new[] { 1 }));
+        Assert.IsFalse(sut.IsSubsetOf(Array.Empty<int>()));
+    }
+
+    // --------------------------------------------------------
+    // IsSupersetOf
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IsSupersetOf(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void IsSupersetOf_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IsSupersetOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that every set is a superset of the empty collection.
+    /// </summary>
+    [TestMethod]
+    public void IsSupersetOf_WhenOtherIsEmpty_ShouldReturnTrue()
+    {
+        OrderedSet<int> empty = new OrderedSet<int>();
+        OrderedSet<int> populated = CreateSet(new[] { 1, 2 });
+
+        Assert.IsTrue(empty.IsSupersetOf(Array.Empty<int>()));
+        Assert.IsTrue(populated.IsSupersetOf(Array.Empty<int>()));
+    }
+
+    /// <summary>
+    /// Verifies the boundary outcomes for <see cref="OrderedSet{T}.IsSupersetOf(System.Collections.Generic.IEnumerable{T})" />.
+    /// </summary>
+    [TestMethod]
+    public void IsSupersetOf_WhenComparisonsVary_ShouldReturnExpected()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.IsSupersetOf(new[] { 1, 2 }));
+        Assert.IsTrue(sut.IsSupersetOf(new[] { 1, 2, 3 }));
+        Assert.IsFalse(sut.IsSupersetOf(new[] { 1, 4 }));
+        Assert.IsFalse(sut.IsSupersetOf(new[] { 1, 2, 3, 4 }));
+    }
+
+    // --------------------------------------------------------
+    // IsProperSubsetOf
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IsProperSubsetOf(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSubsetOf_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IsProperSubsetOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies the boundary outcomes for <see cref="OrderedSet{T}.IsProperSubsetOf(System.Collections.Generic.IEnumerable{T})" />.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSubsetOf_WhenComparisonsVary_ShouldReturnExpected()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2 });
+
+        Assert.IsTrue(sut.IsProperSubsetOf(new[] { 1, 2, 3 }));
+        Assert.IsFalse(sut.IsProperSubsetOf(new[] { 1, 2 }));
+        Assert.IsFalse(sut.IsProperSubsetOf(new[] { 1 }));
+    }
+
+    /// <summary>
+    /// Verifies that an empty set is not a proper subset of itself.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSubsetOf_WhenBothEmpty_ShouldReturnFalse()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsFalse(sut.IsProperSubsetOf(Array.Empty<int>()));
+    }
+
+    // --------------------------------------------------------
+    // IsProperSupersetOf
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.IsProperSupersetOf(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSupersetOf_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.IsProperSupersetOf(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies the boundary outcomes for <see cref="OrderedSet{T}.IsProperSupersetOf(System.Collections.Generic.IEnumerable{T})" />.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSupersetOf_WhenComparisonsVary_ShouldReturnExpected()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.IsProperSupersetOf(new[] { 1, 2 }));
+        Assert.IsFalse(sut.IsProperSupersetOf(new[] { 1, 2, 3 }));
+        Assert.IsFalse(sut.IsProperSupersetOf(new[] { 1, 2, 3, 4 }));
+    }
+
+    /// <summary>
+    /// Verifies that a populated set is a proper superset of the empty collection.
+    /// </summary>
+    [TestMethod]
+    public void IsProperSupersetOf_WhenOtherIsEmptyAndSetPopulated_ShouldReturnTrue()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1 });
+
+        Assert.IsTrue(sut.IsProperSupersetOf(Array.Empty<int>()));
+    }
+
+    // --------------------------------------------------------
+    // Overlaps
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.Overlaps(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void Overlaps_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.Overlaps(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an empty set never overlaps any collection.
+    /// </summary>
+    [TestMethod]
+    public void Overlaps_WhenSetIsEmpty_ShouldReturnFalse()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsFalse(sut.Overlaps(new[] { 1, 2 }));
+        Assert.IsFalse(sut.Overlaps(Array.Empty<int>()));
+    }
+
+    /// <summary>
+    /// Verifies the boundary outcomes for <see cref="OrderedSet{T}.Overlaps(System.Collections.Generic.IEnumerable{T})" />.
+    /// </summary>
+    [TestMethod]
+    public void Overlaps_WhenComparisonsVary_ShouldReturnExpected()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.Overlaps(new[] { 3, 4 }));
+        Assert.IsTrue(sut.Overlaps(new[] { 1 }));
+        Assert.IsFalse(sut.Overlaps(new[] { 4, 5 }));
+        Assert.IsFalse(sut.Overlaps(Array.Empty<int>()));
+    }
+
+    // --------------------------------------------------------
+    // SetEquals
+    // --------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="OrderedSet{T}.SetEquals(System.Collections.Generic.IEnumerable{T})" /> rejects a <see langword="null" /> source.
+    /// </summary>
+    [TestMethod]
+    public void SetEquals_WhenOtherIsNull_ShouldThrowArgumentNullException()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = sut.SetEquals(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that two collections containing the same elements are reported as equal, regardless of order
+    /// or duplicates in the source.
+    /// </summary>
+    [TestMethod]
+    public void SetEquals_WhenSameElementsInDifferentOrder_ShouldReturnTrue()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsTrue(sut.SetEquals(new[] { 3, 2, 1 }));
+        Assert.IsTrue(sut.SetEquals(new[] { 1, 2, 3, 1, 2 }));
+    }
+
+    /// <summary>
+    /// Verifies that differing collections are reported as not equal.
+    /// </summary>
+    [TestMethod]
+    public void SetEquals_WhenContentsDiffer_ShouldReturnFalse()
+    {
+        OrderedSet<int> sut = CreateSet(new[] { 1, 2, 3 });
+
+        Assert.IsFalse(sut.SetEquals(new[] { 1, 2 }));
+        Assert.IsFalse(sut.SetEquals(new[] { 1, 2, 3, 4 }));
+        Assert.IsFalse(sut.SetEquals(new[] { 4, 5, 6 }));
+    }
+
+    /// <summary>
+    /// Verifies that two empty collections are reported as set-equal.
+    /// </summary>
+    [TestMethod]
+    public void SetEquals_WhenBothEmpty_ShouldReturnTrue()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsTrue(sut.SetEquals(Array.Empty<int>()));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic/OrderedSetTests.cs
+++ b/Bodu.Core/test/Collections.Generic/OrderedSetTests.cs
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="OrderedSetTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Collections.Generic;
+
+/// <summary>
+/// Unit tests for <see cref="OrderedSet{T}" />.
+/// </summary>
+[TestClass]
+public partial class OrderedSetTests
+{
+    /// <summary>
+    /// Verifies the happy-path smoke check: adding three unique items preserves insertion order and exposes
+    /// them through the read-only list view.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Add_WhenItemsAreUnique_ShouldPreserveInsertionOrder()
+    {
+        OrderedSet<int> sut = new OrderedSet<int>();
+
+        Assert.IsTrue(sut.Add(1));
+        Assert.IsTrue(sut.Add(2));
+        Assert.IsTrue(sut.Add(3));
+
+        Assert.AreEqual(3, sut.Count);
+        Assert.AreEqual(1, sut[0]);
+        Assert.AreEqual(2, sut[1]);
+        Assert.AreEqual(3, sut[2]);
+    }
+
+    /// <summary>
+    /// Creates an <see cref="OrderedSet{T}" /> seeded with the specified items.
+    /// </summary>
+    /// <param name="items">The items to seed.</param>
+    /// <param name="comparer">An optional comparer.</param>
+    /// <returns>The populated set.</returns>
+    private static OrderedSet<T> CreateSet<T>(IEnumerable<T> items, IEqualityComparer<T>? comparer = null)
+        where T : notnull
+    {
+        OrderedSet<T> set = new OrderedSet<T>(comparer);
+        foreach (T item in items)
+            set.Add(item);
+
+        return set;
+    }
+
+    /// <summary>
+    /// Materialises the elements of <paramref name="set" /> using the public read-only list indexer.
+    /// </summary>
+    /// <param name="set">The set to snapshot.</param>
+    /// <returns>An array containing the elements in insertion order.</returns>
+    private static T[] SnapshotByIndexer<T>(OrderedSet<T> set)
+        where T : notnull
+    {
+        T[] result = new T[set.Count];
+        for (int i = 0; i < set.Count; i++)
+            result[i] = set[i];
+
+        return result;
+    }
+
+    /// <summary>
+    /// Materialises the elements of <paramref name="set" /> using the public enumerator.
+    /// </summary>
+    /// <param name="set">The set to snapshot.</param>
+    /// <returns>A list containing the elements in enumeration order.</returns>
+    private static List<T> SnapshotByEnumerator<T>(OrderedSet<T> set)
+        where T : notnull
+    {
+        List<T> result = new List<T>(set.Count);
+        foreach (T item in set)
+            result.Add(item);
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
This PR refactors `OrderedSet<T>` and `IndexedSet<T>` to share a common internal storage engine via a new `OrderedSetStorage<T>` class. This eliminates code duplication between the two collections while maintaining their distinct public APIs and semantics.

## Key Changes

- **New `OrderedSetStorage<T>` class**: A hand-rolled open-addressing hash table implementation that provides the shared ordered-uniqueness storage engine for both `OrderedSet<T>` and `IndexedSet<T>`. Features include:
  - Contiguous element array for deterministic insertion order
  - Open-addressing hash table with power-of-two bucket counts
  - Automatic rehashing when load factor exceeds 3/4
  - O(1) average-case `Contains` and `IndexOf` operations
  - Version tracking for enumerator invalidation

- **Refactored `IndexedSet<T>`**: Now delegates all storage operations to `OrderedSetStorage<T>`, reducing the class from managing its own hash table to a thin wrapper that exposes the `IList<T>` contract with positional mutation support (`Insert`, `RemoveAt`, `Move`, indexer setter).

- **Refactored `OrderedSet<T>`**: Similarly delegates to `OrderedSetStorage<T>` while exposing the `ISet<T>` contract with set operations (`UnionWith`, `IntersectWith`, `ExceptWith`, `SymmetricExceptWith`, `IsSubsetOf`, `IsSupersetOf`, `SetEquals`).

- **New `Range<T>` and `ValueRange<T>` types**: Extracted from `RangeDictionary<T>` to represent half-open ranges with comparable endpoints.

- **Comprehensive test coverage**: Added extensive test suites for `OrderedSetStorage<T>`, `OrderedSet<T>`, and `IndexedSet<T>` covering constructors, add/remove operations, lookups, capacity management, enumerators, and set operations.

## Implementation Details

- Both `OrderedSet<T>` and `IndexedSet<T>` are now `sealed` classes that wrap a single `OrderedSetStorage<T>` instance
- The storage engine is internal and not thread-safe; consumers are responsible for synchronization
- Elements must be non-null (`where T : notnull`)
- Insertion order is preserved deterministically in a contiguous array
- Hash table uses chaining via a parallel `_next` array for collision resolution
- Version field enables enumerator invalidation detection

https://claude.ai/code/session_01N4Ccpa5UxPwyDBtNdMWD3o