### PR TITLE
Route public Bodu.Core parameter validation through ThrowHelper

### DIFF
--- a/Bodu.Core/src/Extensions/ArrayExtensions.ToMatrix.cs
+++ b/Bodu.Core/src/Extensions/ArrayExtensions.ToMatrix.cs
@@ -35,7 +35,7 @@ public static partial class ArrayExtensions
     public static T[,] ToMatrix<T>(this T[][] source, bool transpose)
     {
         ThrowHelper.ThrowIfNull(source);
-        if (source.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(source));
+        ThrowHelper.ThrowIfArrayLengthIsZero(source);
 
         T[] firstRow = source[0] ?? throw new ArgumentNullException(nameof(source));
         int rows = source.Length;

--- a/Bodu.Core/src/Extensions/BufferConverter.CopyTo.cs
+++ b/Bodu.Core/src/Extensions/BufferConverter.CopyTo.cs
@@ -127,8 +127,7 @@ public static partial class BufferConverter
     public static void CopyTo<T>(this T value, byte[] targetArray, int index)
         where T : unmanaged
     {
-        if (targetArray == null)
-            throw new ArgumentNullException(nameof(targetArray));
+        ThrowHelper.ThrowIfNull(targetArray);
 
 #if NET5_0_OR_GREATER
         var elementSize = System.Runtime.CompilerServices.Unsafe.SizeOf<T>();

--- a/Bodu.Core/src/Extensions/ComparableHelper.Max.cs
+++ b/Bodu.Core/src/Extensions/ComparableHelper.Max.cs
@@ -41,8 +41,10 @@ public static partial class ComparableHelper
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>Use this overload to apply custom comparison logic, such as ordinal or case-insensitive string comparisons.</remarks>
-    public static T? Max<T>(T? first, T? second, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : (first is null ? second : (second is null ? first : (comparer.Compare(first, second) >= 0 ? first : second)));
+    public static T? Max<T>(T? first, T? second, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return first is null ? second : (second is null ? first : (comparer.Compare(first, second) >= 0 ? first : second));
+    }
 }

--- a/Bodu.Core/src/Extensions/ComparableHelper.Min.cs
+++ b/Bodu.Core/src/Extensions/ComparableHelper.Min.cs
@@ -41,7 +41,10 @@ public static partial class ComparableHelper
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>Use this overload to apply custom comparison logic, such as culture-specific string comparisons.</remarks>
-    public static T? Min<T>(T? first, T? second, IComparer<T> comparer) => comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : (first is null ? second : (second is null ? first : (comparer.Compare(first, second) <= 0 ? first : second)));
+    public static T? Min<T>(T? first, T? second, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return first is null ? second : (second is null ? first : (comparer.Compare(first, second) <= 0 ? first : second));
+    }
 }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.ToIsoString.cs
@@ -63,13 +63,18 @@ public static partial class DateTimeExtensions
     /// </list>
     /// </returns>
     /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="kind"/> is not a defined value of the <see cref="DateTimeKind"/> enumeration.</exception>
-    public static string ToIsoString(this DateTime dateTime, DateTimeKind kind) => kind switch
+    public static string ToIsoString(this DateTime dateTime, DateTimeKind kind)
     {
-        DateTimeKind.Utc => dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
-        DateTimeKind.Local => dateTime.ToLocalTime().ToString("o", CultureInfo.InvariantCulture),
-        DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified).ToString("o", CultureInfo.InvariantCulture),
-        _ => throw new ArgumentOutOfRangeException(nameof(kind), "Invalid DateTimeKind value.")
-    };
+        ThrowHelper.ThrowIfEnumValueIsUndefined(kind);
+
+        return kind switch
+        {
+            DateTimeKind.Utc => dateTime.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ", CultureInfo.InvariantCulture),
+            DateTimeKind.Local => dateTime.ToLocalTime().ToString("o", CultureInfo.InvariantCulture),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified).ToString("o", CultureInfo.InvariantCulture),
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), "Invalid DateTimeKind value.")
+        };
+    }
 
     /// <summary>
     /// Returns a string representation of the specified <paramref name="dateTime"/> using a custom format and an optional culture.
@@ -78,10 +83,11 @@ public static partial class DateTimeExtensions
     /// <param name="format">A valid date-time format string (e.g. <c>"yyyy-MM-ddTHH:mm:ss"</c>). Must not be <see langword="null"/> or whitespace.</param>
     /// <param name="culture">An optional <see cref="CultureInfo"/> used for culture-specific formatting. If <see langword="null"/>, <see cref="CultureInfo.InvariantCulture"/> is used.</param>
     /// <returns>A formatted <see cref="string"/> representation of <paramref name="dateTime"/> using the supplied format and culture.</returns>
-    /// <exception cref="ArgumentNullException">Thrown if <paramref name="format"/> is <see langword="null"/>, empty, or whitespace.</exception>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="format"/> is <see langword="null"/>.</exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="format"/> is empty or whitespace.</exception>
     public static string ToIsoString(this DateTime dateTime, string format, CultureInfo? culture = null)
     {
-        if (string.IsNullOrWhiteSpace(format)) throw new ArgumentNullException(nameof(format), "Format string must be specified.");
+        ThrowHelper.ThrowIfNullOrWhiteSpace(format);
 
         return dateTime.ToString(format, culture ?? CultureInfo.InvariantCulture);
     }

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.Truncate.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.Truncate.cs
@@ -31,9 +31,11 @@ public static partial class DateTimeExtensions
     /// <item><term><see cref="DateTimeResolution.Tick"/></term><description><c>2024-04-18T14:37:56.7891234</c> (unchanged)</description></item>
     /// </list>
     /// </remarks>
-    /// <exception cref="ArgumentException">Thrown if <paramref name="resolution"/> is not a defined value of the <see cref="DateTimeResolution"/> enumeration.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="resolution"/> is not a defined value of the <see cref="DateTimeResolution"/> enumeration.</exception>
     public static DateTime Truncate(this DateTime dateTime, DateTimeResolution resolution)
     {
+        ThrowHelper.ThrowIfEnumValueIsUndefined(resolution);
+
         switch (resolution)
         {
             case DateTimeResolution.Year:
@@ -61,9 +63,9 @@ public static partial class DateTimeExtensions
                 return dateTime;
 
             default:
-                throw new ArgumentException(
-                    string.Format(ResourceStrings.Arg_OutOfRangeException_EnumValue, resolution, nameof(DateTimeResolution)),
-                    nameof(resolution));
+                throw new ArgumentOutOfRangeException(
+                    nameof(resolution),
+                    string.Format(ResourceStrings.Arg_OutOfRangeException_EnumValue, resolution, nameof(DateTimeResolution)));
         }
     }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.AtLeast.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.AtLeast.cs
@@ -41,8 +41,10 @@ public static partial class IComparableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>This is a one-sided form of <see cref="Clamp{T}(T, T?, T?, IComparer{T})"/> for cases where only a floor is required.</remarks>
-    public static T AtLeast<T>(this T value, T min, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : comparer.Compare(value, min) >= 0 ? value : min;
+    public static T AtLeast<T>(this T value, T min, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return comparer.Compare(value, min) >= 0 ? value : min;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.AtMost.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.AtMost.cs
@@ -41,8 +41,10 @@ public static partial class IComparableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>This is a one-sided form of <see cref="Clamp{T}(T, T?, T?, IComparer{T})"/> for cases where only a ceiling is required.</remarks>
-    public static T AtMost<T>(this T value, T max, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : comparer.Compare(value, max) <= 0 ? value : max;
+    public static T AtMost<T>(this T value, T max, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return comparer.Compare(value, max) <= 0 ? value : max;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Clamp.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Clamp.cs
@@ -49,10 +49,12 @@ public static partial class IComparableExtensions
     /// Use this overload to apply custom comparison logic when clamping values.
     /// </remarks>
     public static T Clamp<T>(this T value, T? min, T? max, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : (min is not null && comparer.Compare(value, min.Value) < 0) ? min.Value
-                : (max is not null && comparer.Compare(value, max.Value) > 0) ? max.Value
-                : value;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return (min is not null && comparer.Compare(value, min.Value) < 0) ? min.Value
+            : (max is not null && comparer.Compare(value, max.Value) > 0) ? max.Value
+            : value;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsBetween.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsBetween.cs
@@ -51,11 +51,13 @@ public static partial class IComparableExtensions
     /// <para>The order of <paramref name="value1"/> and <paramref name="value2"/> does not matter.</para>
     /// </remarks>
     public static bool IsBetween<T>(this T value, T? value1, T? value2, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : value1 is null || value2 is null ? false
-                : comparer.Compare(value1.Value, value2.Value) > 0
-                    ? comparer.Compare(value, value2.Value) >= 0 && comparer.Compare(value, value1.Value) <= 0
-                    : comparer.Compare(value, value1.Value) >= 0 && comparer.Compare(value, value2.Value) <= 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return value1 is null || value2 is null ? false
+            : comparer.Compare(value1.Value, value2.Value) > 0
+                ? comparer.Compare(value, value2.Value) >= 0 && comparer.Compare(value, value1.Value) <= 0
+                : comparer.Compare(value, value1.Value) >= 0 && comparer.Compare(value, value2.Value) <= 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsEqualTo.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsEqualTo.cs
@@ -29,8 +29,10 @@ public static partial class IComparableExtensions
     /// <see cref="string.Equals(string)"/> does not. For the default equality semantics of <typeparamref name="T"/>
     /// use <see cref="object.Equals(object)"/> or <see cref="IEquatable{T}.Equals(T)"/> directly.
     /// </remarks>
-    public static bool IsEqualTo<T>(this T value, T other, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : comparer.Compare(value, other) == 0;
+    public static bool IsEqualTo<T>(this T value, T other, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return comparer.Compare(value, other) == 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThan.cs
@@ -39,8 +39,10 @@ public static partial class IComparableExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
     public static bool IsGreaterThan<T>(this T value, T? other, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : other is not null && comparer.Compare(value, other.Value) > 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return other is not null && comparer.Compare(value, other.Value) > 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsGreaterThanOrEqual.cs
@@ -39,8 +39,10 @@ public static partial class IComparableExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
     public static bool IsGreaterThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : other is not null && comparer.Compare(value, other.Value) >= 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return other is not null && comparer.Compare(value, other.Value) >= 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThan.cs
@@ -39,8 +39,10 @@ public static partial class IComparableExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
     public static bool IsLessThan<T>(this T value, T? other, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : other is not null && comparer.Compare(value, other.Value) < 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return other is not null && comparer.Compare(value, other.Value) < 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsLessThanOrEqual.cs
@@ -39,8 +39,10 @@ public static partial class IComparableExtensions
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>If <paramref name="other"/> is <see langword="null"/>, the method returns <see langword="false"/>.</remarks>
     public static bool IsLessThanOrEqual<T>(this T value, T? other, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : other is not null && comparer.Compare(value, other.Value) <= 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return other is not null && comparer.Compare(value, other.Value) <= 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.IsOutside.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.IsOutside.cs
@@ -62,11 +62,13 @@ public static partial class IComparableExtensions
     /// <para>The order of <paramref name="value1"/> and <paramref name="value2"/> does not matter.</para>
     /// </remarks>
     public static bool IsOutside<T>(this T value, T? value1, T? value2, IComparer<T> comparer)
-        where T : struct =>
-            comparer is null
-                ? throw new ArgumentNullException(nameof(comparer))
-                : value1 is null || value2 is null ? false
-                : comparer.Compare(value1.Value, value2.Value) > 0
-                    ? comparer.Compare(value, value2.Value) < 0 || comparer.Compare(value, value1.Value) > 0
-                    : comparer.Compare(value, value1.Value) < 0 || comparer.Compare(value, value2.Value) > 0;
+        where T : struct
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return value1 is null || value2 is null ? false
+            : comparer.Compare(value1.Value, value2.Value) > 0
+                ? comparer.Compare(value, value2.Value) < 0 || comparer.Compare(value, value1.Value) > 0
+                : comparer.Compare(value, value1.Value) < 0 || comparer.Compare(value, value2.Value) > 0;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Max.cs
@@ -38,8 +38,10 @@ public static partial class IComparableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
-    public static T Max<T>(this T value, T other, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : comparer.Compare(value, other) >= 0 ? value : other;
+    public static T Max<T>(this T value, T other, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return comparer.Compare(value, other) >= 0 ? value : other;
+    }
 }

--- a/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.Min.cs
@@ -38,8 +38,10 @@ public static partial class IComparableExtensions
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="comparer"/> is <see langword="null"/>.</exception>
     /// <remarks>When the two values compare equal under <paramref name="comparer"/>, <paramref name="value"/> is returned.</remarks>
-    public static T Min<T>(this T value, T other, IComparer<T> comparer) =>
-        comparer is null
-            ? throw new ArgumentNullException(nameof(comparer))
-            : comparer.Compare(value, other) <= 0 ? value : other;
+    public static T Min<T>(this T value, T other, IComparer<T> comparer)
+    {
+        ThrowHelper.ThrowIfNull(comparer);
+
+        return comparer.Compare(value, other) <= 0 ? value : other;
+    }
 }

--- a/Bodu.Core/src/Extensions/NumericExtensions.GreatestCommonDivisor.cs
+++ b/Bodu.Core/src/Extensions/NumericExtensions.GreatestCommonDivisor.cs
@@ -106,13 +106,13 @@ public static partial class NumericExtensions
     public static short GreatestCommonDivisor(this short[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)
         {
             short v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Gcd(acc, (ulong)v);
         }
 
@@ -133,13 +133,13 @@ public static partial class NumericExtensions
     public static int GreatestCommonDivisor(this int[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)
         {
             int v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Gcd(acc, (ulong)v);
         }
 
@@ -160,13 +160,13 @@ public static partial class NumericExtensions
     public static long GreatestCommonDivisor(this long[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)
         {
             long v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Gcd(acc, (ulong)v);
         }
 
@@ -184,7 +184,7 @@ public static partial class NumericExtensions
     public static ushort GreatestCommonDivisor(this ushort[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)
@@ -203,7 +203,7 @@ public static partial class NumericExtensions
     public static uint GreatestCommonDivisor(this uint[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)
@@ -223,7 +223,7 @@ public static partial class NumericExtensions
     public static ulong GreatestCommonDivisor(this ulong[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = 0;
         for (int i = 0; i < values.Length; i++)

--- a/Bodu.Core/src/Extensions/NumericExtensions.LeastCommonMultiple.cs
+++ b/Bodu.Core/src/Extensions/NumericExtensions.LeastCommonMultiple.cs
@@ -137,14 +137,14 @@ public static partial class NumericExtensions
     public static short LeastCommonMultiple(this short[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
-        if (values[0] < 0) throw new ArgumentOutOfRangeException(nameof(values));
+        ThrowHelper.ThrowIfNegative(values[0], nameof(values));
         ulong acc = (ulong)values[0];
         for (int i = 1; i < values.Length; i++)
         {
             short v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Lcm(acc, (ulong)v);
         }
 
@@ -168,14 +168,14 @@ public static partial class NumericExtensions
     public static int LeastCommonMultiple(this int[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
-        if (values[0] < 0) throw new ArgumentOutOfRangeException(nameof(values));
+        ThrowHelper.ThrowIfNegative(values[0], nameof(values));
         ulong acc = (ulong)values[0];
         for (int i = 1; i < values.Length; i++)
         {
             int v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Lcm(acc, (ulong)v);
         }
 
@@ -199,14 +199,14 @@ public static partial class NumericExtensions
     public static long LeastCommonMultiple(this long[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
-        if (values[0] < 0) throw new ArgumentOutOfRangeException(nameof(values));
+        ThrowHelper.ThrowIfNegative(values[0], nameof(values));
         ulong acc = (ulong)values[0];
         for (int i = 1; i < values.Length; i++)
         {
             long v = values[i];
-            if (v < 0) throw new ArgumentOutOfRangeException(nameof(values));
+            ThrowHelper.ThrowIfNegative(v, nameof(values));
             acc = Lcm(acc, (ulong)v);
         }
 
@@ -227,7 +227,7 @@ public static partial class NumericExtensions
     public static ushort LeastCommonMultiple(this ushort[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = values[0];
         for (int i = 1; i < values.Length; i++)
@@ -249,7 +249,7 @@ public static partial class NumericExtensions
     public static uint LeastCommonMultiple(this uint[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = values[0];
         for (int i = 1; i < values.Length; i++)
@@ -272,7 +272,7 @@ public static partial class NumericExtensions
     public static ulong LeastCommonMultiple(this ulong[] values)
     {
         ThrowHelper.ThrowIfNull(values);
-        if (values.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_CollectionIsEmpty, nameof(values));
+        ThrowHelper.ThrowIfArrayLengthIsZero(values);
 
         ulong acc = values[0];
         for (int i = 1; i < values.Length; i++)

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.ToIsoString.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.ToIsoString.cs
@@ -83,12 +83,12 @@ public partial class DateTimeExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="DateTimeExtensions.ToIsoString" />, with EmptyFormat, throws <see cref="ArgumentNullException" />.
+    /// Verifies that <see cref="DateTimeExtensions.ToIsoString" />, with EmptyFormat, throws <see cref="ArgumentException" />.
     /// </summary>
     [TestMethod]
     public void ToIsoString_WithEmptyFormat_ShouldThrowExactly()
     {
         var input = new DateTime(2024, 4, 20);
-        Assert.ThrowsExactly<ArgumentNullException>(() => input.ToIsoString(""));
+        Assert.ThrowsExactly<ArgumentException>(() => input.ToIsoString(""));
     }
 }

--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.Truncate.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.Truncate.cs
@@ -40,14 +40,14 @@ public partial class DateTimeExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="DateTimeExtensions.Truncate" />, when ResolutionIsInvalid, throws <see cref="ArgumentException" />.
+    /// Verifies that <see cref="DateTimeExtensions.Truncate" />, when ResolutionIsInvalid, throws <see cref="ArgumentOutOfRangeException" />.
     /// </summary>
     [TestMethod]
     public void Truncate_WhenResolutionIsInvalid_ShouldThrowExactly()
     {
         DateTimeResolution invalid = (DateTimeResolution)999;
 
-        Assert.ThrowsExactly<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
             _ = Sample.Truncate(invalid);
         });


### PR DESCRIPTION
Replaces inline argument-validation throws across the Bodu.Core public API
surface with the existing ThrowHelper.ThrowIf... helpers, per the convention
in CLAUDE.md. Affects IComparableExtensions and ComparableHelper comparer
null-coalescing ternaries, NumericExtensions GCD/LCM array overloads,
ArrayExtensions.ToMatrix, BufferConverter.CopyTo, and adds upstream enum
guards on DateTimeExtensions.ToIsoString and Truncate.

Two minor BCL-alignment behaviour changes:
- ToIsoString(format) now throws ArgumentException for whitespace (was
  ArgumentNullException), and the XML doc is updated accordingly.
- Truncate(resolution) now throws ArgumentOutOfRangeException for an
  undefined enum (was ArgumentException). Associated tests updated to
  assert the new exception types.