### PR TITLE
Simplify and standardize Rule name attribute across NotableDate XML files

### DIFF
--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
@@ -30,7 +30,7 @@
     <Use name="International Women's Day" territory="CA" />
     <Use name="Halloween" territory="CA" />
     <Use name="Remembrance Day" territory="CA" nonWorking="true">
-      <Rule name="Canadian Remembrance Day With Weekend Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-nov-11-weekend-roll-ca" category="Holiday" nonWorking="true">
         <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
       </Rule>
     </Use>
@@ -46,7 +46,7 @@
     <Use name="Easter Monday" territory="CA" nonWorking="true" />
     <Use name="Christmas Eve" territory="CA" />
     <Use name="Christmas Day" territory="CA" nonWorking="true">
-      <Rule name="Canadian Christmas Day With Non-Working-Day Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-25-nonworking-roll-ca" category="Holiday" nonWorking="true">
         <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
       </Rule>
     </Use>
@@ -66,7 +66,7 @@
   -->
 
   <NotableDate name="Victoria Day">
-    <Rule name="Victoria Day" category="Holiday" territory="CA" nonWorking="true"
+    <Rule name="algo-victoria-day-ca" category="Holiday" territory="CA" nonWorking="true"
           comment="Victoria Day falls on the Monday immediately preceding 25 May (Canada Holidays Act, RSC 1985 c H-5.1). This rule requires a custom INotableDateAlgorithm registered under the key 'victoria-day'.">
       <Algorithm key="victoria-day" />
       <Tag>FederalHoliday</Tag>
@@ -74,7 +74,7 @@
   </NotableDate>
 
   <NotableDate name="Canada Day">
-    <Rule name="Fixed Canada Day With Weekend Roll" category="Holiday" territory="CA" nonWorking="true"
+    <Rule name="fixed-jul-01-weekend-roll-ca" category="Holiday" territory="CA" nonWorking="true"
           comment="When 1 July falls on a Sunday, the following Monday is observed as the statutory holiday (Canada Holidays Act). No substitute day is designated when 1 July falls on a Saturday.">
       <Fixed month="July" day="1" />
       <Tag>FederalHoliday</Tag>
@@ -83,14 +83,14 @@
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In September Labour Day" category="Holiday" territory="CA" nonWorking="true">
+    <Rule name="weekday-1st-mon-sep-ca" category="Holiday" territory="CA" nonWorking="true">
       <DayOfWeekInMonth month="September" dayOfWeek="Monday" weekOrdinal="First" />
       <Tag>FederalHoliday</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="National Day for Truth and Reconciliation">
-    <Rule name="Fixed National Day for Truth and Reconciliation With Weekend Roll"
+    <Rule name="fixed-sep-30-weekend-roll-ca"
           category="Holiday"
           territory="CA"
           nonWorking="true"
@@ -103,14 +103,14 @@
   </NotableDate>
 
   <NotableDate name="Thanksgiving">
-    <Rule name="Second Monday In October Thanksgiving" category="Holiday" territory="CA" nonWorking="true">
+    <Rule name="weekday-2nd-mon-oct-ca" category="Holiday" territory="CA" nonWorking="true">
       <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" />
       <Tag>FederalHoliday</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Boxing Day">
-    <Rule name="Fixed Boxing Day With Non-Working-Day Roll" category="Holiday" territory="CA" nonWorking="true"
+    <Rule name="fixed-dec-26-nonworking-roll-ca" category="Holiday" territory="CA" nonWorking="true"
           comment="A federal statutory holiday. Also a provincial holiday in Ontario and New Brunswick.">
       <Fixed month="December" day="26" />
       <Tag>FederalHoliday</Tag>
@@ -123,7 +123,7 @@
   -->
 
   <NotableDate name="National Indigenous Peoples Day">
-    <Rule name="Fixed National Indigenous Peoples Day" category="Observance" territory="CA" firstYear="1996"
+    <Rule name="fixed-jun-21-ca" category="Observance" territory="CA" firstYear="1996"
           comment="Proclaimed by Governor General Roméo LeBlanc in 1996 on the recommendation of the Royal Commission on Aboriginal Peoples, in recognition of the unique heritage, diverse cultures, and outstanding contributions of Indigenous peoples.">
       <Fixed month="June" day="21" />
     </Rule>
@@ -137,7 +137,7 @@
   -->
 
   <NotableDate name="Family Day">
-    <Rule name="Third Monday In February Family Day (AB)"
+    <Rule name="weekday-3rd-mon-feb-ca-ab"
           category="Holiday"
           territory="CA-AB"
           nonWorking="true"
@@ -146,7 +146,7 @@
       <DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>ProvinceHoliday</Tag>
     </Rule>
-    <Rule name="Third Monday In February Family Day (SK)"
+    <Rule name="weekday-3rd-mon-feb-ca-sk"
           category="Holiday"
           territory="CA-SK"
           nonWorking="true"
@@ -155,7 +155,7 @@
       <DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>ProvinceHoliday</Tag>
     </Rule>
-    <Rule name="Third Monday In February Family Day (ON)"
+    <Rule name="weekday-3rd-mon-feb-ca-on"
           category="Holiday"
           territory="CA-ON"
           nonWorking="true"
@@ -164,7 +164,7 @@
       <DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>ProvinceHoliday</Tag>
     </Rule>
-    <Rule name="Third Monday In February Family Day (BC)"
+    <Rule name="weekday-3rd-mon-feb-ca-bc"
           category="Holiday"
           territory="CA-BC"
           nonWorking="true"
@@ -173,7 +173,7 @@
       <DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>ProvinceHoliday</Tag>
     </Rule>
-    <Rule name="Third Monday In February Family Day (NB)"
+    <Rule name="weekday-3rd-mon-feb-ca-nb"
           category="Holiday"
           territory="CA-NB"
           nonWorking="true"
@@ -185,7 +185,7 @@
   </NotableDate>
 
   <NotableDate name="Island Day">
-    <Rule name="Third Monday In February Island Day"
+    <Rule name="weekday-3rd-mon-feb-ca-pe"
           category="Holiday"
           territory="CA-PE"
           nonWorking="true"
@@ -197,7 +197,7 @@
   </NotableDate>
 
   <NotableDate name="Louis Riel Day">
-    <Rule name="Third Monday In February Louis Riel Day"
+    <Rule name="weekday-3rd-mon-feb-ca-mb"
           category="Holiday"
           territory="CA-MB"
           nonWorking="true"
@@ -209,7 +209,7 @@
   </NotableDate>
 
   <NotableDate name="Nova Scotia Heritage Day">
-    <Rule name="Third Monday In February Nova Scotia Heritage Day"
+    <Rule name="weekday-3rd-mon-feb-ca-ns"
           category="Holiday"
           territory="CA-NS"
           nonWorking="true"
@@ -225,7 +225,7 @@
   -->
 
   <NotableDate name="Fête nationale du Québec">
-    <Rule name="Fixed Fête nationale du Québec With Weekend Roll"
+    <Rule name="fixed-jun-24-weekend-roll-ca-qc"
           category="Holiday"
           territory="CA-QC"
           nonWorking="true"
@@ -244,7 +244,7 @@
   -->
 
   <NotableDate name="Nunavut Day">
-    <Rule name="Fixed Nunavut Day With Weekend Roll"
+    <Rule name="fixed-jul-09-weekend-roll-ca-nu"
           category="Holiday"
           territory="CA-NU"
           nonWorking="true"
@@ -257,7 +257,7 @@
   </NotableDate>
 
   <NotableDate name="British Columbia Day">
-    <Rule name="First Monday In August British Columbia Day"
+    <Rule name="weekday-1st-mon-aug-ca-bc"
           category="Holiday"
           territory="CA-BC"
           nonWorking="true">
@@ -267,7 +267,7 @@
   </NotableDate>
 
   <NotableDate name="Civic Holiday">
-    <Rule name="First Monday In August Civic Holiday"
+    <Rule name="weekday-1st-mon-aug-ca-on"
           category="Holiday"
           territory="CA-ON,CA-MB,CA-SK,CA-NU"
           nonWorking="true"
@@ -278,7 +278,7 @@
   </NotableDate>
 
   <NotableDate name="Heritage Day">
-    <Rule name="First Monday In August Heritage Day (AB)"
+    <Rule name="weekday-1st-mon-aug-ca-ab"
           category="Observance"
           territory="CA-AB"
           comment="Observed on the first Monday of August in Alberta as a general provincial holiday; not a statutory holiday under provincial legislation.">
@@ -288,7 +288,7 @@
   </NotableDate>
 
   <NotableDate name="New Brunswick Day">
-    <Rule name="First Monday In August New Brunswick Day"
+    <Rule name="weekday-1st-mon-aug-ca-nb"
           category="Holiday"
           territory="CA-NB"
           nonWorking="true">
@@ -298,7 +298,7 @@
   </NotableDate>
 
   <NotableDate name="Discovery Day">
-    <Rule name="Third Monday In August Discovery Day (YT)"
+    <Rule name="weekday-3rd-mon-aug-ca-yt"
           category="Holiday"
           territory="CA-YT"
           nonWorking="true"

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
@@ -32,7 +32,7 @@
     <Use name="Easter Sunday" territory="US" />
     <Use name="Christmas Eve" territory="US" />
     <Use name="Christmas Day" territory="US" nonWorking="true">
-      <Rule name="United States Christmas Day With Non-Working-Day Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-25-nonworking-roll-us" category="Holiday" nonWorking="true">
         <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
       </Rule>
     </Use>
@@ -52,42 +52,42 @@
   -->
 
   <NotableDate name="Martin Luther King Jr. Day">
-    <Rule name="Third Monday In January Martin Luther King Jr. Day" category="Holiday" territory="US" nonWorking="true" firstYear="1986"
+    <Rule name="weekday-3rd-mon-jan-us" category="Holiday" territory="US" nonWorking="true" firstYear="1986"
           comment="Designated a federal holiday by the Martin Luther King Jr. Holiday Act signed by President Reagan in 1983. First observed on the third Monday of January 1986.">
       <DayOfWeekInMonth month="January" dayOfWeek="Monday" weekOrdinal="Third" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Presidents' Day">
-    <Rule name="Third Monday In February Presidents' Day" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="weekday-3rd-mon-feb-us" category="Holiday" territory="US" nonWorking="true"
           comment="Officially Washington's Birthday under federal law (5 U.S.C. § 6103). Commonly known as Presidents' Day following the 1971 Uniform Monday Holiday Act, which moved it from 22 February to the third Monday of February.">
       <DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="St. Patrick's Day">
-    <Rule name="Fixed St. Patrick's Day" category="Cultural" territory="US"
+    <Rule name="fixed-mar-17-us" category="Cultural" territory="US"
           comment="Not a federal holiday, but widely celebrated across the United States. Irish-American communities have observed it since the 18th century; the day is now marked by parades, public gatherings, and traditional green decorations in cities nationwide.">
       <Fixed month="March" day="17" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Memorial Day">
-    <Rule name="Last Monday In May Memorial Day" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="weekday-last-mon-may-us" category="Holiday" territory="US" nonWorking="true"
           comment="A federal holiday honouring United States military personnel who have died in the performance of their military duties. Moved to the last Monday of May by the Uniform Monday Holiday Act of 1968.">
       <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="Last" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Flag Day">
-    <Rule name="Fixed Flag Day" category="Observance" territory="US"
+    <Rule name="fixed-jun-14-us" category="Observance" territory="US"
           comment="Commemorates the adoption of the flag of the United States on 14 June 1777 by the Second Continental Congress. Not a federal holiday; designated as National Flag Day by Congress in 1949 (Public Law 81-81).">
       <Fixed month="June" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Juneteenth">
-    <Rule name="Fixed Juneteenth With Weekend Roll" category="Holiday" territory="US" nonWorking="true" firstYear="2021"
+    <Rule name="fixed-jun-19-weekend-roll-us" category="Holiday" territory="US" nonWorking="true" firstYear="2021"
           comment="Juneteenth National Independence Day. Commemorates 19 June 1865, when Union soldiers arrived in Galveston, Texas and announced the end of slavery, more than two months after the end of the Civil War. Established as a federal holiday by the Juneteenth National Independence Day Act signed by President Biden on 17 June 2021.">
       <Fixed month="June" day="19" />
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -95,7 +95,7 @@
   </NotableDate>
 
   <NotableDate name="Independence Day">
-    <Rule name="Fixed Independence Day With Weekend Roll" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="fixed-jul-04-weekend-roll-us" category="Holiday" territory="US" nonWorking="true"
           comment="Commemorates the adoption of the Declaration of Independence on 4 July 1776. When 4 July falls on a weekend, the observed federal holiday shifts to the nearest weekday.">
       <Fixed month="July" day="4" />
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -103,28 +103,28 @@
   </NotableDate>
 
   <NotableDate name="Labor Day">
-    <Rule name="First Monday In September Labor Day" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="weekday-1st-mon-sep-us" category="Holiday" territory="US" nonWorking="true"
           comment="A federal holiday celebrating the American labour movement and the contributions of workers. Moved to the first Monday of September by the Uniform Monday Holiday Act of 1968.">
       <DayOfWeekInMonth month="September" dayOfWeek="Monday" weekOrdinal="First" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Columbus Day">
-    <Rule name="Second Monday In October Columbus Day" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="weekday-2nd-mon-oct-us" category="Holiday" territory="US" nonWorking="true"
           comment="A federal holiday commemorating Christopher Columbus's arrival in the Americas on 12 October 1492. Moved to the second Monday of October by the Uniform Monday Holiday Act of 1968. Many states and municipalities also observe Indigenous Peoples' Day on the same date.">
       <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Indigenous Peoples' Day">
-    <Rule name="Second Monday In October Indigenous Peoples Day" category="Observance" territory="US" firstYear="1992"
+    <Rule name="weekday-2nd-mon-oct-us" category="Observance" territory="US" firstYear="1992"
           comment="Observed by a growing number of U.S. states and municipalities on the second Monday of October — the same date as the federal Columbus Day. First formally adopted by Berkeley, California in 1992. Recognised at the federal level by Presidential Proclamation from 2021.">
       <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Veterans Day">
-    <Rule name="Fixed Veterans Day With Weekend Roll" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="fixed-nov-11-weekend-roll-us" category="Holiday" territory="US" nonWorking="true"
           comment="A federal holiday honouring all United States military veterans. Observed on 11 November, the anniversary of the armistice that ended World War I in 1918. When 11 November falls on a weekend, the observed day shifts to the nearest weekday.">
       <Fixed month="November" day="11" />
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -132,21 +132,21 @@
   </NotableDate>
 
   <NotableDate name="Thanksgiving">
-    <Rule name="Fourth Thursday In November Thanksgiving" category="Holiday" territory="US" nonWorking="true"
+    <Rule name="weekday-4th-thu-nov-us" category="Holiday" territory="US" nonWorking="true"
           comment="A national holiday giving thanks for the harvest and blessings of the previous year. Set on the fourth Thursday of November by Congress in 1941.">
       <DayOfWeekInMonth month="November" dayOfWeek="Thursday" weekOrdinal="Fourth" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Black Friday">
-    <Rule name="Day After Thanksgiving Black Friday" category="Cultural" territory="US"
+    <Rule name="offset-thanksgiving+1-us" category="Cultural" territory="US"
           comment="The day after Thanksgiving, traditionally regarded as the start of the Christmas shopping season. Not a federal holiday; observed informally as a major retail event.">
       <OffsetFromAnchor name="Thanksgiving" offset="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Pearl Harbor Remembrance Day">
-    <Rule name="Fixed Pearl Harbor Remembrance Day" category="Remembrance" territory="US" firstYear="1994"
+    <Rule name="fixed-dec-07-us" category="Remembrance" territory="US" firstYear="1994"
           comment="Designated by Congress in 1994 (Public Law 103-308) to honour the 2,403 Americans killed and 1,178 wounded in the Japanese attack on Pearl Harbor on 7 December 1941. Not a federal holiday.">
       <Fixed month="December" day="7" />
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-au.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-au.xml
@@ -19,7 +19,7 @@
 
   <UseFrom resource="./global-all.xml">
     <Use name="New Year's Day" category="Holiday">
-      <Rule name="Australian New Year's Day" territory="AU" category="Holiday" nonWorking="true">
+      <Rule name="fixed-jan-01-weekend-roll-au" territory="AU" category="Holiday" nonWorking="true">
         <Tag>NationalHoliday</Tag>
       </Rule>
     </Use>
@@ -40,7 +40,7 @@
     <Use name="Easter Monday" territory="AU" nonWorking="true" />
     <Use name="Christmas Eve" territory="AU" />
     <Use name="Christmas Day" territory="AU" nonWorking="true">
-      <Rule name="Australian Christmas Day With Non-Working-Day Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-25-nonworking-roll-au" category="Holiday" nonWorking="true">
         <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
       </Rule>
     </Use>
@@ -64,7 +64,7 @@
   -->
 
   <NotableDate name="Australia Day">
-    <Rule name="Fixed Australia Day With Weekend Roll"
+    <Rule name="fixed-jan-26-weekend-roll-au"
           category="Holiday"
           territory="AU"
           nonWorking="true"
@@ -76,7 +76,7 @@
   </NotableDate>
 
   <NotableDate name="Anzac Day">
-    <Rule name="Fixed Anzac Day With WA And NT Weekend Substitution"
+    <Rule name="fixed-apr-25-weekend-roll-au"
           category="Remembrance"
           territory="AU"
           nonWorking="true"
@@ -89,7 +89,7 @@
   </NotableDate>
 
   <NotableDate name="Boxing Day">
-    <Rule name="Fixed Australian Boxing Day With Non-Working-Day Roll"
+    <Rule name="fixed-dec-26-nonworking-roll-au"
           category="Holiday"
           territory="AU"
           nonWorking="true">
@@ -104,7 +104,7 @@
   -->
 
   <NotableDate name="Harmony Day">
-    <Rule name="Fixed Harmony Day"
+    <Rule name="fixed-mar-21-au"
           category="Observance"
           territory="AU">
       <Fixed month="March" day="21" />
@@ -112,7 +112,7 @@
   </NotableDate>
 
   <NotableDate name="National Sorry Day">
-    <Rule name="Fixed National Sorry Day"
+    <Rule name="fixed-may-26-au"
           category="Remembrance"
           territory="AU">
       <Fixed month="May" day="26" />
@@ -120,7 +120,7 @@
   </NotableDate>
 
   <NotableDate name="National Reconciliation Week">
-    <Rule name="Fixed National Reconciliation Week"
+    <Rule name="fixed-may-27-au"
           category="Observance"
           territory="AU"
           durationDays="7">
@@ -129,7 +129,7 @@
   </NotableDate>
 
   <NotableDate name="Mabo Day">
-    <Rule name="Fixed Mabo Day"
+    <Rule name="fixed-jun-03-au"
           category="Remembrance"
           territory="AU">
       <Fixed month="June" day="3" />
@@ -137,7 +137,7 @@
   </NotableDate>
 
   <NotableDate name="NAIDOC Week">
-    <Rule name="First Sunday In July NAIDOC Week"
+    <Rule name="weekday-1st-sun-jul-au"
           category="Observance"
           durationDays="7"
           territory="AU">
@@ -146,7 +146,7 @@
   </NotableDate>
 
   <NotableDate name="Father's Day">
-    <Rule name="First Sunday In September Father's Day"
+    <Rule name="weekday-1st-sun-sep-au"
           category="Observance"
           territory="AU"
           comment="In Australia and New Zealand, Father's Day is observed on the first Sunday of September, not the third Sunday of June as in most other countries.">
@@ -155,7 +155,7 @@
   </NotableDate>
 
   <NotableDate name="R U OK? Day">
-    <Rule name="Second Thursday In September R U OK Day" 
+    <Rule name="weekday-2nd-thu-sep-au" 
           category="Observance"
           territory="AU">
       <DayOfWeekInMonth month="September" dayOfWeek="Thursday" weekOrdinal="Second" />
@@ -167,7 +167,7 @@
   -->
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (NSW)"
+    <Rule name="weekday-2nd-mon-jun-au-nsw"
           category="Holiday"
           territory="AU-NSW"
           nonWorking="true">
@@ -177,7 +177,7 @@
   </NotableDate>
 
   <NotableDate name="Bank Holiday">
-    <Rule name="First Monday In August Bank Holiday (NSW)"
+    <Rule name="weekday-1st-mon-aug-au-nsw"
           category="Observance"
           territory="AU-NSW"
           comment="Observed by banks and the financial sector only; not a general public holiday.">
@@ -187,7 +187,7 @@
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In October Labour Day (NSW)"
+    <Rule name="weekday-1st-mon-oct-au-nsw"
           category="Holiday"
           territory="AU-NSW"
           nonWorking="true">
@@ -201,7 +201,7 @@
   -->
 
   <NotableDate name="Labour Day">
-    <Rule name="Second Monday In March Labour Day (VIC)"
+    <Rule name="weekday-2nd-mon-mar-au-vic"
           category="Holiday"
           territory="AU-VIC"
           nonWorking="true">
@@ -211,7 +211,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (VIC)"
+    <Rule name="weekday-2nd-mon-jun-au-vic"
           category="Holiday"
           territory="AU-VIC"
           nonWorking="true">
@@ -221,7 +221,7 @@
   </NotableDate>
 
   <NotableDate name="AFL Grand Final Friday">
-    <Rule name="Last Friday In September AFL Grand Final Friday"
+    <Rule name="weekday-last-fri-sep-au-vic"
           category="Holiday"
           territory="AU-VIC"
           firstYear="2015"
@@ -234,7 +234,7 @@
   </NotableDate>
 
   <NotableDate name="Melbourne Cup Day">
-    <Rule name="First Tuesday In November Melbourne Cup Day"
+    <Rule name="weekday-1st-tue-nov-au-vic"
           category="Holiday"
           territory="AU-VIC"
           nonWorking="true"
@@ -249,7 +249,7 @@
   -->
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In May Labour Day (QLD)"
+    <Rule name="weekday-1st-mon-may-au-qld"
           category="Holiday"
           territory="AU-QLD"
           nonWorking="true">
@@ -259,7 +259,7 @@
   </NotableDate>
 
   <NotableDate name="Royal Queensland Show">
-    <Rule name="Second Wednesday In August Royal Queensland Show (Brisbane)"
+    <Rule name="weekday-2nd-wed-aug-au-qld"
           category="Cultural"
           territory="AU-QLD"
           nonWorking="true"
@@ -270,7 +270,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="First Monday In October King's Birthday (QLD)"
+    <Rule name="weekday-1st-mon-oct-au-qld"
           category="Holiday"
           territory="AU-QLD"
           firstYear="2016"
@@ -286,7 +286,7 @@
   -->
 
   <NotableDate name="Adelaide Cup Day">
-    <Rule name="Second Monday In March Adelaide Cup Day"
+    <Rule name="weekday-2nd-mon-mar-au-sa"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true">
@@ -296,7 +296,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (SA)"
+    <Rule name="weekday-2nd-mon-jun-au-sa"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true">
@@ -306,7 +306,7 @@
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In October Labour Day (SA)"
+    <Rule name="weekday-1st-mon-oct-au-sa"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true">
@@ -316,7 +316,7 @@
   </NotableDate>
 
   <NotableDate name="Proclamation Day">
-    <Rule name="Fixed Proclamation Day With Weekend Roll"
+    <Rule name="fixed-dec-26-weekend-roll-au-sa"
           category="Holiday"
           territory="AU-SA"
           nonWorking="true"
@@ -332,7 +332,7 @@
   -->
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In March Labour Day (WA)"
+    <Rule name="weekday-1st-mon-mar-au-wa"
           category="Holiday"
           territory="AU-WA"
           nonWorking="true">
@@ -342,7 +342,7 @@
   </NotableDate>
 
   <NotableDate name="Western Australia Day">
-    <Rule name="First Monday In June Western Australia Day"
+    <Rule name="weekday-1st-mon-jun-au-wa"
           category="Holiday"
           territory="AU-WA"
           nonWorking="true">
@@ -352,7 +352,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Last Monday In September King's Birthday (WA)"
+    <Rule name="weekday-last-mon-sep-au-wa"
           category="Holiday"
           territory="AU-WA"
           nonWorking="true"
@@ -368,7 +368,7 @@
   -->
 
   <NotableDate name="Eight Hours Day">
-    <Rule name="Second Monday In March Eight Hours Day"
+    <Rule name="weekday-2nd-mon-mar-au-tas"
           category="Holiday"
           territory="AU-TAS"
           nonWorking="true">
@@ -378,7 +378,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (TAS)"
+    <Rule name="weekday-2nd-mon-jun-au-tas"
           category="Holiday"
           territory="AU-TAS"
           nonWorking="true">
@@ -388,7 +388,7 @@
   </NotableDate>
 
   <NotableDate name="Recreation Day">
-    <Rule name="First Monday In November Recreation Day"
+    <Rule name="weekday-1st-mon-nov-au-tas"
           category="Holiday"
           territory="AU-TAS"
           nonWorking="true"
@@ -403,7 +403,7 @@
   -->
 
   <NotableDate name="May Day">
-    <Rule name="First Monday In May May Day"
+    <Rule name="weekday-1st-mon-may-au-nt"
           category="Holiday"
           territory="AU-NT"
           nonWorking="true">
@@ -413,7 +413,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (NT)"
+    <Rule name="weekday-2nd-mon-jun-au-nt"
           category="Holiday"
           territory="AU-NT"
           nonWorking="true">
@@ -423,7 +423,7 @@
   </NotableDate>
 
   <NotableDate name="Picnic Day">
-    <Rule name="First Monday In August Picnic Day"
+    <Rule name="weekday-1st-mon-aug-au-nt"
           category="Holiday"
           territory="AU-NT"
           nonWorking="true">
@@ -437,7 +437,7 @@
   -->
 
   <NotableDate name="Canberra Day">
-    <Rule name="Second Monday In March Canberra Day"
+    <Rule name="weekday-2nd-mon-mar-au-act"
           category="Holiday"
           territory="AU-ACT"
           nonWorking="true">
@@ -447,7 +447,7 @@
   </NotableDate>
 
   <NotableDate name="Reconciliation Day">
-    <Rule name="Last Monday In May Reconciliation Day"
+    <Rule name="weekday-last-mon-may-au-act"
           category="Holiday"
           territory="AU-ACT"
           firstYear="2018"
@@ -460,7 +460,7 @@
   </NotableDate>
 
   <NotableDate name="King's Birthday">
-    <Rule name="Second Monday In June King's Birthday (ACT)"
+    <Rule name="weekday-2nd-mon-jun-au-act"
           category="Holiday"
           territory="AU-ACT"
           nonWorking="true">
@@ -470,7 +470,7 @@
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="First Monday In October Labour Day (ACT)"
+    <Rule name="weekday-1st-mon-oct-au-act"
           category="Holiday"
           territory="AU-ACT"
           nonWorking="true">

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-cn.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-cn.xml
@@ -16,21 +16,21 @@
   </UseFrom>
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed China New Year's Day" category="Holiday" territory="CN" nonWorking="true">
+    <Rule name="fixed-jan-01-cn" category="Holiday" territory="CN" nonWorking="true">
       <Fixed month="January" day="1" />
       <Tag>China</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Labour Day">
-    <Rule name="Fixed China Labour Day" category="Holiday" territory="CN" nonWorking="true">
+    <Rule name="fixed-may-01-cn" category="Holiday" territory="CN" nonWorking="true">
       <Fixed month="May" day="1" />
       <Tag>China</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="National Day">
-    <Rule name="Fixed China National Day" category="Holiday" territory="CN" nonWorking="true" durationDays="7"
+    <Rule name="fixed-oct-01-cn" category="Holiday" territory="CN" nonWorking="true" durationDays="7"
           comment="Mainland China National Day Golden Week. The durationDays value of 7 represents the common statutory public-holiday period beginning on 1 October.">
       <Fixed month="October" day="1" />
       <Tag>China</Tag>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-in.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-in.xml
@@ -31,21 +31,21 @@
   </UseFrom>
 
   <NotableDate name="Republic Day">
-    <Rule name="Fixed India Republic Day" category="Holiday" territory="IN" nonWorking="true">
+    <Rule name="fixed-jan-26-in" category="Holiday" territory="IN" nonWorking="true">
       <Fixed month="January" day="26" />
       <Tag>India</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Independence Day">
-    <Rule name="Fixed India Independence Day" category="Holiday" territory="IN" nonWorking="true">
+    <Rule name="fixed-aug-15-in" category="Holiday" territory="IN" nonWorking="true">
       <Fixed month="August" day="15" />
       <Tag>India</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Gandhi Jayanti">
-    <Rule name="Fixed Gandhi Jayanti" category="Holiday" territory="IN" nonWorking="true">
+    <Rule name="fixed-oct-02-in" category="Holiday" territory="IN" nonWorking="true">
       <Fixed month="October" day="2" />
       <Tag>India</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-jp.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-jp.xml
@@ -12,42 +12,42 @@
   </UseFrom>
 
   <NotableDate name="Coming of Age Day">
-    <Rule name="Second Monday In January Coming Of Age Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2000">
+    <Rule name="weekday-2nd-mon-jan-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2000">
       <DayOfWeekInMonth month="January" dayOfWeek="Monday" weekOrdinal="Second" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Setsubun">
-    <Rule name="Fixed Setsubun" category="Cultural" territory="JP">
+    <Rule name="fixed-feb-03-jp" category="Cultural" territory="JP">
       <Fixed month="February" day="3" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="National Foundation Day">
-    <Rule name="Fixed National Foundation Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="fixed-feb-11-jp" category="Holiday" territory="JP" nonWorking="true">
       <Fixed month="February" day="11" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Emperor's Birthday">
-    <Rule name="Fixed Emperor Naruhito Birthday" category="Holiday" territory="JP" nonWorking="true" firstYear="2020">
+    <Rule name="fixed-feb-23-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2020">
       <Fixed month="February" day="23" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Vernal Equinox Day">
-    <Rule name="Vernal Equinox Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="algo-jp-vernal-equinox-jp" category="Holiday" territory="JP" nonWorking="true">
       <Algorithm key="jp-vernal-equinox" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Golden Week">
-    <Rule name="Golden Week" category="Cultural" territory="JP" durationDays="7"
+    <Rule name="fixed-apr-29-jp" category="Cultural" territory="JP" durationDays="7"
           comment="Japanese holiday period beginning on 29 April and conventionally spanning through 5 May. The durationDays value of 7 represents the inclusive 29 April to 5 May period; individual public holidays remain separately defined.">
       <Fixed month="April" day="29" />
       <Tag>Japan</Tag>
@@ -56,49 +56,49 @@
   </NotableDate>
 
   <NotableDate name="Showa Day">
-    <Rule name="Fixed Showa Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2007">
+    <Rule name="fixed-apr-29-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2007">
       <Fixed month="April" day="29" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Constitution Memorial Day">
-    <Rule name="Fixed Constitution Memorial Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="fixed-may-03-jp" category="Holiday" territory="JP" nonWorking="true">
       <Fixed month="May" day="3" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Greenery Day">
-    <Rule name="Fixed Greenery Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2007">
+    <Rule name="fixed-may-04-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2007">
       <Fixed month="May" day="4" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Children's Day">
-    <Rule name="Fixed Japanese Children's Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="fixed-may-05-jp" category="Holiday" territory="JP" nonWorking="true">
       <Fixed month="May" day="5" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Marine Day">
-    <Rule name="Third Monday In July Marine Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2003">
+    <Rule name="weekday-3rd-mon-jul-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2003">
       <DayOfWeekInMonth month="July" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Mountain Day">
-    <Rule name="Fixed Mountain Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2016">
+    <Rule name="fixed-aug-11-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2016">
       <Fixed month="August" day="11" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Obon">
-    <Rule name="Fixed Obon" category="Cultural" territory="JP" durationDays="3"
+    <Rule name="fixed-aug-13-jp" category="Cultural" territory="JP" durationDays="3"
           comment="Japanese ancestral festival commonly observed from 13 to 15 August in many regions. The durationDays value of 3 spans the common August Obon period inclusively.">
       <Fixed month="August" day="13" />
       <Tag>Japan</Tag>
@@ -107,35 +107,35 @@
   </NotableDate>
 
   <NotableDate name="Respect for the Aged Day">
-    <Rule name="Third Monday In September Respect For The Aged Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2003">
+    <Rule name="weekday-3rd-mon-sep-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2003">
       <DayOfWeekInMonth month="September" dayOfWeek="Monday" weekOrdinal="Third" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Autumnal Equinox Day">
-    <Rule name="Autumnal Equinox Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="algo-jp-autumnal-equinox-jp" category="Holiday" territory="JP" nonWorking="true">
       <Algorithm key="jp-autumnal-equinox" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Sports Day">
-    <Rule name="Second Monday In October Sports Day" category="Holiday" territory="JP" nonWorking="true" firstYear="2020">
+    <Rule name="weekday-2nd-mon-oct-jp" category="Holiday" territory="JP" nonWorking="true" firstYear="2020">
       <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Culture Day">
-    <Rule name="Fixed Culture Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="fixed-nov-03-jp" category="Holiday" territory="JP" nonWorking="true">
       <Fixed month="November" day="3" />
       <Tag>Japan</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Labour Thanksgiving Day">
-    <Rule name="Fixed Labour Thanksgiving Day" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="fixed-nov-23-jp" category="Holiday" territory="JP" nonWorking="true">
       <Fixed month="November" day="23" />
       <Tag>Japan</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-jp.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-jp.xml
@@ -40,7 +40,7 @@
   </NotableDate>
 
   <NotableDate name="Vernal Equinox Day">
-    <Rule name="algo-jp-vernal-equinox-jp" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="algo-jp-vernal-equinox" category="Holiday" territory="JP" nonWorking="true">
       <Algorithm key="jp-vernal-equinox" />
       <Tag>Japan</Tag>
     </Rule>
@@ -114,7 +114,7 @@
   </NotableDate>
 
   <NotableDate name="Autumnal Equinox Day">
-    <Rule name="algo-jp-autumnal-equinox-jp" category="Holiday" territory="JP" nonWorking="true">
+    <Rule name="algo-jp-autumnal-equinox" category="Holiday" territory="JP" nonWorking="true">
       <Algorithm key="jp-autumnal-equinox" />
       <Tag>Japan</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-kr.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-kr.xml
@@ -13,63 +13,63 @@
   </UseFrom>
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed Korea New Year's Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-jan-01-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="January" day="1" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Independence Movement Day">
-    <Rule name="Fixed Independence Movement Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-mar-01-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="March" day="1" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Children's Day">
-    <Rule name="Fixed Korea Children's Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-may-05-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="May" day="5" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Memorial Day">
-    <Rule name="Fixed Korea Memorial Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-jun-06-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="June" day="6" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Constitution Day">
-    <Rule name="Fixed Constitution Day" category="Civic" territory="KR">
+    <Rule name="fixed-jul-17-kr" category="Civic" territory="KR">
       <Fixed month="July" day="17" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Liberation Day">
-    <Rule name="Fixed Liberation Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-aug-15-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="August" day="15" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="National Foundation Day">
-    <Rule name="Fixed Korea National Foundation Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-oct-03-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="October" day="3" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Hangul Day">
-    <Rule name="Fixed Hangul Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-oct-09-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="October" day="9" />
       <Tag>Korea</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Christmas Day">
-    <Rule name="Fixed Korea Christmas Day" category="Holiday" territory="KR" nonWorking="true">
+    <Rule name="fixed-dec-25-kr" category="Holiday" territory="KR" nonWorking="true">
       <Fixed month="December" day="25" />
       <Tag>Korea</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-nz.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-nz.xml
@@ -28,7 +28,7 @@
 
   <UseFrom resource="./global-all.xml">
     <Use name="New Year's Day" territory="NZ" nonWorking="true">
-      <Rule name="New Zealand New Year's Day With Weekend Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-jan-01-weekend-roll-nz" category="Holiday" nonWorking="true">
         <Tag>NationalHoliday</Tag>
         <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
       </Rule>
@@ -48,13 +48,13 @@
     <Use name="Easter Sunday" territory="NZ" />
     <Use name="Easter Monday" territory="NZ" nonWorking="true" />
     <Use name="Christmas Day" territory="NZ" nonWorking="true">
-      <Rule name="New Zealand Christmas Day With Weekend Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-25-weekend-roll-nz" category="Holiday" nonWorking="true">
         <Tag>NationalHoliday</Tag>
         <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
       </Rule>
     </Use>
     <Use name="Boxing Day" territory="NZ" nonWorking="true">
-      <Rule name="New Zealand Boxing Day With Weekend Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-26-weekend-roll-nz" category="Holiday" nonWorking="true">
         <Tag>NationalHoliday</Tag>
         <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
       </Rule>
@@ -79,7 +79,7 @@
   -->
 
   <NotableDate name="Day after New Year's Day">
-    <Rule name="Fixed Day After New Year's Day With Weekend Roll"
+    <Rule name="fixed-jan-02-weekend-roll-nz"
           category="Holiday"
           territory="NZ"
           nonWorking="true"
@@ -91,7 +91,7 @@
   </NotableDate>
 
   <NotableDate name="Waitangi Day">
-    <Rule name="Fixed Waitangi Day With Weekend Roll"
+    <Rule name="fixed-feb-06-weekend-roll-nz"
           category="Holiday"
           territory="NZ"
           nonWorking="true"
@@ -103,7 +103,7 @@
   </NotableDate>
 
   <NotableDate name="Anzac Day">
-    <Rule name="Fixed Anzac Day With Weekend Roll"
+    <Rule name="fixed-apr-25-weekend-roll-nz"
           category="Remembrance"
           territory="NZ"
           nonWorking="true"
@@ -115,7 +115,7 @@
   </NotableDate>
 
   <NotableDate name="Sovereign's Birthday">
-    <Rule name="First Monday In June Sovereign's Birthday"
+    <Rule name="weekday-1st-mon-jun-nz"
           category="Holiday"
           territory="NZ"
           nonWorking="true"
@@ -126,7 +126,7 @@
   </NotableDate>
 
   <NotableDate name="Matariki">
-    <Rule name="Matariki"
+    <Rule name="algo-matariki-nz"
           category="Holiday"
           territory="NZ"
           nonWorking="true"
@@ -139,7 +139,7 @@
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="Fourth Monday In October Labour Day"
+    <Rule name="weekday-4th-mon-oct-nz"
           category="Holiday"
           territory="NZ"
           nonWorking="true"
@@ -154,14 +154,14 @@
   -->
 
   <NotableDate name="Father's Day">
-    <Rule name="First Sunday In September Father's Day" category="Observance" territory="NZ"
+    <Rule name="weekday-1st-sun-sep-nz" category="Observance" territory="NZ"
           comment="In New Zealand and Australia, Father's Day is observed on the first Sunday of September, not the third Sunday of June as in most other countries.">
       <DayOfWeekInMonth month="September" dayOfWeek="Sunday" weekOrdinal="First" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Guy Fawkes Night">
-    <Rule name="Fixed Guy Fawkes Night" category="Cultural" territory="NZ"
+    <Rule name="fixed-nov-05-nz" category="Cultural" territory="NZ"
           comment="Commemorates the foiling of the Gunpowder Plot of 5 November 1605. Widely observed in New Zealand as a fireworks celebration, reflecting the country's British heritage.">
       <Fixed month="November" day="5" />
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-sg.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-sg.xml
@@ -26,21 +26,21 @@
   </UseFrom>
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed Singapore New Year's Day" category="Holiday" territory="SG" nonWorking="true">
+    <Rule name="fixed-jan-01-sg" category="Holiday" territory="SG" nonWorking="true">
       <Fixed month="January" day="1" />
       <Tag>Singapore</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Labour Day">
-    <Rule name="Fixed Singapore Labour Day" category="Holiday" territory="SG" nonWorking="true">
+    <Rule name="fixed-may-01-sg" category="Holiday" territory="SG" nonWorking="true">
       <Fixed month="May" day="1" />
       <Tag>Singapore</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="National Day">
-    <Rule name="Fixed Singapore National Day" category="Holiday" territory="SG" nonWorking="true">
+    <Rule name="fixed-aug-09-sg" category="Holiday" territory="SG" nonWorking="true">
       <Fixed month="August" day="9" />
       <Tag>Singapore</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-de.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-de.xml
@@ -63,7 +63,7 @@
   -->
 
   <NotableDate name="German Unity Day">
-    <Rule name="Fixed German Unity Day"
+    <Rule name="fixed-oct-03-de"
           category="Holiday"
           territory="DE"
           nonWorking="true"
@@ -79,7 +79,7 @@
   -->
 
   <NotableDate name="Epiphany">
-    <Rule name="Fixed Epiphany (DE-BW, DE-BY, DE-ST)"
+    <Rule name="fixed-jan-06-de-bw"
           category="Holiday"
           territory="DE-BW,DE-BY,DE-ST"
           nonWorking="true"
@@ -95,7 +95,7 @@
   -->
 
   <NotableDate name="International Women's Day">
-    <Rule name="International Women's Day Non-Working Day (DE-BE, DE-MV)"
+    <Rule name="fixed-mar-08-de-be"
           category="Holiday"
           territory="DE-BE,DE-MV"
           nonWorking="true"
@@ -111,7 +111,7 @@
   -->
 
   <NotableDate name="Corpus Christi">
-    <Rule name="Sixtieth Day After Western Easter Corpus Christi (DE)"
+    <Rule name="offset-easter-sunday+60-de-bw"
           category="Holiday"
           territory="DE-BW,DE-BY,DE-HE,DE-NW,DE-RP,DE-SL"
           nonWorking="true"
@@ -128,7 +128,7 @@
   -->
 
   <NotableDate name="Assumption of Mary">
-    <Rule name="Fixed Assumption of Mary (DE-BY, DE-SL)"
+    <Rule name="fixed-aug-15-de-by"
           category="Holiday"
           territory="DE-BY,DE-SL"
           nonWorking="true"
@@ -144,7 +144,7 @@
   -->
 
   <NotableDate name="Reformation Day">
-    <Rule name="Fixed Reformation Day (DE)"
+    <Rule name="fixed-oct-31-de-bb"
           category="Holiday"
           territory="DE-BB,DE-HB,DE-HH,DE-MV,DE-NI,DE-SN,DE-ST,DE-SH,DE-TH"
           nonWorking="true"
@@ -160,7 +160,7 @@
   -->
 
   <NotableDate name="All Saints' Day">
-    <Rule name="Fixed All Saints Day (DE)"
+    <Rule name="fixed-nov-01-de-bw"
           category="Holiday"
           territory="DE-BW,DE-BY,DE-NW,DE-RP,DE-SL"
           nonWorking="true"
@@ -176,7 +176,7 @@
   -->
 
   <NotableDate name="Repentance Day">
-    <Rule name="Repentance Day (DE-SN)"
+    <Rule name="algo-buss-und-bettag-de-sn"
           category="Holiday"
           territory="DE-SN"
           nonWorking="true"

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-es.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-es.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="National Day of Spain">
-    <Rule name="Spain" category="Holiday" territory="ES" nonWorking="true">
+    <Rule name="fixed-oct-12-es" category="Holiday" territory="ES" nonWorking="true">
       <Fixed month="October" day="12" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-fr.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-fr.xml
@@ -56,7 +56,7 @@
   -->
 
   <NotableDate name="Fête du Travail">
-    <Rule name="Fixed Fête du Travail"
+    <Rule name="fixed-may-01-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true"
@@ -67,7 +67,7 @@
   </NotableDate>
 
   <NotableDate name="Victory in Europe Day">
-    <Rule name="Fixed Victory in Europe Day"
+    <Rule name="fixed-may-08-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true">
@@ -77,7 +77,7 @@
   </NotableDate>
 
   <NotableDate name="Bastille Day">
-    <Rule name="Fixed Bastille Day"
+    <Rule name="fixed-jul-14-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true">
@@ -87,7 +87,7 @@
   </NotableDate>
 
   <NotableDate name="Assumption of Mary">
-    <Rule name="Fixed Assumption of Mary"
+    <Rule name="fixed-aug-15-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true">
@@ -97,7 +97,7 @@
   </NotableDate>
 
   <NotableDate name="All Saints' Day">
-    <Rule name="Fixed All Saints Day"
+    <Rule name="fixed-nov-01-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true">
@@ -107,7 +107,7 @@
   </NotableDate>
 
   <NotableDate name="Armistice Day">
-    <Rule name="Fixed Armistice Day"
+    <Rule name="fixed-nov-11-fr"
           category="Holiday"
           territory="FR"
           nonWorking="true">
@@ -121,7 +121,7 @@
   -->
 
   <NotableDate name="Mother's Day">
-    <Rule name="Last Sunday In May Mother's Day"
+    <Rule name="weekday-last-sun-may-fr"
           category="Observance"
           territory="FR"
           comment="La Fête des Mères. Observed on the last Sunday in May. When the last Sunday of May coincides with Pentecost Sunday, the observance moves to the first Sunday of June by long-standing convention; this edge case is not automatically resolved by this rule.">
@@ -131,7 +131,7 @@
   </NotableDate>
 
   <NotableDate name="World Music Day">
-    <Rule name="Fixed World Music Day"
+    <Rule name="fixed-jun-21-fr"
           category="Cultural"
           territory="FR"
           firstYear="1982"
@@ -145,7 +145,7 @@
   -->
 
   <NotableDate name="Good Friday (Alsace-Moselle)">
-    <Rule name="Friday Before Western Easter Good Friday"
+    <Rule name="offset-easter-sunday-2-fr-67"
           category="Holiday"
           territory="FR-67,FR-68,FR-57"
           nonWorking="true">
@@ -155,7 +155,7 @@
   </NotableDate>
 
   <NotableDate name="Saint Stephen's Day">
-    <Rule name="Fixed Saint Stephen's Day"
+    <Rule name="fixed-dec-26-fr-67"
           category="Holiday"
           territory="FR-67,FR-68,FR-57"
           nonWorking="true">

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-gb.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-gb.xml
@@ -44,7 +44,7 @@
     <Use name="Easter Monday" territory="GB" nonWorking="true" />
     <Use name="Christmas Eve" territory="GB" />
     <Use name="Christmas Day" territory="GB" nonWorking="true">
-      <Rule name="GB Christmas Day With Non-Working-Day Roll" category="Holiday" nonWorking="true">
+      <Rule name="fixed-dec-25-nonworking-roll-gb" category="Holiday" nonWorking="true">
         <Adjustment key="weekend-roll" when="IfNonWorkingDay" action="MoveToNextNonWorkingDay" />
       </Rule>
     </Use>
@@ -67,7 +67,7 @@
   -->
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed New Year's Day With Weekend Roll" category="Holiday" territory="GB" nonWorking="true">
+    <Rule name="fixed-jan-01-weekend-roll-gb" category="Holiday" territory="GB" nonWorking="true">
       <Fixed month="January" day="1" />
       <Tag>BankHoliday</Tag>
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -75,7 +75,7 @@
   </NotableDate>
 
   <NotableDate name="Mothering Sunday">
-    <Rule name="Twenty-First Day Before Western Easter Mothering Sunday"
+    <Rule name="offset-easter-sunday-21-gb"
           category="Cultural"
           territory="GB"
           firstYear="1583"
@@ -86,28 +86,28 @@
   </NotableDate>
 
   <NotableDate name="Early May Bank Holiday">
-    <Rule name="First Monday In May Early May Bank Holiday" category="Holiday" territory="GB" nonWorking="true">
+    <Rule name="weekday-1st-mon-may-gb" category="Holiday" territory="GB" nonWorking="true">
       <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="First" />
       <Tag>BankHoliday</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Spring Bank Holiday">
-    <Rule name="Last Monday In May Spring Bank Holiday" category="Holiday" territory="GB" nonWorking="true">
+    <Rule name="weekday-last-mon-may-gb" category="Holiday" territory="GB" nonWorking="true">
       <DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="Last" />
       <Tag>BankHoliday</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Bonfire Night">
-    <Rule name="Fixed Bonfire Night" category="Cultural" territory="GB"
+    <Rule name="fixed-nov-05-gb" category="Cultural" territory="GB"
           comment="Also known as Guy Fawkes Night. Commemorates the foiling of the Gunpowder Plot of 5 November 1605, when Guy Fawkes and co-conspirators were discovered attempting to blow up the Houses of Parliament. Marked with bonfires, fireworks, and the burning of 'Guy' effigies.">
       <Fixed month="November" day="5" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Remembrance Sunday">
-    <Rule name="Second Sunday In November Remembrance Sunday"
+    <Rule name="weekday-2nd-sun-nov-gb"
           category="Observance"
           territory="GB"
           comment="Observed on the Sunday closest to 11 November (Armistice Day), which falls on the second Sunday of November each year. The principal national act of remembrance is held at the Cenotaph in Whitehall, London. Distinct from Remembrance Day (11 November), which is also observed in the UK.">
@@ -116,7 +116,7 @@
   </NotableDate>
 
   <NotableDate name="Boxing Day">
-    <Rule name="Fixed Boxing Day With Weekend Roll" category="Holiday" territory="GB" nonWorking="true">
+    <Rule name="fixed-dec-26-weekend-roll-gb" category="Holiday" territory="GB" nonWorking="true">
       <Fixed month="December" day="26" />
       <Tag>BankHoliday</Tag>
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -128,7 +128,7 @@
   -->
 
   <NotableDate name="Saint George's Day">
-    <Rule name="Fixed Saint George's Day" category="Cultural" territory="GB-ENG"
+    <Rule name="fixed-apr-23-gb-eng" category="Cultural" territory="GB-ENG"
           comment="Patron saint's day of England, observed on 23 April, the traditional date of the death of Saint George (c. 303 AD). Widely observed as an English cultural day, though not a bank holiday.">
       <Fixed month="April" day="23" />
     </Rule>
@@ -139,7 +139,7 @@
   -->
 
   <NotableDate name="Saint David's Day">
-    <Rule name="Fixed Saint David's Day" category="Cultural" territory="GB-WLS"
+    <Rule name="fixed-mar-01-gb-wls" category="Cultural" territory="GB-WLS"
           comment="Dydd Gŵyl Dewi Sant. Patron saint's day of Wales, observed on 1 March, the traditional date of the death of Saint David (Dewi Sant) in 589 AD. Widely observed in Wales as a national day with parades and the wearing of daffodils or leeks; not a bank holiday.">
       <Fixed month="March" day="1" />
     </Rule>
@@ -150,7 +150,7 @@
   -->
 
   <NotableDate name="2 January">
-    <Rule name="Fixed 2 January With Weekend Roll" category="Holiday" territory="GB-SCT" nonWorking="true">
+    <Rule name="fixed-jan-02-weekend-roll-gb-sct" category="Holiday" territory="GB-SCT" nonWorking="true">
       <Fixed month="January" day="2" />
       <Tag>BankHoliday</Tag>
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -158,21 +158,21 @@
   </NotableDate>
 
   <NotableDate name="Burns Night">
-    <Rule name="Fixed Burns Night" category="Cultural" territory="GB-SCT"
+    <Rule name="fixed-jan-25-gb-sct" category="Cultural" territory="GB-SCT"
           comment="Celebrates the life and poetry of Robert Burns, Scotland's national poet, born 25 January 1759. Marked with traditional suppers of haggis, neeps, and tatties, accompanied by readings of Burns's poetry and the singing of Auld Lang Syne.">
       <Fixed month="January" day="25" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Summer Bank Holiday (Scotland)">
-    <Rule name="First Monday In August Summer Bank Holiday" category="Holiday" territory="GB-SCT" nonWorking="true">
+    <Rule name="weekday-1st-mon-aug-gb-sct" category="Holiday" territory="GB-SCT" nonWorking="true">
       <DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="First" />
       <Tag>BankHoliday</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Saint Andrew's Day">
-    <Rule name="Fixed Saint Andrew's Day With Weekend Roll" category="Holiday" territory="GB-SCT" nonWorking="true"
+    <Rule name="fixed-nov-30-weekend-roll-gb-sct" category="Holiday" territory="GB-SCT" nonWorking="true"
           comment="Scotland's national day, honouring its patron saint Andrew the Apostle. Established as a bank holiday in Scotland by the St Andrew's Day Bank Holiday (Scotland) Act 2007, first observed on 30 November 2007.">
       <Fixed month="November" day="30" />
       <Tag>BankHoliday</Tag>
@@ -185,7 +185,7 @@
   -->
 
   <NotableDate name="Saint Patrick's Day">
-    <Rule name="Fixed Saint Patrick's Day With Weekend Roll" category="Holiday" territory="GB-NIR" nonWorking="true"
+    <Rule name="fixed-mar-17-weekend-roll-gb-nir" category="Holiday" territory="GB-NIR" nonWorking="true"
           comment="A bank holiday in Northern Ireland only, honouring the patron saint of Ireland on the traditional date of his death (17 March, c. 461 AD). Also widely observed as a cultural celebration throughout the rest of the UK and Ireland.">
       <Fixed month="March" day="17" />
       <Tag>BankHoliday</Tag>
@@ -194,7 +194,7 @@
   </NotableDate>
 
   <NotableDate name="Battle of the Boyne">
-    <Rule name="Fixed Battle of the Boyne With Weekend Roll" category="Holiday" territory="GB-NIR" nonWorking="true"
+    <Rule name="fixed-jul-12-weekend-roll-gb-nir" category="Holiday" territory="GB-NIR" nonWorking="true"
           comment="Also known as Orangemen's Day or The Twelfth. Commemorates the Battle of the Boyne on 11 July 1690 (Old Style; 1 July Julian), in which William of Orange defeated James II. The public holiday falls on 12 July.">
       <Fixed month="July" day="12" />
       <Tag>BankHoliday</Tag>
@@ -207,7 +207,7 @@
   -->
 
   <NotableDate name="Summer Bank Holiday">
-    <Rule name="Last Monday In August Summer Bank Holiday" category="Holiday" territory="GB-ENG,GB-WLS,GB-NIR" nonWorking="true">
+    <Rule name="weekday-last-mon-aug-gb-eng" category="Holiday" territory="GB-ENG,GB-WLS,GB-NIR" nonWorking="true">
       <DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="Last" />
       <Tag>BankHoliday</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-ie.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-ie.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="St Patrick's Day">
-    <Rule name="Ireland" category="Holiday" territory="IE" nonWorking="true">
+    <Rule name="fixed-mar-17-ie" category="Holiday" territory="IE" nonWorking="true">
       <Fixed month="March" day="17" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-it.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-it.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="Republic Day">
-    <Rule name="Italy" category="Holiday" territory="IT" nonWorking="true">
+    <Rule name="fixed-jun-02-it" category="Holiday" territory="IT" nonWorking="true">
       <Fixed month="June" day="2" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-nl.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-nl.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="King's Day">
-    <Rule name="Netherlands" category="Holiday" territory="NL" nonWorking="true">
+    <Rule name="fixed-apr-27-nl" category="Holiday" territory="NL" nonWorking="true">
       <Fixed month="April" day="27" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-se.xml
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/Resources/region-se.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="National Day of Sweden">
-    <Rule name="Sweden" category="Holiday" territory="SE" nonWorking="true">
+    <Rule name="fixed-jun-06-se" category="Holiday" territory="SE" nonWorking="true">
       <Fixed month="June" day="6" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/christian-gregorian.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/christian-gregorian.xml
@@ -20,21 +20,21 @@
   -->
 
   <NotableDate name="Epiphany">
-    <Rule name="Fixed Epiphany" category="Observance">
+    <Rule name="fixed-jan-06" category="Observance">
       <Fixed month="January" day="6" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Candlemas">
-    <Rule name="Fixed Candlemas" category="Observance">
+    <Rule name="fixed-feb-02" category="Observance">
       <Fixed month="February" day="2" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Annunciation">
-    <Rule name="Fixed Annunciation" category="Observance">
+    <Rule name="fixed-mar-25" category="Observance">
       <Fixed month="March" day="25" />
       <Tag>Christian</Tag>
     </Rule>
@@ -45,7 +45,7 @@
   -->
 
   <NotableDate name="Easter Sunday">
-    <Rule name="Western Easter Sunday" category="Observance" firstYear="1583">
+    <Rule name="algo-easter-sunday" category="Observance" firstYear="1583">
       <Algorithm key="easter-sunday"
                   type="Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateAlgorithm, Bodu.Globalization.Calendar" />
       <Tag>Christian</Tag>
@@ -57,42 +57,42 @@
   -->
 
   <NotableDate name="Shrove Tuesday">
-    <Rule name="Tuesday Before Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday-47" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-47" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Ash Wednesday">
-    <Rule name="Wednesday Before Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday-46" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-46" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Palm Sunday">
-    <Rule name="Sunday Before Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday-7" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-7" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Maundy Thursday">
-    <Rule name="Thursday Before Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday-3" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-3" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Good Friday">
-    <Rule name="Friday Before Western Easter" category="Holiday" firstYear="1583">
+    <Rule name="offset-easter-sunday-2" category="Holiday" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-2" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Holy Saturday">
-    <Rule name="Saturday Before Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday-1" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="-1" />
       <Tag>Christian</Tag>
     </Rule>
@@ -103,42 +103,42 @@
   -->
 
   <NotableDate name="Easter Monday">
-    <Rule name="Monday After Western Easter" category="Holiday" firstYear="1583">
+    <Rule name="offset-easter-sunday+1" category="Holiday" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="1" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Ascension Day">
-    <Rule name="Thirty-Ninth Day After Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday+39" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="39" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Pentecost Sunday">
-    <Rule name="Forty-Ninth Day After Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday+49" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="49" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Whit Monday">
-    <Rule name="Fiftieth Day After Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday+50" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="50" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Trinity Sunday">
-    <Rule name="Fifty-Sixth Day After Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday+56" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="56" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Corpus Christi">
-    <Rule name="Sixtieth Day After Western Easter" category="Observance" firstYear="1583">
+    <Rule name="offset-easter-sunday+60" category="Observance" firstYear="1583">
       <OffsetFromAnchor name="Easter Sunday" offset="60" />
       <Tag>Christian</Tag>
     </Rule>
@@ -149,28 +149,28 @@
   -->
 
   <NotableDate name="All Saints' Day">
-    <Rule name="Fixed All Saints Day" category="Observance">
+    <Rule name="fixed-nov-01" category="Observance">
       <Fixed month="November" day="1" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="All Souls' Day">
-    <Rule name="Fixed All Souls Day" category="Observance">
+    <Rule name="fixed-nov-02" category="Observance">
       <Fixed month="November" day="2" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Christmas Eve">
-    <Rule name="Fixed Christmas Eve" category="Observance">
+    <Rule name="fixed-dec-24" category="Observance">
       <Fixed month="December" day="24" />
       <Tag>Christian</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Christmas Day">
-    <Rule name="Fixed Christmas Day With Weekend Roll" category="Holiday" nonWorking="true">
+    <Rule name="fixed-dec-25-weekend-roll" category="Holiday" nonWorking="true">
       <Fixed month="December" day="25" />
       <Tag>Christian</Tag>
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
@@ -178,7 +178,7 @@
   </NotableDate>
 
   <NotableDate name="Boxing Day">
-    <Rule name="Fixed Boxing Day" category="Holiday">
+    <Rule name="fixed-dec-26" category="Holiday">
       <Fixed month="December" day="26" />
       <Tag>Christian</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/christian-orthodox.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/christian-orthodox.xml
@@ -23,7 +23,7 @@
   -->
 
   <NotableDate name="Orthodox Christmas Eve">
-    <Rule name="Fixed Orthodox Christmas Eve" category="Observance">
+    <Rule name="fixed-jan-06" category="Observance">
       <Fixed month="January" day="6" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -31,7 +31,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Christmas Day">
-    <Rule name="Fixed Orthodox Christmas Day" category="Holiday" nonWorking="true">
+    <Rule name="fixed-jan-07" category="Holiday" nonWorking="true">
       <Fixed month="January" day="7" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -39,7 +39,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox New Year">
-    <Rule name="Fixed Orthodox New Year" category="Observance">
+    <Rule name="fixed-jan-14" category="Observance">
       <Fixed month="January" day="14" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -47,7 +47,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Epiphany">
-    <Rule name="Fixed Orthodox Epiphany" category="Observance">
+    <Rule name="fixed-jan-19" category="Observance">
       <Fixed month="January" day="19" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -59,7 +59,7 @@
   -->
 
   <NotableDate name="Orthodox Easter Sunday">
-    <Rule name="Orthodox Easter Sunday" category="Religious">
+    <Rule name="algo-orthodox-easter-sunday" category="Religious">
       <Algorithm key="orthodox-easter-sunday" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -71,7 +71,7 @@
   -->
 
   <NotableDate name="Orthodox Clean Monday">
-    <Rule name="Forty-Eighth Day Before Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday-48" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-48" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -79,7 +79,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Lazarus Saturday">
-    <Rule name="Eighth Day Before Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday-8" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-8" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -87,7 +87,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Palm Sunday">
-    <Rule name="Seventh Day Before Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday-7" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-7" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -95,7 +95,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Holy Thursday">
-    <Rule name="Third Day Before Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday-3" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-3" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -103,7 +103,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Good Friday">
-    <Rule name="Second Day Before Orthodox Easter" category="Holiday">
+    <Rule name="offset-orthodox-easter-sunday-2" category="Holiday">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-2" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -111,7 +111,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Holy Saturday">
-    <Rule name="One Day Before Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday-1" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="-1" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -123,7 +123,7 @@
   -->
 
   <NotableDate name="Orthodox Bright Week">
-    <Rule name="Orthodox Bright Week" category="Religious" durationDays="7">
+    <Rule name="offset-orthodox-easter-sunday+0" category="Religious" durationDays="7">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="0" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -131,7 +131,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Easter Monday">
-    <Rule name="One Day After Orthodox Easter" category="Holiday">
+    <Rule name="offset-orthodox-easter-sunday+1" category="Holiday">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="1" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -139,7 +139,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Ascension Day">
-    <Rule name="Thirty-Ninth Day After Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday+39" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="39" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -147,7 +147,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Pentecost">
-    <Rule name="Forty-Ninth Day After Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday+49" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="49" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>
@@ -155,7 +155,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Pentecost Monday">
-    <Rule name="Fiftieth Day After Orthodox Easter" category="Religious">
+    <Rule name="offset-orthodox-easter-sunday+50" category="Religious">
       <OffsetFromAnchor name="Orthodox Easter Sunday" offset="50" />
       <Tag>Christian</Tag>
       <Tag>OrthodoxChristian</Tag>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/default-minimal.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/default-minimal.xml
@@ -13,7 +13,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed New Year's Day With Weekend Roll" category="Holiday" nonWorking="true">
+    <Rule name="fixed-jan-01-weekend-roll" category="Holiday" nonWorking="true">
       <Fixed month="January" day="1" />
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-anchors.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-anchors.xml
@@ -29,7 +29,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Lunar New Year">
-    <Rule name="Lunar New Year"
+    <Rule name="fixed-lunisolar-01-01"
           category="Cultural"
           durationDays="15"
           firstYear="1901"
@@ -43,7 +43,7 @@
   </NotableDate>
 
   <NotableDate name="Ramadan Start">
-    <Rule name="Ramadan Start"
+    <Rule name="fixed-hijri-09-01"
           category="Religious"
           durationDays="30"
           calendarType="System.Globalization.HijriCalendar"
@@ -55,7 +55,7 @@
   </NotableDate>
 
   <NotableDate name="Orthodox Easter">
-    <Rule name="Orthodox Easter" category="Religious">
+    <Rule name="algo-orthodox-easter" category="Religious">
       <Algorithm key="OrthodoxEaster" />
       <Tag>Christian</Tag>
       <Tag>Orthodox</Tag>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-animals.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-animals.xml
@@ -15,49 +15,49 @@
   -->
 
   <NotableDate name="World Wildlife Day">
-    <Rule name="Fixed World Wildlife Day" category="Observance" firstYear="2014"
+    <Rule name="fixed-mar-03" category="Observance" firstYear="2014"
           comment="Proclaimed by the United Nations in 2013 and first observed on 3 March 2014, the date of the 1973 signing of CITES.">
       <Fixed month="March" day="3" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Bee Day">
-    <Rule name="Fixed World Bee Day" category="Observance" firstYear="2018"
+    <Rule name="fixed-may-20" category="Observance" firstYear="2018"
           comment="Designated by the United Nations in 2017 and first observed in 2018. The date marks the birthday of Anton Janša, a pioneer of modern beekeeping.">
       <Fixed month="May" day="20" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Tiger Day">
-    <Rule name="Fixed International Tiger Day" category="Observance" firstYear="2010"
+    <Rule name="fixed-jul-29" category="Observance" firstYear="2010"
           comment="Established at the Saint Petersburg Tiger Summit in 2010 to raise awareness of tiger conservation.">
       <Fixed month="July" day="29" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Cat Day">
-    <Rule name="Fixed International Cat Day" category="Observance" firstYear="2002"
+    <Rule name="fixed-aug-08" category="Observance" firstYear="2002"
           comment="An international cat welfare observance created by the International Fund for Animal Welfare and now associated with cat welfare and responsible care awareness.">
       <Fixed month="August" day="8" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Elephant Day">
-    <Rule name="Fixed World Elephant Day" category="Observance" firstYear="2012"
+    <Rule name="fixed-aug-12" category="Observance" firstYear="2012"
           comment="Founded in 2012 by Patricia Sims and the Elephant Reintroduction Foundation to draw attention to the critical status of both Asian and African elephants.">
       <Fixed month="August" day="12" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Dog Day">
-    <Rule name="Fixed International Dog Day" category="Observance"
+    <Rule name="fixed-aug-26" category="Observance"
           comment="An international companion-animal observance that celebrates dogs, promotes adoption and responsible ownership, and recognises working and assistance dogs.">
       <Fixed month="August" day="26" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Animal Day">
-    <Rule name="Fixed World Animal Day" category="Observance" firstYear="1931"
+    <Rule name="fixed-oct-04" category="Observance" firstYear="1931"
           comment="Originated at a congress of ecologists in Florence in 1931. The date coincides with the Feast of Saint Francis of Assisi, patron saint of animals.">
       <Fixed month="October" day="4" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-buddhist.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-buddhist.xml
@@ -37,7 +37,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Parinirvana Day">
-    <Rule name="Fixed Parinirvana Day"
+    <Rule name="fixed-feb-15"
           category="Religious"
           comment="Nirvana Day. Commemorates the death and final passing into Nirvana (parinirvana) of Siddhartha Gautama (the Buddha) at approximately age 80. Observed primarily in Mahayana Buddhist communities on 15 February by longstanding convention, though the date varies in some traditions (8 February in Japanese Zen, 15 February in Chinese and Tibetan traditions). The 15 February fixed date used here follows the most widely observed Mahayana convention.">
       <Fixed month="February" day="15" />
@@ -46,7 +46,7 @@
   </NotableDate>
 
   <NotableDate name="Losar">
-    <Rule name="Losar"
+    <Rule name="algo-losar"
           category="Religious"
           durationDays="3"
           comment="Tibetan New Year (Losar, lo meaning 'year', sar meaning 'new'). The first day of the first month of the Tibetan lunar calendar, typically falling in February or March in the Gregorian calendar. The most important festival in the Tibetan Buddhist calendar, celebrated over three days with prayers, offerings, traditional foods, and family gatherings. Also observed by Mongolian and Himalayan Buddhist communities. The precise Gregorian date is determined by the Tibetan lunisolar calendar, which may differ from the Chinese lunisolar calendar by up to several days. Requires a custom INotableDateAlgorithm registered under the key 'losar'.">
@@ -57,7 +57,7 @@
   </NotableDate>
 
   <NotableDate name="Vesak">
-    <Rule name="Vesak"
+    <Rule name="algo-vesak"
           category="Religious"
           comment="Buddha Day (Vesak / Wesak / Visakha Bucha). The most important day in the Theravada Buddhist calendar, celebrating the birth, enlightenment (Bodhi), and final passing (parinirvana) of the Gautama Buddha in a single observance. Falls on the full moon of the month of Vaisakha (April/May). Recognised by the United Nations as a day of international recognition since 1999. A public holiday in Thailand, Sri Lanka, Myanmar, Cambodia, Indonesia, and several other countries. The precise Gregorian date varies by year and by whether the Thai, Sri Lankan, or UN calculation method is used. Requires a custom INotableDateAlgorithm registered under the key 'vesak'.">
       <Algorithm key="vesak" />
@@ -66,7 +66,7 @@
   </NotableDate>
 
   <NotableDate name="Asalha Puja">
-    <Rule name="Asalha Puja"
+    <Rule name="algo-asalha-puja"
           category="Religious"
           comment="Dharma Day (Asalha Puja / Asanha Bucha). Falls on the full moon of the month of Asalha (June/July in the Theravada lunisolar calendar). Commemorates the Buddha's first turning of the Wheel of Dharma — the delivery of his first sermon to the five ascetics at Deer Park in Sarnath, India, following his enlightenment. A public holiday in Thailand. Requires a custom INotableDateAlgorithm registered under the key 'asalha-puja'.">
       <Algorithm key="asalha-puja" />
@@ -75,7 +75,7 @@
   </NotableDate>
 
   <NotableDate name="Vassa">
-    <Rule name="Vassa"
+    <Rule name="offset-asalha-puja+1"
           category="Religious"
           durationDays="90"
           comment="The Rains Retreat (Vassa / Buddhist Lent / Khao Phansa). The three-month period of intensified monastic practice observed primarily in Theravada countries. Begins the day after Asalha Puja (the full moon of Asalha) and ends with Pavarana (full moon of Ashvin, approximately three months later). During Vassa, monks and novices reside in their monasteries and limit travel. The beginning of Vassa is a public holiday in Thailand (Asanha Bucha / Khao Phansa). The durationDays value of 90 is an approximation; the exact duration is from the day after Asalha Puja full moon to the Pavarana full moon, which is 89–90 days depending on the year. Resolved via OffsetFromAnchor from Asalha Puja (+1 day); no algorithm registration is required.">
@@ -85,7 +85,7 @@
   </NotableDate>
 
   <NotableDate name="Bodhi Day">
-    <Rule name="Fixed Bodhi Day"
+    <Rule name="fixed-dec-08"
           category="Religious"
           comment="Commemorates the enlightenment (Bodhi) of the Buddha Gautama under the Bodhi tree at Bodh Gaya. Observed on 8 December in Japanese Zen (Rohatsu) and most East Asian Mahayana traditions, following the convention established in Japanese Buddhism. Observed with meditation, recitation of sutras, and other practices. The Theravada tradition incorporates the enlightenment into the Vesak celebration rather than marking it separately.">
       <Fixed month="December" day="8" />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-core.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-core.xml
@@ -16,20 +16,20 @@
   -->
 
   <NotableDate name="New Year's Day">
-    <Rule name="Fixed New Year's Day With Weekend Roll" category="Holiday" nonWorking="true">
+    <Rule name="fixed-jan-01-weekend-roll" category="Holiday" nonWorking="true">
       <Fixed month="January" day="1" />
       <Adjustment key="weekend-roll" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Workers' Day">
-    <Rule name="Fixed International Workers' Day" category="Observance">
+    <Rule name="fixed-may-01" category="Observance">
       <Fixed month="May" day="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="New Year's Eve">
-    <Rule name="Fixed New Year's Eve" category="Cultural"
+    <Rule name="fixed-dec-31" category="Cultural"
           comment="The last day of the year in the Gregorian calendar, universally marked as a transition to the new year and widely celebrated with public gatherings, fireworks, and cultural events.">
       <Fixed month="December" day="31" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-cultural.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-cultural.xml
@@ -16,68 +16,68 @@
   -->
 
   <NotableDate name="Valentine's Day">
-    <Rule name="Fixed Valentine's Day" category="Cultural">
+    <Rule name="fixed-feb-14" category="Cultural">
       <Fixed month="February" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Mother Language Day">
-    <Rule name="Fixed International Mother Language Day" category="Cultural" firstYear="2000"
+    <Rule name="fixed-feb-21" category="Cultural" firstYear="2000"
           comment="Proclaimed by UNESCO in 1999 (resolution 30C/29) and first observed on 21 February 2000, to promote linguistic and cultural diversity. The date marks the 1952 shooting of students protesting for recognition of the Bengali language in Dhaka.">
       <Fixed month="February" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Poetry Day">
-    <Rule name="Fixed World Poetry Day" category="Cultural" firstYear="1999"
+    <Rule name="fixed-mar-21" category="Cultural" firstYear="1999"
           comment="Proclaimed by UNESCO at its 30th General Conference in Paris in 1999, to support linguistic expression through poetic form and to promote the reading, writing, and teaching of poetry worldwide.">
       <Fixed month="March" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Theatre Day">
-    <Rule name="Fixed World Theatre Day" category="Cultural" firstYear="1962"
+    <Rule name="fixed-mar-27" category="Cultural" firstYear="1962"
           comment="Established in 1961 by the International Theatre Institute (ITI) and first celebrated on 27 March 1962. The date was chosen following a proposal by Finnish diplomat Arvi Kivimaa at the ITI World Congress in Vienna.">
       <Fixed month="March" day="27" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="April Fool's Day">
-    <Rule name="Fixed April Fool's Day" category="Cultural">
+    <Rule name="fixed-apr-01" category="Cultural">
       <Fixed month="April" day="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Jazz Day">
-    <Rule name="Fixed International Jazz Day" category="Cultural" firstYear="2012"
+    <Rule name="fixed-apr-30" category="Cultural" firstYear="2012"
           comment="Proclaimed by UNESCO in 2011 (resolution 36C/38) and first celebrated on 30 April 2012. Championed by jazz musician and UNESCO Goodwill Ambassador Herbie Hancock.">
       <Fixed month="April" day="30" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Star Wars Day">
-    <Rule name="Fixed Star Wars Day" category="Cultural"
+    <Rule name="fixed-may-04" category="Cultural"
           comment="An informal international fan observance of the Star Wars franchise, held on 4 May because of the phrase 'May the Fourth be with you'.">
       <Fixed month="May" day="4" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Music Day">
-    <Rule name="Fixed World Music Day" category="Cultural" firstYear="1982"
+    <Rule name="fixed-jun-21" category="Cultural" firstYear="1982"
           comment="Fête de la Musique. Originated in France in 1982 following a proposal by the French Ministry of Culture; now celebrated internationally on the summer solstice, 21 June, with free public performances.">
       <Fixed month="June" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Friendship Day">
-    <Rule name="Fixed International Friendship Day" category="Cultural" firstYear="2011"
+    <Rule name="fixed-jul-30" category="Cultural" firstYear="2011"
           comment="Proclaimed by the United Nations General Assembly in 2011 (resolution 65/275). The concept originated in 1958 when the World Friendship Crusade proposed 30 July as World Friendship Day.">
       <Fixed month="July" day="30" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Halloween">
-    <Rule name="Fixed Halloween" category="Cultural">
+    <Rule name="fixed-oct-31" category="Cultural">
       <Fixed month="October" day="31" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-education.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-education.xml
@@ -16,26 +16,26 @@
   -->
 
   <NotableDate name="International Day of Education">
-    <Rule name="Fixed International Day of Education" category="Observance" firstYear="2019"
+    <Rule name="fixed-jan-24" category="Observance" firstYear="2019"
           comment="Proclaimed by the United Nations General Assembly in 2018 (resolution 73/25) and first observed on 24 January 2019, to celebrate education and its role in peace and development.">
       <Fixed month="January" day="24" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Book and Copyright Day">
-    <Rule name="Fixed World Book and Copyright Day" category="Observance">
+    <Rule name="fixed-apr-23" category="Observance">
       <Fixed month="April" day="23" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Literacy Day">
-    <Rule name="Fixed International Literacy Day" category="Observance">
+    <Rule name="fixed-sep-08" category="Observance">
       <Fixed month="September" day="8" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Teachers' Day">
-    <Rule name="Fixed World Teachers' Day" category="Observance">
+    <Rule name="fixed-oct-05" category="Observance">
       <Fixed month="October" day="5" />
     </Rule>
   </NotableDate>
@@ -45,7 +45,7 @@
   -->
 
   <NotableDate name="Safer Internet Day">
-    <Rule name="Second Tuesday In February Safer Internet Day" category="Observance" firstYear="2004"
+    <Rule name="weekday-2nd-tue-feb" category="Observance" firstYear="2004"
           comment="Organised by the Insafe and INHOPE networks with support of the European Commission. First observed in 2004 as part of the EU-funded SafeBorders project; now promoted in over 180 countries. Observed on the second Tuesday of February each year.">
       <DayOfWeekInMonth month="February" dayOfWeek="Tuesday" weekOrdinal="Second" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-environment.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-environment.xml
@@ -16,66 +16,66 @@
   -->
 
   <NotableDate name="World Wetlands Day">
-    <Rule name="Fixed World Wetlands Day" category="Observance" firstYear="1997"
+    <Rule name="fixed-feb-02" category="Observance" firstYear="1997"
           comment="First observed in 1997 to mark the anniversary of the signing of the Ramsar Convention on Wetlands on 2 February 1971 in Ramsar, Iran.">
       <Fixed month="February" day="2" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Forests">
-    <Rule name="Fixed International Day of Forests" category="Observance" firstYear="2013"
+    <Rule name="fixed-mar-21" category="Observance" firstYear="2013"
           comment="Proclaimed by the United Nations General Assembly in 2012 (resolution 67/200) and first observed on 21 March 2013, to raise awareness of the importance of all types of forests.">
       <Fixed month="March" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Water Day">
-    <Rule name="Fixed World Water Day" category="Observance">
+    <Rule name="fixed-mar-22" category="Observance">
       <Fixed month="March" day="22" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Earth Hour">
-    <Rule name="Last Saturday In March Earth Hour" category="Observance" firstYear="2007"
+    <Rule name="weekday-last-sat-mar" category="Observance" firstYear="2007"
           comment="A global environmental awareness event associated with switching off non-essential lights for one hour, now generally held on the last Saturday in March at 8:30 pm local time.">
       <DayOfWeekInMonth month="March" dayOfWeek="Saturday" weekOrdinal="Last" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Earth Day">
-    <Rule name="Fixed Earth Day" category="Observance">
+    <Rule name="fixed-apr-22" category="Observance">
       <Fixed month="April" day="22" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day for Biological Diversity">
-    <Rule name="Fixed International Day for Biological Diversity" category="Observance" firstYear="2001"
+    <Rule name="fixed-may-22" category="Observance" firstYear="2001"
           comment="Proclaimed by the United Nations in 2000 (resolution 55/201). Observed annually on 22 May, the date of the adoption of the text of the Convention on Biological Diversity in 1992.">
       <Fixed month="May" day="22" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Environment Day">
-    <Rule name="Fixed World Environment Day" category="Observance">
+    <Rule name="fixed-jun-05" category="Observance">
       <Fixed month="June" day="5" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Oceans Day">
-    <Rule name="Fixed World Oceans Day" category="Observance">
+    <Rule name="fixed-jun-08" category="Observance">
       <Fixed month="June" day="8" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Day to Combat Desertification and Drought">
-    <Rule name="Fixed World Day to Combat Desertification and Drought" category="Observance" firstYear="1995"
+    <Rule name="fixed-jun-17" category="Observance" firstYear="1995"
           comment="Proclaimed by the United Nations General Assembly in 1994 (resolution 49/115) and first observed on 17 June 1995, the day of the adoption of the United Nations Convention to Combat Desertification (UNCCD) in 1994.">
       <Fixed month="June" day="17" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Soil Day">
-    <Rule name="Fixed World Soil Day" category="Observance" firstYear="2014"
+    <Rule name="fixed-dec-05" category="Observance" firstYear="2014"
           comment="Recommended by the International Union of Soil Sciences (IUSS) in 2002 and officially designated by the United Nations General Assembly in 2013 (resolution 68/232). The date marks the birthday of King Bhumibol Adulyadej of Thailand, a champion of sustainable land management.">
       <Fixed month="December" day="5" />
     </Rule>
@@ -86,7 +86,7 @@
   -->
 
   <NotableDate name="Plastic Free July">
-    <Rule name="Fixed Plastic Free July" category="Observance" durationDays="31" firstYear="2011"
+    <Rule name="fixed-jul-01" category="Observance" durationDays="31" firstYear="2011"
           comment="A month-long environmental campaign encouraging reduced single-use plastic consumption. The durationDays value of 31 spans the full civil month of July, inclusive of 1 July.">
       <Fixed month="July" day="1" />
       <Tag>Environment</Tag>
@@ -96,7 +96,7 @@
   </NotableDate>
 
   <NotableDate name="Clean Up the World Weekend">
-    <Rule name="Third Friday In September Clean Up the World Weekend" category="Observance" durationDays="3" firstYear="1993"
+    <Rule name="weekday-3rd-fri-sep" category="Observance" durationDays="3" firstYear="1993"
           comment="A global environmental community action weekend commonly observed over the third weekend of September. The durationDays value of 3 spans Friday through Sunday, inclusive of the start date.">
       <DayOfWeekInMonth month="September" dayOfWeek="Friday" weekOrdinal="Third" />
       <Tag>Environment</Tag>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-family-social.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-family-social.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <NotableDates xmlns="urn:bodu:globalization:calendar">
   <NotableDate name="Friendship Day">
-    <Rule name="Friendship Day" category="Observance">
+    <Rule name="weekday-1st-sun-aug" category="Observance">
       <DayOfWeekInMonth month="August" dayOfWeek="Sunday" weekOrdinal="First" />
       <Tag>Social</Tag>
     </Rule>
   </NotableDate>
 
   <NotableDate name="Grandparents Day">
-    <Rule name="Grandparents Day" category="Observance">
+    <Rule name="weekday-1st-sun-sep" category="Observance">
       <DayOfWeekInMonth month="September" dayOfWeek="Sunday" weekOrdinal="First" />
       <Tag>Family</Tag>
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-family.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-family.xml
@@ -31,14 +31,14 @@
   -->
 
   <NotableDate name="Mother's Day">
-    <Rule name="Second Sunday In May Mother's Day" category="Observance"
+    <Rule name="weekday-2nd-sun-may" category="Observance"
           comment="The most widely observed form of Mother's Day, falling on the second Sunday of May. First held in the United States in 1908; adopted by many countries throughout the 20th century. Regional exceptions are defined in their respective region files.">
       <DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Second" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Father's Day">
-    <Rule name="Third Sunday In June Father's Day" category="Observance"
+    <Rule name="weekday-3rd-sun-jun" category="Observance"
           comment="The most widely observed form of Father's Day, falling on the third Sunday of June. Originated in the United States in 1910; now adopted by many countries. Australia and New Zealand instead observe Father's Day on the first Sunday in September (see their respective region files).">
       <DayOfWeekInMonth month="June" dayOfWeek="Sunday" weekOrdinal="Third" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-food.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-food.xml
@@ -16,56 +16,56 @@
   -->
 
   <NotableDate name="World Pulses Day">
-    <Rule name="Fixed World Pulses Day" category="Observance" firstYear="2019"
+    <Rule name="fixed-feb-10" category="Observance" firstYear="2019"
           comment="Proclaimed by the United Nations General Assembly in 2018 (resolution 73/251) and first observed on 10 February 2019, to raise awareness of the nutritional benefits of pulses.">
       <Fixed month="February" day="10" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Tea Day">
-    <Rule name="Fixed International Tea Day" category="Observance" firstYear="2020"
+    <Rule name="fixed-may-21" category="Observance" firstYear="2020"
           comment="Observed by the United Nations on 21 May and led by the Food and Agriculture Organization (FAO), recognising tea's cultural heritage, health benefits, economic importance, and sustainable production.">
       <Fixed month="May" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Food Safety Day">
-    <Rule name="Fixed World Food Safety Day" category="Observance" firstYear="2019"
+    <Rule name="fixed-jun-07" category="Observance" firstYear="2019"
           comment="Established by the United Nations General Assembly in 2018 (resolution 73/250) and first observed on 7 June 2019. Co-sponsored by the Food and Agriculture Organization (FAO) and the World Health Organization (WHO).">
       <Fixed month="June" day="7" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Beer Day">
-    <Rule name="First Friday In August International Beer Day" category="Cultural" firstYear="2007"
+    <Rule name="weekday-1st-fri-aug" category="Cultural" firstYear="2007"
           comment="An informal global beer culture observance founded in Santa Cruz, California, and now generally observed on the first Friday in August.">
       <DayOfWeekInMonth month="August" dayOfWeek="Friday" weekOrdinal="First" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Coffee Day">
-    <Rule name="Fixed International Coffee Day" category="Observance" firstYear="2015"
+    <Rule name="fixed-oct-01" category="Observance" firstYear="2015"
           comment="A global coffee-sector observance promoted by the International Coffee Organization and coffee associations, celebrating coffee culture and raising awareness of the livelihoods of coffee producers.">
       <Fixed month="October" day="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Vegetarian Day">
-    <Rule name="Fixed World Vegetarian Day" category="Cultural" firstYear="1977"
+    <Rule name="fixed-oct-01" category="Cultural" firstYear="1977"
           comment="Established in 1977 by the North American Vegetarian Society and endorsed by the International Vegetarian Union in 1978, to promote the joy, compassion, and life-enhancing possibilities of vegetarianism.">
       <Fixed month="October" day="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Food Day">
-    <Rule name="Fixed World Food Day" category="Observance" firstYear="1979"
+    <Rule name="fixed-oct-16" category="Observance" firstYear="1979"
           comment="Established by the United Nations Food and Agriculture Organization (FAO) in 1979 and first observed on 16 October 1981. The date marks the founding of the FAO in 1945.">
       <Fixed month="October" day="16" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Vegan Day">
-    <Rule name="Fixed World Vegan Day" category="Cultural" firstYear="1994"
+    <Rule name="fixed-nov-01" category="Cultural" firstYear="1994"
           comment="Established in 1994 by the Vegan Society to mark the organisation's 50th anniversary and to celebrate veganism worldwide.">
       <Fixed month="November" day="1" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-health.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-health.xml
@@ -15,67 +15,67 @@
   -->
 
   <NotableDate name="World Cancer Day">
-    <Rule name="Fixed World Cancer Day" category="Observance" firstYear="2000"
+    <Rule name="fixed-feb-04" category="Observance" firstYear="2000"
           comment="Led by the Union for International Cancer Control (UICC) and supported by the World Health Organization. First observed on 4 February 2000 following the Charter of Paris Against Cancer.">
       <Fixed month="February" day="4" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Autism Awareness Day">
-    <Rule name="Fixed World Autism Awareness Day" category="Observance" firstYear="2008"
+    <Rule name="fixed-apr-02" category="Observance" firstYear="2008"
           comment="Designated by the United Nations General Assembly in 2007 (resolution 62/139) and first observed on 2 April 2008, to highlight the need to improve the quality of life of autistic people.">
       <Fixed month="April" day="2" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Health Day">
-    <Rule name="Fixed World Health Day" category="Observance">
+    <Rule name="fixed-apr-07" category="Observance">
       <Fixed month="April" day="7" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World No Tobacco Day">
-    <Rule name="Fixed World No Tobacco Day" category="Observance" firstYear="1987"
+    <Rule name="fixed-may-31" category="Observance" firstYear="1987"
           comment="Established by the World Health Organization in 1987 to draw global attention to the tobacco epidemic and the preventable death and disease it causes.">
       <Fixed month="May" day="31" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Blood Donor Day">
-    <Rule name="Fixed World Blood Donor Day" category="Observance">
+    <Rule name="fixed-jun-14" category="Observance">
       <Fixed month="June" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Hepatitis Day">
-    <Rule name="Fixed World Hepatitis Day" category="Observance" firstYear="2008"
+    <Rule name="fixed-jul-28" category="Observance" firstYear="2008"
           comment="Designated by the World Health Organization and observed annually on the birthday of Nobel Prize-winning virologist Baruch Blumberg, who discovered the hepatitis B virus.">
       <Fixed month="July" day="28" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Suicide Prevention Day">
-    <Rule name="Fixed World Suicide Prevention Day" category="Observance" firstYear="2003"
+    <Rule name="fixed-sep-10" category="Observance" firstYear="2003"
           comment="Organised by the International Association for Suicide Prevention (IASP) in association with the World Health Organization, first observed on 10 September 2003.">
       <Fixed month="September" day="10" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Mental Health Day">
-    <Rule name="Fixed World Mental Health Day" category="Observance">
+    <Rule name="fixed-oct-10" category="Observance">
       <Fixed month="October" day="10" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Diabetes Day">
-    <Rule name="Fixed World Diabetes Day" category="Observance" firstYear="1991"
+    <Rule name="fixed-nov-14" category="Observance" firstYear="1991"
           comment="Established in 1991 by the International Diabetes Federation (IDF) and the World Health Organization. The date marks the birthday of Sir Frederick Banting, who co-discovered insulin in 1922.">
       <Fixed month="November" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World AIDS Day">
-    <Rule name="Fixed World AIDS Day" category="Observance">
+    <Rule name="fixed-dec-01" category="Observance">
       <Fixed month="December" day="1" />
     </Rule>
   </NotableDate>
@@ -85,7 +85,7 @@
   -->
 
   <NotableDate name="Breast Cancer Awareness Month">
-    <Rule name="Fixed Breast Cancer Awareness Month" category="Observance" durationDays="31"
+    <Rule name="fixed-oct-01" category="Observance" durationDays="31"
           comment="A month-long breast cancer awareness campaign observed in October. The durationDays value of 31 spans the full civil month of October, inclusive of 1 October.">
       <Fixed month="October" day="1" />
       <Tag>Health</Tag>
@@ -95,7 +95,7 @@
   </NotableDate>
 
   <NotableDate name="Movember">
-    <Rule name="Fixed Movember" category="Observance" durationDays="30" firstYear="2003"
+    <Rule name="fixed-nov-01" category="Observance" durationDays="30" firstYear="2003"
           comment="A month-long men's health awareness campaign observed in November. The durationDays value of 30 spans the full civil month of November, inclusive of 1 November.">
       <Fixed month="November" day="1" />
       <Tag>Health</Tag>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-hindu.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-hindu.xml
@@ -37,7 +37,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Makar Sankranti">
-    <Rule name="Fixed Makar Sankranti"
+    <Rule name="fixed-jan-14"
           category="Cultural"
           comment="Solar harvest festival marking the sun's transition into Makara. Commonly observed on 14 January by modern civil-calendar convention, though astronomical timing can vary.">
       <Fixed month="January" day="14" />
@@ -46,7 +46,7 @@
   </NotableDate>
 
   <NotableDate name="Pongal">
-    <Rule name="Fixed Pongal"
+    <Rule name="fixed-jan-14"
           category="Cultural"
           durationDays="4"
           comment="Tamil harvest festival. The durationDays value of 4 represents the common sequence of Bhogi, Thai Pongal, Mattu Pongal, and Kaanum Pongal beginning on 14 January by modern civil-calendar convention.">
@@ -57,7 +57,7 @@
   </NotableDate>
 
   <NotableDate name="Saraswati Puja">
-    <Rule name="Saraswati Puja"
+    <Rule name="algo-saraswati-puja"
           category="Religious"
           comment="Vasant Panchami observance dedicated to Saraswati, goddess of learning, music, and the arts. Requires a custom INotableDateAlgorithm registered under the key 'saraswati-puja'.">
       <Algorithm key="saraswati-puja" />
@@ -66,7 +66,7 @@
   </NotableDate>
 
   <NotableDate name="Maha Shivaratri">
-    <Rule name="Maha Shivaratri"
+    <Rule name="algo-maha-shivaratri"
           category="Religious"
           comment="Great Night of Shiva. Observed on the fourteenth night of the dark fortnight in the Hindu month of Phalguna or Magha, depending on regional calendar convention. Requires a custom INotableDateAlgorithm registered under the key 'maha-shivaratri'.">
       <Algorithm key="maha-shivaratri" />
@@ -75,7 +75,7 @@
   </NotableDate>
 
   <NotableDate name="Holi">
-    <Rule name="Holi"
+    <Rule name="algo-holi"
           category="Religious"
           durationDays="2"
           comment="The Festival of Colours. Begins on the full moon (Purnima) of Phalguna with Holika Dahan (the lighting of bonfires symbolising the victory of good over evil), followed the next day by Rangwali Holi (the coloured powder celebration). Widely celebrated across India and Hindu communities worldwide as a spring festival marking the triumph of virtue over vice and the arrival of the harvest season. A public holiday in India and Nepal. Requires a custom INotableDateAlgorithm registered under the key 'holi'.">
@@ -85,7 +85,7 @@
   </NotableDate>
 
   <NotableDate name="Ram Navami">
-    <Rule name="Ram Navami"
+    <Rule name="algo-ram-navami"
           category="Religious"
           comment="The birthday of Lord Rama, the seventh avatar of Vishnu and the hero of the Ramayana. Observed on the ninth day of the bright fortnight of Chaitra, towards the end of the nine-day Chaitra Navaratri festival. Observed with fasting, prayers, devotional singing (bhajan and kirtan), and readings from the Ramayana. Requires a custom INotableDateAlgorithm registered under the key 'ram-navami'.">
       <Algorithm key="ram-navami" />
@@ -94,7 +94,7 @@
   </NotableDate>
 
   <NotableDate name="Raksha Bandhan">
-    <Rule name="Raksha Bandhan"
+    <Rule name="algo-raksha-bandhan"
           category="Cultural"
           comment="Festival celebrating sibling bonds, observed on the full moon day of Shravana. Requires a custom INotableDateAlgorithm registered under the key 'raksha-bandhan'.">
       <Algorithm key="raksha-bandhan" />
@@ -103,7 +103,7 @@
   </NotableDate>
 
   <NotableDate name="Janmashtami">
-    <Rule name="Janmashtami"
+    <Rule name="algo-janmashtami"
           category="Religious"
           comment="The birthday of Lord Krishna, the eighth avatar of Vishnu. Observed on the eighth day (Ashtami) of the dark fortnight of Bhadrapada, typically in August or September. Celebrated with midnight prayer vigils, devotional singing, fasting, and the staging of Krishna's birth scene (jhankis). A public holiday in India and observed by Hindu communities worldwide. Requires a custom INotableDateAlgorithm registered under the key 'janmashtami'.">
       <Algorithm key="janmashtami" />
@@ -112,7 +112,7 @@
   </NotableDate>
 
   <NotableDate name="Ganesh Chaturthi">
-    <Rule name="Ganesh Chaturthi"
+    <Rule name="algo-ganesh-chaturthi"
           category="Religious"
           durationDays="10"
           comment="Festival honouring Lord Ganesha, beginning on the fourth day of the bright fortnight of Bhadrapada. The durationDays value of 10 spans the common festival period through Anant Chaturdashi. Requires a custom INotableDateAlgorithm registered under the key 'ganesh-chaturthi'.">
@@ -122,7 +122,7 @@
   </NotableDate>
 
   <NotableDate name="Onam">
-    <Rule name="Onam"
+    <Rule name="algo-onam"
           category="Cultural"
           durationDays="10"
           comment="Kerala harvest festival centred on Thiruvonam in the Malayalam month of Chingam. The durationDays value of 10 represents the common festival period from Atham to Thiruvonam. Requires a custom INotableDateAlgorithm registered under the key 'onam'.">
@@ -133,7 +133,7 @@
   </NotableDate>
 
   <NotableDate name="Navaratri">
-    <Rule name="Navaratri"
+    <Rule name="algo-navaratri"
           category="Religious"
           durationDays="9"
           comment="Nine nights dedicated to the goddess Durga and her nine forms (Navadurga). The most widely observed Navaratri begins on the first day of the bright fortnight of Ashvin (September/October). Observed with fasting, prayers, traditional dance (Garba, Dandiya), and the construction of Golu (doll displays in South India). Concludes on the tenth day with Vijayadashami (Dussehra). Requires a custom INotableDateAlgorithm registered under the key 'navaratri'.">
@@ -143,7 +143,7 @@
   </NotableDate>
 
   <NotableDate name="Dussehra">
-    <Rule name="Dussehra"
+    <Rule name="algo-dussehra"
           category="Religious"
           comment="Vijayadashami. The tenth day of the bright fortnight of Ashvin, immediately following the conclusion of Navaratri. Celebrates the victory of Lord Rama over the demon king Ravana (in North India) and the victory of the goddess Durga over the buffalo demon Mahishasura (in Bengal and South India). Observed with the burning of effigies of Ravana, Kumbhakarna, and Meghnad, theatrical performances of the Ramayana (Ramlila), and weapon-worship (Ayudha Puja). A national public holiday in India. Requires a custom INotableDateAlgorithm registered under the key 'dussehra'.">
       <Algorithm key="dussehra" />
@@ -152,7 +152,7 @@
   </NotableDate>
 
   <NotableDate name="Karva Chauth">
-    <Rule name="Karva Chauth"
+    <Rule name="algo-karva-chauth"
           category="Cultural"
           comment="Fasting observance commonly followed by married Hindu women, observed on the fourth day after the full moon in Kartik. Requires a custom INotableDateAlgorithm registered under the key 'karva-chauth'.">
       <Algorithm key="karva-chauth" />
@@ -161,7 +161,7 @@
   </NotableDate>
 
   <NotableDate name="Diwali">
-    <Rule name="Diwali"
+    <Rule name="algo-diwali"
           category="Religious"
           durationDays="5"
           comment="Deepavali, the Festival of Lights. The main day falls on the new moon (Amavasya) of the month of Kartik (October/November), with the five-day festival beginning two days before and ending two days after. Celebrates the return of Lord Rama to Ayodhya, the victory of Lord Krishna over the demon Narakasura, and the goddess Lakshmi's blessing of prosperity. Observed with the lighting of oil lamps (diyas) and candles, fireworks, exchange of sweets and gifts, prayers to Lakshmi and Ganesha, and rangoli decoration. A national public holiday in India and a public holiday in several other countries. The durationDays value of 5 spans the entire traditional five-day period from Dhanteras to Bhai Dooj. Requires a custom INotableDateAlgorithm registered under the key 'diwali'.">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-islamic.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-islamic.xml
@@ -33,7 +33,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Ramadan">
-    <Rule name="Ramadan"
+    <Rule name="fixed-hijri-09-01"
           category="Religious"
           durationDays="30"
           calendarType="System.Globalization.HijriCalendar"
@@ -44,7 +44,7 @@
   </NotableDate>
 
   <NotableDate name="Eid al-Fitr">
-    <Rule name="Eid al-Fitr"
+    <Rule name="fixed-hijri-10-01"
           category="Religious"
           durationDays="3"
           calendarType="System.Globalization.HijriCalendar"
@@ -55,7 +55,7 @@
   </NotableDate>
 
   <NotableDate name="Eid al-Adha">
-    <Rule name="Eid al-Adha"
+    <Rule name="fixed-hijri-12-10"
           category="Religious"
           durationDays="4"
           calendarType="System.Globalization.HijriCalendar"
@@ -66,7 +66,7 @@
   </NotableDate>
 
   <NotableDate name="Islamic New Year">
-    <Rule name="Islamic New Year"
+    <Rule name="fixed-hijri-01-01"
           category="Religious"
           calendarType="System.Globalization.HijriCalendar"
           comment="Hijri New Year (Ra's as-Sanah al-Hijriyyah). The first day of Muharram, the opening month of the Islamic lunar calendar. Marks the anniversary of the Prophet Muhammad's migration (Hijra) from Mecca to Medina in 622 CE, from which the Hijri calendar era is dated. A public holiday in many Muslim-majority countries. Resolved via the Fixed strategy using HijriCalendar (month 1, day 1) with sweepCalendarYears.">
@@ -76,7 +76,7 @@
   </NotableDate>
 
   <NotableDate name="Day of Ashura">
-    <Rule name="Day of Ashura"
+    <Rule name="fixed-hijri-01-10"
           category="Religious"
           calendarType="System.Globalization.HijriCalendar"
           comment="Yawm Ashura. Falls on the tenth day of Muharram. For Sunni Muslims it is a recommended fast day commemorating Moses' fast in gratitude for the Israelites' deliverance. For Shia Muslims it is a major day of mourning commemorating the martyrdom of Hussein ibn Ali at the Battle of Karbala (61 AH / 680 CE). Resolved via the Fixed strategy using HijriCalendar (month 1, day 10) with sweepCalendarYears.">
@@ -86,7 +86,7 @@
   </NotableDate>
 
   <NotableDate name="Mawlid al-Nabi">
-    <Rule name="Mawlid al-Nabi"
+    <Rule name="fixed-hijri-03-12"
           category="Religious"
           calendarType="System.Globalization.HijriCalendar"
           comment="The Prophet's Birthday (Mawlid an-Nabawi). Observed on the 12th of Rabi al-Awwal in Sunni tradition. Commemorates the birth of the Prophet Muhammad. A public holiday in many Muslim-majority countries; not observed by some denominations that consider it an innovation (bid'ah). Resolved via the Fixed strategy using HijriCalendar (month 3, day 12) with sweepCalendarYears.">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-jewish.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-jewish.xml
@@ -51,7 +51,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Purim">
-    <Rule name="Purim"
+    <Rule name="fixed-hebrew-lastadar-14"
           category="Religious"
           calendarType="System.Globalization.HebrewCalendar"
           comment="The Feast of Lots. Observed on 14 Adar (or 14 Adar II in a Hebrew leap year — the LastAdar alias resolves to Adar II in leap years and Adar I in standard years). Commemorates the salvation of the Jewish people from Haman's plot to destroy them, as recounted in the Book of Esther. Observed with the public reading of the Megillah (Book of Esther), wearing of costumes, sending of food gifts (mishloach manot), charitable giving, and festive meals. Resolved via the Fixed strategy using HebrewCalendar (month LastAdar, day 14) with sweepCalendarYears.">
@@ -61,7 +61,7 @@
   </NotableDate>
 
   <NotableDate name="Passover">
-    <Rule name="Passover"
+    <Rule name="fixed-hebrew-nisan-15"
           category="Religious"
           durationDays="7"
           calendarType="System.Globalization.HebrewCalendar"
@@ -72,7 +72,7 @@
   </NotableDate>
 
   <NotableDate name="Shavuot">
-    <Rule name="Shavuot"
+    <Rule name="offset-passover+50"
           category="Religious"
           comment="The Feast of Weeks (also Pentecost). Observed on 6 Sivan, fifty days after the first day of Passover (15 Nisan). Commemorates the giving of the Torah at Mount Sinai. Observed with synagogue services, all-night Torah study (tikkun leil Shavuot), and the eating of dairy foods. One day in Israel and among Reform communities; two days in traditional diaspora practice. Authored as a fixed fifty-day offset from Passover; Nisan is always 30 days and Iyar always 29, so this offset is invariant.">
       <OffsetFromAnchor name="Passover" offset="50" />
@@ -81,7 +81,7 @@
   </NotableDate>
 
   <NotableDate name="Rosh Hashanah">
-    <Rule name="Rosh Hashanah"
+    <Rule name="fixed-hebrew-tishri-01"
           category="Religious"
           durationDays="2"
           calendarType="System.Globalization.HebrewCalendar"
@@ -92,7 +92,7 @@
   </NotableDate>
 
   <NotableDate name="Yom Kippur">
-    <Rule name="Yom Kippur"
+    <Rule name="offset-rosh-hashanah+9"
           category="Religious"
           comment="The Day of Atonement. Observed on 10 Tishri, nine days after Rosh Hashanah, closing the Ten Days of Repentance. The holiest day of the Jewish year, dedicated to prayer, fasting, and repentance. Synagogue services run for most of the day. A national holiday in Israel, where public life effectively halts. Authored as a fixed nine-day offset from Rosh Hashanah; the Hebrew calendar guarantees this offset is invariant.">
       <OffsetFromAnchor name="Rosh Hashanah" offset="9" />
@@ -101,7 +101,7 @@
   </NotableDate>
 
   <NotableDate name="Sukkot">
-    <Rule name="Sukkot"
+    <Rule name="offset-rosh-hashanah+14"
           category="Religious"
           durationDays="7"
           comment="The Feast of Tabernacles. Begins on 15 Tishri, fourteen days after Rosh Hashanah and five days after Yom Kippur. Commemorates the forty years the Israelites spent wandering in the desert after the Exodus. Observed by dwelling and eating in a sukkah (temporary hut) for seven days in Israel (eight in the diaspora by traditional practice). The durationDays value here represents the Israeli/Reform seven-day observance; regional rules may override to eight days for diaspora practice. Authored as a fixed fourteen-day offset from Rosh Hashanah; the Hebrew calendar guarantees this offset is invariant.">
@@ -111,7 +111,7 @@
   </NotableDate>
 
   <NotableDate name="Hanukkah">
-    <Rule name="Hanukkah"
+    <Rule name="fixed-hebrew-kislev-25"
           category="Religious"
           durationDays="8"
           calendarType="System.Globalization.HebrewCalendar"

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-jewish.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-jewish.xml
@@ -51,7 +51,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Purim">
-    <Rule name="fixed-hebrew-lastadar-14"
+    <Rule name="fixed-hebrew-last-adar-14"
           category="Religious"
           calendarType="System.Globalization.HebrewCalendar"
           comment="The Feast of Lots. Observed on 14 Adar (or 14 Adar II in a Hebrew leap year — the LastAdar alias resolves to Adar II in leap years and Adar I in standard years). Commemorates the salvation of the Jewish people from Haman's plot to destroy them, as recounted in the Book of Esther. Observed with the public reading of the Megillah (Book of Esther), wearing of costumes, sending of food gifts (mishloach manot), charitable giving, and festive meals. Resolved via the Fixed strategy using HebrewCalendar (month LastAdar, day 14) with sweepCalendarYears.">

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-lunar.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-lunar.xml
@@ -39,7 +39,7 @@
               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
   <NotableDate name="Lunar New Year">
-    <Rule name="Lunar New Year"
+    <Rule name="fixed-lunisolar-01-01"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -52,7 +52,7 @@
   </NotableDate>
 
   <NotableDate name="Lantern Festival">
-    <Rule name="Lantern Festival"
+    <Rule name="offset-lunar-new-year+14"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -64,7 +64,7 @@
   </NotableDate>
 
   <NotableDate name="Qingming Festival">
-    <Rule name="Qingming Festival"
+    <Rule name="algo-qingming"
           category="Observance"
           comment="Qingming Jie (清明節), also known as Tomb-Sweeping Day or Pure Brightness Festival. A solar term that falls on the fifteenth day after the Spring Equinox, typically 4–5 April. Families visit and clean the graves of their ancestors, making offerings of food, flowers, and paper goods. Requires a custom INotableDateAlgorithm registered under the key 'qingming'.">
       <Algorithm key="qingming" />
@@ -74,7 +74,7 @@
   </NotableDate>
 
   <NotableDate name="Dragon Boat Festival">
-    <Rule name="Dragon Boat Festival"
+    <Rule name="fixed-lunisolar-05-05"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -87,7 +87,7 @@
   </NotableDate>
 
   <NotableDate name="Qixi Festival">
-    <Rule name="Qixi Festival"
+    <Rule name="fixed-lunisolar-07-07"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -100,7 +100,7 @@
   </NotableDate>
 
   <NotableDate name="Hungry Ghost Festival">
-    <Rule name="Hungry Ghost Festival"
+    <Rule name="fixed-lunisolar-07-15"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -113,7 +113,7 @@
   </NotableDate>
 
   <NotableDate name="Mid-Autumn Festival">
-    <Rule name="Mid-Autumn Festival"
+    <Rule name="fixed-lunisolar-08-15"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -126,7 +126,7 @@
   </NotableDate>
 
   <NotableDate name="Double Ninth Festival">
-    <Rule name="Double Ninth Festival"
+    <Rule name="fixed-lunisolar-09-09"
           category="Cultural"
           firstYear="1901"
           lastYear="2100"
@@ -139,7 +139,7 @@
   </NotableDate>
 
   <NotableDate name="Winter Solstice Festival">
-    <Rule name="Fixed Winter Solstice Festival"
+    <Rule name="fixed-dec-22"
           category="Cultural"
           comment="Dongzhi Festival (冬至節). Observed on the winter solstice, which falls on 22 December in the majority of years (occasionally 21 or 23 December astronomically). One of the most important festivals in the Chinese calendar, marking the return of longer days and the peak of yin energy. Families gather for reunion meals featuring tangyuan (glutinous rice balls) in southern China and jiaozi (dumplings) in northern China. The date is expressed here as a Fixed rule on 22 December following modern civil-calendar convention. Consumers requiring the exact astronomical winter solstice date should register a custom INotableDateAlgorithm.">
       <Fixed month="December" day="22" />

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-multiday-normalization.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-multiday-normalization.xml
@@ -13,7 +13,7 @@
 <NotableDates xmlns="urn:bodu:globalization:calendar">
 
   <NotableDate name="NAIDOC Week">
-    <Rule name="First Sunday In July NAIDOC Week" category="Observance" territory="AU" durationDays="7"
+    <Rule name="weekday-1st-sun-jul-au" category="Observance" territory="AU" durationDays="7"
           comment="Australian observance beginning on the first Sunday in July. The durationDays value of 7 spans the full week inclusively.">
       <DayOfWeekInMonth month="July" dayOfWeek="Sunday" weekOrdinal="First" />
       <Tag>Indigenous</Tag>
@@ -23,7 +23,7 @@
   </NotableDate>
 
   <NotableDate name="World Space Week">
-    <Rule name="Fixed World Space Week" category="Observance" durationDays="7" firstYear="1999"
+    <Rule name="fixed-oct-04" category="Observance" durationDays="7" firstYear="1999"
           comment="Runs 4–10 October. The durationDays value of 7 spans the full period inclusively from 4 October.">
       <Fixed month="October" day="4" />
       <Tag>Science</Tag>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-remembrance.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-remembrance.xml
@@ -15,27 +15,27 @@
   -->
 
   <NotableDate name="International Holocaust Remembrance Day">
-    <Rule name="Fixed International Holocaust Remembrance Day" category="Remembrance">
+    <Rule name="fixed-jan-27" category="Remembrance">
       <Fixed month="January" day="27" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day for the Elimination of Racial Discrimination">
-    <Rule name="Fixed International Day for the Elimination of Racial Discrimination" category="Remembrance" firstYear="1966"
+    <Rule name="fixed-mar-21" category="Remembrance" firstYear="1966"
           comment="Proclaimed by the United Nations General Assembly in 1966 (resolution 2142 (XXI)) to commemorate the Sharpeville massacre of 21 March 1960, in which South African police opened fire on peaceful anti-apartheid demonstrators, killing 69 people.">
       <Fixed month="March" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day for the Remembrance of the Slave Trade and its Abolition">
-    <Rule name="Fixed International Day for the Remembrance of the Slave Trade and its Abolition" category="Remembrance" firstYear="1998"
+    <Rule name="fixed-aug-23" category="Remembrance" firstYear="1998"
           comment="Proclaimed by UNESCO and first observed on 23 August 1998. The date marks the anniversary of the 1791 uprising in Saint-Domingue (now Haiti and the Dominican Republic) that became a decisive turning point in the abolition of the transatlantic slave trade.">
       <Fixed month="August" day="23" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Remembrance Day">
-    <Rule name="Fixed Remembrance Day" category="Remembrance">
+    <Rule name="fixed-nov-11" category="Remembrance">
       <Fixed month="November" day="11" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-science.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-science.xml
@@ -15,35 +15,35 @@
   -->
 
   <NotableDate name="International Day of Women and Girls in Science">
-    <Rule name="Fixed International Day of Women and Girls in Science" category="Observance" firstYear="2016"
+    <Rule name="fixed-feb-11" category="Observance" firstYear="2016"
           comment="Proclaimed by the United Nations General Assembly in 2015 (resolution 70/212) and first observed on 11 February 2016.">
       <Fixed month="February" day="11" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Mathematics">
-    <Rule name="Fixed International Day of Mathematics" category="Observance" firstYear="2020"
+    <Rule name="fixed-mar-14" category="Observance" firstYear="2020"
           comment="Proclaimed by UNESCO in 2019 and first observed in 2020. The date coincides with Pi Day (3.14), reflecting the mathematical constant π ≈ 3.14159.">
       <Fixed month="March" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Meteorological Day">
-    <Rule name="Fixed World Meteorological Day" category="Observance" firstYear="1961"
+    <Rule name="fixed-mar-23" category="Observance" firstYear="1961"
           comment="Marks the anniversary of the entry into force of the World Meteorological Organization (WMO) Convention on 23 March 1950.">
       <Fixed month="March" day="23" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Intellectual Property Day">
-    <Rule name="Fixed World Intellectual Property Day" category="Observance" firstYear="2000"
+    <Rule name="fixed-apr-26" category="Observance" firstYear="2000"
           comment="Established by the World Intellectual Property Organization (WIPO) in 1999 to mark the date the WIPO Convention entered into force in 1970.">
       <Fixed month="April" day="26" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Light">
-    <Rule name="Fixed International Day of Light" category="Observance" firstYear="2018"
+    <Rule name="fixed-may-16" category="Observance" firstYear="2018"
           comment="Proclaimed by UNESCO in 2017 and first observed on 16 May 2018. The date marks the anniversary of Theodore Maiman's first successful operation of the laser in 1960.">
       <Fixed month="May" day="16" />
     </Rule>
@@ -54,21 +54,21 @@
   -->
 
   <NotableDate name="Pi Day">
-    <Rule name="Fixed Pi Day" category="Cultural" firstYear="1988"
+    <Rule name="fixed-mar-14" category="Cultural" firstYear="1988"
           comment="A mathematical culture observance held on 14 March because 3/14 matches the first three significant digits of pi in month/day notation. The first recognised celebration was organised at the Exploratorium in San Francisco in 1988.">
       <Fixed month="March" day="14" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Space Week">
-    <Rule name="Fixed World Space Week" category="Observance" durationDays="7" firstYear="1999"
+    <Rule name="fixed-oct-04" category="Observance" durationDays="7" firstYear="1999"
           comment="Proclaimed by the United Nations General Assembly in 1999 (resolution 54/68). Runs 4–10 October, marking the launch of Sputnik 1 (4 Oct 1957) and the signing of the Outer Space Treaty (10 Oct 1967).">
       <Fixed month="October" day="4" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Science Day for Peace and Development">
-    <Rule name="Fixed World Science Day for Peace and Development" category="Observance" firstYear="2002"
+    <Rule name="fixed-nov-10" category="Observance" firstYear="2002"
           comment="Proclaimed by UNESCO in 2001 and first observed on 10 November 2002, to highlight the role of science in society and the need to engage the wider public in debates on science.">
       <Fixed month="November" day="10" />
     </Rule>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-social.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-social.xml
@@ -16,27 +16,27 @@
   -->
 
   <NotableDate name="World Day of Social Justice">
-    <Rule name="Fixed World Day of Social Justice" category="Observance" firstYear="2009"
+    <Rule name="fixed-feb-20" category="Observance" firstYear="2009"
           comment="Proclaimed by the United Nations General Assembly in 2007 (resolution 62/10) and first observed on 20 February 2009, to acknowledge that social development and social justice are indispensable to peace and security.">
       <Fixed month="February" day="20" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Families">
-    <Rule name="Fixed International Day of Families" category="Observance">
+    <Rule name="fixed-may-15" category="Observance">
       <Fixed month="May" day="15" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day Against Homophobia, Biphobia and Transphobia">
-    <Rule name="Fixed International Day Against Homophobia, Biphobia and Transphobia" category="Observance" firstYear="2005"
+    <Rule name="fixed-may-17" category="Observance" firstYear="2005"
           comment="Also widely known as IDAHOBIT. Observed on 17 May to mark the 1990 decision by the World Health Organization to remove homosexuality from the International Classification of Diseases.">
       <Fixed month="May" day="17" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Pride Month">
-    <Rule name="Fixed Pride Month" category="Observance" durationDays="30"
+    <Rule name="fixed-jun-01" category="Observance" durationDays="30"
           comment="A month-long LGBTQIA+ cultural and social observance held in June, commonly associated with the anniversary of the 1969 Stonewall uprising and the development of modern Pride marches and events. The durationDays value of 30 spans the full civil month of June, inclusive of 1 June.">
       <Fixed month="June" day="1" />
       <Tag>Social</Tag>
@@ -45,68 +45,68 @@
   </NotableDate>
 
   <NotableDate name="World Day Against Child Labour">
-    <Rule name="Fixed World Day Against Child Labour" category="Observance" firstYear="2002"
+    <Rule name="fixed-jun-12" category="Observance" firstYear="2002"
           comment="Launched by the International Labour Organization (ILO) in 2002 to raise awareness and action to combat child labour and to improve working conditions.">
       <Fixed month="June" day="12" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Refugee Day">
-    <Rule name="Fixed World Refugee Day" category="Observance">
+    <Rule name="fixed-jun-20" category="Observance">
       <Fixed month="June" day="20" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Nelson Mandela International Day">
-    <Rule name="Fixed Nelson Mandela International Day" category="Observance" firstYear="2010"
+    <Rule name="fixed-jul-18" category="Observance" firstYear="2010"
           comment="Proclaimed by the United Nations General Assembly in 2009 (resolution 64/13) and first observed on 18 July 2010, the anniversary of Nelson Mandela's birth, in recognition of his contribution to the culture of peace and freedom.">
       <Fixed month="July" day="18" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Charity">
-    <Rule name="Fixed International Day of Charity" category="Observance" firstYear="2012"
+    <Rule name="fixed-sep-05" category="Observance" firstYear="2012"
           comment="Proclaimed by the United Nations General Assembly in 2012 (resolution 67/105) and first observed on 5 September 2013. The date marks the anniversary of the death of Mother Teresa of Calcutta in 1997.">
       <Fixed month="September" day="5" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Older Persons">
-    <Rule name="Fixed International Day of Older Persons" category="Observance">
+    <Rule name="fixed-oct-01" category="Observance">
       <Fixed month="October" day="1" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of the Girl Child">
-    <Rule name="Fixed International Day of the Girl Child" category="Observance" firstYear="2012"
+    <Rule name="fixed-oct-11" category="Observance" firstYear="2012"
           comment="Proclaimed by the United Nations General Assembly in 2011 (resolution 66/170) and first observed on 11 October 2012, to recognise girls' rights and challenges faced by girls worldwide.">
       <Fixed month="October" day="11" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="World Kindness Day">
-    <Rule name="Fixed World Kindness Day" category="Observance" firstYear="1998"
+    <Rule name="fixed-nov-13" category="Observance" firstYear="1998"
           comment="An international kindness observance promoted by the World Kindness Movement and other kindness organisations, encouraging acts of kindness and community goodwill.">
       <Fixed month="November" day="13" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Men's Day">
-    <Rule name="Fixed International Men's Day" category="Observance" firstYear="1999"
+    <Rule name="fixed-nov-19" category="Observance" firstYear="1999"
           comment="A global awareness day recognising the positive contributions of men and boys and raising awareness of issues affecting men's health, wellbeing, family life, and community participation.">
       <Fixed month="November" day="19" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Universal Children's Day">
-    <Rule name="Fixed Universal Children's Day" category="Observance" firstYear="1954"
+    <Rule name="fixed-nov-20" category="Observance" firstYear="1954"
           comment="Established by the United Nations General Assembly in 1954 (resolution 836(IX)) to promote international togetherness, awareness among children worldwide, and improving children's welfare. The date also marks the adoption of the Convention on the Rights of the Child in 1989.">
       <Fixed month="November" day="20" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Persons with Disabilities">
-    <Rule name="Fixed International Day of Persons with Disabilities" category="Observance">
+    <Rule name="fixed-dec-03" category="Observance">
       <Fixed month="December" day="3" />
     </Rule>
   </NotableDate>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-un.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources/global-un.xml
@@ -16,37 +16,37 @@
   -->
 
   <NotableDate name="International Women's Day">
-    <Rule name="Fixed International Women's Day" category="Observance">
+    <Rule name="fixed-mar-08" category="Observance">
       <Fixed month="March" day="8" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Happiness">
-    <Rule name="Fixed International Day of Happiness" category="Observance">
+    <Rule name="fixed-mar-20" category="Observance">
       <Fixed month="March" day="20" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Youth Day">
-    <Rule name="Fixed International Youth Day" category="Observance">
+    <Rule name="fixed-aug-12" category="Observance">
       <Fixed month="August" day="12" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Peace">
-    <Rule name="Fixed International Day of Peace" category="Observance">
+    <Rule name="fixed-sep-21" category="Observance">
       <Fixed month="September" day="21" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="United Nations Day">
-    <Rule name="Fixed United Nations Day" category="Observance">
+    <Rule name="fixed-oct-24" category="Observance">
       <Fixed month="October" day="24" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="Human Rights Day">
-    <Rule name="Fixed Human Rights Day" category="Observance">
+    <Rule name="fixed-dec-10" category="Observance">
       <Fixed month="December" day="10" />
     </Rule>
   </NotableDate>
@@ -56,7 +56,7 @@
   -->
 
   <NotableDate name="World Interfaith Harmony Week">
-    <Rule name="Fixed World Interfaith Harmony Week" category="Observance" durationDays="7" firstYear="2011"
+    <Rule name="fixed-feb-01" category="Observance" durationDays="7" firstYear="2011"
           comment="Proclaimed by the United Nations General Assembly in 2010 (resolution 65/5) and first observed during 1–7 February 2011, to foster harmony between all people regardless of their faith.">
       <Fixed month="February" day="1" />
     </Rule>
@@ -67,14 +67,14 @@
   -->
 
   <NotableDate name="World Press Freedom Day">
-    <Rule name="Fixed World Press Freedom Day" category="Observance" firstYear="1993"
+    <Rule name="fixed-may-03" category="Observance" firstYear="1993"
           comment="Proclaimed by the United Nations General Assembly in 1993 (resolution A/RES/48/432) following a recommendation from UNESCO's General Conference. First observed on 3 May 1993.">
       <Fixed month="May" day="3" />
     </Rule>
   </NotableDate>
 
   <NotableDate name="International Day of Democracy">
-    <Rule name="Fixed International Day of Democracy" category="Observance" firstYear="2008"
+    <Rule name="fixed-sep-15" category="Observance" firstYear="2008"
           comment="Proclaimed by the United Nations General Assembly in 2007 (resolution 62/7) and first observed on 15 September 2008, coinciding with the anniversary of the Universal Declaration on Democracy adopted by the Inter-Parliamentary Union in 1997.">
       <Fixed month="September" day="15" />
     </Rule>
@@ -85,7 +85,7 @@
   -->
 
   <NotableDate name="World Habitat Day">
-    <Rule name="First Monday In October World Habitat Day" category="Observance" firstYear="1986"
+    <Rule name="weekday-1st-mon-oct" category="Observance" firstYear="1986"
           comment="Established by the United Nations General Assembly in 1985 (resolution 40/202) and first observed on the first Monday of October 1986, to reflect on the state of human settlements and the basic right of all to adequate shelter.">
       <DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" />
     </Rule>


### PR DESCRIPTION
Renames the <Rule name="..."> attribute on every production NotableDate
resource to a structured kebab-case identifier that encodes the rule's
anchor (fixed, weekday, offset, algo), its parameters, any adjustment
modifier, and the override territory. This replaces the previous mix of
prose-style names (e.g. "Fixed Christmas Day With Weekend Roll", "Second
Monday In June King's Birthday (NSW)", "Australian New Year's Day") with
a single predictable shape that is easier to author overrides against.

Format:
  <anchor>-<descriptor>[-<modifier>][-<territory>]

  Fixed (Gregorian):   fixed-<mon3>-<dd>          e.g. fixed-dec-25
  Fixed (calendar):    fixed-<cal>-<m>-<d>        e.g. fixed-lunisolar-01-01
  Weekday in month:    weekday-<ord>-<day3>-<mon3> e.g. weekday-1st-mon-oct
  Offset from anchor:  offset-<anchor>-<N> | +<N>  e.g. offset-easter-sunday-47
  Algorithm:           algo-<key>                  e.g. algo-easter-sunday

  Modifier suffixes (derived from Adjustment action):
    -weekend-roll       MoveToNextWeekday / MoveToPreviousWeekday
    -nonworking-roll    MoveToNextNonWorkingDay
    -substitute         ReplaceWithNamedDate
    -shift              AddDays

  Territory suffix on override rules: lowercased territory code
    (e.g. -au, -au-nsw, -de-by) so AU/AU-VIC overrides remain distinguishable.

Affects every <Rule name="..."> across the four data packages and the
core resource set; covers 347 rule entries in 40 files. No code or
schema changes — only the value of the name attribute is updated.