### PR TITLE
Reach JSON-provider parity in Bodu.Extensions.Configuration.Text

### DIFF
--- a/Bodu.Extensions.Configuration.Text/README.md
+++ b/Bodu.Extensions.Configuration.Text/README.md
@@ -86,6 +86,22 @@ new ConfigurationBuilder()
 When `TargetPath` is `null`, only preamble (top-of-file) keys flow into the configuration view — anchored
 sections are skipped.
 
+## Array binding
+
+`Microsoft.Extensions.Configuration` binds collection types (`List<T>`, `T[]`) when child keys are
+zero-based numeric segments. The Bodu source format produces those keys via the default dotted-segment
+notation:
+
+```
+items.0 = first
+items.1 = second
+items.2 = third
+```
+
+The resolved view exposes `items:0`, `items:1`, `items:2`, which bind through
+`configuration.GetSection("items").Get<List<string>>()` exactly the way JSON arrays bind in
+`Microsoft.Extensions.Configuration.Json`.
+
 ## Default-filename convention
 
 `AddBoduConfiguration()` (no arguments) probes the builder's file provider for `.boduconfig` first, then

--- a/Bodu.Extensions.Configuration.Text/README.md
+++ b/Bodu.Extensions.Configuration.Text/README.md
@@ -1,0 +1,119 @@
+# Bodu.Extensions.Configuration.Text
+
+The EditorConfig-compatible `Microsoft.Extensions.Configuration` provider. This package bridges
+[`Bodu.Text.Configuration`](../Bodu.Text.Configuration) into the standard
+[`Microsoft.Extensions.Configuration`](https://learn.microsoft.com/dotnet/core/extensions/configuration)
+pipeline so consumers can register a `.boduconfig` or `bodu.config` file with the same shape they already
+use for JSON, INI, or XML providers.
+
+## API matrix vs `Microsoft.Extensions.Configuration.Json`
+
+| Feature | `Microsoft.Extensions.Configuration.Json` | `Bodu.Extensions.Configuration.Text` |
+|---|---|---|
+| `AddXxxFile(builder, path)` | `AddJsonFile(builder, path)` | `AddBoduConfiguration(builder, path)` |
+| `AddXxxFile(builder, path, optional, reloadOnChange)` | yes | yes (extra `targetPath`) |
+| `AddXxxFile(builder, provider, path, optional, reloadOnChange)` | yes | yes |
+| `AddXxxFile(builder, Action<XxxSource>)` | yes | yes |
+| `AddXxxStream(builder, Stream)` | `AddJsonStream(builder, stream)` | `AddBoduConfiguration(builder, stream)` |
+| `IFileProvider`-backed reload-on-change | yes | yes (inherited) |
+| `GetReloadToken` / change tokens | yes | yes (inherited) |
+| `GetSection`, `GetChildren`, `Bind` | yes | yes (via colon-delimited keys) |
+| Default-filename convention | none | `.boduconfig` then `bodu.config` |
+| Programmatic-document entry point | none | `AddBoduConfiguration(builder, IniDocument)` |
+| `IOptions<T>` helper | provided by `Microsoft.Extensions.Options.ConfigurationExtensions` | `AddBoduConfigurationOptions<TOptions>` |
+
+## Worked examples
+
+### Load a file by path
+
+```csharp
+using Microsoft.Extensions.Configuration;
+using Bodu.Extensions.Configuration.Text;
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddBoduConfiguration("app.boduconfig", optional: false, reloadOnChange: true)
+    .Build();
+
+string? indentSize = config["format:indent:size"];
+```
+
+The source uses dotted keys (`format.indent.size`), which the bridge translates into colon-delimited keys
+(`format:indent:size`) for `Microsoft.Extensions.Configuration`.
+
+### Load from a stream
+
+```csharp
+using MemoryStream stream = new(Encoding.UTF8.GetBytes("""
+service.name = Bodu
+service.port = 8080
+"""));
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddBoduConfiguration(stream)
+    .Build();
+```
+
+Stream sources are one-shot — the stream is read once when the builder is built and no file watcher is
+attached.
+
+### Load with an explicit `IFileProvider`
+
+```csharp
+using Microsoft.Extensions.FileProviders;
+
+var fileProvider = new PhysicalFileProvider(repoRoot);
+
+IConfiguration config = new ConfigurationBuilder()
+    .AddBoduConfiguration(fileProvider, "app.boduconfig")
+    .Build();
+```
+
+## Target paths and section resolution
+
+Unlike JSON, the source format supports EditorConfig-style glob-anchored sections. Set `TargetPath` to choose
+which section a build resolves against:
+
+```csharp
+new ConfigurationBuilder()
+    .AddBoduConfiguration(source =>
+    {
+        source.Path = "app.boduconfig";
+        source.TargetPath = "src/Foo.cs";  // selects [src/**/*.cs] when present
+    })
+    .Build();
+```
+
+When `TargetPath` is `null`, only preamble (top-of-file) keys flow into the configuration view — anchored
+sections are skipped.
+
+## Default-filename convention
+
+`AddBoduConfiguration()` (no arguments) probes the builder's file provider for `.boduconfig` first, then
+falls back to `bodu.config`. To resolve the dot-prefixed name through `PhysicalFileProvider`, construct the
+provider with `ExclusionFilters.None`:
+
+```csharp
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+
+var builder = new ConfigurationBuilder();
+builder.SetFileProvider(new PhysicalFileProvider(repoRoot, ExclusionFilters.None));
+IConfiguration config = builder.AddBoduConfiguration().Build();
+```
+
+`bodu.config` resolves through the default `Sensitive` exclusion filters without any further configuration.
+
+## `IOptions<T>` binding
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+services.AddOptions();
+services.AddBoduConfigurationOptions<ServiceOptions>(config, sectionName: "service");
+
+var options = provider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+```
+
+The helper is a thin shim over `services.Configure<TOptions>(config.GetSection(name))` — it exists for
+discoverability alongside the `AddBoduConfiguration` API surface.

--- a/Bodu.Extensions.Configuration.Text/src/Bodu.Extensions.Configuration.Text.csproj
+++ b/Bodu.Extensions.Configuration.Text/src/Bodu.Extensions.Configuration.Text.csproj
@@ -25,8 +25,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Primitives" Version="8.0.0" />
   </ItemGroup>
 

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduConfigurationOptionsExtensions.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduConfigurationOptionsExtensions.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduConfigurationOptionsExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Extensions.Configuration.Text;
+
+/// <summary>
+/// Provides convenience extension methods for binding a Bodu Text Configuration section to an
+/// <see cref="Microsoft.Extensions.Options.IOptions{TOptions}" /> instance through an
+/// <see cref="IServiceCollection" />.
+/// </summary>
+/// <remarks>
+/// These helpers are thin shims over
+/// <c>Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure</c>;
+/// they exist purely to keep the call-site short and discoverable for consumers who reach for an
+/// <c>AddBoduConfiguration*</c> API by name. Callers comfortable with
+/// <see cref="Microsoft.Extensions.Options.IOptions{TOptions}" /> binding may continue to call
+/// <see cref="Microsoft.Extensions.DependencyInjection.OptionsConfigurationServiceCollectionExtensions.Configure{TOptions}(IServiceCollection, IConfiguration)" />
+/// directly.
+/// </remarks>
+public static class BoduConfigurationOptionsExtensions
+{
+    /// <summary>
+    /// Registers an <typeparamref name="TOptions" /> binding against the section named
+    /// <paramref name="sectionName" /> in <paramref name="configuration" />.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to bind.</typeparam>
+    /// <param name="services">The service collection to register the binding with.</param>
+    /// <param name="configuration">The configuration root that contains the named section.</param>
+    /// <param name="sectionName">The colon-delimited section name to bind from.</param>
+    /// <returns>The supplied <paramref name="services" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> or <paramref name="configuration" />
+    /// is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="sectionName" /> is <see langword="null" />, empty, or
+    /// whitespace.</exception>
+    public static IServiceCollection AddBoduConfigurationOptions<TOptions>(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        string sectionName)
+        where TOptions : class
+    {
+        ThrowHelper.ThrowIfNull(services);
+        ThrowHelper.ThrowIfNull(configuration);
+        ThrowHelper.ThrowIfNullOrWhiteSpace(sectionName);
+
+        return services.Configure<TOptions>(configuration.GetSection(sectionName));
+    }
+
+    /// <summary>
+    /// Registers an <typeparamref name="TOptions" /> binding against the supplied configuration
+    /// <paramref name="section" />.
+    /// </summary>
+    /// <typeparam name="TOptions">The options type to bind.</typeparam>
+    /// <param name="services">The service collection to register the binding with.</param>
+    /// <param name="section">The configuration section to bind from.</param>
+    /// <returns>The supplied <paramref name="services" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> or <paramref name="section" /> is
+    /// <see langword="null" />.</exception>
+    public static IServiceCollection AddBoduConfigurationOptions<TOptions>(
+        this IServiceCollection services,
+        IConfigurationSection section)
+        where TOptions : class
+    {
+        ThrowHelper.ThrowIfNull(services);
+        ThrowHelper.ThrowIfNull(section);
+
+        return services.Configure<TOptions>(section);
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextConfigurationExtensions.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextConfigurationExtensions.cs
@@ -5,16 +5,34 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System;
+using System.IO;
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
 
 namespace Bodu.Extensions.Configuration.Text;
 
 /// <summary>
 /// Provides convenience extension methods for adding a Bodu Text Configuration source to an
-/// <see cref="IConfigurationBuilder" />.
+/// <see cref="IConfigurationBuilder" />. The overload set mirrors
+/// <c>Microsoft.Extensions.Configuration.Json</c>'s <c>AddJsonFile</c> / <c>AddJsonStream</c> shape so that
+/// consumers familiar with the JSON provider can swap in this provider with no learning curve.
 /// </summary>
 public static class BoduTextConfigurationExtensions
 {
+    /// <summary>
+    /// The conventional file name probed by <see cref="AddBoduConfiguration(IConfigurationBuilder, bool, bool)" />.
+    /// </summary>
+    private const string DefaultDotFileName = ".boduconfig";
+
+    /// <summary>
+    /// The alternative conventional file name probed by
+    /// <see cref="AddBoduConfiguration(IConfigurationBuilder, bool, bool)" /> when
+    /// <see cref="DefaultDotFileName" /> is absent.
+    /// </summary>
+    private const string DefaultPlainFileName = "bodu.config";
+
     /// <summary>
     /// Adds a Bodu Text Configuration source backed by the file at <paramref name="path" />.
     /// </summary>
@@ -33,6 +51,32 @@ public static class BoduTextConfigurationExtensions
         string path,
         string? targetPath = null,
         bool optional = false,
+        bool reloadOnChange = false) =>
+        builder.AddBoduConfiguration(provider: null, path, targetPath, optional, reloadOnChange);
+
+    /// <summary>
+    /// Adds a Bodu Text Configuration source backed by the file at <paramref name="path" /> using the supplied
+    /// <see cref="IFileProvider" />. Mirrors
+    /// <c>AddJsonFile(IConfigurationBuilder, IFileProvider, string, bool, bool)</c>.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="provider">The file provider that locates <paramref name="path" />, or
+    /// <see langword="null" /> to defer to the builder's default file provider.</param>
+    /// <param name="path">The configuration file path, relative to <paramref name="provider" />.</param>
+    /// <param name="targetPath">The optional target path used for glob-anchored resolution.</param>
+    /// <param name="optional">When <see langword="true" />, the file is permitted to be missing.</param>
+    /// <param name="reloadOnChange">When <see langword="true" />, the provider reloads the configuration when
+    /// the underlying file changes.</param>
+    /// <returns>The supplied <paramref name="builder" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="path" /> is <see langword="null" />, empty, or
+    /// whitespace.</exception>
+    public static IConfigurationBuilder AddBoduConfiguration(
+        this IConfigurationBuilder builder,
+        IFileProvider? provider,
+        string path,
+        string? targetPath = null,
+        bool optional = false,
         bool reloadOnChange = false)
     {
         ThrowHelper.ThrowIfNull(builder);
@@ -40,6 +84,7 @@ public static class BoduTextConfigurationExtensions
 
         return builder.AddBoduConfiguration(source =>
         {
+            source.FileProvider = provider;
             source.Path = path;
             source.TargetPath = targetPath;
             source.Optional = optional;
@@ -65,6 +110,141 @@ public static class BoduTextConfigurationExtensions
         BoduTextConfigurationSource source = new();
         configureSource(source);
         builder.Add(source);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a Bodu Text Configuration source backed by the conventional file name <c>.boduconfig</c>, falling
+    /// back to <c>bodu.config</c> when the dot-prefixed name is absent. The file is resolved against the
+    /// builder's default file provider.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="optional">When <see langword="true" /> (the default), neither file is required to exist;
+    /// when <see langword="false" />, at least one of the two conventional names must resolve.</param>
+    /// <param name="reloadOnChange">When <see langword="true" />, the provider reloads the configuration when
+    /// the underlying file changes.</param>
+    /// <returns>The supplied <paramref name="builder" />, for chaining.</returns>
+    /// <remarks>
+    /// The default <c>PhysicalFileProvider</c> filters out dot-prefixed files via its <c>ExclusionFilters</c>
+    /// (<c>Sensitive</c> by default), so to make <c>.boduconfig</c> resolvable the caller must register a
+    /// <c>PhysicalFileProvider</c> constructed with <c>ExclusionFilters.None</c>. The fallback
+    /// <c>bodu.config</c> name is resolved by the default exclusion filters without further configuration.
+    /// </remarks>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    /// <exception cref="FileNotFoundException">
+    /// Both conventional files are absent and <paramref name="optional" /> is <see langword="false" />.
+    /// </exception>
+    public static IConfigurationBuilder AddBoduConfiguration(
+        this IConfigurationBuilder builder,
+        bool optional = true,
+        bool reloadOnChange = false)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        IFileProvider fileProvider = builder.GetFileProvider();
+        string? matched = null;
+        if (fileProvider.GetFileInfo(DefaultDotFileName).Exists)
+            matched = DefaultDotFileName;
+        else if (fileProvider.GetFileInfo(DefaultPlainFileName).Exists)
+            matched = DefaultPlainFileName;
+
+        if (matched is null)
+        {
+            if (!optional)
+            {
+                throw new FileNotFoundException(
+                    $"Neither '{DefaultDotFileName}' nor '{DefaultPlainFileName}' was found in the configured file provider.");
+            }
+
+            return builder.AddBoduConfiguration(source =>
+            {
+                source.FileProvider = fileProvider;
+                source.Path = DefaultDotFileName;
+                source.Optional = true;
+                source.ReloadOnChange = reloadOnChange;
+            });
+        }
+
+        return builder.AddBoduConfiguration(fileProvider, matched, targetPath: null, optional: optional, reloadOnChange: reloadOnChange);
+    }
+
+    /// <summary>
+    /// Adds a Bodu Text Configuration source backed by the supplied <see cref="Stream" />. The stream is read
+    /// once when the configuration is built; no reload-on-change machinery is attached. Mirrors
+    /// <c>AddJsonStream(IConfigurationBuilder, Stream)</c>.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="stream">The stream containing configuration text.</param>
+    /// <param name="targetPath">The optional target path used for glob-anchored resolution.</param>
+    /// <param name="parseOptions">The parse options, or <see langword="null" /> for the defaults.</param>
+    /// <param name="resolveOptions">The resolve options, or <see langword="null" /> for the defaults.</param>
+    /// <returns>The supplied <paramref name="builder" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> or <paramref name="stream" /> is
+    /// <see langword="null" />.</exception>
+    public static IConfigurationBuilder AddBoduConfiguration(
+        this IConfigurationBuilder builder,
+        Stream stream,
+        string? targetPath = null,
+        BoduConfigurationParseOptions? parseOptions = null,
+        BoduConfigurationResolveOptions? resolveOptions = null)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(stream);
+
+        return builder.AddBoduConfiguration(source =>
+        {
+            source.Stream = stream;
+            source.TargetPath = targetPath;
+            source.ParseOptions = parseOptions;
+            source.ResolveOptions = resolveOptions;
+        });
+    }
+
+    /// <summary>
+    /// Adds a Bodu Text Configuration stream source configured via the supplied callback.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="configureSource">A callback that configures the source.</param>
+    /// <returns>The supplied <paramref name="builder" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> or
+    /// <paramref name="configureSource" /> is <see langword="null" />.</exception>
+    public static IConfigurationBuilder AddBoduConfiguration(
+        this IConfigurationBuilder builder,
+        Action<BoduTextStreamConfigurationSource> configureSource)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(configureSource);
+
+        BoduTextStreamConfigurationSource source = new();
+        configureSource(source);
+        builder.Add(source);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an already-parsed <see cref="IniDocument" /> to the configuration. The document is resolved
+    /// against <paramref name="targetPath" /> and the resulting key/value map is added via
+    /// <see cref="MemoryConfigurationBuilderExtensions.AddInMemoryCollection" />.
+    /// </summary>
+    /// <param name="builder">The configuration builder.</param>
+    /// <param name="document">The pre-parsed configuration document.</param>
+    /// <param name="targetPath">The optional target path used for glob-anchored resolution.</param>
+    /// <param name="resolveOptions">The resolve options, or <see langword="null" /> for the defaults.</param>
+    /// <returns>The supplied <paramref name="builder" />, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> or <paramref name="document" />
+    /// is <see langword="null" />.</exception>
+    public static IConfigurationBuilder AddBoduConfiguration(
+        this IConfigurationBuilder builder,
+        IniDocument document,
+        string? targetPath = null,
+        BoduConfigurationResolveOptions? resolveOptions = null)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(document);
+
+        System.Collections.Generic.IDictionary<string, string?> data =
+            BoduTextConfigurationLoader.LoadData(document, targetPath, resolveOptions);
+        builder.AddInMemoryCollection(data);
         return builder;
     }
 }

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextConfigurationLoader.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextConfigurationLoader.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationLoader.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
+
+namespace Bodu.Extensions.Configuration.Text;
+
+/// <summary>
+/// Internal helper that owns the Parse → Resolve → flatten pipeline shared between
+/// <see cref="BoduTextConfigurationProvider" /> (file-backed) and
+/// <see cref="BoduTextStreamConfigurationProvider" /> (stream-backed). Keeps the two providers'
+/// <c>Load</c> implementations in lock-step.
+/// </summary>
+internal static class BoduTextConfigurationLoader
+{
+    /// <summary>
+    /// Parses <paramref name="stream" /> as a Bodu Text Configuration document, resolves it against the
+    /// supplied <paramref name="targetPath" />, and returns the flattened colon-delimited key/value map ready
+    /// to assign to <see cref="Microsoft.Extensions.Configuration.ConfigurationProvider.Data" />.
+    /// </summary>
+    /// <param name="stream">The configuration source stream. The stream is left open.</param>
+    /// <param name="targetPath">The optional target path used to evaluate glob-anchored sections.</param>
+    /// <param name="parseOptions">The parse options, or <see langword="null" /> for
+    /// <see cref="BoduConfigurationParseOptions.Bodu" />.</param>
+    /// <param name="resolveOptions">The resolve options, or <see langword="null" /> for
+    /// <see cref="BoduConfigurationResolveOptions.Bodu" />.</param>
+    /// <returns>A case-insensitive dictionary with colon-delimited logical keys.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="stream" /> is <see langword="null" />.</exception>
+    internal static IDictionary<string, string?> LoadData(
+        Stream stream,
+        string? targetPath,
+        BoduConfigurationParseOptions? parseOptions,
+        BoduConfigurationResolveOptions? resolveOptions)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+
+        BoduConfigurationParseOptions effectiveParse = parseOptions ?? BoduConfigurationParseOptions.Bodu;
+        BoduConfigurationResolveOptions effectiveResolve = resolveOptions ?? BoduConfigurationResolveOptions.Bodu;
+
+        IniDocument document = BoduConfigurationDocument.Load(stream, effectiveParse, leaveOpen: true);
+        return LoadData(document, targetPath, effectiveResolve);
+    }
+
+    /// <summary>
+    /// Resolves an already-parsed <paramref name="document" /> against the supplied
+    /// <paramref name="targetPath" /> and returns the flattened colon-delimited key/value map.
+    /// </summary>
+    /// <param name="document">The parsed configuration document.</param>
+    /// <param name="targetPath">The optional target path used to evaluate glob-anchored sections.</param>
+    /// <param name="resolveOptions">The resolve options, or <see langword="null" /> for
+    /// <see cref="BoduConfigurationResolveOptions.Bodu" />.</param>
+    /// <returns>A case-insensitive dictionary with colon-delimited logical keys.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
+    internal static IDictionary<string, string?> LoadData(
+        IniDocument document,
+        string? targetPath,
+        BoduConfigurationResolveOptions? resolveOptions)
+    {
+        ThrowHelper.ThrowIfNull(document);
+
+        BoduConfigurationResolveOptions effectiveResolve = resolveOptions ?? BoduConfigurationResolveOptions.Bodu;
+        BoduConfigurationView view = document.Resolve(targetPath, effectiveResolve);
+
+        Dictionary<string, string?> data = new(StringComparer.OrdinalIgnoreCase);
+        foreach (KeyValuePair<string, string?> entry in view)
+            data[entry.Key] = entry.Value;
+
+        return data;
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextStreamConfigurationProvider.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextStreamConfigurationProvider.cs
@@ -1,5 +1,5 @@
 // ---------------------------------------------------------------------------------------------------------------
-// <copyright file="BoduTextConfigurationProvider.cs" company="PlaceholderCompany">
+// <copyright file="BoduTextStreamConfigurationProvider.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
@@ -10,24 +10,24 @@ using Microsoft.Extensions.Configuration;
 namespace Bodu.Extensions.Configuration.Text;
 
 /// <summary>
-/// A <see cref="FileConfigurationProvider" /> that parses a Bodu Text Configuration file and populates the
+/// A <see cref="StreamConfigurationProvider" /> that parses a Bodu Text Configuration stream and populates the
 /// configuration data dictionary with the resolved colon-delimited keys.
 /// </summary>
 /// <remarks>
-/// The provider inherits change-token, reload-on-change, optional-file, and exception-wrapping behaviour from
-/// <see cref="FileConfigurationProvider" />. Override <see cref="Load(Stream)" /> only. The Parse → Resolve →
-/// flatten pipeline is shared with <see cref="BoduTextStreamConfigurationProvider" /> via
-/// <see cref="BoduTextConfigurationLoader" />.
+/// Stream-backed providers are one-shot: the stream is consumed during the initial <see cref="Load(Stream)" />
+/// call and no reload-on-change machinery is attached. For file-backed loading with reload support, use
+/// <see cref="BoduTextConfigurationProvider" /> instead. The Parse → Resolve → flatten pipeline is shared with
+/// <see cref="BoduTextConfigurationProvider" /> via <see cref="BoduTextConfigurationLoader" />.
 /// </remarks>
-public sealed class BoduTextConfigurationProvider : FileConfigurationProvider
+public sealed class BoduTextStreamConfigurationProvider : StreamConfigurationProvider
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="BoduTextConfigurationProvider" /> class backed by the
-    /// supplied source.
+    /// Initializes a new instance of the <see cref="BoduTextStreamConfigurationProvider" /> class backed by
+    /// the supplied source.
     /// </summary>
     /// <param name="source">The source that produced this provider.</param>
     /// <exception cref="ArgumentNullException"><paramref name="source" /> is <see langword="null" />.</exception>
-    public BoduTextConfigurationProvider(BoduTextConfigurationSource source)
+    public BoduTextStreamConfigurationProvider(BoduTextStreamConfigurationSource source)
         : base(source)
     {
         ThrowHelper.ThrowIfNull(source);
@@ -37,8 +37,8 @@ public sealed class BoduTextConfigurationProvider : FileConfigurationProvider
     /// <summary>
     /// Gets the typed source that backs this provider.
     /// </summary>
-    /// <returns>The originating <see cref="BoduTextConfigurationSource" />.</returns>
-    public BoduTextConfigurationSource BoduSource { get; }
+    /// <returns>The originating <see cref="BoduTextStreamConfigurationSource" />.</returns>
+    public BoduTextStreamConfigurationSource BoduSource { get; }
 
     /// <inheritdoc />
     public override void Load(Stream stream) =>

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextStreamConfigurationSource.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/BoduTextStreamConfigurationSource.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextStreamConfigurationSource.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Text.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text;
+
+/// <summary>
+/// A <see cref="StreamConfigurationSource" /> that reads a Bodu Text Configuration document from an arbitrary
+/// <see cref="System.IO.Stream" /> and projects its resolved view into the
+/// <see cref="IConfiguration" /> hierarchy as colon-delimited keys.
+/// </summary>
+/// <remarks>
+/// Mirrors the role of <c>JsonStreamConfigurationSource</c> in
+/// <c>Microsoft.Extensions.Configuration.Json</c>. Unlike <see cref="BoduTextConfigurationSource" /> (which is
+/// file-backed and inherits reload-on-change), this source is one-shot: the stream is parsed once when
+/// <see cref="Build(IConfigurationBuilder)" /> is invoked and no file watcher is attached.
+/// </remarks>
+public sealed class BoduTextStreamConfigurationSource : StreamConfigurationSource
+{
+    /// <summary>
+    /// Gets or sets the path used to evaluate glob-anchored sections during resolution. Defaults to
+    /// <see langword="null" />, in which case only non-anchored matches and preamble values apply.
+    /// </summary>
+    /// <returns>The target path supplied to the resolver.</returns>
+    public string? TargetPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets the parse options applied when the stream is loaded.
+    /// </summary>
+    /// <returns>The parse options, or <see langword="null" /> for the defaults.</returns>
+    public BoduConfigurationParseOptions? ParseOptions { get; set; }
+
+    /// <summary>
+    /// Gets or sets the resolve options applied when projecting the document into the configuration view.
+    /// </summary>
+    /// <returns>The resolve options, or <see langword="null" /> for the defaults.</returns>
+    public BoduConfigurationResolveOptions? ResolveOptions { get; set; }
+
+    /// <inheritdoc />
+    public override IConfigurationProvider Build(IConfigurationBuilder builder)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        return new BoduTextStreamConfigurationProvider(this);
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
+++ b/Bodu.Extensions.Configuration.Text/test/Bodu.Extensions.Configuration.Text.Test.csproj
@@ -20,6 +20,8 @@
     <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
     <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationArrayBindingTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationArrayBindingTests.cs
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationArrayBindingTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies array-index key parity with <c>Microsoft.Extensions.Configuration.Json</c>: the Bodu source
+/// format's default dotted-segment notation (<c>items.0 = a</c>) projects into the same colon-delimited
+/// indexed keys (<c>items:0</c>) that JSON arrays produce, so <see cref="ConfigurationBinder" /> binds
+/// collection types identically across both providers.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationArrayBindingTests
+{
+    private const string ArraySample = """
+items.0 = first
+items.1 = second
+items.2 = third
+""";
+
+    /// <summary>
+    /// Verifies that dotted numeric segments project into colon-delimited indexed keys that
+    /// <see cref="ConfigurationBinder" /> binds into a <see cref="List{T}" />.
+    /// </summary>
+    [TestMethod]
+    public void ArrayBinding_WhenSourceUsesDottedIndexSegments_ShouldBindToListOfString()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(ArraySample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        List<string>? items = configuration.GetSection("items").Get<List<string>>();
+
+        Assert.IsNotNull(items);
+        CollectionAssert.AreEqual(new[] { "first", "second", "third" }, items);
+    }
+
+    /// <summary>
+    /// Verifies that the same dotted-index source binds into a primitive array via
+    /// <see cref="ConfigurationBinder.Get{T}(IConfiguration)" />.
+    /// </summary>
+    [TestMethod]
+    public void ArrayBinding_WhenSourceUsesDottedIndexSegments_ShouldBindToArrayOfString()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(ArraySample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        string[]? items = configuration.GetSection("items").Get<string[]>();
+
+        Assert.IsNotNull(items);
+        CollectionAssert.AreEqual(new[] { "first", "second", "third" }, items);
+    }
+
+    /// <summary>
+    /// Verifies that the resolved view exposes the indexed leaf keys (<c>0</c>, <c>1</c>, <c>2</c>) under
+    /// the parent section, matching the shape JSON arrays produce through
+    /// <c>Microsoft.Extensions.Configuration.Json</c>.
+    /// </summary>
+    [TestMethod]
+    public void ArrayBinding_WhenSourceUsesDottedIndexSegments_ShouldExposeIndexedColonKeys()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(ArraySample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        List<string> childKeys = configuration.GetSection("items")
+            .GetChildren()
+            .Select(c => c.Key)
+            .OrderBy(k => k)
+            .ToList();
+
+        CollectionAssert.AreEqual(new[] { "0", "1", "2" }, childKeys);
+        Assert.AreEqual("first", configuration["items:0"]);
+        Assert.AreEqual("second", configuration["items:1"]);
+        Assert.AreEqual("third", configuration["items:2"]);
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationBindingTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationBindingTests.cs
@@ -1,0 +1,107 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationBindingTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies that the bridge produces a configuration view compatible with standard
+/// <c>Microsoft.Extensions.Configuration</c> consumer patterns (POCO binding, section enumeration,
+/// <c>GetSection</c>).
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationBindingTests
+{
+    private const string PocoSample = """
+logging.level.default = Information
+logging.level.console = Warning
+logging.provider = Console
+""";
+
+    /// <summary>
+    /// Verifies that <see cref="ConfigurationBinder.Get{T}(IConfiguration)" /> populates a POCO whose property
+    /// names match the colon-delimited keys.
+    /// </summary>
+    [TestMethod]
+    public void Bind_WhenSectionMapsToPoco_ShouldPopulateFields()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(PocoSample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        LoggingOptions options = configuration.GetSection("logging").Get<LoggingOptions>() ?? new();
+
+        Assert.AreEqual("Console", options.Provider);
+        Assert.IsNotNull(options.Level);
+        Assert.AreEqual("Information", options.Level!["default"]);
+        Assert.AreEqual("Warning", options.Level!["console"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration.GetSection(string)" /> exposes the nested keys via
+    /// <see cref="IConfiguration.GetChildren" /> using the leaf segments as child keys.
+    /// </summary>
+    [TestMethod]
+    public void GetChildren_WhenSectionHasNestedKeys_ShouldEnumerateLeafKeys()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(PocoSample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        IConfigurationSection level = configuration.GetSection("logging:level");
+        List<string> childKeys = level.GetChildren().Select(c => c.Key).OrderBy(k => k).ToList();
+
+        CollectionAssert.AreEquivalent(new[] { "console", "default" }, childKeys);
+        Assert.AreEqual("Information", level["default"]);
+        Assert.AreEqual("Warning", level["console"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration.GetSection(string)" /> returns an existing section whose
+    /// <see cref="IConfigurationSection.Path" /> matches the requested path.
+    /// </summary>
+    [TestMethod]
+    public void GetSection_WhenSectionExists_ShouldExposePathAndKey()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(PocoSample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        IConfigurationSection section = configuration.GetSection("logging");
+
+        Assert.AreEqual("logging", section.Path);
+        Assert.AreEqual("logging", section.Key);
+        Assert.AreEqual("Console", section["provider"]);
+    }
+
+    /// <summary>
+    /// POCO used to validate binding semantics for the logging section.
+    /// </summary>
+    private sealed class LoggingOptions
+    {
+        /// <summary>
+        /// Gets or sets the provider identifier.
+        /// </summary>
+        public string? Provider { get; set; }
+
+        /// <summary>
+        /// Gets or sets the per-category log level map keyed by category name.
+        /// </summary>
+        public Dictionary<string, string>? Level { get; set; }
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationDefaultFilenameTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationDefaultFilenameTests.cs
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationDefaultFilenameTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies the parameterless default-filename overload of <c>AddBoduConfiguration</c>, which probes for
+/// <c>.boduconfig</c> and falls back to <c>bodu.config</c>.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationDefaultFilenameTests
+{
+    private const string Sample = """
+default.filename.loaded = yes
+""";
+
+    /// <summary>
+    /// Verifies that when only the dot-prefixed <c>.boduconfig</c> file exists, the default overload loads it.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WhenNoArgsAndDotConfigPresent_ShouldLoad()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, ".boduconfig"), Sample);
+
+            ConfigurationBuilder builder = new();
+            builder.SetFileProvider(new PhysicalFileProvider(directory, ExclusionFilters.None));
+
+            IConfiguration configuration = builder.AddBoduConfiguration().Build();
+
+            Assert.AreEqual("yes", configuration["default:filename:loaded"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when the dot-prefixed name is absent, the default overload falls back to
+    /// <c>bodu.config</c>.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WhenNoArgsAndPlainConfigPresent_ShouldLoadFallback()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            File.WriteAllText(Path.Combine(directory, "bodu.config"), Sample);
+
+            ConfigurationBuilder builder = new();
+            builder.SetFileProvider(new PhysicalFileProvider(directory));
+
+            IConfiguration configuration = builder.AddBoduConfiguration().Build();
+
+            Assert.AreEqual("yes", configuration["default:filename:loaded"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when neither conventional file is present and the call is optional, the builder
+    /// produces an empty configuration view without throwing.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WhenNoArgsAndAllMissing_ShouldNotThrow()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            ConfigurationBuilder builder = new();
+            builder.SetFileProvider(new PhysicalFileProvider(directory));
+
+            IConfiguration configuration = builder.AddBoduConfiguration(optional: true).Build();
+
+            Assert.IsNull(configuration["default:filename:loaded"]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that when neither conventional file is present and the call is required, the builder throws a
+    /// <see cref="FileNotFoundException" />.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WhenNoArgsAndRequiredAndAllMissing_ShouldThrowFileNotFoundException()
+    {
+        string directory = CreateTempDirectory();
+        try
+        {
+            ConfigurationBuilder builder = new();
+            builder.SetFileProvider(new PhysicalFileProvider(directory));
+
+            Assert.ThrowsExactly<FileNotFoundException>(() =>
+            {
+                _ = builder.AddBoduConfiguration(optional: false).Build();
+            });
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the default-filename overload rejects a <see langword="null" /> builder.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        IConfigurationBuilder builder = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddBoduConfiguration();
+        });
+    }
+
+    private static string CreateTempDirectory()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(directory);
+        return directory;
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationFileProviderTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationFileProviderTests.cs
@@ -1,0 +1,105 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationFileProviderTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies the explicit <see cref="IFileProvider" /> overload of <c>AddBoduConfiguration</c>, mirroring
+/// <c>AddJsonFile(IConfigurationBuilder, IFileProvider, string, bool, bool)</c>.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationFileProviderTests
+{
+    private const string Sample = """
+logging.level.default = Information
+""";
+
+    /// <summary>
+    /// Verifies that the file-provider overload loads the configuration via the supplied
+    /// <see cref="IFileProvider" /> rather than the builder's default.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithExplicitFileProvider_ShouldLoadFromProvider()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".boduconfig");
+        try
+        {
+            File.WriteAllText(path, Sample);
+            PhysicalFileProvider fileProvider = new(Path.GetDirectoryName(path)!);
+
+            IConfiguration configuration = new ConfigurationBuilder()
+                .AddBoduConfiguration(fileProvider, Path.GetFileName(path))
+                .Build();
+
+            Assert.AreEqual("Information", configuration["logging:level:default"]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the file-provider overload tolerates a <see langword="null" /> provider and falls back to
+    /// the builder's default file provider.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithNullFileProvider_ShouldFallBackToBuilderDefault()
+    {
+        string path = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName() + ".boduconfig");
+        try
+        {
+            File.WriteAllText(path, Sample);
+
+            ConfigurationBuilder builder = new();
+            builder.SetBasePath(Path.GetDirectoryName(path)!);
+
+            IConfiguration configuration = builder
+                .AddBoduConfiguration(provider: null, path: Path.GetFileName(path))
+                .Build();
+
+            Assert.AreEqual("Information", configuration["logging:level:default"]);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the file-provider overload rejects a <see langword="null" /> builder.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithNullBuilder_ShouldThrowArgumentNullException()
+    {
+        IConfigurationBuilder builder = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddBoduConfiguration(provider: null, path: "some.boduconfig");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the file-provider overload rejects an empty path.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithEmptyPath_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = new ConfigurationBuilder().AddBoduConfiguration(provider: null, path: "   ");
+        });
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationIniDocumentTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationIniDocumentTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationIniDocumentTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies that the in-memory <see cref="IniDocument" /> overload of <c>AddBoduConfiguration</c> resolves a
+/// pre-parsed document and flattens it into the configuration view via <c>AddInMemoryCollection</c>.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationIniDocumentTests
+{
+    private const string Sample = """
+logging.level.default = Information
+
+[src/**/*.cs]
+logging.level.default = Warning
+""";
+
+    /// <summary>
+    /// Verifies that the <see cref="IniDocument" /> overload flattens a parsed document into the configuration
+    /// view exactly as the file overload would.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithIniDocument_ShouldFlattenIntoConfiguration()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+        IniDocument document = BoduConfigurationDocument.Load(stream, BoduConfigurationParseOptions.Bodu);
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(document)
+            .Build();
+
+        Assert.AreEqual("Information", configuration["logging:level:default"]);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IniDocument" /> overload honours a supplied target path during resolution.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithIniDocument_WhenTargetPathProvided_ShouldApplyMatchingSection()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+        IniDocument document = BoduConfigurationDocument.Load(stream, BoduConfigurationParseOptions.Bodu);
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(document, targetPath: "src/Foo.cs")
+            .Build();
+
+        Assert.AreEqual("Warning", configuration["logging:level:default"]);
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IniDocument" /> overload rejects a <see langword="null" /> document.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithIniDocument_WhenDocumentIsNull_ShouldThrowArgumentNullException()
+    {
+        IniDocument document = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new ConfigurationBuilder().AddBoduConfiguration(document);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the <see cref="IniDocument" /> overload rejects a <see langword="null" /> builder.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfiguration_WithIniDocument_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        IConfigurationBuilder builder = null!;
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+        IniDocument document = BoduConfigurationDocument.Load(stream, BoduConfigurationParseOptions.Bodu);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddBoduConfiguration(document);
+        });
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationMultiSourceTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationMultiSourceTests.cs
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationMultiSourceTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies that multiple Bodu Text Configuration sources layer in the order they are added, matching the
+/// last-writer-wins precedence applied by <c>Microsoft.Extensions.Configuration</c> for every provider.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationMultiSourceTests
+{
+    /// <summary>
+    /// Verifies that when two sources are added, the second source overrides the first for keys present in
+    /// both.
+    /// </summary>
+    [TestMethod]
+    public void MultipleBoduSources_ShouldLayerByOrderAdded()
+    {
+        const string baseSource = """
+service.name = First
+service.port = 8080
+""";
+
+        const string overrideSource = """
+service.name = Second
+""";
+
+        using MemoryStream first = new(Encoding.UTF8.GetBytes(baseSource));
+        using MemoryStream second = new(Encoding.UTF8.GetBytes(overrideSource));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(first)
+            .AddBoduConfiguration(second)
+            .Build();
+
+        Assert.AreEqual("Second", configuration["service:name"]);
+        Assert.AreEqual("8080", configuration["service:port"]);
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationOptionsTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationOptionsTests.cs
@@ -1,0 +1,168 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationOptionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies the <see cref="BoduConfigurationOptionsExtensions" /> helpers for binding configuration sections
+/// to <see cref="IOptions{TOptions}" /> through the dependency-injection container.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationOptionsTests
+{
+    private const string Sample = """
+service.name = Bodu
+service.port = 8080
+""";
+
+    /// <summary>
+    /// Verifies that
+    /// <see cref="BoduConfigurationOptionsExtensions.AddBoduConfigurationOptions{TOptions}(IServiceCollection, IConfiguration, string)" />
+    /// binds the named section to the options instance resolved from the container.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WhenBound_ShouldDeliverViaIOptions()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        ServiceOptions options = provider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+
+        Assert.AreEqual("Bodu", options.Name);
+        Assert.AreEqual(8080, options.Port);
+    }
+
+    /// <summary>
+    /// Verifies that the section-overload of <c>AddBoduConfigurationOptions</c> resolves an equivalent options
+    /// instance.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WithSection_ShouldDeliverViaIOptions()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        ServiceCollection services = new();
+        services.AddOptions();
+        services.AddBoduConfigurationOptions<ServiceOptions>(configuration.GetSection("service"));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        ServiceOptions options = provider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+
+        Assert.AreEqual("Bodu", options.Name);
+        Assert.AreEqual(8080, options.Port);
+    }
+
+    /// <summary>
+    /// Verifies that the name-based overload rejects a <see langword="null" /> service collection.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WhenServicesIsNull_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection services = null!;
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the name-based overload rejects a <see langword="null" /> configuration.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WhenConfigurationIsNull_ShouldThrowArgumentNullException()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the name-based overload rejects a whitespace section name.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WhenSectionNameIsWhitespace_ShouldThrowArgumentException()
+    {
+        ServiceCollection services = new();
+        IConfiguration configuration = new ConfigurationBuilder().Build();
+
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "   ");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the section overload rejects a <see langword="null" /> service collection.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WithSection_WhenServicesIsNull_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection services = null!;
+        IConfigurationSection section = new ConfigurationBuilder().Build().GetSection("anything");
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = services.AddBoduConfigurationOptions<ServiceOptions>(section);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the section overload rejects a <see langword="null" /> section.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationOptions_WithSection_WhenSectionIsNull_ShouldThrowArgumentNullException()
+    {
+        ServiceCollection services = new();
+        IConfigurationSection section = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = services.AddBoduConfigurationOptions<ServiceOptions>(section);
+        });
+    }
+
+    /// <summary>
+    /// POCO used to validate IOptions binding semantics in this fixture.
+    /// </summary>
+    private sealed class ServiceOptions
+    {
+        /// <summary>
+        /// Gets or sets the service name.
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the service port.
+        /// </summary>
+        public int Port { get; set; }
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationReloadTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationReloadTests.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationReloadTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Threading;
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies that <c>reloadOnChange</c> behaviour propagates through the bridge, including reload-token signal
+/// delivery when the underlying configuration file is replaced on disk.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationReloadTests
+{
+    private const string InitialContent = """
+logging.level.default = Information
+""";
+
+    private const string UpdatedContent = """
+logging.level.default = Debug
+""";
+
+    /// <summary>
+    /// Verifies that when the underlying file changes and <c>reloadOnChange</c> is enabled, the reload token
+    /// fires and the new value becomes observable.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenFileChangesOnDisk_ShouldFireToken()
+    {
+        string directory = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(directory);
+        string path = Path.Combine(directory, "reload.boduconfig");
+
+        try
+        {
+            File.WriteAllText(path, InitialContent);
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(-30));
+
+            PhysicalFileProvider fileProvider = new(directory)
+            {
+                UseActivePolling = true,
+                UsePollingFileWatcher = true,
+            };
+
+            IConfigurationRoot configuration = new ConfigurationBuilder()
+                .AddBoduConfiguration(fileProvider, "reload.boduconfig", targetPath: null, optional: false, reloadOnChange: true)
+                .Build();
+
+            Assert.AreEqual("Information", configuration["logging:level:default"]);
+
+            using ManualResetEventSlim signal = new(initialState: false);
+            using IDisposable registration = Microsoft.Extensions.Primitives.ChangeToken.OnChange(
+                configuration.GetReloadToken,
+                () => signal.Set());
+
+            // Ensure the next write has a clearly newer mtime than the original.
+            Thread.Sleep(50);
+            File.WriteAllText(path, UpdatedContent);
+            File.SetLastWriteTimeUtc(path, DateTime.UtcNow);
+
+            bool reloaded = signal.Wait(TimeSpan.FromSeconds(15));
+
+            Assert.IsTrue(reloaded, "Expected the reload token to fire after the file changed on disk.");
+            Assert.AreEqual("Debug", configuration["logging:level:default"]);
+        }
+        finally
+        {
+            try { Directory.Delete(directory, recursive: true); } catch { }
+        }
+    }
+}

--- a/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationStreamTests.cs
+++ b/Bodu.Extensions.Configuration.Text/test/Extensions.Configuration.Text/BoduTextConfigurationStreamTests.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BoduTextConfigurationStreamTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.IO;
+using System.Text;
+using Bodu.Extensions.Configuration.Text;
+using Bodu.Text.Configuration;
+using Microsoft.Extensions.Configuration;
+
+namespace Bodu.Extensions.Configuration.Text.Tests;
+
+/// <summary>
+/// Verifies the stream-based <c>AddBoduConfiguration</c> overloads that mirror
+/// <c>AddJsonStream</c> from <c>Microsoft.Extensions.Configuration.Json</c>.
+/// </summary>
+[TestClass]
+public class BoduTextConfigurationStreamTests
+{
+    private const string Sample = """
+logging.level.default = Information
+
+[src/**/*.cs]
+logging.level.default = Warning
+""";
+
+    /// <summary>
+    /// Verifies that <see cref="BoduTextConfigurationExtensions.AddBoduConfiguration(IConfigurationBuilder, Stream, string?, BoduConfigurationParseOptions?, BoduConfigurationResolveOptions?)" />
+    /// reads from a stream and exposes the resulting keys in colon-delimited form.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_ShouldExposeColonDelimitedKeys()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream)
+            .Build();
+
+        Assert.AreEqual("Information", configuration["logging:level:default"]);
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload honours a supplied target path and applies the matching glob-anchored
+    /// section override.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_WhenTargetPathProvided_ShouldApplyMatchingSection()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(stream, targetPath: "src/Foo.cs")
+            .Build();
+
+        Assert.AreEqual("Warning", configuration["logging:level:default"]);
+    }
+
+    /// <summary>
+    /// Verifies that the action-callback stream overload yields the same view as the direct stream overload.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_WhenConfiguredViaCallback_ShouldExposeColonDelimitedKeys()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(source =>
+            {
+                source.Stream = stream;
+                source.TargetPath = "src/Foo.cs";
+            })
+            .Build();
+
+        Assert.AreEqual("Warning", configuration["logging:level:default"]);
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload rejects a <see langword="null" /> stream.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Stream stream = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new ConfigurationBuilder().AddBoduConfiguration(stream);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the stream-callback overload rejects a <see langword="null" /> configuration callback.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_WhenCallbackIsNull_ShouldThrowArgumentNullException()
+    {
+        Action<BoduTextStreamConfigurationSource> configure = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new ConfigurationBuilder().AddBoduConfiguration(configure);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that supplied parse and resolve options propagate through the stream source to the
+    /// configuration values.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduConfigurationStream_WhenOptionsProvided_ShouldUseTheOptions()
+    {
+        using MemoryStream stream = new(Encoding.UTF8.GetBytes(Sample));
+
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddBoduConfiguration(
+                stream,
+                targetPath: null,
+                parseOptions: BoduConfigurationParseOptions.Bodu,
+                resolveOptions: BoduConfigurationResolveOptions.Bodu)
+            .Build();
+
+        Assert.AreEqual("Information", configuration["logging:level:default"]);
+    }
+}


### PR DESCRIPTION
Mirror the Microsoft.Extensions.Configuration.Json surface so consumers familiar
with AddJsonFile / AddJsonStream can swap in this provider without learning a
new pattern.

- Add BoduTextStreamConfigurationSource / Provider (one-shot stream-backed pair,
  modelled on JsonStreamConfigurationSource / Provider).
- Add new AddBoduConfiguration overloads: explicit IFileProvider; default
  filename probe (.boduconfig then bodu.config); Stream; Stream callback;
  in-memory IniDocument.
- Refactor the Parse -> Resolve -> flatten pipeline into the internal
  BoduTextConfigurationLoader shared by both providers so their Load(Stream)
  bodies collapse to a one-liner and stay in lock-step.
- Add BoduConfigurationOptionsExtensions for IServiceCollection-based IOptions
  binding (thin shim over services.Configure for discoverability).
- Pick up Microsoft.Extensions.Configuration.Binder,
  Microsoft.Extensions.DependencyInjection.Abstractions, and
  Microsoft.Extensions.Options.ConfigurationExtensions package references.

https://claude.ai/code/session_011GB5wYP3hSbdN1qyNguUVu