### PR TITLE
Add WorkingDaysOfWeek enum, WeekPattern presets, and day-of-week predicates

### DIFF
--- a/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
+++ b/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalendarWeekendDefinitionExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides conversions between the legacy <see cref="CalendarWeekendDefinition" /> enum (plus optional
+/// <see cref="IWeekendDefinitionProvider" />) and the canonical <see cref="WeekPattern" /> working-week value type.
+/// </summary>
+public static class CalendarWeekendDefinitionExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="CalendarWeekendDefinition" /> (plus an optional <see cref="IWeekendDefinitionProvider" />
+    /// for <see cref="CalendarWeekendDefinition.Custom" />) into the canonical <see cref="WeekPattern" /> whose
+    /// selected days are the working days implied by the supplied weekend definition.
+    /// </summary>
+    /// <param name="weekend">The weekend definition.</param>
+    /// <param name="provider">An optional custom weekend provider consulted when <paramref name="weekend" /> is <see cref="CalendarWeekendDefinition.Custom" />.</param>
+    /// <returns>The working-week <see cref="WeekPattern" /> implied by <paramref name="weekend" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="weekend" /> is not a defined value of the <see cref="CalendarWeekendDefinition" />
+    /// enumeration, or when <paramref name="weekend" /> is <see cref="CalendarWeekendDefinition.Custom" /> and
+    /// <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The conversion enumerates every <see cref="DayOfWeek" /> value and queries
+    /// <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />,
+    /// selecting each day that is not classified as a weekend. <see cref="CalendarWeekendDefinition.None" /> therefore
+    /// produces a <see cref="WeekPattern" /> with every day selected.
+    /// </para>
+    /// </remarks>
+    public static WeekPattern ToWeekPattern(this CalendarWeekendDefinition weekend, IWeekendDefinitionProvider? provider = null)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(weekend);
+        ThrowHelper.ThrowIfConditionallyRequiredParameterIsNull(provider, weekend, CalendarWeekendDefinition.Custom);
+
+        WeekPattern pattern = WeekPattern.Empty;
+        for (var i = 0; i < 7; i++)
+        {
+            DayOfWeek day = (DayOfWeek)i;
+            if (!DateTimeExtensions.IsWeekend(day, weekend, provider))
+                pattern = pattern.With(day);
+        }
+
+        return pattern;
+    }
+
+    /// <summary>
+    /// Returns the matching <see cref="CalendarWeekendDefinition" /> for the supplied working-week
+    /// <see cref="WeekPattern" />, or <see cref="CalendarWeekendDefinition.Custom" /> when no built-in value matches.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <returns>
+    /// The matching <see cref="CalendarWeekendDefinition" /> value (for example
+    /// <see cref="CalendarWeekendDefinition.SaturdaySunday" /> when <paramref name="workingWeek" /> is Monday through
+    /// Friday), or <see cref="CalendarWeekendDefinition.Custom" /> when <paramref name="workingWeek" /> does not match
+    /// any built-in weekend definition.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Callers that need to distinguish "no match" from "Custom" should use
+    /// <see cref="TryGetCalendarWeekendDefinition(WeekPattern, out CalendarWeekendDefinition)" />.
+    /// </para>
+    /// </remarks>
+    public static CalendarWeekendDefinition ToCalendarWeekendDefinition(this WeekPattern workingWeek) =>
+        TryGetCalendarWeekendDefinition(workingWeek, out CalendarWeekendDefinition value) ? value : CalendarWeekendDefinition.Custom;
+
+    /// <summary>
+    /// Attempts to identify the supplied <see cref="WeekPattern" /> as a built-in
+    /// <see cref="CalendarWeekendDefinition" /> value.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern to identify.</param>
+    /// <param name="value">
+    /// When this method returns <see langword="true" />, contains the matching
+    /// <see cref="CalendarWeekendDefinition" /> value; otherwise <see cref="CalendarWeekendDefinition.Custom" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> when <paramref name="workingWeek" /> corresponds to a built-in weekend definition;
+    /// otherwise <see langword="false" />.
+    /// </returns>
+    public static bool TryGetCalendarWeekendDefinition(this WeekPattern workingWeek, out CalendarWeekendDefinition value)
+    {
+        if (workingWeek == WeekPattern.MondayToFriday) { value = CalendarWeekendDefinition.SaturdaySunday; return true; }
+        if (workingWeek == WeekPattern.SundayToThursday) { value = CalendarWeekendDefinition.FridaySaturday; return true; }
+        if (workingWeek == WeekPattern.SaturdayToWednesday) { value = CalendarWeekendDefinition.ThursdayFriday; return true; }
+        if (workingWeek == WeekPattern.SaturdayToThursday) { value = CalendarWeekendDefinition.FridayOnly; return true; }
+        if (workingWeek == WeekPattern.MondayToSaturday) { value = CalendarWeekendDefinition.SundayOnly; return true; }
+        if (workingWeek.Count == 7) { value = CalendarWeekendDefinition.None; return true; }
+
+        value = CalendarWeekendDefinition.Custom;
+        return false;
+    }
+}

--- a/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
+++ b/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="CalendarWeekendDefinitionExtensions.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -43,7 +43,7 @@ public static class CalendarWeekendDefinitionExtensions
         WeekPattern pattern = WeekPattern.Empty;
         for (var i = 0; i < 7; i++)
         {
-            DayOfWeek day = (DayOfWeek)i;
+            var day = (DayOfWeek)i;
             if (!DateTimeExtensions.IsWeekend(day, weekend, provider))
                 pattern = pattern.With(day);
         }
@@ -69,7 +69,9 @@ public static class CalendarWeekendDefinitionExtensions
     /// </para>
     /// </remarks>
     public static CalendarWeekendDefinition ToCalendarWeekendDefinition(this WeekPattern workingWeek) =>
-        TryGetCalendarWeekendDefinition(workingWeek, out CalendarWeekendDefinition value) ? value : CalendarWeekendDefinition.Custom;
+        TryGetCalendarWeekendDefinition(workingWeek, out CalendarWeekendDefinition value)
+            ? value
+            : CalendarWeekendDefinition.Custom;
 
     /// <summary>
     /// Attempts to identify the supplied <see cref="WeekPattern" /> as a built-in
@@ -84,16 +86,34 @@ public static class CalendarWeekendDefinitionExtensions
     /// <see langword="true" /> when <paramref name="workingWeek" /> corresponds to a built-in weekend definition;
     /// otherwise <see langword="false" />.
     /// </returns>
-    public static bool TryGetCalendarWeekendDefinition(this WeekPattern workingWeek, out CalendarWeekendDefinition value)
+    public static bool TryGetCalendarWeekendDefinition(
+        this WeekPattern workingWeek,
+        out CalendarWeekendDefinition value)
     {
-        if (workingWeek == WeekPattern.MondayToFriday) { value = CalendarWeekendDefinition.SaturdaySunday; return true; }
-        if (workingWeek == WeekPattern.SundayToThursday) { value = CalendarWeekendDefinition.FridaySaturday; return true; }
-        if (workingWeek == WeekPattern.SaturdayToWednesday) { value = CalendarWeekendDefinition.ThursdayFriday; return true; }
-        if (workingWeek == WeekPattern.SaturdayToThursday) { value = CalendarWeekendDefinition.FridayOnly; return true; }
-        if (workingWeek == WeekPattern.MondayToSaturday) { value = CalendarWeekendDefinition.SundayOnly; return true; }
-        if (workingWeek.Count == 7) { value = CalendarWeekendDefinition.None; return true; }
+        (var matched, value) = workingWeek switch
+        {
+            var week when week == WeekPattern.MondayToFriday =>
+                (true, CalendarWeekendDefinition.SaturdaySunday),
 
-        value = CalendarWeekendDefinition.Custom;
-        return false;
+            var week when week == WeekPattern.SundayToThursday =>
+                (true, CalendarWeekendDefinition.FridaySaturday),
+
+            var week when week == WeekPattern.SaturdayToWednesday =>
+                (true, CalendarWeekendDefinition.ThursdayFriday),
+
+            var week when week == WeekPattern.SaturdayToThursday =>
+                (true, CalendarWeekendDefinition.FridayOnly),
+
+            var week when week == WeekPattern.MondayToSaturday =>
+                (true, CalendarWeekendDefinition.SundayOnly),
+
+            var week when week.Count == 7 =>
+                (true, CalendarWeekendDefinition.None),
+
+            _ =>
+                (false, CalendarWeekendDefinition.Custom),
+        };
+
+        return matched;
     }
 }

--- a/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
+++ b/Bodu.Core/src/Extensions/CalendarWeekendDefinitionExtensions.cs
@@ -96,4 +96,43 @@ public static class CalendarWeekendDefinitionExtensions
         value = CalendarWeekendDefinition.Custom;
         return false;
     }
+
+    /// <summary>
+    /// Converts an <see cref="IWeekendDefinitionProvider" /> into the canonical <see cref="WeekPattern" /> whose
+    /// selected days are the complement of the provider's weekend.
+    /// </summary>
+    /// <param name="provider">The provider whose weekend semantics are projected onto a <see cref="WeekPattern" />.</param>
+    /// <returns>The working-week <see cref="WeekPattern" /> implied by <paramref name="provider" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Use this helper when migrating callers from the legacy <see cref="IWeekendDefinitionProvider" /> contract to the
+    /// canonical <see cref="WeekPattern" /> model. The returned pattern can then be passed to APIs that accept a
+    /// <see cref="WeekPattern" /> directly — for example, the <see cref="WeekPattern" />-accepting
+    /// <c>NotableDateService</c> constructor.
+    /// </para>
+    /// <example>
+    /// <code language="csharp">
+    /// <![CDATA[
+    /// IWeekendDefinitionProvider provider = new MyCustomWeekend();
+    /// WeekPattern workingWeek = provider.ToWeekPattern();
+    /// var service = new NotableDateService(ruleProviders, workingWeek);
+    /// ]]>
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public static WeekPattern ToWeekPattern(this IWeekendDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        WeekPattern pattern = WeekPattern.Empty;
+        for (var i = 0; i < 7; i++)
+        {
+            DayOfWeek day = (DayOfWeek)i;
+            if (!provider.IsWeekend(day))
+                pattern = pattern.With(day);
+        }
+
+        return pattern;
+    }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FiscalYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FiscalYear.cs
@@ -1,0 +1,111 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateOnlyExtensions.FiscalYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Returns the fiscal year that contains the supplied <see cref="DateOnly" /> under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="date">The date to identify.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>The fiscal year number under the provider's conventions.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static int FiscalYear(this DateOnly date, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetFiscalYear(date);
+    }
+
+    /// <summary>
+    /// Returns the first calendar day of the supplied fiscal year under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose start date is requested.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>A <see cref="DateOnly" /> representing the first day of the fiscal year.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateOnly FirstDateOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetQuarterStartDate(1, fiscalYear);
+    }
+
+    /// <summary>
+    /// Returns the last calendar day of the supplied fiscal year under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose end date is requested.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>A <see cref="DateOnly" /> representing the last day of the fiscal year.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateOnly LastDateOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetQuarterEndDate(4, fiscalYear);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> when <paramref name="date" /> is the first day of its fiscal year under the
+    /// supplied <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="date">The date to test.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns><see langword="true" /> if <paramref name="date" /> equals the first day of its fiscal year; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static bool IsFirstDateOfFiscalYear(this DateOnly date, IQuarterDefinitionProvider provider) =>
+        date == FirstDateOfFiscalYear(date.FiscalYear(provider), provider);
+
+    /// <summary>
+    /// Returns <see langword="true" /> when <paramref name="date" /> is the last day of its fiscal year under the
+    /// supplied <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="date">The date to test.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns><see langword="true" /> if <paramref name="date" /> equals the last day of its fiscal year; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static bool IsLastDateOfFiscalYear(this DateOnly date, IQuarterDefinitionProvider provider) =>
+        date == LastDateOfFiscalYear(date.FiscalYear(provider), provider);
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> obtained by advancing or retreating <paramref name="date" /> by the signed
+    /// number of fiscal years specified in <paramref name="count" />.
+    /// </summary>
+    /// <param name="date">The starting date.</param>
+    /// <param name="count">The signed number of fiscal years to apply.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>
+    /// A <see cref="DateOnly" /> whose value is offset by <paramref name="count" /> fiscal years, preserving the
+    /// day-index within the fiscal year of <paramref name="date" />. The result is clamped to the last day of the
+    /// target fiscal year when the source day-index does not fit (e.g. a Q4 53rd-week date mapped onto a 52-week year).
+    /// </returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateOnly AddFiscalYears(this DateOnly date, int count, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        if (count == 0) return date;
+
+        int fy = provider.GetFiscalYear(date);
+        DateOnly fyStart = FirstDateOfFiscalYear(fy, provider);
+        int dayIndex = date.DayNumber - fyStart.DayNumber;
+
+        int target = fy + count;
+        DateOnly targetStart = FirstDateOfFiscalYear(target, provider);
+        DateOnly targetEnd = LastDateOfFiscalYear(target, provider);
+
+        int candidate = targetStart.DayNumber + dayIndex;
+        if (candidate > targetEnd.DayNumber) candidate = targetEnd.DayNumber;
+        return DateOnly.FromDayNumber(candidate);
+    }
+}

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.FiscalYear.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.FiscalYear.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="DateOnlyExtensions.FiscalYear.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -96,15 +96,15 @@ public static partial class DateOnlyExtensions
 
         if (count == 0) return date;
 
-        int fy = provider.GetFiscalYear(date);
+        var fy = provider.GetFiscalYear(date);
         DateOnly fyStart = FirstDateOfFiscalYear(fy, provider);
-        int dayIndex = date.DayNumber - fyStart.DayNumber;
+        var dayIndex = date.DayNumber - fyStart.DayNumber;
 
-        int target = fy + count;
+        var target = fy + count;
         DateOnly targetStart = FirstDateOfFiscalYear(target, provider);
         DateOnly targetEnd = LastDateOfFiscalYear(target, provider);
 
-        int candidate = targetStart.DayNumber + dayIndex;
+        var candidate = targetStart.DayNumber + dayIndex;
         if (candidate > targetEnd.DayNumber) candidate = targetEnd.DayNumber;
         return DateOnly.FromDayNumber(candidate);
     }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsInWorkingWeek.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsInWorkingWeek.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateOnlyExtensions.IsInWorkingWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Determines whether the specified <see cref="DateOnly" /> falls on a day that is selected in the supplied
+    /// <see cref="WeekPattern" /> working week.
+    /// </summary>
+    /// <param name="date">The date to evaluate.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="date" />'s <see cref="DayOfWeek" /> is selected in
+    /// <paramref name="workingWeek" />; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// This predicate considers only the day-of-week dimension. It does not consult any holiday catalogue. Combine it
+    /// with a notable-date service when both working-week and holiday awareness are required.
+    /// </remarks>
+    public static bool IsInWorkingWeek(this DateOnly date, WeekPattern workingWeek) =>
+        workingWeek.Contains(date.DayOfWeek);
+
+    /// <summary>
+    /// Determines whether the specified <see cref="DateOnly" /> falls on a day that is selected in the supplied
+    /// <see cref="WorkingDaysOfWeek" /> working week.
+    /// </summary>
+    /// <param name="date">The date to evaluate.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="date" />'s <see cref="DayOfWeek" /> is in the working week;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.
+    /// </exception>
+    public static bool IsInWorkingWeek(this DateOnly date, WorkingDaysOfWeek workingWeek) =>
+        IsInWorkingWeek(date, workingWeek.ToWeekPattern());
+}

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.IsRestDay.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.IsRestDay.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateOnlyExtensions.IsRestDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateOnlyExtensions
+{
+    /// <summary>
+    /// Determines whether the specified <see cref="DateOnly" /> falls on a day that is not selected in the supplied
+    /// <see cref="WeekPattern" /> working week.
+    /// </summary>
+    /// <param name="date">The date to evaluate.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="date" />'s <see cref="DayOfWeek" /> is not selected in
+    /// <paramref name="workingWeek" />; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// This predicate is the complement of <see cref="IsInWorkingWeek(DateOnly, WeekPattern)" /> and considers only
+    /// the day-of-week dimension. It does not consult any holiday catalogue.
+    /// </remarks>
+    public static bool IsRestDay(this DateOnly date, WeekPattern workingWeek) =>
+        !workingWeek.Contains(date.DayOfWeek);
+
+    /// <summary>
+    /// Determines whether the specified <see cref="DateOnly" /> falls on a day that is not selected in the supplied
+    /// <see cref="WorkingDaysOfWeek" /> working week.
+    /// </summary>
+    /// <param name="date">The date to evaluate.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="date" />'s <see cref="DayOfWeek" /> is not in the working week;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.
+    /// </exception>
+    public static bool IsRestDay(this DateOnly date, WorkingDaysOfWeek workingWeek) =>
+        IsRestDay(date, workingWeek.ToWeekPattern());
+}

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.NextWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.NextWeekday.cs
@@ -58,4 +58,26 @@ public static partial class DateOnlyExtensions
 
         return DateOnly.FromDayNumber(dayNumber);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the next day after <paramref name="date" /> whose
+    /// <see cref="DayOfWeek" /> is selected in the supplied <paramref name="workingWeek" />.
+    /// </summary>
+    /// <param name="date">The starting date value from which to search forward.</param>
+    /// <param name="workingWeek">The working-week pattern that determines which days are considered working days.</param>
+    /// <returns>The first calendar day strictly after <paramref name="date" /> whose day-of-week is selected in <paramref name="workingWeek" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />.</exception>
+    public static DateOnly NextWeekday(this DateOnly date, WeekPattern workingWeek)
+    {
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        var dayNumber = date.DayNumber;
+        do
+        {
+            dayNumber += 1;
+        }
+        while (!workingWeek.Contains(DateOnlyExtensions.GetDayOfWeekFromDayNumber(dayNumber)));
+
+        return DateOnly.FromDayNumber(dayNumber);
+    }
 }

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.PreviousWeekday.cs
@@ -58,4 +58,26 @@ public static partial class DateOnlyExtensions
 
         return DateOnly.FromDayNumber(dayNumber);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the previous day before <paramref name="date" /> whose
+    /// <see cref="DayOfWeek" /> is selected in the supplied <paramref name="workingWeek" />.
+    /// </summary>
+    /// <param name="date">The starting date value from which to search backward.</param>
+    /// <param name="workingWeek">The working-week pattern that determines which days are considered working days.</param>
+    /// <returns>The first calendar day strictly before <paramref name="date" /> whose day-of-week is selected in <paramref name="workingWeek" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />.</exception>
+    public static DateOnly PreviousWeekday(this DateOnly date, WeekPattern workingWeek)
+    {
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        var dayNumber = date.DayNumber;
+        do
+        {
+            dayNumber -= 1;
+        }
+        while (!workingWeek.Contains(DateOnlyExtensions.GetDayOfWeekFromDayNumber(dayNumber)));
+
+        return DateOnly.FromDayNumber(dayNumber);
+    }
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.FiscalYear.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.FiscalYear.cs
@@ -1,0 +1,99 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensions.FiscalYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Returns the fiscal year that contains the supplied <see cref="DateTime" /> under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="dateTime">The date to identify.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>The fiscal year number under the provider's conventions.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static int FiscalYear(this DateTime dateTime, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetFiscalYear(dateTime);
+    }
+
+    /// <summary>
+    /// Returns the first calendar day of the supplied fiscal year under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose start date is requested.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>A <see cref="DateTime" /> representing the first day of the fiscal year (midnight).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateTime FirstDateOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetQuarterStart(1, fiscalYear);
+    }
+
+    /// <summary>
+    /// Returns the last calendar day of the supplied fiscal year under the supplied
+    /// <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose end date is requested.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>A <see cref="DateTime" /> representing the last day of the fiscal year (midnight).</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateTime LastDateOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        return provider.GetQuarterEnd(4, fiscalYear);
+    }
+
+    /// <summary>
+    /// Returns <see langword="true" /> when <paramref name="dateTime" />'s date component is the first day of its fiscal
+    /// year under the supplied <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="dateTime">The value to test.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns><see langword="true" /> if the date component equals the first day of its fiscal year; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static bool IsFirstDateOfFiscalYear(this DateTime dateTime, IQuarterDefinitionProvider provider) =>
+        dateTime.Date == FirstDateOfFiscalYear(dateTime.FiscalYear(provider), provider).Date;
+
+    /// <summary>
+    /// Returns <see langword="true" /> when <paramref name="dateTime" />'s date component is the last day of its fiscal
+    /// year under the supplied <see cref="IQuarterDefinitionProvider" />.
+    /// </summary>
+    /// <param name="dateTime">The value to test.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns><see langword="true" /> if the date component equals the last day of its fiscal year; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static bool IsLastDateOfFiscalYear(this DateTime dateTime, IQuarterDefinitionProvider provider) =>
+        dateTime.Date == LastDateOfFiscalYear(dateTime.FiscalYear(provider), provider).Date;
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> obtained by advancing or retreating <paramref name="dateTime" /> by the
+    /// signed number of fiscal years specified in <paramref name="count" />, preserving the time-of-day and
+    /// <see cref="DateTime.Kind" />.
+    /// </summary>
+    /// <param name="dateTime">The starting date and time.</param>
+    /// <param name="count">The signed number of fiscal years to apply.</param>
+    /// <param name="provider">The provider that defines the fiscal year boundaries.</param>
+    /// <returns>The date/time offset by <paramref name="count" /> fiscal years.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> is <see langword="null" />.</exception>
+    public static DateTime AddFiscalYears(this DateTime dateTime, int count, IQuarterDefinitionProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+
+        if (count == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
+
+        DateOnly result = DateOnly.FromDateTime(dateTime).AddFiscalYears(count, provider);
+        return result.ToDateTime(TimeOnly.FromTimeSpan(dateTime.TimeOfDay), dateTime.Kind);
+    }
+}

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsInWorkingWeek.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsInWorkingWeek.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensions.IsInWorkingWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Determines whether the specified <see cref="DateTime" /> falls on a day that is selected in the supplied
+    /// <see cref="WeekPattern" /> working week.
+    /// </summary>
+    /// <param name="dateTime">The date and time to evaluate.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="dateTime" />'s <see cref="DayOfWeek" /> is selected in
+    /// <paramref name="workingWeek" />; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// This predicate considers only the day-of-week dimension. It does not consult any holiday catalogue. Combine it
+    /// with a notable-date service when both working-week and holiday awareness are required.
+    /// </remarks>
+    public static bool IsInWorkingWeek(this DateTime dateTime, WeekPattern workingWeek) =>
+        workingWeek.Contains(dateTime.DayOfWeek);
+
+    /// <summary>
+    /// Determines whether the specified <see cref="DateTime" /> falls on a day that is selected in the supplied
+    /// <see cref="WorkingDaysOfWeek" /> working week.
+    /// </summary>
+    /// <param name="dateTime">The date and time to evaluate.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="dateTime" />'s <see cref="DayOfWeek" /> is in the working week;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.
+    /// </exception>
+    public static bool IsInWorkingWeek(this DateTime dateTime, WorkingDaysOfWeek workingWeek) =>
+        IsInWorkingWeek(dateTime, workingWeek.ToWeekPattern());
+}

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.IsRestDay.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.IsRestDay.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensions.IsRestDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+public static partial class DateTimeExtensions
+{
+    /// <summary>
+    /// Determines whether the specified <see cref="DateTime" /> falls on a day that is not selected in the supplied
+    /// <see cref="WeekPattern" /> working week.
+    /// </summary>
+    /// <param name="dateTime">The date and time to evaluate.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="dateTime" />'s <see cref="DayOfWeek" /> is not selected in
+    /// <paramref name="workingWeek" />; otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// This predicate is the complement of <see cref="IsInWorkingWeek(DateTime, WeekPattern)" /> and considers only
+    /// the day-of-week dimension. It does not consult any holiday catalogue.
+    /// </remarks>
+    public static bool IsRestDay(this DateTime dateTime, WeekPattern workingWeek) =>
+        !workingWeek.Contains(dateTime.DayOfWeek);
+
+    /// <summary>
+    /// Determines whether the specified <see cref="DateTime" /> falls on a day that is not selected in the supplied
+    /// <see cref="WorkingDaysOfWeek" /> working week.
+    /// </summary>
+    /// <param name="dateTime">The date and time to evaluate.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="dateTime" />'s <see cref="DayOfWeek" /> is not in the working week;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.
+    /// </exception>
+    public static bool IsRestDay(this DateTime dateTime, WorkingDaysOfWeek workingWeek) =>
+        IsRestDay(dateTime, workingWeek.ToWeekPattern());
+}

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.NextWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.NextWeekday.cs
@@ -58,4 +58,33 @@ public static partial class DateTimeExtensions
 
         return new DateTime(ticks, dateTime.Kind);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the next day after <paramref name="dateTime" /> whose
+    /// <see cref="DayOfWeek" /> is selected in the supplied <paramref name="workingWeek" />.
+    /// </summary>
+    /// <param name="dateTime">The starting date and time value from which to search forward.</param>
+    /// <param name="workingWeek">The working-week pattern that determines which days are considered working days.</param>
+    /// <returns>The first calendar day strictly after <paramref name="dateTime" /> whose day-of-week is selected in <paramref name="workingWeek" />, with the original time-of-day and <see cref="DateTime.Kind" /> preserved.</returns>
+    /// <remarks>
+    /// <para>
+    /// The walk is bounded by the seven distinct <see cref="DayOfWeek" /> values; when <paramref name="workingWeek" />
+    /// has no days selected (<see cref="WeekPattern.Empty" />) the method will overrun <see cref="DateTime.MaxValue" />
+    /// rather than loop indefinitely. Callers must ensure the supplied pattern selects at least one day.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />.</exception>
+    public static DateTime NextWeekday(this DateTime dateTime, WeekPattern workingWeek)
+    {
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        var ticks = dateTime.Ticks;
+        do
+        {
+            ticks += TicksPerDay;
+        }
+        while (!workingWeek.Contains(GetDayOfWeekFromTicks(ticks)));
+
+        return new DateTime(ticks, dateTime.Kind);
+    }
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousWeekday.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.PreviousWeekday.cs
@@ -58,4 +58,26 @@ public static partial class DateTimeExtensions
 
         return new DateTime(ticks, dateTime.Kind);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the previous day before <paramref name="dateTime" /> whose
+    /// <see cref="DayOfWeek" /> is selected in the supplied <paramref name="workingWeek" />.
+    /// </summary>
+    /// <param name="dateTime">The starting date and time value from which to search backward.</param>
+    /// <param name="workingWeek">The working-week pattern that determines which days are considered working days.</param>
+    /// <returns>The first calendar day strictly before <paramref name="dateTime" /> whose day-of-week is selected in <paramref name="workingWeek" />, with the original time-of-day and <see cref="DateTime.Kind" /> preserved.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />.</exception>
+    public static DateTime PreviousWeekday(this DateTime dateTime, WeekPattern workingWeek)
+    {
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        var ticks = dateTime.Ticks;
+        do
+        {
+            ticks -= TicksPerDay;
+        }
+        while (!workingWeek.Contains(GetDayOfWeekFromTicks(ticks)));
+
+        return new DateTime(ticks, dateTime.Kind);
+    }
 }

--- a/Bodu.Core/src/Extensions/FiscalWeekQuarterProvider.cs
+++ b/Bodu.Core/src/Extensions/FiscalWeekQuarterProvider.cs
@@ -159,6 +159,12 @@ public sealed class FiscalWeekQuarterProvider : IQuarterDefinitionProvider
         Is53WeekFiscalYear(fiscalYear) ? 53 : 52;
 
     /// <inheritdoc />
+    public int GetFiscalYear(DateTime dateTime) => GetFiscalYearFor(dateTime);
+
+    /// <inheritdoc />
+    public int GetFiscalYear(DateOnly dateOnly) => GetFiscalYearFor(dateOnly.ToDateTime(TimeOnly.MinValue));
+
+    /// <inheritdoc />
     public int GetQuarter(DateTime dateTime)
     {
         var fiscalYear = GetFiscalYearFor(dateTime);

--- a/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
+++ b/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
@@ -1,4 +1,4 @@
-// ---------------------------------------------------------------------------------------------------------------
+﻿// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="IQuarterDefinitionProvider.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
@@ -211,8 +211,8 @@ public interface IQuarterDefinitionProvider
     /// </remarks>
     int GetFiscalYear(DateTime dateTime)
     {
-        int calendarYear = dateTime.Year;
-        for (int candidate = calendarYear - 1; candidate <= calendarYear + 1; candidate++)
+        var calendarYear = dateTime.Year;
+        for (var candidate = calendarYear - 1; candidate <= calendarYear + 1; candidate++)
         {
             DateTime q1Start = GetQuarterStart(1, candidate);
             DateTime q4End = GetQuarterEnd(4, candidate);

--- a/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
+++ b/Bodu.Core/src/Extensions/IQuarterDefinitionProvider.cs
@@ -192,4 +192,46 @@ public interface IQuarterDefinitionProvider
     /// <param name="fiscalYear">The fiscal year to query.</param>
     /// <returns>53 in a 53-week fiscal year; otherwise, 52.</returns>
     int GetWeeksInFiscalYear(int fiscalYear);
+
+    /// <summary>
+    /// Returns the fiscal year that contains the supplied <see cref="DateTime"/>.
+    /// </summary>
+    /// <param name="dateTime">The date to identify.</param>
+    /// <returns>The fiscal year number under the provider's conventions.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="dateTime"/> cannot be mapped to any fiscal year known to the provider.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The default implementation probes the calendar years <c>dateTime.Year - 1</c>, <c>dateTime.Year</c>, and
+    /// <c>dateTime.Year + 1</c>, returning the candidate whose Q1 start and Q4 end bracket <paramref name="dateTime"/>.
+    /// This works for any provider whose fiscal year is contiguous and at most one calendar year away from the
+    /// observed calendar year. Implementations may override with a more efficient or more precise computation.
+    /// </para>
+    /// </remarks>
+    int GetFiscalYear(DateTime dateTime)
+    {
+        int calendarYear = dateTime.Year;
+        for (int candidate = calendarYear - 1; candidate <= calendarYear + 1; candidate++)
+        {
+            DateTime q1Start = GetQuarterStart(1, candidate);
+            DateTime q4End = GetQuarterEnd(4, candidate);
+            if (dateTime >= q1Start && dateTime <= q4End)
+                return candidate;
+        }
+
+        throw new ArgumentOutOfRangeException(
+            nameof(dateTime),
+            $"Unable to determine the fiscal year for date '{dateTime:yyyy-MM-dd}'.");
+    }
+
+    /// <summary>
+    /// Returns the fiscal year that contains the supplied <see cref="DateOnly"/>.
+    /// </summary>
+    /// <param name="dateOnly">The date to identify.</param>
+    /// <returns>The fiscal year number under the provider's conventions.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="dateOnly"/> cannot be mapped to any fiscal year known to the provider.
+    /// </exception>
+    int GetFiscalYear(DateOnly dateOnly) => GetFiscalYear(dateOnly.ToDateTime(TimeOnly.MinValue));
 }

--- a/Bodu.Core/src/Extensions/WorkingDaysOfWeekExtensions.cs
+++ b/Bodu.Core/src/Extensions/WorkingDaysOfWeekExtensions.cs
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WorkingDaysOfWeekExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides bidirectional conversion between the <see cref="WorkingDaysOfWeek" /> enum sugar and the
+/// <see cref="WeekPattern" /> value type.
+/// </summary>
+public static class WorkingDaysOfWeekExtensions
+{
+    /// <summary>
+    /// Returns the canonical <see cref="WeekPattern" /> for the supplied <see cref="WorkingDaysOfWeek" /> value.
+    /// </summary>
+    /// <param name="value">The named working-week pattern to convert.</param>
+    /// <returns>The <see cref="WeekPattern" /> whose selected days match <paramref name="value" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a defined member of the <see cref="WorkingDaysOfWeek" /> enumeration.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="value" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.
+    /// </exception>
+    public static WeekPattern ToWeekPattern(this WorkingDaysOfWeek value)
+    {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(value);
+        if (value == WorkingDaysOfWeek.Custom) throw new ArgumentException("Custom has no canonical WeekPattern; pass a WeekPattern directly.", nameof(value));
+
+        return value switch
+        {
+            WorkingDaysOfWeek.MondayToFriday => WeekPattern.MondayToFriday,
+            WorkingDaysOfWeek.MondayToSaturday => WeekPattern.MondayToSaturday,
+            WorkingDaysOfWeek.MondayToThursdayAndSaturday => WeekPattern.MondayToThursdayAndSaturday,
+            WorkingDaysOfWeek.SaturdayToThursday => WeekPattern.SaturdayToThursday,
+            WorkingDaysOfWeek.SaturdayToWednesday => WeekPattern.SaturdayToWednesday,
+            WorkingDaysOfWeek.SundayToFriday => WeekPattern.SundayToFriday,
+            WorkingDaysOfWeek.SundayToThursday => WeekPattern.SundayToThursday,
+            _ => throw new ArgumentOutOfRangeException(nameof(value)),
+        };
+    }
+
+    /// <summary>
+    /// Returns the matching <see cref="WorkingDaysOfWeek" /> value for the supplied <see cref="WeekPattern" />, or
+    /// <see cref="WorkingDaysOfWeek.Custom" /> when no named preset matches.
+    /// </summary>
+    /// <param name="pattern">The pattern to identify.</param>
+    /// <returns>
+    /// The <see cref="WorkingDaysOfWeek" /> whose canonical pattern equals <paramref name="pattern" />, or
+    /// <see cref="WorkingDaysOfWeek.Custom" /> when <paramref name="pattern" /> does not match any named preset.
+    /// </returns>
+    public static WorkingDaysOfWeek ToWorkingDaysOfWeek(this WeekPattern pattern) =>
+        TryGetWorkingDaysOfWeek(pattern, out WorkingDaysOfWeek value) ? value : WorkingDaysOfWeek.Custom;
+
+    /// <summary>
+    /// Attempts to identify the supplied <see cref="WeekPattern" /> as a named <see cref="WorkingDaysOfWeek" /> preset.
+    /// </summary>
+    /// <param name="pattern">The pattern to identify.</param>
+    /// <param name="value">
+    /// When this method returns <see langword="true" />, contains the matching <see cref="WorkingDaysOfWeek" />;
+    /// otherwise, <see cref="WorkingDaysOfWeek.Custom" />.
+    /// </param>
+    /// <returns><see langword="true" /> when <paramref name="pattern" /> matches a named preset; otherwise <see langword="false" />.</returns>
+    public static bool TryGetWorkingDaysOfWeek(this WeekPattern pattern, out WorkingDaysOfWeek value)
+    {
+        if (pattern == WeekPattern.MondayToFriday) { value = WorkingDaysOfWeek.MondayToFriday; return true; }
+        if (pattern == WeekPattern.MondayToSaturday) { value = WorkingDaysOfWeek.MondayToSaturday; return true; }
+        if (pattern == WeekPattern.MondayToThursdayAndSaturday) { value = WorkingDaysOfWeek.MondayToThursdayAndSaturday; return true; }
+        if (pattern == WeekPattern.SaturdayToThursday) { value = WorkingDaysOfWeek.SaturdayToThursday; return true; }
+        if (pattern == WeekPattern.SaturdayToWednesday) { value = WorkingDaysOfWeek.SaturdayToWednesday; return true; }
+        if (pattern == WeekPattern.SundayToFriday) { value = WorkingDaysOfWeek.SundayToFriday; return true; }
+        if (pattern == WeekPattern.SundayToThursday) { value = WorkingDaysOfWeek.SundayToThursday; return true; }
+
+        value = WorkingDaysOfWeek.Custom;
+        return false;
+    }
+}

--- a/Bodu.Core/src/WeekPattern.Presets.cs
+++ b/Bodu.Core/src/WeekPattern.Presets.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WeekPattern.Presets.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+
+namespace Bodu;
+
+public partial struct WeekPattern
+{
+#pragma warning disable IDE1006
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Monday through Friday selected.
+    /// </summary>
+    /// <remarks>This is an alias for <see cref="Weekdays" /> and corresponds to <see cref="WorkingDaysOfWeek.MondayToFriday" />.</remarks>
+    public static readonly WeekPattern MondayToFriday = new WeekPattern(
+        DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Monday through Saturday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.MondayToSaturday" />.</remarks>
+    public static readonly WeekPattern MondayToSaturday = new WeekPattern(
+        DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Monday through Thursday and Saturday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.MondayToThursdayAndSaturday" />.</remarks>
+    public static readonly WeekPattern MondayToThursdayAndSaturday = new WeekPattern(
+        DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Saturday through Thursday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.SaturdayToThursday" />.</remarks>
+    public static readonly WeekPattern SaturdayToThursday = new WeekPattern(
+        DayOfWeek.Saturday, DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Saturday through Wednesday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.SaturdayToWednesday" />.</remarks>
+    public static readonly WeekPattern SaturdayToWednesday = new WeekPattern(
+        DayOfWeek.Saturday, DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Sunday through Friday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.SundayToFriday" />.</remarks>
+    public static readonly WeekPattern SundayToFriday = new WeekPattern(
+        DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday);
+
+    /// <summary>
+    /// Represents a working-week <see cref="WeekPattern" /> with Sunday through Thursday selected.
+    /// </summary>
+    /// <remarks>Corresponds to <see cref="WorkingDaysOfWeek.SundayToThursday" />.</remarks>
+    public static readonly WeekPattern SundayToThursday = new WeekPattern(
+        DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday);
+
+#pragma warning restore IDE1006
+}

--- a/Bodu.Core/src/WorkingDaysOfWeek.cs
+++ b/Bodu.Core/src/WorkingDaysOfWeek.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WorkingDaysOfWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+/// <summary>
+/// Represents a named pattern of working days within a seven-day week.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="WorkingDaysOfWeek" /> enumerates the commonly observed working-week patterns across global regions.
+/// Each named value maps to a canonical <see cref="WeekPattern" /> preset and is interchangeable with the bitmask
+/// representation through the conversion extension methods on <see cref="Bodu.Extensions.WorkingDaysOfWeekExtensions" />.
+/// </para>
+/// <para>
+/// Use a named value when the working week is one of the listed patterns; use <see cref="Custom" /> together with a
+/// caller-supplied <see cref="WeekPattern" /> when the working week is non-standard (for example a four-day week or
+/// an unevenly distributed schedule).
+/// </para>
+/// </remarks>
+public enum WorkingDaysOfWeek
+{
+    /// <summary>
+    /// Indicates a Monday through to Friday working week (Western standard).
+    /// </summary>
+    MondayToFriday = 0,
+
+    /// <summary>
+    /// Indicates a Monday through to Saturday working week.
+    /// </summary>
+    MondayToSaturday = 1,
+
+    /// <summary>
+    /// Indicates a Monday through to Thursday, and Saturday working week.
+    /// </summary>
+    MondayToThursdayAndSaturday = 2,
+
+    /// <summary>
+    /// Indicates a Saturday through to Thursday working week (e.g. parts of the Middle East).
+    /// </summary>
+    SaturdayToThursday = 3,
+
+    /// <summary>
+    /// Indicates a Saturday through to Wednesday working week.
+    /// </summary>
+    SaturdayToWednesday = 4,
+
+    /// <summary>
+    /// Indicates a Sunday through to Friday working week.
+    /// </summary>
+    SundayToFriday = 5,
+
+    /// <summary>
+    /// Indicates a Sunday through to Thursday working week (e.g. Israel, parts of the Middle East).
+    /// </summary>
+    SundayToThursday = 6,
+
+    /// <summary>
+    /// Indicates a non-standard working week whose pattern is supplied externally via a <see cref="WeekPattern" />.
+    /// </summary>
+    Custom = 7,
+}

--- a/Bodu.Core/test/Extensions/CalendarWeekendDefinitionExtensionsTests.cs
+++ b/Bodu.Core/test/Extensions/CalendarWeekendDefinitionExtensionsTests.cs
@@ -1,0 +1,106 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalendarWeekendDefinitionExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+[TestClass]
+public class CalendarWeekendDefinitionExtensionsTests
+{
+    /// <summary>
+    /// Provides the canonical mapping between <see cref="CalendarWeekendDefinition" /> values and the working-week
+    /// <see cref="WeekPattern" /> they imply.
+    /// </summary>
+    public static IEnumerable<object[]> GetWeekendToWorkingWeekTestData()
+    {
+        yield return new object[] { CalendarWeekendDefinition.SaturdaySunday, WeekPattern.MondayToFriday };
+        yield return new object[] { CalendarWeekendDefinition.FridaySaturday, WeekPattern.SundayToThursday };
+        yield return new object[] { CalendarWeekendDefinition.ThursdayFriday, WeekPattern.SaturdayToWednesday };
+        yield return new object[] { CalendarWeekendDefinition.FridayOnly, WeekPattern.SaturdayToThursday };
+        yield return new object[] { CalendarWeekendDefinition.SundayOnly, WeekPattern.MondayToSaturday };
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToWeekPattern" /> maps every built-in weekend
+    /// definition to the expected working-week <see cref="WeekPattern" />.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(GetWeekendToWorkingWeekTestData), DynamicDataSourceType.Method)]
+    public void ToWeekPattern_WhenBuiltInWeekend_ShouldReturnExpectedPattern(CalendarWeekendDefinition weekend, WeekPattern expected)
+    {
+        WeekPattern actual = weekend.ToWeekPattern();
+
+        Assert.AreEqual(expected, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToWeekPattern" /> returns a
+    /// <see cref="WeekPattern" /> with all seven days selected when called with
+    /// <see cref="CalendarWeekendDefinition.None" />.
+    /// </summary>
+    [TestMethod]
+    public void ToWeekPattern_WhenNone_ShouldReturnAllDays()
+    {
+        WeekPattern actual = CalendarWeekendDefinition.None.ToWeekPattern();
+
+        Assert.AreEqual(7, actual.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToWeekPattern" /> throws
+    /// <see cref="ArgumentException" /> when <see cref="CalendarWeekendDefinition.Custom" /> is supplied without a
+    /// provider.
+    /// </summary>
+    [TestMethod]
+    public void ToWeekPattern_WhenCustomAndProviderIsNull_ShouldThrowExactly()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = CalendarWeekendDefinition.Custom.ToWeekPattern();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToCalendarWeekendDefinition" /> round-trips every
+    /// built-in mapping.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(GetWeekendToWorkingWeekTestData), DynamicDataSourceType.Method)]
+    public void ToCalendarWeekendDefinition_WhenRoundTripFromBuiltIn_ShouldReturnOriginal(CalendarWeekendDefinition weekend, WeekPattern workingWeek)
+    {
+        CalendarWeekendDefinition roundTripped = workingWeek.ToCalendarWeekendDefinition();
+
+        Assert.AreEqual(weekend, roundTripped);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToCalendarWeekendDefinition" /> returns
+    /// <see cref="CalendarWeekendDefinition.None" /> for a <see cref="WeekPattern" /> with every day selected.
+    /// </summary>
+    [TestMethod]
+    public void ToCalendarWeekendDefinition_WhenAllDays_ShouldReturnNone()
+    {
+        WeekPattern allDays = ~WeekPattern.Empty;
+
+        Assert.AreEqual(CalendarWeekendDefinition.None, allDays.ToCalendarWeekendDefinition());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalendarWeekendDefinitionExtensions.ToCalendarWeekendDefinition" /> returns
+    /// <see cref="CalendarWeekendDefinition.Custom" /> when the supplied <see cref="WeekPattern" /> does not match any
+    /// built-in definition.
+    /// </summary>
+    [TestMethod]
+    public void ToCalendarWeekendDefinition_WhenNonStandardPattern_ShouldReturnCustom()
+    {
+        WeekPattern oddPattern = new WeekPattern(DayOfWeek.Tuesday, DayOfWeek.Thursday);
+
+        Assert.AreEqual(CalendarWeekendDefinition.Custom, oddPattern.ToCalendarWeekendDefinition());
+    }
+}

--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.IsInWorkingWeek.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.IsInWorkingWeek.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateOnlyExtensionsTests.IsInWorkingWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+public partial class DateOnlyExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsInWorkingWeek(DateOnly, WeekPattern)" /> returns
+    /// <see langword="true" /> when the date's day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenDayInPattern_ShouldReturnTrue()
+    {
+        // 2026-05-11 is a Monday.
+        DateOnly monday = new DateOnly(2026, 5, 11);
+
+        Assert.IsTrue(monday.IsInWorkingWeek(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsInWorkingWeek(DateOnly, WeekPattern)" /> returns
+    /// <see langword="false" /> when the date's day-of-week is not selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenDayNotInPattern_ShouldReturnFalse()
+    {
+        // 2026-05-16 is a Saturday.
+        DateOnly saturday = new DateOnly(2026, 5, 16);
+
+        Assert.IsFalse(saturday.IsInWorkingWeek(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsInWorkingWeek(DateOnly, WorkingDaysOfWeek)" /> agrees
+    /// with the <see cref="WeekPattern" /> overload for a named preset.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenUsingWorkingDaysOfWeekSugar_ShouldMatchWeekPatternOverload()
+    {
+        DateOnly friday = new DateOnly(2026, 5, 15);
+
+        Assert.IsFalse(friday.IsInWorkingWeek(WorkingDaysOfWeek.SundayToThursday));
+        Assert.IsTrue(friday.IsInWorkingWeek(WorkingDaysOfWeek.MondayToFriday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsInWorkingWeek(DateOnly, WorkingDaysOfWeek)" /> throws
+    /// <see cref="ArgumentException" /> when called with <see cref="WorkingDaysOfWeek.Custom" />.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenWorkingDaysOfWeekIsCustom_ShouldThrowExactly()
+    {
+        DateOnly date = new DateOnly(2026, 5, 11);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = date.IsInWorkingWeek(WorkingDaysOfWeek.Custom);
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.IsRestDay.cs
+++ b/Bodu.Core/test/Extensions/DateOnlyExtensionsTests.IsRestDay.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateOnlyExtensionsTests.IsRestDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+public partial class DateOnlyExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsRestDay(DateOnly, WeekPattern)" /> returns
+    /// <see langword="true" /> when the date's day-of-week is not selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenDayNotInPattern_ShouldReturnTrue()
+    {
+        // 2026-05-16 is a Saturday.
+        DateOnly saturday = new DateOnly(2026, 5, 16);
+
+        Assert.IsTrue(saturday.IsRestDay(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsRestDay(DateOnly, WeekPattern)" /> returns
+    /// <see langword="false" /> when the date's day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenDayInPattern_ShouldReturnFalse()
+    {
+        DateOnly monday = new DateOnly(2026, 5, 11);
+
+        Assert.IsFalse(monday.IsRestDay(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsRestDay(DateOnly, WorkingDaysOfWeek)" /> agrees with the
+    /// <see cref="WeekPattern" /> overload for a named preset.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenUsingWorkingDaysOfWeekSugar_ShouldMatchWeekPatternOverload()
+    {
+        DateOnly friday = new DateOnly(2026, 5, 15);
+
+        Assert.IsTrue(friday.IsRestDay(WorkingDaysOfWeek.SundayToThursday));
+        Assert.IsFalse(friday.IsRestDay(WorkingDaysOfWeek.MondayToFriday));
+    }
+}

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsInWorkingWeek.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsInWorkingWeek.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensionsTests.IsInWorkingWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+public partial class DateTimeExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsInWorkingWeek(DateTime, WeekPattern)" /> returns
+    /// <see langword="true" /> when the date's day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenDayInPattern_ShouldReturnTrue()
+    {
+        DateTime monday = new DateTime(2026, 5, 11);
+
+        Assert.IsTrue(monday.IsInWorkingWeek(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsInWorkingWeek(DateTime, WeekPattern)" /> returns
+    /// <see langword="false" /> when the date's day-of-week is not selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenDayNotInPattern_ShouldReturnFalse()
+    {
+        DateTime saturday = new DateTime(2026, 5, 16);
+
+        Assert.IsFalse(saturday.IsInWorkingWeek(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsInWorkingWeek(DateTime, WorkingDaysOfWeek)" /> agrees with the
+    /// <see cref="WeekPattern" /> overload for a named preset.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenUsingWorkingDaysOfWeekSugar_ShouldMatchWeekPatternOverload()
+    {
+        DateTime friday = new DateTime(2026, 5, 15);
+
+        Assert.IsFalse(friday.IsInWorkingWeek(WorkingDaysOfWeek.SundayToThursday));
+        Assert.IsTrue(friday.IsInWorkingWeek(WorkingDaysOfWeek.MondayToFriday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsInWorkingWeek(DateTime, WorkingDaysOfWeek)" /> throws
+    /// <see cref="ArgumentException" /> when called with <see cref="WorkingDaysOfWeek.Custom" />.
+    /// </summary>
+    [TestMethod]
+    public void IsInWorkingWeek_WhenWorkingDaysOfWeekIsCustom_ShouldThrowExactly()
+    {
+        DateTime date = new DateTime(2026, 5, 11);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = date.IsInWorkingWeek(WorkingDaysOfWeek.Custom);
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsRestDay.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.IsRestDay.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensionsTests.IsRestDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+public partial class DateTimeExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsRestDay(DateTime, WeekPattern)" /> returns
+    /// <see langword="true" /> when the date's day-of-week is not selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenDayNotInPattern_ShouldReturnTrue()
+    {
+        DateTime saturday = new DateTime(2026, 5, 16);
+
+        Assert.IsTrue(saturday.IsRestDay(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsRestDay(DateTime, WeekPattern)" /> returns
+    /// <see langword="false" /> when the date's day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenDayInPattern_ShouldReturnFalse()
+    {
+        DateTime monday = new DateTime(2026, 5, 11);
+
+        Assert.IsFalse(monday.IsRestDay(WeekPattern.Weekdays));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.IsRestDay(DateTime, WorkingDaysOfWeek)" /> agrees with the
+    /// <see cref="WeekPattern" /> overload for a named preset.
+    /// </summary>
+    [TestMethod]
+    public void IsRestDay_WhenUsingWorkingDaysOfWeekSugar_ShouldMatchWeekPatternOverload()
+    {
+        DateTime friday = new DateTime(2026, 5, 15);
+
+        Assert.IsTrue(friday.IsRestDay(WorkingDaysOfWeek.SundayToThursday));
+        Assert.IsFalse(friday.IsRestDay(WorkingDaysOfWeek.MondayToFriday));
+    }
+}

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.NextWeekdayWeekPattern.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.NextWeekdayWeekPattern.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DateTimeExtensionsTests.NextWeekdayWeekPattern.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+public partial class DateTimeExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.NextWeekday(DateTime, WeekPattern)" /> returns the first day after
+    /// the input whose day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void NextWeekday_WhenWeekPatternIsMondayToFriday_ShouldSkipWeekend()
+    {
+        // 2024-04-19 is a Friday.
+        DateTime friday = new DateTime(2024, 4, 19);
+
+        DateTime actual = friday.NextWeekday(WeekPattern.MondayToFriday);
+
+        Assert.AreEqual(new DateTime(2024, 4, 22), actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.NextWeekday(DateTime, WeekPattern)" /> with a Sunday-to-Thursday
+    /// pattern lands on Sunday when starting on Thursday (Friday and Saturday are non-working).
+    /// </summary>
+    [TestMethod]
+    public void NextWeekday_WhenWeekPatternIsSundayToThursday_ShouldSkipFridayAndSaturday()
+    {
+        // 2024-04-18 is a Thursday.
+        DateTime thursday = new DateTime(2024, 4, 18);
+
+        DateTime actual = thursday.NextWeekday(WeekPattern.SundayToThursday);
+
+        Assert.AreEqual(new DateTime(2024, 4, 21), actual); // Sunday
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.NextWeekday(DateTime, WeekPattern)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the supplied pattern is empty.
+    /// </summary>
+    [TestMethod]
+    public void NextWeekday_WhenWeekPatternIsEmpty_ShouldThrowExactly()
+    {
+        DateTime monday = new DateTime(2024, 4, 22);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = monday.NextWeekday(WeekPattern.Empty);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.PreviousWeekday(DateTime, WeekPattern)" /> returns the first day
+    /// before the input whose day-of-week is selected in the supplied pattern.
+    /// </summary>
+    [TestMethod]
+    public void PreviousWeekday_WhenWeekPatternIsMondayToFriday_ShouldSkipWeekend()
+    {
+        // 2024-04-22 is a Monday.
+        DateTime monday = new DateTime(2024, 4, 22);
+
+        DateTime actual = monday.PreviousWeekday(WeekPattern.MondayToFriday);
+
+        Assert.AreEqual(new DateTime(2024, 4, 19), actual); // Friday
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateTimeExtensions.PreviousWeekday(DateTime, WeekPattern)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the supplied pattern is empty.
+    /// </summary>
+    [TestMethod]
+    public void PreviousWeekday_WhenWeekPatternIsEmpty_ShouldThrowExactly()
+    {
+        DateTime monday = new DateTime(2024, 4, 22);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = monday.PreviousWeekday(WeekPattern.Empty);
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/FiscalYearExtensionsTests.cs
+++ b/Bodu.Core/test/Extensions/FiscalYearExtensionsTests.cs
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FiscalYearExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu.Extensions;
+
+[TestClass]
+public class FiscalYearExtensionsTests
+{
+    private static FiscalWeekQuarterProvider BuildProvider() =>
+        // 4-4-5 pattern anchored to the Saturday nearest to 31 January (Fiscal-year-end).
+        new FiscalWeekQuarterProvider(
+            month: 1,
+            dayOfWeek: DayOfWeek.Saturday,
+            isFiscalYearEnd: true,
+            useNearestDayOfWeek: true,
+            pattern: FiscalWeekPattern.FourFourFive);
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.FiscalYear" /> returns a consistent fiscal year for a date within a
+    /// known fiscal year of the supplied provider.
+    /// </summary>
+    [TestMethod]
+    public void FiscalYear_WhenWithinKnownFiscalYear_ShouldReturnFiscalYear()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+        // Probe with the Q1 start of fiscal year 2026 — by definition, that date's fiscal year is 2026.
+        DateOnly q1Start = DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider);
+
+        int fy = q1Start.FiscalYear(provider);
+
+        Assert.AreEqual(2026, fy);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.FirstDateOfFiscalYear" /> equals the supplied provider's
+    /// <see cref="IQuarterDefinitionProvider.GetQuarterStartDate(int, int)" /> for quarter 1.
+    /// </summary>
+    [TestMethod]
+    public void FirstDateOfFiscalYear_WhenQueryingKnownYear_ShouldMatchProviderQuarterStart()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+
+        DateOnly first = DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider);
+        DateOnly providerStart = provider.GetQuarterStartDate(1, 2026);
+
+        Assert.AreEqual(providerStart, first);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.LastDateOfFiscalYear" /> equals the supplied provider's
+    /// <see cref="IQuarterDefinitionProvider.GetQuarterEndDate(int, int)" /> for quarter 4.
+    /// </summary>
+    [TestMethod]
+    public void LastDateOfFiscalYear_WhenQueryingKnownYear_ShouldMatchProviderQuarterEnd()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+
+        DateOnly last = DateOnlyExtensions.LastDateOfFiscalYear(2026, provider);
+        DateOnly providerEnd = provider.GetQuarterEndDate(4, 2026);
+
+        Assert.AreEqual(providerEnd, last);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsFirstDateOfFiscalYear" /> returns <see langword="true" /> on the
+    /// fiscal year's start date and <see langword="false" /> on any other day.
+    /// </summary>
+    [TestMethod]
+    public void IsFirstDateOfFiscalYear_WhenStartDate_ShouldReturnTrueOnlyOnTheStart()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+        DateOnly first = DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider);
+
+        Assert.IsTrue(first.IsFirstDateOfFiscalYear(provider));
+        Assert.IsFalse(first.AddDays(1).IsFirstDateOfFiscalYear(provider));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.IsLastDateOfFiscalYear" /> returns <see langword="true" /> on the
+    /// fiscal year's end date and <see langword="false" /> on any other day.
+    /// </summary>
+    [TestMethod]
+    public void IsLastDateOfFiscalYear_WhenEndDate_ShouldReturnTrueOnlyOnTheEnd()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+        DateOnly last = DateOnlyExtensions.LastDateOfFiscalYear(2026, provider);
+
+        Assert.IsTrue(last.IsLastDateOfFiscalYear(provider));
+        Assert.IsFalse(last.AddDays(-1).IsLastDateOfFiscalYear(provider));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.AddFiscalYears" /> applied to the first day of one fiscal year lands
+    /// on the first day of the target fiscal year.
+    /// </summary>
+    [TestMethod]
+    public void AddFiscalYears_WhenStartOfFiscalYear_ShouldReturnStartOfTargetFiscalYear()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+        DateOnly fy2026Start = DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider);
+
+        DateOnly result = fy2026Start.AddFiscalYears(2, provider);
+
+        Assert.AreEqual(DateOnlyExtensions.FirstDateOfFiscalYear(2028, provider), result);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DateOnlyExtensions.FiscalYear" /> throws when the supplied provider is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void FiscalYear_WhenProviderIsNull_ShouldThrowExactly()
+    {
+        DateOnly date = new DateOnly(2026, 5, 14);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = date.FiscalYear(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="DateTime" /> overload of <c>FiscalYear</c> agrees with the <see cref="DateOnly" /> overload.
+    /// </summary>
+    [TestMethod]
+    public void FiscalYear_WhenDateTimeAndDateOnlyOverloadsCalled_ShouldAgree()
+    {
+        FiscalWeekQuarterProvider provider = BuildProvider();
+        DateOnly fy2026Start = DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider);
+
+        int fromDateOnly = fy2026Start.FiscalYear(provider);
+        int fromDateTime = fy2026Start.ToDateTime(TimeOnly.MinValue).FiscalYear(provider);
+
+        Assert.AreEqual(fromDateOnly, fromDateTime);
+    }
+}

--- a/Bodu.Core/test/WeekPatternTests.Presets.cs
+++ b/Bodu.Core/test/WeekPatternTests.Presets.cs
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WeekPatternTests.Presets.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu;
+
+public partial class WeekPatternTests
+{
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.MondayToFriday" /> is equal to <see cref="WeekPattern.Weekdays" />.
+    /// </summary>
+    [TestMethod]
+    public void MondayToFriday_WhenAccessed_ShouldEqualWeekdays() => Assert.AreEqual(WeekPattern.Weekdays, WeekPattern.MondayToFriday);
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.MondayToSaturday" /> contains Monday through Saturday and excludes Sunday.
+    /// </summary>
+    [TestMethod]
+    public void MondayToSaturday_WhenAccessed_ShouldContainMondayThroughSaturday()
+    {
+        WeekPattern pattern = WeekPattern.MondayToSaturday;
+
+        Assert.AreEqual(6, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Friday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Saturday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Sunday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.MondayToThursdayAndSaturday" /> contains Monday through Thursday and Saturday,
+    /// excluding Friday and Sunday.
+    /// </summary>
+    [TestMethod]
+    public void MondayToThursdayAndSaturday_WhenAccessed_ShouldContainExpectedDays()
+    {
+        WeekPattern pattern = WeekPattern.MondayToThursdayAndSaturday;
+
+        Assert.AreEqual(5, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Saturday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Friday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Sunday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.SaturdayToThursday" /> contains Saturday through Thursday and excludes Friday.
+    /// </summary>
+    [TestMethod]
+    public void SaturdayToThursday_WhenAccessed_ShouldContainExpectedDays()
+    {
+        WeekPattern pattern = WeekPattern.SaturdayToThursday;
+
+        Assert.AreEqual(6, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Saturday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Sunday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Friday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.SaturdayToWednesday" /> contains Saturday through Wednesday and excludes
+    /// Thursday and Friday.
+    /// </summary>
+    [TestMethod]
+    public void SaturdayToWednesday_WhenAccessed_ShouldContainExpectedDays()
+    {
+        WeekPattern pattern = WeekPattern.SaturdayToWednesday;
+
+        Assert.AreEqual(5, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Saturday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Sunday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Friday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.SundayToFriday" /> contains Sunday through Friday and excludes Saturday.
+    /// </summary>
+    [TestMethod]
+    public void SundayToFriday_WhenAccessed_ShouldContainExpectedDays()
+    {
+        WeekPattern pattern = WeekPattern.SundayToFriday;
+
+        Assert.AreEqual(6, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Sunday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Friday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Saturday));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WeekPattern.SundayToThursday" /> contains Sunday through Thursday and excludes Friday and
+    /// Saturday.
+    /// </summary>
+    [TestMethod]
+    public void SundayToThursday_WhenAccessed_ShouldContainExpectedDays()
+    {
+        WeekPattern pattern = WeekPattern.SundayToThursday;
+
+        Assert.AreEqual(5, pattern.Count);
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Sunday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Monday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Tuesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Wednesday));
+        Assert.IsTrue(pattern.Contains(DayOfWeek.Thursday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Friday));
+        Assert.IsFalse(pattern.Contains(DayOfWeek.Saturday));
+    }
+}

--- a/Bodu.Core/test/WorkingDaysOfWeekTests.cs
+++ b/Bodu.Core/test/WorkingDaysOfWeekTests.cs
@@ -1,0 +1,132 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WorkingDaysOfWeekTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using Bodu.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Bodu;
+
+[TestClass]
+public class WorkingDaysOfWeekTests
+{
+    /// <summary>
+    /// Provides the canonical mapping between <see cref="WorkingDaysOfWeek" /> values and their
+    /// expected selected <see cref="DayOfWeek" /> sets.
+    /// </summary>
+    public static IEnumerable<object[]> GetNamedPresetTestData()
+    {
+        yield return new object[] { WorkingDaysOfWeek.MondayToFriday, new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday } };
+        yield return new object[] { WorkingDaysOfWeek.MondayToSaturday, new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday } };
+        yield return new object[] { WorkingDaysOfWeek.MondayToThursdayAndSaturday, new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday } };
+        yield return new object[] { WorkingDaysOfWeek.SaturdayToThursday, new[] { DayOfWeek.Saturday, DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday } };
+        yield return new object[] { WorkingDaysOfWeek.SaturdayToWednesday, new[] { DayOfWeek.Saturday, DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday } };
+        yield return new object[] { WorkingDaysOfWeek.SundayToFriday, new[] { DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday } };
+        yield return new object[] { WorkingDaysOfWeek.SundayToThursday, new[] { DayOfWeek.Sunday, DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday } };
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.ToWeekPattern" /> maps each named preset to a
+    /// <see cref="WeekPattern" /> that selects exactly the expected days.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(GetNamedPresetTestData), DynamicDataSourceType.Method)]
+    public void ToWeekPattern_WhenNamedPreset_ShouldSelectExpectedDays(WorkingDaysOfWeek value, DayOfWeek[] expectedDays)
+    {
+        WeekPattern pattern = value.ToWeekPattern();
+
+        Assert.AreEqual(expectedDays.Length, pattern.Count);
+        foreach (DayOfWeek day in expectedDays)
+            Assert.IsTrue(pattern.Contains(day), $"Expected pattern for {value} to include {day}.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.ToWeekPattern" /> throws
+    /// <see cref="ArgumentException" /> when called with <see cref="WorkingDaysOfWeek.Custom" />.
+    /// </summary>
+    [TestMethod]
+    public void ToWeekPattern_WhenCustom_ShouldThrowExactlyArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = WorkingDaysOfWeek.Custom.ToWeekPattern();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.ToWeekPattern" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the enum value is not defined.
+    /// </summary>
+    [TestMethod]
+    public void ToWeekPattern_WhenUndefinedEnumValue_ShouldThrowExactlyArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = ((WorkingDaysOfWeek)99).ToWeekPattern();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.ToWorkingDaysOfWeek" /> round-trips every named
+    /// preset back to its original <see cref="WorkingDaysOfWeek" /> value.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(GetNamedPresetTestData), DynamicDataSourceType.Method)]
+    public void ToWorkingDaysOfWeek_WhenRoundTripFromNamedPreset_ShouldReturnOriginal(WorkingDaysOfWeek value, DayOfWeek[] _)
+    {
+        WeekPattern pattern = value.ToWeekPattern();
+
+        WorkingDaysOfWeek roundTripped = pattern.ToWorkingDaysOfWeek();
+
+        Assert.AreEqual(value, roundTripped);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.ToWorkingDaysOfWeek" /> returns
+    /// <see cref="WorkingDaysOfWeek.Custom" /> for a <see cref="WeekPattern" /> that does not match any named preset.
+    /// </summary>
+    [TestMethod]
+    public void ToWorkingDaysOfWeek_WhenNotANamedPreset_ShouldReturnCustom()
+    {
+        WeekPattern oddPattern = new WeekPattern(DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday);
+
+        WorkingDaysOfWeek value = oddPattern.ToWorkingDaysOfWeek();
+
+        Assert.AreEqual(WorkingDaysOfWeek.Custom, value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.TryGetWorkingDaysOfWeek" /> returns
+    /// <see langword="true" /> and the expected value for every named preset.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(GetNamedPresetTestData), DynamicDataSourceType.Method)]
+    public void TryGetWorkingDaysOfWeek_WhenNamedPreset_ShouldReturnTrueAndExpectedValue(WorkingDaysOfWeek value, DayOfWeek[] _)
+    {
+        WeekPattern pattern = value.ToWeekPattern();
+
+        var success = pattern.TryGetWorkingDaysOfWeek(out WorkingDaysOfWeek actual);
+
+        Assert.IsTrue(success);
+        Assert.AreEqual(value, actual);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="WorkingDaysOfWeekExtensions.TryGetWorkingDaysOfWeek" /> returns
+    /// <see langword="false" /> and yields <see cref="WorkingDaysOfWeek.Custom" /> when no named preset matches.
+    /// </summary>
+    [TestMethod]
+    public void TryGetWorkingDaysOfWeek_WhenNotANamedPreset_ShouldReturnFalseAndCustom()
+    {
+        WeekPattern oddPattern = new WeekPattern(DayOfWeek.Tuesday, DayOfWeek.Thursday);
+
+        var success = oddPattern.TryGetWorkingDaysOfWeek(out WorkingDaysOfWeek value);
+
+        Assert.IsFalse(success);
+        Assert.AreEqual(WorkingDaysOfWeek.Custom, value);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateFiscalExtensions
+{
+    /// <summary>
+    /// Returns the first working day on or after the start of the supplied fiscal quarter.
+    /// </summary>
+    /// <param name="quarter">The fiscal quarter number (1-4).</param>
+    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
+    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The first working day on or after the fiscal quarter start.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
+    public static DateOnly FirstWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+
+        DateOnly start = provider.GetQuarterStartDate(quarter, fiscalYear);
+        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.FirstWorkingDayOfFiscalYear.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.FirstWorkingDayOfFiscalYear.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensions.FirstWorkingDayOfFiscalYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateFiscalExtensions
+{
+    /// <summary>
+    /// Returns the first working day on or after the start of the supplied fiscal year.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose first working day is requested.</param>
+    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The first working day on or after the fiscal year start.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly FirstWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly start = DateOnlyExtensions.FirstDateOfFiscalYear(fiscalYear, provider);
+        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.LastWorkingDayOfFiscalQuarter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.LastWorkingDayOfFiscalQuarter.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensions.LastWorkingDayOfFiscalQuarter.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateFiscalExtensions
+{
+    /// <summary>
+    /// Returns the last working day on or before the end of the supplied fiscal quarter.
+    /// </summary>
+    /// <param name="quarter">The fiscal quarter number (1-4).</param>
+    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
+    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The last working day on or before the fiscal quarter end.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
+    public static DateOnly LastWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+
+        DateOnly end = provider.GetQuarterEndDate(quarter, fiscalYear);
+        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.LastWorkingDayOfFiscalYear.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.LastWorkingDayOfFiscalYear.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensions.LastWorkingDayOfFiscalYear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateFiscalExtensions
+{
+    /// <summary>
+    /// Returns the last working day on or before the end of the supplied fiscal year.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose last working day is requested.</param>
+    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The last working day on or before the fiscal year end.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly LastWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly end = DateOnlyExtensions.LastDateOfFiscalYear(fiscalYear, provider);
+        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides working-day-aware fiscal anchors that compose <see cref="IQuarterDefinitionProvider" /> fiscal boundaries
+/// with <see cref="INotableDateService" /> holiday classification.
+/// </summary>
+public static class NotableDateFiscalExtensions
+{
+    /// <summary>
+    /// Returns the first working day on or after the start of the supplied fiscal year.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose first working day is requested.</param>
+    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The first working day on or after the fiscal year start.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly FirstWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly start = DateOnlyExtensions.FirstDateOfFiscalYear(fiscalYear, provider);
+        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns the last working day on or before the end of the supplied fiscal year.
+    /// </summary>
+    /// <param name="fiscalYear">The fiscal year whose last working day is requested.</param>
+    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The last working day on or before the fiscal year end.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly LastWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly end = DateOnlyExtensions.LastDateOfFiscalYear(fiscalYear, provider);
+        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns the first working day on or after the start of the supplied fiscal quarter.
+    /// </summary>
+    /// <param name="quarter">The fiscal quarter number (1-4).</param>
+    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
+    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The first working day on or after the fiscal quarter start.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
+    public static DateOnly FirstWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+
+        DateOnly start = provider.GetQuarterStartDate(quarter, fiscalYear);
+        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns the last working day on or before the end of the supplied fiscal quarter.
+    /// </summary>
+    /// <param name="quarter">The fiscal quarter number (1-4).</param>
+    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
+    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The last working day on or before the fiscal quarter end.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
+    public static DateOnly LastWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(provider);
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
+
+        DateOnly end = provider.GetQuarterEndDate(quarter, fiscalYear);
+        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Snaps <paramref name="date" /> forward to the first working day on or after itself, honouring the
+    /// supplied or service-default working week.
+    /// </summary>
+    private static DateOnly SnapForward(DateOnly date, INotableDateService service, WeekPattern? workingWeek, string? territoryCode, Type? calendarType)
+    {
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        if (date.IsWorkingDay(service, week, territoryCode, calendarType))
+            return date;
+
+        return date.NextWorkingDay(service, week, count: 1, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Snaps <paramref name="date" /> backward to the last working day on or before itself, honouring the
+    /// supplied or service-default working week.
+    /// </summary>
+    private static DateOnly SnapBackward(DateOnly date, INotableDateService service, WeekPattern? workingWeek, string? territoryCode, Type? calendarType)
+    {
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        if (date.IsWorkingDay(service, week, territoryCode, calendarType))
+            return date;
+
+        return date.PreviousWorkingDay(service, week, count: 1, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateFiscalExtensions.cs
@@ -12,98 +12,28 @@ namespace Bodu.Extensions;
 /// Provides working-day-aware fiscal anchors that compose <see cref="IQuarterDefinitionProvider" /> fiscal boundaries
 /// with <see cref="INotableDateService" /> holiday classification.
 /// </summary>
-public static class NotableDateFiscalExtensions
+/// <remarks>
+/// <para>
+/// Each method snaps the underlying fiscal boundary (either the start of the fiscal year or quarter, or the end) to
+/// the nearest working day in the appropriate direction: forward for "first" anchors, backward for "last" anchors.
+/// </para>
+/// <para>
+/// The <see cref="WeekPattern" /> parameter on each method is optional. When <see langword="null" />, the
+/// <see cref="INotableDateService.WorkingWeek" /> configured on the supplied service is used.
+/// </para>
+/// </remarks>
+public static partial class NotableDateFiscalExtensions
 {
     /// <summary>
-    /// Returns the first working day on or after the start of the supplied fiscal year.
+    /// Snaps <paramref name="date" /> forward to the first working day on or after itself, honouring the supplied or
+    /// service-default working week.
     /// </summary>
-    /// <param name="fiscalYear">The fiscal year whose first working day is requested.</param>
-    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
+    /// <param name="date">The boundary date to snap forward.</param>
     /// <param name="service">The notable-date service consulted for holiday classification.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="workingWeek">An optional working-week pattern.</param>
     /// <param name="territoryCode">An optional territory scope.</param>
     /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>The first working day on or after the fiscal year start.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static DateOnly FirstWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateOnly start = DateOnlyExtensions.FirstDateOfFiscalYear(fiscalYear, provider);
-        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Returns the last working day on or before the end of the supplied fiscal year.
-    /// </summary>
-    /// <param name="fiscalYear">The fiscal year whose last working day is requested.</param>
-    /// <param name="provider">The provider that defines fiscal year boundaries.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>The last working day on or before the fiscal year end.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static DateOnly LastWorkingDayOfFiscalYear(int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateOnly end = DateOnlyExtensions.LastDateOfFiscalYear(fiscalYear, provider);
-        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Returns the first working day on or after the start of the supplied fiscal quarter.
-    /// </summary>
-    /// <param name="quarter">The fiscal quarter number (1-4).</param>
-    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
-    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>The first working day on or after the fiscal quarter start.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
-    public static DateOnly FirstWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        ThrowHelper.ThrowIfNull(service);
-        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
-
-        DateOnly start = provider.GetQuarterStartDate(quarter, fiscalYear);
-        return SnapForward(start, service, workingWeek, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Returns the last working day on or before the end of the supplied fiscal quarter.
-    /// </summary>
-    /// <param name="quarter">The fiscal quarter number (1-4).</param>
-    /// <param name="fiscalYear">The fiscal year that contains the quarter.</param>
-    /// <param name="provider">The provider that defines fiscal year and quarter boundaries.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>The last working day on or before the fiscal quarter end.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="provider" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="quarter" /> is not between 1 and 4.</exception>
-    public static DateOnly LastWorkingDayOfFiscalQuarter(int quarter, int fiscalYear, IQuarterDefinitionProvider provider, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(provider);
-        ThrowHelper.ThrowIfNull(service);
-        ThrowHelper.ThrowIfOutOfRange(quarter, 1, 4);
-
-        DateOnly end = provider.GetQuarterEndDate(quarter, fiscalYear);
-        return SnapBackward(end, service, workingWeek, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Snaps <paramref name="date" /> forward to the first working day on or after itself, honouring the
-    /// supplied or service-default working week.
-    /// </summary>
+    /// <returns>The first working day on or after <paramref name="date" />.</returns>
     private static DateOnly SnapForward(DateOnly date, INotableDateService service, WeekPattern? workingWeek, string? territoryCode, Type? calendarType)
     {
         WeekPattern week = workingWeek ?? service.WorkingWeek;
@@ -114,9 +44,15 @@ public static class NotableDateFiscalExtensions
     }
 
     /// <summary>
-    /// Snaps <paramref name="date" /> backward to the last working day on or before itself, honouring the
-    /// supplied or service-default working week.
+    /// Snaps <paramref name="date" /> backward to the last working day on or before itself, honouring the supplied or
+    /// service-default working week.
     /// </summary>
+    /// <param name="date">The boundary date to snap backward.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification.</param>
+    /// <param name="workingWeek">An optional working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>The last working day on or before <paramref name="date" />.</returns>
     private static DateOnly SnapBackward(DateOnly date, INotableDateService service, WeekPattern? workingWeek, string? territoryCode, Type? calendarType)
     {
         WeekPattern week = workingWeek ?? service.WorkingWeek;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.AddWorkingDays.cs
@@ -44,4 +44,43 @@ public static partial class NotableDateOnlyExtensions
             ? NextWorkingDay(date, service, days, territoryCode, calendarType)
             : PreviousWorkingDay(date, service, -days, territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> obtained by advancing or retreating <paramref name="date" /> by the signed
+    /// number of working days specified in <paramref name="days" />, under the supplied <paramref name="workingWeek" />
+    /// composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to walk.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day reached after applying <paramref name="days" /> to <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" /> or when applying <paramref name="days" /> would overrun the <see cref="DateOnly" /> range.</exception>
+    public static DateOnly AddWorkingDays(this DateOnly date, INotableDateService service, WeekPattern workingWeek, int days, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (days == 0) return DateOnly.FromDayNumber(date.DayNumber);
+        return days > 0
+            ? NextWorkingDay(date, service, workingWeek, days, territoryCode, calendarType)
+            : PreviousWorkingDay(date, service, workingWeek, -days, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> obtained by advancing or retreating <paramref name="date" /> by the signed
+    /// number of working days specified in <paramref name="days" />, under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to walk.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day reached after applying <paramref name="days" /> to <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly AddWorkingDays(this DateOnly date, INotableDateService service, WorkingDaysOfWeek workingWeek, int days, string? territoryCode = null, Type? calendarType = null) =>
+        AddWorkingDays(date, service, workingWeek.ToWeekPattern(), days, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.IsNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.IsNonWorkingDay.cs
@@ -37,4 +37,32 @@ public static partial class NotableDateOnlyExtensions
 
         return service.IsNonWorkingDay(date.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateOnly" /> is a non-working day under the supplied
+    /// <paramref name="workingWeek" />, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The <see cref="DateOnly" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="date" />'s day-of-week is not selected in <paramref name="workingWeek" /> or a non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateOnly date, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        !IsWorkingDay(date, service, workingWeek, territoryCode, calendarType);
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateOnly" /> is a non-working day under the supplied named
+    /// <paramref name="workingWeek" /> preset, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The <see cref="DateOnly" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="date" /> is not in the working week or is covered by a non-working notable date; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateOnly date, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        IsNonWorkingDay(date, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.IsWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.IsWorkingDay.cs
@@ -37,4 +37,39 @@ public static partial class NotableDateOnlyExtensions
 
         return !service.IsNonWorkingDay(date.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateOnly" /> is a working day under the supplied
+    /// <paramref name="workingWeek" />, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The <see cref="DateOnly" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern that determines which days-of-week are treated as working days.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="date" />'s day-of-week is selected in <paramref name="workingWeek" /> and no non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsWorkingDay(this DateOnly date, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (!workingWeek.Contains(date.DayOfWeek)) return false;
+        return !service.IsHolidayNonWorkingDay(date.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateOnly" /> is a working day under the supplied named
+    /// <paramref name="workingWeek" /> preset, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The <see cref="DateOnly" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="date" />'s day-of-week is in the working week and no non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />.</exception>
+    public static bool IsWorkingDay(this DateOnly date, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        IsWorkingDay(date, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.NextWorkingDay.cs
@@ -57,4 +57,58 @@ public static partial class NotableDateOnlyExtensions
 
         return DateOnly.FromDayNumber(dayNumber);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly after <paramref name="date" /> under the supplied <paramref name="workingWeek" />, composed with the
+    /// holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to search forward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly after <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative, when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />, or when advancing would overrun <see cref="DateOnly.MaxValue" />.</exception>
+    public static DateOnly NextWorkingDay(this DateOnly date, INotableDateService service, WeekPattern workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfNegative(count);
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        if (count == 0) return DateOnly.FromDayNumber(date.DayNumber);
+
+        var dayNumber = date.DayNumber;
+        var remaining = count;
+        while (remaining > 0)
+        {
+            if (dayNumber >= DateOnly.MaxValue.DayNumber)
+                throw new ArgumentOutOfRangeException(nameof(count), "Advancing the requested number of working days would overrun DateOnly.MaxValue.");
+
+            dayNumber++;
+            var candidate = DateOnly.FromDayNumber(dayNumber);
+            if (!workingWeek.Contains(candidate.DayOfWeek)) continue;
+            if (service.IsHolidayNonWorkingDay(candidate.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType)) continue;
+            remaining--;
+        }
+
+        return DateOnly.FromDayNumber(dayNumber);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly after <paramref name="date" /> under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to search forward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly after <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly NextWorkingDay(this DateOnly date, INotableDateService service, WorkingDaysOfWeek workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null) =>
+        NextWorkingDay(date, service, workingWeek.ToWeekPattern(), count, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.PreviousWorkingDay.cs
@@ -57,4 +57,58 @@ public static partial class NotableDateOnlyExtensions
 
         return DateOnly.FromDayNumber(dayNumber);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly before <paramref name="date" /> under the supplied <paramref name="workingWeek" />, composed with the
+    /// holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to search backward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly before <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative, when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />, or when retreating would underrun <see cref="DateOnly.MinValue" />.</exception>
+    public static DateOnly PreviousWorkingDay(this DateOnly date, INotableDateService service, WeekPattern workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfNegative(count);
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        if (count == 0) return DateOnly.FromDayNumber(date.DayNumber);
+
+        var dayNumber = date.DayNumber;
+        var remaining = count;
+        while (remaining > 0)
+        {
+            if (dayNumber <= DateOnly.MinValue.DayNumber)
+                throw new ArgumentOutOfRangeException(nameof(count), "Retreating the requested number of working days would underrun DateOnly.MinValue.");
+
+            dayNumber--;
+            var candidate = DateOnly.FromDayNumber(dayNumber);
+            if (!workingWeek.Contains(candidate.DayOfWeek)) continue;
+            if (service.IsHolidayNonWorkingDay(candidate.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType)) continue;
+            remaining--;
+        }
+
+        return DateOnly.FromDayNumber(dayNumber);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateOnly" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly before <paramref name="date" /> under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="date">The starting <see cref="DateOnly" /> from which to search backward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly before <paramref name="date" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateOnly PreviousWorkingDay(this DateOnly date, INotableDateService service, WorkingDaysOfWeek workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null) =>
+        PreviousWorkingDay(date, service, workingWeek.ToWeekPattern(), count, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.WorkingDaysBetween.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.WorkingDaysBetween.cs
@@ -52,4 +52,55 @@ public static partial class NotableDateOnlyExtensions
 
         return count;
     }
+
+    /// <summary>
+    /// Returns the inclusive count of working days between <paramref name="startDate" /> and <paramref name="endDate" />
+    /// under the supplied <paramref name="workingWeek" />, composed with the holiday catalogue exposed by
+    /// <paramref name="service" />.
+    /// </summary>
+    /// <param name="startDate">One end of the inclusive range.</param>
+    /// <param name="endDate">The other end of the inclusive range. The arguments may appear in either chronological order.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateOnly startDate, DateOnly endDate, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (endDate < startDate) (startDate, endDate) = (endDate, startDate);
+
+        var dayNumber = startDate.DayNumber;
+        var endDayNumber = endDate.DayNumber;
+        var count = 0;
+        while (dayNumber <= endDayNumber)
+        {
+            var cursor = DateOnly.FromDayNumber(dayNumber);
+            if (workingWeek.Contains(cursor.DayOfWeek)
+                && !service.IsHolidayNonWorkingDay(cursor.ToDateTime(TimeOnly.MinValue), territoryCode, calendarType))
+            {
+                count++;
+            }
+            dayNumber++;
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Returns the inclusive count of working days between <paramref name="startDate" /> and <paramref name="endDate" />
+    /// under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="startDate">One end of the inclusive range.</param>
+    /// <param name="endDate">The other end of the inclusive range.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateOnly startDate, DateOnly endDate, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        WorkingDaysBetween(startDate, endDate, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.AddWorkingDays.cs
@@ -51,4 +51,42 @@ public static partial class NotableDateTimeExtensions
             ? NextWorkingDay(dateTime, service, days, territoryCode, calendarType)
             : PreviousWorkingDay(dateTime, service, -days, territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> obtained by advancing or retreating <paramref name="dateTime" /> by the signed
+    /// number of working days specified in <paramref name="days" />, under the supplied <paramref name="workingWeek" />
+    /// composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to walk.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day reached after applying <paramref name="days" /> to <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTime AddWorkingDays(this DateTime dateTime, INotableDateService service, WeekPattern workingWeek, int days, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (days == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
+        return days > 0
+            ? NextWorkingDay(dateTime, service, workingWeek, days, territoryCode, calendarType)
+            : PreviousWorkingDay(dateTime, service, workingWeek, -days, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> obtained by advancing or retreating <paramref name="dateTime" /> by the signed
+    /// number of working days specified in <paramref name="days" />, under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to walk.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day reached after applying <paramref name="days" /> to <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTime AddWorkingDays(this DateTime dateTime, INotableDateService service, WorkingDaysOfWeek workingWeek, int days, string? territoryCode = null, Type? calendarType = null) =>
+        AddWorkingDays(dateTime, service, workingWeek.ToWeekPattern(), days, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.IsNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.IsNonWorkingDay.cs
@@ -37,4 +37,32 @@ public static partial class NotableDateTimeExtensions
 
         return service.IsNonWorkingDay(dateTime, territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateTime" /> is a non-working day under the supplied
+    /// <paramref name="workingWeek" />, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The <see cref="DateTime" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="dateTime" />'s day-of-week is not selected in <paramref name="workingWeek" /> or a non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateTime dateTime, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        !IsWorkingDay(dateTime, service, workingWeek, territoryCode, calendarType);
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateTime" /> is a non-working day under the supplied named
+    /// <paramref name="workingWeek" /> preset, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The <see cref="DateTime" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="dateTime" /> is not in the working week or is covered by a non-working notable date; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateTime dateTime, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        IsNonWorkingDay(dateTime, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.IsWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.IsWorkingDay.cs
@@ -40,4 +40,39 @@ public static partial class NotableDateTimeExtensions
 
         return !service.IsNonWorkingDay(dateTime, territoryCode, calendarType);
     }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateTime" /> is a working day under the supplied
+    /// <paramref name="workingWeek" />, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The <see cref="DateTime" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="dateTime" />'s day-of-week is selected in <paramref name="workingWeek" /> and no non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsWorkingDay(this DateTime dateTime, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (!workingWeek.Contains(dateTime.DayOfWeek)) return false;
+        return !service.IsHolidayNonWorkingDay(dateTime, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns an indication whether the specified <see cref="DateTime" /> is a working day under the supplied named
+    /// <paramref name="workingWeek" /> preset, composed with the holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The <see cref="DateTime" /> value to evaluate.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns><see langword="true" /> when <paramref name="dateTime" />'s day-of-week is in the working week and no non-working notable date covers it; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingWeek" /> is not a defined value of the <see cref="WorkingDaysOfWeek" /> enumeration.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="workingWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />.</exception>
+    public static bool IsWorkingDay(this DateTime dateTime, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        IsWorkingDay(dateTime, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.NextWorkingDay.cs
@@ -64,4 +64,58 @@ public static partial class NotableDateTimeExtensions
 
         return new DateTime(ticks, dateTime.Kind);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly after <paramref name="dateTime" /> under the supplied <paramref name="workingWeek" />, composed with the
+    /// holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to search forward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly after <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative, when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />, or when advancing would overrun <see cref="DateTime.MaxValue" />.</exception>
+    public static DateTime NextWorkingDay(this DateTime dateTime, INotableDateService service, WeekPattern workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfNegative(count);
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        if (count == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
+
+        var ticks = dateTime.Ticks;
+        var remaining = count;
+        while (remaining > 0)
+        {
+            if (DateTime.MaxValue.Ticks - ticks < DateTimeExtensions.TicksPerDay)
+                throw new ArgumentOutOfRangeException(nameof(count), "Advancing the requested number of working days would overrun DateTime.MaxValue.");
+
+            ticks += DateTimeExtensions.TicksPerDay;
+            var candidate = new DateTime(ticks, dateTime.Kind);
+            if (!workingWeek.Contains(candidate.DayOfWeek)) continue;
+            if (service.IsHolidayNonWorkingDay(candidate, territoryCode, calendarType)) continue;
+            remaining--;
+        }
+
+        return new DateTime(ticks, dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly after <paramref name="dateTime" /> under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to search forward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly after <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTime NextWorkingDay(this DateTime dateTime, INotableDateService service, WorkingDaysOfWeek workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null) =>
+        NextWorkingDay(dateTime, service, workingWeek.ToWeekPattern(), count, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.PreviousWorkingDay.cs
@@ -57,4 +57,58 @@ public static partial class NotableDateTimeExtensions
 
         return new DateTime(ticks, dateTime.Kind);
     }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly before <paramref name="dateTime" /> under the supplied <paramref name="workingWeek" />, composed with the
+    /// holiday catalogue exposed by <paramref name="service" />.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to search backward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly before <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative, when <paramref name="workingWeek" /> is <see cref="WeekPattern.Empty" />, or when retreating would underrun <see cref="DateTime.MinValue" />.</exception>
+    public static DateTime PreviousWorkingDay(this DateTime dateTime, INotableDateService service, WeekPattern workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+        ThrowHelper.ThrowIfNegative(count);
+        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), "The working week must select at least one day.");
+
+        if (count == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
+
+        var ticks = dateTime.Ticks;
+        var remaining = count;
+        while (remaining > 0)
+        {
+            if (ticks - DateTime.MinValue.Ticks < DateTimeExtensions.TicksPerDay)
+                throw new ArgumentOutOfRangeException(nameof(count), "Retreating the requested number of working days would underrun DateTime.MinValue.");
+
+            ticks -= DateTimeExtensions.TicksPerDay;
+            var candidate = new DateTime(ticks, dateTime.Kind);
+            if (!workingWeek.Contains(candidate.DayOfWeek)) continue;
+            if (service.IsHolidayNonWorkingDay(candidate, territoryCode, calendarType)) continue;
+            remaining--;
+        }
+
+        return new DateTime(ticks, dateTime.Kind);
+    }
+
+    /// <summary>
+    /// Returns a new <see cref="DateTime" /> representing the working day that is <paramref name="count" /> working days
+    /// strictly before <paramref name="dateTime" /> under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="dateTime">The starting <see cref="DateTime" /> from which to search backward.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>The working day that is <paramref name="count" /> working days strictly before <paramref name="dateTime" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTime PreviousWorkingDay(this DateTime dateTime, INotableDateService service, WorkingDaysOfWeek workingWeek, int count = 1, string? territoryCode = null, Type? calendarType = null) =>
+        PreviousWorkingDay(dateTime, service, workingWeek.ToWeekPattern(), count, territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.WorkingDaysBetween.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.WorkingDaysBetween.cs
@@ -58,4 +58,54 @@ public static partial class NotableDateTimeExtensions
 
         return count;
     }
+
+    /// <summary>
+    /// Returns the inclusive count of working days between <paramref name="startDate" /> and <paramref name="endDate" />
+    /// under the supplied <paramref name="workingWeek" />, composed with the holiday catalogue exposed by
+    /// <paramref name="service" />.
+    /// </summary>
+    /// <param name="startDate">One end of the inclusive range.</param>
+    /// <param name="endDate">The other end of the inclusive range.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateTime startDate, DateTime endDate, INotableDateService service, WeekPattern workingWeek, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(service);
+
+        if (endDate < startDate) (startDate, endDate) = (endDate, startDate);
+
+        DateTime cursor = startDate.Date;
+        DateTime end = endDate.Date;
+        var count = 0;
+        while (cursor <= end)
+        {
+            if (workingWeek.Contains(cursor.DayOfWeek)
+                && !service.IsHolidayNonWorkingDay(cursor, territoryCode, calendarType))
+            {
+                count++;
+            }
+            cursor = cursor.AddDays(1);
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Returns the inclusive count of working days between <paramref name="startDate" /> and <paramref name="endDate" />
+    /// under the supplied named <paramref name="workingWeek" /> preset.
+    /// </summary>
+    /// <param name="startDate">One end of the inclusive range.</param>
+    /// <param name="endDate">The other end of the inclusive range.</param>
+    /// <param name="service">The <see cref="INotableDateService" /> consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The named working-week pattern.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope forwarded to the service for rule resolution.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateTime startDate, DateTime endDate, INotableDateService service, WorkingDaysOfWeek workingWeek, string? territoryCode = null, Type? calendarType = null) =>
+        WorkingDaysBetween(startDate, endDate, service, workingWeek.ToWeekPattern(), territoryCode, calendarType);
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.AddWorkingDays.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.AddWorkingDays.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.AddWorkingDays.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is obtained by applying
+    /// the signed working-day offset <paramref name="days" /> to the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTimeOffset AddWorkingDays(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int days, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        if (days == 0) return instant;
+        return days > 0
+            ? NextWorkingDay(instant, timeZone, service, days, workingWeek, territoryCode, calendarType)
+            : PreviousWorkingDay(instant, timeZone, service, -days, workingWeek, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.IsNonWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.IsNonWorkingDay.cs
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.IsNonWorkingDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a non-working
+    /// day under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue.
+    /// </summary>
+    /// <param name="instant">The instant to evaluate.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns><see langword="true" /> when the civil date is non-working in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null) =>
+        !IsWorkingDay(instant, timeZone, service, workingWeek, territoryCode, calendarType);
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.IsWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.IsWorkingDay.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.IsWorkingDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a working day
+    /// under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue exposed by
+    /// <paramref name="service" />.
+    /// </summary>
+    /// <param name="instant">The instant to evaluate.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns><see langword="true" /> when the civil date is a working day in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        return local.IsWorkingDay(service, week, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.NextWorkingDay.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.NextWorkingDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the next working day
+    /// after the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
+    public static DateTimeOffset NextWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        DateOnly nextDate = DateOnly.FromDateTime(local).NextWorkingDay(service, week, count, territoryCode, calendarType);
+        return CombineInZone(nextDate, local.TimeOfDay, timeZone);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.PreviousWorkingDay.cs
@@ -1,0 +1,37 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.PreviousWorkingDay.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the previous working
+    /// day before the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
+    public static DateTimeOffset PreviousWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        DateOnly prevDate = DateOnly.FromDateTime(local).PreviousWorkingDay(service, week, count, territoryCode, calendarType);
+        return CombineInZone(prevDate, local.TimeOfDay, timeZone);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.WorkingDaysBetween.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.WorkingDaysBetween.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.WorkingDaysBetween.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+public static partial class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns the inclusive count of working days between the civil dates of <paramref name="startInstant" /> and
+    /// <paramref name="endInstant" /> in <paramref name="timeZone" />.
+    /// </summary>
+    /// <param name="startInstant">One end of the inclusive range.</param>
+    /// <param name="endInstant">The other end of the inclusive range.</param>
+    /// <param name="timeZone">The zone in which the civil dates are taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateTimeOffset startInstant, DateTimeOffset endInstant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly start = DateOnly.FromDateTime(LocalDateTimeIn(startInstant, timeZone));
+        DateOnly end = DateOnly.FromDateTime(LocalDateTimeIn(endInstant, timeZone));
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        return start.WorkingDaysBetween(end, service, week, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.cs
@@ -18,161 +18,36 @@ namespace Bodu.Extensions;
 /// same zone preserving the original time-of-day. The resulting <see cref="DateTimeOffset.Offset" /> reflects the
 /// zone's rules for the returned civil date (which may differ from the input's offset across DST transitions).
 /// </para>
+/// <para>
+/// The <see cref="WeekPattern" /> parameter on each method is optional. When <see langword="null" />, the
+/// <see cref="INotableDateService.WorkingWeek" /> configured on the supplied service is used.
+/// </para>
 /// </remarks>
-public static class NotableDateTimeOffsetExtensions
+public static partial class NotableDateTimeOffsetExtensions
 {
     /// <summary>
     /// Returns the civil <see cref="DateTime" /> equivalent of <paramref name="instant" /> in the supplied
     /// <paramref name="timeZone" />.
     /// </summary>
+    /// <param name="instant">The instant to convert.</param>
+    /// <param name="timeZone">The destination time zone.</param>
+    /// <returns>The civil <see cref="DateTime" /> in <paramref name="timeZone" />.</returns>
     private static DateTime LocalDateTimeIn(DateTimeOffset instant, TimeZoneInfo timeZone) =>
         TimeZoneInfo.ConvertTime(instant, timeZone).DateTime;
 
     /// <summary>
     /// Returns a <see cref="DateTimeOffset" /> with the supplied civil <paramref name="localDate" /> at the original
-    /// <paramref name="timeOfDay" />, anchored to the supplied <paramref name="timeZone" /> using its base UTC offset
-    /// for that local date.
+    /// <paramref name="timeOfDay" />, anchored to the supplied <paramref name="timeZone" /> using its UTC offset for
+    /// that local date.
     /// </summary>
+    /// <param name="localDate">The civil date in <paramref name="timeZone" />.</param>
+    /// <param name="timeOfDay">The time-of-day to apply on <paramref name="localDate" />.</param>
+    /// <param name="timeZone">The zone whose offset is consulted for the resulting instant.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> representing the supplied civil date and time in the zone.</returns>
     private static DateTimeOffset CombineInZone(DateOnly localDate, TimeSpan timeOfDay, TimeZoneInfo timeZone)
     {
         DateTime local = localDate.ToDateTime(TimeOnly.MinValue) + timeOfDay;
         TimeSpan offset = timeZone.GetUtcOffset(local);
         return new DateTimeOffset(local, offset);
-    }
-
-    /// <summary>
-    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a working day
-    /// under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue exposed by
-    /// <paramref name="service" />.
-    /// </summary>
-    /// <param name="instant">The instant to evaluate.</param>
-    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns><see langword="true" /> when the civil date is a working day in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static bool IsWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(timeZone);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateTime local = LocalDateTimeIn(instant, timeZone);
-        WeekPattern week = workingWeek ?? service.WorkingWeek;
-        return local.IsWorkingDay(service, week, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a non-working
-    /// day under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue.
-    /// </summary>
-    /// <param name="instant">The instant to evaluate.</param>
-    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns><see langword="true" /> when the civil date is non-working in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static bool IsNonWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null) =>
-        !IsWorkingDay(instant, timeZone, service, workingWeek, territoryCode, calendarType);
-
-    /// <summary>
-    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the next working day
-    /// after the civil date of <paramref name="instant" />.
-    /// </summary>
-    /// <param name="instant">The starting instant.</param>
-    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="count">The number of working days to advance.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
-    public static DateTimeOffset NextWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(timeZone);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateTime local = LocalDateTimeIn(instant, timeZone);
-        WeekPattern week = workingWeek ?? service.WorkingWeek;
-        DateOnly nextDate = DateOnly.FromDateTime(local).NextWorkingDay(service, week, count, territoryCode, calendarType);
-        return CombineInZone(nextDate, local.TimeOfDay, timeZone);
-    }
-
-    /// <summary>
-    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the previous working
-    /// day before the civil date of <paramref name="instant" />.
-    /// </summary>
-    /// <param name="instant">The starting instant.</param>
-    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="count">The number of working days to retreat.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
-    public static DateTimeOffset PreviousWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(timeZone);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateTime local = LocalDateTimeIn(instant, timeZone);
-        WeekPattern week = workingWeek ?? service.WorkingWeek;
-        DateOnly prevDate = DateOnly.FromDateTime(local).PreviousWorkingDay(service, week, count, territoryCode, calendarType);
-        return CombineInZone(prevDate, local.TimeOfDay, timeZone);
-    }
-
-    /// <summary>
-    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is obtained by applying
-    /// the signed working-day offset <paramref name="days" /> to the civil date of <paramref name="instant" />.
-    /// </summary>
-    /// <param name="instant">The starting instant.</param>
-    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="days">The signed number of working days to apply.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static DateTimeOffset AddWorkingDays(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int days, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(timeZone);
-        ThrowHelper.ThrowIfNull(service);
-
-        if (days == 0) return instant;
-        return days > 0
-            ? NextWorkingDay(instant, timeZone, service, days, workingWeek, territoryCode, calendarType)
-            : PreviousWorkingDay(instant, timeZone, service, -days, workingWeek, territoryCode, calendarType);
-    }
-
-    /// <summary>
-    /// Returns the inclusive count of working days between the civil dates of <paramref name="startInstant" /> and
-    /// <paramref name="endInstant" /> in <paramref name="timeZone" />.
-    /// </summary>
-    /// <param name="startInstant">One end of the inclusive range.</param>
-    /// <param name="endInstant">The other end of the inclusive range.</param>
-    /// <param name="timeZone">The zone in which the civil dates are taken. Must not be <see langword="null" />.</param>
-    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
-    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
-    /// <param name="territoryCode">An optional territory scope.</param>
-    /// <param name="calendarType">An optional calendar scope.</param>
-    /// <returns>A non-negative count of working days within the range.</returns>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
-    public static int WorkingDaysBetween(this DateTimeOffset startInstant, DateTimeOffset endInstant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
-    {
-        ThrowHelper.ThrowIfNull(timeZone);
-        ThrowHelper.ThrowIfNull(service);
-
-        DateOnly start = DateOnly.FromDateTime(LocalDateTimeIn(startInstant, timeZone));
-        DateOnly end = DateOnly.FromDateTime(LocalDateTimeIn(endInstant, timeZone));
-        WeekPattern week = workingWeek ?? service.WorkingWeek;
-        return start.WorkingDaysBetween(end, service, week, territoryCode, calendarType);
     }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensions.cs
@@ -1,0 +1,178 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides time-zone-aware working-day extension methods on <see cref="DateTimeOffset" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each method converts the supplied <see cref="DateTimeOffset" /> instant to its civil date in the supplied
+/// <see cref="TimeZoneInfo" />, performs working-day math on that civil date, and re-anchors the result back to the
+/// same zone preserving the original time-of-day. The resulting <see cref="DateTimeOffset.Offset" /> reflects the
+/// zone's rules for the returned civil date (which may differ from the input's offset across DST transitions).
+/// </para>
+/// </remarks>
+public static class NotableDateTimeOffsetExtensions
+{
+    /// <summary>
+    /// Returns the civil <see cref="DateTime" /> equivalent of <paramref name="instant" /> in the supplied
+    /// <paramref name="timeZone" />.
+    /// </summary>
+    private static DateTime LocalDateTimeIn(DateTimeOffset instant, TimeZoneInfo timeZone) =>
+        TimeZoneInfo.ConvertTime(instant, timeZone).DateTime;
+
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> with the supplied civil <paramref name="localDate" /> at the original
+    /// <paramref name="timeOfDay" />, anchored to the supplied <paramref name="timeZone" /> using its base UTC offset
+    /// for that local date.
+    /// </summary>
+    private static DateTimeOffset CombineInZone(DateOnly localDate, TimeSpan timeOfDay, TimeZoneInfo timeZone)
+    {
+        DateTime local = localDate.ToDateTime(TimeOnly.MinValue) + timeOfDay;
+        TimeSpan offset = timeZone.GetUtcOffset(local);
+        return new DateTimeOffset(local, offset);
+    }
+
+    /// <summary>
+    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a working day
+    /// under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue exposed by
+    /// <paramref name="service" />.
+    /// </summary>
+    /// <param name="instant">The instant to evaluate.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns><see langword="true" /> when the civil date is a working day in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        return local.IsWorkingDay(service, week, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Determines whether the civil date of <paramref name="instant" /> in <paramref name="timeZone" /> is a non-working
+    /// day under the supplied <paramref name="workingWeek" /> composed with the holiday catalogue.
+    /// </summary>
+    /// <param name="instant">The instant to evaluate.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns><see langword="true" /> when the civil date is non-working in <paramref name="timeZone" />; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static bool IsNonWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null) =>
+        !IsWorkingDay(instant, timeZone, service, workingWeek, territoryCode, calendarType);
+
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the next working day
+    /// after the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="count">The number of working days to advance.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
+    public static DateTimeOffset NextWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        DateOnly nextDate = DateOnly.FromDateTime(local).NextWorkingDay(service, week, count, territoryCode, calendarType);
+        return CombineInZone(nextDate, local.TimeOfDay, timeZone);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is the previous working
+    /// day before the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="count">The number of working days to retreat.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="count" /> is negative.</exception>
+    public static DateTimeOffset PreviousWorkingDay(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int count = 1, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateTime local = LocalDateTimeIn(instant, timeZone);
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        DateOnly prevDate = DateOnly.FromDateTime(local).PreviousWorkingDay(service, week, count, territoryCode, calendarType);
+        return CombineInZone(prevDate, local.TimeOfDay, timeZone);
+    }
+
+    /// <summary>
+    /// Returns a <see cref="DateTimeOffset" /> whose civil date in <paramref name="timeZone" /> is obtained by applying
+    /// the signed working-day offset <paramref name="days" /> to the civil date of <paramref name="instant" />.
+    /// </summary>
+    /// <param name="instant">The starting instant.</param>
+    /// <param name="timeZone">The zone in which the civil date is taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="days">The signed number of working days to apply.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A <see cref="DateTimeOffset" /> at the requested working day in <paramref name="timeZone" />, preserving the local time-of-day.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static DateTimeOffset AddWorkingDays(this DateTimeOffset instant, TimeZoneInfo timeZone, INotableDateService service, int days, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        if (days == 0) return instant;
+        return days > 0
+            ? NextWorkingDay(instant, timeZone, service, days, workingWeek, territoryCode, calendarType)
+            : PreviousWorkingDay(instant, timeZone, service, -days, workingWeek, territoryCode, calendarType);
+    }
+
+    /// <summary>
+    /// Returns the inclusive count of working days between the civil dates of <paramref name="startInstant" /> and
+    /// <paramref name="endInstant" /> in <paramref name="timeZone" />.
+    /// </summary>
+    /// <param name="startInstant">One end of the inclusive range.</param>
+    /// <param name="endInstant">The other end of the inclusive range.</param>
+    /// <param name="timeZone">The zone in which the civil dates are taken. Must not be <see langword="null" />.</param>
+    /// <param name="service">The notable-date service consulted for holiday classification. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">An optional working-week pattern. When <see langword="null" />, the service's configured working week is used.</param>
+    /// <param name="territoryCode">An optional territory scope.</param>
+    /// <param name="calendarType">An optional calendar scope.</param>
+    /// <returns>A non-negative count of working days within the range.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="timeZone" /> or <paramref name="service" /> is <see langword="null" />.</exception>
+    public static int WorkingDaysBetween(this DateTimeOffset startInstant, DateTimeOffset endInstant, TimeZoneInfo timeZone, INotableDateService service, WeekPattern? workingWeek = null, string? territoryCode = null, Type? calendarType = null)
+    {
+        ThrowHelper.ThrowIfNull(timeZone);
+        ThrowHelper.ThrowIfNull(service);
+
+        DateOnly start = DateOnly.FromDateTime(LocalDateTimeIn(startInstant, timeZone));
+        DateOnly end = DateOnly.FromDateTime(LocalDateTimeIn(endInstant, timeZone));
+        WeekPattern week = workingWeek ?? service.WorkingWeek;
+        return start.WorkingDaysBetween(end, service, week, territoryCode, calendarType);
+    }
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -4,7 +4,6 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using BoduExt = Bodu.Extensions;
 
 namespace Bodu.Globalization.Calendar.RangeResolution;
 
@@ -33,8 +32,7 @@ internal sealed class NotableDateRangePipeline
     private readonly RuleStaticAnalysis _analysis;
     private readonly NotableDateRuleResolver _ruleResolver;
     private readonly NotableDateRangePlanner _planner;
-    private readonly BoduExt.CalendarWeekendDefinition _weekendDefinition;
-    private readonly BoduExt.IWeekendDefinitionProvider? _weekendProvider;
+    private readonly WeekPattern _workingWeek;
     private readonly IAdjustmentHandlerRegistry? _handlerRegistry;
     private readonly IReadOnlyList<RuleRemoval> _overrideRemovals;
 
@@ -43,8 +41,7 @@ internal sealed class NotableDateRangePipeline
     /// </summary>
     /// <param name="analysis">The static rule analysis.</param>
     /// <param name="ruleResolver">The resolver used to compute fixed and algorithmic anchor dates.</param>
-    /// <param name="weekendDefinition">The weekend definition used during adjustment evaluation.</param>
-    /// <param name="weekendProvider">The optional custom weekend provider.</param>
+    /// <param name="workingWeek">The working-week pattern used during adjustment evaluation.</param>
     /// <param name="handlerRegistry">The optional custom adjustment handler registry.</param>
     /// <param name="overrideRemovals">The override removals consulted when materializing rules. Each entry suppresses a rule for matching years and territories.</param>
     /// <exception cref="ArgumentNullException">
@@ -53,16 +50,14 @@ internal sealed class NotableDateRangePipeline
     public NotableDateRangePipeline(
         RuleStaticAnalysis analysis,
         NotableDateRuleResolver ruleResolver,
-        BoduExt.CalendarWeekendDefinition weekendDefinition,
-        BoduExt.IWeekendDefinitionProvider? weekendProvider = null,
+        WeekPattern workingWeek,
         IAdjustmentHandlerRegistry? handlerRegistry = null,
         IReadOnlyList<RuleRemoval>? overrideRemovals = null)
     {
         _analysis = analysis ?? throw new ArgumentNullException(nameof(analysis));
         _ruleResolver = ruleResolver ?? throw new ArgumentNullException(nameof(ruleResolver));
         _planner = new NotableDateRangePlanner(analysis);
-        _weekendDefinition = weekendDefinition;
-        _weekendProvider = weekendProvider;
+        _workingWeek = workingWeek;
         _handlerRegistry = handlerRegistry;
         _overrideRemovals = overrideRemovals ?? [];
     }
@@ -400,8 +395,7 @@ internal sealed class NotableDateRangePipeline
         NotableDateAdjuster adjuster = new(
             IsWeekend,
             (date, territory, calendar) => IsNonWorkingDay(cache, date, territory, calendar),
-            _weekendDefinition,
-            _weekendProvider,
+            _workingWeek,
             _handlerRegistry,
             (name, year, territory, calendar) => cache.ResolveObservedByName(name, year, territory, calendar));
 
@@ -509,8 +503,7 @@ internal sealed class NotableDateRangePipeline
     /// </summary>
     /// <param name="date">The date to test.</param>
     /// <returns><see langword="true" /> when the date is a weekend; otherwise, <see langword="false" />.</returns>
-    private bool IsWeekend(DateTime date) =>
-        BoduExt.DateTimeExtensions.IsWeekend(date, _weekendDefinition, _weekendProvider);
+    private bool IsWeekend(DateTime date) => !_workingWeek.Contains(date.DayOfWeek);
 
     /// <summary>
     /// Constructs a <see cref="NotableDate" /> from a rule, its resolved date, and any observance-adjustment metadata.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
@@ -27,7 +27,7 @@ namespace Bodu.Globalization.Calendar;
 /// NotableDateService service = new NotableDateService(
 ///     ruleProviders: new[] { AustraliaCalendarData.CreateProvider() },
 ///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-///     adjustmentHandlers: handlers);
+///     options: new NotableDateServiceOptions { AdjustmentHandlers = handlers });
 ///
 /// // A rule's adjustment can now reference the handler by key:
 /// ObservanceAdjustment custom = new ObservanceAdjustment

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithmRegistry.cs
@@ -33,7 +33,7 @@ namespace Bodu.Globalization.Calendar;
 ///         "MyApp/Calendar/Resources/rules.xml",
 ///         new ResourcePathResolver()) },
 ///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-///     algorithmRegistry: registry);
+///     options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 /// </code>
 /// </example>
 public interface INotableDateAlgorithmRegistry

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -45,6 +45,20 @@ namespace Bodu.Globalization.Calendar;
 public interface INotableDateService
 {
     /// <summary>
+    /// Gets the working-week pattern in effect for this service.
+    /// </summary>
+    /// <value>The <see cref="WeekPattern" /> whose selected days are treated as working days when classifying dates.</value>
+    /// <returns>The configured working-week <see cref="WeekPattern" />. The default-implemented value is <see cref="WeekPattern.Weekdays" /> (Monday through Friday) for implementations that do not override this property.</returns>
+    /// <remarks>
+    /// <para>
+    /// The default implementation returns <see cref="WeekPattern.Weekdays" /> so that pre-existing
+    /// <see cref="INotableDateService" /> implementors continue to compile and behave identically. Implementors that
+    /// support configurable working weeks should override this property to surface their effective pattern.
+    /// </para>
+    /// </remarks>
+    WeekPattern WorkingWeek => WeekPattern.Weekdays;
+
+    /// <summary>
     /// Determines whether the supplied date falls on a weekend under the configured weekend definition.
     /// </summary>
     /// <param name="date">The date to evaluate.</param>
@@ -59,6 +73,32 @@ public interface INotableDateService
     /// <param name="calendarType">Optional calendar scope (e.g. <see cref="SysGlobal.GregorianCalendar" />).</param>
     /// <returns><see langword="true" /> if the date is a non-working day; otherwise <see langword="false" />.</returns>
     bool IsNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null);
+
+    /// <summary>
+    /// Determines whether the supplied date is covered by a non-working notable date for the supplied territory and
+    /// calendar context, ignoring the working-week dimension.
+    /// </summary>
+    /// <param name="date">The date to evaluate.</param>
+    /// <param name="territoryCode">Optional territory scope (e.g. <c>"AU"</c>, <c>"AU-NSW"</c>).</param>
+    /// <param name="calendarType">Optional calendar scope (e.g. <see cref="SysGlobal.GregorianCalendar" />).</param>
+    /// <returns><see langword="true" /> if a non-working notable date covers <paramref name="date" />; otherwise <see langword="false" />.</returns>
+    /// <remarks>
+    /// <para>
+    /// This method answers only the holiday side of "is this a non-working day" so that callers can compose it with a
+    /// caller-supplied working-week pattern. The default implementation walks the result of
+    /// <see cref="GetNotableDates(DateTime, string?, Type?)" /> and returns <see langword="true" /> when any covering
+    /// notable date is flagged non-working. Concrete services may override this with a more efficient evaluation.
+    /// </para>
+    /// </remarks>
+    bool IsHolidayNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null)
+    {
+        foreach (NotableDate notable in GetNotableDates(date, territoryCode, calendarType))
+        {
+            if (notable.IsNonWorkingDay) return true;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Retrieves every notable date occurring within the supplied year.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
@@ -33,11 +33,8 @@ internal sealed class NotableDateAdjuster
     /// <summary>Predicate for determining whether a given date is a non-working day in the specified territory and calendar context.</summary>
     private readonly Func<DateTime, string?, Type?, bool> _isNonWorkingDay;
 
-    /// <summary>The configured weekend definition, forwarded to shift actions that move dates to a weekday.</summary>
-    private readonly CalendarWeekendDefinition _weekendDefinition;
-
-    /// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="Bodu.Extensions.CalendarWeekendDefinition.Custom" />.</summary>
-    private readonly IWeekendDefinitionProvider? _weekendProvider;
+    /// <summary>The configured working-week pattern; the complement of the days treated as weekend / non-working.</summary>
+    private readonly WeekPattern _workingWeek;
 
     /// <summary>An optional registry of custom <see cref="IAdjustmentHandler" /> instances looked up by key.</summary>
     private readonly IAdjustmentHandlerRegistry? _handlerRegistry;
@@ -50,23 +47,20 @@ internal sealed class NotableDateAdjuster
     /// </summary>
     /// <param name="isWeekend">A predicate for weekend evaluation.</param>
     /// <param name="isNonWorkingDay">A predicate for non-working-day evaluation, scoped by territory and calendar.</param>
-    /// <param name="weekendDefinition">The configured weekend definition.</param>
-    /// <param name="weekendProvider">An optional custom weekend provider.</param>
+    /// <param name="workingWeek">The working-week pattern used to drive shift-to-weekday actions.</param>
     /// <param name="handlerRegistry">An optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
     /// <param name="resolveByName">An optional callback used by <see cref="AdjustmentAction.ReplaceWithNamedDate" /> to look up another rule's resolved date for the same year.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="isWeekend" /> or <paramref name="isNonWorkingDay" /> is <see langword="null" />.</exception>
     public NotableDateAdjuster(
         Func<DateTime, bool> isWeekend,
         Func<DateTime, string?, Type?, bool> isNonWorkingDay,
-        CalendarWeekendDefinition weekendDefinition,
-        IWeekendDefinitionProvider? weekendProvider,
+        WeekPattern workingWeek,
         IAdjustmentHandlerRegistry? handlerRegistry = null,
         Func<string, int, string?, Type?, DateTime?>? resolveByName = null)
     {
         _isWeekend = isWeekend ?? throw new ArgumentNullException(nameof(isWeekend));
         _isNonWorkingDay = isNonWorkingDay ?? throw new ArgumentNullException(nameof(isNonWorkingDay));
-        _weekendDefinition = weekendDefinition;
-        _weekendProvider = weekendProvider;
+        _workingWeek = workingWeek;
         _handlerRegistry = handlerRegistry;
         _resolveByName = resolveByName;
     }
@@ -225,8 +219,8 @@ internal sealed class NotableDateAdjuster
             {
                 AdjustmentAction.None => original,
                 AdjustmentAction.AddDays => original.AddDays(adjustment.OffsetDays),
-                AdjustmentAction.MoveToNextWeekday => original.NextWeekday(_weekendDefinition, _weekendProvider),
-                AdjustmentAction.MoveToPreviousWeekday => original.PreviousWeekday(_weekendDefinition, _weekendProvider),
+                AdjustmentAction.MoveToNextWeekday => original.NextWeekday(_workingWeek),
+                AdjustmentAction.MoveToPreviousWeekday => original.PreviousWeekday(_workingWeek),
                 AdjustmentAction.MoveToNextNonWorkingDay => MoveToNextNonWorkingDay(original, territoryCode, calendarType),
                 AdjustmentAction.ReplaceWithNamedDate => ResolveReplacement(adjustment, original, territoryCode, calendarType),
                 AdjustmentAction.Custom => ApplyCustomHandler(adjustment, rule, original, territoryCode, calendarType).AdjustedDate,

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
@@ -49,7 +49,7 @@ namespace Bodu.Globalization.Calendar;
 /// NotableDateService service = new NotableDateService(
 ///     ruleProviders: new[] { new InMemoryRuleProvider(new[] { easterSunday }) },
 ///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-///     algorithmRegistry: registry);
+///     options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 /// </code>
 /// </example>
 public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -125,7 +125,7 @@ public sealed class NotableDateService : INotableDateService
         [
             (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver())
         ],
-        CalendarWeekendDefinition.SaturdaySunday)
+        WeekPattern.MondayToFriday)
     { }
 
     /// <summary>
@@ -158,12 +158,82 @@ public sealed class NotableDateService : INotableDateService
     { }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="NotableDateService" /> class.
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using a built-in
+    /// <see cref="CalendarWeekendDefinition" /> as a shorthand for the working week.
     /// </summary>
     /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
-    /// <param name="weekendDefinition">The weekend definition to apply when evaluating weekends.</param>
+    /// <param name="weekendDefinition">A built-in weekend pattern. The working week is the complement of the configured weekend.</param>
     /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
-    /// <param name="weekendProvider">An optional custom weekend provider.</param>
+    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
+    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
+    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
+    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
+    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
+    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="weekendDefinition" /> is not a defined value of the <see cref="CalendarWeekendDefinition" /> enumeration.</exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.
+    /// <see cref="CalendarWeekendDefinition.Custom" /> requires an out-of-band weekend source; convert it to a
+    /// <see cref="WeekPattern" /> first (see remarks) and use the <see cref="WeekPattern" /> constructor instead.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This is a convenience overload for callers whose working week corresponds to one of the built-in
+    /// <see cref="CalendarWeekendDefinition" /> values. Internally it delegates to the canonical
+    /// <see cref="WeekPattern" /> constructor after calling
+    /// <see cref="Bodu.Extensions.CalendarWeekendDefinitionExtensions.ToWeekPattern(CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />.
+    /// </para>
+    /// <para>
+    /// For non-standard weekends, do <em>not</em> use this overload with <see cref="CalendarWeekendDefinition.Custom" />.
+    /// Instead, convert your weekend source (e.g. an <see cref="IWeekendDefinitionProvider" />) to a
+    /// <see cref="WeekPattern" /> and use the <see cref="WeekPattern" /> constructor:
+    /// </para>
+    /// <example>
+    /// <code language="csharp">
+    /// <![CDATA[
+    /// // From an IWeekendDefinitionProvider:
+    /// IWeekendDefinitionProvider provider = new MyCustomWeekend();
+    /// WeekPattern workingWeek = provider.ToWeekPattern();
+    /// var service = new NotableDateService(ruleProviders, workingWeek);
+    ///
+    /// // Or directly from a built-in definition:
+    /// WeekPattern workingWeek = CalendarWeekendDefinition.FridaySaturday.ToWeekPattern();
+    /// var service = new NotableDateService(ruleProviders, workingWeek);
+    /// ]]>
+    /// </code>
+    /// </example>
+    /// </remarks>
+    public NotableDateService(
+        IEnumerable<INotableDateRuleProvider> ruleProviders,
+        CalendarWeekendDefinition weekendDefinition,
+        IResourcePathResolver? resourcePathResolver = null,
+        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
+        INotableDateAlgorithmRegistry? algorithmRegistry = null,
+        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
+        INotableDateCollisionResolver? collisionResolver = null,
+        INotableDateNameLocalizer? nameLocalizer = null,
+        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
+        : this(
+            ruleProviders,
+            weekendDefinition.ToWeekPattern(),
+            resourcePathResolver,
+            overrideProviders,
+            algorithmRegistry,
+            adjustmentHandlers,
+            collisionResolver,
+            nameLocalizer,
+            plugins)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using a caller-supplied
+    /// <see cref="WeekPattern" /> as the working week. This is the canonical constructor; every other overload routes
+    /// through it.
+    /// </summary>
+    /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern used when classifying dates.</param>
+    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
     /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
     /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
     /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
@@ -171,11 +241,26 @@ public sealed class NotableDateService : INotableDateService
     /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
     /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />. Rule providers exposed by plugins are appended to <paramref name="ruleProviders" /> and participate in the normal flatten pipeline; named algorithms are registered onto an internal algorithm registry that falls back to <paramref name="algorithmRegistry" /> when supplied (caller-supplied registrations win on key collision).</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// To use a custom weekend supplied by an <see cref="IWeekendDefinitionProvider" />, convert it to a
+    /// <see cref="WeekPattern" /> first via
+    /// <see cref="Bodu.Extensions.CalendarWeekendDefinitionExtensions.ToWeekPattern(IWeekendDefinitionProvider)" />:
+    /// </para>
+    /// <example>
+    /// <code language="csharp">
+    /// <![CDATA[
+    /// IWeekendDefinitionProvider provider = new MyCustomWeekend();
+    /// WeekPattern workingWeek = provider.ToWeekPattern();
+    /// var service = new NotableDateService(ruleProviders, workingWeek);
+    /// ]]>
+    /// </code>
+    /// </example>
+    /// </remarks>
     public NotableDateService(
         IEnumerable<INotableDateRuleProvider> ruleProviders,
-        CalendarWeekendDefinition weekendDefinition,
+        WeekPattern workingWeek,
         IResourcePathResolver? resourcePathResolver = null,
-        IWeekendDefinitionProvider? weekendProvider = null,
         IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
         INotableDateAlgorithmRegistry? algorithmRegistry = null,
         IAdjustmentHandlerRegistry? adjustmentHandlers = null,
@@ -184,8 +269,6 @@ public sealed class NotableDateService : INotableDateService
         IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
     {
         if (ruleProviders is null) throw new ArgumentNullException(nameof(ruleProviders));
-        ThrowHelper.ThrowIfEnumValueIsUndefined(weekendDefinition);
-        ThrowHelper.ThrowIfConditionallyRequiredParameterIsNull(weekendProvider, weekendDefinition, CalendarWeekendDefinition.Custom);
 
         // Fan plugin contributions into the provider list and the algorithm registry. The merge order means host-level
         // rule providers are loaded first and therefore win composite-key collisions inside the flatten pipeline, and
@@ -230,7 +313,7 @@ public sealed class NotableDateService : INotableDateService
         // and removes a runaway vector for providers that return fresh, infinite, or expensive enumerables on each invocation.
         _overrideRemovals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
 
-        _workingWeek = weekendDefinition.ToWeekPattern(weekendProvider);
+        _workingWeek = workingWeek;
         _collisionResolver = collisionResolver ?? new DefaultNotableDateCollisionResolver();
         _nameLocalizer = nameLocalizer;
         _resourcePathResolver = resourcePathResolver ?? new ResourcePathResolver();
@@ -239,52 +322,6 @@ public sealed class NotableDateService : INotableDateService
         _resolver = new NotableDateRuleResolver(_effectiveRules, effectiveRegistry);
         _adjustmentHandlers = adjustmentHandlers;
     }
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="NotableDateService" /> class using a caller-supplied
-    /// <see cref="WeekPattern" /> as the working week.
-    /// </summary>
-    /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
-    /// <param name="workingWeek">The working-week pattern used when classifying dates.</param>
-    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
-    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
-    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
-    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
-    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
-    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
-    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
-    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
-    /// <remarks>
-    /// <para>
-    /// Internally, the working week is bridged to the existing <see cref="CalendarWeekendDefinition" /> infrastructure
-    /// as <see cref="CalendarWeekendDefinition.Custom" /> with an <see cref="IWeekendDefinitionProvider" /> derived from
-    /// the supplied <see cref="WeekPattern" />. This preserves backwards compatibility with consumers that read the
-    /// legacy weekend definition while exposing the canonical <see cref="WorkingWeek" /> via the
-    /// <see cref="INotableDateService" /> contract.
-    /// </para>
-    /// </remarks>
-    public NotableDateService(
-        IEnumerable<INotableDateRuleProvider> ruleProviders,
-        WeekPattern workingWeek,
-        IResourcePathResolver? resourcePathResolver = null,
-        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
-        INotableDateAlgorithmRegistry? algorithmRegistry = null,
-        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
-        INotableDateCollisionResolver? collisionResolver = null,
-        INotableDateNameLocalizer? nameLocalizer = null,
-        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
-        : this(
-            ruleProviders,
-            CalendarWeekendDefinition.Custom,
-            resourcePathResolver,
-            new WeekPatternWeekendProvider(workingWeek),
-            overrideProviders,
-            algorithmRegistry,
-            adjustmentHandlers,
-            collisionResolver,
-            nameLocalizer,
-            plugins)
-    { }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="NotableDateService" /> class using a named
@@ -1050,35 +1087,6 @@ public sealed class NotableDateService : INotableDateService
         }
 
         return null;
-    }
-
-    /// <summary>
-    /// Adapts a <see cref="WeekPattern" /> to the legacy <see cref="IWeekendDefinitionProvider" /> contract so that the
-    /// <see cref="WeekPattern" />-accepting constructors can chain through the existing
-    /// <see cref="CalendarWeekendDefinition.Custom" /> path during initialization.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Instances of this class are passed alongside <see cref="CalendarWeekendDefinition.Custom" /> when constructing a
-    /// <see cref="NotableDateService" /> from a <see cref="WeekPattern" />.
-    /// </para>
-    /// </remarks>
-    private sealed class WeekPatternWeekendProvider : IWeekendDefinitionProvider
-    {
-        /// <summary>The working-week pattern whose unselected days are treated as weekend days.</summary>
-        private readonly WeekPattern _workingWeek;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="WeekPatternWeekendProvider" /> class.
-        /// </summary>
-        /// <param name="workingWeek">The working-week pattern.</param>
-        public WeekPatternWeekendProvider(WeekPattern workingWeek)
-        {
-            _workingWeek = workingWeek;
-        }
-
-        /// <inheritdoc />
-        public bool IsWeekend(DayOfWeek dayOfWeek) => !_workingWeek.Contains(dayOfWeek);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -98,13 +98,7 @@ public sealed class NotableDateService : INotableDateService
     /// <summary>The optional localizer used to translate notable date names into the active culture.</summary>
     private readonly INotableDateNameLocalizer? _nameLocalizer;
 
-    /// <summary>The configured weekend definition used for weekend and non-working-day evaluation.</summary>
-    private readonly CalendarWeekendDefinition _weekendDefinition;
-
-    /// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="Bodu.Extensions.CalendarWeekendDefinition.Custom" />.</summary>
-    private readonly IWeekendDefinitionProvider? _weekendProvider;
-
-    /// <summary>The working-week pattern derived from the configured weekend definition; surfaced via <see cref="WorkingWeek" />.</summary>
+    /// <summary>The canonical working-week pattern; the complement of the days treated as weekend / non-working.</summary>
     private readonly WeekPattern _workingWeek;
 
     /// <summary>The resolver used to locate embedded XML resource files.</summary>
@@ -236,9 +230,7 @@ public sealed class NotableDateService : INotableDateService
         // and removes a runaway vector for providers that return fresh, infinite, or expensive enumerables on each invocation.
         _overrideRemovals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
 
-        _weekendDefinition = weekendDefinition;
-        _weekendProvider = weekendProvider;
-        _workingWeek = WorkingWeekFromWeekend(weekendDefinition, weekendProvider);
+        _workingWeek = weekendDefinition.ToWeekPattern(weekendProvider);
         _collisionResolver = collisionResolver ?? new DefaultNotableDateCollisionResolver();
         _nameLocalizer = nameLocalizer;
         _resourcePathResolver = resourcePathResolver ?? new ResourcePathResolver();
@@ -340,7 +332,7 @@ public sealed class NotableDateService : INotableDateService
     public WeekPattern WorkingWeek => _workingWeek;
 
     /// <inheritdoc />
-    public bool IsWeekend(DateTime date) => date.IsWeekend(_weekendDefinition, _weekendProvider);
+    public bool IsWeekend(DateTime date) => !_workingWeek.Contains(date.DayOfWeek);
 
     /// <inheritdoc />
     public bool IsNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null)
@@ -610,8 +602,7 @@ public sealed class NotableDateService : INotableDateService
         return new RangeResolution.NotableDateRangePipeline(
             analysis,
             _resolver,
-            _weekendDefinition,
-            _weekendProvider,
+            _workingWeek,
             _adjustmentHandlers,
             _overrideRemovals);
     }
@@ -829,8 +820,7 @@ public sealed class NotableDateService : INotableDateService
             IsWeekend,
             (date, territoryCode, calendarType) =>
                 context.IsNonWorkingDay(date, territoryCode, calendarType, IsWeekend),
-            _weekendDefinition,
-            _weekendProvider,
+            _workingWeek,
             _adjustmentHandlers,
             (ruleName, year, territoryCode, calendarType) =>
                 context.ResolveByName(ruleName, year, territoryCode, calendarType));
@@ -1063,35 +1053,9 @@ public sealed class NotableDateService : INotableDateService
     }
 
     /// <summary>
-    /// Computes the canonical working-week <see cref="WeekPattern" /> implied by a legacy
-    /// <see cref="CalendarWeekendDefinition" /> plus optional <see cref="IWeekendDefinitionProvider" />.
-    /// </summary>
-    /// <param name="weekendDefinition">The configured weekend definition.</param>
-    /// <param name="weekendProvider">An optional custom weekend provider consulted when <paramref name="weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</param>
-    /// <returns>The <see cref="WeekPattern" /> whose selected days are the complement of the configured weekend.</returns>
-    /// <remarks>
-    /// <para>
-    /// The helper iterates every <see cref="DayOfWeek" /> value and delegates each query to the existing
-    /// <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
-    /// helper so the conversion remains aligned with the legacy weekend evaluation.
-    /// </para>
-    /// </remarks>
-    private static WeekPattern WorkingWeekFromWeekend(CalendarWeekendDefinition weekendDefinition, IWeekendDefinitionProvider? weekendProvider)
-    {
-        WeekPattern pattern = WeekPattern.Empty;
-        for (var i = 0; i < 7; i++)
-        {
-            DayOfWeek day = (DayOfWeek)i;
-            if (!DateTimeExtensions.IsWeekend(day, weekendDefinition, weekendProvider))
-                pattern = pattern.With(day);
-        }
-
-        return pattern;
-    }
-
-    /// <summary>
     /// Adapts a <see cref="WeekPattern" /> to the legacy <see cref="IWeekendDefinitionProvider" /> contract so that the
-    /// existing weekend-aware extension methods route through the supplied working week.
+    /// <see cref="WeekPattern" />-accepting constructors can chain through the existing
+    /// <see cref="CalendarWeekendDefinition.Custom" /> path during initialization.
     /// </summary>
     /// <remarks>
     /// <para>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -1,8 +1,8 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
-// <copyright file="NotableDateService.cs" company="PlaceholderCompany">
-//     Copyright (c) PlaceholderCompany. All rights reserved.
-// </copyright>
-// ---------------------------------------------------------------------------------------------------------------
+﻿// // ---------------------------------------------------------------------------------------------------------------
+// // <copyright file="NotableDateService.cs" company="PlaceholderCompany">
+// //     Copyright (c) PlaceholderCompany. All rights reserved.
+// // </copyright>
+// // ---------------------------------------------------------------------------------------------------------------
 
 using Bodu.Extensions;
 using Bodu.Globalization.Calendar.Plugins;
@@ -98,9 +98,6 @@ public sealed class NotableDateService : INotableDateService
     /// <summary>The optional localizer used to translate notable date names into the active culture.</summary>
     private readonly INotableDateNameLocalizer? _nameLocalizer;
 
-    /// <summary>The canonical working-week pattern; the complement of the days treated as weekend / non-working.</summary>
-    private readonly WeekPattern _workingWeek;
-
     /// <summary>The resolver used to locate embedded XML resource files.</summary>
     private readonly IResourcePathResolver _resourcePathResolver;
 
@@ -123,7 +120,7 @@ public sealed class NotableDateService : INotableDateService
     public NotableDateService()
         : this(
         [
-            (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver())
+            (new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver()))
         ],
         CalendarWeekendDefinition.SaturdaySunday)
     { }
@@ -141,7 +138,7 @@ public sealed class NotableDateService : INotableDateService
     public NotableDateService(WeekPattern workingWeek)
         : this(
         [
-            (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver())
+            (new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver()))
         ],
         workingWeek)
     { }
@@ -230,7 +227,7 @@ public sealed class NotableDateService : INotableDateService
         // and removes a runaway vector for providers that return fresh, infinite, or expensive enumerables on each invocation.
         _overrideRemovals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
 
-        _workingWeek = weekendDefinition.ToWeekPattern(weekendProvider);
+        this.WorkingWeek = weekendDefinition.ToWeekPattern(weekendProvider);
         _collisionResolver = collisionResolver ?? new DefaultNotableDateCollisionResolver();
         _nameLocalizer = nameLocalizer;
         _resourcePathResolver = resourcePathResolver ?? new ResourcePathResolver();
@@ -329,10 +326,51 @@ public sealed class NotableDateService : INotableDateService
     // --------------------------------------------------------------------------------------
 
     /// <inheritdoc />
-    public WeekPattern WorkingWeek => _workingWeek;
+    public WeekPattern WorkingWeek { get; }
+
+    /// <summary>
+    /// Gets the chronological windows that have been resolved by <see cref="ResolveNotableDatesInRange" /> since the service was
+    /// constructed or <see cref="Invalidate()" /> was last called. The list is sorted ascending by start date and contains the
+    /// minimum number of disjoint intervals describing the same coverage.
+    /// </summary>
+    /// <returns>
+    /// A snapshot of the disjoint <see cref="DateRange" /> instances representing the union of every requested window. An empty
+    /// list indicates that no range request has been served yet.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The property reflects the windows the consumer has <em>asked about</em>, not the rule-set's effective range. Adjacent or
+    /// overlapping requests are merged. The returned list is a snapshot; subsequent calls to
+    /// <see cref="ResolveNotableDatesInRange" /> may extend it.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyList<DateRange> ResolvedWindows
+    {
+        get
+        {
+            lock (_resolvedWindowsGate)
+            {
+                return [.. _resolvedWindows.Ranges];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Orders base occurrences for deterministic adjustment evaluation.
+    /// </summary>
+    /// <param name="occurrences">The base occurrences to order.</param>
+    /// <returns>The ordered occurrences.</returns>
+    private static IEnumerable<ResolvedNotableDateOccurrence> OrderForAdjustment(IEnumerable<ResolvedNotableDateOccurrence> occurrences)
+    {
+        return occurrences
+            .OrderBy(occurrence => occurrence.AnchorDate)
+            .ThenBy(occurrence => occurrence.Rule.Priority)
+            .ThenBy(occurrence => occurrence.Rule.Name, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(occurrence => occurrence.TerritoryCode, StringComparer.OrdinalIgnoreCase);
+    }
 
     /// <inheritdoc />
-    public bool IsWeekend(DateTime date) => !_workingWeek.Contains(date.DayOfWeek);
+    public bool IsWeekend(DateTime date) => !WorkingWeek.Contains(date.DayOfWeek);
 
     /// <inheritdoc />
     public bool IsNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null)
@@ -547,33 +585,6 @@ public sealed class NotableDateService : INotableDateService
     }
 
     /// <summary>
-    /// Gets the chronological windows that have been resolved by <see cref="ResolveNotableDatesInRange" /> since the service was
-    /// constructed or <see cref="Invalidate()" /> was last called. The list is sorted ascending by start date and contains the
-    /// minimum number of disjoint intervals describing the same coverage.
-    /// </summary>
-    /// <returns>
-    /// A snapshot of the disjoint <see cref="DateRange" /> instances representing the union of every requested window. An empty
-    /// list indicates that no range request has been served yet.
-    /// </returns>
-    /// <remarks>
-    /// <para>
-    /// The property reflects the windows the consumer has <em>asked about</em>, not the rule-set's effective range. Adjacent or
-    /// overlapping requests are merged. The returned list is a snapshot; subsequent calls to
-    /// <see cref="ResolveNotableDatesInRange" /> may extend it.
-    /// </para>
-    /// </remarks>
-    public IReadOnlyList<DateRange> ResolvedWindows
-    {
-        get
-        {
-            lock (_resolvedWindowsGate)
-            {
-                return [.. _resolvedWindows.Ranges];
-            }
-        }
-    }
-
-    /// <summary>
     /// Determines whether the supplied chronological range has already been resolved in its entirety by a previous call to
     /// <see cref="ResolveNotableDatesInRange" />.
     /// </summary>
@@ -602,7 +613,7 @@ public sealed class NotableDateService : INotableDateService
         return new RangeResolution.NotableDateRangePipeline(
             analysis,
             _resolver,
-            _workingWeek,
+            WorkingWeek,
             _adjustmentHandlers,
             _overrideRemovals);
     }
@@ -795,21 +806,6 @@ public sealed class NotableDateService : INotableDateService
     }
 
     /// <summary>
-    /// Orders base occurrences for deterministic adjustment evaluation.
-    /// </summary>
-    /// <param name="occurrences">The base occurrences to order.</param>
-    /// <returns>The ordered occurrences.</returns>
-    private static IEnumerable<ResolvedNotableDateOccurrence> OrderForAdjustment(IEnumerable<ResolvedNotableDateOccurrence> occurrences)
-    {
-        return occurrences
-            .OrderBy(occurrence => occurrence.AnchorDate)
-            .ThenBy(occurrence => occurrence.Rule.Priority)
-            .ThenBy(occurrence => occurrence.Rule.Name, StringComparer.OrdinalIgnoreCase)
-            .ThenBy(occurrence => occurrence.TerritoryCode, StringComparer.OrdinalIgnoreCase);
-    }
-
-
-    /// <summary>
     /// Creates an adjustment evaluator bound to the supplied generation context.
     /// </summary>
     /// <param name="context">The generation context.</param>
@@ -820,7 +816,7 @@ public sealed class NotableDateService : INotableDateService
             IsWeekend,
             (date, territoryCode, calendarType) =>
                 context.IsNonWorkingDay(date, territoryCode, calendarType, IsWeekend),
-            _workingWeek,
+            WorkingWeek,
             _adjustmentHandlers,
             (ruleName, year, territoryCode, calendarType) =>
                 context.ResolveByName(ruleName, year, territoryCode, calendarType));

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -54,7 +54,7 @@ namespace Bodu.Globalization.Calendar;
 ///         "MyApp/Calendar/Resources/custom-rules.xml",
 ///         new ResourcePathResolver()) },
 ///     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-///     algorithmRegistry: registry);
+///     options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ///
 /// // Invalidate the cache when runtime overrides change:
 /// service.Invalidate();
@@ -163,13 +163,7 @@ public sealed class NotableDateService : INotableDateService
     /// </summary>
     /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
     /// <param name="weekendDefinition">A built-in weekend pattern. The working week is the complement of the configured weekend.</param>
-    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
-    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
-    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
-    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
-    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
-    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
-    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
+    /// <param name="options">Optional service configuration. When <see langword="null" />, defaults apply.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="weekendDefinition" /> is not a defined value of the <see cref="CalendarWeekendDefinition" /> enumeration.</exception>
     /// <exception cref="ArgumentException">
@@ -179,14 +173,14 @@ public sealed class NotableDateService : INotableDateService
     /// </exception>
     /// <remarks>
     /// <para>
-    /// This is a convenience overload for callers whose working week corresponds to one of the built-in
-    /// <see cref="CalendarWeekendDefinition" /> values. Internally it delegates to the canonical
-    /// <see cref="WeekPattern" /> constructor after calling
+    /// Convenience overload for callers whose working week corresponds to one of the built-in
+    /// <see cref="CalendarWeekendDefinition" /> values. Internally delegates to the canonical
+    /// <see cref="WeekPattern" /> constructor via
     /// <see cref="Bodu.Extensions.CalendarWeekendDefinitionExtensions.ToWeekPattern(CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />.
     /// </para>
     /// <para>
     /// For non-standard weekends, do <em>not</em> use this overload with <see cref="CalendarWeekendDefinition.Custom" />.
-    /// Instead, convert your weekend source (e.g. an <see cref="IWeekendDefinitionProvider" />) to a
+    /// Convert your weekend source (for example an <see cref="IWeekendDefinitionProvider" />) to a
     /// <see cref="WeekPattern" /> and use the <see cref="WeekPattern" /> constructor:
     /// </para>
     /// <example>
@@ -207,23 +201,8 @@ public sealed class NotableDateService : INotableDateService
     public NotableDateService(
         IEnumerable<INotableDateRuleProvider> ruleProviders,
         CalendarWeekendDefinition weekendDefinition,
-        IResourcePathResolver? resourcePathResolver = null,
-        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
-        INotableDateAlgorithmRegistry? algorithmRegistry = null,
-        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
-        INotableDateCollisionResolver? collisionResolver = null,
-        INotableDateNameLocalizer? nameLocalizer = null,
-        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
-        : this(
-            ruleProviders,
-            weekendDefinition.ToWeekPattern(),
-            resourcePathResolver,
-            overrideProviders,
-            algorithmRegistry,
-            adjustmentHandlers,
-            collisionResolver,
-            nameLocalizer,
-            plugins)
+        NotableDateServiceOptions? options = null)
+        : this(ruleProviders, weekendDefinition.ToWeekPattern(), options)
     { }
 
     /// <summary>
@@ -233,13 +212,7 @@ public sealed class NotableDateService : INotableDateService
     /// </summary>
     /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
     /// <param name="workingWeek">The working-week pattern used when classifying dates.</param>
-    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
-    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
-    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
-    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
-    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
-    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
-    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />. Rule providers exposed by plugins are appended to <paramref name="ruleProviders" /> and participate in the normal flatten pipeline; named algorithms are registered onto an internal algorithm registry that falls back to <paramref name="algorithmRegistry" /> when supplied (caller-supplied registrations win on key collision).</param>
+    /// <param name="options">Optional service configuration. When <see langword="null" />, defaults apply.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
     /// <remarks>
     /// <para>
@@ -253,6 +226,14 @@ public sealed class NotableDateService : INotableDateService
     /// IWeekendDefinitionProvider provider = new MyCustomWeekend();
     /// WeekPattern workingWeek = provider.ToWeekPattern();
     /// var service = new NotableDateService(ruleProviders, workingWeek);
+    ///
+    /// // With advanced configuration:
+    /// var options = new NotableDateServiceOptions
+    /// {
+    ///     OverrideProviders = new[] { myOverrideProvider },
+    ///     AlgorithmRegistry  = myAlgorithmRegistry,
+    /// };
+    /// var configured = new NotableDateService(ruleProviders, workingWeek, options);
     /// ]]>
     /// </code>
     /// </example>
@@ -260,27 +241,23 @@ public sealed class NotableDateService : INotableDateService
     public NotableDateService(
         IEnumerable<INotableDateRuleProvider> ruleProviders,
         WeekPattern workingWeek,
-        IResourcePathResolver? resourcePathResolver = null,
-        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
-        INotableDateAlgorithmRegistry? algorithmRegistry = null,
-        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
-        INotableDateCollisionResolver? collisionResolver = null,
-        INotableDateNameLocalizer? nameLocalizer = null,
-        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
+        NotableDateServiceOptions? options = null)
     {
         if (ruleProviders is null) throw new ArgumentNullException(nameof(ruleProviders));
+
+        NotableDateServiceOptions opts = options ?? new NotableDateServiceOptions();
 
         // Fan plugin contributions into the provider list and the algorithm registry. The merge order means host-level
         // rule providers are loaded first and therefore win composite-key collisions inside the flatten pipeline, and
         // host-supplied algorithm registrations take precedence over plugin-supplied ones with the same key.
         var effectiveProviders = ruleProviders.ToList();
-        INotableDateAlgorithmRegistry? effectiveRegistry = algorithmRegistry;
+        INotableDateAlgorithmRegistry? effectiveRegistry = opts.AlgorithmRegistry;
 
-        if (plugins is not null)
+        if (opts.Plugins is not null)
         {
             var pluginAlgorithms = new List<KeyValuePair<string, INotableDateAlgorithm>>();
 
-            foreach (INotableDatePlugin plugin in plugins)
+            foreach (INotableDatePlugin plugin in opts.Plugins)
             {
                 if (plugin is Plugins.INotableDateRulePlugin rulePlugin)
                 {
@@ -305,7 +282,7 @@ public sealed class NotableDateService : INotableDateService
         _baseRules = [.. effectiveProviders
             .SelectMany(p => p.LoadRules() ?? [])
             .Where(r => r is not null)];
-        _overrideProviders = overrideProviders?.ToList() ?? (IReadOnlyList<INotableDateRuleOverrideProvider>)[];
+        _overrideProviders = opts.OverrideProviders?.ToList() ?? (IReadOnlyList<INotableDateRuleOverrideProvider>)[];
 
         // Snapshot every override provider's removals at construction so that IsRemovedByOverride iterates a materialized list
         // once per rule × year × territory rather than re-invoking GetRemovals on every check. This pins the cost of any
@@ -314,13 +291,13 @@ public sealed class NotableDateService : INotableDateService
         _overrideRemovals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
 
         _workingWeek = workingWeek;
-        _collisionResolver = collisionResolver ?? new DefaultNotableDateCollisionResolver();
-        _nameLocalizer = nameLocalizer;
-        _resourcePathResolver = resourcePathResolver ?? new ResourcePathResolver();
+        _collisionResolver = opts.CollisionResolver ?? new DefaultNotableDateCollisionResolver();
+        _nameLocalizer = opts.NameLocalizer;
+        _resourcePathResolver = opts.ResourcePathResolver ?? new ResourcePathResolver();
 
         _effectiveRules = ApplyOverrides(_baseRules, _overrideProviders);
         _resolver = new NotableDateRuleResolver(_effectiveRules, effectiveRegistry);
-        _adjustmentHandlers = adjustmentHandlers;
+        _adjustmentHandlers = opts.AdjustmentHandlers;
     }
 
     /// <summary>
@@ -329,36 +306,15 @@ public sealed class NotableDateService : INotableDateService
     /// </summary>
     /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
     /// <param name="workingDaysOfWeek">The named working-week pattern used when classifying dates.</param>
-    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
-    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
-    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
-    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
-    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
-    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
-    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
+    /// <param name="options">Optional service configuration. When <see langword="null" />, defaults apply.</param>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingDaysOfWeek" /> is not a defined member of the <see cref="WorkingDaysOfWeek" /> enumeration.</exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="workingDaysOfWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.</exception>
     public NotableDateService(
         IEnumerable<INotableDateRuleProvider> ruleProviders,
         WorkingDaysOfWeek workingDaysOfWeek,
-        IResourcePathResolver? resourcePathResolver = null,
-        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
-        INotableDateAlgorithmRegistry? algorithmRegistry = null,
-        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
-        INotableDateCollisionResolver? collisionResolver = null,
-        INotableDateNameLocalizer? nameLocalizer = null,
-        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
-        : this(
-            ruleProviders,
-            workingDaysOfWeek.ToWeekPattern(),
-            resourcePathResolver,
-            overrideProviders,
-            algorithmRegistry,
-            adjustmentHandlers,
-            collisionResolver,
-            nameLocalizer,
-            plugins)
+        NotableDateServiceOptions? options = null)
+        : this(ruleProviders, workingDaysOfWeek.ToWeekPattern(), options)
     { }
 
     // --------------------------------------------------------------------------------------

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -104,6 +104,9 @@ public sealed class NotableDateService : INotableDateService
     /// <summary>An optional custom weekend provider consulted when <see cref="_weekendDefinition" /> is <see cref="Bodu.Extensions.CalendarWeekendDefinition.Custom" />.</summary>
     private readonly IWeekendDefinitionProvider? _weekendProvider;
 
+    /// <summary>The working-week pattern derived from the configured weekend definition; surfaced via <see cref="WorkingWeek" />.</summary>
+    private readonly WeekPattern _workingWeek;
+
     /// <summary>The resolver used to locate embedded XML resource files.</summary>
     private readonly IResourcePathResolver _resourcePathResolver;
 
@@ -129,6 +132,35 @@ public sealed class NotableDateService : INotableDateService
             (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver())
         ],
         CalendarWeekendDefinition.SaturdaySunday)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using the embedded minimal default rule set and
+    /// the supplied <see cref="WeekPattern" /> working week.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern used when classifying dates.</param>
+    /// <remarks>
+    /// Equivalent to the parameterless constructor but with a caller-supplied working week. Use the full
+    /// <see cref="NotableDateService(IEnumerable{INotableDateRuleProvider}, WeekPattern, IResourcePathResolver?, IEnumerable{INotableDateRuleOverrideProvider}?, INotableDateAlgorithmRegistry?, IAdjustmentHandlerRegistry?, INotableDateCollisionResolver?, INotableDateNameLocalizer?, IEnumerable{Plugins.INotableDatePlugin}?)" />
+    /// constructor when region-specific rule providers are required.
+    /// </remarks>
+    public NotableDateService(WeekPattern workingWeek)
+        : this(
+        [
+            (INotableDateRuleProvider)new XmlResourceNotableDateRuleProvider(DefaultResourceName, new ResourcePathResolver())
+        ],
+        workingWeek)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using the embedded minimal default rule set and
+    /// the supplied named <see cref="WorkingDaysOfWeek" /> working week.
+    /// </summary>
+    /// <param name="workingDaysOfWeek">The named working-week pattern used when classifying dates.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingDaysOfWeek" /> is not a defined member of the <see cref="WorkingDaysOfWeek" /> enumeration.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="workingDaysOfWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.</exception>
+    public NotableDateService(WorkingDaysOfWeek workingDaysOfWeek)
+        : this(workingDaysOfWeek.ToWeekPattern())
     { }
 
     /// <summary>
@@ -206,6 +238,7 @@ public sealed class NotableDateService : INotableDateService
 
         _weekendDefinition = weekendDefinition;
         _weekendProvider = weekendProvider;
+        _workingWeek = WorkingWeekFromWeekend(weekendDefinition, weekendProvider);
         _collisionResolver = collisionResolver ?? new DefaultNotableDateCollisionResolver();
         _nameLocalizer = nameLocalizer;
         _resourcePathResolver = resourcePathResolver ?? new ResourcePathResolver();
@@ -215,9 +248,96 @@ public sealed class NotableDateService : INotableDateService
         _adjustmentHandlers = adjustmentHandlers;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using a caller-supplied
+    /// <see cref="WeekPattern" /> as the working week.
+    /// </summary>
+    /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
+    /// <param name="workingWeek">The working-week pattern used when classifying dates.</param>
+    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
+    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
+    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
+    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
+    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
+    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
+    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
+    /// <remarks>
+    /// <para>
+    /// Internally, the working week is bridged to the existing <see cref="CalendarWeekendDefinition" /> infrastructure
+    /// as <see cref="CalendarWeekendDefinition.Custom" /> with an <see cref="IWeekendDefinitionProvider" /> derived from
+    /// the supplied <see cref="WeekPattern" />. This preserves backwards compatibility with consumers that read the
+    /// legacy weekend definition while exposing the canonical <see cref="WorkingWeek" /> via the
+    /// <see cref="INotableDateService" /> contract.
+    /// </para>
+    /// </remarks>
+    public NotableDateService(
+        IEnumerable<INotableDateRuleProvider> ruleProviders,
+        WeekPattern workingWeek,
+        IResourcePathResolver? resourcePathResolver = null,
+        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
+        INotableDateAlgorithmRegistry? algorithmRegistry = null,
+        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
+        INotableDateCollisionResolver? collisionResolver = null,
+        INotableDateNameLocalizer? nameLocalizer = null,
+        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
+        : this(
+            ruleProviders,
+            CalendarWeekendDefinition.Custom,
+            resourcePathResolver,
+            new WeekPatternWeekendProvider(workingWeek),
+            overrideProviders,
+            algorithmRegistry,
+            adjustmentHandlers,
+            collisionResolver,
+            nameLocalizer,
+            plugins)
+    { }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateService" /> class using a named
+    /// <see cref="WorkingDaysOfWeek" /> preset as the working week.
+    /// </summary>
+    /// <param name="ruleProviders">Sources of base notable date rules. Must not be <see langword="null" />.</param>
+    /// <param name="workingDaysOfWeek">The named working-week pattern used when classifying dates.</param>
+    /// <param name="resourcePathResolver">An optional resource path resolver. Defaults to <see cref="ResourcePathResolver" /> when <see langword="null" />.</param>
+    /// <param name="overrideProviders">Optional layered override providers, applied after the base rules in registration order.</param>
+    /// <param name="algorithmRegistry">Optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.</param>
+    /// <param name="adjustmentHandlers">Optional registry of custom <see cref="IAdjustmentHandler" /> instances.</param>
+    /// <param name="collisionResolver">Optional collision resolver. Defaults to <see cref="DefaultNotableDateCollisionResolver" />.</param>
+    /// <param name="nameLocalizer">Optional localizer used to translate notable date names into the active culture.</param>
+    /// <param name="plugins">Optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="ruleProviders" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="workingDaysOfWeek" /> is not a defined member of the <see cref="WorkingDaysOfWeek" /> enumeration.</exception>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="workingDaysOfWeek" /> is <see cref="WorkingDaysOfWeek.Custom" />, which has no canonical pattern.</exception>
+    public NotableDateService(
+        IEnumerable<INotableDateRuleProvider> ruleProviders,
+        WorkingDaysOfWeek workingDaysOfWeek,
+        IResourcePathResolver? resourcePathResolver = null,
+        IEnumerable<INotableDateRuleOverrideProvider>? overrideProviders = null,
+        INotableDateAlgorithmRegistry? algorithmRegistry = null,
+        IAdjustmentHandlerRegistry? adjustmentHandlers = null,
+        INotableDateCollisionResolver? collisionResolver = null,
+        INotableDateNameLocalizer? nameLocalizer = null,
+        IEnumerable<Plugins.INotableDatePlugin>? plugins = null)
+        : this(
+            ruleProviders,
+            workingDaysOfWeek.ToWeekPattern(),
+            resourcePathResolver,
+            overrideProviders,
+            algorithmRegistry,
+            adjustmentHandlers,
+            collisionResolver,
+            nameLocalizer,
+            plugins)
+    { }
+
     // --------------------------------------------------------------------------------------
     // INotableDateService surface
     // --------------------------------------------------------------------------------------
+
+    /// <inheritdoc />
+    public WeekPattern WorkingWeek => _workingWeek;
 
     /// <inheritdoc />
     public bool IsWeekend(DateTime date) => date.IsWeekend(_weekendDefinition, _weekendProvider);
@@ -227,6 +347,12 @@ public sealed class NotableDateService : INotableDateService
     {
         if (IsWeekend(date)) return true;
 
+        return IsHolidayNonWorkingDay(date, territoryCode, calendarType);
+    }
+
+    /// <inheritdoc />
+    public bool IsHolidayNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null)
+    {
         IReadOnlyList<NotableDate> perYear = GetOrGenerateYear(date.Year);
         foreach (NotableDate notable in perYear)
         {
@@ -934,6 +1060,61 @@ public sealed class NotableDateService : INotableDateService
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Computes the canonical working-week <see cref="WeekPattern" /> implied by a legacy
+    /// <see cref="CalendarWeekendDefinition" /> plus optional <see cref="IWeekendDefinitionProvider" />.
+    /// </summary>
+    /// <param name="weekendDefinition">The configured weekend definition.</param>
+    /// <param name="weekendProvider">An optional custom weekend provider consulted when <paramref name="weekendDefinition" /> is <see cref="CalendarWeekendDefinition.Custom" />.</param>
+    /// <returns>The <see cref="WeekPattern" /> whose selected days are the complement of the configured weekend.</returns>
+    /// <remarks>
+    /// <para>
+    /// The helper iterates every <see cref="DayOfWeek" /> value and delegates each query to the existing
+    /// <see cref="DateTimeExtensions.IsWeekend(DayOfWeek, CalendarWeekendDefinition, IWeekendDefinitionProvider?)" />
+    /// helper so the conversion remains aligned with the legacy weekend evaluation.
+    /// </para>
+    /// </remarks>
+    private static WeekPattern WorkingWeekFromWeekend(CalendarWeekendDefinition weekendDefinition, IWeekendDefinitionProvider? weekendProvider)
+    {
+        WeekPattern pattern = WeekPattern.Empty;
+        for (var i = 0; i < 7; i++)
+        {
+            DayOfWeek day = (DayOfWeek)i;
+            if (!DateTimeExtensions.IsWeekend(day, weekendDefinition, weekendProvider))
+                pattern = pattern.With(day);
+        }
+
+        return pattern;
+    }
+
+    /// <summary>
+    /// Adapts a <see cref="WeekPattern" /> to the legacy <see cref="IWeekendDefinitionProvider" /> contract so that the
+    /// existing weekend-aware extension methods route through the supplied working week.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Instances of this class are passed alongside <see cref="CalendarWeekendDefinition.Custom" /> when constructing a
+    /// <see cref="NotableDateService" /> from a <see cref="WeekPattern" />.
+    /// </para>
+    /// </remarks>
+    private sealed class WeekPatternWeekendProvider : IWeekendDefinitionProvider
+    {
+        /// <summary>The working-week pattern whose unselected days are treated as weekend days.</summary>
+        private readonly WeekPattern _workingWeek;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WeekPatternWeekendProvider" /> class.
+        /// </summary>
+        /// <param name="workingWeek">The working-week pattern.</param>
+        public WeekPatternWeekendProvider(WeekPattern workingWeek)
+        {
+            _workingWeek = workingWeek;
+        }
+
+        /// <inheritdoc />
+        public bool IsWeekend(DayOfWeek dayOfWeek) => !_workingWeek.Contains(dayOfWeek);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceOptions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceOptions.cs
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceOptions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Bundles the optional configuration accepted by <see cref="NotableDateService" />, keeping the constructor surface
+/// to three parameters — rule providers, working week, and this options bag.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every property is independently optional. Where a property is <see langword="null" /> the service uses its
+/// default behaviour for that concern (for example, <see cref="CollisionResolver" /> defaults to
+/// <see cref="DefaultNotableDateCollisionResolver" />). Construct an instance with a C# 9 object initializer and
+/// pass it to the relevant <see cref="NotableDateService" /> constructor.
+/// </para>
+/// <example>
+/// <code language="csharp">
+/// <![CDATA[
+/// var options = new NotableDateServiceOptions
+/// {
+///     OverrideProviders = new[] { myOverrideProvider },
+///     AlgorithmRegistry = new NotableDateAlgorithmRegistry()
+///         .Register("easter-sunday", new GregorianEasterSundayNotableDateProvider()),
+/// };
+///
+/// var service = new NotableDateService(ruleProviders, WeekPattern.Weekdays, options);
+/// ]]>
+/// </code>
+/// </example>
+/// </remarks>
+public sealed class NotableDateServiceOptions
+{
+    /// <summary>
+    /// Gets the optional resource path resolver used to locate embedded XML rule files.
+    /// </summary>
+    /// <value>An <see cref="IResourcePathResolver" />, or <see langword="null" /> to use the default <see cref="ResourcePathResolver" />.</value>
+    /// <returns>The configured resolver, or <see langword="null" /> when defaults apply.</returns>
+    public IResourcePathResolver? ResourcePathResolver { get; init; }
+
+    /// <summary>
+    /// Gets the optional layered override providers, applied after the base rules in registration order.
+    /// </summary>
+    /// <value>A sequence of <see cref="INotableDateRuleOverrideProvider" />, or <see langword="null" /> for no overrides.</value>
+    /// <returns>The configured override providers, or <see langword="null" /> when no overrides are layered.</returns>
+    public IEnumerable<INotableDateRuleOverrideProvider>? OverrideProviders { get; init; }
+
+    /// <summary>
+    /// Gets the optional registry used to resolve <see cref="DateResolutionStrategy.Algorithm" /> rules.
+    /// </summary>
+    /// <value>An <see cref="INotableDateAlgorithmRegistry" />, or <see langword="null" /> for no algorithm dispatch.</value>
+    /// <returns>The configured registry, or <see langword="null" /> when no algorithm registrations are supplied.</returns>
+    public INotableDateAlgorithmRegistry? AlgorithmRegistry { get; init; }
+
+    /// <summary>
+    /// Gets the optional registry of custom <see cref="IAdjustmentHandler" /> instances looked up by key.
+    /// </summary>
+    /// <value>An <see cref="IAdjustmentHandlerRegistry" />, or <see langword="null" /> for no custom adjustments.</value>
+    /// <returns>The configured handler registry, or <see langword="null" /> when no custom handlers are supplied.</returns>
+    public IAdjustmentHandlerRegistry? AdjustmentHandlers { get; init; }
+
+    /// <summary>
+    /// Gets the optional collision resolver that arbitrates same-day rule collisions.
+    /// </summary>
+    /// <value>An <see cref="INotableDateCollisionResolver" />, or <see langword="null" /> to use <see cref="DefaultNotableDateCollisionResolver" />.</value>
+    /// <returns>The configured collision resolver, or <see langword="null" /> when the default is used.</returns>
+    public INotableDateCollisionResolver? CollisionResolver { get; init; }
+
+    /// <summary>
+    /// Gets the optional localizer used to translate notable date names into the active culture.
+    /// </summary>
+    /// <value>An <see cref="INotableDateNameLocalizer" />, or <see langword="null" /> for no localization.</value>
+    /// <returns>The configured localizer, or <see langword="null" /> when names are emitted verbatim.</returns>
+    public INotableDateNameLocalizer? NameLocalizer { get; init; }
+
+    /// <summary>
+    /// Gets the optional external plugins loaded via <see cref="Plugins.ExternalPluginLoader" />.
+    /// </summary>
+    /// <value>A sequence of <see cref="Plugins.INotableDatePlugin" />, or <see langword="null" /> for no plugins.</value>
+    /// <returns>The configured plugins, or <see langword="null" /> when no plugins are loaded.</returns>
+    /// <remarks>
+    /// <para>
+    /// Rule providers exposed by plugins are appended to the constructor's <c>ruleProviders</c> argument and participate
+    /// in the normal flatten pipeline. Named algorithms supplied by plugins are registered onto an internal algorithm
+    /// registry that falls back to <see cref="AlgorithmRegistry" /> when supplied (the explicit
+    /// <see cref="AlgorithmRegistry" /> wins on key collision).
+    /// </para>
+    /// </remarks>
+    public IEnumerable<Plugins.INotableDatePlugin>? Plugins { get; init; }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateExtensionsWorkingWeekOverloadsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateExtensionsWorkingWeekOverloadsTests.cs
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateExtensionsWorkingWeekOverloadsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar;
+
+[TestClass]
+public class NotableDateExtensionsWorkingWeekOverloadsTests
+{
+	private static NotableDateService BuildService() => new();
+
+	/// <summary>
+	/// Verifies that the per-call <see cref="WeekPattern" /> overload of <c>IsWorkingDay</c> treats Friday as
+	/// non-working under a Sunday-to-Thursday pattern.
+	/// </summary>
+	[TestMethod]
+	public void IsWorkingDay_WhenSundayToThursdayPatternAndFriday_ShouldReturnFalse()
+	{
+		NotableDateService service = BuildService();
+
+		// 2026-05-15 is a Friday.
+		Assert.IsFalse(new DateOnly(2026, 5, 15).IsWorkingDay(service, WeekPattern.SundayToThursday));
+		Assert.IsFalse(new DateTime(2026, 5, 15).IsWorkingDay(service, WeekPattern.SundayToThursday));
+	}
+
+	/// <summary>
+	/// Verifies that the per-call <see cref="WorkingDaysOfWeek" /> sugar overload of <c>IsWorkingDay</c> agrees with the
+	/// <see cref="WeekPattern" /> overload.
+	/// </summary>
+	[TestMethod]
+	public void IsWorkingDay_WhenSugarOverloadAndPatternOverload_ShouldAgree()
+	{
+		NotableDateService service = BuildService();
+		DateOnly friday = new DateOnly(2026, 5, 15);
+
+		Assert.AreEqual(
+			friday.IsWorkingDay(service, WeekPattern.SundayToThursday),
+			friday.IsWorkingDay(service, WorkingDaysOfWeek.SundayToThursday));
+	}
+
+	/// <summary>
+	/// Verifies that the <see cref="WeekPattern" /> overload of <c>AddWorkingDays</c> skips Fridays and Saturdays under a
+	/// Sunday-to-Thursday pattern.
+	/// </summary>
+	[TestMethod]
+	public void AddWorkingDays_WhenSundayToThursdayPattern_ShouldSkipFridayAndSaturday()
+	{
+		NotableDateService service = BuildService();
+
+		// 2026-05-14 is a Thursday. +1 working day → Sunday 2026-05-17.
+		DateOnly thursday = new DateOnly(2026, 5, 14);
+
+		DateOnly next = thursday.AddWorkingDays(service, WeekPattern.SundayToThursday, 1);
+
+		Assert.AreEqual(new DateOnly(2026, 5, 17), next);
+	}
+
+	/// <summary>
+	/// Verifies that the <see cref="WeekPattern" /> overload of <c>NextWorkingDay</c> on a Friday under Sun-Thu rolls
+	/// forward to Sunday.
+	/// </summary>
+	[TestMethod]
+	public void NextWorkingDay_WhenFridayUnderSundayToThursdayPattern_ShouldReturnSunday()
+	{
+		NotableDateService service = BuildService();
+		DateOnly friday = new DateOnly(2026, 5, 15);
+
+		DateOnly next = friday.NextWorkingDay(service, WeekPattern.SundayToThursday, 1);
+
+		Assert.AreEqual(new DateOnly(2026, 5, 17), next);
+	}
+
+	/// <summary>
+	/// Verifies that the <see cref="WeekPattern" /> overload of <c>PreviousWorkingDay</c> on a Saturday under Sun-Thu
+	/// rolls back to Thursday.
+	/// </summary>
+	[TestMethod]
+	public void PreviousWorkingDay_WhenSaturdayUnderSundayToThursdayPattern_ShouldReturnThursday()
+	{
+		NotableDateService service = BuildService();
+		DateOnly saturday = new DateOnly(2026, 5, 16);
+
+		DateOnly prev = saturday.PreviousWorkingDay(service, WeekPattern.SundayToThursday, 1);
+
+		Assert.AreEqual(new DateOnly(2026, 5, 14), prev);
+	}
+
+	/// <summary>
+	/// Verifies that the <see cref="WeekPattern" /> overload of <c>WorkingDaysBetween</c> counts only days that are both
+	/// in the working week and not flagged non-working by the holiday catalogue.
+	/// </summary>
+	[TestMethod]
+	public void WorkingDaysBetween_WhenSundayToThursdayPattern_ShouldCountFiveDaysInOneWorkingWeek()
+	{
+		NotableDateService service = BuildService();
+
+		// 2026-05-10 is a Sunday; 2026-05-16 is a Saturday. Under Sun-Thu, the working days are 10..14 = 5 days.
+		int count = new DateOnly(2026, 5, 10).WorkingDaysBetween(new DateOnly(2026, 5, 16), service, WeekPattern.SundayToThursday);
+
+		Assert.AreEqual(5, count);
+	}
+
+	/// <summary>
+	/// Verifies that the <see cref="WeekPattern" /> overload of <c>IsNonWorkingDay</c> is the complement of
+	/// <c>IsWorkingDay</c>.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenSundayToThursdayPattern_ShouldBeComplementOfIsWorkingDay()
+	{
+		NotableDateService service = BuildService();
+		DateOnly friday = new DateOnly(2026, 5, 15);
+
+		bool working = friday.IsWorkingDay(service, WeekPattern.SundayToThursday);
+		bool nonWorking = friday.IsNonWorkingDay(service, WeekPattern.SundayToThursday);
+
+		Assert.AreNotEqual(working, nonWorking);
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateFiscalExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateFiscalExtensionsTests.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateFiscalExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar;
+
+[TestClass]
+public class NotableDateFiscalExtensionsTests
+{
+	private static FiscalWeekQuarterProvider BuildProvider() =>
+		new FiscalWeekQuarterProvider(
+			month: 1,
+			dayOfWeek: DayOfWeek.Saturday,
+			isFiscalYearEnd: true,
+			useNearestDayOfWeek: true,
+			pattern: FiscalWeekPattern.FourFourFive);
+
+	private static NotableDateService BuildService() => new();
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFiscalExtensions.FirstWorkingDayOfFiscalYear" /> returns a working day on or
+	/// after the fiscal year start.
+	/// </summary>
+	[TestMethod]
+	public void FirstWorkingDayOfFiscalYear_WhenKnownYear_ShouldReturnWorkingDay()
+	{
+		FiscalWeekQuarterProvider provider = BuildProvider();
+		NotableDateService service = BuildService();
+
+		DateOnly first = NotableDateFiscalExtensions.FirstWorkingDayOfFiscalYear(2026, provider, service);
+
+		Assert.IsTrue(first.IsWorkingDay(service));
+		Assert.IsTrue(first >= DateOnlyExtensions.FirstDateOfFiscalYear(2026, provider));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFiscalExtensions.LastWorkingDayOfFiscalYear" /> returns a working day on or
+	/// before the fiscal year end.
+	/// </summary>
+	[TestMethod]
+	public void LastWorkingDayOfFiscalYear_WhenKnownYear_ShouldReturnWorkingDay()
+	{
+		FiscalWeekQuarterProvider provider = BuildProvider();
+		NotableDateService service = BuildService();
+
+		DateOnly last = NotableDateFiscalExtensions.LastWorkingDayOfFiscalYear(2026, provider, service);
+
+		Assert.IsTrue(last.IsWorkingDay(service));
+		Assert.IsTrue(last <= DateOnlyExtensions.LastDateOfFiscalYear(2026, provider));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter" /> returns a working day on
+	/// or after the fiscal quarter start.
+	/// </summary>
+	[TestMethod]
+	public void FirstWorkingDayOfFiscalQuarter_WhenKnownQuarter_ShouldReturnWorkingDay()
+	{
+		FiscalWeekQuarterProvider provider = BuildProvider();
+		NotableDateService service = BuildService();
+
+		DateOnly first = NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter(2, 2026, provider, service);
+
+		Assert.IsTrue(first.IsWorkingDay(service));
+		Assert.IsTrue(first >= provider.GetQuarterStartDate(2, 2026));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFiscalExtensions.LastWorkingDayOfFiscalQuarter" /> returns a working day on
+	/// or before the fiscal quarter end.
+	/// </summary>
+	[TestMethod]
+	public void LastWorkingDayOfFiscalQuarter_WhenKnownQuarter_ShouldReturnWorkingDay()
+	{
+		FiscalWeekQuarterProvider provider = BuildProvider();
+		NotableDateService service = BuildService();
+
+		DateOnly last = NotableDateFiscalExtensions.LastWorkingDayOfFiscalQuarter(3, 2026, provider, service);
+
+		Assert.IsTrue(last.IsWorkingDay(service));
+		Assert.IsTrue(last <= provider.GetQuarterEndDate(3, 2026));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter" /> rejects quarter values
+	/// outside the 1-4 range.
+	/// </summary>
+	[TestMethod]
+	public void FirstWorkingDayOfFiscalQuarter_WhenQuarterIsZero_ShouldThrowExactly()
+	{
+		FiscalWeekQuarterProvider provider = BuildProvider();
+		NotableDateService service = BuildService();
+
+		Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+		{
+			_ = NotableDateFiscalExtensions.FirstWorkingDayOfFiscalQuarter(0, 2026, provider, service);
+		});
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Extensions/NotableDateTimeOffsetExtensionsTests.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateTimeOffsetExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar;
+
+[TestClass]
+public class NotableDateTimeOffsetExtensionsTests
+{
+	private static readonly TimeZoneInfo Utc = TimeZoneInfo.Utc;
+
+	private static NotableDateService BuildService() => new();
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.IsWorkingDay" /> returns <see langword="false" /> on a
+	/// Saturday civil date when the service uses the default Mon-Fri working week.
+	/// </summary>
+	[TestMethod]
+	public void IsWorkingDay_WhenSaturdayInUtc_ShouldReturnFalseUnderMondayToFriday()
+	{
+		NotableDateService service = BuildService();
+		// 2026-05-16 is a Saturday.
+		DateTimeOffset saturday = new DateTimeOffset(2026, 5, 16, 9, 0, 0, TimeSpan.Zero);
+
+		Assert.IsFalse(saturday.IsWorkingDay(Utc, service));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.IsWorkingDay" /> with an explicit Sun-Thu working week
+	/// treats Friday as non-working.
+	/// </summary>
+	[TestMethod]
+	public void IsWorkingDay_WhenFridayAndSundayToThursdayPattern_ShouldReturnFalse()
+	{
+		NotableDateService service = BuildService();
+		DateTimeOffset friday = new DateTimeOffset(2026, 5, 15, 9, 0, 0, TimeSpan.Zero);
+
+		Assert.IsFalse(friday.IsWorkingDay(Utc, service, WeekPattern.SundayToThursday));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.AddWorkingDays" /> advances by one working day under the
+	/// default Mon-Fri week, returning a result anchored in the same time zone with the same time-of-day.
+	/// </summary>
+	[TestMethod]
+	public void AddWorkingDays_WhenFridayPlusOneAndDefaultWeek_ShouldReturnMonday()
+	{
+		NotableDateService service = BuildService();
+		// 2026-05-15 is a Friday.
+		DateTimeOffset friday = new DateTimeOffset(2026, 5, 15, 9, 30, 0, TimeSpan.Zero);
+
+		DateTimeOffset monday = friday.AddWorkingDays(Utc, service, 1);
+
+		Assert.AreEqual(new DateOnly(2026, 5, 18), DateOnly.FromDateTime(monday.DateTime));
+		Assert.AreEqual(new TimeSpan(9, 30, 0), monday.TimeOfDay);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.AddWorkingDays" /> with zero days returns the input.
+	/// </summary>
+	[TestMethod]
+	public void AddWorkingDays_WhenDaysIsZero_ShouldReturnInput()
+	{
+		NotableDateService service = BuildService();
+		DateTimeOffset input = new DateTimeOffset(2026, 5, 15, 9, 30, 0, TimeSpan.Zero);
+
+		DateTimeOffset result = input.AddWorkingDays(Utc, service, 0);
+
+		Assert.AreEqual(input, result);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.WorkingDaysBetween" /> counts working days inclusively
+	/// across the civil-date interval in the supplied zone.
+	/// </summary>
+	[TestMethod]
+	public void WorkingDaysBetween_WhenMondayToFridayDefaultWeek_ShouldReturnFive()
+	{
+		NotableDateService service = BuildService();
+		// Mon 2026-05-11 → Fri 2026-05-15 → 5 working days inclusive.
+		DateTimeOffset monday = new DateTimeOffset(2026, 5, 11, 0, 0, 0, TimeSpan.Zero);
+		DateTimeOffset friday = new DateTimeOffset(2026, 5, 15, 23, 59, 0, TimeSpan.Zero);
+
+		int count = monday.WorkingDaysBetween(friday, Utc, service);
+
+		Assert.AreEqual(5, count);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="NotableDateTimeOffsetExtensions.IsWorkingDay" /> throws when <paramref name="timeZone" />
+	/// is <see langword="null" />.
+	/// </summary>
+	[TestMethod]
+	public void IsWorkingDay_WhenTimeZoneIsNull_ShouldThrowExactly()
+	{
+		NotableDateService service = BuildService();
+		DateTimeOffset instant = DateTimeOffset.UtcNow;
+
+		Assert.ThrowsExactly<ArgumentNullException>(() =>
+		{
+			_ = instant.IsWorkingDay(null!, service);
+		});
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.RadicalScenarios.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.RadicalScenarios.cs
@@ -59,10 +59,13 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new INotableDateRuleOverrideProvider[]
+			options: new NotableDateServiceOptions
 			{
-				new StaticOverrideProvider(additions: new[] { addA }),
-				new StaticOverrideProvider(additions: new[] { addB }),
+				OverrideProviders = new INotableDateRuleOverrideProvider[]
+				{
+					new StaticOverrideProvider(additions: new[] { addA }),
+					new StaticOverrideProvider(additions: new[] { addB }),
+				},
 			});
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
@@ -614,9 +617,12 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRules.ToArray()) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new INotableDateRuleOverrideProvider[]
+			options: new NotableDateServiceOptions
 			{
-				new StaticOverrideProvider(additions, removals),
+				OverrideProviders = new INotableDateRuleOverrideProvider[]
+				{
+					new StaticOverrideProvider(additions, removals),
+				},
 			});
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.WeakSpots.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.WeakSpots.cs
@@ -308,7 +308,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(anchor, dependent) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: registry);
+			options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 1, 1),
@@ -336,7 +336,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: new NotableDateAlgorithmRegistry());
+			options: new NotableDateServiceOptions { AlgorithmRegistry = new NotableDateAlgorithmRegistry() });
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 1, 1),
@@ -501,7 +501,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			adjustmentHandlers: new AdjustmentHandlerRegistry());
+			options: new NotableDateServiceOptions { AdjustmentHandlers = new AdjustmentHandlerRegistry() });
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 7, 1),
@@ -545,7 +545,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			adjustmentHandlers: handlers);
+			options: new NotableDateServiceOptions { AdjustmentHandlers = handlers });
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 7, 1),
@@ -662,7 +662,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: registry);
+			options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 1, 1),

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineScenarioTests.cs
@@ -808,7 +808,7 @@ public sealed partial class NotableDateRangePipelineScenarioTests
 		return new NotableDateService(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rules) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: registry);
+			options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 	}
 
 	private static void AssertSingleEmittedOn(IReadOnlyList<NotableDate> resolved, string name, DateTime expectedDate)

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.AlgorithmicAnchors.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.AlgorithmicAnchors.cs
@@ -296,7 +296,7 @@ public sealed class NotableDateRangePipelineAlgorithmicAnchorsTests
 		return new NotableDateRangePipeline(
 			analysis,
 			resolver,
-			CalendarWeekendDefinition.SaturdaySunday);
+			WeekPattern.Weekdays);
 	}
 
 	/// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.OverrideRemoval.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.OverrideRemoval.cs
@@ -156,8 +156,7 @@ public sealed class NotableDateRangePipelineTestsOverrideRemoval
 		return new NotableDateRangePipeline(
 			analysis,
 			resolver,
-			CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null,
+			WeekPattern.Weekdays,
 			handlerRegistry: null,
 			overrideRemovals: removals);
 	}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.RangeResolution/NotableDateRangePipelineTests.cs
@@ -55,8 +55,11 @@ public sealed class NotableDateRangePipelineTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(easter, lent, palmSunday) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: new NotableDateAlgorithmRegistry()
-				.Register("easter-sunday", new GregorianEasterSundayAlgorithm()));
+			options: new NotableDateServiceOptions
+			{
+				AlgorithmRegistry = new NotableDateAlgorithmRegistry()
+					.Register("easter-sunday", new GregorianEasterSundayAlgorithm()),
+			});
 
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(
 			new DateTime(2026, 1, 1),
@@ -468,7 +471,7 @@ public sealed class NotableDateRangePipelineTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			adjustmentHandlers: handlers);
+			options: new NotableDateServiceOptions { AdjustmentHandlers = handlers });
 
 		// Anchor 1 Nov 2025 + 90 days = 30 Jan 2026. Default ±31 fringe would not admit this; the explicit declaration must.
 		IReadOnlyList<NotableDate> resolved = service.ResolveNotableDatesInRange(

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
@@ -277,8 +277,7 @@ public sealed class CoverageGapFillTests
 		var adjuster = new NotableDateAdjuster(
 			isWeekend: _ => false,
 			isNonWorkingDay: (_, _, _) => false,
-			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null);
+			workingWeek: WeekPattern.Weekdays);
 		var adjustment = new ObservanceAdjustment
 		{
 			Key = "k",
@@ -306,8 +305,7 @@ public sealed class CoverageGapFillTests
 		var adjuster = new NotableDateAdjuster(
 			isWeekend: _ => false,
 			isNonWorkingDay: (_, _, _) => false,
-			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null);
+			workingWeek: WeekPattern.Weekdays);
 		var adjustment = new ObservanceAdjustment
 		{
 			Key = "k",
@@ -333,8 +331,7 @@ public sealed class CoverageGapFillTests
 		var adjuster = new NotableDateAdjuster(
 			isWeekend: _ => false,
 			isNonWorkingDay: (_, _, _) => false,
-			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null);
+			workingWeek: WeekPattern.Weekdays);
 		var adjustment = new ObservanceAdjustment
 		{
 			Key = "k",
@@ -363,8 +360,7 @@ public sealed class CoverageGapFillTests
 		var adjuster = new NotableDateAdjuster(
 			isWeekend: _ => false,
 			isNonWorkingDay: (_, _, _) => false,
-			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null,
+			workingWeek: WeekPattern.Weekdays,
 			handlerRegistry: registry);
 		var adjustment = new ObservanceAdjustment
 		{

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CoverageGapFillTests.cs
@@ -128,7 +128,7 @@ public sealed class CoverageGapFillTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: nullAlgorithmRegistry);
+			new NotableDateServiceOptions { AlgorithmRegistry = nullAlgorithmRegistry });
 
 		IReadOnlyList<NotableDate> result = service.GetNotableDates(2025);
 
@@ -172,11 +172,14 @@ public sealed class CoverageGapFillTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(FixedRule("Real", 1, 1)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[]
+			new NotableDateServiceOptions
 			{
-				(INotableDateRuleOverrideProvider)new OverrideProvider
+				OverrideProviders = new[]
 				{
-					Removals = new[] { new RuleRemoval("Irrelevant") },
+					(INotableDateRuleOverrideProvider)new OverrideProvider
+					{
+						Removals = new[] { new RuleRemoval("Irrelevant") },
+					},
 				},
 			});
 
@@ -198,11 +201,14 @@ public sealed class CoverageGapFillTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(FixedRule("Global", 1, 1)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[]
+			new NotableDateServiceOptions
 			{
-				(INotableDateRuleOverrideProvider)new OverrideProvider
+				OverrideProviders = new[]
 				{
-					Removals = new[] { new RuleRemoval("Global", TerritoryCode: "AU") },
+					(INotableDateRuleOverrideProvider)new OverrideProvider
+					{
+						Removals = new[] { new RuleRemoval("Global", TerritoryCode: "AU") },
+					},
 				},
 			});
 
@@ -222,11 +228,14 @@ public sealed class CoverageGapFillTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(FixedRule("Picnic", 8, 4, territory: "AU-NSW")) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[]
+			new NotableDateServiceOptions
 			{
-				(INotableDateRuleOverrideProvider)new OverrideProvider
+				OverrideProviders = new[]
 				{
-					Removals = new[] { new RuleRemoval("Picnic", TerritoryCode: "MALFORMED!!") },
+					(INotableDateRuleOverrideProvider)new OverrideProvider
+					{
+						Removals = new[] { new RuleRemoval("Picnic", TerritoryCode: "MALFORMED!!") },
+					},
 				},
 			});
 
@@ -463,8 +472,11 @@ public sealed class CoverageGapFillTests
 		var service = new NotableDateService(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: hostRegistry,
-			plugins: new[] { (INotableDatePlugin)plugin });
+			options: new NotableDateServiceOptions
+			{
+				AlgorithmRegistry = hostRegistry,
+				Plugins = new[] { (INotableDatePlugin)plugin },
+			});
 
 		NotableDate resolved = service.GetNotableDates(2030).Single();
 		Assert.AreEqual(new DateTime(2030, 7, 1), resolved.Date);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAdjusterTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAdjusterTests.cs
@@ -31,8 +31,7 @@ public sealed partial class NotableDateAdjusterTests
 		return new NotableDateAdjuster(
 			isWeekend ?? (d => d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday),
 			isNonWorking ?? ((d, t, c) => false),
-			CalendarWeekendDefinition.SaturdaySunday,
-			weekendProvider: null,
+			WeekPattern.Weekdays,
 			handlerRegistry: handlers,
 			resolveByName: resolveByName);
 	}
@@ -433,8 +432,7 @@ public sealed partial class NotableDateAdjusterTests
 			_ = new NotableDateAdjuster(
 				isWeekend: null!,
 				isNonWorkingDay: (d, t, c) => false,
-				weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-				weekendProvider: null);
+				workingWeek: WeekPattern.Weekdays);
 		});
 
 		Assert.AreEqual("isWeekend", ex.ParamName);
@@ -452,8 +450,7 @@ public sealed partial class NotableDateAdjusterTests
 			_ = new NotableDateAdjuster(
 				isWeekend: _ => false,
 				isNonWorkingDay: null!,
-				weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-				weekendProvider: null);
+				workingWeek: WeekPattern.Weekdays);
 		});
 
 		Assert.AreEqual("isNonWorkingDay", ex.ParamName);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.CustomProvider.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.CustomProvider.cs
@@ -228,7 +228,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)baseProvider },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)overrideProvider });
+			new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)overrideProvider },
+			});
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -304,7 +307,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)baseProvider },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)override_ });
+			new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)override_ },
+			});
 
 		_ = service.GetNotableDates(2024, territoryCode: "AU-NSW");
 		_ = service.GetNotableDates(2025, territoryCode: "AU-NSW");
@@ -331,7 +337,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)baseProvider },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)override_ });
+			new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)override_ },
+			});
 
 		_ = service.GetNotableDates(2024);
 		_ = service.GetNotableDates(2025);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.EdgeCases.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.EdgeCases.cs
@@ -202,10 +202,11 @@ public sealed partial class NotableDateServiceTests
 		};
 
 		// Every day is a weekend, so IsNonWorkingDay always returns true; the walk never finds a working day and falls back.
+		// Convert the IWeekendDefinitionProvider into the canonical WeekPattern (empty) and use the WeekPattern ctor.
+		WeekPattern workingWeek = new AlwaysWeekendProvider().ToWeekPattern();
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
-			CalendarWeekendDefinition.Custom,
-			weekendProvider: new AlwaysWeekendProvider());
+			workingWeek);
 
 		var results = service.GetNotableDates(2025)
 			.Where(r => r.Name == "Unreachable Shift")

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.EdgeCases.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.EdgeCases.cs
@@ -260,7 +260,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(walkTrigger, probe) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: registry);
+			new NotableDateServiceOptions { AlgorithmRegistry = registry });
 
 		var walkResults = service.GetNotableDates(2025)
 			.Where(r => r.Name == "Walk Trigger")

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Exceptions.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Exceptions.cs
@@ -37,22 +37,20 @@ public sealed partial class NotableDateServiceTests
 	}
 
 	/// <summary>
-	/// Verifies that the <see cref="NotableDateService" /> constructor surfaces the
-	/// <c>weekendProvider</c> parameter name when <see cref="CalendarWeekendDefinition.Custom" />
-	/// is requested without a provider.
+	/// Verifies that the <see cref="NotableDateService" /> constructor rejects
+	/// <see cref="CalendarWeekendDefinition.Custom" /> because it has no canonical
+	/// <see cref="WeekPattern" />; callers must convert their <see cref="IWeekendDefinitionProvider" /> to a
+	/// <see cref="WeekPattern" /> and use the <see cref="WeekPattern" /> constructor instead.
 	/// </summary>
 	[TestMethod]
-	public void Constructor_WhenWeekendDefinitionIsCustomAndProviderIsNull_ShouldThrowArgumentExceptionWithParamName()
+	public void Constructor_WhenWeekendDefinitionIsCustom_ShouldThrowArgumentException()
 	{
-		var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+		Assert.ThrowsExactly<ArgumentException>(() =>
 		{
 			_ = new NotableDateService(
 				Array.Empty<INotableDateRuleProvider>(),
-				CalendarWeekendDefinition.Custom,
-				weekendProvider: null);
+				CalendarWeekendDefinition.Custom);
 		});
-
-		Assert.AreEqual("weekendProvider", ex.ParamName);
 	}
 
 	// -----------------------------------------------------------------------------------------

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.MalformedProviders.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.MalformedProviders.cs
@@ -183,7 +183,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			adjustmentHandlers: handlerRegistry);
+			new NotableDateServiceOptions { AdjustmentHandlers = handlerRegistry });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -221,7 +221,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule, sanity) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			adjustmentHandlers: handlerRegistry);
+			new NotableDateServiceOptions { AdjustmentHandlers = handlerRegistry });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -255,7 +255,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(algorithmRule, sanity) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: new NullAlgorithmRegistry());
+			new NotableDateServiceOptions { AlgorithmRegistry = new NullAlgorithmRegistry() });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -280,7 +280,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Any Holiday", 6, 15)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			collisionResolver: new NullReturningCollisionResolver());
+			new NotableDateServiceOptions { CollisionResolver = new NullReturningCollisionResolver() });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(new DateTime(2025, 6, 15));
 
@@ -306,7 +306,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			nameLocalizer: new DelegateLocaliser((_, _) => null!));
+			new NotableDateServiceOptions { NameLocalizer = new DelegateLocaliser((_, _) => null!) });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -341,7 +341,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(rule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: registry);
+			new NotableDateServiceOptions { AlgorithmRegistry = registry });
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2025);
 
@@ -388,7 +388,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			ruleProviders: Array.Empty<INotableDateRuleProvider>(),
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			plugins: new[] { (INotableDatePlugin)new NullProvidersRulePlugin() });
+			options: new NotableDateServiceOptions { Plugins = new[] { (INotableDatePlugin)new NullProvidersRulePlugin() } });
 
 		Assert.AreEqual(0, service.GetNotableDates(2025).Count);
 	}
@@ -405,7 +405,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			ruleProviders: Array.Empty<INotableDateRuleProvider>(),
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			plugins: new[] { (INotableDatePlugin)new NullAlgorithmsPlugin() });
+			options: new NotableDateServiceOptions { Plugins = new[] { (INotableDatePlugin)new NullAlgorithmsPlugin() } });
 
 		Assert.AreEqual(0, service.GetNotableDates(2025).Count);
 	}
@@ -431,7 +431,10 @@ public sealed partial class NotableDateServiceTests
 			_ = new NotableDateService(
 				new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Holiday", 1, 1)) },
 				CalendarWeekendDefinition.SaturdaySunday,
-				overrideProviders: new[] { (INotableDateRuleOverrideProvider)overrideProvider });
+				new NotableDateServiceOptions
+				{
+					OverrideProviders = new[] { (INotableDateRuleOverrideProvider)overrideProvider },
+				});
 		});
 
 		Assert.IsTrue(ex.Message.Contains("removal source unavailable", StringComparison.Ordinal));

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.MultiOverride.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.MultiOverride.cs
@@ -28,10 +28,13 @@ public partial class NotableDateServiceTests
 		NotableDateService service = new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new INotableDateRuleOverrideProvider[]
+			options: new NotableDateServiceOptions
 			{
-				new TestOverrideProvider(removals: Array.Empty<RuleRemoval>(), additions: new[] { earlyRule }),
-				new TestOverrideProvider(removals: Array.Empty<RuleRemoval>(), additions: new[] { lateRule }),
+				OverrideProviders = new INotableDateRuleOverrideProvider[]
+				{
+					new TestOverrideProvider(removals: Array.Empty<RuleRemoval>(), additions: new[] { earlyRule }),
+					new TestOverrideProvider(removals: Array.Empty<RuleRemoval>(), additions: new[] { lateRule }),
+				},
 			});
 
 		IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Overrides.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Overrides.cs
@@ -177,5 +177,8 @@ public partial class NotableDateServiceTests
 		new(
 			ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRules.ToArray()) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)new TestOverrideProvider(removals, additions) });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)new TestOverrideProvider(removals, additions) },
+			});
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.WorkingWeek.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.WorkingWeek.cs
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.WorkingWeek.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+
+namespace Bodu.Globalization.Calendar;
+
+public sealed partial class NotableDateServiceTests
+{
+	/// <summary>
+	/// Verifies that the parameterless <see cref="NotableDateService" /> constructor surfaces
+	/// <see cref="WeekPattern.Weekdays" /> as its <see cref="INotableDateService.WorkingWeek" />.
+	/// </summary>
+	[TestMethod]
+	public void WorkingWeek_WhenDefaultService_ShouldExposeWeekdays()
+	{
+		INotableDateService service = new NotableDateService();
+
+		Assert.AreEqual(WeekPattern.Weekdays, service.WorkingWeek);
+	}
+
+	/// <summary>
+	/// Verifies that a <see cref="NotableDateService" /> constructed with an explicit
+	/// <see cref="WeekPattern" /> surfaces that pattern via <see cref="INotableDateService.WorkingWeek" />.
+	/// </summary>
+	[TestMethod]
+	public void WorkingWeek_WhenConstructedWithWeekPattern_ShouldExposeSamePattern()
+	{
+		INotableDateService service = new NotableDateService(WeekPattern.SundayToThursday);
+
+		Assert.AreEqual(WeekPattern.SundayToThursday, service.WorkingWeek);
+	}
+
+	/// <summary>
+	/// Verifies that a <see cref="NotableDateService" /> constructed with a
+	/// <see cref="WorkingDaysOfWeek" /> preset surfaces the equivalent <see cref="WeekPattern" />.
+	/// </summary>
+	[TestMethod]
+	public void WorkingWeek_WhenConstructedWithWorkingDaysOfWeek_ShouldExposeMatchingPattern()
+	{
+		INotableDateService service = new NotableDateService(WorkingDaysOfWeek.SundayToThursday);
+
+		Assert.AreEqual(WeekPattern.SundayToThursday, service.WorkingWeek);
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.IsNonWorkingDay" /> treats Friday and Saturday as non-working when
+	/// the configured working week is Sunday through Thursday.
+	/// </summary>
+	[TestMethod]
+	public void IsNonWorkingDay_WhenSundayToThursdayWorkingWeek_ShouldTreatFridayAsNonWorking()
+	{
+		var service = new NotableDateService(
+			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			WorkingDaysOfWeek.SundayToThursday);
+
+		// 2026-05-15 is a Friday; 2026-05-16 is a Saturday; 2026-05-17 is a Sunday.
+		Assert.IsTrue(service.IsNonWorkingDay(new DateTime(2026, 5, 15)), "Friday must be non-working under Sun-Thu working week.");
+		Assert.IsTrue(service.IsNonWorkingDay(new DateTime(2026, 5, 16)), "Saturday must be non-working under Sun-Thu working week.");
+		Assert.IsFalse(service.IsNonWorkingDay(new DateTime(2026, 5, 17)), "Sunday must be working under Sun-Thu working week.");
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.IsWeekend" /> returns the complement of the configured
+	/// <see cref="WorkingWeek" />.
+	/// </summary>
+	[TestMethod]
+	public void IsWeekend_WhenSundayToThursdayWorkingWeek_ShouldReturnTrueForFridayAndSaturday()
+	{
+		var service = new NotableDateService(
+			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider() },
+			WorkingDaysOfWeek.SundayToThursday);
+
+		Assert.IsTrue(service.IsWeekend(new DateTime(2026, 5, 15)));
+		Assert.IsTrue(service.IsWeekend(new DateTime(2026, 5, 16)));
+		Assert.IsFalse(service.IsWeekend(new DateTime(2026, 5, 17)));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.IsHolidayNonWorkingDay" /> returns <see langword="false" /> on a
+	/// Saturday with no holiday, even though that Saturday is classified non-working by <see cref="INotableDateService.IsNonWorkingDay" />.
+	/// </summary>
+	[TestMethod]
+	public void IsHolidayNonWorkingDay_WhenSaturdayWithoutHoliday_ShouldReturnFalse()
+	{
+		var service = BuildService();
+
+		// 2025-01-04 is a Saturday with no holiday under the minimal rule set.
+		Assert.IsTrue(service.IsNonWorkingDay(new DateTime(2025, 1, 4)));
+		Assert.IsFalse(service.IsHolidayNonWorkingDay(new DateTime(2025, 1, 4)));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.IsHolidayNonWorkingDay" /> returns <see langword="true" /> when a
+	/// non-working notable date covers the supplied day, irrespective of the working week.
+	/// </summary>
+	[TestMethod]
+	public void IsHolidayNonWorkingDay_WhenHolidayOnDay_ShouldReturnTrue()
+	{
+		var service = BuildService(Fixed("Christmas Day", 12, 25, nonWorking: true));
+
+		Assert.IsTrue(service.IsHolidayNonWorkingDay(new DateTime(2025, 12, 25)));
+	}
+
+	/// <summary>
+	/// Verifies that <see cref="INotableDateService.IsHolidayNonWorkingDay" /> returns <see langword="false" /> for a
+	/// notable date that is not flagged as non-working.
+	/// </summary>
+	[TestMethod]
+	public void IsHolidayNonWorkingDay_WhenObservanceOnlyHoliday_ShouldReturnFalse()
+	{
+		var service = BuildService(Fixed("Earth Day", 4, 22, nonWorking: false));
+
+		Assert.IsFalse(service.IsHolidayNonWorkingDay(new DateTime(2025, 4, 22)));
+	}
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
@@ -257,18 +257,18 @@ public sealed partial class NotableDateServiceTests
 	}
 
 	/// <summary>
-	/// Verifies that the <see cref="NotableDateService" /> constructor rejects a
-	/// <see cref="CalendarWeekendDefinition.Custom" /> value with no weekend provider.
+	/// Verifies that the <see cref="NotableDateService" /> constructor rejects
+	/// <see cref="CalendarWeekendDefinition.Custom" /> because it has no canonical <see cref="WeekPattern" />;
+	/// callers must convert their <see cref="IWeekendDefinitionProvider" /> to a <see cref="WeekPattern" /> first.
 	/// </summary>
 	[TestMethod]
-	public void Constructor_WhenWeekendDefinitionIsCustomAndProviderIsNull_ShouldThrow()
+	public void Constructor_WhenWeekendDefinitionIsCustom_ShouldThrow()
 	{
 		Assert.ThrowsExactly<ArgumentException>(() =>
 		{
 			_ = new NotableDateService(
 				Array.Empty<INotableDateRuleProvider>(),
-				CalendarWeekendDefinition.Custom,
-				weekendProvider: null);
+				CalendarWeekendDefinition.Custom);
 		});
 	}
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
@@ -190,7 +190,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)override_ });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)override_ },
+			});
 
 		Assert.AreEqual(0, service.GetNotableDates(2025).Count);
 		Assert.AreEqual(1, service.GetNotableDates(2026).Count);
@@ -210,7 +213,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Holiday", 1, 1)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)override_ });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)override_ },
+			});
 
 		var results = service.GetNotableDates(2025);
 		Assert.IsTrue(results.Any(r => r.Name == "Royal Wedding"));
@@ -406,7 +412,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)provider });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)provider },
+			});
 
 		int count = service.GetNotableDates(year).Count(r => r.Name == "Holiday");
 
@@ -433,7 +442,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)provider });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)provider },
+			});
 
 		int count = service.GetNotableDates(2025, territoryCode: ruleTerritory).Count(r => r.Name == "Picnic");
 
@@ -455,7 +467,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)provider });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)provider },
+			});
 
 		int count = service.GetNotableDates(2025).Count(r => r.Name == "Holiday");
 
@@ -476,7 +491,10 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			overrideProviders: new[] { (INotableDateRuleOverrideProvider)provider });
+			options: new NotableDateServiceOptions
+			{
+				OverrideProviders = new[] { (INotableDateRuleOverrideProvider)provider },
+			});
 
 		IReadOnlyList<NotableDate> result = service.GetNotableDates(2025, territoryCode: "AU-NSW");
 
@@ -498,7 +516,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("New Year's Day", 1, 1)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			nameLocalizer: localiser);
+			options: new NotableDateServiceOptions { NameLocalizer = localiser });
 
 		NotableDate result = service.GetNotableDates(2025)[0];
 
@@ -516,7 +534,7 @@ public sealed partial class NotableDateServiceTests
 		var service = new NotableDateService(
 			new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("New Year's Day", 1, 1)) },
 			CalendarWeekendDefinition.SaturdaySunday,
-			nameLocalizer: localiser);
+			options: new NotableDateServiceOptions { NameLocalizer = localiser });
 
 		NotableDate first = service.GetNotableDates(2025)[0];
 		NotableDate second = service.GetNotableDates(2025)[0];

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/Plugins/NotableDateServicePluginIntegrationTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/Plugins/NotableDateServicePluginIntegrationTests.cs
@@ -35,7 +35,7 @@ public sealed class NotableDateServicePluginIntegrationTests
 		var service = new NotableDateService(
 			ruleProviders: Array.Empty<INotableDateRuleProvider>(),
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			plugins: new[] { plugin });
+			options: new NotableDateServiceOptions { Plugins = new[] { plugin } });
 
 		// Plugin1's HarnessPlugin contributes "Harness Test Day" on 15 June with territory "ZZ".
 		var results = service.GetNotableDates(2030, "ZZ");
@@ -67,7 +67,7 @@ public sealed class NotableDateServicePluginIntegrationTests
 		var service = new NotableDateService(
 			ruleProviders: new[] { new InMemoryRuleProvider(consumerRule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			plugins: new[] { plugin });
+			options: new NotableDateServiceOptions { Plugins = new[] { plugin } });
 
 		var results = service.GetNotableDates(2027);
 		var resolved = results.SingleOrDefault(r => r.Name == "Test Plugin Algorithm Day");
@@ -103,8 +103,11 @@ public sealed class NotableDateServicePluginIntegrationTests
 		var service = new NotableDateService(
 			ruleProviders: new[] { new InMemoryRuleProvider(consumerRule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: hostRegistry,
-			plugins: new[] { plugin });
+			options: new NotableDateServiceOptions
+			{
+				AlgorithmRegistry = hostRegistry,
+				Plugins = new[] { plugin },
+			});
 
 		var resolved = service.GetNotableDates(2099).SingleOrDefault(r => r.Name == "Composite Test Day");
 
@@ -146,8 +149,11 @@ public sealed class NotableDateServicePluginIntegrationTests
 		var service = new NotableDateService(
 			ruleProviders: new[] { new InMemoryRuleProvider(hostOnlyRule, pluginOnlyRule) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: hostRegistry,
-			plugins: new[] { plugin });
+			options: new NotableDateServiceOptions
+			{
+				AlgorithmRegistry = hostRegistry,
+				Plugins = new[] { plugin },
+			});
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2050);
 
@@ -181,8 +187,11 @@ public sealed class NotableDateServicePluginIntegrationTests
 		var service = new NotableDateService(
 			ruleProviders: new[] { new InMemoryRuleProvider(orphan) },
 			weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-			algorithmRegistry: hostRegistry,
-			plugins: new[] { plugin });
+			options: new NotableDateServiceOptions
+			{
+				AlgorithmRegistry = hostRegistry,
+				Plugins = new[] { plugin },
+			});
 
 		IReadOnlyList<NotableDate> results = service.GetNotableDates(2050);
 

--- a/docs/docs/calendar/getting-started.md
+++ b/docs/docs/calendar/getting-started.md
@@ -113,8 +113,8 @@ INotableDateRuleOverrideProvider  overrides = new MyCorporateOverrideProvider();
 
 INotableDateService service = new NotableDateService(
     ruleProviders:     [ auRules ],
-    weekendDefinition:  CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: [ overrides ]);
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    options: new NotableDateServiceOptions { OverrideProviders = [ overrides ] });
 ```
 
 Override providers can add new rules (via `INotableDateRuleProvider.LoadRules`), remove a base rule by name and territory (via `GetRemovals` returning `RuleRemoval` values), or layer adjustment overrides. Implement <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider> directly, or store overrides in your own XML / JSON file and load them through <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider> / <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>.

--- a/docs/guides/calendar/adjustment-rules.md
+++ b/docs/guides/calendar/adjustment-rules.md
@@ -611,9 +611,9 @@ AdjustmentHandlerRegistry handlers = new AdjustmentHandlerRegistry()
     .Register("next-working-day", new NextWorkingDayHandler());
 
 var service = new NotableDateService(
-    ruleProviders:      new[] { myProvider },
-    weekendDefinition:  CalendarWeekendDefinition.SaturdaySunday,
-    adjustmentHandlers: handlers);
+    ruleProviders:     new[] { myProvider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    options: new NotableDateServiceOptions { AdjustmentHandlers = handlers });
 ```
 
 Wire the handler to an adjustment with `HandlerKey`:

--- a/docs/guides/calendar/algorithms.md
+++ b/docs/guides/calendar/algorithms.md
@@ -92,7 +92,7 @@ var service = new NotableDateService(
                            "MyApp/Calendar/Resources/rules.xml",
                            new ResourcePathResolver()) },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 Most built-in algorithm rules are already defined in the embedded global XML rule set and do not need to be registered manually when using the default `NotableDateService()` constructor.
@@ -221,7 +221,7 @@ NotableDateRule mothersDay = new NotableDateRule
 var service = new NotableDateService(
     ruleProviders:     new[] { new InMemoryRuleProvider(new[] { mothersDay }) },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 ## Where to go next

--- a/docs/guides/calendar/building-the-service.md
+++ b/docs/guides/calendar/building-the-service.md
@@ -49,7 +49,7 @@ var provider = new XmlResourceNotableDateRuleProvider(
 var service = new NotableDateService(
     ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 ---
@@ -130,7 +130,7 @@ NotableDateRule mothersDay = new NotableDateRule
 var service = new NotableDateService(
     ruleProviders:     new[] { new InMemoryRuleProvider(mothersDay) },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 ---
@@ -153,7 +153,7 @@ AdjustmentHandlerRegistry handlers = new AdjustmentHandlerRegistry()
 var service = new NotableDateService(
     ruleProviders:      new[] { provider },
     weekendDefinition:  CalendarWeekendDefinition.SaturdaySunday,
-    adjustmentHandlers: handlers);
+    options: new NotableDateServiceOptions { AdjustmentHandlers = handlers });
 ```
 
 ### IAdjustmentHandler contract
@@ -347,7 +347,10 @@ public sealed class CompanyCalendarOverrides : INotableDateRuleOverrideProvider
 var service = new NotableDateService(
     ruleProviders:     new[] { baseProvider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: new[] { new CompanyCalendarOverrides() });
+    options: new NotableDateServiceOptions
+    {
+        OverrideProviders = new[] { new CompanyCalendarOverrides() },
+    });
 ```
 
 ### Cache invalidation after override state changes
@@ -404,8 +407,9 @@ var localizer = new ResourceFileNameLocalizer(
     new ResourceManager("MyApp.Resources.HolidayNames", typeof(Program).Assembly));
 
 var service = new NotableDateService(
-    ruleProviders:  new[] { provider },
-    nameLocalizer:  localizer);
+    ruleProviders:     new[] { provider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    options: new NotableDateServiceOptions { NameLocalizer = localizer });
 ```
 
 When a caller requests `NotableDate.DisplayName`, the service invokes
@@ -464,7 +468,7 @@ public sealed class HighestPriorityCollisionResolver : INotableDateCollisionReso
 var service = new NotableDateService(
     ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    collisionResolver: new HighestPriorityCollisionResolver());
+    options: new NotableDateServiceOptions { CollisionResolver = new HighestPriorityCollisionResolver() });
 ```
 
 ---
@@ -516,8 +520,9 @@ ExternalPluginLoader loader = new ExternalPluginLoader(trust);
 INotableDatePlugin plugin = loader.Load("/path/to/MyCalendarPlugin.dll");
 
 var service = new NotableDateService(
-    ruleProviders: new[] { baseProvider },
-    plugins:       new[] { plugin });
+    ruleProviders:     new[] { baseProvider },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    options: new NotableDateServiceOptions { Plugins = new[] { plugin } });
 ```
 
 ### Trust policies
@@ -598,13 +603,16 @@ HighestPriorityCollisionResolver collisionResolver = new HighestPriorityCollisio
 
 // 7. Assemble the service
 NotableDateService service = new NotableDateService(
-    ruleProviders:      new[] { globalRules, apacRules },
-    weekendDefinition:  CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders:  new[] { overrides },
-    algorithmRegistry:  algorithms,
-    adjustmentHandlers: adjustmentHandlers,
-    collisionResolver:  collisionResolver,
-    nameLocalizer:      localizer);
+    ruleProviders:     new[] { globalRules, apacRules },
+    weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
+    options: new NotableDateServiceOptions
+    {
+        OverrideProviders  = new[] { overrides },
+        AlgorithmRegistry  = algorithms,
+        AdjustmentHandlers = adjustmentHandlers,
+        CollisionResolver  = collisionResolver,
+        NameLocalizer      = localizer,
+    });
 
 // 8. Query
 IReadOnlyList<NotableDate> dates = service.GetNotableDates(2026, "AU");

--- a/docs/guides/calendar/data-packs.md
+++ b/docs/guides/calendar/data-packs.md
@@ -108,7 +108,7 @@ var registry = new NotableDateAlgorithmRegistry()
 var service = new NotableDateService(
     ruleProviders:     AsiaPacificCalendarData.CreateProviders(),
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 See [Date calculation algorithms](algorithms.md) for the full list of algorithm keys each pack expects.

--- a/docs/guides/calendar/notable-dates.md
+++ b/docs/guides/calendar/notable-dates.md
@@ -169,7 +169,7 @@ INotableDateRuleOverrideProvider orgOverrides = new XmlResourceNotableDateRulePr
 var service = new NotableDateService(
     ruleProviders:     [baseProvider],
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: [orgOverrides]);
+    options: new NotableDateServiceOptions { OverrideProviders = [orgOverrides] });
 ```
 
 ## Pattern 7 — cache invalidation
@@ -264,7 +264,10 @@ var provider = new XmlResourceNotableDateRuleProvider(
 var service = new NotableDateService(
     ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: new[] { new CompanyCalendarOverrides() });
+    options: new NotableDateServiceOptions
+    {
+        OverrideProviders = new[] { new CompanyCalendarOverrides() },
+    });
 ```
 
 ## Pattern 8 — cache invalidation

--- a/docs/guides/calendar/rule-authoring.md
+++ b/docs/guides/calendar/rule-authoring.md
@@ -150,7 +150,7 @@ var provider = new InMemoryRuleProvider(easterSunday, goodFriday, easterMonday, 
 var service = new NotableDateService(
     ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    algorithmRegistry: registry);
+    options: new NotableDateServiceOptions { AlgorithmRegistry = registry });
 ```
 
 ---
@@ -448,7 +448,10 @@ Register override providers via the `overrideProviders` constructor parameter:
 var service = new NotableDateService(
     ruleProviders:     new[] { provider },
     weekendDefinition: CalendarWeekendDefinition.SaturdaySunday,
-    overrideProviders: new[] { new CompanyCalendarOverrides() });
+    options: new NotableDateServiceOptions
+    {
+        OverrideProviders = new[] { new CompanyCalendarOverrides() },
+    });
 ```
 
 After changing override state, call `Invalidate()` to clear the resolved cache:

--- a/docs/images/diagrams/calendar-rule-authoring.svg
+++ b/docs/images/diagrams/calendar-rule-authoring.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 260" role="img" aria-labelledby="ra-t ra-d">
   <title id="ra-t">Rule authoring — three provider approaches</title>
-  <desc id="ra-d">Three approaches supply rules to NotableDateService. In-Code Objects implement INotableDateRuleProvider directly. XML Resource Files use XmlResourceNotableDateRuleProvider with an embedded .xml file. Satellite Assemblies use the same provider but pass a separate assembly. All three are passed via the ruleProviders constructor parameter. Optional runtime overrides implement INotableDateRuleOverrideProvider and are passed via overrideProviders.</desc>
+  <desc id="ra-d">Three approaches supply rules to NotableDateService. In-Code Objects implement INotableDateRuleProvider directly. XML Resource Files use XmlResourceNotableDateRuleProvider with an embedded .xml file. Satellite Assemblies use the same provider but pass a separate assembly. All three are passed via the ruleProviders constructor parameter. Optional runtime overrides implement INotableDateRuleOverrideProvider and are passed via NotableDateServiceOptions.OverrideProviders.</desc>
 
   <defs>
     <style>
@@ -91,9 +91,9 @@
       <rect class="svc" width="288" height="100" rx="5"/>
       <text class="lbl" x="144" y="18">NotableDateService</text>
       <text class="sub" x="144" y="36">ruleProviders: INotableDateRuleProvider[]</text>
-      <text class="sub" x="144" y="51">weekendDefinition: CalendarWeekendDefinition</text>
-      <text class="sub" x="144" y="66">overrideProviders: INotableDateRuleOverrideProvider[]</text>
-      <text class="mut" x="144" y="82">algorithmRegistry · adjustmentHandlers · …</text>
+      <text class="sub" x="144" y="51">workingWeek: WeekPattern (or CalendarWeekendDefinition)</text>
+      <text class="sub" x="144" y="66">options: NotableDateServiceOptions { OverrideProviders, … }</text>
+      <text class="mut" x="144" y="82">AlgorithmRegistry · AdjustmentHandlers · Plugins · …</text>
       <text class="mut" x="144" y="95">per-year cache (ConcurrentDictionary)</text>
     </g>
 


### PR DESCRIPTION
Introduces a named working-week sugar (WorkingDaysOfWeek) alongside the
existing WeekPattern bitmask in Bodu.Core, with bidirectional conversion
extensions and complementary IsInWorkingWeek / IsRestDay predicates on
DateOnly and DateTime. Lays the foundation for working-week-aware
NotableDateService configuration in the next commit.

https://claude.ai/code/session_01XdBi6t1yKbHoHeLdeVJ5fu