### PR TITLE
Add test coverage for BlockCipher ctor validation, Threefish Rekey, and TransformAsync cancellation contracts

### DIFF
--- a/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/ICryptoTransformExtensionsTests.TransformAsync.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography.Extensions/ICryptoTransformExtensionsTests.TransformAsync.cs
@@ -153,11 +153,13 @@ public partial class ICryptoTransformExtensionsTests
 
     /// <summary>
     /// Verifies that <see cref="ICryptoTransformExtensions.TransformAsync(ICryptoTransform,Stream,Stream,int,CancellationToken)" />
-    /// throws <see cref="OperationCanceledException" /> or <see cref="TaskCanceledException" /> when the
-    /// cancellation token is signalled during a slow read operation.
+    /// throws <see cref="TaskCanceledException" /> when the cancellation token is signalled while
+    /// <c>ReadAsync</c> is blocked. The implementation catches the <see cref="OperationCanceledException" />
+    /// raised by the stream and converts it to a fresh <see cref="TaskCanceledException" />, so the exact
+    /// subtype is contractually significant.
     /// </summary>
     [TestMethod]
-    public async Task TransformAsync_Stream_WhenCancelled_ShouldThrowCancelledException()
+    public async Task TransformAsync_Stream_WhenCancelledDuringRead_ShouldThrowTaskCanceledException()
     {
         using SymmetricAlgorithm algorithm = CreateAlgorithm();
         algorithm.Padding = PaddingMode.None;
@@ -167,24 +169,21 @@ public partial class ICryptoTransformExtensionsTests
         using ICryptoTransform encryptor = algorithm.CreateEncryptor();
         using var cts = new CancellationTokenSource(millisecondsDelay: 150);
 
-        try
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () =>
         {
             await encryptor.TransformAsync(source, target, bufferSize: 32, cts.Token);
-            Assert.Fail("Expected OperationCanceledException or TaskCanceledException.");
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected — either OperationCanceledException or its subtype TaskCanceledException.
-        }
+        });
     }
 
     /// <summary>
     /// Verifies that <see cref="ICryptoTransformExtensions.TransformAsync(ICryptoTransform,Stream,Stream,int,CancellationToken)" />
-    /// throws immediately when the cancellation token is already cancelled before the call.
+    /// throws <see cref="TaskCanceledException" /> when the cancellation token is already cancelled before
+    /// the call. The cancelled <c>ReadAsync</c> raises <see cref="OperationCanceledException" />, which the
+    /// implementation converts to a fresh <see cref="TaskCanceledException" />.
     /// </summary>
     [TestMethod]
     [DynamicData(nameof(GetValidTransformTestData))]
-    public async Task TransformAsync_Stream_WhenAlreadyCancelled_ShouldThrowImmediately(KnownAnswerTest kat)
+    public async Task TransformAsync_Stream_WhenAlreadyCancelled_ShouldThrowTaskCanceledException(KnownAnswerTest kat)
     {
         using var source = new MemoryStream(kat.Input);
         using var target = new MemoryStream();
@@ -192,15 +191,10 @@ public partial class ICryptoTransformExtensionsTests
         using var cts = new CancellationTokenSource();
         cts.Cancel();
 
-        try
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(async () =>
         {
             await transform.TransformAsync(source, target, bufferSize: kat.Input.Length, cts.Token);
-            Assert.Fail($"[{kat.Name}] Expected OperationCanceledException.");
-        }
-        catch (OperationCanceledException)
-        {
-            // Expected.
-        }
+        });
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.Ctors.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherTests.Ctors.cs
@@ -1,0 +1,172 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherTests.Ctors.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.Security.Cryptography;
+
+public abstract partial class BlockCipherTests<TTest, TCipher, TVariant>
+{
+    /// <summary>
+    /// Returns test data covering invalid key lengths for each cipher variant. Always includes an empty key
+    /// and a one-byte-short key; also includes a one-byte-over key for tweakable variants, whose key length
+    /// is fixed by the specification.
+    /// </summary>
+    /// <remarks>
+    /// A row is emitted for every variant regardless of whether it is tweakable, ensuring the data source
+    /// is never empty. Non-tweakable variants are silently skipped inside the test method via
+    /// <see cref="Assert.Inconclusive(string)" /> because their key-size exception types vary by cipher
+    /// family and are validated in the concrete test class instead.
+    /// </remarks>
+    public static IEnumerable<object[]> GetInvalidKeySizeCtorData()
+    {
+        var instance = new TTest();
+        foreach (TVariant variant in instance.GetBlockCipherVariants())
+        {
+            BlockCipherSpecification spec = instance.GetSpecification(variant);
+            byte[] validTweak = spec.TestTweak ?? (spec.TweakSize > 0 ? new byte[spec.TweakSize] : Array.Empty<byte>());
+
+            yield return new object[] { variant, Array.Empty<byte>(), validTweak };
+
+            if (spec.KeySize > 1)
+                yield return new object[] { variant, new byte[spec.KeySize - 1], validTweak };
+
+            // Over-length keys are only unambiguously invalid when the key length is fixed. Tweakable
+            // ciphers in this suite always have a fixed key length that equals the block size, so this
+            // path is safe to test for them. Variable-length ciphers (Blowfish, AES, …) may accept
+            // KeySize + 1 if that length falls within their legal range, so we skip it for those.
+            if (spec.IsTweakable)
+                yield return new object[] { variant, new byte[spec.KeySize + 1], validTweak };
+        }
+    }
+
+    /// <summary>
+    /// Returns test data covering invalid tweak lengths for each cipher variant. A sentinel row is emitted
+    /// for non-tweakable variants to prevent an empty-data-source error; those rows are skipped inside the
+    /// test method via <see cref="Assert.Inconclusive(string)" />.
+    /// </summary>
+    public static IEnumerable<object[]> GetInvalidTweakSizeCtorData()
+    {
+        var instance = new TTest();
+        foreach (TVariant variant in instance.GetBlockCipherVariants())
+        {
+            BlockCipherSpecification spec = instance.GetSpecification(variant);
+            byte[] validKey = spec.TestKey ?? new byte[spec.KeySize];
+
+            if (!spec.IsTweakable)
+            {
+                // Sentinel row: the test method will call Assert.Inconclusive immediately.
+                yield return new object[] { variant, validKey, Array.Empty<byte>() };
+                continue;
+            }
+
+            yield return new object[] { variant, validKey, Array.Empty<byte>() };
+
+            if (spec.TweakSize > 1)
+                yield return new object[] { variant, validKey, new byte[spec.TweakSize - 1] };
+
+            yield return new object[] { variant, validKey, new byte[spec.TweakSize + 1] };
+        }
+    }
+
+    /// <summary>Returns a display name for invalid-key-size constructor test rows.</summary>
+    public static string GetInvalidKeySizeCtorTestDisplayName(MethodInfo methodInfo, object[] data)
+    {
+        ArgumentNullException.ThrowIfNull(methodInfo);
+        ArgumentNullException.ThrowIfNull(data);
+
+        var variant = (TVariant)data[0];
+        var key = (byte[])data[1];
+        return $"Key: {key.Length} bytes (Variant: {variant})";
+    }
+
+    /// <summary>Returns a display name for invalid-tweak-size constructor test rows.</summary>
+    public static string GetInvalidTweakSizeCtorTestDisplayName(MethodInfo methodInfo, object[] data)
+    {
+        ArgumentNullException.ThrowIfNull(methodInfo);
+        ArgumentNullException.ThrowIfNull(data);
+
+        var variant = (TVariant)data[0];
+        var tweak = (byte[])data[2];
+        return $"Tweak: {tweak.Length} bytes (Variant: {variant})";
+    }
+
+    /// <summary>
+    /// Verifies that constructing <typeparamref name="TCipher" /> with a key whose length does not match the
+    /// expected key size throws <see cref="ArgumentException" />.
+    /// </summary>
+    /// <remarks>
+    /// This assertion applies only to tweakable ciphers, whose key sizes are always fixed and whose
+    /// constructors uniformly throw <see cref="ArgumentException" /> for length mismatches. Non-tweakable
+    /// ciphers (AES, Blowfish, Camellia, …) vary in both key-size semantics and exception type; their
+    /// constructor validation is covered in the concrete test class and this test marks itself
+    /// <see cref="Assert.Inconclusive(string)" /> for those variants.
+    /// </remarks>
+    /// <param name="variant">The cipher variant that determines the expected key size.</param>
+    /// <param name="key">A key buffer whose length is invalid for this cipher.</param>
+    /// <param name="tweak">
+    /// A valid tweak buffer (ignored by non-tweakable ciphers). Provides a well-formed tweak so that the
+    /// only rejection reason is the key length.
+    /// </param>
+    [TestMethod]
+    [DynamicData(nameof(GetInvalidKeySizeCtorData), DynamicDataDisplayName = nameof(GetInvalidKeySizeCtorTestDisplayName))]
+    public void Ctor_WhenKeyIsWrongSize_ShouldThrowArgumentException(TVariant variant, byte[] key, byte[] tweak)
+    {
+        BlockCipherSpecification spec = GetSpecification(variant);
+        if (!spec.IsTweakable)
+        {
+            Assert.Inconclusive(
+                $"[{variant}] Non-tweakable cipher; key-size exception type varies by cipher family " +
+                "and is validated in the concrete test class.");
+            return;
+        }
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = CreateBlockCipherForAnswer(new BlockCipherKnownAnswer
+            {
+                Name = "ctor-invalid-key",
+                Plaintext = Array.Empty<byte>(),
+                Ciphertext = Array.Empty<byte>(),
+                Key = key,
+                Tweak = tweak.Length > 0 ? tweak : null,
+            });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that constructing <typeparamref name="TCipher" /> with a tweak whose length does not match
+    /// the expected tweak size throws <see cref="ArgumentException" />. Non-tweakable variants are marked
+    /// inconclusive because tweak validation is not applicable to them.
+    /// </summary>
+    /// <param name="variant">The cipher variant that determines the expected tweak size.</param>
+    /// <param name="key">A valid key buffer. Provides a well-formed key so that the only rejection reason
+    /// is the tweak length.</param>
+    /// <param name="tweak">A tweak buffer whose length is invalid for this cipher.</param>
+    [TestMethod]
+    [DynamicData(nameof(GetInvalidTweakSizeCtorData), DynamicDataDisplayName = nameof(GetInvalidTweakSizeCtorTestDisplayName))]
+    public void Ctor_WhenTweakIsWrongSize_ShouldThrowArgumentException(TVariant variant, byte[] key, byte[] tweak)
+    {
+        BlockCipherSpecification spec = GetSpecification(variant);
+        if (!spec.IsTweakable)
+        {
+            Assert.Inconclusive($"[{variant}] Non-tweakable cipher; tweak validation is not applicable.");
+            return;
+        }
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = CreateBlockCipherForAnswer(new BlockCipherKnownAnswer
+            {
+                Name = "ctor-invalid-tweak",
+                Plaintext = Array.Empty<byte>(),
+                Ciphertext = Array.Empty<byte>(),
+                Key = key,
+                Tweak = tweak,
+            });
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishBlockCipherTests.Rekey.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishBlockCipherTests.Rekey.cs
@@ -1,0 +1,153 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThreefishBlockCipherTests.Rekey.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+internal sealed partial class ThreefishBlockCipherTests
+{
+    // ---------------------------------------------------------------------------------------------------------------
+    // ThreefishBlockCipher.Rekey(ReadOnlySpan<byte> key, ReadOnlySpan<byte> tweak)
+    // ---------------------------------------------------------------------------------------------------------------
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when the supplied key is shorter than the required key size.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenKeyIsTooShort_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(new byte[31], s_validTweak);
+        });
+
+        Assert.AreEqual("key", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when the supplied key is longer than the required key size.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenKeyIsTooLong_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(new byte[33], s_validTweak);
+        });
+
+        Assert.AreEqual("key", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when supplied an empty key.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenKeyIsEmpty_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(ReadOnlySpan<byte>.Empty, s_validTweak);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when the supplied tweak is shorter than the required 16-byte tweak size.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenTweakIsTooShort_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(s_validKey256, new byte[15]);
+        });
+
+        Assert.AreEqual("tweak", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when the supplied tweak is longer than the required 16-byte tweak size.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenTweakIsTooLong_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(s_validKey256, new byte[17]);
+        });
+
+        Assert.AreEqual("tweak", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ArgumentException" />
+    /// when supplied an empty tweak.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenTweakIsEmpty_ShouldThrowArgumentException()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            cipher.Rekey(s_validKey256, ReadOnlySpan<byte>.Empty);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ThreefishBlockCipher.Rekey" /> throws <see cref="ObjectDisposedException" />
+    /// when called on a disposed cipher instance.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenDisposed_ShouldThrowObjectDisposedException()
+    {
+        var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            cipher.Rekey(s_validKey256, s_validTweak);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a successful <see cref="ThreefishBlockCipher.Rekey" /> call changes the encryption
+    /// output, confirming that the new key and tweak are actually applied.
+    /// </summary>
+    [TestMethod]
+    public void Rekey_WhenValidKeyAndTweakProvided_ShouldChangeEncryptionOutput()
+    {
+        using var cipher = new Threefish256Cipher(s_validKey256, s_validTweak);
+
+        var plaintext = new byte[32];
+        var outputBefore = new byte[32];
+        var outputAfter = new byte[32];
+
+        cipher.Encrypt(plaintext, outputBefore);
+
+        var newKey = new byte[32];
+        newKey[0] = 0x01;
+        cipher.Rekey(newKey, s_validTweak);
+
+        cipher.Encrypt(plaintext, outputAfter);
+
+        CollectionAssert.AreNotEqual(outputBefore, outputAfter,
+            "Rekey with a different key must produce different ciphertext.");
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishBlockCipherTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/ThreefishBlockCipherTests.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThreefishBlockCipherTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Tests for the <see cref="ThreefishBlockCipher" /> abstract base — specifically for members defined
+/// at the base class level that are not exercised by the variant-specific
+/// <see cref="BlockCipherTests{TTest, TCipher, TVariant}" /> harness.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Tests that apply across all three Threefish variants (256, 512, 1024) are implemented here against
+/// <see cref="Threefish256Cipher" />, which uses the smallest key and tweak sizes and exercises every
+/// code path in <see cref="ThreefishBlockCipher" /> with the least memory overhead.
+/// </para>
+/// </remarks>
+[TestClass]
+internal sealed partial class ThreefishBlockCipherTests
+{
+    private static readonly byte[] s_validKey256 = new byte[32];
+    private static readonly byte[] s_validTweak = new byte[16];
+}


### PR DESCRIPTION
- BlockCipherTests.Ctors.cs: new partial adds Ctor_WhenKeyIsWrongSize and Ctor_WhenTweakIsWrongSize
  to the shared base class; tweakable cipher variants assert ArgumentException, non-tweakable variants
  mark Inconclusive (their ctor coverage lives in the concrete test class with the correct exception type).
- ThreefishBlockCipherTests.cs + .Rekey.cs: eight new tests for the internal Rekey() method —
  key too short/long/empty, tweak too short/long/empty, call after dispose (ObjectDisposedException),
  and a positive test that encryption output changes after re-keying.
- ICryptoTransformExtensionsTests.TransformAsync.cs: tighten two cancellation tests from a broad
  OperationCanceledException catch to Assert.ThrowsExactlyAsync<TaskCanceledException>, matching
  the implementation contract that wraps OperationCanceledException in a fresh TaskCanceledException.

https://claude.ai/code/session_01UvrH7qiCERyoWx9ysveDq6