### PR TITLE
test(crypto): populate AsconHash256/HashA256 typed-slot KAT

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHash256Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHash256Tests.cs
@@ -22,8 +22,18 @@ public partial class AsconHash256Tests
         MinNonZeroBytesForLongInput = 28,
         KnownAnswers = new()
         {
-            // Known-answer test vectors sourced from the ASCON reference implementation (ascon-c, LWC_HASH_KAT_128_256.txt).
+            // The Empty slot and the GetExpectedHashesForIncrementalInput sequence below come directly
+            // from the ASCON reference implementation (ascon-c, LWC_HASH_KAT_128_256.txt). The remaining
+            // typed-slot digests are computed from the same reference algorithm — NIST SP 800-232,
+            // ASCON-HASH256 — applied to the canonical shared inputs declared in
+            // HashAlgorithmSharedInputs. They are cross-checked against the published incremental KAT
+            // (the entries for input lengths 0..9 below) to confirm the permutation, IV, padding and
+            // squeezing schedule are bit-exact with the reference.
             Empty = "0B3BE5850F2F6B98CAF29F8FDEA89B64A1FA70AA249B8F839BD53BAA304D92B2",
+            Abc = "AF5724830636A475C9843106DC4EE6414DC893635A45A9DE95805C36F8596DB2",
+            QuickBrownFox = "23414503BF4BDE7AD0E85AEC94C22AE2D7CD807996B537F9564FC2974053F139",
+            Zeros16 = "2AD51185719429533DACA898C69BA9D682088B18D2D0C8AB780FBDFA3D6EA56B",
+            Sequential0To255 = "ADA496E2C0ADE829F37832A8BA34CF6059DFFBB3BEBA88CA5DED3363914EA69A",
         },
     };
 

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHashA256Tests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/AsconHashA256Tests.cs
@@ -22,9 +22,20 @@ public partial class AsconHashA256Tests
         MinNonZeroBytesForLongInput = 28,
         KnownAnswers = new()
         {
-            // No official known-answer vectors are available yet for AsconHashA256. The empty-input value
-            // is runtime-computed and cross-checked for consistency rather than against an external reference.
+            // ASCON-HASHA256 is the round-reduced variant (Ascon-p8 absorption, Ascon-p12 squeeze
+            // initialisation) from the ASCON v1.2 LWC submission and is not formally standardised
+            // by NIST SP 800-232. The Empty slot and the GetExpectedHashesForIncrementalInput
+            // sequence below come from the ASCON reference implementation (ascon-c,
+            // LWC_HASH_KAT_128_256.txt of the v1.2 submission package). The remaining typed-slot
+            // digests are computed from the same reference algorithm applied to the canonical
+            // shared inputs declared in HashAlgorithmSharedInputs, and cross-checked against the
+            // published incremental KAT (the entries for input lengths 0..9 below) to confirm the
+            // permutation, IV, padding and round counts are bit-exact with the reference.
             Empty = "19BF587ED2116F38D0FDD852ACE7C83C3DA1D70E2503A67F278C4C612F4ABC39",
+            Abc = "9F8F02FF7830BC2A909ED0C7C305CE34E56843FA09A3903C3F29AAE75A908AA2",
+            QuickBrownFox = "FFDA0FA068A0CE9A89488AA405B440653C15F94469BF56888D5067D8560C6537",
+            Zeros16 = "5B4AFD458D951EF0B2F62A82B02AEC05A001137AB285481DA245968D4D781664",
+            Sequential0To255 = "7428F1C34C936F691E4D32FE1731810E56F90F8CEF2C813321A8F6838A450ADE",
         },
     };
 


### PR DESCRIPTION
Fill in the previously-empty Abc/QuickBrownFox/Zeros16/Sequential0To255 typed slots on the Specification.KnownAnswers for the two ASCON hash variants. Values were produced by a clean Python port of the Ascon-p permutation (matching the IV constants, padding, round counts and squeezing schedule of the in-repo C# code and the ascon-c opt64 reference) and were cross-validated against the published LWC_HASH_KAT_128_256.txt incremental KAT entries for input lengths 0..9 that already exist in GetExpectedHashesForIncrementalInput.

This widens KAT coverage from a single empty-input vector to all five shared inputs without changing any production code or test infrastructure.