### PR TITLE
Add Bodu.Text.Encoding hero image and inline diagrams

### DIFF
--- a/docs/docs/text-encoding/concepts.md
+++ b/docs/docs/text-encoding/concepts.md
@@ -50,17 +50,7 @@ For power-of-two radices (Base16, Base32, Base64), encoding is a **bit-stream op
 concatenated into a bit stream, then chunked into N-bit groups (where N is `log2(radix)`). Each N-bit group becomes
 one output symbol.
 
-```
-Base16 (4 bits / symbol):  AB → 10101011 → 1010 1011 → 'a' 'b'
-Base32 (5 bits / symbol):  fooba → 01100110 01101111 01101111 01100010 01100001
-                                  → 01100 11001 10111 10110 11000 10011 00001
-                                  → 12 25 23 22 24 19 1
-                                  → M  Z  X  W  Y  T  B
-Base64 (6 bits / symbol):  foo   → 01100110 01101111 01101111
-                                  → 011001 100110 111101 101111
-                                  → 25 38 61 47
-                                  → Z  m  9  v
-```
+![Bit-stream packing — Base16, Base32, Base64](../../images/diagrams/encoding-bit-packing.svg)
 
 Base58 is **not** a power of two: it uses big-integer divmod by 58. Base85 uses **4-byte blocks** packed into a
 32-bit unsigned integer, then divided by 85 four times to emit five characters.
@@ -69,6 +59,8 @@ Base58 is **not** a power of two: it uses big-integer divmod by 58. Base85 uses 
 
 The **terminal quantum** is the last group at the end of the input. When the input does not divide evenly into
 the group size, the spec defines which character counts are legal and how padding aligns the output.
+
+![Terminal quantum and padding — RFC 4648](../../images/diagrams/encoding-terminal-quantum.svg)
 
 RFC 4648 quantum rules:
 

--- a/docs/docs/text-encoding/index.md
+++ b/docs/docs/text-encoding/index.md
@@ -17,36 +17,17 @@ It fills two gaps that `System.Convert` and `System.Buffers.Text.Base64` leave o
 
 ## Core mental model
 
-Every encoding in the library follows the same conceptual pipeline:
+![Encode and decode pipeline — binary bytes to encoded text and back](../../images/diagrams/encoding-pipeline.svg)
 
-```
-                   ┌──────────────────────────────────────────────────────────────┐
-                   │                       binary bytes                            │
-                   └──────────────────────────────────────────────────────────────┘
-                                            │
-                  ┌─────────────────────────┴──────────────────────────────────┐
-                  │ Encode                                                     │
-                  │  • bit-stream pack into N-bit symbols (Base16/32/64)       │
-                  │  • big-integer divmod (Base58)                             │
-                  │  • 4-byte block → 5 chars (Base85)                         │
-                  └─────────────────────────┬──────────────────────────────────┘
-                                            │
-                  ┌─────────────────────────┴──────────────────────────────────┐
-                  │ Apply variant transforms                                   │
-                  │  • alphabet (Standard / hex / URL-safe / Crockford / Z85)  │
-                  │  • padding (=) / shortcut (Ascii85 'z')                    │
-                  │  • optional decoration (UpperCase / spacing / line breaks) │
-                  └─────────────────────────┬──────────────────────────────────┘
-                                            │
-                   ┌────────────────────────┴─────────────────────────────────┐
-                   │                       encoded text                         │
-                   └──────────────────────────────────────────────────────────────┘
-```
-
-Decoding is the same path in reverse: optional decoration stripping → alphabet lookup → bit-stream unpack
-(or divmod / 5-char block expansion).
+Every encoding in the library follows the same four-stage pipeline. Encoding takes raw binary bytes, runs the
+radix conversion (bit-stream pack for Base16 / Base32 / Base64, big-integer divmod for Base58, 4-byte block packing
+for Base85), applies the variant-specific transform (alphabet swap, padding, shortcut), and optionally adds
+decorations (case folding, prefix, byte spacing, line breaks). Decoding is the same path in reverse — strip
+decoration, apply alphabet lookup, then bit-stream unpack / divmod / block expansion.
 
 ## Where each encoding fits
+
+![Encoding families — payload expansion at a glance](../../images/diagrams/encoding-families.svg)
 
 | Encoding | Bits per symbol | Payload expansion | Typical use cases |
 |---|---|---|---|

--- a/docs/guides/text-encoding/index.md
+++ b/docs/guides/text-encoding/index.md
@@ -9,6 +9,14 @@ package, start with the **[Introduction](../../docs/text-encoding/index.md)** an
 **[Core concepts](../../docs/text-encoding/concepts.md)** pages first — the guides below assume you know the
 vocabulary (alphabet, variant, terminal quantum, padding, decoration, OperationStatus).
 
+## How the library works
+
+![Encode and decode pipeline — binary bytes to encoded text and back](../../images/diagrams/encoding-pipeline.svg)
+
+Every encoding follows the same four-stage pipeline — radix conversion, variant transform, optional decoration,
+encoded output. The per-encoding guides drill into the stages that vary by family: the bit-stream packing for
+Base16 / Base32 / Base64, the big-integer arithmetic for Base58, and the 4-byte block packing for Base85.
+
 ## At a glance
 
 | Family | Expansion | Variants | Use cases |

--- a/docs/images/diagrams/encoding-bit-packing.svg
+++ b/docs/images/diagrams/encoding-bit-packing.svg
@@ -1,0 +1,203 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 340" role="img" aria-labelledby="bp-t bp-d">
+  <title id="bp-t">Bit-stream packing — Base16, Base32, Base64</title>
+  <desc id="bp-d">For power-of-two radices the encoder concatenates input bytes into a bit stream and chunks it into N-bit groups. Base16 takes 4-bit nibbles and emits two characters per byte. Base32 takes 5-bit groups and emits 8 characters per 5 input bytes. Base64 takes 6-bit groups and emits 4 characters per 3 input bytes. Each N-bit group's numeric value is its alphabet index.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; letter-spacing: 1px; }
+      .mono  { font-family: "Consolas","Menlo",monospace; }
+      .b16   { fill: #2DD4BF; }
+      .b32   { fill: #60A5FA; }
+      .b64   { fill: #A78BFA; }
+      .row   { fill: #1F2937; stroke: #334155; stroke-width: 1; }
+      .bits16{ fill: #0D3331; stroke: #2DD4BF; stroke-width: 1; }
+      .bits32{ fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .bits64{ fill: #2A1B54; stroke: #A78BFA; stroke-width: 1; }
+      .alpha { fill: #431407; stroke: #FBBF24; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="820" height="340"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="320" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Bit-stream packing — Base16 · Base32 · Base64</text>
+
+    <!-- ============================================== Base16 row ============================================== -->
+    <g transform="translate(20 56)">
+      <text class="ttag b16" x="0" y="0">BASE16  ·  4 BITS / SYMBOL  ·  100% EXPANSION</text>
+
+      <!-- Input byte AB (10101011) -->
+      <rect class="row" x="0" y="10" width="120" height="28" rx="4"/>
+      <text class="mono lbl" x="60" y="29" fill="#F8FAFC">byte 0xAB</text>
+
+      <!-- 8-bit cells -->
+      <g class="mono" font-size="11" font-weight="700">
+        <g fill="#0D3331" stroke="#2DD4BF" stroke-width="1">
+          <rect x="140" y="10" width="22" height="28"/>
+          <rect x="162" y="10" width="22" height="28"/>
+          <rect x="184" y="10" width="22" height="28"/>
+          <rect x="206" y="10" width="22" height="28"/>
+        </g>
+        <g fill="#1B3A38" stroke="#2DD4BF" stroke-width="1">
+          <rect x="232" y="10" width="22" height="28"/>
+          <rect x="254" y="10" width="22" height="28"/>
+          <rect x="276" y="10" width="22" height="28"/>
+          <rect x="298" y="10" width="22" height="28"/>
+        </g>
+        <g fill="#F8FAFC" text-anchor="middle">
+          <text x="151" y="29">1</text>
+          <text x="173" y="29">0</text>
+          <text x="195" y="29">1</text>
+          <text x="217" y="29">0</text>
+          <text x="243" y="29">1</text>
+          <text x="265" y="29">0</text>
+          <text x="287" y="29">1</text>
+          <text x="309" y="29">1</text>
+        </g>
+      </g>
+
+      <!-- Group brackets -->
+      <g class="mono" font-size="10" fill="#94A3B8">
+        <text x="184" y="55" text-anchor="middle">└── 4 bits (10102) = 10 ──┘</text>
+        <text x="276" y="55" text-anchor="middle">└── 4 bits (10112) = 11 ──┘</text>
+      </g>
+
+      <!-- Output chars -->
+      <g class="mono" font-weight="700">
+        <rect class="alpha" x="400" y="10" width="48" height="28" rx="4"/>
+        <rect class="alpha" x="452" y="10" width="48" height="28" rx="4"/>
+        <text x="424" y="29" fill="#F8FAFC" text-anchor="middle" font-size="14">'a'</text>
+        <text x="476" y="29" fill="#F8FAFC" text-anchor="middle" font-size="14">'b'</text>
+      </g>
+
+      <!-- arrow -->
+      <g stroke="#94A3B8" stroke-width="1.4" fill="none">
+        <line x1="328" y1="24" x2="396" y2="24" marker-end="url(#bpk-a)"/>
+      </g>
+
+      <text class="mut" x="364" y="20" text-anchor="middle">→</text>
+
+      <!-- caption -->
+      <text class="mut" x="660" y="29" style="text-anchor: middle">1 byte → 2 hex chars   ·   ABCDEF / 0–9</text>
+    </g>
+
+    <!-- ============================================== Base32 row ============================================== -->
+    <g transform="translate(20 110)">
+      <text class="ttag b32" x="0" y="0">BASE32  ·  5 BITS / SYMBOL  ·  60% EXPANSION</text>
+
+      <!-- Input 5 bytes "fooba" → 40 bits packed -->
+      <text class="mono mut" x="0" y="22" style="text-anchor: start">bytes "fooba" (40 bits)</text>
+
+      <!-- 40 bit stream rendered as 8 groups of 5 bits -->
+      <g class="mono" font-size="10" font-weight="700">
+        <g>
+          <rect class="bits32" x="180" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="222" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="264" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="306" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="348" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="390" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="432" y="10" width="40" height="22" rx="3"/>
+          <rect class="bits32" x="474" y="10" width="40" height="22" rx="3"/>
+        </g>
+        <g fill="#E2E8F0" text-anchor="middle">
+          <text x="200" y="25">01100</text>
+          <text x="242" y="25">11001</text>
+          <text x="284" y="25">10111</text>
+          <text x="326" y="25">10110</text>
+          <text x="368" y="25">11000</text>
+          <text x="410" y="25">10011</text>
+          <text x="452" y="25">00001</text>
+          <text x="494" y="25" fill="#64748B">·····</text>
+        </g>
+      </g>
+
+      <text class="mut" x="368" y="48" text-anchor="middle">each 5-bit group → alphabet index 0–31</text>
+
+      <!-- Output chars MZXWYTB -->
+      <g class="mono" font-weight="700" font-size="13">
+        <rect class="alpha" x="552" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="576" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="600" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="624" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="648" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="672" y="10" width="22" height="22" rx="3"/>
+        <rect class="alpha" x="696" y="10" width="22" height="22" rx="3"/>
+        <g fill="#F8FAFC" text-anchor="middle">
+          <text x="563" y="26">M</text>
+          <text x="587" y="26">Z</text>
+          <text x="611" y="26">X</text>
+          <text x="635" y="26">W</text>
+          <text x="659" y="26">Y</text>
+          <text x="683" y="26">T</text>
+          <text x="707" y="26">B</text>
+        </g>
+      </g>
+
+      <text class="mut" x="389" y="68" text-anchor="middle">5 bytes → 8 chars   ·   A–Z / 2–7 (Standard RFC 4648 §6)</text>
+    </g>
+
+    <!-- ============================================== Base64 row ============================================== -->
+    <g transform="translate(20 200)">
+      <text class="ttag b64" x="0" y="0">BASE64  ·  6 BITS / SYMBOL  ·  33% EXPANSION</text>
+
+      <text class="mono mut" x="0" y="22" style="text-anchor: start">bytes "foo" (24 bits)</text>
+
+      <!-- 24 bits in four 6-bit groups -->
+      <g class="mono" font-size="11" font-weight="700">
+        <g>
+          <rect class="bits64" x="160" y="10" width="60" height="22" rx="3"/>
+          <rect class="bits64" x="224" y="10" width="60" height="22" rx="3"/>
+          <rect class="bits64" x="288" y="10" width="60" height="22" rx="3"/>
+          <rect class="bits64" x="352" y="10" width="60" height="22" rx="3"/>
+        </g>
+        <g fill="#E2E8F0" text-anchor="middle">
+          <text x="190" y="25">011001</text>
+          <text x="254" y="25">100110</text>
+          <text x="318" y="25">111101</text>
+          <text x="382" y="25">101111</text>
+        </g>
+      </g>
+
+      <g class="mono mut" font-size="10" text-anchor="middle">
+        <text x="190" y="48">= 25</text>
+        <text x="254" y="48">= 38</text>
+        <text x="318" y="48">= 61</text>
+        <text x="382" y="48">= 47</text>
+      </g>
+
+      <!-- Output chars -->
+      <g class="mono" font-weight="700" font-size="14">
+        <rect class="alpha" x="500" y="10" width="38" height="22" rx="3"/>
+        <rect class="alpha" x="542" y="10" width="38" height="22" rx="3"/>
+        <rect class="alpha" x="584" y="10" width="38" height="22" rx="3"/>
+        <rect class="alpha" x="626" y="10" width="38" height="22" rx="3"/>
+        <g fill="#F8FAFC" text-anchor="middle">
+          <text x="519" y="26">Z</text>
+          <text x="561" y="26">m</text>
+          <text x="603" y="26">9</text>
+          <text x="645" y="26">v</text>
+        </g>
+      </g>
+
+      <text class="mut" x="388" y="68" text-anchor="middle">3 bytes → 4 chars   ·   A–Z / a–z / 0–9 / +  /  (Standard RFC 4648 §4)</text>
+    </g>
+
+    <!-- ============================================== Bottom notes ============================================== -->
+    <g transform="translate(20 290)">
+      <text class="lbl" x="0" y="0" style="text-anchor: start">Non-power-of-two radices</text>
+      <text class="mut" x="0" y="18" style="text-anchor: start"><tspan fill="#F8FAFC" font-weight="700">Base58</tspan>  uses big-integer divmod by 58 — leading zero bytes are preserved as leading '1' characters.</text>
+      <text class="mut" x="0" y="32" style="text-anchor: start"><tspan fill="#F8FAFC" font-weight="700">Base85</tspan>  packs 4 input bytes into a uint32, divides four times by 85, and emits 5 characters per block.</text>
+    </g>
+  </g>
+</svg>

--- a/docs/images/diagrams/encoding-families.svg
+++ b/docs/images/diagrams/encoding-families.svg
@@ -1,0 +1,97 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" role="img" aria-labelledby="ef-t ef-d">
+  <title id="ef-t">Encoding families — payload expansion at a glance</title>
+  <desc id="ef-d">The five encoding families ship in Bodu.Text.Encoding. Base16 takes 4 bits per character and produces 100 percent expansion — two characters for every byte. Base32 takes 5 bits per character and produces 60 percent expansion. Base64 takes 6 bits per character and produces 33 percent expansion — the lowest of the power-of-two radices. Base58 uses a non-power-of-two radix and big-integer arithmetic with roughly 37 percent expansion. Base85 uses 4-byte block packing and produces 25 percent expansion, the lowest in the library. Each bar in the chart shows the encoded length per 100 input bytes.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; }
+      .num   { fill: #F8FAFC; font: 700 13px/1 "Consolas","Menlo",monospace; }
+      .axis  { stroke: #334155; stroke-width: 1; fill: none; }
+      .b1    { fill: #14B8A6; }
+      .b2    { fill: #3B82F6; }
+      .b3    { fill: #A78BFA; }
+      .b4    { fill: #F59E0B; }
+      .b5    { fill: #EC4899; }
+      .raw   { fill: #475569; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="820" height="320"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="300" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Encoding families — payload expansion at a glance</text>
+
+    <!-- ===== Bar chart: 5 horizontal bars, scale 0..200 chars per 100 input bytes ===== -->
+    <!-- Plot area: x = 120..720 (600px width). 100 input bytes baseline at x=120. -->
+    <!-- Each unit = 3px. 100% expansion bar = 100 units = 300px → ends at x=420. -->
+
+    <g transform="translate(20 60)">
+
+      <!-- Baseline (raw 100 bytes) marker -->
+      <line class="axis" x1="100" y1="0"   x2="100" y2="208" stroke-dasharray="3 3"/>
+      <text class="mut" x="100" y="-8" text-anchor="middle">100 raw bytes (reference)</text>
+
+      <!-- Horizontal axis markers at 25, 50, 75, 100, 200 chars per 100 bytes -->
+      <g class="mut" text-anchor="middle">
+        <line class="axis" x1="175" y1="0" x2="175" y2="208" stroke-dasharray="2 4" opacity="0.3"/>
+        <text x="175" y="222">+25%</text>
+        <line class="axis" x1="250" y1="0" x2="250" y2="208" stroke-dasharray="2 4" opacity="0.3"/>
+        <text x="250" y="222">+50%</text>
+        <line class="axis" x1="325" y1="0" x2="325" y2="208" stroke-dasharray="2 4" opacity="0.3"/>
+        <text x="325" y="222">+75%</text>
+        <line class="axis" x1="400" y1="0" x2="400" y2="208" stroke-dasharray="2 4" opacity="0.3"/>
+        <text x="400" y="222">+100%</text>
+      </g>
+
+      <!-- Row 1: Base85 — 25% (125 chars / 100 bytes) -->
+      <g transform="translate(0 4)">
+        <text class="lbl" x="92" y="20" style="text-anchor: end">Base85</text>
+        <rect class="b5" x="100" y="6" width="75" height="22" rx="3"/>
+        <text class="num" x="183" y="22">25%   ·   125 chars / 100 bytes</text>
+        <text class="mut" x="0"   y="36">Ascii85 (Adobe), Z85 (ZeroMQ) — PDF / PostScript, shell-safe keys</text>
+      </g>
+
+      <!-- Row 2: Base64 — 33% (~134 chars / 100 bytes) -->
+      <g transform="translate(0 48)">
+        <text class="lbl" x="92" y="20" style="text-anchor: end">Base64</text>
+        <rect class="b3" x="100" y="6" width="100" height="22" rx="3"/>
+        <text class="num" x="208" y="22">33%   ·   134 chars / 100 bytes</text>
+        <text class="mut" x="0"   y="36">Standard, URL-safe, MIME — JWT, certificates, generic binary-in-text</text>
+      </g>
+
+      <!-- Row 3: Base58 — 37% (~137 chars / 100 bytes) -->
+      <g transform="translate(0 92)">
+        <text class="lbl" x="92" y="20" style="text-anchor: end">Base58</text>
+        <rect class="b4" x="100" y="6" width="111" height="22" rx="3"/>
+        <text class="num" x="219" y="22">~37%   ·   ~137 chars / 100 bytes</text>
+        <text class="mut" x="0"   y="36">Bitcoin / Flickr, Ripple — Bitcoin addresses, IPFS CIDs, Solana, Stellar</text>
+      </g>
+
+      <!-- Row 4: Base32 — 60% (160 chars / 100 bytes) -->
+      <g transform="translate(0 136)">
+        <text class="lbl" x="92" y="20" style="text-anchor: end">Base32</text>
+        <rect class="b2" x="100" y="6" width="180" height="22" rx="3"/>
+        <text class="num" x="288" y="22">60%   ·   160 chars / 100 bytes</text>
+        <text class="mut" x="0"   y="36">Standard, HexExtended, Crockford, Z-Base-32 — TOTP, DNSSEC, human-spoken IDs</text>
+      </g>
+
+      <!-- Row 5: Base16 — 100% (200 chars / 100 bytes) -->
+      <g transform="translate(0 180)">
+        <text class="lbl" x="92" y="20" style="text-anchor: end">Base16</text>
+        <rect class="b1" x="100" y="6" width="300" height="22" rx="3"/>
+        <text class="num" x="408" y="22">100%   ·   200 chars / 100 bytes</text>
+        <text class="mut" x="0"   y="36">Hex (lower / upper) — hex dumps, hash digests, low-level binary inspection</text>
+      </g>
+    </g>
+
+  </g>
+</svg>

--- a/docs/images/diagrams/encoding-pipeline.svg
+++ b/docs/images/diagrams/encoding-pipeline.svg
@@ -1,0 +1,129 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" role="img" aria-labelledby="ep-t ep-d">
+  <title id="ep-t">Bodu.Text.Encoding — encode/decode pipeline</title>
+  <desc id="ep-d">Every encoding follows the same four-stage pipeline. Encoding takes raw binary bytes, packs them into N-bit symbols (Base16, Base32, Base64) or performs big-integer divmod (Base58) or 4-byte block packing (Base85), applies variant transforms (alphabet swap, padding, shortcut), and optionally adds decorations (case folding, prefix, spacing, line breaks). The result is encoded text. Decoding is the same path in reverse: strip decorations, apply alphabet lookup, then bit-stream unpack, divmod, or block expansion. The bottom row labels the strategy each radix family uses.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; letter-spacing: 1px; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .rowd  { fill: #A78BFA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .src   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .mid   { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .dec   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out   { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .wp    { stroke: #A78BFA; stroke-width: 1.6; fill: none; }
+      .legend{ fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; }
+    </style>
+    <marker id="ept-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="epd-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="320"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="300" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Bodu.Text.Encoding — encode/decode pipeline</text>
+
+    <!-- ===== Top row — ENCODE (left-to-right, teal) ===== -->
+    <text class="row" x="20" y="58">ENCODE  ▸ binary bytes → encoded text</text>
+
+    <g transform="translate(20 70)">
+      <rect class="src" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="22">Binary bytes</text>
+      <text class="mut" x="80" y="38">ReadOnlySpan&lt;byte&gt;</text>
+      <text class="mut" x="80" y="50">byte[]</text>
+    </g>
+
+    <line class="wt" x1="180" y1="98" x2="220" y2="98" marker-end="url(#ept-a)"/>
+
+    <g transform="translate(220 70)">
+      <rect class="mid" width="160" height="56" rx="6"/>
+      <text class="lbl" x="80" y="20">Radix conversion</text>
+      <text class="mut" x="80" y="35">bit-stream pack · divmod</text>
+      <text class="mut" x="80" y="49">4-byte block → 5 chars</text>
+    </g>
+
+    <line class="wt" x1="380" y1="98" x2="420" y2="98" marker-end="url(#ept-a)"/>
+
+    <g transform="translate(420 70)">
+      <rect class="dec" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">Variant transform</text>
+      <text class="mut" x="80" y="35">alphabet · padding</text>
+      <text class="mut" x="80" y="49">shortcut · decoration</text>
+    </g>
+
+    <line class="wt" x1="580" y1="98" x2="620" y2="98" marker-end="url(#ept-a)"/>
+
+    <g transform="translate(620 70)">
+      <rect class="out" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="22">Encoded text</text>
+      <text class="mut" x="80" y="38">string · char[]</text>
+      <text class="mut" x="80" y="50">UTF-8 bytes</text>
+    </g>
+
+    <!-- ===== Middle separator ===== -->
+    <line x1="20" y1="142" x2="780" y2="142" stroke="#334155" stroke-width="1"/>
+
+    <!-- ===== Bottom row — DECODE (left-to-right, purple) ===== -->
+    <text class="rowd" x="20" y="164">DECODE  ▸ encoded text → binary bytes</text>
+
+    <g transform="translate(20 176)">
+      <rect class="out" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="22">Encoded text</text>
+      <text class="mut" x="80" y="38">string · char[]</text>
+      <text class="mut" x="80" y="50">UTF-8 bytes</text>
+    </g>
+
+    <line class="wp" x1="180" y1="204" x2="220" y2="204" marker-end="url(#epd-a)"/>
+
+    <g transform="translate(220 176)">
+      <rect class="dec" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">Strip decoration</text>
+      <text class="mut" x="80" y="35">whitespace · prefix</text>
+      <text class="mut" x="80" y="49">case-fold to alphabet</text>
+    </g>
+
+    <line class="wp" x1="380" y1="204" x2="420" y2="204" marker-end="url(#epd-a)"/>
+
+    <g transform="translate(420 176)">
+      <rect class="mid" width="160" height="56" rx="6"/>
+      <text class="lbl" x="80" y="20">Radix inversion</text>
+      <text class="mut" x="80" y="35">bit-stream unpack · divmod</text>
+      <text class="mut" x="80" y="49">5-char block → 4 bytes</text>
+    </g>
+
+    <line class="wp" x1="580" y1="204" x2="620" y2="204" marker-end="url(#epd-a)"/>
+
+    <g transform="translate(620 176)">
+      <rect class="src" width="160" height="56" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="22">Binary bytes</text>
+      <text class="mut" x="80" y="38">byte[] · Span&lt;byte&gt;</text>
+      <text class="mut" x="80" y="50">OperationStatus</text>
+    </g>
+
+    <!-- ===== Strategy-by-family legend ===== -->
+    <g transform="translate(20 250)">
+      <text class="lbl" x="0" y="0" style="text-anchor: start">Radix strategy by family</text>
+
+      <g font-family="'Segoe UI',Arial,sans-serif" font-size="10.5">
+        <text class="legend" x="0"   y="20" style="text-anchor: start"><tspan fill="#F8FAFC" font-weight="700">Base16 / Base32 / Base64</tspan>  ▸  bit-stream pack into N-bit symbols   <tspan fill="#64748B">(4 / 5 / 6 bits)</tspan></text>
+        <text class="legend" x="0"   y="36" style="text-anchor: start"><tspan fill="#F8FAFC" font-weight="700">Base58</tspan>  ▸  non-power-of-two radix; big-integer divmod by 58; preserves leading zero bytes</text>
+        <text class="legend" x="0"   y="52" style="text-anchor: start"><tspan fill="#F8FAFC" font-weight="700">Base85</tspan>  ▸  4-byte block packed into uint32; four divisions by 85; emits five characters per block</text>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/docs/images/diagrams/encoding-terminal-quantum.svg
+++ b/docs/images/diagrams/encoding-terminal-quantum.svg
@@ -1,0 +1,128 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" role="img" aria-labelledby="tq-t tq-d">
+  <title id="tq-t">Terminal quantum and padding — RFC 4648</title>
+  <desc id="tq-d">The terminal quantum is the last partial group at the end of the input. Base64 packs 3 input bytes into 4 output characters; if the input is shorter than a multiple of 3 bytes, Base64 emits 2 or 3 characters and pads with one or two equals signs to maintain 4-character alignment. Base32 packs 5 input bytes into 8 output characters and pads to alignment with up to 6 equals signs. Base16 has no terminal quantum: input must be an even number of nibbles. Crockford Base32 and z-base-32 omit padding by convention.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; letter-spacing: 1px; }
+      .mono  { font: 700 13px/1 "Consolas","Menlo",monospace; fill: #F8FAFC; }
+      .data  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1; }
+      .pad   { fill: #431407; stroke: #FBBF24; stroke-width: 1; }
+      .none  { fill: #1F2937; stroke: #475569; stroke-width: 1; stroke-dasharray: 3 3; }
+      .by    { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="820" height="320"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="300" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Terminal quantum and padding — RFC 4648</text>
+
+    <!-- ============== BASE64 row ============== -->
+    <g transform="translate(20 50)">
+      <text class="ttag" x="0" y="0" fill="#60A5FA">BASE64 ·  3 BYTES → 4 CHARS  ·  GROUP SIZE 3</text>
+
+      <!-- Label columns -->
+      <text class="mut" x="80"   y="56" text-anchor="middle">input bytes</text>
+      <text class="mut" x="350"  y="56" text-anchor="middle">→</text>
+      <text class="mut" x="600"  y="56" text-anchor="middle">encoded output (chars + padding)</text>
+
+      <!-- Three rows: 3, 2, 1 input bytes -->
+      <!-- 3 bytes -->
+      <g transform="translate(0 70)">
+        <rect class="by" x="0"   y="0" width="42" height="22" rx="3"/>
+        <rect class="by" x="44"  y="0" width="42" height="22" rx="3"/>
+        <rect class="by" x="88"  y="0" width="42" height="22" rx="3"/>
+        <g class="mono" font-size="11" text-anchor="middle">
+          <text x="21"  y="16">66</text>
+          <text x="65"  y="16">6F</text>
+          <text x="109" y="16">6F</text>
+        </g>
+        <text class="mut" x="-8" y="16" text-anchor="end">3 bytes</text>
+
+        <rect class="data" x="240" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="274" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="308" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="342" y="0" width="32" height="22" rx="3"/>
+        <g class="mono" font-size="13" text-anchor="middle">
+          <text x="256" y="16">Z</text>
+          <text x="290" y="16">m</text>
+          <text x="324" y="16">9</text>
+          <text x="358" y="16">v</text>
+        </g>
+        <text class="mut" x="420" y="16" style="text-anchor: start">4 chars, no padding</text>
+      </g>
+
+      <!-- 2 bytes -->
+      <g transform="translate(0 100)">
+        <rect class="by" x="0"   y="0" width="42" height="22" rx="3"/>
+        <rect class="by" x="44"  y="0" width="42" height="22" rx="3"/>
+        <rect class="none" x="88" y="0" width="42" height="22" rx="3"/>
+        <g class="mono" font-size="11" text-anchor="middle">
+          <text x="21"  y="16">66</text>
+          <text x="65"  y="16">6F</text>
+        </g>
+        <text class="mut" x="-8" y="16" text-anchor="end">2 bytes</text>
+
+        <rect class="data" x="240" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="274" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="308" y="0" width="32" height="22" rx="3"/>
+        <rect class="pad"  x="342" y="0" width="32" height="22" rx="3"/>
+        <g class="mono" font-size="13" text-anchor="middle">
+          <text x="256" y="16">Z</text>
+          <text x="290" y="16">m</text>
+          <text x="324" y="16">8</text>
+          <text x="358" y="16" fill="#FBBF24">=</text>
+        </g>
+        <text class="mut" x="420" y="16" style="text-anchor: start">3 chars + 1 '=' pad</text>
+      </g>
+
+      <!-- 1 byte -->
+      <g transform="translate(0 130)">
+        <rect class="by" x="0"   y="0" width="42" height="22" rx="3"/>
+        <rect class="none" x="44"  y="0" width="42" height="22" rx="3"/>
+        <rect class="none" x="88"  y="0" width="42" height="22" rx="3"/>
+        <g class="mono" font-size="11" text-anchor="middle">
+          <text x="21"  y="16">66</text>
+        </g>
+        <text class="mut" x="-8" y="16" text-anchor="end">1 byte</text>
+
+        <rect class="data" x="240" y="0" width="32" height="22" rx="3"/>
+        <rect class="data" x="274" y="0" width="32" height="22" rx="3"/>
+        <rect class="pad"  x="308" y="0" width="32" height="22" rx="3"/>
+        <rect class="pad"  x="342" y="0" width="32" height="22" rx="3"/>
+        <g class="mono" font-size="13" text-anchor="middle">
+          <text x="256" y="16">Z</text>
+          <text x="290" y="16">g</text>
+          <text x="324" y="16" fill="#FBBF24">=</text>
+          <text x="358" y="16" fill="#FBBF24">=</text>
+        </g>
+        <text class="mut" x="420" y="16" style="text-anchor: start">2 chars + 2 '=' pad</text>
+      </g>
+    </g>
+
+    <!-- ============== Base32 + Base16 summary block ============== -->
+    <g transform="translate(20 222)">
+      <text class="ttag" x="0" y="0" fill="#A78BFA">BASE32 ·  5 BYTES → 8 CHARS  ·  GROUP SIZE 5</text>
+      <text class="mut" x="0" y="18">Valid terminal-quantum data-character counts: {0, 2, 4, 5, 7, 8}. Counts 1, 3, 6 are invalid.</text>
+      <text class="mut" x="0" y="32">Standard / HexExtended pad with '=' to 8-character alignment. Crockford and z-base-32 omit padding by spec convention.</text>
+
+      <text class="ttag" x="430" y="0" fill="#2DD4BF">BASE16 ·  1 BYTE → 2 CHARS  ·  NO PADDING</text>
+      <text class="mut" x="430" y="18">Input length is always an even number of nibbles (length % 2 == 0).</text>
+      <text class="mut" x="430" y="32">There is no terminal quantum or padding character.</text>
+    </g>
+
+    <!-- ============== Footer ============== -->
+    <text class="mut" x="20" y="285" style="text-anchor: start">Control padding at encode time with <tspan class="mono" font-size="11" fill="#F8FAFC">BaseFormattingOptions.OmitPadding</tspan>; accept unpadded input at decode time with <tspan class="mono" font-size="11" fill="#F8FAFC">BaseFormatStyles.AllowMissingPadding</tspan>.</text>
+  </g>
+</svg>

--- a/docs/images/hero-text.svg
+++ b/docs/images/hero-text.svg
@@ -1,0 +1,85 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.Text.Encoding — binary-to-text encoders">
+  <title>Bodu.Text.Encoding</title>
+  <defs>
+    <linearGradient id="txt-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="txt-byte" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+    <linearGradient id="txt-char" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#A78BFA"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#txt-bg)"/>
+
+  <!-- Top row: byte cells -->
+  <g transform="translate(60 46)" font-family="'Consolas','Menlo',monospace" font-size="12" font-weight="700">
+    <g stroke="#3B82F6" stroke-width="1.4" fill="url(#txt-byte)">
+      <rect x="0"   y="0" width="44" height="30" rx="4"/>
+      <rect x="48"  y="0" width="44" height="30" rx="4"/>
+      <rect x="96"  y="0" width="44" height="30" rx="4"/>
+      <rect x="144" y="0" width="44" height="30" rx="4"/>
+      <rect x="192" y="0" width="44" height="30" rx="4"/>
+      <rect x="240" y="0" width="44" height="30" rx="4"/>
+      <rect x="288" y="0" width="44" height="30" rx="4"/>
+    </g>
+    <g fill="#F8FAFC" text-anchor="middle">
+      <text x="22"  y="20">DE</text>
+      <text x="70"  y="20">AD</text>
+      <text x="118" y="20">BE</text>
+      <text x="166" y="20">EF</text>
+      <text x="214" y="20">CA</text>
+      <text x="262" y="20">FE</text>
+      <text x="310" y="20">00</text>
+    </g>
+    <text x="-12" y="20" fill="#94A3B8" font-weight="400" font-size="11" text-anchor="end">bytes</text>
+  </g>
+
+  <!-- bit stream -->
+  <g transform="translate(60 90)" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="10.5" opacity="0.9">
+    <text x="0" y="0">11011110 10101101 10111110 11101111 11001010 11111110 00000000</text>
+    <text x="-12" y="0" fill="#94A3B8" font-size="10" text-anchor="end" opacity="0.8">bits</text>
+  </g>
+
+  <!-- arrow down -->
+  <g transform="translate(240 102)" fill="none" stroke="#A78BFA" stroke-width="2" stroke-linecap="round">
+    <line x1="0" y1="0" x2="0" y2="16"/>
+    <polygon points="0,18 -4,10 4,10" fill="#A78BFA" stroke="none"/>
+  </g>
+
+  <!-- Bottom row: chars (encoded) -->
+  <g transform="translate(60 130)" font-family="'Consolas','Menlo',monospace" font-size="13" font-weight="700">
+    <g stroke="#A78BFA" stroke-width="1.4" fill="url(#txt-char)">
+      <rect x="0"   y="0" width="34" height="34" rx="4"/>
+      <rect x="38"  y="0" width="34" height="34" rx="4"/>
+      <rect x="76"  y="0" width="34" height="34" rx="4"/>
+      <rect x="114" y="0" width="34" height="34" rx="4"/>
+      <rect x="152" y="0" width="34" height="34" rx="4"/>
+      <rect x="190" y="0" width="34" height="34" rx="4"/>
+      <rect x="228" y="0" width="34" height="34" rx="4"/>
+      <rect x="266" y="0" width="34" height="34" rx="4"/>
+      <rect x="304" y="0" width="34" height="34" rx="4"/>
+    </g>
+    <g fill="#F8FAFC" text-anchor="middle">
+      <text x="17"  y="22">3</text>
+      <text x="55"  y="22">q</text>
+      <text x="93"  y="22">2</text>
+      <text x="131" y="22">+</text>
+      <text x="169" y="22">7</text>
+      <text x="207" y="22">8</text>
+      <text x="245" y="22">r</text>
+      <text x="283" y="22">+</text>
+      <text x="321" y="22">A</text>
+    </g>
+    <text x="-12" y="22" fill="#94A3B8" font-weight="400" font-size="11" text-anchor="end">text</text>
+  </g>
+
+  <!-- footer caption -->
+  <g font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="10.5" fill="#94A3B8">
+    <text x="240" y="186" text-anchor="middle">Base16 · Base32 · Base64 · Base58 · Base85</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -74,6 +74,7 @@ Six independent NuGet packages that share a single solution, a single set of con
 </div>
 
 <div class="bodu-card">
+  <img src="images/hero-text.svg" alt="Bodu.Text.Encoding" />
   <h3>Bodu.Text.Encoding</h3>
   <p>Binary-to-text encoders for <strong>Base16</strong>, <strong>Base32</strong>, <strong>Base64</strong>, <strong>Base58</strong>, and <strong>Base85</strong> with every common variant — RFC 4648 standard / hex-extended / URL-safe / MIME, Crockford, z-base-32, Bitcoin / Flickr / Ripple, Adobe Ascii85, ZeroMQ Z85. Every encoding exposes the same modern API shape: span- and UTF-8-friendly overloads, <code>OperationStatus</code> streaming methods, length-prediction helpers, validation predicates, plus a unified <code>IBinaryEncoding</code> interface for runtime-pluggable encoding choice.</p>
   <div class="bodu-card-links">


### PR DESCRIPTION
## Summary

Adds graphics for the Bodu.Text.Encoding documentation to match the visual treatment used by the Calendar and Formats libraries.

- Hero image (`hero-text.svg`) for the library card on the landing page — fills the gap where Bodu.Text.Encoding was the only library without one.
- Encode/decode pipeline diagram (`encoding-pipeline.svg`) — 4-stage flow with per-family radix-strategy legend.
- Bit-stream packing diagram (`encoding-bit-packing.svg`) — Base16 / Base32 / Base64 byte → N-bit group → alphabet symbol.
- Payload-expansion bar chart (`encoding-families.svg`) — visual comparison of 25 % / 33 % / 37 % / 60 % / 100 % expansion across the five families.
- Terminal-quantum diagram (`encoding-terminal-quantum.svg`) — RFC 4648 padding rules for the 3 / 2 / 1 byte cases.

Wires the new SVGs into the existing intro, concepts, guides-landing, and library-card pages, replacing the ASCII art that previously stood in for them.

## Test plan

- [ ] DocFX build picks up the new SVGs from `docs/images/`
- [ ] `docs/index.md` Bodu.Text.Encoding card renders with the hero image
- [ ] `docs/docs/text-encoding/index.md` "Core mental model" and "Where each encoding fits" sections render the pipeline and families diagrams
- [ ] `docs/docs/text-encoding/concepts.md` "Bit packing" and "Terminal quantum" sections render their diagrams
- [ ] `docs/guides/text-encoding/index.md` renders the pipeline diagram under the new "How the library works" section

https://claude.ai/code/session_01MeT7YGJMcM31Y5TG12Puyn

---
_Generated by [Claude Code](https://claude.ai/code/session_01MeT7YGJMcM31Y5TG12Puyn)_