### PR TITLE
Add Bodu.Text.Formats DocFX pages, guides, and diagrams

### DIFF
--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -20,16 +20,20 @@ Each top-level namespace has a landing page that introduces its purpose, lists i
 - **[Bodu.Globalization.Calendar — notable-date resolution](../apidoc/Bodu.Globalization.Calendar.md)**
   Rule-driven notable-date resolution with fixed, day-of-week-in-month, offset, and algorithm strategies — including Gregorian and Orthodox Easter, Hindu Lunar dates, Losar, Vesak, Asalha Puja, and Qingming — driven from pluggable XML or JSON rule sources, an observance-adjustment pipeline, and a trust-policy-driven plugin host.
 
+- **[Bodu.Text.Formats — self-framing binary serialization formats](../docs/formats/index.md)**
+  Strongly-typed value model and a span- and stream-friendly codec for self-framing binary formats. Ships **Bencode** (the BitTorrent BEP 3 grammar) as the first format — `Bencode.Encode` / `Decode` / `TryEncode` / `TryDecode` / `GetEncodedLength` over `ReadOnlySpan<byte>`, `byte[]`, and `Stream`, an immutable `BencodedValue` tree (`Integer`, `String`, `List`, `Dictionary`), and full canonicality enforcement on both sides of the pipeline.
+
 ## Guides
 
 - **[Bodu.Core guides](../guides/core/index.md)** — circular buffer, deque, evicting dictionary, week pattern.
 - **[Bodu.IO.Hashing guides](../guides/io-hashing/index.md)** — fingerprints (FNV, CityHash, MurmurHash3, Pearson, classic string hashes), checksums (CRC, Fletcher, Adler), and check digits.
 - **[Bodu.Security.Cryptography guides](../guides/cryptography/index.md)** — encryption basics, cipher block modes, AEAD, padding, composing primitives, keyed and cryptographic hashing, the ASCON family.
 - **[Bodu.Globalization.Calendar guides](../guides/calendar/index.md)** — `NotableDateService`, built-in algorithms, rule authoring, data packs.
+- **[Bodu.Text.Formats guides](../guides/formats/index.md)** — using the `Bencode` codec, the `BencodedValue` tree model, and stream support.
 
 ## Project documentation
 
 - [Introduction](../docs/introduction.md) — project overview, design principles, and the per-library map.
 - [Getting started](../docs/getting-started.md) — prerequisites, install commands, and one-minute samples per library.
 - [Algorithm families](../docs/algorithm-families.md) — cross-library taxonomy of fingerprints, checksums, check digits, cryptographic hashes, keyed hashes, and the three symmetric-cipher subtypes (standard, tweakable, AEAD).
-- Per-library introductions: [Bodu.Core](../docs/core/index.md) · [Bodu.IO.Hashing](../docs/io-hashing/index.md) · [Bodu.Security.Cryptography](../docs/cryptography/index.md) · [Bodu.Globalization.Calendar](../docs/calendar/index.md).
+- Per-library introductions: [Bodu.Core](../docs/core/index.md) · [Bodu.IO.Hashing](../docs/io-hashing/index.md) · [Bodu.Security.Cryptography](../docs/cryptography/index.md) · [Bodu.Globalization.Calendar](../docs/calendar/index.md) · [Bodu.Text.Formats](../docs/formats/index.md).

--- a/docs/docs/formats/concepts.md
+++ b/docs/docs/formats/concepts.md
@@ -1,0 +1,168 @@
+---
+title: Bodu.Text.Formats — Core concepts
+---
+
+# Bodu.Text.Formats — Core concepts
+
+This page is the vocabulary the rest of the documentation assumes. Read it once before the [getting-started samples](getting-started.md) or the [guides](../../guides/formats/index.md), and refer back to it whenever a term feels imprecise.
+
+For the high-level shape of the library and the encode/decode pipeline diagram, start with the [introduction](index.md).
+
+## Format and codec
+
+A **format** is the wire grammar — for now, **Bencode** as specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html). The grammar defines four kinds of value (integer, byte string, list, dictionary), the framing tokens that delimit each kind, and the invariants every encoder must preserve.
+
+A **codec** is the static façade that exposes encode and decode operations for a format. For Bencode it is <xref:Bodu.Text.Formats.Bencode> — a single `static partial class` with the recursive writer, the forward-only parser, and the span / array / stream overloads layered around them.
+
+## Value and document
+
+A **value** is one node in the decoded tree — a `BencodedInteger`, `BencodedString`, `BencodedList`, or `BencodedDictionary`. Every value derives from <xref:Bodu.Text.Formats.BencodedValue> and exposes a `Kind` property that returns the matching <xref:Bodu.Text.Formats.BencodedValueKind> member.
+
+A **document** is exactly one top-level value (in practice, almost always a `BencodedDictionary`). `Bencode.Decode(source)` returns that root value; the parser also checks that the entire input was consumed, so a payload with trailing bytes after a complete value is rejected.
+
+## Value kinds
+
+![Bencode value grammar — four kinds, four framings](../../images/diagrams/formats-bencode-grammar.svg)
+
+Bencode defines exactly four value kinds. Each kind has its own framing and its own invariants.
+
+### Integer (`BencodedInteger`)
+
+A signed 64-bit integer framed between `i` and `e` — `i-1024e`, `i0e`, `i9223372036854775807e`. BEP 3 invariants enforced by the parser:
+
+- No leading zeros — `i01e` is rejected.
+- No negative zero — `i-0e` is rejected.
+- Must fit in `Int64` — values that overflow are rejected with *outside the supported Int64 range*.
+- Must be terminated by `e` before end of input.
+
+The encoder always emits the shortest canonical form.
+
+### Byte string (`BencodedString`)
+
+A length-prefixed raw byte payload — `5:hello`, `0:`, `20:` + 20 bytes of binary. The length is an ASCII decimal integer, the separator is `:`, and the payload is exactly that many bytes of opaque binary.
+
+BEP 3 invariants enforced by the parser:
+
+- The length must be a non-negative integer with no leading zeros.
+- The colon separator must follow the length.
+- The declared payload must fit in the remaining input.
+- The length itself must fit in `Int32`.
+
+A bencoded string is **not** required to be text. Consumers that know a field is UTF-8 can call <xref:Bodu.Text.Formats.BencodedString.GetUtf8String> to project it, or build one from a `string` via <xref:Bodu.Text.Formats.BencodedString.FromUtf8>. For arbitrary binary, hold onto the raw `Bytes` directly.
+
+### List (`BencodedList`)
+
+An ordered sequence of values, framed between `l` and `e` — `l4:spami42ee` is a two-element list containing the string `spam` and the integer `42`. Elements may be any kind, and lists may nest to any depth.
+
+The constructor rejects a `null` element with an `ArgumentException`. List ordering is preserved exactly.
+
+### Dictionary (`BencodedDictionary`)
+
+A keyed mapping framed between `d` and `e` — `d3:cow3:moo4:spam4:eggse` is `{cow → moo, spam → eggs}`. Keys are **byte strings** (BEP 3 forbids non-string keys); values may be any kind.
+
+BEP 3 invariants enforced by the parser:
+
+- Every key is parsed as a `BencodedString` — `dii42ee` (with an integer key) is rejected.
+- Keys must appear in **strict ascending raw byte order**. Out-of-order or duplicate keys cause the parser to reject the input.
+
+The constructor likewise rejects `null` keys, `null` values, and duplicates. Internally the dictionary stores its items in a `SortedDictionary` keyed by <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal>, so iteration order is always canonical regardless of insertion order.
+
+## Framing tokens
+
+A **framing token** is a single ASCII byte that announces the kind of the next value to the parser:
+
+| Token | Role |
+|---|---|
+| `i` | Start of an integer; matching `e` terminates the body. |
+| `0`–`9` | Start of a byte-string length; ends at the `:` separator. |
+| `l` | Start of a list; matching `e` terminates it. |
+| `d` | Start of a dictionary; matching `e` terminates it. |
+| `e` | End of an integer, list, or dictionary. |
+| `:` | Separator between a string length and its payload. |
+| `-` | Sign marker inside an integer body (only as the first character after `i`). |
+
+The parser is forward-only and dispatches solely on the first byte of each value. There is no look-ahead beyond the leading token.
+
+## Canonical encoding
+
+A bencoded value has exactly one **canonical encoding**:
+
+- Integers use the shortest decimal representation with no padding and no `+` sign.
+- Byte-string lengths use the shortest decimal representation.
+- Dictionary keys are sorted by raw byte order before encoding.
+- No whitespace is permitted anywhere in the stream.
+
+The encoder always produces canonical output. The parser rejects every form of non-canonical input — leading zeros, negative zero, unsorted keys, trailing bytes, and so on. This rejection is intentional: any equivalence between two encodings would break content-addressed identifiers (the SHA-1 of a torrent's `info` dictionary, in the BitTorrent case).
+
+`Bencode.GetEncodedLength(value)` walks the tree once and returns the exact canonical-encoded size in bytes, suitable for sizing the destination span or buffer before encoding.
+
+## Encode and decode
+
+**Encode** takes a `BencodedValue` and produces canonical bytes:
+
+| API | Result |
+|---|---|
+| `byte[] Bencode.Encode(BencodedValue)` | Allocate a `byte[]` sized to `GetEncodedLength` and write into it. |
+| `bool Bencode.TryEncode(value, Span<byte>, out int written)` | Write into a caller-provided span; `false` if the span is too small. |
+| `void Bencode.Encode(value, Stream)` | Stage to a pooled buffer of exact size and `Write` it in one call. |
+| `ValueTask Bencode.EncodeAsync(value, Stream, CancellationToken)` | Async variant using `WriteAsync`. |
+
+**Decode** takes bytes and produces a `BencodedValue`:
+
+| API | Result |
+|---|---|
+| `BencodedValue Bencode.Decode(ReadOnlySpan<byte>)` | Parse a complete document; reject trailing bytes. |
+| `BencodedValue Bencode.Decode(byte[])` | Same, with a `null` guard. |
+| `bool Bencode.TryDecode(span, out value, out consumed)` | Parse a single value; `false` on `BencodeFormatException`. |
+| `BencodedValue Bencode.Decode(Stream)` | Read the stream to its end into a pooled buffer, then parse. |
+| `ValueTask<BencodedValue> Bencode.DecodeAsync(Stream, CancellationToken)` | Async variant of the above. |
+
+The synchronous `Decode(Stream)` and asynchronous `DecodeAsync(Stream)` overloads buffer the entire stream before parsing — bencode is not a streaming format because a value's framing tokens can be arbitrarily far apart and the parser must consume them in order. The pooled `MemoryStream` is disposed before the parser runs.
+
+## Format exception
+
+A <xref:Bodu.Text.Formats.BencodeFormatException> derives from <xref:System.FormatException> and is thrown by the throwing `Decode` overloads on any structural violation. The message identifies the exact failure mode:
+
+| Message | Trigger |
+|---|---|
+| *Unexpected end of bencoded data.* | Source ends before a complete value is read. |
+| *Unexpected bencode token '{0}' at offset {1}.* | A leading byte does not match any known framing token. |
+| *Unterminated bencoded integer.* | `i` opened but `e` was not seen before end of input. |
+| *Invalid bencoded integer.* | The integer body is missing or malformed. |
+| *Bencoded integers cannot contain leading zeros.* | e.g. `i01e`. |
+| *Negative zero is not a valid bencoded integer.* | `i-0e`. |
+| *The bencoded integer is outside the supported Int64 range.* | Value would overflow `long`. |
+| *Expected a bencoded string length.* | A string slot did not start with a digit. |
+| *Bencoded string lengths cannot contain leading zeros.* | e.g. `02:ab`. |
+| *Expected ':' after bencoded string length.* | Length digits not followed by `:`. |
+| *The bencoded string length exceeds Int32.MaxValue.* | Length numeric overflow. |
+| *The bencoded string length exceeds the available input.* | Declared length runs past end of input. |
+| *Unterminated bencoded list.* | `l` opened but `e` was not seen before end of input. |
+| *Unterminated bencoded dictionary.* | `d` opened but `e` was not seen before end of input. |
+| *Bencoded dictionary keys must be byte strings.* | A non-string token appeared in a key slot. |
+| *Bencoded dictionary keys must be unique and sorted by raw byte order.* | Duplicate or out-of-order key. |
+| *The bencoded value contains trailing data.* | A complete value was followed by extra bytes. |
+
+`TryDecode` and `TryEncode` swallow these exceptions and report failure as a `bool` instead.
+
+## Byte string vs. text
+
+Bencoded strings are **bytes**, not characters. Treating them as text is a per-field decision driven by the consuming format:
+
+- **Always text.** `info.name` in a torrent file is UTF-8 (the BEP says so) — call `GetUtf8String()`.
+- **Never text.** `info.pieces` is a concatenation of 20-byte SHA-1 hashes — keep the raw `Bytes`.
+- **Sometimes text.** Custom extensions vary; consult the extension spec before projecting.
+
+When you build a value, use `BencodedString.FromUtf8(string)` for the text case and `new BencodedString(ReadOnlySpan<byte>)` / `new BencodedString(byte[])` for raw bytes.
+
+## Ordering and equality
+
+Dictionary keys are ordered and compared by raw byte ordinal — *not* by Unicode collation, locale, or codepoint. The library exposes this as <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal>, a singleton that implements both `IComparer<BencodedString>` and `IEqualityComparer<BencodedString>`. Use it when you build a `SortedDictionary` of bencoded keys yourself.
+
+`BencodedString.Equals` compares the underlying byte sequences. `BencodedInteger.Equals` compares `long` values. The container types do not override `Equals`; deep equality of two trees is something the consumer composes.
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — install + runnable minimal samples.
+- **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — deep-dive walk-throughs for every concept above.
+- **[Introduction](index.md)** — the high-level shape of the library.

--- a/docs/docs/formats/getting-started.md
+++ b/docs/docs/formats/getting-started.md
@@ -1,0 +1,195 @@
+---
+title: Bodu.Text.Formats — Getting started
+---
+
+# Bodu.Text.Formats — Getting started
+
+Unfamiliar with terms like *framed format*, *value tree*, *byte string*, *canonical encoding*, or *framing token*? Read [Core concepts](concepts.md) first.
+
+## Install
+
+```bash
+dotnet add package Bodu.Text.Formats
+```
+
+Targets `net8.0`. The package depends on `Bodu.Core` for shared throw-helpers and on `Bodu.Text.Encoding` for the embedded `Base16` helpers used in test vectors; no other NuGet references.
+
+## Minimal samples
+
+### Decode a torrent file
+
+```csharp
+using Bodu.Text.Formats;
+
+byte[] payload = File.ReadAllBytes("ubuntu.iso.torrent");
+
+BencodedValue root = Bencode.Decode(payload);
+BencodedDictionary doc = (BencodedDictionary)root;
+
+string tracker = ((BencodedString)doc["announce"]).GetUtf8String();
+BencodedDictionary info = (BencodedDictionary)doc["info"];
+string name = ((BencodedString)info["name"]).GetUtf8String();
+long pieceLength = ((BencodedInteger)info["piece length"]).Value;
+```
+
+The cast pattern is intentional — a bencoded document is dynamically typed (the same key can hold different kinds in different documents), so the consumer projects each field to its expected type. Use `switch (value.Kind)` for safer dispatch:
+
+```csharp
+foreach (var kvp in info.GetOrderedItems())
+{
+    switch (kvp.Value.Kind)
+    {
+        case BencodedValueKind.Integer:    Console.WriteLine($"{kvp.Key}: {((BencodedInteger)kvp.Value).Value}"); break;
+        case BencodedValueKind.String:     Console.WriteLine($"{kvp.Key}: <{((BencodedString)kvp.Value).Length} bytes>"); break;
+        case BencodedValueKind.List:       Console.WriteLine($"{kvp.Key}: list[{((BencodedList)kvp.Value).Count}]"); break;
+        case BencodedValueKind.Dictionary: Console.WriteLine($"{kvp.Key}: dict[{((BencodedDictionary)kvp.Value).Count}]"); break;
+    }
+}
+```
+
+### Decode without throwing
+
+```csharp
+using Bodu.Text.Formats;
+
+if (Bencode.TryDecode(input, out BencodedValue? value, out int consumed))
+{
+    // value is non-null and 'consumed' bytes were read
+}
+else
+{
+    // input was malformed — show an error
+}
+```
+
+`TryDecode` succeeds when the parser reads exactly one well-formed value. `consumed` records how many bytes that value occupied. The throwing `Decode(ReadOnlySpan<byte>)` overload additionally rejects trailing bytes; `TryDecode` does not, leaving it to the caller to decide whether more values may follow.
+
+### Build and encode a small document
+
+```csharp
+using Bodu.Text.Formats;
+
+var info = new BencodedDictionary([
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("length"),
+        new BencodedInteger(1024)),
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("name"),
+        BencodedString.FromUtf8("hello.bin")),
+]);
+
+var doc = new BencodedDictionary([
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("announce"),
+        BencodedString.FromUtf8("https://tracker.example/announce")),
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("info"),
+        info),
+]);
+
+byte[] encoded = Bencode.Encode(doc);
+```
+
+The constructor accepts items in any order — `BencodedDictionary` stores them in raw byte-ordinal key order using <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal>, so `Encode` emits the canonical key ordering regardless of how the document was assembled.
+
+### Pre-size the destination
+
+```csharp
+using Bodu.Text.Formats;
+
+int size = Bencode.GetEncodedLength(doc);  // exact, not an upper bound
+
+byte[] buffer = new byte[size];
+bool ok = Bencode.TryEncode(doc, buffer, out int written);
+// ok == true, written == size
+```
+
+`GetEncodedLength` does the same recursive walk as the encoder but only sums byte counts. It throws `OverflowException` if the encoded length would exceed `int.MaxValue`.
+
+### Encode and decode streams
+
+```csharp
+using Bodu.Text.Formats;
+
+// Write canonically to a stream.
+using (FileStream fs = File.Create("doc.bencode"))
+{
+    Bencode.Encode(doc, fs);
+}
+
+// Read it back.
+using (FileStream fs = File.OpenRead("doc.bencode"))
+{
+    BencodedValue root = Bencode.Decode(fs);
+}
+```
+
+The stream overloads stage to an `ArrayPool<byte>` buffer sized exactly to `GetEncodedLength`. The stream is **not** closed by the codec — the caller's `using` block owns its lifetime. For async I/O use `Bencode.EncodeAsync` / `Bencode.DecodeAsync`:
+
+```csharp
+await using FileStream fs = File.OpenRead("doc.bencode");
+BencodedValue root = await Bencode.DecodeAsync(fs, cancellationToken);
+```
+
+### Look up a key by UTF-8 text
+
+```csharp
+using Bodu.Text.Formats;
+
+if (info.TryGetValue("piece length", out BencodedValue pieceLengthValue))
+{
+    long pieceLength = ((BencodedInteger)pieceLengthValue).Value;
+}
+```
+
+The `TryGetValue(string)` overload converts the UTF-8 key to a `BencodedString` internally and dispatches through the same byte-ordered lookup as `TryGetValue(BencodedString)`.
+
+### Validate a payload before processing
+
+```csharp
+using Bodu.Text.Formats;
+
+try
+{
+    BencodedValue value = Bencode.Decode(networkPayload);
+    Process(value);
+}
+catch (BencodeFormatException ex)
+{
+    log.Warn("Malformed bencode at byte offset {Offset}: {Message}", offset, ex.Message);
+}
+```
+
+`BencodeFormatException` derives from `FormatException` and carries an English-language message that identifies the exact failure mode — *Unterminated bencoded dictionary*, *Bencoded dictionary keys must be unique and sorted by raw byte order*, *The bencoded string length exceeds the available input*, and so on. See [Core concepts](concepts.md#format-exception) for the full list.
+
+## Round-trip example
+
+```csharp
+using Bodu.Text.Formats;
+
+var original = new BencodedList([
+    new BencodedInteger(-1024),
+    BencodedString.FromUtf8("spam"),
+    new BencodedDictionary([
+        new KeyValuePair<BencodedString, BencodedValue>(
+            BencodedString.FromUtf8("k"),
+            new BencodedInteger(0)),
+    ]),
+]);
+
+byte[] encoded = Bencode.Encode(original);
+// encoded == "li-1024e4:spamd1:ki0eee"u8.ToArray()
+
+BencodedValue decoded = Bencode.Decode(encoded);
+byte[] reEncoded = Bencode.Encode(decoded);
+
+Debug.Assert(encoded.SequenceEqual(reEncoded));   // round-trip is bit-exact
+```
+
+The library passes every positive Known Answer Test vector from BEP 3 in both directions, and rejects every negative vector with a `BencodeFormatException`. See [`BencodeTests.KnownAnswerVectors`](https://github.com/bslater/bodu) for the catalogue.
+
+## Where to go next
+
+- **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — per-API deep dives.
+- **[Core concepts](concepts.md)** — vocabulary refresher.
+- **[Introduction](index.md)** — type map and scenario index.

--- a/docs/docs/formats/index.md
+++ b/docs/docs/formats/index.md
@@ -1,0 +1,99 @@
+---
+title: Bodu.Text.Formats — Introduction
+---
+
+# Bodu.Text.Formats
+
+**Bodu.Text.Formats** decodes and encodes self-framing binary serialization formats — formats that describe their own structure inline rather than relying on an external schema. The first format the library ships is **Bencode** (the BitTorrent serialization grammar specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html)), exposed through a small, immutable object model and a span- and stream-friendly codec.
+
+The library is intentionally narrow: each format gets a strongly-typed value tree, a static `Encode` / `Decode` entry point, `Try*` variants that swap exceptions for `bool` results, an explicit `GetEncodedLength` for pre-sizing destinations, and synchronous + asynchronous `Stream` overloads. No reflection, no `dynamic`, no allocations beyond the immutable result graph.
+
+## Core mental model
+
+![Bencode encode/decode pipeline — object tree to canonical bytes and back](../../images/diagrams/formats-bencode-pipeline.svg)
+
+A bencoded document is a single tree of typed values. Encoding walks the tree with a recursive writer that emits framing tokens (`i…e`, `l…e`, `d…e`, or a length-prefixed byte string) into a destination span; decoding runs a forward-only parser that peeks the leading byte, dispatches on it, validates the BEP 3 invariants, and rebuilds the tree.
+
+A **`BencodedValue`** is the abstract base. **`Bencode`** is the codec — static `Encode` / `Decode` / `TryEncode` / `TryDecode` / `GetEncodedLength` over `ReadOnlySpan<byte>`, `byte[]`, and `Stream`. The pipeline never silently repairs malformed input: every BEP 3 invariant (no leading zeros, no negative zero, sorted dictionary keys, no trailing bytes) is enforced.
+
+## Key concepts
+
+| Concept | Plain-language meaning |
+|---|---|
+| **Framed format** | Each value carries its own framing — a leading prefix and trailing delimiter (or a length prefix) — so the parser never needs a schema to know where a value starts or ends. |
+| **Value tree** | The decoded document is a `BencodedValue` (Integer · String · List · Dictionary) that may nest other values to any depth. |
+| **Byte string** | Bencoded strings are raw bytes with a known length, not necessarily UTF-8. The library preserves the exact payload and offers an opt-in `GetUtf8String()` when the consuming format guarantees text. |
+| **Canonical encoding** | A single byte sequence is the canonical form of any given value. Encoding always produces it; decoding rejects non-canonical input (leading zeros, unsorted keys, …). |
+| **Codec** | The static façade (`Bencode`) that exposes `Encode` / `Decode` / `Try…` / `GetEncodedLength` / stream overloads. |
+| **Format exception** | A `BencodeFormatException` (a `FormatException`) is thrown for any structural violation, with a precise message keyed to the failure mode. |
+
+For the full glossary, see [Core concepts](concepts.md).
+
+### Self-framing vs. binary text encoding
+
+Bencode is not a binary-to-text encoding like Base64. It is a **binary serialization grammar**: integers and structure tokens are emitted as ASCII for human readability, but the string payload is raw bytes — a torrent file's `pieces` field is a SHA-1 hash table, not text. Use [`Bodu.Text.Encoding`](../text-encoding/index.md) when you need to convert raw bytes into a printable alphabet; use **Bodu.Text.Formats** when you need to (de)serialize a structured value tree.
+
+### Canonicality
+
+A bencoded value has exactly one canonical encoding: `i42e`, not `i+42e` or `i042e`; dictionary keys are sorted by raw byte order, not insertion order. The codec produces the canonical form and the parser rejects every non-canonical input. This is a load-bearing property for content-addressed identifiers — the SHA-1 of a torrent's `info` dictionary (the *infohash*) only works because every parser agrees on the canonical bytes.
+
+## Worked example — a one-key torrent dictionary
+
+A single document traces the pipeline end-to-end:
+
+1. Author a value: `new BencodedDictionary([new("length"_utf8, new BencodedInteger(1024))])`.
+2. `Bencode.GetEncodedLength(root)` walks the tree once and returns the exact destination size — `d6:lengthi1024ee` is 16 bytes.
+3. `Bencode.Encode(root)` rents a buffer of that exact size, recursively emits framing tokens and payload bytes, and returns the byte array.
+4. The same bytes round-trip back through `Bencode.Decode(bytes)`. The parser reads `d`, expects key/value pairs, parses `6:length` as the key, parses `i1024e` as the value, reads the trailing `e`, then checks that no input remains.
+5. If the source bytes were `d6:lengthi1024e` — missing the trailing `e` — the parser throws `BencodeFormatException` with the message *Unterminated bencoded dictionary*.
+
+Encoding is allocation-conscious: stream variants stage to a pooled buffer of the exact size, the span path writes straight into the caller's destination, and `TryEncode` reports overflow with `false` instead of an exception.
+
+## Common scenarios
+
+| Scenario | Reach for |
+|---|---|
+| Decode a torrent file from disk | `Bencode.Decode(File.ReadAllBytes(path))` |
+| Decode a bencoded payload from a network stream | `await Bencode.DecodeAsync(stream, cancellationToken)` |
+| Walk the value tree by kind | `value.Kind` + a switch over `BencodedValueKind` |
+| Look up a UTF-8 key in a dictionary | `dict.TryGetValue("announce", out var v)` |
+| Re-encode a tree canonically | `Bencode.Encode(tree)` |
+| Pre-size a destination span | `int size = Bencode.GetEncodedLength(tree);` |
+| Parse without throwing on malformed input | `Bencode.TryDecode(source, out var value, out var consumed)` |
+| Write canonically to a `Stream` | `Bencode.Encode(tree, stream)` / `EncodeAsync(tree, stream)` |
+| Compare byte-string keys ordinally | <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal> |
+| Treat a key payload as text | <xref:Bodu.Text.Formats.BencodedString.GetUtf8String> |
+
+## Main types
+
+The same surface, grouped by what role you're playing rather than by namespace.
+
+### Types most consumers use
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Formats.Bencode> | Static codec — `Encode`, `Decode`, `TryEncode`, `TryDecode`, `GetEncodedLength` over spans, byte arrays, and `Stream`. |
+| <xref:Bodu.Text.Formats.BencodedValue> | Abstract base for every decoded value; exposes `Kind` for switch-style dispatch. |
+| <xref:Bodu.Text.Formats.BencodedValueKind> | `Integer` · `String` · `List` · `Dictionary`. |
+| <xref:Bodu.Text.Formats.BencodeFormatException> | Thrown for any BEP 3 violation; the message identifies the exact failure mode. |
+
+### Value types
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Formats.BencodedInteger> | Signed 64-bit integer; rejects leading zeros, negative zero, and values outside `Int64` range. |
+| <xref:Bodu.Text.Formats.BencodedString> | Raw byte string with a `Bytes` payload and helpers (`FromUtf8`, `GetUtf8String`) for the text case. |
+| <xref:Bodu.Text.Formats.BencodedList> | Ordered list of values; constructor rejects `null` elements. |
+| <xref:Bodu.Text.Formats.BencodedDictionary> | Byte-string-keyed dictionary; keys are stored sorted by raw byte order. Indexer, `TryGetValue(BencodedString)`, and `TryGetValue(string)` (UTF-8) all work. |
+
+### Supporting types
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Formats.BencodedStringComparer> | Singleton `Ordinal` comparer for raw byte-string ordering; implements both `IComparer<BencodedString>` and `IEqualityComparer<BencodedString>`. |
+
+## Where to go next
+
+- **[Core concepts](concepts.md)** — full vocabulary: value vs. document, canonical encoding, framing tokens, byte string vs. text, format exception.
+- **[Getting started](getting-started.md)** — install + minimal samples for `Decode`, `Encode`, `Try*`, and the stream overloads.
+- **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — using the Bencode codec, the value model, and stream support.

--- a/docs/docs/formats/toc.yml
+++ b/docs/docs/formats/toc.yml
@@ -1,0 +1,6 @@
+- name: Introduction
+  href: index.md
+- name: Core concepts
+  href: concepts.md
+- name: Getting started
+  href: getting-started.md

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -11,6 +11,7 @@ This page is a **cross-library tour**. It installs every Bodu package and runs o
 - [Bodu.Security.Cryptography — getting started](cryptography/getting-started.md)
 - [Bodu.Globalization.Calendar — getting started](calendar/getting-started.md)
 - [Bodu.Text.Encoding — getting started](text-encoding/getting-started.md)
+- [Bodu.Text.Formats — getting started](formats/getting-started.md)
 
 ## Prerequisites
 
@@ -30,6 +31,7 @@ dotnet add package Bodu.IO.Hashing
 dotnet add package Bodu.Security.Cryptography
 dotnet add package Bodu.Globalization.Calendar
 dotnet add package Bodu.Text.Encoding
+dotnet add package Bodu.Text.Formats
 
 # Optional region-specific calendar data packs:
 dotnet add package Bodu.Globalization.Calendar.Data.Americas
@@ -129,10 +131,31 @@ For lenient parsing (whitespace, `0x` prefix, missing padding), `OperationStatus
 options like MIME line wrapping or Crockford alias decoding, see the
 [Bodu.Text.Encoding getting-started](text-encoding/getting-started.md).
 
+### Bodu.Text.Formats — decode a Bencode document
+
+```csharp
+using Bodu.Text.Formats;
+
+byte[] payload = File.ReadAllBytes("ubuntu.iso.torrent");
+
+BencodedValue root = Bencode.Decode(payload);
+BencodedDictionary doc = (BencodedDictionary)root;
+
+string tracker = ((BencodedString)doc["announce"]).GetUtf8String();
+BencodedDictionary info = (BencodedDictionary)doc["info"];
+string name = ((BencodedString)info["name"]).GetUtf8String();
+long pieceLength = ((BencodedInteger)info["piece length"]).Value;
+```
+
+The parser enforces every BEP 3 invariant — no leading zeros, no negative zero, dictionary keys sorted by raw byte
+order, no trailing bytes — so a successful decode round-trips bit-exactly through `Bencode.Encode`. For
+non-throwing parsing, stream support, and the full value model, see the
+[Bodu.Text.Formats getting-started](formats/getting-started.md).
+
 ## Where to go next
 
 - **[Introduction](introduction.md)** — what each library is for and how they fit together.
 - **[Algorithm families](algorithm-families.md)** — the cross-library taxonomy if your problem touches hashing, checksums, or encryption.
-- **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md) · [Bodu.Text.Encoding](text-encoding/index.md).
+- **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md) · [Bodu.Text.Encoding](text-encoding/index.md) · [Bodu.Text.Formats](formats/index.md).
 - **API references:** [Bodu.Collections.Generic](../apidoc/Bodu.Collections.Generic.md) · [Bodu.IO.Hashing](../apidoc/Bodu.IO.Hashing.md) · [Bodu.Security.Cryptography](../apidoc/Bodu.Security.Cryptography.md) · [Bodu.Globalization.Calendar](../apidoc/Bodu.Globalization.Calendar.md).
-- **Guides:** [Bodu.Core](../guides/core/index.md) · [Bodu.IO.Hashing](../guides/io-hashing/index.md) · [Bodu.Security.Cryptography](../guides/cryptography/index.md) · [Bodu.Globalization.Calendar](../guides/calendar/index.md) · [Bodu.Text.Encoding](../guides/text-encoding/index.md).
+- **Guides:** [Bodu.Core](../guides/core/index.md) · [Bodu.IO.Hashing](../guides/io-hashing/index.md) · [Bodu.Security.Cryptography](../guides/cryptography/index.md) · [Bodu.Globalization.Calendar](../guides/calendar/index.md) · [Bodu.Text.Encoding](../guides/text-encoding/index.md) · [Bodu.Text.Formats](../guides/formats/index.md).

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -4,7 +4,7 @@ title: Introduction
 
 # Introduction
 
-**Bodu** is a solution that ships five independent .NET NuGet packages, each focused on a narrow, well-defined problem domain. The packages share nothing at runtime — every assembly is self-contained — but they share a single set of source and documentation conventions, a single analyzer and test configuration, and a single quality bar.
+**Bodu** is a solution that ships six independent .NET NuGet packages, each focused on a narrow, well-defined problem domain. The packages share nothing at runtime — every assembly is self-contained — but they share a single set of source and documentation conventions, a single analyzer and test configuration, and a single quality bar.
 
 If you are new to Bodu, start with the **library introductions** below to understand what each package is for. The deeper conceptual map across the hashing and cryptography libraries lives in [Algorithm families](algorithm-families.md).
 
@@ -17,8 +17,9 @@ If you are new to Bodu, start with the **library introductions** below to unders
 | **[Bodu.Security.Cryptography](cryptography/index.md)** | Cryptographic primitives on the BCL <xref:System.Security.Cryptography.SymmetricAlgorithm?displayProperty=nameWithType> and <xref:System.Security.Cryptography.HashAlgorithm?displayProperty=nameWithType> contracts — managed block ciphers (Threefish, Serpent, Camellia, Twofish, Blowfish, Skipjack), AES paired with six AEAD mode transforms (GCM, CCM, OCB, EAX, SIV, GCM-SIV), keyed hashes (SipHash, Poly1305), cryptographic digests (Tiger, CubeHash, Snefru, Whirlpool, BLAKE2/3, Skein, Shake), Merkle-tree hashing, and the full ASCON family. | `net8.0` |
 | **[Bodu.Globalization.Calendar](calendar/index.md)** | Rule-driven notable-date resolution — public holidays, observances, religious festivals — for any year, territory, or calendar system. Built-in algorithms cover Gregorian and Orthodox Easter, Hindu Lunar dates, Losar, Vesak, Asalha Puja, and Qingming, with a pluggable algorithm registry, observance-adjustment pipeline, and trust-policy-driven plugin host. | `net8.0` |
 | **[Bodu.Text.Encoding](text-encoding/index.md)** | Binary-to-text encoders for Base16, Base32, Base64, Base58, and Base85 with every common variant (RFC 4648 standard / hex-extended / URL-safe / MIME, Crockford, z-base-32, Bitcoin/Flickr / Ripple, Ascii85 / Z85). Each encoding exposes the same modern API shape: span- and UTF-8-friendly overloads, `OperationStatus` streaming, length-prediction helpers, validation predicates, plus a unified `IBinaryEncoding` interface for runtime-pluggable encoding choice. | `net8.0` |
+| **[Bodu.Text.Formats](formats/index.md)** | Self-framing binary serialization formats with a strongly-typed value model and a span- and stream-friendly codec. Ships **Bencode** (the BitTorrent serialization grammar from BEP 3) as the first format — `Bencode.Encode` / `Decode` / `TryEncode` / `TryDecode` / `GetEncodedLength` over `ReadOnlySpan<byte>`, `byte[]`, and `Stream`; an immutable `BencodedValue` tree (`Integer`, `String`, `List`, `Dictionary`); and BEP 3 canonicality enforcement on both sides of the pipeline. | `net8.0` |
 
-Each package is versioned and released independently. Take the one you need and ignore the others — there are no cross-package runtime dependencies. `Bodu.IO.Hashing`, `Bodu.Security.Cryptography`, and `Bodu.Text.Encoding` all depend on `Bodu.Core` for shared argument-validation helpers.
+Each package is versioned and released independently. Take the one you need and ignore the others — there are no cross-package runtime dependencies. `Bodu.IO.Hashing`, `Bodu.Security.Cryptography`, `Bodu.Text.Encoding`, and `Bodu.Text.Formats` all depend on `Bodu.Core` for shared argument-validation helpers; `Bodu.Text.Formats` additionally references `Bodu.Text.Encoding`.
 
 ## Library introductions
 
@@ -80,6 +81,16 @@ Each library has a dedicated introduction page that explains its namespaces, the
   </div>
 </div>
 
+<div class="bodu-card">
+  <h3><a href="formats/index.md">Bodu.Text.Formats</a></h3>
+  <p>Self-framing binary serialization formats with a strongly-typed value tree and a span- and stream-friendly codec. Ships Bencode (BitTorrent BEP 3) as the first format, with full canonicality enforcement on both sides of the pipeline.</p>
+  <div class="bodu-card-links">
+    <a href="formats/index.md">Introduction</a>
+    <a href="formats/getting-started.md">Getting started</a>
+    <a href="../guides/formats/index.md">Guides</a>
+  </div>
+</div>
+
 </div>
 
 ## Cross-library map: which library do I need?
@@ -104,6 +115,8 @@ If your problem touches **hashing**, **checksums**, or **encryption**, the [Algo
 | Decode a JWT token segment (URL-safe Base64) | `Base64.Decode(token, Base64Variant.UrlSafe, BaseFormatStyles.AllowMissingPadding)` | Bodu.Text.Encoding |
 | Parse a Bitcoin / IPFS / Solana identifier | `Base58.Decode(id)` | Bodu.Text.Encoding |
 | Format a TOTP / HOTP shared secret for a user | `Base32.Encode(secret, Base32Variant.Standard, BaseFormattingOptions.OmitPadding)` | Bodu.Text.Encoding |
+| Decode a `.torrent` file or other Bencode payload | `Bencode.Decode(bytes)` | Bodu.Text.Formats |
+| Canonically re-encode a Bencode value tree | `Bencode.Encode(tree)` | Bodu.Text.Formats |
 
 ## Design principles
 
@@ -122,5 +135,5 @@ The solution uses **MSTest** with a partial-class test layout that mirrors the s
 
 - **[Getting started](getting-started.md)** — prerequisites, install commands, and a one-minute sample from each library.
 - **[Algorithm families](algorithm-families.md)** — the cross-library taxonomy of fingerprints, checksums, check digits, cryptographic hashes, keyed hashes, and symmetric ciphers.
-- **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md) · [Bodu.Text.Encoding](text-encoding/index.md).
+- **Library introductions:** [Bodu.Core](core/index.md) · [Bodu.IO.Hashing](io-hashing/index.md) · [Bodu.Security.Cryptography](cryptography/index.md) · [Bodu.Globalization.Calendar](calendar/index.md) · [Bodu.Text.Encoding](text-encoding/index.md) · [Bodu.Text.Formats](formats/index.md).
 - **API references:** [Bodu.Collections.Generic](../apidoc/Bodu.Collections.Generic.md) · [Bodu.IO.Hashing](../apidoc/Bodu.IO.Hashing.md) · [Bodu.Security.Cryptography](../apidoc/Bodu.Security.Cryptography.md) · [Bodu.Globalization.Calendar](../apidoc/Bodu.Globalization.Calendar.md).

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -39,3 +39,11 @@
       href: text-encoding/concepts.md
     - name: Getting started
       href: text-encoding/getting-started.md
+- name: Bodu.Text.Formats
+  items:
+    - name: Introduction
+      href: formats/index.md
+    - name: Core concepts
+      href: formats/concepts.md
+    - name: Getting started
+      href: formats/getting-started.md

--- a/docs/guides/formats/bencode.md
+++ b/docs/guides/formats/bencode.md
@@ -1,0 +1,179 @@
+---
+title: Using Bencode
+---
+
+# Using Bencode
+
+`Bencode` is the static codec for the [BEP 3 Bencode grammar](https://www.bittorrent.org/beps/bep_0003.html). It exposes a small, predictable surface — `Encode` / `Decode` over spans, byte arrays, and streams; `TryEncode` / `TryDecode` for non-throwing callers; `GetEncodedLength` for pre-sizing destinations.
+
+For the vocabulary used below (value vs. document, canonical encoding, framing tokens, byte string vs. text) see [Core concepts](../../docs/formats/concepts.md).
+
+## Pattern 1 — decode bytes you already have
+
+```csharp
+using Bodu.Text.Formats;
+
+byte[] payload = File.ReadAllBytes("torrent.torrent");
+BencodedValue root = Bencode.Decode(payload);
+```
+
+`Decode(byte[])` is a `null`-guarded shim over the span overload `Decode(ReadOnlySpan<byte>)`. Both parse exactly one complete value and reject any trailing bytes — a payload that holds two concatenated values throws `BencodeFormatException` with the message *The bencoded value contains trailing data*.
+
+If you genuinely need to read one value out of a larger buffer (for example a Mainline DHT message that carries a bencode header followed by other data), use `TryDecode`, which returns the byte count it consumed.
+
+## Pattern 2 — non-throwing decode
+
+```csharp
+using Bodu.Text.Formats;
+
+if (Bencode.TryDecode(buffer, out BencodedValue? value, out int consumed))
+{
+    Process(value);
+    buffer = buffer[consumed..];   // continue reading what follows
+}
+else
+{
+    log.Warn("Malformed bencode at byte offset {Offset}", offset);
+}
+```
+
+`TryDecode` succeeds when the parser reads exactly one well-formed value. On failure it returns `false`, sets `value` to `null`, and sets `consumed` to zero. Unlike `Decode(ReadOnlySpan<byte>)` it does **not** reject trailing bytes — the parser stops after the first complete value and leaves the rest of the buffer to the caller.
+
+## Pattern 3 — pre-size and encode into a caller buffer
+
+```csharp
+using Bodu.Text.Formats;
+
+int size = Bencode.GetEncodedLength(value);
+Span<byte> destination = size <= 256 ? stackalloc byte[size] : new byte[size];
+
+if (!Bencode.TryEncode(value, destination, out int written))
+    throw new InvalidOperationException("Buffer too small.");
+
+return destination[..written];
+```
+
+`GetEncodedLength` walks the tree once with `checked` arithmetic and returns the exact destination size — never an upper bound. `TryEncode` writes into a caller-provided span and returns `false` if the destination is shorter than the encoded length; the allocating `Encode(BencodedValue)` overload calls `GetEncodedLength` internally and sizes a fresh `byte[]` to fit.
+
+For values that may exceed `int.MaxValue` bytes, `GetEncodedLength` throws `OverflowException` — wrap the call in a `try` if you intend to accept arbitrarily large inputs.
+
+## Pattern 4 — encode straight to a stream
+
+```csharp
+using Bodu.Text.Formats;
+
+using FileStream fs = File.Create("doc.bencode");
+Bencode.Encode(value, fs);
+```
+
+The synchronous `Encode(value, Stream)` stages to an `ArrayPool<byte>` buffer sized exactly to `GetEncodedLength`, writes it in a single `Write` call, returns the buffer to the pool, and leaves the stream open. The async variant follows the same pattern using `WriteAsync`:
+
+```csharp
+await using FileStream fs = File.Create("doc.bencode");
+await Bencode.EncodeAsync(value, fs, cancellationToken);
+```
+
+Both stream overloads validate that the stream supports writing before allocating the buffer and throw `ArgumentException` with the offending parameter name if not. See [Streams and async I/O](streaming.md) for the buffer-lifecycle details.
+
+## Pattern 5 — decode from a stream
+
+```csharp
+using Bodu.Text.Formats;
+
+await using FileStream fs = File.OpenRead("doc.bencode");
+BencodedValue root = await Bencode.DecodeAsync(fs, cancellationToken);
+```
+
+`Decode(Stream)` and `DecodeAsync(Stream)` copy the entire stream into a pooled `MemoryStream`, then dispatch to the existing span parser. Bencode is **not** a streaming format — a value's framing tokens can be arbitrarily far apart, and dictionary key ordering can only be validated once all keys have been seen, so the parser must have the complete buffer in front of it.
+
+For seekable streams of known length, the cost is one extra copy versus reading into a span yourself. For network streams you usually want the async overload because of the cancellation support.
+
+## Pattern 6 — round-trip equality
+
+```csharp
+using Bodu.Text.Formats;
+
+byte[] originalEncoded = File.ReadAllBytes("input.torrent");
+
+BencodedValue decoded = Bencode.Decode(originalEncoded);
+byte[] reEncoded = Bencode.Encode(decoded);
+
+Debug.Assert(originalEncoded.SequenceEqual(reEncoded));
+```
+
+A canonical bencode payload round-trips bit-for-bit: the parser rejects every non-canonical input, the encoder always emits the canonical form, so any input the parser accepts will re-encode to the same bytes. This is the foundation of the BitTorrent *infohash* — `SHA-1(re-encode(decode(info)))` equals `SHA-1(info)` exactly because the decoder-encoder pair is the identity on canonical input.
+
+If the round-trip assertion ever fires, you have either accepted non-canonical input (a parser bug) or emitted non-canonical output (an encoder bug) — both are contract violations the library is designed to make impossible.
+
+## Pattern 7 — validate without retaining the result
+
+```csharp
+using Bodu.Text.Formats;
+
+public static bool IsWellFormedBencode(ReadOnlySpan<byte> source) =>
+    Bencode.TryDecode(source, out _, out int consumed) && consumed == source.Length;
+```
+
+`TryDecode` exits early on the first structural error; the resulting `BencodedValue` is immediately discarded by `_`. This is useful for input filters at the edge of an application — accept only payloads that parse cleanly, log the rest, drop the rest before any other code touches them.
+
+For the strict *complete-document* semantics of `Decode(ReadOnlySpan<byte>)` (no trailing bytes), check `consumed == source.Length` as shown above.
+
+## Pattern 8 — guard against malicious input
+
+Bencode itself has no built-in size limit on byte strings or recursion depth. For untrusted input — incoming network bytes, user-supplied torrent files — apply an outer length cap before calling the parser:
+
+```csharp
+using Bodu.Text.Formats;
+
+const int maxBytes = 16 * 1024 * 1024;   // 16 MB cap
+
+if (payload.Length > maxBytes)
+{
+    log.Warn("Bencode payload exceeds {Max} bytes; dropping.", maxBytes);
+    return;
+}
+
+BencodedValue root = Bencode.Decode(payload);
+```
+
+The parser already rejects unbounded length prefixes — `BencodeFormatException_StringLengthTooLarge` fires when a single string declares a length larger than `int.MaxValue`. The outer cap above adds protection against an attacker who sends a series of valid-but-massive nested structures.
+
+## Pattern 9 — what happens on malformed input
+
+```csharp
+using Bodu.Text.Formats;
+
+byte[] invalid = "d3:cow"u8.ToArray();    // dictionary missing value and 'e'
+
+try
+{
+    BencodedValue root = Bencode.Decode(invalid);
+}
+catch (BencodeFormatException ex)
+{
+    // ex.Message → "Unexpected end of bencoded data." (the next value never started)
+}
+```
+
+See [Core concepts — Format exception](../../docs/formats/concepts.md#format-exception) for the full message catalogue. Every BEP 3 invariant has a dedicated message; the parser never reports a generic *invalid input* error.
+
+## When to use which overload
+
+| Source | Recommended overload | Notes |
+|---|---|---|
+| `byte[]` from disk / memory | `Bencode.Decode(byte[])` | Null-guarded; throws on malformed input. |
+| `ReadOnlySpan<byte>` from a larger buffer | `Bencode.Decode(span)` or `Bencode.TryDecode(span, …)` | Choose based on whether trailing data is an error or expected. |
+| File / network `Stream` | `Bencode.Decode(stream)` / `DecodeAsync(stream)` | Buffers to end before parsing. |
+| Speculative parse (might fail) | `Bencode.TryDecode(...)` | Returns `false` instead of throwing. |
+
+| Destination | Recommended overload | Notes |
+|---|---|---|
+| Fresh `byte[]` | `Bencode.Encode(value)` | Allocates `GetEncodedLength(value)` bytes. |
+| Caller-owned `Span<byte>` | `Bencode.TryEncode(value, dest, out written)` | `false` if `dest` is shorter than the encoded length. |
+| File / network `Stream` | `Bencode.Encode(value, stream)` / `EncodeAsync(value, stream, ct)` | Pooled buffer, single `Write`. |
+
+## Where to go next
+
+- **[The BencodedValue model](value-model.md)** — the value types and their construction rules.
+- **[Streams and async I/O](streaming.md)** — buffer lifecycle, cancellation, and stream contracts.
+- **[Core concepts](../../docs/formats/concepts.md)** — vocabulary refresher.

--- a/docs/guides/formats/index.md
+++ b/docs/guides/formats/index.md
@@ -1,0 +1,56 @@
+---
+title: Bodu.Text.Formats guides
+---
+
+# Bodu.Text.Formats guides
+
+Recipe-style walk-throughs for **Bodu.Text.Formats**, organized by namespace and concern.
+
+If you are new to the library, start with the [introduction](../../docs/formats/index.md), the [Core concepts](../../docs/formats/concepts.md) glossary, and the [getting-started page](../../docs/formats/getting-started.md). The guides below assume you know the vocabulary (framed format, value tree, byte string, canonical encoding, framing token).
+
+## How the library works
+
+![Bencode encode/decode pipeline — object tree to canonical bytes and back](../../images/diagrams/formats-bencode-pipeline.svg)
+
+A bencoded document is a single tree of typed values. **`Bencode`** is the static codec — encode walks the tree with a recursive writer, decode runs a forward-only parser that dispatches on the leading framing token. The library enforces BEP 3 canonicality on both sides: encoders always emit the canonical form, parsers reject every non-canonical input.
+
+## Namespace map
+
+| Namespace | What lives here | Guides |
+|---|---|---|
+| `Bodu.Text.Formats` | Codec entry point (`Bencode`), value model (`BencodedValue` and the four kinds), supporting types (`BencodedStringComparer`, `BencodedValueKind`), and `BencodeFormatException`. | [Using Bencode](bencode.md) · [The BencodedValue model](value-model.md) · [Streams and async I/O](streaming.md) |
+
+## Guides
+
+### `Bodu.Text.Formats` — Codec
+
+<div class="bodu-cards">
+
+<div class="bodu-card">
+  <h3><a href="bencode.md">Using Bencode</a></h3>
+  <p>The static <code>Bencode</code> codec — <code>Encode</code>, <code>Decode</code>, <code>TryEncode</code>, <code>TryDecode</code>, <code>GetEncodedLength</code>, and the BEP 3 invariants enforced on both sides of the pipeline.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="value-model.md">The BencodedValue model</a></h3>
+  <p>Walk-through of <code>BencodedInteger</code>, <code>BencodedString</code>, <code>BencodedList</code>, and <code>BencodedDictionary</code> — their construction rules, dispatch via <code>BencodedValueKind</code>, and the ordinal <code>BencodedStringComparer</code> that drives dictionary ordering.</p>
+</div>
+
+</div>
+
+### `Bodu.Text.Formats` — I/O
+
+<div class="bodu-cards">
+
+<div class="bodu-card">
+  <h3><a href="streaming.md">Streams and async I/O</a></h3>
+  <p>Sync and async stream overloads — buffer staging via <code>ArrayPool&lt;byte&gt;</code>, cancellation, lifetime contracts, and when to prefer the span path over <code>Stream</code>.</p>
+</div>
+
+</div>
+
+## Where to go next
+
+- [Bodu.Text.Formats introduction](../../docs/formats/index.md) — mental model, headline types, scenarios.
+- [Core concepts](../../docs/formats/concepts.md) — vocabulary used throughout these guides.
+- [Bodu.Text.Formats getting started](../../docs/formats/getting-started.md) — install and minimal samples.

--- a/docs/guides/formats/streaming.md
+++ b/docs/guides/formats/streaming.md
@@ -1,0 +1,132 @@
+---
+title: Streams and async I/O
+---
+
+# Streams and async I/O
+
+Bencode is a **buffered**, not a *streaming*, format: a single value can declare an arbitrarily long byte string, dictionary key validation requires the full key set, and the parser is forward-only. The library reflects that by reading and writing the entire payload through pooled buffers — the stream overloads are convenience wrappers around the span path, not incremental codecs.
+
+For the synchronous span / array surface see [Using Bencode](bencode.md); this guide focuses specifically on the `Stream` overloads.
+
+## At a glance
+
+| Direction | Sync | Async |
+|---|---|---|
+| Decode | `BencodedValue Bencode.Decode(Stream)` | `ValueTask<BencodedValue> Bencode.DecodeAsync(Stream, CancellationToken)` |
+| Encode | `void Bencode.Encode(BencodedValue, Stream)` | `ValueTask Bencode.EncodeAsync(BencodedValue, Stream, CancellationToken)` |
+
+All four overloads:
+
+- Throw `ArgumentNullException` for a `null` stream or value.
+- Throw `ArgumentException` if the stream does not support the required direction (the parameter name in the exception is the offending stream).
+- Throw `BencodeFormatException` for any structural violation in the payload (decode path).
+- Throw `OverflowException` if the encoded length would exceed `int.MaxValue` (encode path).
+- Throw `OperationCanceledException` if `cancellationToken` is signalled during the async copy (async path).
+- **Do not close the stream** — lifetime is the caller's responsibility.
+
+## Pattern 1 — decode synchronously from a file
+
+```csharp
+using Bodu.Text.Formats;
+
+using FileStream fs = File.OpenRead("doc.bencode");
+BencodedValue root = Bencode.Decode(fs);
+```
+
+`Decode(Stream)` copies the stream to a pooled `MemoryStream`, then dispatches to the span parser. The pooled buffer is disposed before this method returns. The file stream is left open — the `using` block is what closes it.
+
+For seekable streams of known length this approach is fine in absolute cost (the copy is one pass through the bytes). For network streams it is the right shape: a half-arrived bencode payload cannot be partially parsed anyway.
+
+## Pattern 2 — decode asynchronously with cancellation
+
+```csharp
+using Bodu.Text.Formats;
+
+await using FileStream fs = File.OpenRead("doc.bencode");
+BencodedValue root = await Bencode.DecodeAsync(fs, cancellationToken);
+```
+
+`DecodeAsync` does the same buffer-then-parse, using `Stream.CopyToAsync` to absorb the source. Cancellation is checked by the underlying copy — if the token fires mid-copy, `OperationCanceledException` propagates and the parser never runs.
+
+The `BencodedValue` result is built from a temporary byte buffer that is disposed before the method returns; the returned value owns its own copies of every byte string and is safe to keep beyond the call.
+
+## Pattern 3 — encode synchronously to a file
+
+```csharp
+using Bodu.Text.Formats;
+
+using FileStream fs = File.Create("doc.bencode");
+Bencode.Encode(root, fs);
+```
+
+The synchronous `Encode(value, Stream)`:
+
+1. Validates `value` and `destination` for `null` and writability.
+2. Calls `GetEncodedLength(value)` to obtain the exact byte count.
+3. Rents a `byte[]` of that size from `ArrayPool<byte>.Shared`.
+4. Writes the encoded bytes into the rented buffer with the span path.
+5. Calls `destination.Write(buffer, 0, length)` once.
+6. Returns the buffer to the pool in a `finally` block.
+
+`GetEncodedLength` uses `checked` arithmetic — if the encoded length would not fit in `int`, it throws `OverflowException` and the rented buffer is never allocated.
+
+## Pattern 4 — encode asynchronously with cancellation
+
+```csharp
+using Bodu.Text.Formats;
+
+await using FileStream fs = File.Create("doc.bencode");
+await Bencode.EncodeAsync(root, fs, cancellationToken);
+```
+
+`EncodeAsync` is structurally identical to the sync path but uses `WriteAsync(ReadOnlyMemory<byte>, CancellationToken)` for the single output call. Cancellation is checked by the underlying write — if the token fires before the write completes, `OperationCanceledException` propagates and the pooled buffer is still returned via the `finally` clause.
+
+The token is **not** checked between encoding and writing — encoding is synchronous and (typically) fast; the cancellation surface is the I/O call itself.
+
+## Pattern 5 — pipe one bencode payload through a stream
+
+```csharp
+using Bodu.Text.Formats;
+
+await using FileStream input = File.OpenRead("source.bencode");
+await using FileStream output = File.Create("normalized.bencode");
+
+BencodedValue tree = await Bencode.DecodeAsync(input, cancellationToken);
+await Bencode.EncodeAsync(tree, output, cancellationToken);
+```
+
+The output is canonical: every dictionary in the source is re-emitted in raw byte order, every integer in shortest form, every string with the minimal length prefix. Use this pattern to normalize a corpus of bencoded files that may have been produced by encoders with different ordering conventions.
+
+For two-way piping through a network handshake, build the tree once and pass it to both `Encode` calls — the encoder is deterministic, so the same tree produces the same bytes every time.
+
+## Pattern 6 — limit input size
+
+Stream `Decode` reads to end of stream. For untrusted streams, wrap the source in a length-limited adapter or apply a server-level cap before calling:
+
+```csharp
+using Bodu.Text.Formats;
+
+const long maxBytes = 16L * 1024 * 1024;
+
+if (stream.CanSeek && stream.Length > maxBytes)
+    throw new InvalidOperationException("Bencode payload too large.");
+
+BencodedValue root = await Bencode.DecodeAsync(stream, cancellationToken);
+```
+
+For non-seekable streams (network sockets, decompressors), wrap the stream in a `StreamReader`-style throttle — copy at most `maxBytes` into a `MemoryStream` yourself, then pass that to `Decode`. The bencode parser cannot help here because the size limit is a transport-layer concern.
+
+## Why there is no incremental decoder
+
+A streaming `OperationStatus`-style decoder is a non-goal for bencode for two reasons:
+
+- **Byte-string framing.** A single `5000000:` length prefix declares 5 MB of opaque payload that the parser must read contiguously. Suspending and resuming the parser at byte 3 of that payload would require a stateful machine for a single byte-copy operation.
+- **Key ordering.** Dictionary keys must be globally sorted. The parser cannot validate the ordering invariant on the *N*th key without having read every key before it. Suspending mid-dictionary trades complexity for no real benefit.
+
+Streaming-friendly formats (CBOR, MessagePack, length-prefixed protobufs) are better choices when incremental decode actually matters. For bencode, the buffer-then-parse approach is both simpler and identical in total work.
+
+## Where to go next
+
+- **[Using Bencode](bencode.md)** — the codec surface and the BEP 3 invariants it enforces.
+- **[The BencodedValue model](value-model.md)** — the value types you parse into and encode from.
+- **[Core concepts](../../docs/formats/concepts.md)** — vocabulary refresher.

--- a/docs/guides/formats/toc.yml
+++ b/docs/guides/formats/toc.yml
@@ -1,0 +1,12 @@
+- name: Overview
+  href: index.md
+- name: Bodu.Text.Formats — Codec
+  items:
+    - name: Using Bencode
+      href: bencode.md
+    - name: The BencodedValue model
+      href: value-model.md
+- name: Bodu.Text.Formats — I/O
+  items:
+    - name: Streams and async I/O
+      href: streaming.md

--- a/docs/guides/formats/value-model.md
+++ b/docs/guides/formats/value-model.md
@@ -1,0 +1,216 @@
+---
+title: The BencodedValue model
+---
+
+# The `BencodedValue` model
+
+A decoded bencode document is a tree of <xref:Bodu.Text.Formats.BencodedValue> instances. The base class exposes a single read-only property, <xref:Bodu.Text.Formats.BencodedValue.Kind>, that returns the matching <xref:Bodu.Text.Formats.BencodedValueKind> member. Four concrete subtypes implement the four grammar productions.
+
+For the grammar itself see [Core concepts — Value kinds](../../docs/formats/concepts.md#value-kinds).
+
+## Value kinds at a glance
+
+![Bencode value grammar — four kinds, four framings](../../images/diagrams/formats-bencode-grammar.svg)
+
+| Subtype | `Kind` | Wire form (example) | Notes |
+|---|---|---|---|
+| <xref:Bodu.Text.Formats.BencodedInteger> | `Integer` | `i-1024e` | Signed 64-bit integer; no leading zeros, no `-0`. |
+| <xref:Bodu.Text.Formats.BencodedString> | `String` | `5:hello` | Length-prefixed raw bytes; not necessarily UTF-8. |
+| <xref:Bodu.Text.Formats.BencodedList> | `List` | `l4:spami42ee` | Ordered list of values; constructor rejects null elements. |
+| <xref:Bodu.Text.Formats.BencodedDictionary> | `Dictionary` | `d3:cow3:mooe` | Byte-string keyed; stored sorted by raw byte order. |
+
+## Dispatching on `Kind`
+
+A `BencodedValue` is the lowest common denominator. Real code projects each node to its expected subtype using a switch on `Kind`:
+
+```csharp
+using Bodu.Text.Formats;
+
+string Describe(BencodedValue value) => value.Kind switch
+{
+    BencodedValueKind.Integer    => $"int    {((BencodedInteger)value).Value}",
+    BencodedValueKind.String     => $"bytes  {((BencodedString)value).Length}",
+    BencodedValueKind.List       => $"list   {((BencodedList)value).Count} items",
+    BencodedValueKind.Dictionary => $"dict   {((BencodedDictionary)value).Count} pairs",
+    _ => throw new InvalidOperationException("Unreachable: BencodedValueKind is closed."),
+};
+```
+
+`BencodedValueKind` is a small closed enum. The decoder never produces any other value; the `_` branch in the switch is there only to keep the compiler happy when the enum is later expanded.
+
+## `BencodedInteger`
+
+```csharp
+using Bodu.Text.Formats;
+
+var one = new BencodedInteger(1);
+var negative = new BencodedInteger(-1_024);
+var hugeButLegal = new BencodedInteger(long.MaxValue);
+
+long v = one.Value;
+string s = one.ToString();  // "1" (CultureInfo.InvariantCulture)
+```
+
+The constructor accepts any `long`. The decoder enforces the BEP 3 invariants on incoming data:
+
+- No leading zeros — `i01e` is rejected with *Bencoded integers cannot contain leading zeros*.
+- No negative zero — `i-0e` is rejected with *Negative zero is not a valid bencoded integer*.
+- Must fit in `Int64` — values that overflow are rejected with *outside the supported Int64 range*.
+
+`BencodedInteger.Equals(BencodedInteger?)` compares the underlying `long`; `GetHashCode` delegates to `long.GetHashCode`.
+
+## `BencodedString`
+
+`BencodedString` wraps a raw byte payload. It exposes the bytes as `ReadOnlyMemory<byte>` and offers helpers for the text case:
+
+```csharp
+using Bodu.Text.Formats;
+
+// From bytes.
+var raw = new BencodedString(new byte[] { 0xDE, 0xAD, 0xBE, 0xEF });
+
+// From bytes (span overload — defensively copies).
+ReadOnlySpan<byte> span = stackalloc byte[] { 1, 2, 3, 4 };
+var fromSpan = new BencodedString(span);
+
+// From text (UTF-8 encoded).
+var hello = BencodedString.FromUtf8("hello");
+
+// Project back to text (only valid if the field is known to be UTF-8).
+string s = hello.GetUtf8String();   // "hello"
+
+// Length and raw access.
+int length = hello.Length;
+ReadOnlyMemory<byte> bytes = hello.Bytes;
+```
+
+The byte constructors always defensively copy the input, so the caller's source array can be mutated without affecting the value. Equality compares byte sequences:
+
+```csharp
+BencodedString.FromUtf8("info") == BencodedString.FromUtf8("info");   // true (Equals is value-based)
+```
+
+`ToString()` returns the UTF-8 projection — useful for `Console.WriteLine` and debugger display, but **not** safe for fields that hold raw binary like SHA-1 piece hashes.
+
+## `BencodedList`
+
+A list is an ordered sequence of values. The constructor accepts any `IEnumerable<BencodedValue>` and materializes it once:
+
+```csharp
+using Bodu.Text.Formats;
+
+var list = new BencodedList([
+    new BencodedInteger(42),
+    BencodedString.FromUtf8("spam"),
+    new BencodedList([new BencodedInteger(1), new BencodedInteger(2)]),  // nested
+]);
+
+int count = list.Count;
+BencodedValue first = list[0];
+foreach (BencodedValue item in list.Items)
+    Console.WriteLine(item.Kind);
+```
+
+- `null` elements throw `ArgumentException` with the message *The list cannot contain null values.*
+- `null` source enumerable throws `ArgumentNullException`.
+- Iteration order is exactly the wire order — lists are not sorted on construction.
+
+`Items` returns an `IReadOnlyList<BencodedValue>`; the indexer is a direct pass-through to the underlying array.
+
+## `BencodedDictionary`
+
+A dictionary maps byte-string keys to values. The constructor accepts an `IEnumerable<KeyValuePair<BencodedString, BencodedValue>>` and stores them in a `SortedDictionary` keyed by <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal>:
+
+```csharp
+using Bodu.Text.Formats;
+
+var info = new BencodedDictionary([
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("length"),
+        new BencodedInteger(1024)),
+    new KeyValuePair<BencodedString, BencodedValue>(
+        BencodedString.FromUtf8("name"),
+        BencodedString.FromUtf8("hello.bin")),
+]);
+
+int count = info.Count;
+
+// Lookup by BencodedString key.
+BencodedString lengthKey = BencodedString.FromUtf8("length");
+BencodedValue lengthValue = info[lengthKey];
+
+// Lookup by UTF-8 text key.
+if (info.TryGetValue("name", out BencodedValue nameValue))
+    Console.WriteLine(((BencodedString)nameValue).GetUtf8String());
+```
+
+Construction validates the BEP 3 dictionary invariants:
+
+- `null` keys throw *The dictionary cannot contain null keys.*
+- `null` values throw *The dictionary cannot contain null values.*
+- Duplicate keys throw *The dictionary cannot contain duplicate keys.*
+
+Iteration via `GetOrderedItems()` returns the items in canonical (raw byte) order regardless of insertion order. `Items` exposes the same sequence as an `IReadOnlyDictionary<BencodedString, BencodedValue>` for LINQ-friendly access.
+
+### Lookup overloads
+
+```csharp
+// Strict byte-string lookup (zero allocation if the key is already a BencodedString).
+info.TryGetValue(someKey, out BencodedValue v1);
+
+// UTF-8 text lookup — allocates a temporary BencodedString.
+info.TryGetValue("piece length", out BencodedValue v2);
+```
+
+Use the `BencodedString` overload in hot paths where the key is already in canonical form. The `string` overload is the convenience entry point — it converts the input via `BencodedString.FromUtf8` and dispatches through the same lookup.
+
+## `BencodedStringComparer`
+
+The library's dictionary keys are ordered and compared by **raw byte ordinal**, not by Unicode collation. <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal> is the singleton comparer that drives this:
+
+```csharp
+using Bodu.Text.Formats;
+
+IComparer<BencodedString>          ordering = BencodedStringComparer.Ordinal;
+IEqualityComparer<BencodedString>  equality = BencodedStringComparer.Ordinal;
+
+// Use it to build your own SortedDictionary that matches the library's ordering:
+var mine = new SortedDictionary<BencodedString, BencodedValue>(BencodedStringComparer.Ordinal);
+```
+
+It implements both `IComparer<BencodedString>` and `IEqualityComparer<BencodedString>`. `Compare` does a lexicographic byte-by-byte comparison and breaks ties on length. `Equals` returns `Compare(...) == 0`. `GetHashCode` hashes the byte sequence with `HashCode.Add`.
+
+The comparer is the same one `BencodedDictionary` uses internally; you only need to reach for it if you maintain your own collection of `BencodedString` keys outside the library types.
+
+## Building a tree fluently
+
+For small documents the constructor literals are the most concise form. For larger trees, build the leaves first and assemble the dictionary last:
+
+```csharp
+using Bodu.Text.Formats;
+
+static KeyValuePair<BencodedString, BencodedValue> Entry(string key, BencodedValue value) =>
+    new(BencodedString.FromUtf8(key), value);
+
+var info = new BencodedDictionary([
+    Entry("length",       new BencodedInteger(fileLength)),
+    Entry("name",         BencodedString.FromUtf8(fileName)),
+    Entry("piece length", new BencodedInteger(pieceLength)),
+    Entry("pieces",       new BencodedString(pieceHashes)),
+]);
+
+var doc = new BencodedDictionary([
+    Entry("announce", BencodedString.FromUtf8(trackerUrl)),
+    Entry("info",     info),
+]);
+
+byte[] encoded = Bencode.Encode(doc);
+```
+
+The order in which entries are passed to the constructor does not matter — the dictionary sorts them by raw key bytes on construction, so `Bencode.Encode` always emits the canonical key order.
+
+## Where to go next
+
+- **[Using Bencode](bencode.md)** — the codec entry points and the BEP 3 invariants they enforce.
+- **[Streams and async I/O](streaming.md)** — buffer lifecycle and cancellation.
+- **[Core concepts](../../docs/formats/concepts.md)** — vocabulary refresher.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -383,3 +383,35 @@ runtime-pluggable encoding choice.
 </div>
 
 </div>
+
+---
+
+## Bodu.Text.Formats
+
+Self-framing binary serialization formats with a strongly-typed value model and a span- and stream-friendly codec.
+The first format the package ships is **Bencode** (the BitTorrent BEP 3 grammar) — full canonicality enforcement
+on both sides of the pipeline.
+
+<div class="bodu-cards">
+
+<div class="bodu-card">
+  <h3><a href="formats/index.md">Overview</a></h3>
+  <p>Namespace map, pipeline diagram, and where each guide fits.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="formats/bencode.md">Using Bencode</a></h3>
+  <p>The static codec — <code>Encode</code>, <code>Decode</code>, <code>TryEncode</code>, <code>TryDecode</code>, <code>GetEncodedLength</code>, and the BEP 3 invariants enforced on both sides.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="formats/value-model.md">The BencodedValue model</a></h3>
+  <p><code>BencodedInteger</code>, <code>BencodedString</code>, <code>BencodedList</code>, and <code>BencodedDictionary</code> — construction rules, <code>Kind</code>-based dispatch, and the ordinal <code>BencodedStringComparer</code> that drives dictionary ordering.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="formats/streaming.md">Streams and async I/O</a></h3>
+  <p>Sync and async stream overloads — buffer staging via <code>ArrayPool&lt;byte&gt;</code>, cancellation, lifetime contracts, and when to prefer the span path over <code>Stream</code>.</p>
+</div>
+
+</div>

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -157,3 +157,18 @@
       items:
         - name: The IBinaryEncoding interface
           href: text-encoding/binary-encodings-interface.md
+- name: Bodu.Text.Formats
+  href: formats/
+  items:
+    - name: Overview
+      href: formats/index.md
+    - name: Bodu.Text.Formats — Codec
+      items:
+        - name: Using Bencode
+          href: formats/bencode.md
+        - name: The BencodedValue model
+          href: formats/value-model.md
+    - name: Bodu.Text.Formats — I/O
+      items:
+        - name: Streams and async I/O
+          href: formats/streaming.md

--- a/docs/images/diagrams/formats-bencode-grammar.svg
+++ b/docs/images/diagrams/formats-bencode-grammar.svg
@@ -1,0 +1,102 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 300" role="img" aria-labelledby="bg-t bg-d">
+  <title id="bg-t">Bencode value grammar — four kinds, four framings</title>
+  <desc id="bg-d">Bencode defines four value kinds. An integer is framed by 'i' and 'e' around an ASCII signed decimal. A byte string is length-prefixed by an ASCII integer, a colon separator, and a raw byte payload. A list is framed by 'l' and 'e' around zero or more child values. A dictionary is framed by 'd' and 'e' around an ordered sequence of byte-string keys paired with values. Keys must appear in raw byte-ordinal order.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; letter-spacing: 1px; }
+      .mono  { font: 700 13px/1 "Consolas","Menlo",monospace; fill: #E2E8F0; text-anchor: middle; }
+      .tok   { fill: #FBBF24; font: 700 13px/1 "Consolas","Menlo",monospace; }
+      .alt   { fill: #60A5FA; font: 700 13px/1 "Consolas","Menlo",monospace; }
+      .b1    { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .b2    { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .b3    { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .b4    { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="820" height="300"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="280" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Bencode value grammar — four kinds, four framings</text>
+
+    <!-- ============ Integer ============ -->
+    <g transform="translate(28 56)">
+      <text class="ttag" x="86" y="0">INTEGER</text>
+      <rect class="b1" width="172" height="58" y="8" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="86" y="30">BencodedInteger</text>
+      <text x="86" y="54" class="mono">
+        <tspan class="tok">i</tspan>-1024<tspan class="tok">e</tspan>
+      </text>
+      <text class="mut" x="86" y="84">signed decimal, 64-bit</text>
+      <text class="mut" x="86" y="98">no leading zeros, no -0</text>
+    </g>
+
+    <!-- ============ Byte string ============ -->
+    <g transform="translate(220 56)">
+      <text class="ttag" x="86" y="0">BYTE STRING</text>
+      <rect class="b2" width="172" height="58" y="8" rx="6"/>
+      <text class="lbl" fill="#93C5FD" x="86" y="30">BencodedString</text>
+      <text x="86" y="54" class="mono">
+        5<tspan class="tok">:</tspan>hello
+      </text>
+      <text class="mut" x="86" y="84">length-prefixed raw bytes</text>
+      <text class="mut" x="86" y="98">opaque — not necessarily UTF-8</text>
+    </g>
+
+    <!-- ============ List ============ -->
+    <g transform="translate(412 56)">
+      <text class="ttag" x="86" y="0">LIST</text>
+      <rect class="b3" width="172" height="58" y="8" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="86" y="30">BencodedList</text>
+      <text x="86" y="54" class="mono">
+        <tspan class="tok">l</tspan>4<tspan class="tok">:</tspan>spam<tspan class="tok">i</tspan>42<tspan class="tok">ee</tspan>
+      </text>
+      <text class="mut" x="86" y="84">ordered sequence of values</text>
+      <text class="mut" x="86" y="98">any kind, any depth</text>
+    </g>
+
+    <!-- ============ Dictionary ============ -->
+    <g transform="translate(604 56)">
+      <text class="ttag" x="86" y="0">DICTIONARY</text>
+      <rect class="b4" width="172" height="58" y="8" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="86" y="30">BencodedDictionary</text>
+      <text x="86" y="54" class="mono">
+        <tspan class="tok">d</tspan>3<tspan class="tok">:</tspan>cow3<tspan class="tok">:</tspan>moo<tspan class="tok">e</tspan>
+      </text>
+      <text class="mut" x="86" y="84">byte-string keys → values</text>
+      <text class="mut" x="86" y="98">ordered by raw key bytes</text>
+    </g>
+
+    <!-- ============ Framing-token legend ============ -->
+    <g transform="translate(28 168)">
+      <text class="lbl" fill="#F8FAFC" x="0" y="0" style="text-anchor: start">Framing tokens</text>
+
+      <g transform="translate(0 14)" font-family="'Consolas','Menlo',monospace" font-size="13">
+        <text class="tok" x="0"   y="14">i ... e</text>
+        <text class="mut" x="80"  y="14" style="text-anchor: start">integer body between 'i' and 'e'</text>
+
+        <text class="tok" x="0"   y="34">N : bytes</text>
+        <text class="mut" x="80"  y="34" style="text-anchor: start">decimal length, ':' separator, exactly N bytes</text>
+
+        <text class="tok" x="0"   y="54">l ... e</text>
+        <text class="mut" x="80"  y="54" style="text-anchor: start">list elements between 'l' and 'e'</text>
+
+        <text class="tok" x="0"   y="74">d K V K V e</text>
+        <text class="mut" x="100" y="74" style="text-anchor: start">dictionary key/value pairs between 'd' and 'e' — keys are byte strings, sorted by raw byte order</text>
+      </g>
+    </g>
+
+    <text class="mut" x="400" y="266" text-anchor="middle">A full document is exactly one top-level value (typically a dictionary). Trailing bytes are rejected.</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/formats-bencode-pipeline.svg
+++ b/docs/images/diagrams/formats-bencode-pipeline.svg
@@ -1,0 +1,112 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 280" role="img" aria-labelledby="bp-t bp-d">
+  <title id="bp-t">Bencode encode/decode pipeline</title>
+  <desc id="bp-d">The Bencode pipeline runs in both directions. Encoding takes a BencodedValue object tree, walks it with a recursive writer, emits framing tokens and raw payload bytes into a span-, array-, or stream-sized destination, and writes a canonical byte stream. Decoding takes a byte source, runs a forward-only parser that recognises the leading token for each value, builds the matching BencodedValue subtype, validates BEP 3 invariants (no leading zeros, no negative zero, sorted dictionary keys, no trailing data), and returns the object tree.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; letter-spacing: 1px; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .rowd  { fill: #A78BFA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .src   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .mid   { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .dst   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out   { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .wp    { stroke: #A78BFA; stroke-width: 1.6; fill: none; }
+    </style>
+    <marker id="bpt-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="bpd-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="280"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="260" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Bencode encode/decode pipeline</text>
+
+    <!-- ===== Top row — ENCODE (left-to-right, teal) ===== -->
+    <text class="row" x="20" y="58">ENCODE  ▸ object tree → canonical bytes</text>
+
+    <g transform="translate(20 70)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">BencodedValue tree</text>
+      <text class="mut" x="80" y="36">Integer · String · List · Dict</text>
+    </g>
+
+    <line class="wt" x1="180" y1="93" x2="220" y2="93" marker-end="url(#bpt-a)"/>
+
+    <g transform="translate(220 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">GetEncodedLength</text>
+      <text class="mut" x="80" y="36">measure exact byte count</text>
+    </g>
+
+    <line class="wt" x1="380" y1="93" x2="420" y2="93" marker-end="url(#bpt-a)"/>
+
+    <g transform="translate(420 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">WriteValue (recursive)</text>
+      <text class="mut" x="80" y="36">emit framing + payload</text>
+    </g>
+
+    <line class="wt" x1="580" y1="93" x2="620" y2="93" marker-end="url(#bpt-a)"/>
+
+    <g transform="translate(620 70)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">byte[] / Span&lt;byte&gt;</text>
+      <text class="mut" x="80" y="36">canonical encoding</text>
+    </g>
+
+    <!-- ===== Middle separator ===== -->
+    <line x1="20" y1="138" x2="780" y2="138" stroke="#334155" stroke-width="1"/>
+
+    <!-- ===== Bottom row — DECODE (left-to-right, purple) ===== -->
+    <text class="rowd" x="20" y="160">DECODE  ▸ canonical bytes → object tree</text>
+
+    <g transform="translate(20 172)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">byte[] / Stream</text>
+      <text class="mut" x="80" y="36">network · file · cache</text>
+    </g>
+
+    <line class="wp" x1="180" y1="195" x2="220" y2="195" marker-end="url(#bpd-a)"/>
+
+    <g transform="translate(220 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">Parser (ref struct)</text>
+      <text class="mut" x="80" y="36">peek prefix → dispatch</text>
+    </g>
+
+    <line class="wp" x1="380" y1="195" x2="420" y2="195" marker-end="url(#bpd-a)"/>
+
+    <g transform="translate(420 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">Validate invariants</text>
+      <text class="mut" x="80" y="36">no leading zeros · sorted keys</text>
+    </g>
+
+    <line class="wp" x1="580" y1="195" x2="620" y2="195" marker-end="url(#bpd-a)"/>
+
+    <g transform="translate(620 172)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">BencodedValue tree</text>
+      <text class="mut" x="80" y="36">strongly typed result</text>
+    </g>
+
+    <!-- Footer note -->
+    <text class="mut" x="400" y="244" text-anchor="middle">Try variants (TryEncode / TryDecode) return false / null instead of throwing; stream overloads stage to a pooled buffer before passing the span path.</text>
+  </g>
+</svg>

--- a/docs/images/hero-formats.svg
+++ b/docs/images/hero-formats.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.Text.Formats — framed binary serialization formats">
+  <title>Bodu.Text.Formats</title>
+  <defs>
+    <linearGradient id="fmt-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="fmt-cell" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#fmt-bg)"/>
+
+  <!-- Left column: source object tree -->
+  <g transform="translate(28 30)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11">
+    <rect width="138" height="160" rx="8" fill="#1E293B" stroke="#334155" stroke-width="1.2"/>
+    <rect width="138" height="22" rx="8" fill="#3B82F6"/>
+    <rect y="14" width="138" height="8" fill="#3B82F6"/>
+    <text x="69" y="16" fill="#F8FAFC" text-anchor="middle" font-weight="700" font-size="11">object tree</text>
+
+    <g fill="#E2E8F0" font-family="'Consolas','Menlo',monospace" font-size="11">
+      <text x="10" y="42">dict</text>
+      <text x="22" y="60" fill="#60A5FA">"announce"</text>
+      <text x="22" y="76">  "tracker..."</text>
+      <text x="22" y="94" fill="#60A5FA">"info"</text>
+      <text x="22" y="110">  dict</text>
+      <text x="34" y="126" fill="#60A5FA">"length"</text>
+      <text x="34" y="142">    1024</text>
+    </g>
+  </g>
+
+  <!-- middle: bidirectional pipeline arrows -->
+  <g transform="translate(176 80)" fill="none" stroke="#60A5FA" stroke-width="2" stroke-linecap="round">
+    <!-- encode arrow (top, ltr) -->
+    <line x1="0" y1="0" x2="120" y2="0"/>
+    <polygon points="120,0 112,-4 112,4" fill="#60A5FA" stroke="none"/>
+    <!-- decode arrow (bottom, rtl) -->
+    <line x1="120" y1="36" x2="0" y2="36"/>
+    <polygon points="0,36 8,32 8,40" fill="#60A5FA" stroke="none"/>
+  </g>
+  <g transform="translate(176 80)" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="10" text-anchor="middle">
+    <text x="60" y="-6">encode</text>
+    <text x="60" y="56">decode</text>
+  </g>
+
+  <!-- Right column: encoded byte stream -->
+  <g transform="translate(310 30)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11">
+    <rect width="142" height="160" rx="8" fill="#1E293B" stroke="#334155" stroke-width="1.2"/>
+    <rect width="142" height="22" rx="8" fill="#A78BFA"/>
+    <rect y="14" width="142" height="8" fill="#A78BFA"/>
+    <text x="71" y="16" fill="#F8FAFC" text-anchor="middle" font-weight="700" font-size="11">byte stream</text>
+
+    <g fill="#E2E8F0" font-family="'Consolas','Menlo',monospace" font-size="11">
+      <text x="10" y="42"><tspan fill="#FBBF24">d</tspan>8:announce</text>
+      <text x="10" y="58">12:tracker...</text>
+      <text x="10" y="74">4:info</text>
+      <text x="10" y="90"><tspan fill="#FBBF24">d</tspan>6:length</text>
+      <text x="10" y="106"><tspan fill="#FBBF24">i</tspan>1024<tspan fill="#FBBF24">e</tspan></text>
+      <text x="10" y="122"><tspan fill="#FBBF24">e</tspan></text>
+      <text x="10" y="138"><tspan fill="#FBBF24">e</tspan></text>
+    </g>
+  </g>
+
+  <!-- bottom note: bencode -->
+  <g fill="#94A3B8" font-family="'Consolas','Menlo',monospace" font-size="10">
+    <text x="240" y="206" text-anchor="middle">framed · self-describing · canonical</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,10 +20,10 @@ _disableBreadcrumb: true
 
 <div class="bodu-hero">
   <h1>Bodu</h1>
-  <p class="tagline">A suite of small, focused .NET libraries for collections, non-cryptographic hashing, cryptography, calendar computation, and binary-to-text encoding.</p>
+  <p class="tagline">A suite of small, focused .NET libraries for collections, non-cryptographic hashing, cryptography, calendar computation, binary-to-text encoding, and self-framing binary formats.</p>
 </div>
 
-Five independent NuGet packages that share a single solution, a single set of conventions, and a single bar for quality: nullable-enabled, analyzer-clean, deterministic builds, and framework-style XML documentation.
+Six independent NuGet packages that share a single solution, a single set of conventions, and a single bar for quality: nullable-enabled, analyzer-clean, deterministic builds, and framework-style XML documentation.
 
 ## Libraries
 
@@ -82,6 +82,16 @@ Five independent NuGet packages that share a single solution, a single set of co
   </div>
 </div>
 
+<div class="bodu-card">
+  <img src="images/hero-formats.svg" alt="Bodu.Text.Formats" />
+  <h3>Bodu.Text.Formats</h3>
+  <p>Self-framing binary serialization formats with a strongly-typed value model and a span- and stream-friendly codec. The first format the package ships is <strong>Bencode</strong> (the BitTorrent serialization grammar from BEP 3) — <code>Bencode.Encode</code> / <code>Decode</code> / <code>TryEncode</code> / <code>TryDecode</code> / <code>GetEncodedLength</code> over <code>ReadOnlySpan&lt;byte&gt;</code>, <code>byte[]</code>, and <code>Stream</code>, an immutable <code>BencodedValue</code> tree (<code>Integer</code>, <code>String</code>, <code>List</code>, <code>Dictionary</code>), and full BEP 3 canonicality enforcement on both sides of the pipeline.</p>
+  <div class="bodu-card-links">
+    <a href="docs/formats/index.md">Introduction</a>
+    <a href="guides/formats/index.md">Guides</a>
+  </div>
+</div>
+
 </div>
 
 ## Install
@@ -94,6 +104,7 @@ dotnet add package Bodu.IO.Hashing
 dotnet add package Bodu.Security.Cryptography
 dotnet add package Bodu.Globalization.Calendar
 dotnet add package Bodu.Text.Encoding
+dotnet add package Bodu.Text.Formats
 
 # Optional region-specific calendar data packs:
 dotnet add package Bodu.Globalization.Calendar.Data.Americas


### PR DESCRIPTION
Introduce the Bencode codec documentation following the same docs/guides
structure used by Bodu.Globalization.Calendar — three intro pages
(index, concepts, getting-started), four guide pages (overview, codec,
value model, streams), TOC entries, and SVG diagrams for the encode/
decode pipeline and the four-kind value grammar.

https://claude.ai/code/session_01MeT7YGJMcM31Y5TG12Puyn