### PR TITLE
test: close coverage gaps in buffer fallbacks, randomize, cache, IsOu…

### DIFF
--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsOutside.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsOutside.cs
@@ -67,6 +67,6 @@ public static partial class IComparableExtensions
                 ? throw new ArgumentNullException(nameof(comparer))
                 : value1 is null || value2 is null ? false
                 : comparer.Compare(value1.Value, value2.Value) > 0
-                    ? comparer.Compare(value, value2.Value) < 0 && comparer.Compare(value, value1.Value) > 0
-                    : comparer.Compare(value, value1.Value) < 0 && comparer.Compare(value, value2.Value) > 0;
+                    ? comparer.Compare(value, value2.Value) < 0 || comparer.Compare(value, value1.Value) > 0
+                    : comparer.Compare(value, value1.Value) < 0 || comparer.Compare(value, value2.Value) > 0;
 }

--- a/Bodu.Core/test/Bodu.Core.Test.csproj
+++ b/Bodu.Core/test/Bodu.Core.Test.csproj
@@ -30,7 +30,6 @@
 
   <!-- Exclude files that are not supported in .net standards -->
   <ItemGroup>
-    <Compile Remove="Collections.Generic.Concurrent\ConcurrentCircularBufferTests.NonGenericInterfaces.cs" />
     <Compile Remove="Collections.Generic.Concurrent\ConcurrentCircularBufferTests.TrimExcess.cs" />
     <Compile Remove="Extensions\DateOnlyExtensionsTests.NextOccurrence.cs" />
   </ItemGroup>

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.BestEffortSnapshot.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.BestEffortSnapshot.cs
@@ -1,0 +1,164 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConcurrentCircularBufferTests.BestEffortSnapshot.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.Collections.Generic.Concurrent;
+
+public partial class ConcurrentCircularBufferTests
+{
+    /// <summary>
+    /// Verifies that the private <c>BestEffortSnapshot</c> fallback returns an empty array when invoked on an empty buffer.
+    /// </summary>
+    [TestMethod]
+    public void BestEffortSnapshot_WhenBufferIsEmpty_ShouldReturnEmptyArray()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(8);
+
+        TestItem[] snapshot = InvokeBestEffortSnapshot(buffer);
+
+        Assert.AreEqual(0, snapshot.Length);
+    }
+
+    /// <summary>
+    /// Verifies that the private <c>BestEffortSnapshot</c> fallback returns the live elements in FIFO order when no concurrent
+    /// mutation is interfering with the slot reads, exercising the happy-path branch of the fallback.
+    /// </summary>
+    [TestMethod]
+    public void BestEffortSnapshot_WhenBufferIsQuiescent_ShouldReturnExpectedFifoOrder()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(4);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+
+        TestItem[] snapshot = InvokeBestEffortSnapshot(buffer);
+
+        CollectionAssert.AreEqual(
+            new[] { 1, 2, 3 },
+            snapshot.Select(x => x.Value).ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that the private <c>BestEffortSnapshot</c> fallback writes <see langword="null" /> for any slot whose sequence number
+    /// disagrees with the expected publication mark — the failure mode the fallback exists to handle — rather than reading a
+    /// torn or stale-generation value.
+    /// </summary>
+    [TestMethod]
+    public void BestEffortSnapshot_WhenSlotCannotBeStabilised_ShouldWriteDefaultForThatSlot()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(4);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+
+        // Corrupt the sequence of the middle slot so TryReadStableSlot rejects it as not-yet-published.
+        // The seqlock pre-check (seqPre != expectedSequence) makes BestEffortSnapshot fall back to
+        // default(T) for that slot, leaving the surrounding slots intact.
+        CorruptSlotSequence(buffer, slotIndex: 1, newSequence: int.MinValue);
+
+        TestItem[] snapshot = InvokeBestEffortSnapshot(buffer);
+
+        Assert.AreEqual(3, snapshot.Length);
+        Assert.IsNotNull(snapshot[0]);
+        Assert.AreEqual(1, snapshot[0].Value);
+        Assert.IsNull(snapshot[1]);
+        Assert.IsNotNull(snapshot[2]);
+        Assert.AreEqual(3, snapshot[2].Value);
+    }
+
+    /// <summary>
+    /// Verifies that the public <see cref="ConcurrentCircularBuffer{T}.ToArray" /> method falls through to <c>BestEffortSnapshot</c>
+    /// and returns a same-length array of default values when every slot's sequence has been forced into an unstable state, exercising
+    /// the <c>return BestEffortSnapshot();</c> branch after the outer retry budget is exhausted.
+    /// </summary>
+    [TestMethod]
+    public void ToArray_WhenAllSlotsAreUnstable_ShouldFallBackToBestEffortSnapshot()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+
+        // Force every slot's published sequence to a non-matching value. With no slot satisfying
+        // the expected publication mark, the seqlock pre-check fails on every retry, exhausting the
+        // outer retry budget and steering ToArray into the BestEffortSnapshot fallback.
+        for (var i = 0; i < 3; i++)
+            CorruptSlotSequence(buffer, slotIndex: i, newSequence: int.MinValue);
+
+        TestItem[] snapshot = buffer.ToArray();
+
+        Assert.AreEqual(3, snapshot.Length);
+        foreach (TestItem item in snapshot)
+            Assert.IsNull(item);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ConcurrentCircularBuffer{T}.Contains" /> returns <see langword="false" /> via the fallback snapshot
+    /// scan when every slot is forced into an unstable state — exercising the post-outer-retry-budget fallback path
+    /// (<c>foreach (T? x in ToArray()) ...</c>) at the end of <c>Contains</c>.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenAllSlotsAreUnstable_ShouldFallBackToSnapshotScanAndReturnFalse()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        var target = new TestItem(42);
+        buffer.Enqueue(target);
+        buffer.Enqueue(new TestItem(99));
+
+        // Corrupt every slot so the in-place seqlock scan inside Contains exhausts its outer
+        // retry budget; the fallback path then reads via ToArray (which itself falls back to
+        // BestEffortSnapshot, writing default for each unstable slot). Default values cannot
+        // match a real element so the final result is false.
+        for (var i = 0; i < 3; i++)
+            CorruptSlotSequence(buffer, slotIndex: i, newSequence: int.MinValue);
+
+        Assert.IsFalse(buffer.Contains(target));
+    }
+
+    /// <summary>
+    /// Invokes the private <c>BestEffortSnapshot</c> method on <paramref name="buffer"/> via reflection.
+    /// </summary>
+    /// <typeparam name="T">The buffer element type.</typeparam>
+    /// <param name="buffer">The buffer to snapshot.</param>
+    /// <returns>The best-effort snapshot produced by the private fallback.</returns>
+    private static T[] InvokeBestEffortSnapshot<T>(ConcurrentCircularBuffer<T> buffer)
+        where T : class?
+    {
+        MethodInfo method = typeof(ConcurrentCircularBuffer<T>).GetMethod(
+            "BestEffortSnapshot",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("BestEffortSnapshot method not found.");
+
+        return (T[])method.Invoke(buffer, Array.Empty<object>())!;
+    }
+
+    /// <summary>
+    /// Overwrites the <c>Sequence</c> field of the slot at <paramref name="slotIndex"/> in <paramref name="buffer"/>'s internal
+    /// array to <paramref name="newSequence"/> via reflection, simulating a torn or unpublished slot that the seqlock pre-check
+    /// will reject.
+    /// </summary>
+    /// <typeparam name="T">The buffer element type.</typeparam>
+    /// <param name="buffer">The buffer whose slot to corrupt.</param>
+    /// <param name="slotIndex">The zero-based physical slot index to modify.</param>
+    /// <param name="newSequence">The sequence value to write into the slot.</param>
+    private static void CorruptSlotSequence<T>(ConcurrentCircularBuffer<T> buffer, int slotIndex, int newSequence)
+        where T : class?
+    {
+        FieldInfo bufferField = typeof(ConcurrentCircularBuffer<T>).GetField(
+            "_buffer",
+            BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("_buffer field not found.");
+
+        Array slotArray = (Array)bufferField.GetValue(buffer)!;
+        object slot = slotArray.GetValue(slotIndex)!;
+        FieldInfo sequenceField = slot.GetType().GetField("Sequence", BindingFlags.Instance | BindingFlags.Public)
+            ?? throw new InvalidOperationException("Slot.Sequence field not found.");
+
+        sequenceField.SetValue(slot, newSequence);
+        slotArray.SetValue(slot, slotIndex);
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.NonGenericInterfaces.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.NonGenericInterfaces.cs
@@ -17,9 +17,32 @@ public partial class ConcurrentCircularBufferTests
     [TestMethod]
     public void IsSynchronized_WhenAccessed_ShouldReturnFalse()
     {
-        var buffer = new ConcurrentCircularBuffer<int>(2);
+        var buffer = new ConcurrentCircularBuffer<TestItem>(2);
         ICollection collection = buffer;
 
+        Assert.IsFalse(collection.IsSynchronized);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ICollection.IsSynchronized" /> remains <see langword="false" /> regardless of whether the buffer is
+    /// empty, partially populated, or full.
+    /// </summary>
+    [TestMethod]
+    public void IsSynchronized_WhenBufferStateVaries_ShouldRemainFalse()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        ICollection collection = buffer;
+
+        Assert.IsFalse(collection.IsSynchronized);
+
+        buffer.Enqueue(new TestItem(1));
+        Assert.IsFalse(collection.IsSynchronized);
+
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+        Assert.IsFalse(collection.IsSynchronized);
+
+        buffer.Clear();
         Assert.IsFalse(collection.IsSynchronized);
     }
 
@@ -31,7 +54,7 @@ public partial class ConcurrentCircularBufferTests
     [TestMethod]
     public void SyncRoot_WhenAccessed_ShouldThrowExactly()
     {
-        var buffer = new ConcurrentCircularBuffer<int>(2);
+        var buffer = new ConcurrentCircularBuffer<TestItem>(2);
         ICollection collection = buffer;
 
         Assert.ThrowsExactly<NotSupportedException>(() =>
@@ -41,40 +64,147 @@ public partial class ConcurrentCircularBufferTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="ICollection.SyncRoot" /> throws <see cref="NotSupportedException" /> on every access — accessing the
+    /// property must never lazily create a lock object that a caller could subsequently lock on.
+    /// </summary>
+    [TestMethod]
+    public void SyncRoot_WhenAccessedRepeatedly_ShouldThrowOnEveryCall()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(2);
+        ICollection collection = buffer;
+
+        for (var i = 0; i < 3; i++)
+        {
+            Assert.ThrowsExactly<NotSupportedException>(() =>
+            {
+                _ = collection.SyncRoot;
+            });
+        }
+    }
+
+    /// <summary>
     /// Verifies that the non-generic <see cref="IEnumerable.GetEnumerator" /> on a
     /// <see cref="ConcurrentCircularBuffer{T}" /> yields the same elements as the strongly typed enumerator.
     /// </summary>
     [TestMethod]
     public void NonGenericGetEnumerator_WhenBufferHasElements_ShouldYieldAllElementsInOrder()
     {
-        var buffer = new ConcurrentCircularBuffer<int>(3);
-        buffer.Enqueue(1);
-        buffer.Enqueue(2);
-        buffer.Enqueue(3);
+        var buffer = new ConcurrentCircularBuffer<string>(3);
+        buffer.Enqueue("a");
+        buffer.Enqueue("b");
+        buffer.Enqueue("c");
 
         IEnumerable nonGeneric = buffer;
-        var observed = new List<int>();
+        var observed = new List<string>();
         foreach (object item in nonGeneric)
-            observed.Add((int)item);
+            observed.Add((string)item);
+
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, observed);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IEnumerable.GetEnumerator" /> on an empty buffer returns an enumerator that immediately reports
+    /// end-of-sequence on the first <see cref="IEnumerator.MoveNext" /> call.
+    /// </summary>
+    [TestMethod]
+    public void NonGenericGetEnumerator_WhenBufferIsEmpty_ShouldReturnEnumeratorThatIsImmediatelyExhausted()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        IEnumerable nonGeneric = buffer;
+
+        IEnumerator enumerator = nonGeneric.GetEnumerator();
+
+        Assert.IsFalse(enumerator.MoveNext());
+    }
+
+    /// <summary>
+    /// Verifies that two enumerators obtained from the non-generic <see cref="IEnumerable.GetEnumerator" /> are independent — exhausting
+    /// one does not affect the other.
+    /// </summary>
+    [TestMethod]
+    public void NonGenericGetEnumerator_WhenCalledTwice_ShouldReturnIndependentSnapshots()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(10));
+        buffer.Enqueue(new TestItem(20));
+
+        IEnumerable nonGeneric = buffer;
+
+        IEnumerator first = nonGeneric.GetEnumerator();
+        IEnumerator second = nonGeneric.GetEnumerator();
+
+        Assert.IsTrue(first.MoveNext());
+        Assert.IsTrue(first.MoveNext());
+        Assert.IsFalse(first.MoveNext());
+
+        // The second enumerator is unaffected by the first being exhausted.
+        Assert.IsTrue(second.MoveNext());
+        Assert.AreEqual(10, ((TestItem)second.Current).Value);
+    }
+
+    /// <summary>
+    /// Verifies that the generic <see cref="IEnumerable{T}.GetEnumerator" /> explicit-interface implementation returns an enumerator
+    /// that walks every element in FIFO order, exercising the explicit interface path independently of the public
+    /// <c>GetEnumerator</c> overload that returns the value-type <c>Enumerator</c> struct.
+    /// </summary>
+    [TestMethod]
+    public void GenericEnumerableGetEnumerator_WhenAccessedThroughInterface_ShouldYieldAllElementsInOrder()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+
+        IEnumerable<TestItem> generic = buffer;
+        var observed = new List<int>();
+        using (IEnumerator<TestItem> enumerator = generic.GetEnumerator())
+        {
+            while (enumerator.MoveNext())
+                observed.Add(enumerator.Current.Value);
+        }
 
         CollectionAssert.AreEqual(new[] { 1, 2, 3 }, observed);
     }
 
     /// <summary>
-    /// Verifies that the non-generic enumerator's <see cref="IEnumerator.Current" /> returns the same value as the strongly typed
-    /// <c>Current</c> after a successful <c>MoveNext</c>.
+    /// Verifies that the non-generic enumerator's <see cref="IEnumerator.Current" /> property returns the same value as the strongly
+    /// typed <c>Current</c> after a successful <c>MoveNext</c>, exercising the explicit
+    /// <see cref="System.Collections.IEnumerator.Current"/> implementation on
+    /// <see cref="ConcurrentCircularBuffer{T}.Enumerator"/>.
     /// </summary>
     [TestMethod]
     public void Enumerator_NonGenericCurrent_AfterMoveNext_ShouldReturnLatestElement()
     {
-        var buffer = new ConcurrentCircularBuffer<int>(2);
-        buffer.Enqueue(99);
+        var buffer = new ConcurrentCircularBuffer<string>(2);
+        buffer.Enqueue("seed");
 
-        using ConcurrentCircularBuffer<int>.Enumerator typed = buffer.GetEnumerator();
+        using ConcurrentCircularBuffer<string>.Enumerator typed = buffer.GetEnumerator();
         IEnumerator legacy = typed;
 
         Assert.IsTrue(typed.MoveNext());
-        Assert.AreEqual(99, legacy.Current);
+        Assert.AreEqual("seed", legacy.Current);
+    }
+
+    /// <summary>
+    /// Verifies that the non-generic enumerator's <see cref="IEnumerator.Current" /> property surfaces each element produced by
+    /// successive <see cref="IEnumerator.MoveNext" /> calls, walking the entire snapshot through the explicit interface.
+    /// </summary>
+    [TestMethod]
+    public void Enumerator_NonGenericCurrent_WhenWalkedToEnd_ShouldReturnEveryElementInOrder()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+        buffer.Enqueue(new TestItem(3));
+
+        ConcurrentCircularBuffer<TestItem>.Enumerator typed = buffer.GetEnumerator();
+        IEnumerator legacy = typed;
+
+        var observed = new List<int>();
+        while (legacy.MoveNext())
+            observed.Add(((TestItem)legacy.Current!).Value);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, observed);
     }
 
     /// <summary>
@@ -84,20 +214,20 @@ public partial class ConcurrentCircularBufferTests
     [TestMethod]
     public void Enumerator_Reset_ShouldRewindToBeginning()
     {
-        var buffer = new ConcurrentCircularBuffer<int>(3);
-        buffer.Enqueue(10);
-        buffer.Enqueue(20);
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(10));
+        buffer.Enqueue(new TestItem(20));
 
-        var enumerator = buffer.GetEnumerator();
+        ConcurrentCircularBuffer<TestItem>.Enumerator enumerator = buffer.GetEnumerator();
         Assert.IsTrue(enumerator.MoveNext());
-        Assert.AreEqual(10, enumerator.Current);
+        Assert.AreEqual(10, enumerator.Current.Value);
 
         enumerator.Reset();
 
         Assert.IsTrue(enumerator.MoveNext());
-        Assert.AreEqual(10, enumerator.Current);
+        Assert.AreEqual(10, enumerator.Current.Value);
         Assert.IsTrue(enumerator.MoveNext());
-        Assert.AreEqual(20, enumerator.Current);
+        Assert.AreEqual(20, enumerator.Current.Value);
         Assert.IsFalse(enumerator.MoveNext());
     }
 }

--- a/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.TryPeek.cs
+++ b/Bodu.Core/test/Collections.Generic.Concurrent/ConcurrentCircularBufferTests.TryPeek.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -303,5 +304,59 @@ public partial class ConcurrentCircularBufferTests
         Assert.IsTrue(buffer.TryPeek(out TestItem? item));
         Assert.IsNotNull(item);
         Assert.AreEqual(2, item!.Value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ConcurrentCircularBuffer{T}.TryPeek" /> retries — rather than returning a stale value — when the
+    /// slot's coordination sequence is observed to be greater than the publication mark, which models the
+    /// "another thread dequeued this slot" race window in the consumer protocol. Once the sequence is corrected back into the
+    /// published state, the peek succeeds and returns the live head element.
+    /// </summary>
+    [TestMethod]
+    public void TryPeek_WhenSlotSequenceIsAheadOfHead_ShouldRetryUntilSequenceRealignsAndSucceed()
+    {
+        var buffer = new ConcurrentCircularBuffer<TestItem>(3);
+        buffer.Enqueue(new TestItem(1));
+        buffer.Enqueue(new TestItem(2));
+
+        FieldInfo bufferField = typeof(ConcurrentCircularBuffer<TestItem>).GetField(
+            "_buffer", BindingFlags.Instance | BindingFlags.NonPublic)!;
+        Array slotArray = (Array)bufferField.GetValue(buffer)!;
+
+        // Read the current head-slot Sequence and pre-bump it so the first iteration of TryPeek
+        // observes diff > 0 (the "stale head read — another thread dequeued this slot" branch).
+        object slot0 = slotArray.GetValue(0)!;
+        FieldInfo sequenceField = slot0.GetType().GetField("Sequence", BindingFlags.Instance | BindingFlags.Public)!;
+        var originalSequence = (int)sequenceField.GetValue(slot0)!;
+
+        sequenceField.SetValue(slot0, originalSequence + 1);
+        slotArray.SetValue(slot0, 0);
+
+        // Run the realign worker on a separate thread that restores the published sequence
+        // shortly after the peek begins. TryPeek has no retry budget on the diff > 0 branch, so
+        // a missed realign would hang the test runner — Task.WaitAll's timeout below converts
+        // that into a test failure instead.
+        Task realignTask = Task.Run(() =>
+        {
+            for (var i = 0; i < 16; i++) Thread.SpinWait(100);
+            object slot = slotArray.GetValue(0)!;
+            sequenceField.SetValue(slot, originalSequence);
+            slotArray.SetValue(slot, 0);
+        });
+
+        TestItem? captured = null;
+        var peekResult = false;
+        Task peekTask = Task.Run(() =>
+        {
+            peekResult = buffer.TryPeek(out captured);
+        });
+
+        var completed = Task.WaitAll(new[] { realignTask, peekTask }, TimeSpan.FromSeconds(10));
+
+        Assert.IsTrue(completed,
+            "TryPeek did not return after the slot sequence was restored — possible scheduling issue or missed realign.");
+        Assert.IsTrue(peekResult, "TryPeek must eventually succeed once the slot sequence realigns with the head.");
+        Assert.IsNotNull(captured);
+        Assert.AreEqual(1, captured!.Value);
     }
 }

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Cache.CtorAndDispose.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Cache.CtorAndDispose.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.Cache.CtorAndDispose.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using Bodu.Infrastructure;
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public sealed partial class IEnumerableExtensionsTests_Cache
+{
+    /// <summary>
+    /// Verifies that the private <c>CacheEnumerable&lt;T&gt;</c> constructor throws <see cref="ArgumentNullException" /> with the
+    /// expected parameter name when the source argument is <see langword="null" />, exercising the constructor's null guard
+    /// directly (independently of the public <see cref="IEnumerableExtensions.Cache{T}" /> overload's switch-expression null branch).
+    /// </summary>
+    [TestMethod]
+    public void CacheEnumerableCtor_WhenSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        Type cacheEnumerableType = GetCacheEnumerableType<int>();
+        ConstructorInfo ctor = cacheEnumerableType.GetConstructor(
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            types: new[] { typeof(IEnumerable<int>) },
+            modifiers: null)
+            ?? throw new InvalidOperationException("CacheEnumerable<T> constructor not found.");
+
+        TargetInvocationException ex = Assert.ThrowsExactly<TargetInvocationException>(() =>
+        {
+            _ = ctor.Invoke(new object?[] { null });
+        });
+
+        Assert.IsInstanceOfType<ArgumentNullException>(ex.InnerException);
+        Assert.AreEqual("source", ((ArgumentNullException)ex.InnerException!).ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that disposing a cached sequence before any element has been requested releases the wrapper's state without
+    /// throwing — the constructor-only state must be safe to release even when initialisation has not begun.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledBeforeEnumeration_ShouldNotThrow()
+    {
+        IEnumerable<int> cached = new TrackingEnumerable<int>(YieldingSequence()).Cache();
+        Assert.IsInstanceOfType<IDisposable>(cached, "Lazy cached sequence must be disposable.");
+
+        ((IDisposable)cached).Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IDisposable.Dispose" /> twice on a cached sequence is idempotent and never throws.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledMultipleTimes_ShouldBeIdempotent()
+    {
+        var tracker = new TrackingEnumerable<int>(YieldingSequence());
+        IEnumerable<int> cached = tracker.Cache();
+        Assert.IsInstanceOfType<IDisposable>(cached);
+
+        _ = cached.ToList();
+
+        var disposable = (IDisposable)cached;
+        disposable.Dispose();
+        disposable.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that disposing the cached sequence while an active enumerator is still in progress causes the next
+    /// <c>MoveNext</c> on that enumerator to throw <see cref="ObjectDisposedException" />, confirming that the dispose
+    /// path zeroes the cache field that <c>Enumerator.MoveNext</c> dereferences on every call.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledMidEnumeration_ShouldCauseLiveEnumeratorMoveNextToThrowObjectDisposed()
+    {
+        IEnumerable<int> cached = new TrackingEnumerable<int>(YieldingSequence()).Cache();
+        Assert.IsInstanceOfType<IDisposable>(cached);
+
+        IEnumerator<int> active = cached.GetEnumerator();
+        Assert.IsTrue(active.MoveNext());
+        Assert.IsTrue(active.MoveNext());
+
+        ((IDisposable)cached).Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            active.MoveNext();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that disposing a cached sequence after it has been fully materialised resets the wrapper's internal initialisation
+    /// state, so that a fresh <see cref="IEnumerable{T}.GetEnumerator" /> call after the dispose triggers a brand-new source
+    /// enumeration rather than returning the previously cached prefix.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_AfterFullEnumeration_ShouldReinitialiseFromSourceOnNextEnumeration()
+    {
+        var sourceEnumerations = 0;
+        var tracker = new TrackingEnumerable<int>(YieldingSequence(), onEnumerate: () => sourceEnumerations++);
+        IEnumerable<int> cached = tracker.Cache();
+        Assert.IsInstanceOfType<IDisposable>(cached);
+
+        // First pass materialises the cache and triggers exactly one source enumeration.
+        var firstPass = cached.ToList();
+        Assert.AreEqual(1, sourceEnumerations,
+            "First enumeration of a freshly cached sequence must enumerate the source once.");
+
+        ((IDisposable)cached).Dispose();
+
+        // After dispose, the wrapper resets its initialisation state to 0 and clears _cache.
+        // A subsequent enumeration must re-enter the EnsureInitialized claim path and pull
+        // values from the source again, so the on-enumerate callback fires a second time.
+        var secondPass = cached.ToList();
+
+        CollectionAssert.AreEqual(firstPass, secondPass);
+        Assert.AreEqual(2, sourceEnumerations,
+            "Dispose must clear cached state so subsequent enumeration re-walks the source.");
+    }
+
+    /// <summary>
+    /// Resolves the closed generic <c>CacheEnumerable&lt;T&gt;</c> nested type defined by
+    /// <see cref="IEnumerableExtensions" /> so test code can construct it directly without going through the public factory.
+    /// </summary>
+    /// <typeparam name="T">The element type for the closed generic <c>CacheEnumerable&lt;T&gt;</c>.</typeparam>
+    /// <returns>The closed generic <see cref="Type" /> for <c>CacheEnumerable&lt;T&gt;</c>.</returns>
+    private static Type GetCacheEnumerableType<T>()
+    {
+        Type openGeneric = typeof(IEnumerableExtensions)
+            .GetNestedType("CacheEnumerable`1", BindingFlags.NonPublic)
+            ?? throw new InvalidOperationException("CacheEnumerable<T> nested type not found.");
+        return openGeneric.MakeGenericType(typeof(T));
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Randomize.StreamWindowed.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Randomize.StreamWindowed.cs
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.Randomize.StreamWindowed.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public sealed partial class IEnumerableExtensionsTests_Randomize
+{
+    /// <summary>
+    /// Verifies that <see cref="RandomizationMode.StreamWindowed" /> yields every source element when the source is exactly the
+    /// internal window size (64 elements), so the streaming-replacement loop body is never entered and only the final flush
+    /// is exercised.
+    /// </summary>
+    [TestMethod]
+    public void Randomize_StreamWindowed_WhenSourceEqualsWindowSize_ShouldReturnPermutationOfSource()
+    {
+        const int windowSize = 64;
+        var source = Enumerable.Range(1, windowSize).ToArray();
+
+        int[] result = source
+            .Randomize(RandomizationMode.StreamWindowed, CreateSeededRng())
+            .ToArray();
+
+        Assert.AreEqual(windowSize, result.Length, "All source elements must be yielded when source == window size.");
+        CollectionAssert.AreEquivalent(source, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RandomizationMode.StreamWindowed" /> yields a permutation of the entire source when the source is
+    /// larger than the internal 64-element window, exercising the streaming-replacement loop body that swaps incoming elements into
+    /// random window slots before yielding the displaced value.
+    /// </summary>
+    [TestMethod]
+    public void Randomize_StreamWindowed_WhenSourceExceedsWindowSize_ShouldReturnPermutationOfSource()
+    {
+        // The window size baked into StreamWindowedShuffle is 64; produce a source that comfortably
+        // overflows the initial fill so the streaming-replacement loop runs many times.
+        var source = Enumerable.Range(1, 200).ToArray();
+
+        int[] result = source
+            .Randomize(RandomizationMode.StreamWindowed, CreateSeededRng())
+            .ToArray();
+
+        Assert.AreEqual(source.Length, result.Length,
+            "Stream-windowed shuffle must yield every source element exactly once.");
+        CollectionAssert.AreEquivalent(source, result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RandomizationMode.StreamWindowed" /> applied to a source larger than the window size produces a
+    /// permutation that genuinely differs from the input order — confirming the streaming-replacement loop actually permutes the
+    /// sequence rather than yielding the input verbatim.
+    /// </summary>
+    [TestMethod]
+    public void Randomize_StreamWindowed_WhenSourceExceedsWindowSize_ShouldNotYieldSourceInExactlyOriginalOrder()
+    {
+        var source = Enumerable.Range(1, 200).ToArray();
+
+        int[] result = source
+            .Randomize(RandomizationMode.StreamWindowed, CreateSeededRng())
+            .ToArray();
+
+        Assert.IsFalse(source.SequenceEqual(result),
+            "Stream-windowed shuffle of 200 items must permute the input rather than yield it in original order.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RandomizationMode.StreamWindowed" /> with an empty source yields no items and never enters the
+    /// streaming-replacement loop.
+    /// </summary>
+    [TestMethod]
+    public void Randomize_StreamWindowed_WhenSourceIsEmpty_ShouldYieldNoItems()
+    {
+        int[] source = Array.Empty<int>();
+
+        int[] result = source
+            .Randomize(RandomizationMode.StreamWindowed, CreateSeededRng())
+            .ToArray();
+
+        Assert.AreEqual(0, result.Length);
+    }
+}

--- a/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsOutside.Extended.cs
+++ b/Bodu.Core/test/Extensions/IComparableExtensionsTests.IsOutside.Extended.cs
@@ -55,4 +55,47 @@ public partial class IComparableExtensionsTests
         Assert.IsFalse(5.IsOutside((int?)1, (int?)null, comparer));
         Assert.IsFalse(5.IsOutside((int?)null, (int?)null, comparer));
     }
+
+    /// <summary>
+    /// Verifies that the comparer overload of <see cref="IComparableExtensions.IsOutside{T}(T, T?, T?, IComparer{T})" /> matches
+    /// <c>IsBetween</c>'s complement under the default comparer for inside, on-boundary, outside, and reversed-boundary cases.
+    /// </summary>
+    [TestMethod]
+    [DataRow(5, 1, 10, false, DisplayName = "Default comparer: value inside range returns false")]
+    [DataRow(1, 1, 10, false, DisplayName = "Default comparer: value on lower boundary returns false")]
+    [DataRow(10, 1, 10, false, DisplayName = "Default comparer: value on upper boundary returns false")]
+    [DataRow(0, 1, 10, true, DisplayName = "Default comparer: value below range returns true")]
+    [DataRow(11, 1, 10, true, DisplayName = "Default comparer: value above range returns true")]
+    [DataRow(5, 10, 1, false, DisplayName = "Default comparer: reversed boundaries with value inside returns false")]
+    [DataRow(0, 10, 1, true, DisplayName = "Default comparer: reversed boundaries with value outside returns true")]
+    [DataRow(11, 10, 1, true, DisplayName = "Default comparer: reversed boundaries with value above outside returns true")]
+    [DataRow(5, 5, 5, false, DisplayName = "Default comparer: equal boundaries with matching value returns false")]
+    [DataRow(4, 5, 5, true, DisplayName = "Default comparer: equal boundaries with non-matching value returns true")]
+    public void IsOutside_WhenComparerProvided_ShouldReturnExpectedResult(
+        int value, int lower, int upper, bool expected)
+    {
+        IComparer<int> comparer = Comparer<int>.Default;
+
+        Assert.AreEqual(expected, value.IsOutside((int?)lower, (int?)upper, comparer));
+    }
+
+    /// <summary>
+    /// Verifies that the comparer overload honours a custom comparer whose ordering is reversed from the natural ordering — items
+    /// that are "outside" the natural range are "inside" the reversed range, and vice versa.
+    /// </summary>
+    [TestMethod]
+    public void IsOutside_WhenUsingReverseComparer_ShouldHonorComparerOrdering()
+    {
+        IComparer<int> comparer = ReverseIntComparer.Instance;
+
+        // With reverse ordering, 10 is the "lower" boundary and 1 is the "upper" boundary, so:
+        //  - 5 is inside,
+        //  - 0 (which is "greater" under reverse ordering) is outside,
+        //  - 11 (which is "less" under reverse ordering) is outside.
+        Assert.IsFalse(5.IsOutside((int?)1, (int?)10, comparer), "5 should be inside the reverse-ordered range.");
+        Assert.IsFalse(1.IsOutside((int?)1, (int?)10, comparer), "1 is on the boundary and must not be reported as outside.");
+        Assert.IsFalse(10.IsOutside((int?)1, (int?)10, comparer), "10 is on the boundary and must not be reported as outside.");
+        Assert.IsTrue(0.IsOutside((int?)1, (int?)10, comparer), "0 falls outside the reverse-ordered range.");
+        Assert.IsTrue(11.IsOutside((int?)1, (int?)10, comparer), "11 falls outside the reverse-ordered range.");
+    }
 }

--- a/Bodu.Core/test/Xml.Linq/XmlNamespaceResolverTests.cs
+++ b/Bodu.Core/test/Xml.Linq/XmlNamespaceResolverTests.cs
@@ -143,4 +143,48 @@ public sealed class XmlNamespaceResolverTests
             _ = resolver.Elements(null!, "child").ToList();
         });
     }
+
+    /// <summary>
+    /// Verifies that the constructor captures <see cref="XNamespace.None" /> when the root element has no explicit namespace, and that
+    /// the resolver subsequently produces unqualified <see cref="XName" /> values that match the source document.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="XName.Namespace" /> is contractually never <see langword="null" /> in <c>System.Xml.Linq</c> — unqualified names
+    /// carry <see cref="XNamespace.None" /> rather than a missing namespace. This test exercises that boundary so that any future
+    /// change to the resolver's null-handling contract is detected.
+    /// </remarks>
+    [TestMethod]
+    public void Constructor_WhenRootHasNoNamespace_ShouldCaptureXNamespaceNoneAndResolveLocalNames()
+    {
+        var root = new XElement("root",
+            new XElement("child", "value"));
+
+        var resolver = new XmlNamespaceResolver(root);
+
+        XName qualified = resolver.Name("child");
+        Assert.AreEqual(XNamespace.None, qualified.Namespace);
+        Assert.AreEqual("child", qualified.LocalName);
+
+        XElement? child = resolver.Element(root, "child");
+        Assert.IsNotNull(child);
+        Assert.AreEqual("value", child!.Value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="XmlNamespaceResolver.Elements" /> returns every matching unqualified child when the resolver was
+    /// constructed from a namespace-less root, confirming that the resolver does not silently filter to a non-default namespace.
+    /// </summary>
+    [TestMethod]
+    public void Elements_WhenRootHasNoNamespace_ShouldReturnAllMatchingUnqualifiedChildren()
+    {
+        var root = new XElement("root",
+            new XElement("item", "one"),
+            new XElement("item", "two"),
+            new XElement("item", "three"));
+        var resolver = new XmlNamespaceResolver(root);
+
+        var items = resolver.Elements(root, "item").Select(e => e.Value).ToArray();
+
+        CollectionAssert.AreEqual(new[] { "one", "two", "three" }, items);
+    }
 }


### PR DESCRIPTION
…tside

Adds focused tests for previously uncovered fallback and edge-cases:

* ConcurrentCircularBuffer: deterministically exercise BestEffortSnapshot via reflection (empty, quiescent, partially-corrupt slot, and ToArray / Contains outer-budget exhaustion). Test TryPeek's "diff > 0" retry path by transiently bumping the head-slot sequence and restoring it from a worker task. Re-enable and rewrite the NonGenericInterfaces test file to use the reference-typed buffer (T : class?) so IsSynchronized, SyncRoot, the explicit IEnumerable / IEnumerable<T> GetEnumerator, and Enumerator.IEnumerator.Current are exercised.

* XmlNamespaceResolver: cover the namespace-less root construction path (the XNamespace.None branch behind the null-coalescing throw).

* IEnumerableExtensions.Randomize: cover the StreamWindowedShuffle inner streaming loop with a source larger than the 64-element window, plus empty and equal-to-window cases.

* IEnumerableExtensions.Cache: cover the CacheEnumerable<T> constructor's null guard via reflection (unreachable from the public factory) and add Dispose lifecycle tests (pre-enumeration, idempotency, mid-enumeration ObjectDisposedException, and post-dispose re-initialisation).

* IComparableExtensions.IsOutside (comparer overload): fix a logic bug where `&&` was used instead of `||`, which caused the predicate to always return false; add data-driven tests for both the default and a reverse comparer to match the existing non-comparer overload's contract.

https://claude.ai/code/session_01LtfCerpLteJZWw9CF5Hbdn