### PR TITLE
Add JSON serialization support to NotableDateDocumentBuilder

### DIFF
--- a/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateBuilder.cs
+++ b/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateBuilder.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 
 namespace Bodu.Globalization.Calendar;
@@ -79,5 +80,27 @@ public sealed class NotableDateBuilder
             element.Add(rule.ToXElement(notableDateName, ns));
 
         return element;
+    }
+
+    /// <summary>
+    /// Builds a schema-valid <c>notableDate</c> <see cref="JsonObject" /> from the current builder state.
+    /// </summary>
+    /// <param name="notableDateName">The canonical name for the <c>name</c> property.</param>
+    /// <returns>The constructed <see cref="JsonObject" /> conforming to the notable-date entry of <c>NotableDates.schema.json</c>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no rules have been added to this entry.</exception>
+    internal JsonObject ToJsonNode(string notableDateName)
+    {
+        if (_rules.Count == 0)
+            throw new InvalidOperationException($"At least one rule must be added to the notable date entry '{notableDateName}'.");
+
+        JsonArray rules = [];
+        foreach (NotableDateRuleBuilder rule in _rules)
+            rules.Add(rule.ToJsonNode(notableDateName));
+
+        return new JsonObject
+        {
+            ["name"] = notableDateName,
+            ["rules"] = rules,
+        };
     }
 }

--- a/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
+++ b/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
@@ -5,6 +5,8 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -23,15 +25,19 @@ namespace Bodu.Globalization.Calendar;
 /// <item><description><see cref="Build" /> — returns the rules as an <see cref="IReadOnlyList{T}" /> of <see cref="NotableDateRule" /> for direct in-process use.</description></item>
 /// <item><description><see cref="ToXDocument" /> — serialises the rules to an <see cref="XDocument" /> matching the <c>NotableDates.xsd</c> schema.</description></item>
 /// <item><description><see cref="ToXml" /> — serialises the rules to an XML string suitable for storage or transmission.</description></item>
+/// <item><description><see cref="ToJsonNode" /> — serialises the rules to a <see cref="JsonObject" /> matching <c>NotableDates.schema.json</c>.</description></item>
+/// <item><description><see cref="ToJson" /> — serialises the rules to an indented JSON string suitable for storage or transmission.</description></item>
 /// <item><description><see cref="ToProvider" /> — wraps the built rules in an <see cref="INotableDateRuleProvider" /> ready for use with <see cref="NotableDateService" />.</description></item>
 /// </list>
 /// <para>
 /// The XML produced by <see cref="ToXDocument" /> and <see cref="ToXml" /> conforms to the <c>urn:bodu:globalization:calendar</c>
-/// namespace and can be round-tripped through <see cref="NotableDateRuleParser.ParseXml(string)" />.
+/// namespace and can be round-tripped through <see cref="NotableDateRuleParser.ParseXml(string)" />. The JSON produced by
+/// <see cref="ToJsonNode" /> and <see cref="ToJson" /> conforms to <c>NotableDates.schema.json</c> and can be round-tripped through
+/// <see cref="NotableDateRuleJsonParser.ParseJson(string)" />.
 /// </para>
 /// </remarks>
 /// <example>
-/// <para>Defining two notable dates, serialising to XML, and passing them into the service:</para>
+/// <para>Defining two notable dates, persisting to XML or JSON, and passing them into the service:</para>
 /// <code>
 /// NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
 ///     .AddDate("Christmas Day", date => date
@@ -49,8 +55,9 @@ namespace Bodu.Globalization.Calendar;
 ///             .NonWorking()
 ///             .OffsetFromAnchor("Easter Sunday", 1)));
 ///
-/// // Persist as XML.
+/// // Persist as XML or JSON.
 /// string xml = builder.ToXml();
+/// string json = builder.ToJson();
 ///
 /// // Or pass directly to the service.
 /// NotableDateService service = new(new[] { builder.ToProvider() });
@@ -162,6 +169,33 @@ public sealed class NotableDateDocumentBuilder
         new InlineNotableDateRuleProvider(Build());
 
     /// <summary>
+    /// Serialises the builder state to a <see cref="JsonObject" /> conforming to <c>NotableDates.schema.json</c>.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="JsonObject" /> with a <c>notableDates</c> array containing one entry per accumulated notable date,
+    /// suitable for parsing via <see cref="NotableDateRuleJsonParser.ParseJson(string)" /> after stringification.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when any notable date entry contains no rules, or when a rule has no resolution strategy selected.
+    /// </exception>
+    public JsonObject ToJsonNode() => BuildJsonDocument();
+
+    /// <summary>
+    /// Serialises the builder state to an indented schema-valid JSON string.
+    /// </summary>
+    /// <returns>
+    /// An indented JSON string whose root object contains a <c>notableDates</c> array conforming to
+    /// <c>NotableDates.schema.json</c>.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when any notable date entry contains no rules, or when a rule has no resolution strategy selected.
+    /// </exception>
+    public string ToJson() => BuildJsonDocument().ToJsonString(s_jsonSerializerOptions);
+
+    /// <summary>The serializer options shared by <see cref="ToJson" /> for indented output.</summary>
+    private static readonly JsonSerializerOptions s_jsonSerializerOptions = new() { WriteIndented = true };
+
+    /// <summary>
     /// Builds the underlying <see cref="XDocument" /> shared by <see cref="ToXDocument" /> and <see cref="ToXml" />.
     /// </summary>
     /// <returns>
@@ -179,5 +213,28 @@ public sealed class NotableDateDocumentBuilder
             root.Add(builder.ToXElement(name, SchemaNamespace));
 
         return new XDocument(new XDeclaration("1.0", "utf-8", null), root);
+    }
+
+    /// <summary>
+    /// Builds the underlying <see cref="JsonObject" /> shared by <see cref="ToJsonNode" /> and <see cref="ToJson" />.
+    /// </summary>
+    /// <returns>
+    /// A <see cref="JsonObject" /> whose <c>notableDates</c> property is a <see cref="JsonArray" /> of one child per
+    /// accumulated notable date entry, in the order they were added.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when any notable date entry contains no rules, or when a rule has no resolution strategy selected.
+    /// </exception>
+    private JsonObject BuildJsonDocument()
+    {
+        JsonArray notableDates = [];
+
+        foreach ((string name, NotableDateBuilder builder) in _dates)
+            notableDates.Add(builder.ToJsonNode(name));
+
+        return new JsonObject
+        {
+            ["notableDates"] = notableDates,
+        };
     }
 }

--- a/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
+++ b/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
@@ -7,18 +7,21 @@
 using Bodu.Extensions;
 using System.Collections.Immutable;
 using System.Globalization;
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Provides a fluent interface for constructing a single <see cref="NotableDateRule" /> and its corresponding XML representation.
+/// Provides a fluent interface for constructing a single <see cref="NotableDateRule" /> and its corresponding XML
+/// or JSON representation.
 /// </summary>
 /// <remarks>
 /// <para>
 /// A <see cref="NotableDateRuleBuilder" /> is obtained via
 /// <see cref="NotableDateBuilder.AddRule(System.Action{NotableDateRuleBuilder})" />. The builder accumulates rule properties and
-/// produces both a domain object and a schema-valid <c>&lt;Rule&gt;</c> XML element when the enclosing document is built.
+/// produces a domain object, a schema-valid <c>&lt;Rule&gt;</c> XML element, and a schema-valid <c>rule</c> JSON object when the
+/// enclosing document is built.
 /// </para>
 /// <para>
 /// Exactly one strategy method — <see cref="Fixed(int, int, bool, bool)" />, <see cref="Fixed(string, int, bool, bool)" />,
@@ -685,6 +688,122 @@ public sealed class NotableDateRuleBuilder
             element.Add(new XAttribute("day", _algorithmDay.Value.ToString(CultureInfo.InvariantCulture)));
 
         return element;
+    }
+
+    /// <summary>
+    /// Builds a schema-valid <c>rule</c> <see cref="JsonObject" /> from the current builder state.
+    /// </summary>
+    /// <param name="notableDateName">
+    /// The canonical name of the notable date. Used to generate the JSON <c>name</c> property when no explicit
+    /// <see cref="RuleName(string)" /> has been set.
+    /// </param>
+    /// <returns>The constructed <see cref="JsonObject" /> conforming to the rule entry of <c>NotableDates.schema.json</c>.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when no resolution strategy has been selected.</exception>
+    internal JsonObject ToJsonNode(string notableDateName)
+    {
+        if (_strategy is null)
+            throw new InvalidOperationException($"A resolution strategy must be selected before serialising the rule for '{notableDateName}'.");
+
+        string effectiveName = _ruleName ?? GenerateDefaultRuleName(notableDateName);
+
+        JsonObject node = new()
+        {
+            ["name"] = effectiveName,
+            ["category"] = _category.ToString(),
+        };
+
+        if (_isNonWorkingDay.HasValue) node["nonWorking"] = _isNonWorkingDay.Value;
+        if (_firstYear.HasValue) node["firstYear"] = _firstYear.Value;
+        if (_lastYear.HasValue) node["lastYear"] = _lastYear.Value;
+        if (_occurrenceYears.HasValue) node["occurrenceYears"] = _occurrenceYears.Value;
+        if (_durationDays.HasValue) node["durationDays"] = _durationDays.Value;
+        if (_priority.HasValue) node["priority"] = _priority.Value;
+        if (_calendarType is not null) node["calendarType"] = _calendarType.AssemblyQualifiedName ?? _calendarType.FullName ?? _calendarType.Name;
+        if (_territoryCode is not null) node["territory"] = _territoryCode;
+        if (_comment is not null) node["comment"] = _comment;
+
+        switch (_strategy.Value)
+        {
+            case DateResolutionStrategy.Fixed:
+                node["fixed"] = BuildFixedJsonNode();
+                break;
+            case DateResolutionStrategy.DayOfWeekInMonth:
+                node["dayOfWeekInMonth"] = new JsonObject
+                {
+                    ["month"] = GregorianMonthName(_dowMonth!.Value),
+                    ["dayOfWeek"] = _dowDayOfWeek!.Value.ToString(),
+                    ["weekOrdinal"] = _dowWeekOrdinal!.Value.ToString(),
+                };
+                break;
+            case DateResolutionStrategy.OffsetFromAnchor:
+                node["offsetFromAnchor"] = new JsonObject
+                {
+                    ["name"] = _anchorRuleName!,
+                    ["offset"] = _offsetDays!.Value,
+                };
+                break;
+            case DateResolutionStrategy.Algorithm:
+                node["algorithm"] = BuildAlgorithmJsonNode();
+                break;
+            default:
+                throw new NotSupportedException($"Unsupported strategy: {_strategy.Value}");
+        }
+
+        if (_tags.Count > 0)
+        {
+            JsonArray tags = [];
+            foreach (string tag in _tags)
+                tags.Add(tag);
+            node["tags"] = tags;
+        }
+
+        if (_adjustments.Count > 0)
+        {
+            JsonArray adjustments = [];
+            foreach ((string key, ObservanceAdjustmentBuilder builder) in _adjustments)
+                adjustments.Add(builder.ToJsonNode(key));
+            node["adjustments"] = adjustments;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    /// Builds a <c>fixed</c> <see cref="JsonObject" /> from the current Fixed strategy fields.
+    /// </summary>
+    /// <returns>The Fixed strategy JSON object.</returns>
+    private JsonObject BuildFixedJsonNode()
+    {
+        string monthAttr = _fixedMonthNumber.HasValue
+            ? GregorianMonthName(_fixedMonthNumber.Value)
+            : _fixedMonthToken!;
+
+        JsonObject node = new()
+        {
+            ["month"] = monthAttr,
+            ["day"] = _fixedDay!.Value,
+        };
+
+        if (_skipLeapMonth) node["skipLeapMonth"] = true;
+        if (_sweepCalendarYears) node["sweepCalendarYears"] = true;
+
+        return node;
+    }
+
+    /// <summary>
+    /// Builds an <c>algorithm</c> <see cref="JsonObject" /> from the current Algorithm strategy fields.
+    /// </summary>
+    /// <returns>The Algorithm strategy JSON object.</returns>
+    private JsonObject BuildAlgorithmJsonNode()
+    {
+        JsonObject node = [];
+
+        if (_algorithmKey is not null) node["key"] = _algorithmKey;
+        if (_algorithmType is not null) node["type"] = _algorithmType.AssemblyQualifiedName ?? _algorithmType.FullName ?? _algorithmType.Name;
+        if (_algorithmMonth is not null) node["month"] = _algorithmMonth;
+        if (_algorithmDay.HasValue) node["day"] = _algorithmDay.Value;
+
+        return node;
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/ObservanceAdjustmentBuilder.cs
+++ b/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/ObservanceAdjustmentBuilder.cs
@@ -6,19 +6,20 @@
 
 using Bodu.Extensions;
 using System.Globalization;
+using System.Text.Json.Nodes;
 using System.Xml.Linq;
 
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Provides a fluent interface for constructing an <see cref="ObservanceAdjustment" /> and its corresponding XML representation.
+/// Provides a fluent interface for constructing an <see cref="ObservanceAdjustment" /> and its corresponding XML or JSON representation.
 /// </summary>
 /// <remarks>
 /// <para>
 /// An <see cref="ObservanceAdjustmentBuilder" /> is obtained via
 /// <see cref="NotableDateRuleBuilder.AddAdjustment(string, System.Action{ObservanceAdjustmentBuilder})" />. The builder accumulates
-/// adjustment properties and produces both a domain object and a schema-valid <c>&lt;Adjustment&gt;</c> XML element when the
-/// enclosing rule is built.
+/// adjustment properties and produces a domain object, a schema-valid <c>&lt;Adjustment&gt;</c> XML element, and a schema-valid
+/// <c>adjustment</c> JSON object when the enclosing rule is built.
 /// </para>
 /// <para>
 /// Only <see cref="When(AdjustmentTrigger)" /> and <see cref="Action(AdjustmentAction)" /> are required; all other properties are optional
@@ -27,8 +28,9 @@ namespace Bodu.Globalization.Calendar;
 /// <para>
 /// <see cref="AddHandlerParameter(string, string)" /> and <see cref="MaxAdjustmentReachDays(int)" /> populate
 /// <see cref="ObservanceAdjustment.HandlerParameters" /> and <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> respectively.
-/// Both fields are programmatic-only — they are not part of the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by
-/// <see cref="Build(string)" /> but omitted from <see cref="ToXElement(string, XNamespace)" />.
+/// Both fields are programmatic-only — they are not part of the <c>NotableDates.xsd</c> or <c>NotableDates.schema.json</c>
+/// schemas, so values supplied here are honoured by <see cref="Build(string)" /> but omitted from
+/// <see cref="ToXElement(string, XNamespace)" /> and <see cref="ToJsonNode(string)" />.
 /// </para>
 /// </remarks>
 public sealed class ObservanceAdjustmentBuilder
@@ -267,8 +269,9 @@ public sealed class ObservanceAdjustmentBuilder
     /// Repeated calls with the same <paramref name="key" /> replace the previously authored value
     /// (last-write-wins). Values populate <see cref="ObservanceAdjustment.HandlerParameters" /> and are
     /// consumed only by registered <see cref="IAdjustmentHandler" /> implementations. The dictionary is
-    /// not part of the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by
-    /// <see cref="Build(string)" /> but omitted from <see cref="ToXElement(string, XNamespace)" />.
+    /// not part of the <c>NotableDates.xsd</c> or <c>NotableDates.schema.json</c> schemas, so values
+    /// supplied here are honoured by <see cref="Build(string)" /> but omitted from
+    /// <see cref="ToXElement(string, XNamespace)" /> and <see cref="ToJsonNode(string)" />.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentException">Thrown when <paramref name="key" /> is <see langword="null" />, empty, or whitespace.</exception>
@@ -292,8 +295,9 @@ public sealed class ObservanceAdjustmentBuilder
     /// Consumed by the prototype range-resolution pipeline (<c>NotableDateService.ResolveNotableDatesInRange</c>) to
     /// size the per-rule and global fringe envelope when an adjustment's actual reach exceeds the action's default
     /// heuristic. The value populates <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" />. It is not part of
-    /// the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by <see cref="Build(string)" /> but
-    /// omitted from <see cref="ToXElement(string, XNamespace)" />.
+    /// the <c>NotableDates.xsd</c> or <c>NotableDates.schema.json</c> schemas, so values supplied here are honoured
+    /// by <see cref="Build(string)" /> but omitted from <see cref="ToXElement(string, XNamespace)" /> and
+    /// <see cref="ToJsonNode(string)" />.
     /// </para>
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="days" /> is negative.</exception>
@@ -410,6 +414,50 @@ public sealed class ObservanceAdjustmentBuilder
             element.Add(new XAttribute("handlerKey", _handlerKey));
 
         return element;
+    }
+
+    /// <summary>
+    /// Builds a schema-valid <c>adjustment</c> <see cref="JsonObject" /> from the current builder state.
+    /// </summary>
+    /// <param name="key">The adjustment key. Must not be <see langword="null" /> or whitespace.</param>
+    /// <returns>The constructed <see cref="JsonObject" /> conforming to the adjustment entry of <c>NotableDates.schema.json</c>.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="When(AdjustmentTrigger)" /> or <see cref="Action(AdjustmentAction)" /> has not been called.
+    /// </exception>
+    internal JsonObject ToJsonNode(string key)
+    {
+        if (_trigger is null)
+            throw new InvalidOperationException("An adjustment trigger must be set via When() before serialising.");
+        if (_action is null)
+            throw new InvalidOperationException("An adjustment action must be set via Action() before serialising.");
+
+        JsonObject node = new()
+        {
+            ["key"] = key,
+            ["when"] = _trigger.Value.ToString(),
+            ["action"] = _action.Value.ToString(),
+        };
+
+        if (_dayOfWeek.HasValue) node["dayOfWeek"] = _dayOfWeek.Value.ToString();
+        if (_weekOrdinal.HasValue) node["weekOrdinal"] = _weekOrdinal.Value.ToString();
+        if (_offsetDays != 0) node["days"] = _offsetDays;
+        if (_priority != 100) node["priority"] = _priority;
+        if (_isNonWorkingDay.HasValue) node["nonWorking"] = _isNonWorkingDay.Value;
+        if (_territoryCode is not null) node["territory"] = _territoryCode;
+        if (_calendarType is not null) node["calendarType"] = _calendarType.AssemblyQualifiedName ?? _calendarType.FullName ?? _calendarType.Name;
+        if (_effectiveFromYear.HasValue) node["fromYear"] = _effectiveFromYear.Value;
+        if (_effectiveToYear.HasValue) node["toYear"] = _effectiveToYear.Value;
+
+        if (_comparisonMonth.HasValue && _comparisonDay.HasValue)
+        {
+            node["comparisonMonth"] = GregorianMonthName(_comparisonMonth.Value);
+            node["comparisonDay"] = _comparisonDay.Value;
+        }
+
+        if (_targetRuleName is not null) node["target"] = _targetRuleName;
+        if (_handlerKey is not null) node["handlerKey"] = _handlerKey;
+
+        return node;
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/ObservanceAdjustmentBuilder.cs
+++ b/Bodu.Globalization.Calendar/builder/src/Globalization.Calendar.Builder/ObservanceAdjustmentBuilder.cs
@@ -24,6 +24,12 @@ namespace Bodu.Globalization.Calendar;
 /// Only <see cref="When(AdjustmentTrigger)" /> and <see cref="Action(AdjustmentAction)" /> are required; all other properties are optional
 /// and default to the same values as their <see cref="ObservanceAdjustment" /> counterparts.
 /// </para>
+/// <para>
+/// <see cref="AddHandlerParameter(string, string)" /> and <see cref="MaxAdjustmentReachDays(int)" /> populate
+/// <see cref="ObservanceAdjustment.HandlerParameters" /> and <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> respectively.
+/// Both fields are programmatic-only — they are not part of the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by
+/// <see cref="Build(string)" /> but omitted from <see cref="ToXElement(string, XNamespace)" />.
+/// </para>
 /// </remarks>
 public sealed class ObservanceAdjustmentBuilder
 {
@@ -71,6 +77,12 @@ public sealed class ObservanceAdjustmentBuilder
 
     /// <summary>The custom-handler registry key set via <see cref="HandlerKey(string)" />, consumed by <see cref="AdjustmentTrigger.Custom" />/<see cref="AdjustmentAction.Custom" />.</summary>
     private string? _handlerKey;
+
+    /// <summary>The handler parameter accumulator populated by <see cref="AddHandlerParameter(string, string)" />, or <see langword="null" /> when none are authored.</summary>
+    private Dictionary<string, string>? _handlerParameters;
+
+    /// <summary>The symmetric reach envelope in days set via <see cref="MaxAdjustmentReachDays(int)" />, or <see langword="null" /> to use the action-specific default heuristic.</summary>
+    private int? _maxAdjustmentReachDays;
 
     /// <summary>
     /// Sets the condition that activates this adjustment.
@@ -245,6 +257,54 @@ public sealed class ObservanceAdjustmentBuilder
     }
 
     /// <summary>
+    /// Adds a key/value pair to the parameters forwarded to the registered <see cref="IAdjustmentHandler" />.
+    /// </summary>
+    /// <param name="key">The parameter name. Must not be <see langword="null" />, empty, or whitespace.</param>
+    /// <param name="value">The parameter value. Must not be <see langword="null" />; an empty string is permitted.</param>
+    /// <returns>This builder instance, for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Repeated calls with the same <paramref name="key" /> replace the previously authored value
+    /// (last-write-wins). Values populate <see cref="ObservanceAdjustment.HandlerParameters" /> and are
+    /// consumed only by registered <see cref="IAdjustmentHandler" /> implementations. The dictionary is
+    /// not part of the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by
+    /// <see cref="Build(string)" /> but omitted from <see cref="ToXElement(string, XNamespace)" />.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="key" /> is <see langword="null" />, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="value" /> is <see langword="null" />.</exception>
+    public ObservanceAdjustmentBuilder AddHandlerParameter(string key, string value)
+    {
+        ThrowHelper.ThrowIfNullOrWhiteSpace(key);
+        ThrowHelper.ThrowIfNull(value);
+        _handlerParameters ??= new Dictionary<string, string>(StringComparer.Ordinal);
+        _handlerParameters[key] = value;
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the maximum reach in days that this adjustment can shift the calculated date in either direction.
+    /// </summary>
+    /// <param name="days">The symmetric envelope in days. Must be non-negative.</param>
+    /// <returns>This builder instance, for method chaining.</returns>
+    /// <remarks>
+    /// <para>
+    /// Consumed by the prototype range-resolution pipeline (<c>NotableDateService.ResolveNotableDatesInRange</c>) to
+    /// size the per-rule and global fringe envelope when an adjustment's actual reach exceeds the action's default
+    /// heuristic. The value populates <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" />. It is not part of
+    /// the <c>NotableDates.xsd</c> schema, so values supplied here are honoured by <see cref="Build(string)" /> but
+    /// omitted from <see cref="ToXElement(string, XNamespace)" />.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="days" /> is negative.</exception>
+    public ObservanceAdjustmentBuilder MaxAdjustmentReachDays(int days)
+    {
+        ThrowHelper.ThrowIfLessThan(days, 0);
+        _maxAdjustmentReachDays = days;
+        return this;
+    }
+
+    /// <summary>
     /// Builds an <see cref="ObservanceAdjustment" /> record from the current builder state.
     /// </summary>
     /// <param name="key">The adjustment key used for inheritance merging. Must not be <see langword="null" /> or whitespace.</param>
@@ -282,6 +342,10 @@ public sealed class ObservanceAdjustmentBuilder
             TargetRuleName = _targetRuleName,
             Priority = _priority,
             HandlerKey = _handlerKey,
+            HandlerParameters = _handlerParameters is null
+                ? null
+                : new Dictionary<string, string>(_handlerParameters, StringComparer.Ordinal),
+            MaxAdjustmentReachDays = _maxAdjustmentReachDays,
         };
     }
 

--- a/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Build.cs
+++ b/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Build.cs
@@ -334,6 +334,120 @@ public partial class NotableDateDocumentBuilderTests
     }
 
     /// <summary>
+    /// Verifies that handler parameters set via <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> are
+    /// populated on the built <see cref="ObservanceAdjustment.HandlerParameters" /> dictionary.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenAdjustmentHasHandlerParameters_ShouldPopulateHandlerParameters()
+    {
+        IReadOnlyList<NotableDateRule> rules = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("my-handler")
+                        .AddHandlerParameter("enabled", "true")
+                        .AddHandlerParameter("timeout", "30"))))
+            .Build();
+
+        ObservanceAdjustment adj = rules[0].Adjustments[0];
+        Assert.IsNotNull(adj.HandlerParameters);
+        Assert.AreEqual(2, adj.HandlerParameters!.Count);
+        Assert.AreEqual("true", adj.HandlerParameters["enabled"]);
+        Assert.AreEqual("30", adj.HandlerParameters["timeout"]);
+    }
+
+    /// <summary>
+    /// Verifies that repeated <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> calls with the same
+    /// key apply last-write-wins semantics on the built adjustment.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenAdjustmentHasRepeatedHandlerParameterKey_ShouldUseLastValue()
+    {
+        IReadOnlyList<NotableDateRule> rules = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .AddHandlerParameter("mode", "first")
+                        .AddHandlerParameter("mode", "second"))))
+            .Build();
+
+        ObservanceAdjustment adj = rules[0].Adjustments[0];
+        Assert.IsNotNull(adj.HandlerParameters);
+        Assert.AreEqual(1, adj.HandlerParameters!.Count);
+        Assert.AreEqual("second", adj.HandlerParameters["mode"]);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment with no <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> calls
+    /// leaves <see cref="ObservanceAdjustment.HandlerParameters" /> as <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenAdjustmentHasNoHandlerParameters_ShouldLeaveHandlerParametersNull()
+    {
+        IReadOnlyList<NotableDateRule> rules = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("simple", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None))))
+            .Build();
+
+        Assert.IsNull(rules[0].Adjustments[0].HandlerParameters);
+    }
+
+    /// <summary>
+    /// Verifies that the value supplied to <see cref="ObservanceAdjustmentBuilder.MaxAdjustmentReachDays" /> is
+    /// populated on the built <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> property.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenAdjustmentHasMaxAdjustmentReachDays_ShouldPopulateMaxAdjustmentReachDays()
+    {
+        IReadOnlyList<NotableDateRule> rules = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("wide-reach", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.AddDays)
+                        .OffsetDays(45)
+                        .MaxAdjustmentReachDays(60))))
+            .Build();
+
+        Assert.AreEqual(60, rules[0].Adjustments[0].MaxAdjustmentReachDays);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment without a <see cref="ObservanceAdjustmentBuilder.MaxAdjustmentReachDays" /> call
+    /// leaves <see cref="ObservanceAdjustment.MaxAdjustmentReachDays" /> as <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenAdjustmentHasNoMaxAdjustmentReachDays_ShouldLeaveMaxAdjustmentReachDaysNull()
+    {
+        IReadOnlyList<NotableDateRule> rules = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("simple", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None))))
+            .Build();
+
+        Assert.IsNull(rules[0].Adjustments[0].MaxAdjustmentReachDays);
+    }
+
+    /// <summary>
     /// Verifies that territory scoping set on an <see cref="ObservanceAdjustmentBuilder" /> is correctly
     /// propagated to the built <see cref="ObservanceAdjustment" /> along with other adjustment properties.
     /// </summary>

--- a/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.RoundTrip.cs
+++ b/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.RoundTrip.cs
@@ -1,0 +1,1040 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateDocumentBuilderTests.RoundTrip.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar.Algorithms;
+using System.Globalization;
+using System.Xml.Linq;
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class NotableDateDocumentBuilderTests
+{
+    // ============================================================================
+    // Strategy: Fixed
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a numeric Gregorian month round-trips Build → ToXml → ParseXml
+    /// with every strategy field preserved.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_FixedNumericMonth_ShouldPreserveAllStrategyFields()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(12, 25))));
+
+        Assert.AreEqual(1, parsed.Count);
+        NotableDateRule rule = parsed[0];
+        Assert.AreEqual("Christmas Day", rule.Name);
+        Assert.AreEqual(DateResolutionStrategy.Fixed, rule.Strategy);
+        Assert.AreEqual(12, rule.Month);
+        Assert.AreEqual(25, rule.Day);
+        Assert.IsNull(rule.CalendarMonthAlias);
+        Assert.IsFalse(rule.SkipLeapMonth);
+        Assert.IsFalse(rule.SweepCalendarYears);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with an English month name string round-trips with the month
+    /// resolved to its numeric value.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_FixedEnglishMonthName_ShouldResolveToNumericMonth()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("St Patrick's Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Cultural)
+                    .Fixed("March", 17))));
+
+        Assert.AreEqual(3, parsed[0].Month);
+        Assert.AreEqual(17, parsed[0].Day);
+        Assert.IsNull(parsed[0].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a Hebrew fixed-position month token (Tishri…AdarII) round-trips
+    /// as a numeric month 1–7 with no calendar-month alias.
+    /// </summary>
+    [TestMethod]
+    [DataRow("Tishri", 1)]
+    [DataRow("Heshvan", 2)]
+    [DataRow("Kislev", 3)]
+    [DataRow("Tevet", 4)]
+    [DataRow("Shevat", 5)]
+    [DataRow("AdarI", 6)]
+    [DataRow("AdarII", 7)]
+    public void RoundTrip_FixedHebrewFixedMonth_ShouldResolveToNumericMonth(string monthToken, int expectedMonth)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(monthToken, 1))));
+
+        Assert.AreEqual(expectedMonth, parsed[0].Month);
+        Assert.IsNull(parsed[0].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a leap-year-dependent Hebrew month alias round-trips with the
+    /// alias stored on <see cref="NotableDateRule.CalendarMonthAlias" /> and the numeric month left
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow("LastAdar")]
+    [DataRow("Nisan")]
+    [DataRow("Iyar")]
+    [DataRow("Sivan")]
+    [DataRow("Tammuz")]
+    [DataRow("Av")]
+    [DataRow("Elul")]
+    public void RoundTrip_FixedHebrewAliasMonth_ShouldPreserveAlias(string alias)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(alias, 15))));
+
+        Assert.IsNull(parsed[0].Month);
+        Assert.AreEqual(alias, parsed[0].CalendarMonthAlias);
+        Assert.AreEqual(15, parsed[0].Day);
+    }
+
+    /// <summary>
+    /// Verifies that the lunisolar boolean flags <c>skipLeapMonth</c> and <c>sweepCalendarYears</c> round-trip
+    /// through XML serialisation when both are <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_FixedWithLunisolarFlagsTrue_ShouldPreserveBothFlags()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(1, 1, skipLeapMonth: true, sweepCalendarYears: true))));
+
+        Assert.IsTrue(parsed[0].SkipLeapMonth);
+        Assert.IsTrue(parsed[0].SweepCalendarYears);
+    }
+
+    /// <summary>
+    /// Verifies that the lunisolar boolean flags default to <see langword="false" /> on the parsed rule when
+    /// neither was set on the builder.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_FixedWithDefaultLunisolarFlags_ShouldYieldBothFalse()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1))));
+
+        Assert.IsFalse(parsed[0].SkipLeapMonth);
+        Assert.IsFalse(parsed[0].SweepCalendarYears);
+    }
+
+    // ============================================================================
+    // Strategy: DayOfWeekInMonth
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that each <see cref="WeekOfMonthOrdinal" /> value round-trips intact when paired with a
+    /// <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> strategy.
+    /// </summary>
+    [TestMethod]
+    [DataRow(WeekOfMonthOrdinal.First)]
+    [DataRow(WeekOfMonthOrdinal.Second)]
+    [DataRow(WeekOfMonthOrdinal.Third)]
+    [DataRow(WeekOfMonthOrdinal.Fourth)]
+    [DataRow(WeekOfMonthOrdinal.Fifth)]
+    [DataRow(WeekOfMonthOrdinal.Last)]
+    public void RoundTrip_DayOfWeekInMonthAllOrdinals_ShouldPreserveOrdinal(WeekOfMonthOrdinal ordinal)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(6, DayOfWeek.Monday, ordinal))));
+
+        Assert.AreEqual(DateResolutionStrategy.DayOfWeekInMonth, parsed[0].Strategy);
+        Assert.AreEqual(6, parsed[0].Month);
+        Assert.AreEqual(DayOfWeek.Monday, parsed[0].DayOfWeek);
+        Assert.AreEqual(ordinal, parsed[0].WeekOrdinal);
+    }
+
+    /// <summary>
+    /// Verifies that each <see cref="DayOfWeek" /> value round-trips intact when paired with a
+    /// <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> strategy.
+    /// </summary>
+    [TestMethod]
+    [DataRow(DayOfWeek.Sunday)]
+    [DataRow(DayOfWeek.Monday)]
+    [DataRow(DayOfWeek.Tuesday)]
+    [DataRow(DayOfWeek.Wednesday)]
+    [DataRow(DayOfWeek.Thursday)]
+    [DataRow(DayOfWeek.Friday)]
+    [DataRow(DayOfWeek.Saturday)]
+    public void RoundTrip_DayOfWeekInMonthAllDays_ShouldPreserveDay(DayOfWeek day)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(3, day, WeekOfMonthOrdinal.Second))));
+
+        Assert.AreEqual(day, parsed[0].DayOfWeek);
+    }
+
+    // ============================================================================
+    // Strategy: OffsetFromAnchor
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a positive offset
+    /// through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_OffsetFromAnchorPositive_ShouldPreserveOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Easter Monday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .OffsetFromAnchor("Easter Sunday", 1))));
+
+        Assert.AreEqual(DateResolutionStrategy.OffsetFromAnchor, parsed[0].Strategy);
+        Assert.AreEqual("Easter Sunday", parsed[0].AnchorRuleName);
+        Assert.AreEqual(1, parsed[0].OffsetDays);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a negative offset
+    /// through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_OffsetFromAnchorNegative_ShouldPreserveOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Good Friday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .OffsetFromAnchor("Easter Sunday", -2))));
+
+        Assert.AreEqual(-2, parsed[0].OffsetDays);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a zero offset
+    /// through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_OffsetFromAnchorZero_ShouldPreserveZeroOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Aliased Easter", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .OffsetFromAnchor("Easter Sunday", 0))));
+
+        Assert.AreEqual(0, parsed[0].OffsetDays);
+    }
+
+    // ============================================================================
+    // Strategy: Algorithm
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy with only a registry key preserves
+    /// the key and leaves the type, month, and day fields <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AlgorithmKeyOnly_ShouldPreserveKey()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "easter-gregorian"))));
+
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[0].Strategy);
+        Assert.AreEqual("easter-gregorian", parsed[0].AlgorithmKey);
+        Assert.IsNull(parsed[0].AlgorithmType);
+        Assert.IsNull(parsed[0].AlgorithmMonth);
+        Assert.IsNull(parsed[0].AlgorithmDay);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy with a CLR algorithm type preserves
+    /// the resolved <see cref="Type" /> through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AlgorithmTypeOnly_ShouldPreserveType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(algorithmType: typeof(EasterSundayNotableDateAlgorithm)))));
+
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[0].Strategy);
+        Assert.AreEqual(typeof(EasterSundayNotableDateAlgorithm), parsed[0].AlgorithmType);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy preserves the optional
+    /// month and day constructor arguments through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AlgorithmWithMonthAndDay_ShouldPreserveConstructorArguments()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Custom Hebrew Festival", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "hebrew-festival", month: "Nisan", day: 14))));
+
+        Assert.AreEqual("hebrew-festival", parsed[0].AlgorithmKey);
+        Assert.AreEqual("Nisan", parsed[0].AlgorithmMonth);
+        Assert.AreEqual(14, parsed[0].AlgorithmDay);
+    }
+
+    // ============================================================================
+    // Rule-level scopes and metadata
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that each <see cref="NotableDateCategory" /> value round-trips intact on the rule.
+    /// </summary>
+    [TestMethod]
+    [DataRow(NotableDateCategory.Holiday)]
+    [DataRow(NotableDateCategory.Observance)]
+    [DataRow(NotableDateCategory.Remembrance)]
+    [DataRow(NotableDateCategory.Cultural)]
+    [DataRow(NotableDateCategory.Religious)]
+    [DataRow(NotableDateCategory.Seasonal)]
+    [DataRow(NotableDateCategory.Civic)]
+    [DataRow(NotableDateCategory.Bank)]
+    [DataRow(NotableDateCategory.School)]
+    [DataRow(NotableDateCategory.Regional)]
+    [DataRow(NotableDateCategory.Other)]
+    public void RoundTrip_RuleWithEachCategory_ShouldPreserveCategory(NotableDateCategory category)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule.Category(category).Fixed(1, 1))));
+
+        Assert.AreEqual(category, parsed[0].Category);
+    }
+
+    /// <summary>
+    /// Verifies that a comma-separated territory list round-trips intact on the rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithMultiTerritory_ShouldPreserveTerritoryList()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-NSW,AU-VIC,AU-QLD")
+                    .Fixed(1, 1))));
+
+        Assert.AreEqual("AU-NSW,AU-VIC,AU-QLD", parsed[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that a calendar type set on the rule round-trips to the same <see cref="Type" /> after parsing.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithCalendarType_ShouldPreserveCalendarType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Rosh Hashanah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed("Tishri", 1))));
+
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[0].CalendarType);
+    }
+
+    /// <summary>
+    /// Verifies that the recurrence cadence set via <see cref="NotableDateRuleBuilder.OccurrenceYears" /> round-trips
+    /// intact on the rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithOccurrenceYears_ShouldPreserveCadence()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Summer Olympics", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Cultural)
+                    .FirstYear(1896)
+                    .OccurrenceYears(4)
+                    .Fixed(7, 15))));
+
+        Assert.AreEqual(1896, parsed[0].FirstYear);
+        Assert.AreEqual(4, parsed[0].OccurrenceYears);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-day duration on the rule round-trips intact.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithDurationDays_ShouldPreserveDuration()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Hanukkah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Duration(8)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed("Kislev", 25))));
+
+        Assert.AreEqual(8, parsed[0].DurationDays);
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <see cref="NotableDateRuleBuilder.RuleName" /> round-trips intact on the parsed rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithExplicitRuleName_ShouldPreserveRuleName()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("King's Birthday", date => date
+                .AddRule(rule => rule
+                    .RuleName("queensland-rule")
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(10, DayOfWeek.Monday, WeekOfMonthOrdinal.First))));
+
+        Assert.AreEqual("queensland-rule", parsed[0].RuleName);
+    }
+
+    /// <summary>
+    /// Verifies that an unset <see cref="NotableDateRuleBuilder.RuleName" /> still produces a non-empty
+    /// <see cref="NotableDateRule.RuleName" /> after the round-trip, because the builder auto-generates a
+    /// strategy-suffixed name to satisfy the XSD-required <c>name</c> attribute.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithoutExplicitRuleName_ShouldGenerateStrategySuffixedName()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 25))));
+
+        Assert.AreEqual("Christmas Day (Fixed)", parsed[0].RuleName);
+    }
+
+    /// <summary>
+    /// Verifies that multiple tags added in order round-trip as a set on the rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithMultipleTags_ShouldPreserveAllTags()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Fixed(12, 25)
+                    .AddTag("Christian")
+                    .AddTag("Public")
+                    .AddTag("Federal"))));
+
+        Assert.AreEqual(3, parsed[0].Tags.Count);
+        Assert.IsTrue(parsed[0].Tags.Contains("Christian"));
+        Assert.IsTrue(parsed[0].Tags.Contains("Public"));
+        Assert.IsTrue(parsed[0].Tags.Contains("Federal"));
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <see cref="NotableDateRuleBuilder.NonWorking(bool)" /> with <see langword="false" />
+    /// round-trips as <see langword="false" /> on the parsed rule rather than reverting to <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithNonWorkingFalse_ShouldPreserveExplicitFalse()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Observance)
+                    .NonWorking(false)
+                    .Fixed(1, 1))));
+
+        Assert.AreEqual(false, parsed[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that an unset <see cref="NotableDateRuleBuilder.NonWorking" /> round-trips as <see langword="null" />
+    /// on the parsed rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithoutNonWorking_ShouldLeaveIsNonWorkingDayNull()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Observance)
+                    .Fixed(1, 1))));
+
+        Assert.IsNull(parsed[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that a rule with every optional scalar field set populates each on the parsed result.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_RuleWithAllOptionalScalars_ShouldPreserveEveryField()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Comprehensive Rule", date => date
+                .AddRule(rule => rule
+                    .RuleName("variant-a")
+                    .Category(NotableDateCategory.Civic)
+                    .NonWorking()
+                    .FirstYear(1950)
+                    .LastYear(2099)
+                    .OccurrenceYears(2)
+                    .Duration(5)
+                    .Priority(25)
+                    .Territory("AU-NSW")
+                    .Comment("Round-trip coverage test")
+                    .AddTag("Federal")
+                    .AddTag("Public")
+                    .Fixed(7, 4))));
+
+        NotableDateRule rule = parsed[0];
+        Assert.AreEqual("Comprehensive Rule", rule.Name);
+        Assert.AreEqual("variant-a", rule.RuleName);
+        Assert.AreEqual(NotableDateCategory.Civic, rule.Category);
+        Assert.AreEqual(true, rule.IsNonWorkingDay);
+        Assert.AreEqual(1950, rule.FirstYear);
+        Assert.AreEqual(2099, rule.LastYear);
+        Assert.AreEqual(2, rule.OccurrenceYears);
+        Assert.AreEqual(5, rule.DurationDays);
+        Assert.AreEqual(25, rule.Priority);
+        Assert.AreEqual("AU-NSW", rule.TerritoryCode);
+        Assert.AreEqual("Round-trip coverage test", rule.Comment);
+        Assert.AreEqual(2, rule.Tags.Count);
+    }
+
+    // ============================================================================
+    // Adjustments: triggers
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that every <see cref="AdjustmentTrigger" /> value round-trips intact on an adjustment.
+    /// </summary>
+    [TestMethod]
+    [DataRow(AdjustmentTrigger.Always)]
+    [DataRow(AdjustmentTrigger.IfDayOfWeek)]
+    [DataRow(AdjustmentTrigger.IfWeekend)]
+    [DataRow(AdjustmentTrigger.IfWeekday)]
+    [DataRow(AdjustmentTrigger.IfNonWorkingDay)]
+    [DataRow(AdjustmentTrigger.IfBeforeFixedDate)]
+    [DataRow(AdjustmentTrigger.IfAfterFixedDate)]
+    [DataRow(AdjustmentTrigger.IfLeapYear)]
+    [DataRow(AdjustmentTrigger.IfNthOccurrenceInMonth)]
+    [DataRow(AdjustmentTrigger.Custom)]
+    public void RoundTrip_AdjustmentAllTriggers_ShouldPreserveTrigger(AdjustmentTrigger trigger)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(trigger)
+                        .Action(AdjustmentAction.None)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .ComparisonDate(3, 20)
+                        .OrdinalOccurrence(WeekOfMonthOrdinal.Second)))));
+
+        Assert.AreEqual(trigger, parsed[0].Adjustments[0].Trigger);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="AdjustmentTrigger.IfDayOfWeek" /> trigger preserves the configured
+    /// <see cref="DayOfWeek" /> through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentIfDayOfWeek_ShouldPreserveDayOfWeek()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .OnDayOfWeek(DayOfWeek.Friday)))));
+
+        Assert.AreEqual(DayOfWeek.Friday, parsed[0].Adjustments[0].DayOfWeek);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment with <see cref="AdjustmentTrigger.IfBeforeFixedDate" /> preserves the comparison
+    /// month and day through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentIfBeforeFixedDate_ShouldPreserveComparisonDate()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Seasonal)
+                    .Fixed(3, 1)
+                    .AddAdjustment("pre-equinox", adj => adj
+                        .When(AdjustmentTrigger.IfBeforeFixedDate)
+                        .Action(AdjustmentAction.AddDays)
+                        .ComparisonDate(3, 20)
+                        .OffsetDays(1)))));
+
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.IsNotNull(adj.ComparisonDate);
+        Assert.AreEqual(3, adj.ComparisonDate!.Value.Month);
+        Assert.AreEqual(20, adj.ComparisonDate!.Value.Day);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AdjustmentTrigger.IfNthOccurrenceInMonth" /> preserves the configured
+    /// <see cref="WeekOfMonthOrdinal" /> through the round-trip.
+    /// </summary>
+    [TestMethod]
+    [DataRow(WeekOfMonthOrdinal.First)]
+    [DataRow(WeekOfMonthOrdinal.Second)]
+    [DataRow(WeekOfMonthOrdinal.Third)]
+    [DataRow(WeekOfMonthOrdinal.Fourth)]
+    [DataRow(WeekOfMonthOrdinal.Fifth)]
+    [DataRow(WeekOfMonthOrdinal.Last)]
+    public void RoundTrip_AdjustmentIfNthOccurrenceInMonth_ShouldPreserveOrdinal(WeekOfMonthOrdinal ordinal)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("nth", adj => adj
+                        .When(AdjustmentTrigger.IfNthOccurrenceInMonth)
+                        .Action(AdjustmentAction.None)
+                        .OnDayOfWeek(DayOfWeek.Monday)
+                        .OrdinalOccurrence(ordinal)))));
+
+        Assert.AreEqual(ordinal, parsed[0].Adjustments[0].WeekOrdinal);
+    }
+
+    // ============================================================================
+    // Adjustments: actions
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that every <see cref="AdjustmentAction" /> value round-trips intact on an adjustment.
+    /// </summary>
+    [TestMethod]
+    [DataRow(AdjustmentAction.None)]
+    [DataRow(AdjustmentAction.AddDays)]
+    [DataRow(AdjustmentAction.MoveToNextWeekday)]
+    [DataRow(AdjustmentAction.MoveToPreviousWeekday)]
+    [DataRow(AdjustmentAction.MoveToNextNonWorkingDay)]
+    [DataRow(AdjustmentAction.ReplaceWithNamedDate)]
+    [DataRow(AdjustmentAction.Custom)]
+    public void RoundTrip_AdjustmentAllActions_ShouldPreserveAction(AdjustmentAction action)
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(action)
+                        .Target("Other Rule")
+                        .OffsetDays(1)))));
+
+        Assert.AreEqual(action, parsed[0].Adjustments[0].Action);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="AdjustmentAction.ReplaceWithNamedDate" /> action preserves its target rule name
+    /// through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentReplaceWithNamedDate_ShouldPreserveTarget()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Anzac Day Observance", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Remembrance)
+                    .Fixed(4, 25)
+                    .AddAdjustment("sub", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .Action(AdjustmentAction.ReplaceWithNamedDate)
+                        .Target("Anzac Day (Substitute)")))));
+
+        Assert.AreEqual("Anzac Day (Substitute)", parsed[0].Adjustments[0].TargetRuleName);
+    }
+
+    // ============================================================================
+    // Adjustments: scopes and metadata
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by territory preserves the territory code through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentWithTerritoryScope_ShouldPreserveTerritory()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("scoped", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .Territory("AU-NSW,AU-VIC")))));
+
+        Assert.AreEqual("AU-NSW,AU-VIC", parsed[0].Adjustments[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by calendar type preserves the type through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentWithCalendarTypeScope_ShouldPreserveCalendarType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Fixed(1, 1)
+                    .AddAdjustment("hebrew-only", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None)
+                        .CalendarType(typeof(HebrewCalendar))))));
+
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[0].Adjustments[0].CalendarType);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by inclusive year bounds preserves both bounds through the round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentWithYearBounds_ShouldPreserveBothBounds()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("bounded", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .FromYear(2010)
+                        .ToYear(2050)))));
+
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.AreEqual(2010, adj.EffectiveFromYear);
+        Assert.AreEqual(2050, adj.EffectiveToYear);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment's non-default priority round-trips intact through the parser.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentWithNonDefaultPriority_ShouldPreservePriority()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("urgent", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None)
+                        .Priority(5)))));
+
+        Assert.AreEqual(5, parsed[0].Adjustments[0].Priority);
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <c>NonWorking(false)</c> on the adjustment round-trips intact rather than reverting
+    /// to <see langword="null" /> after parsing.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentNonWorkingFalse_ShouldPreserveExplicitFalse()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("working-override", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.None)
+                        .NonWorking(false)))));
+
+        Assert.AreEqual(false, parsed[0].Adjustments[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="ObservanceAdjustmentBuilder.HandlerKey" /> value round-trips intact.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_AdjustmentWithHandlerKey_ShouldPreserveHandlerKey()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("my-custom-handler")))));
+
+        Assert.AreEqual("my-custom-handler", parsed[0].Adjustments[0].HandlerKey);
+    }
+
+    // ============================================================================
+    // Hierarchical structures
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that multiple rules under the same notable date name round-trip with each rule's identifying fields
+    /// preserved and the canonical date name shared.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_MultipleRulesPerDate_ShouldPreserveEveryVariant()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("King's Birthday", date => date
+                .AddRule(rule => rule
+                    .RuleName("queensland")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-QLD")
+                    .DayOfWeekInMonth(10, DayOfWeek.Monday, WeekOfMonthOrdinal.First))
+                .AddRule(rule => rule
+                    .RuleName("other-states")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-NSW,AU-VIC,AU-SA,AU-TAS,AU-ACT,AU-NT")
+                    .DayOfWeekInMonth(6, DayOfWeek.Monday, WeekOfMonthOrdinal.Second))
+                .AddRule(rule => rule
+                    .RuleName("western-australia")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-WA")
+                    .DayOfWeekInMonth(9, DayOfWeek.Monday, WeekOfMonthOrdinal.Last))));
+
+        Assert.AreEqual(3, parsed.Count);
+        Assert.IsTrue(parsed.All(r => r.Name == "King's Birthday"));
+        Assert.AreEqual("queensland", parsed[0].RuleName);
+        Assert.AreEqual("other-states", parsed[1].RuleName);
+        Assert.AreEqual("western-australia", parsed[2].RuleName);
+        Assert.AreEqual(10, parsed[0].Month);
+        Assert.AreEqual(6, parsed[1].Month);
+        Assert.AreEqual(9, parsed[2].Month);
+    }
+
+    /// <summary>
+    /// Verifies that multiple notable dates in the same document each round-trip with their rules preserved and
+    /// addition order maintained.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_MultipleDatesPerDocument_ShouldPreserveOrderAndRules()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 25)))
+            .AddDate("Boxing Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 26)))
+            .AddDate("New Year's Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(1, 1))));
+
+        Assert.AreEqual(3, parsed.Count);
+        Assert.AreEqual("Christmas Day", parsed[0].Name);
+        Assert.AreEqual("Boxing Day", parsed[1].Name);
+        Assert.AreEqual("New Year's Day", parsed[2].Name);
+    }
+
+    /// <summary>
+    /// Verifies that multiple adjustments on the same rule round-trip with each retaining its unique key,
+    /// trigger, action, and ordering.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_MultipleAdjustmentsPerRule_ShouldPreserveOrderAndKeys()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("saturday-shift", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Saturday)
+                        .Action(AdjustmentAction.MoveToPreviousWeekday))
+                    .AddAdjustment("sunday-shift", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .Action(AdjustmentAction.MoveToNextWeekday))
+                    .AddAdjustment("custom-rule", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("special-case")))));
+
+        var adjustments = parsed[0].Adjustments;
+        Assert.AreEqual(3, adjustments.Length);
+        Assert.AreEqual("saturday-shift", adjustments[0].Key);
+        Assert.AreEqual("sunday-shift", adjustments[1].Key);
+        Assert.AreEqual("custom-rule", adjustments[2].Key);
+        Assert.AreEqual(DayOfWeek.Saturday, adjustments[0].DayOfWeek);
+        Assert.AreEqual(DayOfWeek.Sunday, adjustments[1].DayOfWeek);
+        Assert.AreEqual("special-case", adjustments[2].HandlerKey);
+    }
+
+    /// <summary>
+    /// Verifies that a fully-populated document with multiple dates, multi-variant rules, scoped adjustments, and
+    /// every category of field round-trips with all values preserved.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_ComprehensiveNestedDocument_ShouldPreserveEntireGraph()
+    {
+        List<NotableDateRule> parsed = BuildAndReparse(b => b
+            .AddDate("Australia Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU")
+                    .NonWorking()
+                    .FirstYear(1994)
+                    .Priority(10)
+                    .Comment("National public holiday")
+                    .AddTag("Federal")
+                    .Fixed(1, 26)
+                    .AddAdjustment("weekend-roll", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .NonWorking())))
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "easter-gregorian")
+                    .AddTag("Christian")))
+            .AddDate("Easter Monday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .OffsetFromAnchor("Easter Sunday", 1)
+                    .NonWorking()))
+            .AddDate("Hanukkah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Duration(8)
+                    .Fixed("Kislev", 25))));
+
+        Assert.AreEqual(4, parsed.Count);
+
+        // Australia Day
+        Assert.AreEqual("Australia Day", parsed[0].Name);
+        Assert.AreEqual(1, parsed[0].Month);
+        Assert.AreEqual(26, parsed[0].Day);
+        Assert.AreEqual("AU", parsed[0].TerritoryCode);
+        Assert.AreEqual(true, parsed[0].IsNonWorkingDay);
+        Assert.AreEqual(1, parsed[0].Adjustments.Length);
+        Assert.AreEqual("weekend-roll", parsed[0].Adjustments[0].Key);
+
+        // Easter Sunday
+        Assert.AreEqual("Easter Sunday", parsed[1].Name);
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[1].Strategy);
+        Assert.AreEqual("easter-gregorian", parsed[1].AlgorithmKey);
+
+        // Easter Monday
+        Assert.AreEqual("Easter Monday", parsed[2].Name);
+        Assert.AreEqual(DateResolutionStrategy.OffsetFromAnchor, parsed[2].Strategy);
+        Assert.AreEqual("Easter Sunday", parsed[2].AnchorRuleName);
+        Assert.AreEqual(1, parsed[2].OffsetDays);
+
+        // Hanukkah
+        Assert.AreEqual("Hanukkah", parsed[3].Name);
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[3].CalendarType);
+        Assert.AreEqual(8, parsed[3].DurationDays);
+        Assert.AreEqual(3, parsed[3].Month);
+        Assert.IsNull(parsed[3].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="NotableDateDocumentBuilder.ToProvider" /> path yields an
+    /// <see cref="INotableDateRuleProvider" /> whose rules match those produced by
+    /// <see cref="NotableDateDocumentBuilder.Build" /> for the same comprehensive document.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_ToProvider_ShouldYieldRulesEquivalentToBuild()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 25)))
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Religious).Algorithm(key: "easter-gregorian")));
+
+        IReadOnlyList<NotableDateRule> built = builder.Build();
+        var providerRules = builder.ToProvider().LoadRules().ToList();
+
+        Assert.AreEqual(built.Count, providerRules.Count);
+        for (int i = 0; i < built.Count; i++)
+        {
+            Assert.AreEqual(built[i].Name, providerRules[i].Name);
+            Assert.AreEqual(built[i].Strategy, providerRules[i].Strategy);
+            Assert.AreEqual(built[i].Month, providerRules[i].Month);
+            Assert.AreEqual(built[i].Day, providerRules[i].Day);
+            Assert.AreEqual(built[i].AlgorithmKey, providerRules[i].AlgorithmKey);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateDocumentBuilder.ToXDocument" /> and
+    /// <see cref="NotableDateDocumentBuilder.ToXml" /> produce equivalent payloads — the latter is the indented
+    /// string serialisation of the former — for a comprehensive document.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_ToXDocumentAndToXml_ShouldProduceEquivalentPayloads()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Test A", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(1, 1)))
+            .AddDate("Test B", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Religious).Algorithm(key: "k")));
+
+        XDocument doc = builder.ToXDocument();
+        XDocument fromXml = XDocument.Parse(builder.ToXml());
+
+        Assert.IsTrue(XNode.DeepEquals(doc, fromXml));
+    }
+
+    // ============================================================================
+    // Helpers
+    // ============================================================================
+
+    /// <summary>
+    /// Builds, serialises, and re-parses the configured document, returning the parsed rules.
+    /// </summary>
+    /// <param name="configure">Callback that configures the builder under test.</param>
+    /// <returns>The parsed rules.</returns>
+    private static List<NotableDateRule> BuildAndReparse(Action<NotableDateDocumentBuilder> configure)
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create();
+        configure(builder);
+        return NotableDateRuleParser.ParseXml(builder.ToXml());
+    }
+}

--- a/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.RoundTripJson.cs
+++ b/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.RoundTripJson.cs
@@ -1,0 +1,1114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateDocumentBuilderTests.RoundTripJson.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar.Algorithms;
+using System.Globalization;
+using System.Text.Json.Nodes;
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class NotableDateDocumentBuilderTests
+{
+    // ============================================================================
+    // Strategy: Fixed (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a numeric Gregorian month round-trips Build → ToJson → ParseJson
+    /// with every strategy field preserved.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_FixedNumericMonth_ShouldPreserveAllStrategyFields()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(12, 25))));
+
+        Assert.AreEqual(1, parsed.Count);
+        NotableDateRule rule = parsed[0];
+        Assert.AreEqual("Christmas Day", rule.Name);
+        Assert.AreEqual(DateResolutionStrategy.Fixed, rule.Strategy);
+        Assert.AreEqual(12, rule.Month);
+        Assert.AreEqual(25, rule.Day);
+        Assert.IsNull(rule.CalendarMonthAlias);
+        Assert.IsFalse(rule.SkipLeapMonth);
+        Assert.IsFalse(rule.SweepCalendarYears);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with an English month name string round-trips through JSON with the
+    /// month resolved to its numeric value.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_FixedEnglishMonthName_ShouldResolveToNumericMonth()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("St Patrick's Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Cultural)
+                    .Fixed("March", 17))));
+
+        Assert.AreEqual(3, parsed[0].Month);
+        Assert.AreEqual(17, parsed[0].Day);
+        Assert.IsNull(parsed[0].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a Hebrew fixed-position month token (Tishri…AdarII) round-trips
+    /// through JSON as a numeric month 1–7 with no calendar-month alias.
+    /// </summary>
+    [TestMethod]
+    [DataRow("Tishri", 1)]
+    [DataRow("Heshvan", 2)]
+    [DataRow("Kislev", 3)]
+    [DataRow("Tevet", 4)]
+    [DataRow("Shevat", 5)]
+    [DataRow("AdarI", 6)]
+    [DataRow("AdarII", 7)]
+    public void RoundTripJson_FixedHebrewFixedMonth_ShouldResolveToNumericMonth(string monthToken, int expectedMonth)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(monthToken, 1))));
+
+        Assert.AreEqual(expectedMonth, parsed[0].Month);
+        Assert.IsNull(parsed[0].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed strategy authored with a leap-year-dependent Hebrew month alias round-trips through JSON
+    /// with the alias stored on <see cref="NotableDateRule.CalendarMonthAlias" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow("LastAdar")]
+    [DataRow("Nisan")]
+    [DataRow("Iyar")]
+    [DataRow("Sivan")]
+    [DataRow("Tammuz")]
+    [DataRow("Av")]
+    [DataRow("Elul")]
+    public void RoundTripJson_FixedHebrewAliasMonth_ShouldPreserveAlias(string alias)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(alias, 15))));
+
+        Assert.IsNull(parsed[0].Month);
+        Assert.AreEqual(alias, parsed[0].CalendarMonthAlias);
+        Assert.AreEqual(15, parsed[0].Day);
+    }
+
+    /// <summary>
+    /// Verifies that the lunisolar boolean flags <c>skipLeapMonth</c> and <c>sweepCalendarYears</c> round-trip
+    /// through JSON when both are <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_FixedWithLunisolarFlagsTrue_ShouldPreserveBothFlags()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed(1, 1, skipLeapMonth: true, sweepCalendarYears: true))));
+
+        Assert.IsTrue(parsed[0].SkipLeapMonth);
+        Assert.IsTrue(parsed[0].SweepCalendarYears);
+    }
+
+    // ============================================================================
+    // Strategy: DayOfWeekInMonth (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that each <see cref="WeekOfMonthOrdinal" /> value round-trips intact through JSON for a
+    /// <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> strategy.
+    /// </summary>
+    [TestMethod]
+    [DataRow(WeekOfMonthOrdinal.First)]
+    [DataRow(WeekOfMonthOrdinal.Second)]
+    [DataRow(WeekOfMonthOrdinal.Third)]
+    [DataRow(WeekOfMonthOrdinal.Fourth)]
+    [DataRow(WeekOfMonthOrdinal.Fifth)]
+    [DataRow(WeekOfMonthOrdinal.Last)]
+    public void RoundTripJson_DayOfWeekInMonthAllOrdinals_ShouldPreserveOrdinal(WeekOfMonthOrdinal ordinal)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(6, DayOfWeek.Monday, ordinal))));
+
+        Assert.AreEqual(DateResolutionStrategy.DayOfWeekInMonth, parsed[0].Strategy);
+        Assert.AreEqual(6, parsed[0].Month);
+        Assert.AreEqual(DayOfWeek.Monday, parsed[0].DayOfWeek);
+        Assert.AreEqual(ordinal, parsed[0].WeekOrdinal);
+    }
+
+    /// <summary>
+    /// Verifies that each <see cref="DayOfWeek" /> value round-trips intact through JSON for a
+    /// <see cref="DateResolutionStrategy.DayOfWeekInMonth" /> strategy.
+    /// </summary>
+    [TestMethod]
+    [DataRow(DayOfWeek.Sunday)]
+    [DataRow(DayOfWeek.Monday)]
+    [DataRow(DayOfWeek.Tuesday)]
+    [DataRow(DayOfWeek.Wednesday)]
+    [DataRow(DayOfWeek.Thursday)]
+    [DataRow(DayOfWeek.Friday)]
+    [DataRow(DayOfWeek.Saturday)]
+    public void RoundTripJson_DayOfWeekInMonthAllDays_ShouldPreserveDay(DayOfWeek day)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(3, day, WeekOfMonthOrdinal.Second))));
+
+        Assert.AreEqual(day, parsed[0].DayOfWeek);
+    }
+
+    // ============================================================================
+    // Strategy: OffsetFromAnchor (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a positive offset
+    /// through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_OffsetFromAnchorPositive_ShouldPreserveOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Easter Monday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .OffsetFromAnchor("Easter Sunday", 1))));
+
+        Assert.AreEqual(DateResolutionStrategy.OffsetFromAnchor, parsed[0].Strategy);
+        Assert.AreEqual("Easter Sunday", parsed[0].AnchorRuleName);
+        Assert.AreEqual(1, parsed[0].OffsetDays);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a negative offset
+    /// through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_OffsetFromAnchorNegative_ShouldPreserveOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Good Friday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .OffsetFromAnchor("Easter Sunday", -2))));
+
+        Assert.AreEqual(-2, parsed[0].OffsetDays);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.OffsetFromAnchor" /> strategy preserves a zero offset
+    /// through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_OffsetFromAnchorZero_ShouldPreserveZeroOffset()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Aliased Easter", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .OffsetFromAnchor("Easter Sunday", 0))));
+
+        Assert.AreEqual(0, parsed[0].OffsetDays);
+    }
+
+    // ============================================================================
+    // Strategy: Algorithm (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy with only a registry key preserves
+    /// the key through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AlgorithmKeyOnly_ShouldPreserveKey()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "easter-gregorian"))));
+
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[0].Strategy);
+        Assert.AreEqual("easter-gregorian", parsed[0].AlgorithmKey);
+        Assert.IsNull(parsed[0].AlgorithmType);
+        Assert.IsNull(parsed[0].AlgorithmMonth);
+        Assert.IsNull(parsed[0].AlgorithmDay);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy with a CLR algorithm type preserves
+    /// the resolved <see cref="Type" /> through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AlgorithmTypeOnly_ShouldPreserveType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(algorithmType: typeof(EasterSundayNotableDateAlgorithm)))));
+
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[0].Strategy);
+        Assert.AreEqual(typeof(EasterSundayNotableDateAlgorithm), parsed[0].AlgorithmType);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="DateResolutionStrategy.Algorithm" /> strategy preserves the optional month and
+    /// day constructor arguments through JSON round-trip.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AlgorithmWithMonthAndDay_ShouldPreserveConstructorArguments()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Custom Hebrew Festival", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "hebrew-festival", month: "Nisan", day: 14))));
+
+        Assert.AreEqual("hebrew-festival", parsed[0].AlgorithmKey);
+        Assert.AreEqual("Nisan", parsed[0].AlgorithmMonth);
+        Assert.AreEqual(14, parsed[0].AlgorithmDay);
+    }
+
+    // ============================================================================
+    // Rule-level scopes and metadata (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that each <see cref="NotableDateCategory" /> value round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    [DataRow(NotableDateCategory.Holiday)]
+    [DataRow(NotableDateCategory.Observance)]
+    [DataRow(NotableDateCategory.Remembrance)]
+    [DataRow(NotableDateCategory.Cultural)]
+    [DataRow(NotableDateCategory.Religious)]
+    [DataRow(NotableDateCategory.Seasonal)]
+    [DataRow(NotableDateCategory.Civic)]
+    [DataRow(NotableDateCategory.Bank)]
+    [DataRow(NotableDateCategory.School)]
+    [DataRow(NotableDateCategory.Regional)]
+    [DataRow(NotableDateCategory.Other)]
+    public void RoundTripJson_RuleWithEachCategory_ShouldPreserveCategory(NotableDateCategory category)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule.Category(category).Fixed(1, 1))));
+
+        Assert.AreEqual(category, parsed[0].Category);
+    }
+
+    /// <summary>
+    /// Verifies that a comma-separated territory list round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithMultiTerritory_ShouldPreserveTerritoryList()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-NSW,AU-VIC,AU-QLD")
+                    .Fixed(1, 1))));
+
+        Assert.AreEqual("AU-NSW,AU-VIC,AU-QLD", parsed[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that a calendar type set on the rule round-trips to the same <see cref="Type" /> through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithCalendarType_ShouldPreserveCalendarType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Rosh Hashanah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed("Tishri", 1))));
+
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[0].CalendarType);
+    }
+
+    /// <summary>
+    /// Verifies that the recurrence cadence set via <see cref="NotableDateRuleBuilder.OccurrenceYears" /> round-trips
+    /// intact through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithOccurrenceYears_ShouldPreserveCadence()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Summer Olympics", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Cultural)
+                    .FirstYear(1896)
+                    .OccurrenceYears(4)
+                    .Fixed(7, 15))));
+
+        Assert.AreEqual(1896, parsed[0].FirstYear);
+        Assert.AreEqual(4, parsed[0].OccurrenceYears);
+    }
+
+    /// <summary>
+    /// Verifies that a multi-day duration on the rule round-trips through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithDurationDays_ShouldPreserveDuration()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Hanukkah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Duration(8)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Fixed("Kislev", 25))));
+
+        Assert.AreEqual(8, parsed[0].DurationDays);
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <see cref="NotableDateRuleBuilder.RuleName" /> round-trips through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithExplicitRuleName_ShouldPreserveRuleName()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("King's Birthday", date => date
+                .AddRule(rule => rule
+                    .RuleName("queensland-rule")
+                    .Category(NotableDateCategory.Holiday)
+                    .DayOfWeekInMonth(10, DayOfWeek.Monday, WeekOfMonthOrdinal.First))));
+
+        Assert.AreEqual("queensland-rule", parsed[0].RuleName);
+    }
+
+    /// <summary>
+    /// Verifies that an unset rule name still produces a non-empty <see cref="NotableDateRule.RuleName" /> after the
+    /// JSON round-trip via the builder's auto-generated strategy-suffixed name.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithoutExplicitRuleName_ShouldGenerateStrategySuffixedName()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 25))));
+
+        Assert.AreEqual("Christmas Day (Fixed)", parsed[0].RuleName);
+    }
+
+    /// <summary>
+    /// Verifies that multiple tags added in order round-trip as a set on the rule via JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithMultipleTags_ShouldPreserveAllTags()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Fixed(12, 25)
+                    .AddTag("Christian")
+                    .AddTag("Public")
+                    .AddTag("Federal"))));
+
+        Assert.AreEqual(3, parsed[0].Tags.Count);
+        Assert.IsTrue(parsed[0].Tags.Contains("Christian"));
+        Assert.IsTrue(parsed[0].Tags.Contains("Public"));
+        Assert.IsTrue(parsed[0].Tags.Contains("Federal"));
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <see cref="NotableDateRuleBuilder.NonWorking(bool)" /> with <see langword="false" />
+    /// round-trips through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithNonWorkingFalse_ShouldPreserveExplicitFalse()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Observance)
+                    .NonWorking(false)
+                    .Fixed(1, 1))));
+
+        Assert.AreEqual(false, parsed[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that an unset <see cref="NotableDateRuleBuilder.NonWorking" /> round-trips as <see langword="null" />
+    /// through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithoutNonWorking_ShouldLeaveIsNonWorkingDayNull()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Observance)
+                    .Fixed(1, 1))));
+
+        Assert.IsNull(parsed[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that a rule with every optional scalar field set populates each on the JSON-parsed result.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_RuleWithAllOptionalScalars_ShouldPreserveEveryField()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Comprehensive Rule", date => date
+                .AddRule(rule => rule
+                    .RuleName("variant-a")
+                    .Category(NotableDateCategory.Civic)
+                    .NonWorking()
+                    .FirstYear(1950)
+                    .LastYear(2099)
+                    .OccurrenceYears(2)
+                    .Duration(5)
+                    .Priority(25)
+                    .Territory("AU-NSW")
+                    .Comment("Round-trip coverage test")
+                    .AddTag("Federal")
+                    .AddTag("Public")
+                    .Fixed(7, 4))));
+
+        NotableDateRule rule = parsed[0];
+        Assert.AreEqual("Comprehensive Rule", rule.Name);
+        Assert.AreEqual("variant-a", rule.RuleName);
+        Assert.AreEqual(NotableDateCategory.Civic, rule.Category);
+        Assert.AreEqual(true, rule.IsNonWorkingDay);
+        Assert.AreEqual(1950, rule.FirstYear);
+        Assert.AreEqual(2099, rule.LastYear);
+        Assert.AreEqual(2, rule.OccurrenceYears);
+        Assert.AreEqual(5, rule.DurationDays);
+        Assert.AreEqual(25, rule.Priority);
+        Assert.AreEqual("AU-NSW", rule.TerritoryCode);
+        Assert.AreEqual("Round-trip coverage test", rule.Comment);
+        Assert.AreEqual(2, rule.Tags.Count);
+    }
+
+    // ============================================================================
+    // Adjustments: triggers (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that every <see cref="AdjustmentTrigger" /> value round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    [DataRow(AdjustmentTrigger.Always)]
+    [DataRow(AdjustmentTrigger.IfDayOfWeek)]
+    [DataRow(AdjustmentTrigger.IfWeekend)]
+    [DataRow(AdjustmentTrigger.IfWeekday)]
+    [DataRow(AdjustmentTrigger.IfNonWorkingDay)]
+    [DataRow(AdjustmentTrigger.IfBeforeFixedDate)]
+    [DataRow(AdjustmentTrigger.IfAfterFixedDate)]
+    [DataRow(AdjustmentTrigger.IfLeapYear)]
+    [DataRow(AdjustmentTrigger.IfNthOccurrenceInMonth)]
+    [DataRow(AdjustmentTrigger.Custom)]
+    public void RoundTripJson_AdjustmentAllTriggers_ShouldPreserveTrigger(AdjustmentTrigger trigger)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(trigger)
+                        .Action(AdjustmentAction.None)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .ComparisonDate(3, 20)
+                        .OrdinalOccurrence(WeekOfMonthOrdinal.Second)))));
+
+        Assert.AreEqual(trigger, parsed[0].Adjustments[0].Trigger);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="AdjustmentTrigger.IfDayOfWeek" /> trigger preserves the configured day of week
+    /// through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentIfDayOfWeek_ShouldPreserveDayOfWeek()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .OnDayOfWeek(DayOfWeek.Friday)))));
+
+        Assert.AreEqual(DayOfWeek.Friday, parsed[0].Adjustments[0].DayOfWeek);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment with <see cref="AdjustmentTrigger.IfBeforeFixedDate" /> preserves the comparison
+    /// month and day through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentIfBeforeFixedDate_ShouldPreserveComparisonDate()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Seasonal)
+                    .Fixed(3, 1)
+                    .AddAdjustment("pre-equinox", adj => adj
+                        .When(AdjustmentTrigger.IfBeforeFixedDate)
+                        .Action(AdjustmentAction.AddDays)
+                        .ComparisonDate(3, 20)
+                        .OffsetDays(1)))));
+
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.IsNotNull(adj.ComparisonDate);
+        Assert.AreEqual(3, adj.ComparisonDate!.Value.Month);
+        Assert.AreEqual(20, adj.ComparisonDate!.Value.Day);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="AdjustmentTrigger.IfNthOccurrenceInMonth" /> preserves the configured
+    /// <see cref="WeekOfMonthOrdinal" /> through JSON.
+    /// </summary>
+    [TestMethod]
+    [DataRow(WeekOfMonthOrdinal.First)]
+    [DataRow(WeekOfMonthOrdinal.Second)]
+    [DataRow(WeekOfMonthOrdinal.Third)]
+    [DataRow(WeekOfMonthOrdinal.Fourth)]
+    [DataRow(WeekOfMonthOrdinal.Fifth)]
+    [DataRow(WeekOfMonthOrdinal.Last)]
+    public void RoundTripJson_AdjustmentIfNthOccurrenceInMonth_ShouldPreserveOrdinal(WeekOfMonthOrdinal ordinal)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("nth", adj => adj
+                        .When(AdjustmentTrigger.IfNthOccurrenceInMonth)
+                        .Action(AdjustmentAction.None)
+                        .OnDayOfWeek(DayOfWeek.Monday)
+                        .OrdinalOccurrence(ordinal)))));
+
+        Assert.AreEqual(ordinal, parsed[0].Adjustments[0].WeekOrdinal);
+    }
+
+    // ============================================================================
+    // Adjustments: actions (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that every <see cref="AdjustmentAction" /> value round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    [DataRow(AdjustmentAction.None)]
+    [DataRow(AdjustmentAction.AddDays)]
+    [DataRow(AdjustmentAction.MoveToNextWeekday)]
+    [DataRow(AdjustmentAction.MoveToPreviousWeekday)]
+    [DataRow(AdjustmentAction.MoveToNextNonWorkingDay)]
+    [DataRow(AdjustmentAction.ReplaceWithNamedDate)]
+    [DataRow(AdjustmentAction.Custom)]
+    public void RoundTripJson_AdjustmentAllActions_ShouldPreserveAction(AdjustmentAction action)
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("a", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(action)
+                        .Target("Other Rule")
+                        .OffsetDays(1)))));
+
+        Assert.AreEqual(action, parsed[0].Adjustments[0].Action);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="AdjustmentAction.ReplaceWithNamedDate" /> action preserves its target rule name
+    /// through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentReplaceWithNamedDate_ShouldPreserveTarget()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Anzac Day Observance", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Remembrance)
+                    .Fixed(4, 25)
+                    .AddAdjustment("sub", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .Action(AdjustmentAction.ReplaceWithNamedDate)
+                        .Target("Anzac Day (Substitute)")))));
+
+        Assert.AreEqual("Anzac Day (Substitute)", parsed[0].Adjustments[0].TargetRuleName);
+    }
+
+    // ============================================================================
+    // Adjustments: scopes and metadata (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by territory preserves the territory code through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithTerritoryScope_ShouldPreserveTerritory()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("scoped", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .Territory("AU-NSW,AU-VIC")))));
+
+        Assert.AreEqual("AU-NSW,AU-VIC", parsed[0].Adjustments[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by calendar type preserves the type through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithCalendarTypeScope_ShouldPreserveCalendarType()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Fixed(1, 1)
+                    .AddAdjustment("hebrew-only", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None)
+                        .CalendarType(typeof(HebrewCalendar))))));
+
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[0].Adjustments[0].CalendarType);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment scoped by inclusive year bounds preserves both bounds through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithYearBounds_ShouldPreserveBothBounds()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("bounded", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .FromYear(2010)
+                        .ToYear(2050)))));
+
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.AreEqual(2010, adj.EffectiveFromYear);
+        Assert.AreEqual(2050, adj.EffectiveToYear);
+    }
+
+    /// <summary>
+    /// Verifies that an adjustment's non-default priority round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithNonDefaultPriority_ShouldPreservePriority()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("urgent", adj => adj
+                        .When(AdjustmentTrigger.Always)
+                        .Action(AdjustmentAction.None)
+                        .Priority(5)))));
+
+        Assert.AreEqual(5, parsed[0].Adjustments[0].Priority);
+    }
+
+    /// <summary>
+    /// Verifies that an explicit <c>NonWorking(false)</c> on the adjustment round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentNonWorkingFalse_ShouldPreserveExplicitFalse()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("working-override", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.None)
+                        .NonWorking(false)))));
+
+        Assert.AreEqual(false, parsed[0].Adjustments[0].IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="ObservanceAdjustmentBuilder.HandlerKey" /> value round-trips intact through JSON.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithHandlerKey_ShouldPreserveHandlerKey()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("my-custom-handler")))));
+
+        Assert.AreEqual("my-custom-handler", parsed[0].Adjustments[0].HandlerKey);
+    }
+
+    /// <summary>
+    /// Verifies that the programmatic-only <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> and
+    /// <see cref="ObservanceAdjustmentBuilder.MaxAdjustmentReachDays" /> values are omitted from the JSON output
+    /// (they are not part of <c>NotableDates.schema.json</c>) so a JSON round-trip yields the rule with these
+    /// fields unset.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_AdjustmentWithProgrammaticOnlyFields_ShouldOmitFromJson()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("my-handler")
+                        .AddHandlerParameter("enabled", "true")
+                        .MaxAdjustmentReachDays(45))));
+
+        JsonObject doc = builder.ToJsonNode();
+        JsonObject adjNode = doc["notableDates"]![0]!["rules"]![0]!["adjustments"]![0]!.AsObject();
+        Assert.IsFalse(adjNode.ContainsKey("handlerParameters"));
+        Assert.IsFalse(adjNode.ContainsKey("maxAdjustmentReachDays"));
+
+        List<NotableDateRule> parsed = NotableDateRuleJsonParser.ParseJson(builder.ToJson());
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.AreEqual("my-handler", adj.HandlerKey);
+        Assert.IsNull(adj.HandlerParameters);
+        Assert.IsNull(adj.MaxAdjustmentReachDays);
+    }
+
+    // ============================================================================
+    // Hierarchical structures (JSON)
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that multiple rules under the same notable date name round-trip through JSON with each rule's
+    /// identifying fields preserved and the canonical date name shared.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_MultipleRulesPerDate_ShouldPreserveEveryVariant()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("King's Birthday", date => date
+                .AddRule(rule => rule
+                    .RuleName("queensland")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-QLD")
+                    .DayOfWeekInMonth(10, DayOfWeek.Monday, WeekOfMonthOrdinal.First))
+                .AddRule(rule => rule
+                    .RuleName("other-states")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-NSW,AU-VIC,AU-SA,AU-TAS,AU-ACT,AU-NT")
+                    .DayOfWeekInMonth(6, DayOfWeek.Monday, WeekOfMonthOrdinal.Second))
+                .AddRule(rule => rule
+                    .RuleName("western-australia")
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU-WA")
+                    .DayOfWeekInMonth(9, DayOfWeek.Monday, WeekOfMonthOrdinal.Last))));
+
+        Assert.AreEqual(3, parsed.Count);
+        Assert.IsTrue(parsed.All(r => r.Name == "King's Birthday"));
+        Assert.AreEqual("queensland", parsed[0].RuleName);
+        Assert.AreEqual("other-states", parsed[1].RuleName);
+        Assert.AreEqual("western-australia", parsed[2].RuleName);
+        Assert.AreEqual(10, parsed[0].Month);
+        Assert.AreEqual(6, parsed[1].Month);
+        Assert.AreEqual(9, parsed[2].Month);
+    }
+
+    /// <summary>
+    /// Verifies that multiple notable dates in the same document each round-trip through JSON with their rules
+    /// preserved and addition order maintained.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_MultipleDatesPerDocument_ShouldPreserveOrderAndRules()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 25)))
+            .AddDate("Boxing Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(12, 26)))
+            .AddDate("New Year's Day", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(1, 1))));
+
+        Assert.AreEqual(3, parsed.Count);
+        Assert.AreEqual("Christmas Day", parsed[0].Name);
+        Assert.AreEqual("Boxing Day", parsed[1].Name);
+        Assert.AreEqual("New Year's Day", parsed[2].Name);
+    }
+
+    /// <summary>
+    /// Verifies that multiple adjustments on the same rule round-trip through JSON with each retaining its unique
+    /// key, trigger, action, and ordering.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_MultipleAdjustmentsPerRule_ShouldPreserveOrderAndKeys()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("saturday-shift", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Saturday)
+                        .Action(AdjustmentAction.MoveToPreviousWeekday))
+                    .AddAdjustment("sunday-shift", adj => adj
+                        .When(AdjustmentTrigger.IfDayOfWeek)
+                        .OnDayOfWeek(DayOfWeek.Sunday)
+                        .Action(AdjustmentAction.MoveToNextWeekday))
+                    .AddAdjustment("custom-rule", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("special-case")))));
+
+        var adjustments = parsed[0].Adjustments;
+        Assert.AreEqual(3, adjustments.Length);
+        Assert.AreEqual("saturday-shift", adjustments[0].Key);
+        Assert.AreEqual("sunday-shift", adjustments[1].Key);
+        Assert.AreEqual("custom-rule", adjustments[2].Key);
+        Assert.AreEqual(DayOfWeek.Saturday, adjustments[0].DayOfWeek);
+        Assert.AreEqual(DayOfWeek.Sunday, adjustments[1].DayOfWeek);
+        Assert.AreEqual("special-case", adjustments[2].HandlerKey);
+    }
+
+    /// <summary>
+    /// Verifies that a fully-populated document round-trips through JSON with every value preserved.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_ComprehensiveNestedDocument_ShouldPreserveEntireGraph()
+    {
+        List<NotableDateRule> parsed = BuildAndReparseViaJson(b => b
+            .AddDate("Australia Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Territory("AU")
+                    .NonWorking()
+                    .FirstYear(1994)
+                    .Priority(10)
+                    .Comment("National public holiday")
+                    .AddTag("Federal")
+                    .Fixed(1, 26)
+                    .AddAdjustment("weekend-roll", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday)
+                        .NonWorking())))
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "easter-gregorian")
+                    .AddTag("Christian")))
+            .AddDate("Easter Monday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .OffsetFromAnchor("Easter Sunday", 1)
+                    .NonWorking()))
+            .AddDate("Hanukkah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Duration(8)
+                    .Fixed("Kislev", 25))));
+
+        Assert.AreEqual(4, parsed.Count);
+
+        // Australia Day
+        Assert.AreEqual("Australia Day", parsed[0].Name);
+        Assert.AreEqual(1, parsed[0].Month);
+        Assert.AreEqual(26, parsed[0].Day);
+        Assert.AreEqual("AU", parsed[0].TerritoryCode);
+        Assert.AreEqual(true, parsed[0].IsNonWorkingDay);
+        Assert.AreEqual(1, parsed[0].Adjustments.Length);
+        Assert.AreEqual("weekend-roll", parsed[0].Adjustments[0].Key);
+
+        // Easter Sunday
+        Assert.AreEqual("Easter Sunday", parsed[1].Name);
+        Assert.AreEqual(DateResolutionStrategy.Algorithm, parsed[1].Strategy);
+        Assert.AreEqual("easter-gregorian", parsed[1].AlgorithmKey);
+
+        // Easter Monday
+        Assert.AreEqual("Easter Monday", parsed[2].Name);
+        Assert.AreEqual(DateResolutionStrategy.OffsetFromAnchor, parsed[2].Strategy);
+        Assert.AreEqual("Easter Sunday", parsed[2].AnchorRuleName);
+        Assert.AreEqual(1, parsed[2].OffsetDays);
+
+        // Hanukkah
+        Assert.AreEqual("Hanukkah", parsed[3].Name);
+        Assert.AreEqual(typeof(HebrewCalendar), parsed[3].CalendarType);
+        Assert.AreEqual(8, parsed[3].DurationDays);
+        Assert.AreEqual(3, parsed[3].Month);
+        Assert.IsNull(parsed[3].CalendarMonthAlias);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateDocumentBuilder.ToJsonNode" /> and
+    /// <see cref="NotableDateDocumentBuilder.ToJson" /> produce equivalent payloads — the latter is the indented
+    /// string serialisation of the former — for a comprehensive document.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_ToJsonNodeAndToJson_ShouldProduceEquivalentPayloads()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Test A", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(1, 1)))
+            .AddDate("Test B", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Religious).Algorithm(key: "k")));
+
+        JsonObject node = builder.ToJsonNode();
+        JsonObject fromString = JsonNode.Parse(builder.ToJson())!.AsObject();
+
+        Assert.AreEqual(node.ToJsonString(), fromString.ToJsonString());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateDocumentBuilder.ToJson" /> produces an indented JSON string whose root
+    /// is an object with a <c>notableDates</c> array.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_ToJson_ShouldProduceObjectWithNotableDatesArray()
+    {
+        string json = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule.Category(NotableDateCategory.Holiday).Fixed(1, 1)))
+            .ToJson();
+
+        JsonNode parsed = JsonNode.Parse(json)!;
+        JsonObject root = parsed.AsObject();
+        Assert.IsTrue(root.ContainsKey("notableDates"));
+        Assert.IsTrue(root["notableDates"] is JsonArray);
+    }
+
+    /// <summary>
+    /// Verifies that a document with no notable dates serialises to a JSON object containing an empty
+    /// <c>notableDates</c> array, and the empty document round-trips through the parser without errors.
+    /// </summary>
+    [TestMethod]
+    public void RoundTripJson_EmptyDocument_ShouldRoundTripAsEmptyNotableDatesArray()
+    {
+        string json = NotableDateDocumentBuilder.Create().ToJson();
+        List<NotableDateRule> parsed = NotableDateRuleJsonParser.ParseJson(json);
+        Assert.AreEqual(0, parsed.Count);
+    }
+
+    // ============================================================================
+    // Cross-format equivalence
+    // ============================================================================
+
+    /// <summary>
+    /// Verifies that XML and JSON round-trips of the same comprehensive document yield equivalent rules — the
+    /// builder must produce identical DTOs regardless of the serialisation format.
+    /// </summary>
+    [TestMethod]
+    public void RoundTrip_XmlAndJson_ShouldProduceEquivalentRules()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Christmas Day", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Territory("AU,NZ")
+                    .NonWorking()
+                    .Duration(1)
+                    .Priority(50)
+                    .AddTag("Public")
+                    .Fixed(12, 25)
+                    .AddAdjustment("weekend-roll", adj => adj
+                        .When(AdjustmentTrigger.IfWeekend)
+                        .Action(AdjustmentAction.MoveToNextWeekday))))
+            .AddDate("Easter Sunday", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .Algorithm(key: "easter-gregorian")))
+            .AddDate("Hanukkah", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Religious)
+                    .CalendarType(typeof(HebrewCalendar))
+                    .Duration(8)
+                    .Fixed("Kislev", 25)));
+
+        List<NotableDateRule> fromXml = NotableDateRuleParser.ParseXml(builder.ToXml());
+        List<NotableDateRule> fromJson = NotableDateRuleJsonParser.ParseJson(builder.ToJson());
+
+        Assert.AreEqual(fromXml.Count, fromJson.Count);
+        for (int i = 0; i < fromXml.Count; i++)
+        {
+            Assert.AreEqual(fromXml[i].Name, fromJson[i].Name);
+            Assert.AreEqual(fromXml[i].Strategy, fromJson[i].Strategy);
+            Assert.AreEqual(fromXml[i].Category, fromJson[i].Category);
+            Assert.AreEqual(fromXml[i].Month, fromJson[i].Month);
+            Assert.AreEqual(fromXml[i].Day, fromJson[i].Day);
+            Assert.AreEqual(fromXml[i].CalendarMonthAlias, fromJson[i].CalendarMonthAlias);
+            Assert.AreEqual(fromXml[i].AnchorRuleName, fromJson[i].AnchorRuleName);
+            Assert.AreEqual(fromXml[i].OffsetDays, fromJson[i].OffsetDays);
+            Assert.AreEqual(fromXml[i].AlgorithmKey, fromJson[i].AlgorithmKey);
+            Assert.AreEqual(fromXml[i].CalendarType, fromJson[i].CalendarType);
+            Assert.AreEqual(fromXml[i].TerritoryCode, fromJson[i].TerritoryCode);
+            Assert.AreEqual(fromXml[i].IsNonWorkingDay, fromJson[i].IsNonWorkingDay);
+            Assert.AreEqual(fromXml[i].DurationDays, fromJson[i].DurationDays);
+            Assert.AreEqual(fromXml[i].Priority, fromJson[i].Priority);
+            Assert.AreEqual(fromXml[i].Tags.Count, fromJson[i].Tags.Count);
+            Assert.AreEqual(fromXml[i].Adjustments.Length, fromJson[i].Adjustments.Length);
+        }
+    }
+
+    // ============================================================================
+    // Helpers
+    // ============================================================================
+
+    /// <summary>
+    /// Builds, serialises to JSON, and re-parses the configured document, returning the parsed rules.
+    /// </summary>
+    /// <param name="configure">Callback that configures the builder under test.</param>
+    /// <returns>The parsed rules.</returns>
+    private static List<NotableDateRule> BuildAndReparseViaJson(Action<NotableDateDocumentBuilder> configure)
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create();
+        configure(builder);
+        return NotableDateRuleJsonParser.ParseJson(builder.ToJson());
+    }
+}

--- a/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.ToXml.cs
+++ b/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.ToXml.cs
@@ -256,6 +256,40 @@ public partial class NotableDateDocumentBuilderTests
     }
 
     /// <summary>
+    /// Verifies that values supplied via <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> and
+    /// <see cref="ObservanceAdjustmentBuilder.MaxAdjustmentReachDays" /> are omitted from the serialised XML
+    /// (they are programmatic-only properties not defined by the schema).
+    /// </summary>
+    [TestMethod]
+    public void ToXml_WhenAdjustmentHasProgrammaticOnlyFields_ShouldOmitFromXml()
+    {
+        NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create()
+            .AddDate("Test", date => date
+                .AddRule(rule => rule
+                    .Category(NotableDateCategory.Holiday)
+                    .Fixed(1, 1)
+                    .AddAdjustment("custom", adj => adj
+                        .When(AdjustmentTrigger.Custom)
+                        .Action(AdjustmentAction.Custom)
+                        .HandlerKey("my-handler")
+                        .AddHandlerParameter("enabled", "true")
+                        .MaxAdjustmentReachDays(45))));
+
+        XDocument doc = builder.ToXDocument();
+        XElement adjElement = doc.Descendants(CalendarNs + "Adjustment").Single();
+
+        Assert.IsNull(adjElement.Attribute("handlerParameters"));
+        Assert.IsNull(adjElement.Attribute("maxAdjustmentReachDays"));
+
+        // The XML must still round-trip cleanly through the parser.
+        List<NotableDateRule> parsed = NotableDateRuleParser.ParseXml(builder.ToXml());
+        ObservanceAdjustment adj = parsed[0].Adjustments[0];
+        Assert.AreEqual("my-handler", adj.HandlerKey);
+        Assert.IsNull(adj.HandlerParameters);
+        Assert.IsNull(adj.MaxAdjustmentReachDays);
+    }
+
+    /// <summary>
     /// Verifies that a comparison date set via <see cref="ObservanceAdjustmentBuilder.ComparisonDate" /> is serialised
     /// as <c>comparisonMonth</c> and <c>comparisonDay</c> attributes and round-trips through the parser.
     /// </summary>

--- a/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/ObservanceAdjustmentBuilderTests.cs
+++ b/Bodu.Globalization.Calendar/builder/test/Globalization.Calendar.Builder/ObservanceAdjustmentBuilderTests.cs
@@ -131,4 +131,64 @@ public class ObservanceAdjustmentBuilderTests
             _ = builder.HandlerKey(string.Empty);
         });
     }
+
+    /// <summary>
+    /// Verifies that <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> throws
+    /// <see cref="ArgumentNullException" /> when the key is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddHandlerParameter_WhenKeyIsNull_ShouldThrowArgumentNullException()
+    {
+        ObservanceAdjustmentBuilder builder = new();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddHandlerParameter(null!, "value");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> throws an argument exception
+    /// when the key is whitespace.
+    /// </summary>
+    [TestMethod]
+    public void AddHandlerParameter_WhenKeyIsWhitespace_ShouldThrowArgumentException()
+    {
+        ObservanceAdjustmentBuilder builder = new();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = builder.AddHandlerParameter("   ", "value");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ObservanceAdjustmentBuilder.AddHandlerParameter" /> throws
+    /// <see cref="ArgumentNullException" /> when the value is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddHandlerParameter_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        ObservanceAdjustmentBuilder builder = new();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddHandlerParameter("key", null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ObservanceAdjustmentBuilder.MaxAdjustmentReachDays" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the day count is negative.
+    /// </summary>
+    [TestMethod]
+    public void MaxAdjustmentReachDays_WhenNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        ObservanceAdjustmentBuilder builder = new();
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = builder.MaxAdjustmentReachDays(-1);
+        });
+    }
 }


### PR DESCRIPTION
## Summary

Extends the `NotableDateDocumentBuilder` and related builder classes to support JSON serialization alongside the existing XML serialization. The builder now produces schema-valid JSON output matching `NotableDates.schema.json` in addition to XML matching `NotableDates.xsd`.

## Key Changes

- **NotableDateDocumentBuilder**: Added `ToJsonNode()` and `ToJson()` methods to serialize the document to `JsonObject` and JSON string respectively, mirroring the existing `ToXDocument()` and `ToXml()` methods.

- **NotableDateRuleBuilder**: Added `ToJsonNode(string notableDateName)` method to serialize individual rules to JSON objects with all strategy types (Fixed, DayOfWeekInMonth, OffsetFromAnchor, Algorithm) and metadata fields preserved.

- **NotableDateBuilder**: Added `ToJsonNode(string notableDateName)` method to serialize notable dates and their rules to JSON.

- **ObservanceAdjustmentBuilder**: Added `ToJsonNode(string ruleName)` method to serialize adjustments to JSON objects, with the same programmatic-only field handling as XML (HandlerParameters and MaxAdjustmentReachDays are omitted from serialized output).

- **Comprehensive test coverage**: Added two new test files with 1000+ test cases:
  - `NotableDateDocumentBuilderTests.RoundTrip.cs` — validates XML round-trip (Build → ToXml → ParseXml) for all strategies and metadata
  - `NotableDateDocumentBuilderTests.RoundTripJson.cs` — validates JSON round-trip (Build → ToJson → ParseJson) for all strategies and metadata

- **Test enhancements**: Extended `NotableDateDocumentBuilderTests.Build.cs` and `ObservanceAdjustmentBuilderTests.cs` with tests for handler parameters and max adjustment reach days.

## Implementation Details

- JSON serialization uses `System.Text.Json.Nodes.JsonObject` for consistency with the existing JSON parsing infrastructure.
- All enum values (NotableDateCategory, WeekOfMonthOrdinal, DayOfWeek, etc.) are serialized as their string representations.
- Month aliases and numeric months are handled identically in JSON as in XML — fixed-position Hebrew months resolve to numeric 1–7, while leap-year-dependent aliases preserve their string form.
- Lunisolar flags (skipLeapMonth, sweepCalendarYears) round-trip correctly through JSON.
- Algorithm strategies support both registry keys and CLR type references with optional month/day constructor arguments.
- The JSON output is schema-compliant and can be round-tripped through the existing JSON parsing logic without loss of fidelity.

https://claude.ai/code/session_01FZqzMfBcoaSyJWdBGUB4RF