### PR TITLE
Add comprehensive helper methods and tests for cryptographic operations

### DIFF
--- a/Bodu.Security.Cryptography/src/CryptoResourceStrings.Designer.cs
+++ b/Bodu.Security.Cryptography/src/CryptoResourceStrings.Designer.cs
@@ -79,11 +79,74 @@ namespace Bodu {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The initialisation vector must be {0} bits ({1} bytes) long; the supplied IV is {2} bits ({3} bytes)..
+        /// </summary>
+        internal static string ArgumentException_InvalidIVBits {
+            get {
+                return ResourceManager.GetString("ArgumentException_InvalidIVBits", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Invalid IV size {0}. Size of IV must be {1}..
         /// </summary>
         internal static string ArgumentException_InvalidIvLength {
             get {
                 return ResourceManager.GetString("ArgumentException_InvalidIvLength", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input is not a valid {0} padded block sequence..
+        /// </summary>
+        internal static string ArgumentException_InvalidPaddedSequence {
+            get {
+                return ResourceManager.GetString("ArgumentException_InvalidPaddedSequence", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Camellia key must be 16, 24, or 32 bytes in length..
+        /// </summary>
+        internal static string ArgumentException_Camellia_InvalidKeyLength {
+            get {
+                return ResourceManager.GetString("ArgumentException_Camellia_InvalidKeyLength", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The Twofish key must be 16, 24, or 32 bytes in length..
+        /// </summary>
+        internal static string ArgumentException_Twofish_InvalidKeyLength {
+            get {
+                return ResourceManager.GetString("ArgumentException_Twofish_InvalidKeyLength", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skipjack requires an 80-bit key (10 bytes)..
+        /// </summary>
+        internal static string ArgumentException_Skipjack_InvalidKeyLength {
+            get {
+                return ResourceManager.GetString("ArgumentException_Skipjack_InvalidKeyLength", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input must be a multiple of block size when using no padding..
+        /// </summary>
+        internal static string ArgumentException_NoPadding_InputNotAligned {
+            get {
+                return ResourceManager.GetString("ArgumentException_NoPadding_InputNotAligned", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input must be at least {0} bytes (the tag size)..
+        /// </summary>
+        internal static string ArgumentException_InputTooShortForTag {
+            get {
+                return ResourceManager.GetString("ArgumentException_InputTooShortForTag", resourceCulture);
             }
         }
         
@@ -168,6 +231,24 @@ namespace Bodu {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to The hash algorithm's destination buffer was too small..
+        /// </summary>
+        internal static string CryptographicException_HashAlgorithmDestinationBufferTooSmall {
+            get {
+                return ResourceManager.GetString("CryptographicException_HashAlgorithmDestinationBufferTooSmall", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hash algorithm did not produce a value..
+        /// </summary>
+        internal static string CryptographicException_HashAlgorithmDidNotProduceValue {
+            get {
+                return ResourceManager.GetString("CryptographicException_HashAlgorithmDidNotProduceValue", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Invalid hash size: The hash size must be a positive multiple of {0} bytes..
         /// </summary>
@@ -257,6 +338,15 @@ namespace Bodu {
                 return ResourceManager.GetString("CryptographicException_InvalidPadding", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid {0} padding..
+        /// </summary>
+        internal static string CryptographicException_InvalidPaddingScheme {
+            get {
+                return ResourceManager.GetString("CryptographicException_InvalidPaddingScheme", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to The specified value for &apos;{0}&apos; is not supported by this algorithm..
@@ -330,6 +420,15 @@ namespace Bodu {
             }
         }
         
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported padding mode: {0}..
+        /// </summary>
+        internal static string CryptographicException_UnsupportedPaddingMode {
+            get {
+                return ResourceManager.GetString("CryptographicException_UnsupportedPaddingMode", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The customization string must be set before any data is absorbed..
         /// </summary>
@@ -421,11 +520,92 @@ namespace Bodu {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The cipher factory returned null..
+        /// </summary>
+        internal static string InvalidOperationException_CipherFactoryReturnedNull {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_CipherFactoryReturnedNull", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The MemoryStream does not expose its underlying buffer..
+        /// </summary>
+        internal static string InvalidOperationException_MemoryStreamBufferInaccessible {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_MemoryStreamBufferInaccessible", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No input data was provided..
+        /// </summary>
+        internal static string InvalidOperationException_NoInputData {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_NoInputData", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skein bypasses the BlockHashAlgorithm PadBlock pipeline; UBI encodes message length in the tweak..
+        /// </summary>
+        internal static string InvalidOperationException_SkeinBypassesPadBlock {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_SkeinBypassesPadBlock", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skein bypasses the BlockHashAlgorithm ProcessBlock pipeline; UBI lookahead requires HashCore / HashFinal to drive compression directly..
+        /// </summary>
+        internal static string InvalidOperationException_SkeinBypassesProcessBlock {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_SkeinBypassesProcessBlock", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Skein bypasses the BlockHashAlgorithm ProcessFinalBlock pipeline; the OUTPUT UBI phase is driven from HashFinal..
+        /// </summary>
+        internal static string InvalidOperationException_SkeinBypassesProcessFinalBlock {
+            get {
+                return ResourceManager.GetString("InvalidOperationException_SkeinBypassesProcessFinalBlock", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The cryptographic transform has already been finalized and cannot be reused..
         /// </summary>
         internal static string InvalidOperationException_TransformAlreadyFinalized {
             get {
                 return ResourceManager.GetString("InvalidOperationException_TransformAlreadyFinalized", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AAD must be shorter than {0} bytes for {1}-byte length encoding..
+        /// </summary>
+        internal static string NotSupportedException_AadTooLongForLengthEncoding {
+            get {
+                return ResourceManager.GetString("NotSupportedException_AadTooLongForLengthEncoding", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Poly1305 does not use block padding..
+        /// </summary>
+        internal static string NotSupportedException_Poly1305DoesNotUsePadding {
+            get {
+                return ResourceManager.GetString("NotSupportedException_Poly1305DoesNotUsePadding", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The cipher mode '{0}' is not supported..
+        /// </summary>
+        internal static string NotSupportedException_UnsupportedCipherMode {
+            get {
+                return ResourceManager.GetString("NotSupportedException_UnsupportedCipherMode", resourceCulture);
             }
         }
     }

--- a/Bodu.Security.Cryptography/src/CryptoResourceStrings.resx
+++ b/Bodu.Security.Cryptography/src/CryptoResourceStrings.resx
@@ -240,4 +240,64 @@
   <data name="CryptographicException_CtrCounterWrapped" xml:space="preserve">
     <value>The CTR counter has wrapped to its initial value. Continuing would reuse the keystream.</value>
   </data>
+  <data name="ArgumentException_InvalidIVBits" xml:space="preserve">
+    <value>The initialisation vector must be {0} bits ({1} bytes) long; the supplied IV is {2} bits ({3} bytes).</value>
+  </data>
+  <data name="ArgumentException_InvalidPaddedSequence" xml:space="preserve">
+    <value>Input is not a valid {0} padded block sequence.</value>
+  </data>
+  <data name="ArgumentException_Camellia_InvalidKeyLength" xml:space="preserve">
+    <value>The Camellia key must be 16, 24, or 32 bytes in length.</value>
+  </data>
+  <data name="ArgumentException_Twofish_InvalidKeyLength" xml:space="preserve">
+    <value>The Twofish key must be 16, 24, or 32 bytes in length.</value>
+  </data>
+  <data name="ArgumentException_Skipjack_InvalidKeyLength" xml:space="preserve">
+    <value>Skipjack requires an 80-bit key (10 bytes).</value>
+  </data>
+  <data name="ArgumentException_NoPadding_InputNotAligned" xml:space="preserve">
+    <value>Input must be a multiple of block size when using no padding.</value>
+  </data>
+  <data name="ArgumentException_InputTooShortForTag" xml:space="preserve">
+    <value>Input must be at least {0} bytes (the tag size).</value>
+  </data>
+  <data name="CryptographicException_HashAlgorithmDestinationBufferTooSmall" xml:space="preserve">
+    <value>The hash algorithm's destination buffer was too small.</value>
+  </data>
+  <data name="CryptographicException_HashAlgorithmDidNotProduceValue" xml:space="preserve">
+    <value>Hash algorithm did not produce a value.</value>
+  </data>
+  <data name="CryptographicException_InvalidPaddingScheme" xml:space="preserve">
+    <value>Invalid {0} padding.</value>
+  </data>
+  <data name="CryptographicException_UnsupportedPaddingMode" xml:space="preserve">
+    <value>Unsupported padding mode: {0}.</value>
+  </data>
+  <data name="InvalidOperationException_CipherFactoryReturnedNull" xml:space="preserve">
+    <value>The cipher factory returned null.</value>
+  </data>
+  <data name="InvalidOperationException_MemoryStreamBufferInaccessible" xml:space="preserve">
+    <value>The MemoryStream does not expose its underlying buffer.</value>
+  </data>
+  <data name="InvalidOperationException_NoInputData" xml:space="preserve">
+    <value>No input data was provided.</value>
+  </data>
+  <data name="InvalidOperationException_SkeinBypassesPadBlock" xml:space="preserve">
+    <value>Skein bypasses the BlockHashAlgorithm PadBlock pipeline; UBI encodes message length in the tweak.</value>
+  </data>
+  <data name="InvalidOperationException_SkeinBypassesProcessBlock" xml:space="preserve">
+    <value>Skein bypasses the BlockHashAlgorithm ProcessBlock pipeline; UBI lookahead requires HashCore / HashFinal to drive compression directly.</value>
+  </data>
+  <data name="InvalidOperationException_SkeinBypassesProcessFinalBlock" xml:space="preserve">
+    <value>Skein bypasses the BlockHashAlgorithm ProcessFinalBlock pipeline; the OUTPUT UBI phase is driven from HashFinal.</value>
+  </data>
+  <data name="NotSupportedException_AadTooLongForLengthEncoding" xml:space="preserve">
+    <value>AAD must be shorter than {0} bytes for {1}-byte length encoding.</value>
+  </data>
+  <data name="NotSupportedException_Poly1305DoesNotUsePadding" xml:space="preserve">
+    <value>Poly1305 does not use block padding.</value>
+  </data>
+  <data name="NotSupportedException_UnsupportedCipherMode" xml:space="preserve">
+    <value>The cipher mode '{0}' is not supported.</value>
+  </data>
 </root>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -177,7 +177,7 @@ public static class AeadBlockCipherModeTransformExtensions
 
         if (ciphertextWithTag.Length < transform.TagSize)
             throw new ArgumentException(
-                $"Input must be at least {transform.TagSize} bytes (the tag size).",
+                string.Format(CryptoResourceStrings.ArgumentException_InputTooShortForTag, transform.TagSize),
                 nameof(ciphertextWithTag));
 
         transform.ProcessAssociatedData(associatedData);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.Transform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.Transform.cs
@@ -207,9 +207,7 @@ public static partial class ICryptoTransformExtensions
         cryptoStream.Write(input);
         cryptoStream.FlushFinalBlock();
 
-        if (!ms.TryGetBuffer(out ArraySegment<byte> segment))
-            throw new InvalidOperationException("Failed to access the internal transformed data buffer.");
-
+        ArraySegment<byte> segment = CryptoHelpers.GetBufferOrThrowIfInaccessible(ms);
         segment.AsSpan().CopyTo(destination);
         return segment.Count;
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.TransformAsync.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.TransformAsync.cs
@@ -200,9 +200,7 @@ public static partial class ICryptoTransformExtensions
 
             await cryptoStream.FlushFinalBlockAsync(cancellationToken).ConfigureAwait(false);
 
-            if (!ms.TryGetBuffer(out ArraySegment<byte> segment))
-                throw new InvalidOperationException("Failed to access the internal transformed data buffer.");
-
+            ArraySegment<byte> segment = CryptoHelpers.GetBufferOrThrowIfInaccessible(ms);
             segment.AsSpan().CopyTo(destination.Span);
             completed = true;
             return segment.Count;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -88,7 +88,7 @@ public sealed class Ansix923Padding : IPaddingStrategy
 
         // Constant-time verification to mitigate CBC padding-oracle attacks.
         if (input.Length == 0 || input.Length % blockSize != 0)
-            throw new ArgumentException("Input is not a valid ANSI X.923 padded block sequence.", nameof(input));
+            CryptoHelpers.ThrowInvalidPaddedSequence("ANSI X.923", nameof(input));
 
         var length = input.Length;
         int padLen = input[length - 1];
@@ -123,7 +123,7 @@ public sealed class Ansix923Padding : IPaddingStrategy
         }
 
         if (valid == 0)
-            throw new CryptographicException("Invalid ANSI X.923 padding.");
+            CryptoHelpers.ThrowInvalidPadding("ANSI X.923");
 
         return input[..(length - padLen)].ToArray();
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
@@ -84,7 +84,8 @@ public static class BlockCipherModeFactory
                 return new CtrModeTransform(cipher, iv!);
 
             default:
-                throw new NotSupportedException($"The cipher mode '{mode}' is not supported.");
+                throw new NotSupportedException(
+                    string.Format(CryptoResourceStrings.NotSupportedException_UnsupportedCipherMode, mode));
         }
     }
 
@@ -102,13 +103,20 @@ public static class BlockCipherModeFactory
     {
         if (iv is null)
         {
-            throw new ArgumentException("An initialisation vector is required for this mode.", name);
+            throw new ArgumentException(
+                CryptoResourceStrings.CryptographicException_IVRequiredForMode,
+                name);
         }
 
         if (iv.Length != requiredLength)
         {
             throw new ArgumentException(
-                $"The initialisation vector must be {requiredLength * 8} bits ({requiredLength} bytes) long; the supplied IV is {iv.Length * 8} bits ({iv.Length} bytes).",
+                string.Format(
+                    CryptoResourceStrings.ArgumentException_InvalidIVBits,
+                    requiredLength * 8,
+                    requiredLength,
+                    iv.Length * 8,
+                    iv.Length),
                 name);
         }
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CamelliaBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CamelliaBlockCipher.cs
@@ -122,7 +122,9 @@ public sealed class CamelliaBlockCipher
     public CamelliaBlockCipher(ReadOnlySpan<byte> key)
     {
         if (key.Length is not (Key128SizeInBytes or Key192SizeInBytes or Key256SizeInBytes))
-            throw new ArgumentException("The Camellia key must be 16, 24, or 32 bytes in length.", nameof(key));
+            throw new ArgumentException(
+                CryptoResourceStrings.ArgumentException_Camellia_InvalidKeyLength,
+                nameof(key));
 
         _usesExtendedKeySchedule = key.Length > Key128SizeInBytes;
         _kw = new ulong[4];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -247,7 +247,8 @@ public sealed class CcmModeTransform
         if (hasAad)
         {
             if (aad.Length >= 0xFF00)
-                throw new NotSupportedException("AAD must be shorter than 65280 bytes for 2-byte length encoding.");
+                throw new NotSupportedException(
+                    string.Format(CryptoResourceStrings.NotSupportedException_AadTooLongForLengthEncoding, 0xFF00, 2));
 
             // Encode: 2-byte length + aad + zero-padding to block multiple.
             var encodedLen = 2 + aad.Length;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.DisposeHelpers.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.DisposeHelpers.cs
@@ -151,13 +151,11 @@ internal static partial class CryptoHelpers
     /// </remarks>
     public static void ClearAndNullify(MemoryStream stream)
     {
-        ArgumentNullException.ThrowIfNull(stream);
+        ArraySegment<byte> segment = CryptoHelpers.GetBufferOrThrowIfInaccessible(stream);
 
-        if (!stream.TryGetBuffer(out ArraySegment<byte> segment) || segment.Array is null)
-        {
+        if (segment.Array is null)
             throw new InvalidOperationException(
-                "The MemoryStream does not expose its underlying buffer.");
-        }
+                CryptoResourceStrings.InvalidOperationException_MemoryStreamBufferInaccessible);
 
         CryptographicOperations.ZeroMemory(segment.Array.AsSpan(0, segment.Array.Length));
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.ThrowHelper.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.ThrowHelper.cs
@@ -367,4 +367,129 @@ internal static partial class CryptoHelpers
                     CryptoHelpers.FormatLegalSizes(legalBlockSizes)),
                 paramValueName);
     }
+
+    /// <summary>
+    /// Throws a <see cref="CryptographicException" /> indicating that the input contains invalid padding for the specified scheme.
+    /// </summary>
+    /// <param name="paddingScheme">The name of the padding scheme reported in the exception message (for example <c>"PKCS#7"</c>).</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="paddingScheme" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="CryptographicException">
+    /// Always thrown when invoked; the exception message identifies the failing <paramref name="paddingScheme" />.
+    /// </exception>
+    /// <remarks>
+    /// Intended for use after a constant-time padding validation has determined that the trailing bytes do not match the
+    /// expected layout. The exception type matches the framework convention for invalid padding so that consumers can
+    /// catch <see cref="CryptographicException" /> uniformly.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    public static void ThrowInvalidPadding(string paddingScheme)
+    {
+        ThrowHelper.ThrowIfNull(paddingScheme);
+        throw new CryptographicException(
+            string.Format(CryptoResourceStrings.CryptographicException_InvalidPaddingScheme, paddingScheme));
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> indicating that the supplied input is not a valid padded block sequence
+    /// for the specified scheme.
+    /// </summary>
+    /// <param name="paddingScheme">The name of the padding scheme reported in the exception message (for example <c>"PKCS#7"</c>).</param>
+    /// <param name="paramName">The name of the parameter whose value was rejected.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="paddingScheme" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Always thrown when invoked; the exception message identifies the failing <paramref name="paddingScheme" />.
+    /// </exception>
+    /// <remarks>
+    /// Used by <c>Unpad</c> entry points when the input length is not a positive multiple of the block size, signalling
+    /// that the caller passed something other than the output of a matching <c>Pad</c> operation.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    public static void ThrowInvalidPaddedSequence(string paddingScheme, string? paramName)
+    {
+        ThrowHelper.ThrowIfNull(paddingScheme);
+        throw new ArgumentException(
+            string.Format(CryptoResourceStrings.ArgumentException_InvalidPaddedSequence, paddingScheme),
+            paramName);
+    }
+
+    /// <summary>
+    /// Throws a <see cref="CryptographicException" /> when <paramref name="success" /> is <see langword="false" />,
+    /// indicating that <see cref="HashAlgorithm.TryComputeHash" /> failed because the destination buffer was too small.
+    /// </summary>
+    /// <param name="success">
+    /// The result returned from <see cref="HashAlgorithm.TryComputeHash" /> or an equivalent call.
+    /// </param>
+    /// <exception cref="CryptographicException">
+    /// Thrown when <paramref name="success" /> is <see langword="false" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfHashAlgorithmDestinationTooSmall(bool success)
+    {
+        if (!success)
+            throw new CryptographicException(
+                CryptoResourceStrings.CryptographicException_HashAlgorithmDestinationBufferTooSmall);
+    }
+
+    /// <summary>
+    /// Throws a <see cref="CryptographicException" /> when <paramref name="hash" /> is <see langword="null" />,
+    /// indicating that the hash algorithm completed without producing a hash value.
+    /// </summary>
+    /// <param name="hash">The hash value returned by the algorithm, or <see langword="null" /> if no value was produced.</param>
+    /// <returns>The non-<see langword="null" /> <paramref name="hash" /> value.</returns>
+    /// <exception cref="CryptographicException">
+    /// Thrown when <paramref name="hash" /> is <see langword="null" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static byte[] ThrowIfHashAlgorithmProducedNoValue(byte[]? hash) =>
+        hash ?? throw new CryptographicException(
+            CryptoResourceStrings.CryptographicException_HashAlgorithmDidNotProduceValue);
+
+    /// <summary>
+    /// Throws a <see cref="CryptographicException" /> indicating that the specified padding mode is not supported.
+    /// </summary>
+    /// <typeparam name="T">The enumeration type representing the padding mode (for example <see cref="PaddingMode" /> or <see cref="BlockPaddingMode" />).</typeparam>
+    /// <param name="mode">The unsupported padding mode value.</param>
+    /// <exception cref="CryptographicException">
+    /// Always thrown when invoked; the exception message identifies the rejected <paramref name="mode" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [System.Diagnostics.CodeAnalysis.DoesNotReturn]
+    public static void ThrowUnsupportedPaddingMode<T>(T mode)
+        where T : struct, Enum =>
+        throw new CryptographicException(
+            string.Format(CryptoResourceStrings.CryptographicException_UnsupportedPaddingMode, mode));
+
+    /// <summary>
+    /// Retrieves the underlying buffer of <paramref name="stream" /> via
+    /// <see cref="MemoryStream.TryGetBuffer(out ArraySegment{byte})" />, or throws an
+    /// <see cref="InvalidOperationException" /> if the buffer is not exposed.
+    /// </summary>
+    /// <param name="stream">The <see cref="MemoryStream" /> whose buffer is required.</param>
+    /// <returns>The <see cref="ArraySegment{T}" /> describing the active portion of the stream's buffer.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the supplied <see cref="MemoryStream" /> was constructed in a mode that does not expose its underlying buffer.
+    /// </exception>
+    /// <remarks>
+    /// Used by transform helpers that rely on zero-copy access to the stream's buffer; the failure mode corresponds to the
+    /// <see cref="MemoryStream(byte[], bool)" /> overload used to suppress buffer publication.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static ArraySegment<byte> GetBufferOrThrowIfInaccessible(MemoryStream stream)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+        if (!stream.TryGetBuffer(out ArraySegment<byte> segment))
+            throw new InvalidOperationException(
+                CryptoResourceStrings.InvalidOperationException_MemoryStreamBufferInaccessible);
+
+        return segment;
+    }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -126,7 +126,8 @@ public sealed class GcmSivModeTransform
         {
             this._authKey = authKey;
             this._encCipher = cipherFactory(encKeyMaterial)
-                ?? throw new InvalidOperationException("The cipher factory returned null.");
+                ?? throw new InvalidOperationException(
+                    CryptoResourceStrings.InvalidOperationException_CipherFactoryReturnedNull);
         }
         catch
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
@@ -71,8 +71,8 @@ public static class HashAlgorithmHelper
         using T algorithm = factory.Create();
         var hashSizeBytes = algorithm.HashSize >> 3;
         var result = new byte[hashSizeBytes];
-        if (!algorithm.TryComputeHash(input, result, out var bytesWritten))
-            throw new CryptographicException("The hash algorithm's destination buffer was too small.");
+        CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(
+            algorithm.TryComputeHash(input, result, out var bytesWritten));
         if (bytesWritten == result.Length)
             return result;
 
@@ -99,7 +99,7 @@ public static class HashAlgorithmHelper
         using T algorithm = factory.Create();
         AppendDataFromStreamInternal(algorithm, stream);
 
-        return algorithm.Hash ?? throw new CryptographicException("Hash algorithm did not produce a value.");
+        return CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(algorithm.Hash);
     }
 
     /// <summary>
@@ -124,7 +124,7 @@ public static class HashAlgorithmHelper
         using T algorithm = factory.Create();
         await AppendDataFromStreamInternalAsync(algorithm, stream, cancellationToken).ConfigureAwait(false);
 
-        return algorithm.Hash ?? throw new CryptographicException("Hash algorithm did not produce a value.");
+        return CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(algorithm.Hash);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -95,14 +95,14 @@ public sealed class Iso10126Padding : IPaddingStrategy
                 string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
 
         if (input.Length == 0 || input.Length % blockSize != 0)
-            throw new ArgumentException("Input is not a valid ISO 10126 padded block sequence.", nameof(input));
+            CryptoHelpers.ThrowInvalidPaddedSequence("ISO 10126", nameof(input));
 
         var length = input.Length;
         int padLen = input[length - 1];
 
         // Only the trailing length byte can be validated; interior pad bytes are random.
         if (padLen < 1 || padLen > blockSize)
-            throw new CryptographicException("Invalid ISO 10126 padding.");
+            CryptoHelpers.ThrowInvalidPadding("ISO 10126");
 
         return input[..(length - padLen)].ToArray();
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -88,7 +88,7 @@ public sealed class Iso7816_4Padding : IPaddingStrategy
                 string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
 
         if (input.Length == 0 || input.Length % blockSize != 0)
-            throw new ArgumentException("Input is not a valid ISO/IEC 7816-4 padded block sequence.", nameof(input));
+            CryptoHelpers.ThrowInvalidPaddedSequence("ISO/IEC 7816-4", nameof(input));
 
         var length = input.Length;
         var start = length - blockSize;
@@ -128,7 +128,7 @@ public sealed class Iso7816_4Padding : IPaddingStrategy
         }
 
         if (terminatorSeen == 0 || valid == 0)
-            throw new CryptographicException("Invalid ISO/IEC 7816-4 padding.");
+            CryptoHelpers.ThrowInvalidPadding("ISO/IEC 7816-4");
 
         return input[..terminatorIndex].ToArray();
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -324,8 +324,8 @@ public sealed class MerkleTreeHash : IDisposable
     {
         using HashAlgorithm hasher = this._algorithmFactory();
         var result = new byte[hasher.HashSize >> 3];
-        if (!hasher.TryComputeHash(span, result, out var bytesWritten))
-            throw new CryptographicException("The hash algorithm's destination buffer was too small.");
+        CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(
+            hasher.TryComputeHash(span, result, out var bytesWritten));
         if (bytesWritten == result.Length)
             return result;
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -57,7 +57,9 @@ public sealed class NoPadding : IPaddingStrategy
                 string.Format(CryptoResourceStrings.ArgumentOutOfRangeException_BlockSizeMustBeGreaterThan, 0));
 
         if (input.Length % blockSize != 0)
-            throw new ArgumentException("Input must be a multiple of block size when using no padding.", nameof(input));
+            throw new ArgumentException(
+                CryptoResourceStrings.ArgumentException_NoPadding_InputNotAligned,
+                nameof(input));
         return input.ToArray();
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
@@ -45,7 +45,8 @@ public static class PaddingFactory
         PaddingMode.None => new NoPadding(),
         PaddingMode.ANSIX923 => new Ansix923Padding(),
         PaddingMode.ISO10126 => new Iso10126Padding(),
-        _ => throw new CryptographicException($"Unsupported padding mode: {mode}")
+        _ => throw new CryptographicException(
+            string.Format(CryptoResourceStrings.CryptographicException_UnsupportedPaddingMode, mode))
     };
 
     /// <summary>
@@ -63,6 +64,7 @@ public static class PaddingFactory
         BlockPaddingMode.ANSIX923 => new Ansix923Padding(),
         BlockPaddingMode.ISO10126 => new Iso10126Padding(),
         BlockPaddingMode.ISO7816_4 => new Iso7816_4Padding(),
-        _ => throw new CryptographicException($"Unsupported padding mode: {mode}")
+        _ => throw new CryptographicException(
+            string.Format(CryptoResourceStrings.CryptographicException_UnsupportedPaddingMode, mode))
     };
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -631,7 +631,8 @@ public sealed class ParallelMerkleTreeHash : IDisposable
 #pragma warning restore VSTHRD003
         }
 
-        return this._rootHash ?? throw new InvalidOperationException("No input data was provided.");
+        return this._rootHash ?? throw new InvalidOperationException(
+            CryptoResourceStrings.InvalidOperationException_NoInputData);
     }
 
     /// <summary>
@@ -677,8 +678,8 @@ public sealed class ParallelMerkleTreeHash : IDisposable
     {
         using var hasher = this._algorithmFactory();
         var result = new byte[hasher.HashSize / 8];
-        if (!hasher.TryComputeHash(data, result, out _))
-            throw new CryptographicException("TryComputeHash returned false; the output buffer may be too small.");
+        CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(
+            hasher.TryComputeHash(data, result, out _));
         return result;
     }
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -89,7 +89,7 @@ public sealed class Pkcs7Padding : IPaddingStrategy
 
         // Constant-time padding verification to mitigate CBC padding-oracle attacks (Vaudenay 2002).
         if (input.Length == 0 || input.Length % blockSize != 0)
-            throw new ArgumentException("Input is not a valid PKCS#7 padded block sequence.", nameof(input));
+            CryptoHelpers.ThrowInvalidPaddedSequence("PKCS#7", nameof(input));
 
         var length = input.Length;
         int padLen = input[length - 1];
@@ -122,7 +122,7 @@ public sealed class Pkcs7Padding : IPaddingStrategy
         }
 
         if (valid == 0)
-            throw new CryptographicException("Invalid PKCS#7 padding.");
+            CryptoHelpers.ThrowInvalidPadding("PKCS#7");
 
         return input[..(length - padLen)].ToArray();
     }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -160,7 +160,8 @@ public sealed class Poly1305
     }
 
     /// <inheritdoc />
-    protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) => throw new NotSupportedException("Poly1305 does not use block padding.");
+    protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) =>
+        throw new NotSupportedException(CryptoResourceStrings.NotSupportedException_Poly1305DoesNotUsePadding);
 
     /// <inheritdoc />
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.cs
@@ -324,7 +324,8 @@ public abstract partial class Skein<T>
     /// <param name="block">Ignored.</param>
     /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
     protected override void ProcessBlock(ReadOnlySpan<byte> block) =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessBlock pipeline; UBI lookahead requires HashCore / HashFinal to drive compression directly.");
+        throw new InvalidOperationException(
+            CryptoResourceStrings.InvalidOperationException_SkeinBypassesProcessBlock);
 
     /// <summary>
     /// Pipeline contract marker — see the section comment above. Skein's UBI tweak field carries the
@@ -335,7 +336,8 @@ public abstract partial class Skein<T>
     /// <returns>Never returns — always throws.</returns>
     /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
     protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm PadBlock pipeline; UBI encodes message length in the tweak.");
+        throw new InvalidOperationException(
+            CryptoResourceStrings.InvalidOperationException_SkeinBypassesPadBlock);
 
     /// <summary>
     /// Pipeline contract marker — see the section comment above. Skein finalises via the OUTPUT UBI phase
@@ -344,7 +346,8 @@ public abstract partial class Skein<T>
     /// <returns>Never returns — always throws.</returns>
     /// <exception cref="InvalidOperationException">Always thrown — this method is not on the happy path.</exception>
     protected override byte[] ProcessFinalBlock() =>
-        throw new InvalidOperationException("Skein bypasses the BlockHashAlgorithm ProcessFinalBlock pipeline; the OUTPUT UBI phase is driven from HashFinal.");
+        throw new InvalidOperationException(
+            CryptoResourceStrings.InvalidOperationException_SkeinBypassesProcessFinalBlock);
 
     /// <summary>
     /// Releases the unmanaged resources used by the algorithm, securely clears all intermediate state, and disposes the

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
@@ -93,7 +93,9 @@ public sealed class SkipjackBlockCipher
     public SkipjackBlockCipher(ReadOnlySpan<byte> keyBytes)
     {
         if (keyBytes.Length != KeySize)
-            throw new ArgumentException("Skipjack requires an 80-bit key (10 bytes).", nameof(keyBytes));
+            throw new ArgumentException(
+                CryptoResourceStrings.ArgumentException_Skipjack_InvalidKeyLength,
+                nameof(keyBytes));
 
         this._key0 = new int[32];
         this._key1 = new int[32];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TwofishBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TwofishBlockCipher.cs
@@ -80,7 +80,9 @@ public sealed class TwofishBlockCipher
     public TwofishBlockCipher(ReadOnlySpan<byte> key)
     {
         if (key.Length is not (16 or 24 or 32))
-            throw new ArgumentException("The Twofish key must be 16, 24, or 32 bytes in length.", nameof(key));
+            throw new ArgumentException(
+                CryptoResourceStrings.ArgumentException_Twofish_InvalidKeyLength,
+                nameof(key));
 
         this.InitialiseKeySchedule(key);
     }

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.Clear.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.Clear.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.Clear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear{T}(Memory{T})"/> zeroes the contents of the supplied
+    /// memory buffer.
+    /// </summary>
+    [TestMethod]
+    public void Clear_Memory_WhenInvoked_ShouldZeroAllBytes()
+    {
+        Memory<byte> memory = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+
+        CryptoHelpers.Clear(memory);
+
+        foreach (var b in memory.Span)
+            Assert.AreEqual(0, b);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear{T}(Span{T})"/> zeroes the contents of the supplied span.
+    /// </summary>
+    [TestMethod]
+    public void Clear_Span_WhenInvoked_ShouldZeroAllBytes()
+    {
+        var array = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+        Span<byte> span = array;
+
+        CryptoHelpers.Clear(span);
+
+        foreach (var b in array)
+            Assert.AreEqual(0, b);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear(byte[])"/> zeroes the contents of the supplied byte array.
+    /// </summary>
+    [TestMethod]
+    public void Clear_ByteArray_WhenInvoked_ShouldZeroAllBytes()
+    {
+        var array = new byte[] { 1, 2, 3, 4 };
+
+        CryptoHelpers.Clear(array);
+
+        Assert.AreEqual(0, array[0]);
+        Assert.AreEqual(0, array[1]);
+        Assert.AreEqual(0, array[2]);
+        Assert.AreEqual(0, array[3]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear(byte[])"/> is a no-op when the supplied array is
+    /// <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void Clear_ByteArray_WhenNull_ShouldNotThrow()
+    {
+        CryptoHelpers.Clear((byte[]?)null);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear{T}(T[])"/> zeroes the contents of the supplied unmanaged array.
+    /// </summary>
+    [TestMethod]
+    public void Clear_GenericArray_WhenInvoked_ShouldZeroAllElements()
+    {
+        var array = new ulong[] { 0x1122334455667788UL, 0x99AABBCCDDEEFF00UL };
+
+        CryptoHelpers.Clear(array);
+
+        Assert.AreEqual(0UL, array[0]);
+        Assert.AreEqual(0UL, array[1]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear{T}(T[])"/> is a no-op when the supplied unmanaged array is
+    /// <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void Clear_GenericArray_WhenNull_ShouldNotThrow()
+    {
+        CryptoHelpers.Clear<ulong>(null!);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.Clear{T}(ref T)"/> zeroes the bytes of the supplied unmanaged value.
+    /// </summary>
+    [TestMethod]
+    public void Clear_RefValue_WhenInvoked_ShouldZeroAllBytes()
+    {
+        ulong value = 0xDEADBEEFCAFEBABEUL;
+
+        CryptoHelpers.Clear(ref value);
+
+        Assert.AreEqual(0UL, value);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ClearAndNullify.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ClearAndNullify.cs
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ClearAndNullify.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ClearAndNullify{T}(ref T[])"/> zeroes the contents of the
+    /// supplied unmanaged array and sets the caller's reference to <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ClearAndNullify_Array_WhenInvoked_ShouldZeroAndNullifyReference()
+    {
+        byte[]? array = new byte[] { 1, 2, 3, 4 };
+
+        CryptoHelpers.ClearAndNullify(ref array);
+
+        Assert.IsNull(array);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ClearAndNullify{T}(ref T[])"/> is a no-op when the supplied
+    /// reference is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ClearAndNullify_Array_WhenNull_ShouldNotThrow()
+    {
+        byte[]? array = null;
+        CryptoHelpers.ClearAndNullify(ref array);
+        Assert.IsNull(array);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ClearAndNullify(MemoryStream)"/> overwrites the underlying buffer,
+    /// resets the stream length, and disposes the supplied <see cref="MemoryStream"/>.
+    /// </summary>
+    [TestMethod]
+    public void ClearAndNullify_MemoryStream_WhenInvoked_ShouldClearAndDispose()
+    {
+        var stream = new MemoryStream();
+        stream.WriteByte(0xAA);
+        stream.WriteByte(0xBB);
+        stream.WriteByte(0xCC);
+
+        CryptoHelpers.ClearAndNullify(stream);
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = stream.Length;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ClearAndNullify(MemoryStream)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the supplied stream is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ClearAndNullify_MemoryStream_WhenNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ClearAndNullify((MemoryStream)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ClearAndNullify(MemoryStream)"/> throws an
+    /// <see cref="InvalidOperationException"/> when the supplied stream was constructed in a mode that suppresses
+    /// buffer publication.
+    /// </summary>
+    [TestMethod]
+    public void ClearAndNullify_MemoryStream_WhenBufferInaccessible_ShouldThrowInvalidOperationException()
+    {
+        var bytes = new byte[] { 0x01, 0x02, 0x03 };
+        var stream = new MemoryStream(bytes, index: 0, count: bytes.Length, writable: false, publiclyVisible: false);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            CryptoHelpers.ClearAndNullify(stream);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.FormatLegalSizes.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.FormatLegalSizes.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.FormatLegalSizes.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.FormatLegalSizes(KeySizes[])"/> returns an empty string when
+    /// the supplied array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void FormatLegalSizes_WhenArrayIsNull_ShouldReturnEmptyString()
+    {
+        var result = CryptoHelpers.FormatLegalSizes(null);
+
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.FormatLegalSizes(KeySizes[])"/> returns an empty string when
+    /// the supplied array is empty.
+    /// </summary>
+    [TestMethod]
+    public void FormatLegalSizes_WhenArrayIsEmpty_ShouldReturnEmptyString()
+    {
+        var result = CryptoHelpers.FormatLegalSizes(Array.Empty<KeySizes>());
+
+        Assert.AreEqual(string.Empty, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.FormatLegalSizes(KeySizes[])"/> returns a single size value when
+    /// the <see cref="KeySizes.SkipSize"/> is zero.
+    /// </summary>
+    [TestMethod]
+    public void FormatLegalSizes_WhenSkipSizeIsZero_ShouldReturnSingleSize()
+    {
+        var sizes = new[] { new KeySizes(128, 128, 0) };
+
+        var result = CryptoHelpers.FormatLegalSizes(sizes);
+
+        Assert.AreEqual("128", result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.FormatLegalSizes(KeySizes[])"/> enumerates each value in the range
+    /// using the supplied skip step.
+    /// </summary>
+    [TestMethod]
+    public void FormatLegalSizes_WhenRangeWithSkip_ShouldReturnAllSteps()
+    {
+        var sizes = new[] { new KeySizes(128, 256, 64) };
+
+        var result = CryptoHelpers.FormatLegalSizes(sizes);
+
+        Assert.AreEqual("128, 192, 256", result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.FormatLegalSizes(KeySizes[])"/> merges values from multiple ranges,
+    /// removes duplicates, and orders them in ascending order.
+    /// </summary>
+    [TestMethod]
+    public void FormatLegalSizes_WhenMultipleRanges_ShouldDeduplicateAndOrderAscending()
+    {
+        var sizes = new[]
+        {
+            new KeySizes(256, 256, 0),
+            new KeySizes(128, 192, 64)
+        };
+
+        var result = CryptoHelpers.FormatLegalSizes(sizes);
+
+        Assert.AreEqual("128, 192, 256", result);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.GetBufferOrThrowIfInaccessible.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.GetBufferOrThrowIfInaccessible.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.GetBufferOrThrowIfInaccessible.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.GetBufferOrThrowIfInaccessible(MemoryStream)"/> returns the underlying
+    /// buffer segment when the <see cref="MemoryStream"/> was constructed in publicly visible mode.
+    /// </summary>
+    [TestMethod]
+    public void GetBufferOrThrowIfInaccessible_WhenStreamExposesBuffer_ShouldReturnSegment()
+    {
+        using var stream = new MemoryStream();
+        stream.WriteByte(0x01);
+        stream.WriteByte(0x02);
+
+        var segment = CryptoHelpers.GetBufferOrThrowIfInaccessible(stream);
+
+        Assert.IsNotNull(segment.Array);
+        Assert.AreEqual(2, segment.Count);
+        Assert.AreEqual(0x01, segment.Array[segment.Offset]);
+        Assert.AreEqual(0x02, segment.Array[segment.Offset + 1]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.GetBufferOrThrowIfInaccessible(MemoryStream)"/> returns a segment
+    /// with a zero count for an empty stream.
+    /// </summary>
+    [TestMethod]
+    public void GetBufferOrThrowIfInaccessible_WhenStreamIsEmpty_ShouldReturnEmptySegment()
+    {
+        using var stream = new MemoryStream();
+
+        var segment = CryptoHelpers.GetBufferOrThrowIfInaccessible(stream);
+
+        Assert.AreEqual(0, segment.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.GetBufferOrThrowIfInaccessible(MemoryStream)"/> throws an
+    /// <see cref="InvalidOperationException"/> when the <see cref="MemoryStream"/> was constructed in a mode
+    /// that suppresses buffer publication.
+    /// </summary>
+    [TestMethod]
+    public void GetBufferOrThrowIfInaccessible_WhenStreamHidesBuffer_ShouldThrowInvalidOperationException()
+    {
+        var bytes = new byte[] { 0x01, 0x02, 0x03 };
+        using var stream = new MemoryStream(bytes, index: 0, count: bytes.Length, writable: false, publiclyVisible: false);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = CryptoHelpers.GetBufferOrThrowIfInaccessible(stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.GetBufferOrThrowIfInaccessible(MemoryStream)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the supplied stream is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void GetBufferOrThrowIfInaccessible_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = CryptoHelpers.GetBufferOrThrowIfInaccessible(null!);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfAlreadyCompleted.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfAlreadyCompleted.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfAlreadyCompleted.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAlreadyCompleted(bool)"/> throws an
+    /// <see cref="InvalidOperationException"/> when the transform is reported as completed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAlreadyCompleted_WhenCompleted_ShouldThrowInvalidOperationException()
+    {
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            CryptoHelpers.ThrowIfAlreadyCompleted(true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAlreadyCompleted(bool)"/> does not throw when the
+    /// transform is not yet completed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAlreadyCompleted_WhenNotCompleted_ShouldNotThrow()
+    {
+        CryptoHelpers.ThrowIfAlreadyCompleted(false);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfArrayOffsetOrCountInvalid.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfArrayOffsetOrCountInvalid.cs
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfArrayOffsetOrCountInvalid.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(Array, int, int, string, string, string)"/>
+    /// does not throw when the offset and count describe a valid segment.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 8)]
+    [DataRow(2, 4)]
+    [DataRow(0, 0)]
+    [DataRow(8, 0)]
+    public void ThrowIfArrayOffsetOrCountInvalid_WhenSegmentIsValid_ShouldNotThrow(int offset, int count)
+    {
+        var array = new byte[8];
+        CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(array, offset, count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(Array, int, int, string, string, string)"/>
+    /// throws an <see cref="ArgumentNullException"/> when the array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfArrayOffsetOrCountInvalid_WhenArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(null!, 0, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(Array, int, int, string, string, string)"/>
+    /// throws an <see cref="ArgumentOutOfRangeException"/> when the offset is negative or exceeds the array length.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1, 0)]
+    [DataRow(9, 0)]
+    public void ThrowIfArrayOffsetOrCountInvalid_WhenOffsetIsOutOfRange_ShouldThrowArgumentOutOfRangeException(int offset, int count)
+    {
+        var array = new byte[8];
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(array, offset, count);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(Array, int, int, string, string, string)"/>
+    /// throws an <see cref="ArgumentException"/> when the count is negative or exceeds the array length.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, -1)]
+    [DataRow(0, 9)]
+    public void ThrowIfArrayOffsetOrCountInvalid_WhenCountIsInvalid_ShouldThrowArgumentException(int offset, int count)
+    {
+        var array = new byte[8];
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(array, offset, count);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(Array, int, int, string, string, string)"/>
+    /// throws an <see cref="ArgumentException"/> when offset + count exceeds the array length.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfArrayOffsetOrCountInvalid_WhenSegmentExceedsArrayLength_ShouldThrowArgumentException()
+    {
+        var array = new byte[8];
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(array, 4, 5);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfAssociatedData.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfAssociatedData.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfAssociatedData.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAssociatedDataAlreadyProcessed(bool)"/> throws an
+    /// <see cref="InvalidOperationException"/> when associated data has already been processed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAssociatedDataAlreadyProcessed_WhenAlreadyProcessed_ShouldThrowInvalidOperationException()
+    {
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            CryptoHelpers.ThrowIfAssociatedDataAlreadyProcessed(true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAssociatedDataAlreadyProcessed(bool)"/> does not throw
+    /// when associated data has not yet been processed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAssociatedDataAlreadyProcessed_WhenNotProcessed_ShouldNotThrow()
+    {
+        CryptoHelpers.ThrowIfAssociatedDataAlreadyProcessed(false);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAssociatedDataNotProcessed(bool)"/> throws a
+    /// <see cref="CryptographicException"/> when associated data has not yet been processed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAssociatedDataNotProcessed_WhenNotProcessed_ShouldThrowCryptographicException()
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfAssociatedDataNotProcessed(false);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfAssociatedDataNotProcessed(bool)"/> does not throw
+    /// when associated data has been processed.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfAssociatedDataNotProcessed_WhenProcessed_ShouldNotThrow()
+    {
+        CryptoHelpers.ThrowIfAssociatedDataNotProcessed(true);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfCiphertextTooShort.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfCiphertextTooShort.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfCiphertextTooShort.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfCiphertextTooShort(ReadOnlySpan{byte}, int, string)"/>
+    /// does not throw when the input length equals the required tag size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCiphertextTooShort_WhenLengthEqualsTagSize_ShouldNotThrow()
+    {
+        ReadOnlySpan<byte> input = stackalloc byte[16];
+        CryptoHelpers.ThrowIfCiphertextTooShort(input, 16);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfCiphertextTooShort(ReadOnlySpan{byte}, int, string)"/>
+    /// does not throw when the input length exceeds the required tag size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCiphertextTooShort_WhenLengthExceedsTagSize_ShouldNotThrow()
+    {
+        ReadOnlySpan<byte> input = stackalloc byte[32];
+        CryptoHelpers.ThrowIfCiphertextTooShort(input, 16);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfCiphertextTooShort(ReadOnlySpan{byte}, int, string)"/>
+    /// throws an <see cref="ArgumentException"/> when the input cannot accommodate the authentication tag.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfCiphertextTooShort_WhenLengthLessThanTagSize_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            ReadOnlySpan<byte> input = stackalloc byte[4];
+            CryptoHelpers.ThrowIfCiphertextTooShort(input, 16);
+        });
+
+        Assert.AreEqual("input", ex.ParamName);
+        Assert.IsTrue(ex.Message.Contains("16", StringComparison.Ordinal));
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfHashAlgorithmDestinationTooSmall.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfHashAlgorithmDestinationTooSmall.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfHashAlgorithmDestinationTooSmall.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(bool)"/> does not throw
+    /// when the supplied success flag is <see langword="true"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfHashAlgorithmDestinationTooSmall_WhenSuccess_ShouldNotThrow()
+    {
+        CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(true);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(bool)"/> throws a
+    /// <see cref="CryptographicException"/> when the supplied success flag is <see langword="false"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfHashAlgorithmDestinationTooSmall_WhenFailure_ShouldThrowCryptographicException()
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfHashAlgorithmDestinationTooSmall(false);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfHashAlgorithmProducedNoValue.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfHashAlgorithmProducedNoValue.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfHashAlgorithmProducedNoValue.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(byte[])"/> returns the supplied
+    /// hash unchanged when the value is non-<see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfHashAlgorithmProducedNoValue_WhenHashIsNotNull_ShouldReturnSameReference()
+    {
+        var hash = new byte[] { 0x01, 0x02, 0x03 };
+
+        var result = CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(hash);
+
+        Assert.AreSame(hash, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(byte[])"/> returns the supplied
+    /// empty array unchanged when the value is non-<see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfHashAlgorithmProducedNoValue_WhenHashIsEmpty_ShouldReturnSameReference()
+    {
+        var hash = Array.Empty<byte>();
+
+        var result = CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(hash);
+
+        Assert.AreSame(hash, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(byte[])"/> throws a
+    /// <see cref="CryptographicException"/> when the supplied hash is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfHashAlgorithmProducedNoValue_WhenHashIsNull_ShouldThrowCryptographicException()
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = CryptoHelpers.ThrowIfHashAlgorithmProducedNoValue(null);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidBlockSize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidBlockSize.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfInvalidBlockSize.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    private static readonly KeySizes[] LegalBlockSizesForBlockSize = new[] { new KeySizes(128, 128, 0) };
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidBlockSize(byte[], int, KeySizes[], string)"/> does not
+    /// throw when the supplied block matches the expected block size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidBlockSize_WhenBlockSizeMatches_ShouldNotThrow()
+    {
+        var block = new byte[16];
+        CryptoHelpers.ThrowIfInvalidBlockSize(block, 16, LegalBlockSizesForBlockSize);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidBlockSize(byte[], int, KeySizes[], string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the block is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidBlockSize_WhenBlockIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidBlockSize(null!, 16, LegalBlockSizesForBlockSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidBlockSize(byte[], int, KeySizes[], string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the legal-block-sizes array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidBlockSize_WhenLegalBlockSizesIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidBlockSize(new byte[16], 16, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidBlockSize(byte[], int, KeySizes[], string)"/> throws a
+    /// <see cref="CryptographicException"/> when the block length does not match the expected size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(8, 16)]
+    [DataRow(32, 16)]
+    public void ThrowIfInvalidBlockSize_WhenBlockHasWrongLength_ShouldThrowCryptographicException(int actual, int expected)
+    {
+        var block = new byte[actual];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidBlockSize(block, expected, LegalBlockSizesForBlockSize);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidHashSize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidHashSize.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfInvalidHashSize.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidHashSize(int, int[], string)"/> does not throw when
+    /// the hash size is present in the permitted list.
+    /// </summary>
+    [TestMethod]
+    [DataRow(128)]
+    [DataRow(256)]
+    [DataRow(512)]
+    public void ThrowIfInvalidHashSize_WhenSizeIsPermitted_ShouldNotThrow(int size)
+    {
+        CryptoHelpers.ThrowIfInvalidHashSize(size, new[] { 128, 256, 512 });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidHashSize(int, int[], string)"/> throws an
+    /// <see cref="ArgumentOutOfRangeException"/> when the hash size is not present in the permitted list.
+    /// </summary>
+    [TestMethod]
+    [DataRow(64)]
+    [DataRow(200)]
+    [DataRow(1024)]
+    public void ThrowIfInvalidHashSize_WhenSizeIsNotPermitted_ShouldThrowArgumentOutOfRangeException(int size)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidHashSize(size, new[] { 128, 256, 512 });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidHashSize(int, int[], string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the permitted-sizes array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidHashSize_WhenPermittedListIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidHashSize(256, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidHashSize(int, int[], string)"/> includes both the
+    /// rejected size and the list of valid sizes in the exception message.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidHashSize_WhenSizeIsRejected_ShouldIncludeSizeAndValidSizesInMessage()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidHashSize(64, new[] { 128, 256 });
+        });
+
+        Assert.IsTrue(ex.Message.Contains("64", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("128", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("256", StringComparison.Ordinal));
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidIVForMode.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidIVForMode.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfInvalidIVForMode.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    private static readonly KeySizes[] LegalBlockSizes = new[] { new KeySizes(128, 128, 0) };
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidIVForMode(byte[], CipherBlockMode, int, KeySizes[], string)"/>
+    /// does not throw when the IV length equals the block size and the mode requires an IV.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidIVForMode_WhenIVIsValid_ShouldNotThrow()
+    {
+        var iv = new byte[16];
+        CryptoHelpers.ThrowIfInvalidIVForMode(iv, CipherBlockMode.CBC, 16, LegalBlockSizes);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidIVForMode(byte[], CipherBlockMode, int, KeySizes[], string)"/>
+    /// does not throw for <see cref="CipherBlockMode.ECB"/> even when no IV is provided.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidIVForMode_WhenIVNullAndModeIsECB_ShouldNotThrow()
+    {
+        CryptoHelpers.ThrowIfInvalidIVForMode(null, CipherBlockMode.ECB, 16, LegalBlockSizes);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidIVForMode(byte[], CipherBlockMode, int, KeySizes[], string)"/>
+    /// throws a <see cref="CryptographicException"/> when the IV is <see langword="null"/> and the mode requires one.
+    /// </summary>
+    [TestMethod]
+    [DataRow(CipherBlockMode.CBC)]
+    [DataRow(CipherBlockMode.CFB)]
+    [DataRow(CipherBlockMode.OFB)]
+    [DataRow(CipherBlockMode.CTR)]
+    public void ThrowIfInvalidIVForMode_WhenIVNullAndModeRequiresIV_ShouldThrowCryptographicException(CipherBlockMode mode)
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidIVForMode(null, mode, 16, LegalBlockSizes);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidIVForMode(byte[], CipherBlockMode, int, KeySizes[], string)"/>
+    /// throws a <see cref="CryptographicException"/> when the IV length does not match the block size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidIVForMode_WhenIVHasWrongLength_ShouldThrowCryptographicException()
+    {
+        var iv = new byte[8];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidIVForMode(iv, CipherBlockMode.CBC, 16, LegalBlockSizes);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidKeySize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidKeySize.cs
@@ -1,0 +1,68 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfInvalidKeySize.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    private static readonly KeySizes[] LegalKeySizes = new[] { new KeySizes(128, 256, 64) };
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidKeySize(byte[], int, KeySizes[], string)"/> does not
+    /// throw when the supplied key matches the expected size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidKeySize_WhenKeyMatchesExpectedSize_ShouldNotThrow()
+    {
+        var key = new byte[16];
+        CryptoHelpers.ThrowIfInvalidKeySize(key, 16, LegalKeySizes);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidKeySize(byte[], int, KeySizes[], string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the key is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidKeySize_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidKeySize(null!, 16, LegalKeySizes);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidKeySize(byte[], int, KeySizes[], string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the legal-key-sizes array is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidKeySize_WhenLegalKeySizesIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidKeySize(new byte[16], 16, null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidKeySize(byte[], int, KeySizes[], string)"/> throws a
+    /// <see cref="CryptographicException"/> when the key length does not match the expected size.
+    /// </summary>
+    [TestMethod]
+    [DataRow(8, 16)]
+    [DataRow(32, 16)]
+    public void ThrowIfInvalidKeySize_WhenKeyHasWrongLength_ShouldThrowCryptographicException(int actual, int expected)
+    {
+        var key = new byte[actual];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidKeySize(key, expected, LegalKeySizes);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfIvLengthInvalid.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfIvLengthInvalid.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfIvLengthInvalid.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfIvLengthInvalid(byte[], int, string)"/> does not throw when
+    /// the IV length matches the expected length.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfIvLengthInvalid_WhenLengthMatches_ShouldNotThrow()
+    {
+        var iv = new byte[16];
+        CryptoHelpers.ThrowIfIvLengthInvalid(iv, 16);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfIvLengthInvalid(byte[], int, string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the IV is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfIvLengthInvalid_WhenIvIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowIfIvLengthInvalid(null!, 16);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfIvLengthInvalid(byte[], int, string)"/> throws an
+    /// <see cref="ArgumentException"/> when the IV length does not match the expected length.
+    /// </summary>
+    [TestMethod]
+    [DataRow(8, 16)]
+    [DataRow(32, 16)]
+    public void ThrowIfIvLengthInvalid_WhenLengthMismatches_ShouldThrowArgumentException(int actual, int expected)
+    {
+        var iv = new byte[actual];
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CryptoHelpers.ThrowIfIvLengthInvalid(iv, expected);
+        });
+
+        Assert.AreEqual("iv", ex.ParamName);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfNotPositiveMultipleOf.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfNotPositiveMultipleOf.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfNotPositiveMultipleOf.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfNotPositiveMultipleOf{T}(T, T, string)"/> does not
+    /// throw when the value is a positive multiple of the divisor.
+    /// </summary>
+    [TestMethod]
+    [DataRow(8, 8)]
+    [DataRow(16, 8)]
+    [DataRow(64, 32)]
+    public void ThrowIfNotPositiveMultipleOf_WhenValueIsValidMultiple_ShouldNotThrow(int value, int divisor)
+    {
+        CryptoHelpers.ThrowIfNotPositiveMultipleOf(value, divisor);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfNotPositiveMultipleOf{T}(T, T, string)"/> throws a
+    /// <see cref="CryptographicException"/> when the value is not a multiple of the divisor.
+    /// </summary>
+    [TestMethod]
+    [DataRow(7, 8)]
+    [DataRow(15, 8)]
+    [DataRow(33, 16)]
+    public void ThrowIfNotPositiveMultipleOf_WhenValueIsNotMultiple_ShouldThrowCryptographicException(int value, int divisor)
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfNotPositiveMultipleOf(value, divisor);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfNotPositiveMultipleOf{T}(T, T, string)"/> throws a
+    /// <see cref="CryptographicException"/> when the value is zero or negative.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    [DataRow(-8)]
+    public void ThrowIfNotPositiveMultipleOf_WhenValueIsZeroOrNegative_ShouldThrowCryptographicException(int value)
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfNotPositiveMultipleOf(value, 8);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfNotPositiveMultipleOf{T}(T, T, string)"/> throws an
+    /// <see cref="ArgumentOutOfRangeException"/> when the divisor is zero or negative.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    public void ThrowIfNotPositiveMultipleOf_WhenDivisorIsNotPositive_ShouldThrowArgumentOutOfRangeException(int divisor)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CryptoHelpers.ThrowIfNotPositiveMultipleOf(64, divisor);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfOutputBufferTooSmall.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfOutputBufferTooSmall.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfOutputBufferTooSmall.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfOutputBufferTooSmall(Span{byte}, int, string)"/> does not throw
+    /// when the output buffer length matches the required size.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfOutputBufferTooSmall_WhenBufferIsExactSize_ShouldNotThrow()
+    {
+        Span<byte> buffer = stackalloc byte[8];
+        CryptoHelpers.ThrowIfOutputBufferTooSmall(buffer, 8);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfOutputBufferTooSmall(Span{byte}, int, string)"/> does not throw
+    /// when the output buffer is larger than required.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfOutputBufferTooSmall_WhenBufferLargerThanRequired_ShouldNotThrow()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+        CryptoHelpers.ThrowIfOutputBufferTooSmall(buffer, 8);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfOutputBufferTooSmall(Span{byte}, int, string)"/> throws an
+    /// <see cref="ArgumentException"/> when the output buffer is smaller than required.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfOutputBufferTooSmall_WhenBufferTooSmall_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            Span<byte> buffer = stackalloc byte[4];
+            CryptoHelpers.ThrowIfOutputBufferTooSmall(buffer, 8);
+        });
+
+        Assert.AreEqual("buffer", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfOutputBufferTooSmall(Span{byte}, int, string)"/> includes the
+    /// required size in the exception message.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfOutputBufferTooSmall_WhenBufferTooSmall_ShouldIncludeRequiredSizeInMessage()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            Span<byte> buffer = stackalloc byte[4];
+            CryptoHelpers.ThrowIfOutputBufferTooSmall(buffer, 16);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("16", StringComparison.Ordinal));
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfSpanLengthNotPositiveMultipleOf.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfSpanLengthNotPositiveMultipleOf.cs
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfSpanLengthNotPositiveMultipleOf.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf{T}(ReadOnlySpan{T}, int, bool, string)"/>
+    /// does not throw when the span length is a positive multiple of the divisor.
+    /// </summary>
+    [TestMethod]
+    [DataRow(8, 8)]
+    [DataRow(16, 8)]
+    [DataRow(32, 16)]
+    public void ThrowIfSpanLengthNotPositiveMultipleOf_WhenSpanIsValidMultiple_ShouldNotThrow(int length, int divisor)
+    {
+        ReadOnlySpan<byte> span = new byte[length];
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(span, divisor);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf{T}(ReadOnlySpan{T}, int, bool, string)"/>
+    /// throws a <see cref="CryptographicException"/> when the span length is not a multiple of the divisor.
+    /// </summary>
+    [TestMethod]
+    [DataRow(7, 8)]
+    [DataRow(15, 8)]
+    [DataRow(33, 16)]
+    public void ThrowIfSpanLengthNotPositiveMultipleOf_WhenSpanIsNotMultiple_ShouldThrowCryptographicException(int length, int divisor)
+    {
+        ReadOnlySpan<byte> span = new byte[length];
+        var bytes = span.ToArray();
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf<byte>(bytes, divisor);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf{T}(ReadOnlySpan{T}, int, bool, string)"/>
+    /// rejects an empty span by default (<paramref name="throwIfZero"/> defaults to <see langword="true"/>).
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfSpanLengthNotPositiveMultipleOf_WhenSpanIsEmpty_ShouldThrowCryptographicException()
+    {
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf<byte>(Array.Empty<byte>(), 8);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf{T}(ReadOnlySpan{T}, int, bool, string)"/>
+    /// accepts an empty span when <paramref name="throwIfZero"/> is <see langword="false"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfSpanLengthNotPositiveMultipleOf_WhenSpanIsEmptyAndZeroAllowed_ShouldNotThrow()
+    {
+        ReadOnlySpan<byte> empty = Array.Empty<byte>();
+        CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(empty, 8, throwIfZero: false);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf{T}(ReadOnlySpan{T}, int, bool, string)"/>
+    /// throws <see cref="ArgumentOutOfRangeException"/> when the divisor is zero or negative.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0)]
+    [DataRow(-1)]
+    [DataRow(-8)]
+    public void ThrowIfSpanLengthNotPositiveMultipleOf_WhenDivisorNotPositive_ShouldThrowArgumentOutOfRangeException(int divisor)
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf<byte>(new byte[8], divisor);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowInvalidPaddedSequence.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowInvalidPaddedSequence.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowInvalidPaddedSequence.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowInvalidPaddedSequence(string, string)"/> throws an
+    /// <see cref="ArgumentException"/> whose message identifies the supplied padding scheme and whose
+    /// <see cref="ArgumentException.ParamName"/> matches the supplied parameter name.
+    /// </summary>
+    [TestMethod]
+    [DataRow("PKCS#7", "input")]
+    [DataRow("ANSI X.923", "input")]
+    [DataRow("ISO 10126", "input")]
+    [DataRow("ISO/IEC 7816-4", "input")]
+    public void ThrowInvalidPaddedSequence_WhenInvoked_ShouldThrowArgumentExceptionWithSchemeAndParam(
+        string scheme, string paramName)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CryptoHelpers.ThrowInvalidPaddedSequence(scheme, paramName);
+        });
+
+        Assert.IsTrue(ex.Message.Contains(scheme, StringComparison.Ordinal));
+        Assert.AreEqual(paramName, ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowInvalidPaddedSequence(string, string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the padding scheme is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowInvalidPaddedSequence_WhenSchemeIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowInvalidPaddedSequence(null!, "input");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowInvalidPaddedSequence(string, string)"/> accepts a
+    /// <see langword="null"/> parameter name; the produced <see cref="ArgumentException.ParamName"/> is
+    /// <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowInvalidPaddedSequence_WhenParamNameIsNull_ShouldThrowArgumentExceptionWithNullParamName()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CryptoHelpers.ThrowInvalidPaddedSequence("PKCS#7", null!);
+        });
+
+        Assert.IsNull(ex.ParamName);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowInvalidPadding.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowInvalidPadding.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowInvalidPadding.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowInvalidPadding(string)"/> throws a
+    /// <see cref="CryptographicException"/> whose message identifies the supplied padding scheme.
+    /// </summary>
+    [TestMethod]
+    [DataRow("PKCS#7")]
+    [DataRow("ANSI X.923")]
+    [DataRow("ISO 10126")]
+    [DataRow("ISO/IEC 7816-4")]
+    public void ThrowInvalidPadding_WhenInvoked_ShouldThrowCryptographicExceptionWithScheme(string scheme)
+    {
+        var ex = Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowInvalidPadding(scheme);
+        });
+
+        Assert.IsTrue(ex.Message.Contains(scheme, StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowInvalidPadding(string)"/> throws an
+    /// <see cref="ArgumentNullException"/> when the padding scheme is <see langword="null"/>.
+    /// </summary>
+    [TestMethod]
+    public void ThrowInvalidPadding_WhenSchemeIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            CryptoHelpers.ThrowInvalidPadding(null!);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowUnsupportedPaddingMode.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowUnsupportedPaddingMode.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowUnsupportedPaddingMode.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowUnsupportedPaddingMode{T}(T)"/> throws a
+    /// <see cref="CryptographicException"/> for an undefined <see cref="PaddingMode"/> value.
+    /// </summary>
+    [TestMethod]
+    public void ThrowUnsupportedPaddingMode_WhenPaddingModeIsUndefined_ShouldThrowCryptographicException()
+    {
+        var undefined = (PaddingMode)999;
+
+        var ex = Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowUnsupportedPaddingMode(undefined);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("999", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowUnsupportedPaddingMode{T}(T)"/> throws a
+    /// <see cref="CryptographicException"/> for an undefined <see cref="BlockPaddingMode"/> value.
+    /// </summary>
+    [TestMethod]
+    public void ThrowUnsupportedPaddingMode_WhenBlockPaddingModeIsUndefined_ShouldThrowCryptographicException()
+    {
+        var undefined = (BlockPaddingMode)999;
+
+        var ex = Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowUnsupportedPaddingMode(undefined);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("999", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
## Summary
This PR adds a comprehensive set of helper methods to the `CryptoHelpers` class for common cryptographic validation and error handling scenarios, along with extensive unit tests covering all new functionality.

## Key Changes

### New Helper Methods in CryptoHelpers.ThrowHelper.cs
- **`ThrowInvalidPadding(string paddingScheme)`** - Throws `CryptographicException` for invalid padding with constant-time validation support
- **`ThrowInvalidPaddedSequence(string paddingScheme, string? paramName)`** - Throws `ArgumentException` when input is not a valid padded block sequence
- Additional throw helpers for cryptographic validation scenarios

### Resource Strings Added (CryptoResourceStrings.resx)
- `ArgumentException_InvalidIVBits` - IV length validation with bit/byte information
- `ArgumentException_InvalidPaddedSequence` - Invalid padding sequence message
- `ArgumentException_Camellia_InvalidKeyLength` - Camellia-specific key validation
- `ArgumentException_Twofish_InvalidKeyLength` - Twofish-specific key validation
- `ArgumentException_Skipjack_InvalidKeyLength` - Skipjack-specific key validation
- `ArgumentException_NoPadding_InputNotAligned` - No-padding mode alignment validation
- `ArgumentException_InputTooShortForTag` - Tag size validation
- `CryptographicException_HashAlgorithmDestinationBufferTooSmall` - Hash output buffer validation
- `CryptographicException_HashAlgorithmDidNotProduceValue` - Hash algorithm failure detection

### Comprehensive Unit Tests
Added 20+ new test files covering:
- `CryptoHelpersTests.Clear.cs` - Memory/span/array clearing operations
- `CryptoHelpersTests.ClearAndNullify.cs` - Secure clearing with nullification
- `CryptoHelpersTests.ThrowIfArrayOffsetOrCountInvalid.cs` - Array segment validation
- `CryptoHelpersTests.ThrowIfSpanLengthNotPositiveMultipleOf.cs` - Span alignment validation
- `CryptoHelpersTests.FormatLegalSizes.cs` - Key size formatting
- `CryptoHelpersTests.GetBufferOrThrowIfInaccessible.cs` - MemoryStream buffer access
- `CryptoHelpersTests.ThrowIfNotPositiveMultipleOf.cs` - Multiple validation
- `CryptoHelpersTests.ThrowIfInvalidHashSize.cs` - Hash size validation
- `CryptoHelpersTests.ThrowIfInvalidBlockSize.cs` - Block size validation
- `CryptoHelpersTests.ThrowIfInvalidKeySize.cs` - Key size validation
- `CryptoHelpersTests.ThrowIfInvalidIVForMode.cs` - IV mode-specific validation
- `CryptoHelpersTests.ThrowIfOutputBufferTooSmall.cs` - Output buffer validation
- `CryptoHelpersTests.ThrowInvalidPaddedSequence.cs` - Invalid padding sequence handling
- `CryptoHelpersTests.ThrowIfAssociatedData.cs` - AEAD associated data validation
- `CryptoHelpersTests.ThrowIfHashAlgorithmProducedNoValue.cs` - Hash algorithm result validation
- `CryptoHelpersTests.ThrowIfIvLengthInvalid.cs` - IV length validation
- `CryptoHelpersTests.ThrowIfCiphertextTooShort.cs` - Ciphertext length validation
- `CryptoHelpersTests.ThrowUnsupportedPaddingMode.cs` - Padding mode support validation
- `CryptoHelpersTests.ThrowInvalidPadding.cs` - Invalid padding detection
- `CryptoHelpersTests.ThrowIfHashAlgorithmDestinationTooSmall.cs` - Hash destination buffer validation
- `CryptoHelpersTests.ThrowIfAlreadyCompleted.cs` - Transform completion state

https://claude.ai/code/session_01Wh4UtcD9tPeURcxCMZ5QaE