### PR TITLE
Add documentation for Bodu.Text.Configuration and Extensions.Configuration.Text

### DIFF
--- a/docs/apidoc/Bodu.Extensions.Configuration.Text.md
+++ b/docs/apidoc/Bodu.Extensions.Configuration.Text.md
@@ -1,0 +1,97 @@
+---
+uid: Bodu.Extensions.Configuration.Text
+---
+
+## Purpose
+
+**Bodu.Extensions.Configuration.Text** bridges <xref:Bodu.Text.Configuration> to <xref:Microsoft.Extensions.Configuration>. It exposes the conventional `AddBoduConfiguration` entry point on <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder> — the overload set mirrors `Microsoft.Extensions.Configuration.Json`'s `AddJsonFile` / `AddJsonStream` — so a Bodu Text Configuration file can be layered alongside JSON, INI, XML, and environment-variable sources with no learning curve.
+
+Once added, the source loads the file (or stream, or pre-parsed document), parses it with <xref:Bodu.Text.Configuration.BoduConfigurationDocument>, resolves it for the configured `TargetPath`, and copies the flattened view into the standard <xref:Microsoft.Extensions.Configuration.IConfiguration> dictionary as colon-delimited keys. A companion <xref:Bodu.Extensions.Configuration.Text.BoduConfigurationOptionsExtensions> helper binds a section to an <xref:Microsoft.Extensions.Options.IOptions`1> instance through the standard DI container.
+
+## Static documentation
+
+- **[Bodu.Extensions.Configuration.Text introduction](~/docs/extensions-configuration-text/index.md)** — shape of the library, headline types, scenarios.
+- **[Bodu.Extensions.Configuration.Text core concepts](~/docs/extensions-configuration-text/concepts.md)** — vocabulary: source vs provider, target path, parse/resolve option propagation, reload-on-change, options binding.
+- **[Bodu.Extensions.Configuration.Text getting started](~/docs/extensions-configuration-text/getting-started.md)** — install and minimal samples for the file overload, stream overload, conventional probe, options binding.
+- **[Bodu.Text.Configuration](~/docs/text-configuration/index.md)** — the underlying parser, resolver, and view model.
+
+## Key types
+
+**Builder extensions**
+
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationExtensions> — the primary entry point. Six `AddBoduConfiguration` overloads:
+    - `AddBoduConfiguration(builder, string path, string? targetPath, bool optional, bool reloadOnChange)` — file path.
+    - `AddBoduConfiguration(builder, IFileProvider?, string path, string? targetPath, bool optional, bool reloadOnChange)` — file path through a specific file provider.
+    - `AddBoduConfiguration(builder, Action<BoduTextConfigurationSource> configureSource)` — configure callback.
+    - `AddBoduConfiguration(builder, bool optional, bool reloadOnChange)` — conventional file probe (`.boduconfig` → `bodu.config`).
+    - `AddBoduConfiguration(builder, Stream)` — stream source (no reload-on-change).
+    - `AddBoduConfiguration(builder, IniDocument, string? targetPath)` — pre-parsed document source.
+
+**Sources and providers**
+
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> — file-backed configuration source. Subclasses <xref:Microsoft.Extensions.Configuration.FileConfigurationSource>; inherits `Path`, `Optional`, `ReloadOnChange`, `FileProvider`; adds `TargetPath`, `ParseOptions`, `ResolveOptions`.
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationProvider> — the matching `FileConfigurationProvider`. Reads the file via the standard MEC pipeline and projects the resolved view into the inherited `Data` dictionary.
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource> — stream-backed configuration source. Subclasses <xref:Microsoft.Extensions.Configuration.StreamConfigurationSource>; adds the same `TargetPath` / `ParseOptions` / `ResolveOptions` triple. One-shot — no reload-on-change.
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationProvider> — the matching `StreamConfigurationProvider`.
+- <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationLoader> — internal helper shared by both providers that parses a stream into an `IniDocument`, resolves it for `TargetPath`, and flattens the resolved view into `Dictionary<string, string?>`.
+
+**Options binding**
+
+- <xref:Bodu.Extensions.Configuration.Text.BoduConfigurationOptionsExtensions> — DI helpers:
+    - `AddBoduConfigurationOptions<TOptions>(services, IConfiguration configuration, string sectionName)` — section by name.
+    - `AddBoduConfigurationOptions<TOptions>(services, IConfigurationSection section)` — already-projected section.
+  Both are thin shims over `services.Configure<TOptions>(...)` — provided for IntelliSense discoverability.
+
+## Example
+
+```csharp
+using Bodu.Extensions.Configuration.Text;
+using Bodu.Text.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Options;
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration(src =>
+    {
+        src.FileProvider     = new PhysicalFileProvider("/etc/myapp");
+        src.Path             = "settings.boduconfig";
+        src.TargetPath       = "src/Foo.cs";
+        src.Optional         = true;
+        src.ReloadOnChange   = true;
+        src.ParseOptions     = BoduConfigurationParseOptions.EditorConfigCompatible;
+        src.ResolveOptions   = new BoduConfigurationResolveOptions
+        {
+            UnsetValueMode = BoduConfigurationUnsetValueMode.RemoveEffectiveValue,
+        };
+    })
+    .Build();
+
+string? logLevel = configuration["logging:level:default"];
+
+// Bind a section to a POCO through the DI container.
+ServiceCollection services = new();
+services.AddOptions();
+services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+
+using ServiceProvider provider = services.BuildServiceProvider();
+ServiceOptions options = provider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+
+sealed class ServiceOptions
+{
+    public string? Name { get; set; }
+    public int Port { get; set; }
+}
+```
+
+## Notes
+
+- **Conventional file probe.** The no-argument overload probes the builder's default file provider for `.boduconfig`, then `bodu.config`. The first file present is loaded; if neither exists and `optional` is `true`, the call is a no-op. This matches the dotfile / plain-file convention common in version-controlled repos.
+- **Reload-on-change.** <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> inherits `ReloadOnChange` from `FileConfigurationSource`. When set, the provider attaches a file watcher via the configured `IFileProvider`, reparses on change, and triggers the standard `IConfiguration` reload tokens — so consumers using `Microsoft.Extensions.Options.IOptionsMonitor<T>` rebind automatically. <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource> does **not** support reload; the stream is parsed once when `Build` is called.
+- **File-provider precedence.** When `AddBoduConfiguration` is given an explicit `IFileProvider`, that wins; otherwise the source's `FileProvider` wins; otherwise the builder's default applies. Standard MEC precedence is preserved.
+- **Parse / resolve option propagation.** Both `ParseOptions` and `ResolveOptions` default to `null`, in which case `BoduConfigurationParseOptions.Bodu` and `BoduConfigurationResolveOptions.Bodu` are used. Set them per-source to mix profiles within a single builder (an EditorConfig-strict file alongside a Bodu-permissive one).
+- **Target path.** `TargetPath` is per-source. Each source resolves the document for its own target; multiple sources with the same path but different targets are a supported pattern when the application needs configuration evaluated for several paths in parallel.
+- **DI integration.** <xref:Bodu.Extensions.Configuration.Text.BoduConfigurationOptionsExtensions> is a discoverability shim. Calls to `services.Configure<TOptions>(configuration.GetSection(name))` produce equivalent bindings. Callers comfortable with the MEC pattern may use either form interchangeably.
+- **Validation.** All public entry points validate inputs via `ThrowHelper`. `ArgumentNullException` covers null builders / configurations / streams / sections; `ArgumentException` covers null, empty, or whitespace path / section-name strings.
+- **See also:** the [introduction](~/docs/extensions-configuration-text/index.md), [core concepts](~/docs/extensions-configuration-text/concepts.md), and [getting-started](~/docs/extensions-configuration-text/getting-started.md); the underlying parser, resolver, and view in [Bodu.Text.Configuration](~/docs/text-configuration/index.md).

--- a/docs/apidoc/Bodu.Text.Configuration.md
+++ b/docs/apidoc/Bodu.Text.Configuration.md
@@ -1,0 +1,109 @@
+---
+uid: Bodu.Text.Configuration
+---
+
+## Purpose
+
+**Bodu.Text.Configuration** is the configuration-layering package of the Bodu suite. It parses INI / EditorConfig-style text, optionally collects diagnostics, layers a preamble plus glob-anchored sections in source order for a target path, and projects the result into a flat, colon-delimited <xref:Bodu.Text.Configuration.BoduConfigurationView>. The view exposes typed accessors (`GetString`, `GetInt32`, `GetBoolean`, `GetEnum<T>`, `GetValue<T>` for any <xref:System.ISpanParsable`1>) and integrates directly with `Microsoft.Extensions.Configuration` through the sibling <xref:Bodu.Extensions.Configuration.Text> package.
+
+Reach for this library when you need EditorConfig-style file-targeted configuration layering, programmatic INI parsing with diagnostic collection, or a `Microsoft.Extensions.Configuration`-compatible flat key/value view without taking a dependency on `Microsoft.Extensions.*` from the parser itself. The underlying data model is <xref:Bodu.Text.Formats.IniDocument> from the <xref:Bodu.Text.Formats> package, so anything the INI codec can read is something `Bodu.Text.Configuration` can resolve.
+
+## Static documentation
+
+- **[Bodu.Text.Configuration introduction](~/docs/text-configuration/index.md)** — shape of the library, headline types, scenarios.
+- **[Bodu.Text.Configuration core concepts](~/docs/text-configuration/concepts.md)** — vocabulary: document vs view, profile, parse/resolve/write options, key mapping, glob pattern, preamble, target path, diagnostic mode, unset.
+- **[Bodu.Text.Configuration getting started](~/docs/text-configuration/getting-started.md)** — install and minimal samples for parse-resolve-read, profile presets, diagnostics, round-trip save.
+- **[Bodu.Extensions.Configuration.Text](~/docs/extensions-configuration-text/index.md)** — `IConfigurationBuilder` bridge.
+
+## Key types
+
+**Document and view**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationDocument> — static façade for parsing and saving. `Parse`, `ParseWithDiagnostics`, `Load(path | Stream | TextReader)`, `Save(document, path | Stream | TextWriter, options?)`. Backed by <xref:Bodu.Text.Formats.IniDocument>.
+- <xref:Bodu.Text.Configuration.BoduConfigurationView> — read-only, one-shot resolved snapshot for a target path; implements `IEnumerable<KeyValuePair<string, string?>>`; exposes `Values`, `Keys`, `Count`, indexer, and the `GetXxx` / `TryGetXxx` / `GetValue<T>` / `TryGetValue<T>` family.
+- <xref:Bodu.Text.Configuration.BoduConfigurationExtensions> — extension methods over the underlying INI primitives: `Resolve(targetPath)` on `IniDocument`, `IsMatch(relativePath)` on `IniSection`, `ConfigurationKey()` on `IniEntry`, `Preamble()` on `IniDocument`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationParseResult> — output of `ParseWithDiagnostics`: the document and an `ImmutableArray<BoduConfigurationDiagnostic>` of recoverable issues collected during the parse.
+- <xref:Bodu.Text.Configuration.BoduConfigurationParseException> — thrown by the throwing parse / load overloads under `BoduConfigurationDiagnosticMode.Throw`.
+
+**Profiles and options**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationProfile> — `Bodu` (default), `EditorConfigCompatible`, `Strict`, `Relaxed`. Each option type has a static `For(profile)` factory and four named property presets.
+- <xref:Bodu.Text.Configuration.BoduConfigurationParseOptions> — reader behaviour: `InlineCommentMode`, `DuplicateKeyMode`, `DuplicateSectionMode`, `DiagnosticMode`, `MaxLineLength`, `MaxKeyLength`, `TrimKeysAndValues`, `AllowKeyOnlyProperties`, `DefaultEncoding`, `KeyOptions`. Static presets `Bodu`, `EditorConfigCompatible`, `Strict`, `Relaxed`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions> — resolver behaviour: `PathRoot`, `MissingPathRootMode`, `ApplyPreambleProperties`, `PathComparison`, `UnsetValueMode`, `KeyOptions`. Static presets aligned with the same four profiles.
+- <xref:Bodu.Text.Configuration.BoduConfigurationWriteOptions> — writer behaviour: encoding (default UTF-8 without BOM), newline style, blank-line policy, property formatting. Static presets aligned with the same four profiles.
+
+**Keys**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationKey> — read-only struct with `RawKey`, `ConfigurationKey`, `Segments`, `CaseSensitive`. Static `Parse(rawKey, options?)` / `TryParse(rawKey, options?, out result)` factories.
+- <xref:Bodu.Text.Configuration.BoduConfigurationKeyOptions> — `SegmentSeparators` (default `{ '.', ':' }`), `Mapping` (`DotToColon` default / `Colon` / `Identity`), `CaseSensitive` (default `false`), `AllowEmptySegments` (default `false`).
+- <xref:Bodu.Text.Configuration.BoduConfigurationKeyMapping> — `DotToColon` (default), `Colon`, `Identity`.
+
+**Diagnostics**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationDiagnostic> — immutable record carrying `Severity`, `Code`, `Message`, `Location`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticSeverity> — `Warning`, `Error`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticCode> — stable category identifier (duplicate key, invalid section header, invalid unset, line-length exceeded, …).
+- <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticMode> — `Throw` (default), `Collect`, `Ignore`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationSourceLocation> — line / column / file metadata pointing into the source text.
+
+**Modes**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationInlineCommentMode> — `Disabled` (EditorConfig), `WhitespaceIntroduced` (default), `Always`.
+- <xref:Bodu.Text.Configuration.BoduConfigurationUnsetValueMode> — `TreatAsLiteral` (default), `RemoveEffectiveValue` (EditorConfig sentinel).
+- <xref:Bodu.Text.Configuration.BoduConfigurationMissingPathRootMode> — `UseEmptyRoot` (default), `Throw`, `IgnoreAnchoredPatterns`.
+
+**Pattern engine**
+
+- <xref:Bodu.Text.Configuration.BoduConfigurationPattern> — compiled EditorConfig-style glob pattern. `Compile(text)` + `IsMatch(path)`. Used internally by the resolver and exposed for callers that want to test pattern matching standalone.
+
+## Example
+
+```csharp
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
+
+const string source = """
+# Bodu configuration sample
+root = true
+
+[*.cs]
+format.indent.style = space
+format.indent.size  = 4
+logging.level.default = Information
+
+[src/**/*.{cs,csproj}]
+format.indent.size = 2
+logging.level.default = Warning
+""";
+
+// Parse, optionally collect diagnostics, then resolve for a target path.
+BoduConfigurationParseResult result = BoduConfigurationDocument.ParseWithDiagnostics(source);
+IniDocument doc = result.Document;
+
+BoduConfigurationView view = doc.Resolve("src/Bodu.Text.Configuration/src/Foo.cs");
+
+string indentStyle = view.GetString("format:indent:style");      // "space"
+int indentSize     = view.GetInt32("format:indent:size");        // 2 — last-wins from [src/**]
+string logLevel    = view.GetString("logging:level:default");    // "Warning"
+double threshold   = view.GetValue<double>("limits:cpu:threshold", fallback: 0.8);
+
+// Profile presets — swap the parser into EditorConfig-strict mode.
+IniDocument editorConfig = BoduConfigurationDocument.Parse(
+    source,
+    BoduConfigurationParseOptions.EditorConfigCompatible);
+
+// Round-trip back to text.
+using StringWriter sw = new();
+BoduConfigurationDocument.Save(doc, sw);
+string canonicalText = sw.ToString();
+```
+
+## Notes
+
+- **Immutable views.** <xref:Bodu.Text.Configuration.BoduConfigurationView> is a one-shot snapshot. The underlying dictionary is exposed read-only through `Values`; subsequent mutations of the originating `IniDocument` do not propagate. Take a fresh view after every meaningful document edit.
+- **Thread safety.** The view is safe to read from any number of threads concurrently. The parser, resolver, and save APIs are short-lived and stateless across calls; the document model itself is not thread-safe for concurrent mutation but is safe for concurrent read.
+- **Determinism.** All parsing, resolving, and typed conversion uses <xref:System.Globalization.CultureInfo.InvariantCulture>. Output bytes from `Save` are byte-stable for documents the library produced; documents authored by hand may be reformatted to the canonical layout on first save.
+- **Last-wins precedence.** The resolver walks the document once in source order; for any configuration key, the value from the later matching section wins. There is no override / inherit hierarchy beyond "later in the file wins" — this matches EditorConfig and is intentional.
+- **EditorConfig conformance.** Setting the profile to <xref:Bodu.Text.Configuration.BoduConfigurationProfile.EditorConfigCompatible> aligns inline-comment, preamble, key-mapping, and unset behaviour with the EditorConfig 0.17.2 specification. Bodu-specific extensions (whitespace-introduced inline comments, dotted-to-colon key mapping, preamble layering) are opt-out under that profile.
+- **Validation.** Public entry points validate inputs through `ThrowHelper` and the package-local `ConfigurationThrowHelper`. Null inputs surface as `ArgumentNullException`; empty or whitespace strings surface as `ArgumentException` with the parameter name set via `CallerArgumentExpression`.
+- **See also:** the [introduction](~/docs/text-configuration/index.md), [core concepts](~/docs/text-configuration/concepts.md), and [getting-started](~/docs/text-configuration/getting-started.md); the underlying <xref:Bodu.Text.Formats.IniDocument> model in [Bodu.Text.Formats](~/docs/formats/index.md); and the `Microsoft.Extensions.Configuration` bridge in [Bodu.Extensions.Configuration.Text](~/docs/extensions-configuration-text/index.md).

--- a/docs/apidoc/Bodu.Text.Encoding.md
+++ b/docs/apidoc/Bodu.Text.Encoding.md
@@ -1,0 +1,99 @@
+---
+uid: Bodu.Text.Encoding
+---
+
+![Bodu.Text.Encoding](~/images/hero-text.svg)
+
+## Purpose
+
+**Bodu.Text.Encoding** is a focused, allocation-conscious library of **binary-to-text encodings**. It implements the five practical radix encodings .NET applications reach for — **Base16**, **Base32**, **Base64**, **Base58**, **Base85** — and gives each the same modern API shape: span- and UTF-8-friendly overloads, `OperationStatus`-returning streaming methods, length-prediction helpers, validation predicates, and a unified <xref:Bodu.Text.Encoding.IBinaryEncoding> interface that lets code select an encoding at runtime.
+
+The package fills two gaps that <xref:System.Convert> and `System.Buffers.Text.Base64` leave open: **variants** the BCL does not cover (base32hex, Crockford Base32, z-base-32, Base58 Bitcoin / Flickr / Ripple, Ascii85, Z85), and **lenient parsing** / **formatting decoration** — `0x` prefix tolerance, whitespace stripping, byte spacing, line breaks every 64 / 76 characters — for the encodings that benefit from them.
+
+For structured binary serialization formats with their own framing grammar (Bencode, INI), see the companion <xref:Bodu.Text.Formats> package.
+
+## Static documentation
+
+- **[Bodu.Text.Encoding introduction](~/docs/text-encoding/index.md)** — namespaces, headline types, scenarios.
+- **[Bodu.Text.Encoding core concepts](~/docs/text-encoding/concepts.md)** — vocabulary: alphabet, variant, terminal quantum, padding, shortcut, decoration, `OperationStatus`.
+- **[Bodu.Text.Encoding getting started](~/docs/text-encoding/getting-started.md)** — install and minimal samples for each encoding.
+- **[Bodu.Text.Encoding guides](~/guides/text-encoding/index.md)** — per-encoding deep dives plus the `IBinaryEncoding` runtime-selection pattern.
+
+## Key types
+
+**Per-encoding static classes (`Bodu.Text.Encoding`)**
+
+- <xref:Bodu.Text.Encoding.Base16> — hexadecimal; 4 bits per symbol; flexible formatting (case, `0x` prefix, line breaks, byte spacing); lenient parsing.
+- <xref:Bodu.Text.Encoding.Base32> — 5 bits per symbol; four variants via <xref:Bodu.Text.Encoding.Base32Variant>: Standard (RFC 4648 §6), HexExtended (RFC 4648 §7), Crockford, ZBase32; padding control.
+- <xref:Bodu.Text.Encoding.Base64> — 6 bits per symbol; three variants via <xref:Bodu.Text.Encoding.Base64Variant>: Standard (RFC 4648 §4), UrlSafe (RFC 4648 §5), Mime (RFC 2045 with 76-char wrap). Delegates inner conversion to the BCL for SIMD speed.
+- <xref:Bodu.Text.Encoding.Base58> — non-power-of-two radix using big-integer divmod; two variants via <xref:Bodu.Text.Encoding.Base58Variant>: BitcoinFlickr (default), Ripple. Preserves leading zeros.
+- <xref:Bodu.Text.Encoding.Base85> — 4-byte block → 5 chars; two variants via <xref:Bodu.Text.Encoding.Base85Variant>: Ascii85 (Adobe, with `z` shortcut), Z85 (RFC 32 ZeroMQ; 4-byte alignment).
+
+**Runtime selection**
+
+- <xref:Bodu.Text.Encoding.IBinaryEncoding> — unified contract for runtime-pluggable encoding choice. `Encode`, `Decode`, `GetEncodedLength`, `GetMaxDecodedLength`, `IsValid`.
+- <xref:Bodu.Text.Encoding.BinaryEncodings> — pre-configured singleton instances (`Base16`, `Base32`, `Base32Crockford`, `Base64`, `Base64UrlSafe`, `Base58`, `Ascii85`, `Z85`, …) plus the `Get(name)` lookup for configuration-driven selection.
+- <xref:Bodu.Text.Encoding.BinaryEncodingExtensions> — fluent extension methods on `byte[]`, `ReadOnlySpan<byte>`, and `string` (`ToBase16String`, `FromBase64String`, …).
+
+**Shared option types**
+
+- <xref:Bodu.Text.Encoding.BaseFormattingOptions> — encode-side flags: `UpperCase`, `InsertLineBreaks`, `IncludePrefix`, `InsertSpacing`, `OmitPadding`.
+- <xref:Bodu.Text.Encoding.BaseFormatStyles> — decode-side flags: `AllowPrefix`, `IgnoreWhitespace`, `AllowMissingPadding`.
+
+## Example
+
+```csharp
+using Bodu.Text.Encoding;
+using System.Buffers;
+using System.Security.Cryptography;
+
+// --- Base16: print a hash digest as a formatted hex dump ----------------------
+byte[] digest = SHA256.HashData("hello"u8.ToArray());
+string dump   = Base16.Encode(digest,
+    BaseFormattingOptions.UpperCase
+        | BaseFormattingOptions.InsertSpacing
+        | BaseFormattingOptions.IncludePrefix);
+// dump → "0x2C F2 4D BA ..."
+
+// --- Base64 URL-safe: decode a JWT segment with no padding -------------------
+byte[] headerBytes = Base64.Decode(
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9",
+    Base64Variant.UrlSafe,
+    BaseFormatStyles.AllowMissingPadding);
+
+// --- Base32 Standard: TOTP secret for a user --------------------------------
+byte[] secret  = RandomNumberGenerator.GetBytes(20);
+string display = Base32.Encode(secret, Base32Variant.Standard, BaseFormattingOptions.OmitPadding);
+
+// --- Base58 BitcoinFlickr: decode a mainnet P2PKH address -------------------
+byte[] payload = Base58.Decode("1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L");
+
+// --- Base85 Ascii85 with the z shortcut -------------------------------------
+string ascii85 = Base85.Encode(new byte[] { 0, 0, 0, 0 }, Base85Variant.Ascii85);
+// ascii85 → "z"
+
+// --- Runtime selection via IBinaryEncoding ----------------------------------
+IBinaryEncoding encoding = BinaryEncodings.Get("base64-urlsafe");
+string token = encoding.Encode(secret);
+byte[] back  = encoding.Decode(token);
+
+// --- Streaming UTF-8 decode with OperationStatus ----------------------------
+OperationStatus status = Base16.DecodeFromUtf8(
+    utf8Source,
+    outputBuffer,
+    out int consumed,
+    out int written,
+    BaseFormatStyles.None,
+    isFinalBlock: true);
+```
+
+## Notes
+
+- **ASCII alphabets / UTF-8 byte path.** Every variant's alphabet is pure ASCII, so the UTF-8 byte form is bit-identical to the character form. The `EncodeToUtf8` / `DecodeFromUtf8` overloads are the natural choice when bytes come from a network or file pipeline — they avoid the allocation of an intermediate `string` or `char[]`.
+- **`OperationStatus` and streaming.** Base16, Base32, and Base64 expose the `System.Buffers`-style `OperationStatus` return convention used by `System.Buffers.Text.Base64`: `Done`, `DestinationTooSmall`, `InvalidData`, and (streaming only, `isFinalBlock: false`) `NeedMoreData`. This makes them safe to drop into chunked stream pipelines without buffering the entire input.
+- **Base58 and Base85 are not streamable.** Base58 needs the entire input for its big-integer divmod; Base85 needs fixed-size block packing. Both surfaces accept `isFinalBlock` for API consistency but ignore the flag — pass the entire input as a single span.
+- **Stateless encodings.** Every encoding type is a `static class` with no instance state. There is no lookup-table cache to share across instances (encodings are stateless), no thread-affinity, and no global configuration. The runtime-selection types in <xref:Bodu.Text.Encoding.BinaryEncodings> are pre-configured singletons over the same static APIs.
+- **Decoder strictness.** Decoders are **strict** by default — only the canonical alphabet, padding, and quantum length are accepted — and **lenient** when one or more <xref:Bodu.Text.Encoding.BaseFormatStyles> flags are set: `AllowPrefix` accepts a `0x` / `0X` prefix; `IgnoreWhitespace` strips ASCII space, tab, CR, LF anywhere; `AllowMissingPadding` accepts inputs without trailing `=`. `Decode` throws `FormatException` on validation failure; `TryDecode` returns `false`.
+- **Determinism and portability.** Encoders are deterministic — given a byte sequence and an option set they always produce the same canonical output across platforms and architectures. The `Pearson` family's permutation tables are bit-identical to the published references; the same applies to the BCL-delegated Base64 path.
+- **No coupling to other Bodu packages at the consumer surface.** The only dependency is `Bodu.Core` for shared throw helpers. The package has no external NuGet references.
+- **See also:** the [introduction](~/docs/text-encoding/index.md), [core concepts](~/docs/text-encoding/concepts.md), and [getting-started](~/docs/text-encoding/getting-started.md); the per-encoding guides under [Bodu.Text.Encoding guides](~/guides/text-encoding/index.md); and the [`IBinaryEncoding` interface](~/guides/text-encoding/binary-encodings-interface.md) for runtime selection.

--- a/docs/apidoc/Bodu.Text.Formats.md
+++ b/docs/apidoc/Bodu.Text.Formats.md
@@ -1,0 +1,91 @@
+---
+uid: Bodu.Text.Formats
+---
+
+![Bodu.Text.Formats](~/images/hero-formats.svg)
+
+## Purpose
+
+**Bodu.Text.Formats** decodes and encodes **self-framing binary serialization formats** — formats that describe their own structure inline rather than relying on an external schema. The package ships **Bencode** (the BitTorrent serialization grammar specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html)) and the underlying **INI** primitives used by both <xref:Bodu.Text.Configuration> and direct INI consumers.
+
+Each format is exposed through the same shape: a strongly-typed value tree, a static codec with `Encode` / `Decode` / `TryEncode` / `TryDecode` / `GetEncodedLength` over `ReadOnlySpan<byte>` / `byte[]` / `Stream`, and per-format invariants that the encoder always honours and the parser always enforces. No reflection, no `dynamic`, no schema, no allocations beyond the immutable result graph.
+
+For binary-to-text encodings (Base16 / Base32 / Base64 / Base58 / Base85) that operate on flat byte sequences without a structural grammar, see the companion <xref:Bodu.Text.Encoding> package. For EditorConfig / INI configuration layering on top of <xref:Bodu.Text.Formats.IniDocument>, see <xref:Bodu.Text.Configuration>.
+
+## Static documentation
+
+- **[Bodu.Text.Formats introduction](~/docs/formats/index.md)** — namespaces, headline types, scenarios.
+- **[Bodu.Text.Formats core concepts](~/docs/formats/concepts.md)** — vocabulary: format vs codec, value vs document, framing tokens, canonical encoding, byte string vs text, format exception.
+- **[Bodu.Text.Formats getting started](~/docs/formats/getting-started.md)** — install and minimal samples for `Decode`, `Encode`, `Try*`, and the stream overloads.
+- **[Bodu.Text.Formats guides](~/guides/formats/index.md)** — Using Bencode, the `BencodedValue` model, streams and async I/O.
+
+## Key types
+
+**Bencode codec (`Bodu.Text.Formats`)**
+
+- <xref:Bodu.Text.Formats.Bencode> — static codec. Exposes `Encode`, `Decode`, `TryEncode`, `TryDecode`, `GetEncodedLength`, plus synchronous and asynchronous `Stream` overloads. The recursive writer emits framing tokens and payload bytes into a destination span; the forward-only parser peeks the leading byte, dispatches on the matching value kind, and rebuilds the value tree under BEP 3 invariants.
+- <xref:Bodu.Text.Formats.BencodedValue> — abstract base for every decoded value. Exposes `Kind` for switch-style dispatch.
+- <xref:Bodu.Text.Formats.BencodedValueKind> — `Integer`, `String`, `List`, `Dictionary`.
+- <xref:Bodu.Text.Formats.BencodedInteger> — signed 64-bit integer; rejects leading zeros, negative zero, and out-of-range overflow.
+- <xref:Bodu.Text.Formats.BencodedString> — length-prefixed raw byte payload. `Bytes`, `Length`, `FromUtf8(string)`, `GetUtf8String()`.
+- <xref:Bodu.Text.Formats.BencodedList> — ordered, possibly-nested list. Constructor rejects `null` elements.
+- <xref:Bodu.Text.Formats.BencodedDictionary> — byte-string-keyed mapping. Keys are stored sorted by raw byte ordinal using <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal>; the constructor rejects `null` keys / values and duplicates. Indexer and `TryGetValue(BencodedString)` / `TryGetValue(string)` (UTF-8) look up by byte order.
+- <xref:Bodu.Text.Formats.BencodedStringComparer> — singleton `Ordinal` comparer; implements both `IComparer<BencodedString>` and `IEqualityComparer<BencodedString>`.
+- <xref:Bodu.Text.Formats.BencodeFormatException> — derives from <xref:System.FormatException>; thrown on any BEP 3 violation. The message identifies the exact failure mode.
+
+**INI primitives (`Bodu.Text.Formats`)**
+
+- <xref:Bodu.Text.Formats.IniDocument> — root model: a preamble (global section) and zero or more named sections in source order. Mutable; supports round-trip parse + save.
+- <xref:Bodu.Text.Formats.IniSection> — a named section with an ordered list of <xref:Bodu.Text.Formats.IniEntry> values, plus comment lines preserved verbatim.
+- <xref:Bodu.Text.Formats.IniEntry> — a single `key = value` line with optional trailing comment.
+- <xref:Bodu.Text.Formats.Ini> — static codec for INI files: `Parse(text, options?)`, `Load(path | Stream)`, `Save(document, path | Stream | TextWriter, options?)`.
+- <xref:Bodu.Text.Formats.IniParseOptions> — duplicate-key, duplicate-section, comment-preservation, case-sensitivity options for the INI parser.
+- <xref:Bodu.Text.Formats.IniDuplicateKeyBehavior> — `LastWins`, `FirstWins`, `Disallowed`, `Merge`.
+- <xref:Bodu.Text.Formats.IniDuplicateSectionBehavior> — `Preserve`, `Merge`, `Disallowed`.
+
+## Example
+
+```csharp
+using Bodu.Text.Formats;
+
+// --- Bencode round-trip ----------------------------------------------------
+byte[] payload = File.ReadAllBytes("ubuntu.iso.torrent");
+
+BencodedValue root = Bencode.Decode(payload);
+BencodedDictionary doc = (BencodedDictionary)root;
+
+string tracker = ((BencodedString)doc["announce"]).GetUtf8String();
+BencodedDictionary info = (BencodedDictionary)doc["info"];
+string name = ((BencodedString)info["name"]).GetUtf8String();
+long pieceLength = ((BencodedInteger)info["piece length"]).Value;
+
+// Pre-size and re-emit canonically.
+int size = Bencode.GetEncodedLength(doc);
+byte[] reEncoded = new byte[size];
+Bencode.TryEncode(doc, reEncoded, out int written);
+Debug.Assert(written == size);
+
+// --- INI round-trip --------------------------------------------------------
+IniDocument iniDoc = Ini.Parse("""
+[server]
+host = localhost
+port = 8080
+""");
+
+string host = iniDoc.Sections[0]["host"]!;     // "localhost"
+int port = iniDoc.Sections[0].GetValue<int>("port");
+
+using StringWriter sw = new();
+Ini.Save(iniDoc, sw);   // re-emits the canonical form
+```
+
+## Notes
+
+- **Canonical encoding.** Bencode has exactly one canonical encoding for any value — integers use the shortest decimal representation with no padding and no `+` sign; byte-string lengths use the shortest decimal representation; dictionary keys are sorted by raw byte order; no whitespace is permitted anywhere. The encoder always produces canonical output; the parser rejects every non-canonical input. This rejection is intentional — equivalence between two encodings would break content-addressed identifiers (the SHA-1 of a torrent's `info` dictionary, the *infohash*).
+- **BEP 3 strictness.** Leading zeros, negative zero, unsorted or duplicate dictionary keys, missing terminators, and trailing data all surface as <xref:Bodu.Text.Formats.BencodeFormatException>. The exception message identifies the exact failure mode (e.g. *Bencoded dictionary keys must be unique and sorted by raw byte order*). `TryDecode` and `TryEncode` swap these exceptions for `bool` results.
+- **Byte string vs text.** Bencoded strings are raw bytes, not characters. Treating them as text is a per-field decision driven by the consuming format — `info.name` in a torrent is UTF-8, `info.pieces` is a concatenation of 20-byte SHA-1 hashes. <xref:Bodu.Text.Formats.BencodedString.GetUtf8String> projects when the field is known to be text; <xref:Bodu.Text.Formats.BencodedString.FromUtf8(System.String)> goes the other way.
+- **Stream buffering.** `Bencode.Decode(Stream)` and `DecodeAsync(Stream)` buffer the entire stream into a pooled `MemoryStream` before parsing — Bencode is not a streaming format because framing tokens can be arbitrarily far apart and the parser must consume them in order. The pooled buffer is sized to the stream length where available and released back to <xref:System.Buffers.ArrayPool`1> before the parser runs. Stream encoding writes in a single `Write` / `WriteAsync` call sized to `GetEncodedLength`.
+- **Immutable value tree.** Every <xref:Bodu.Text.Formats.BencodedValue> subclass is immutable from the consumer's perspective — `BencodedDictionary` keys arrive sorted, `BencodedList` items are stored in their construction order, `BencodedString.Bytes` is exposed as a read-only span. Deep equality between two trees is something the consumer composes — `BencodedString.Equals` and `BencodedInteger.Equals` give per-leaf equality, the container types do not.
+- **Ordering and equality.** Dictionary keys are ordered and compared by raw byte ordinal — never by Unicode collation, locale, or codepoint. <xref:Bodu.Text.Formats.BencodedStringComparer.Ordinal> is the singleton comparer used internally; surface it directly when building your own `SortedDictionary` keyed by bencoded values.
+- **Determinism.** All encode and decode operations produce identical output across platforms and architectures for the same input. There is no random seed, no thread-local state, and no culture-sensitive code path.
+- **See also:** the [introduction](~/docs/formats/index.md), [core concepts](~/docs/formats/concepts.md), and [getting-started](~/docs/formats/getting-started.md); the [Bencode](~/guides/formats/bencode.md), [value-model](~/guides/formats/value-model.md), and [streaming](~/guides/formats/streaming.md) guides; the EditorConfig-style layering on top of `IniDocument` in [Bodu.Text.Configuration](~/docs/text-configuration/index.md).

--- a/docs/docs/extensions-configuration-text/concepts.md
+++ b/docs/docs/extensions-configuration-text/concepts.md
@@ -1,0 +1,177 @@
+---
+title: Bodu.Extensions.Configuration.Text — Core concepts
+---
+
+# Bodu.Extensions.Configuration.Text — Core concepts
+
+This page is the vocabulary the rest of the documentation assumes. Read it once before the
+[getting-started samples](getting-started.md), and refer back whenever a term feels imprecise.
+
+For the high-level shape of the library, start with the [introduction](index.md).
+
+## Source vs provider vs loader
+
+The library follows the three-part contract every `Microsoft.Extensions.Configuration` provider uses:
+
+| Role | Type | Responsibility |
+|---|---|---|
+| **Source** | <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource>, <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource> | Holds the configuration of "what to load and how" — the path, target path, parse and resolve options, reload behaviour. Implements `Build(IConfigurationBuilder)`. |
+| **Provider** | <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationProvider>, <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationProvider> | Performs the actual load. Subclasses `FileConfigurationProvider` / `StreamConfigurationProvider`; inherits change-token plumbing. Populates the inherited `Data` dictionary. |
+| **Loader** | <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationLoader> | Internal helper that parses a stream into an <xref:Bodu.Text.Formats.IniDocument>, resolves it, and flattens the view into `Dictionary<string, string?>` for the provider. |
+
+Both providers share the same loader, so behaviour stays in lockstep across file and stream backings.
+
+## File vs stream source
+
+The two source types correspond to the two file shapes Microsoft ships:
+
+| Source | Backing | Reload-on-change |
+|---|---|---|
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> | Path resolved through an `IFileProvider` | Yes |
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource> | Arbitrary `System.IO.Stream` | No |
+
+File sources are the common case — they layer naturally with `appsettings.json`, support hot reload, and accept the
+same path-based options every provider does. Stream sources are useful for tests, embedded resources, or in-memory
+fixtures where the configuration data does not live on disk.
+
+## Target path
+
+`TargetPath` is the value the source hands to `BoduConfigurationDocument.Resolve(targetPath)`. It anchors glob
+matching for sections whose headers contain path separators.
+
+```csharp
+builder.AddBoduConfiguration(
+    "team.boduconfig",
+    targetPath: "src/MyApp/Program.cs");
+```
+
+When the file says
+
+```ini
+[src/**/*.cs]
+logging.level.default = Warning
+```
+
+the `[src/**]` pattern matches `src/MyApp/Program.cs`, so the resolved view picks up that section's properties on top
+of any earlier matches. When `TargetPath` is `null`, only unanchored patterns and preamble values contribute.
+
+`TargetPath` is **per source** — different sources in the same builder can have different anchors. If your application
+needs configuration evaluated for several paths in parallel, add several sources with the same `Path` but different
+`TargetPath` values.
+
+## Parse and resolve option propagation
+
+A source carries two optional bags:
+
+| Source property | Drives |
+|---|---|
+| `ParseOptions` | The <xref:Bodu.Text.Configuration.BoduConfigurationParseOptions> passed to the reader. Controls inline-comment mode, duplicate handling, diagnostic mode, length limits. |
+| `ResolveOptions` | The <xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions> passed to the resolver. Controls `PathRoot`, `MissingPathRootMode`, `UnsetValueMode`, `PathComparison`. |
+
+Both default to `null`, in which case the library uses
+<xref:Bodu.Text.Configuration.BoduConfigurationParseOptions.Bodu> and
+<xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions.Bodu>. Set them per-source when one file in a builder
+needs different semantics — for example, an EditorConfig-strict file alongside a Bodu-permissive one.
+
+```csharp
+builder.AddBoduConfiguration(src =>
+{
+    src.Path = ".editorconfig";
+    src.ParseOptions   = BoduConfigurationParseOptions.EditorConfigCompatible;
+    src.ResolveOptions = BoduConfigurationResolveOptions.EditorConfigCompatible;
+    src.TargetPath     = "src/Foo.cs";
+});
+```
+
+## Conventional file probe
+
+The no-argument overload of `AddBoduConfiguration` is a convenience helper for the common "drop a file in the project
+root" pattern:
+
+```csharp
+builder.AddBoduConfiguration(optional: true, reloadOnChange: true);
+```
+
+The probe runs against the builder's default file provider and looks for two file names in order:
+
+1. **`.boduconfig`** — the dotfile form, common in version-control-friendly repos.
+2. **`bodu.config`** — the plain form, common on Windows where dotfiles need explicit attribute toggles.
+
+The first file found is added; if neither is present and `optional` is `true`, the helper returns the builder
+unchanged. The probe is cheap (it consults `IFileProvider.GetFileInfo(name).Exists`) and runs once per `Build` call.
+
+## Reload-on-change
+
+`FileConfigurationSource.ReloadOnChange` is inherited as-is. When `true`, the provider:
+
+1. Attaches a file watcher via the source's `IFileProvider`.
+2. On a change notification, reparses the file and rebuilds the resolved view.
+3. Triggers the standard `IConfiguration` reload tokens, so callers using `IOptionsMonitor<TOptions>` re-bind to the
+   new values automatically.
+
+Reload is **not** atomic with respect to multiple providers — if your builder has three file sources and two change
+at once, the providers reload independently, in the order their watchers fire. This matches the MEC contract and is
+not specific to Bodu.
+
+The stream source does not support reload. The stream is parsed once when `Build` is called; the stream's lifetime
+ends with that parse. If you need dynamic stream-backed inputs, rebuild the configuration.
+
+## File provider precedence
+
+`AddBoduConfiguration` resolves the `IFileProvider` in the standard MEC order:
+
+1. If a provider is supplied directly to the overload, use it.
+2. Otherwise, if the source's `FileProvider` is set, use that.
+3. Otherwise, defer to the builder's default file provider — typically a `PhysicalFileProvider` rooted at
+   `Directory.GetCurrentDirectory()`.
+
+Tests typically supply a `PhysicalFileProvider` rooted at a temp directory; production code typically relies on the
+builder default.
+
+## Options binding
+
+<xref:Bodu.Extensions.Configuration.Text.BoduConfigurationOptionsExtensions> wraps the standard
+`services.Configure<TOptions>(...)` shape:
+
+```csharp
+services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+// equivalent to:
+services.Configure<ServiceOptions>(configuration.GetSection("service"));
+```
+
+The wrapper exists for discoverability — call sites that reach for an `AddBoduConfiguration*` API by IntelliSense
+find an options helper with the same prefix. The shape is identical to the MEC version; callers who already use
+`Configure<T>` are not penalised, and callers who switch to `AddBoduConfigurationOptions` are not locked in.
+
+The two overloads:
+
+| Overload | Use when |
+|---|---|
+| `AddBoduConfigurationOptions<T>(services, configuration, sectionName)` | Section is identified by colon-delimited name in an `IConfiguration` root. |
+| `AddBoduConfigurationOptions<T>(services, section)` | Section is already projected via `configuration.GetSection(...)`. |
+
+Both throw `ArgumentNullException` for null `services` / `configuration` / `section`; the name-based overload throws
+`ArgumentException` for an empty or whitespace section name.
+
+## Colon-delimited key model
+
+`IConfiguration` keys are colon-delimited by convention — `service:name`, `logging:level:default`. Bodu's reader
+projects raw keys to the same shape under the default `DotToColon` mapping, so a file written as
+
+```ini
+service.name = Bodu
+service.port = 8080
+logging.level.default = Information
+```
+
+surfaces as `configuration["service:name"]`, `configuration["service:port"]`,
+`configuration["logging:level:default"]`. Switching to `BoduConfigurationKeyMapping.Identity` preserves the original
+delimiter — useful when the file is also consumed by tools that interpret dots as path separators (e.g. AppSettings
+patches).
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — install + runnable minimal samples.
+- **[Bodu.Text.Configuration](../text-configuration/index.md)** — the underlying parser, resolver, and view.
+- **[Bodu.Extensions.Configuration.Text API reference](../../apidoc/Bodu.Extensions.Configuration.Text.md)** — full type-by-type docs.
+- **[Introduction](index.md)** — the high-level shape of the library.

--- a/docs/docs/extensions-configuration-text/getting-started.md
+++ b/docs/docs/extensions-configuration-text/getting-started.md
@@ -1,0 +1,207 @@
+---
+title: Bodu.Extensions.Configuration.Text — Getting started
+---
+
+# Bodu.Extensions.Configuration.Text — Getting started
+
+Unfamiliar with terms like *source*, *provider*, *target path*, *conventional probe*, *reload-on-change*, or *options
+binding*? Read [Core concepts](concepts.md) first.
+
+## Install
+
+```bash
+dotnet add package Bodu.Extensions.Configuration.Text
+```
+
+Targets `net8.0`. Depends on:
+
+- `Bodu.Core` and `Bodu.Text.Configuration` (the parser, resolver, and view).
+- `Microsoft.Extensions.Configuration`, `Microsoft.Extensions.Configuration.FileExtensions`,
+  `Microsoft.Extensions.Configuration.Binder`, `Microsoft.Extensions.FileProviders.Physical`,
+  `Microsoft.Extensions.Options.ConfigurationExtensions`, and the associated abstractions packages — all at the .NET
+  8.0 LTS line.
+
+## Minimal samples
+
+### Add a configuration file
+
+```csharp
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration("appsettings.bodu")
+    .Build();
+
+string? logLevel = configuration["logging:level:default"];
+```
+
+The overload is named to match the JSON provider's `AddJsonFile` — same arguments, same defaults, same shape. The
+file is required by default; pass `optional: true` to tolerate a missing file.
+
+### Conventional file probe
+
+```csharp
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration(optional: true, reloadOnChange: true)
+    .Build();
+```
+
+The no-argument overload probes the builder's base path for `.boduconfig`, then `bodu.config`. The first file found
+is loaded; if neither exists and `optional` is `true`, the call is a no-op. Use this when your application has a
+single conventional configuration file in its working directory.
+
+### Anchor glob resolution to a source path
+
+```csharp
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration(
+        path: "team.boduconfig",
+        targetPath: "src/MyApp/Program.cs",
+        optional: false,
+        reloadOnChange: true)
+    .Build();
+```
+
+The `targetPath` is handed to `BoduConfigurationDocument.Resolve(targetPath)` — sections whose header globs match
+contribute to the resolved view, in source order, last-wins.
+
+### Configure via callback
+
+```csharp
+using Bodu.Text.Configuration;
+using Microsoft.Extensions.FileProviders;
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration(source =>
+    {
+        source.FileProvider     = new PhysicalFileProvider("/etc/myapp");
+        source.Path             = "settings.bodu";
+        source.TargetPath       = "src/Foo.cs";
+        source.Optional         = true;
+        source.ReloadOnChange   = true;
+        source.ParseOptions     = BoduConfigurationParseOptions.EditorConfigCompatible;
+        source.ResolveOptions   = new BoduConfigurationResolveOptions
+        {
+            UnsetValueMode = BoduConfigurationUnsetValueMode.RemoveEffectiveValue,
+        };
+    })
+    .Build();
+```
+
+The callback receives the <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> directly, so every
+property is reachable. Use this overload when several knobs need to be set together — a one-liner overload exists for
+the common "just give me the file" case.
+
+### Load from a stream
+
+```csharp
+using MemoryStream stream = new(Encoding.UTF8.GetBytes("""
+service.name = Bodu
+service.port = 8080
+"""));
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration(stream)
+    .Build();
+
+string? name = configuration["service:name"];   // "Bodu"
+int port = configuration.GetValue<int>("service:port");
+```
+
+Stream sources are one-shot — no reload-on-change. Useful for tests, embedded resources, and HTTP-fetched
+configuration.
+
+### Bind to a POCO via DI
+
+```csharp
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+ServiceCollection services = new();
+services.AddOptions();
+services.AddBoduConfigurationOptions<ServiceOptions>(configuration, "service");
+
+using ServiceProvider provider = services.BuildServiceProvider();
+ServiceOptions options = provider.GetRequiredService<IOptions<ServiceOptions>>().Value;
+
+Console.WriteLine($"{options.Name} on port {options.Port}");
+
+sealed class ServiceOptions
+{
+    public string? Name { get; set; }
+    public int Port { get; set; }
+}
+```
+
+The section-overload is equivalent and useful when the section is already projected:
+
+```csharp
+services.AddBoduConfigurationOptions<ServiceOptions>(configuration.GetSection("service"));
+```
+
+### Combine with other providers
+
+The Bodu source layers with anything else in the builder. Standard MEC precedence applies — later sources override
+earlier ones for the same key:
+
+```csharp
+IConfiguration configuration = new ConfigurationBuilder()
+    .SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile("appsettings.json", optional: true)
+    .AddBoduConfiguration("appsettings.bodu", optional: true)
+    .AddEnvironmentVariables()
+    .Build();
+```
+
+Defaults come from `appsettings.json`, project-specific overrides from `appsettings.bodu`, deployment overrides from
+environment variables.
+
+### Watch for changes
+
+```csharp
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration("appsettings.bodu", reloadOnChange: true)
+    .Build();
+
+ChangeToken.OnChange(
+    () => configuration.GetReloadToken(),
+    () => Console.WriteLine("Configuration reloaded"));
+```
+
+The file watcher is attached through the configured `IFileProvider`. Edits, atomic replaces, and `touch` all trigger
+a reload.
+
+## Pattern — Bodu + IOptionsMonitor for hot-swappable settings
+
+```csharp
+using Bodu.Extensions.Configuration.Text;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+IConfiguration configuration = new ConfigurationBuilder()
+    .AddBoduConfiguration("settings.bodu", optional: false, reloadOnChange: true)
+    .Build();
+
+ServiceCollection services = new();
+services.AddSingleton(configuration);
+services.AddOptions();
+services.AddBoduConfigurationOptions<FeatureOptions>(configuration, "features");
+
+using ServiceProvider provider = services.BuildServiceProvider();
+IOptionsMonitor<FeatureOptions> monitor = provider.GetRequiredService<IOptionsMonitor<FeatureOptions>>();
+
+monitor.OnChange(updated => Console.WriteLine($"Reload — beta = {updated.BetaEnabled}"));
+```
+
+`IOptionsMonitor<T>` re-binds automatically whenever the underlying file changes — there is no manual reload step.
+
+## Where to go next
+
+- **[Core concepts](concepts.md)** — vocabulary refresher.
+- **[Introduction](index.md)** — type map and scenario index.
+- **[Bodu.Text.Configuration](../text-configuration/index.md)** — the underlying parser, resolver, and view.
+- **[Bodu.Extensions.Configuration.Text API reference](../../apidoc/Bodu.Extensions.Configuration.Text.md)** — full type-by-type docs.

--- a/docs/docs/extensions-configuration-text/index.md
+++ b/docs/docs/extensions-configuration-text/index.md
@@ -1,0 +1,121 @@
+---
+title: Bodu.Extensions.Configuration.Text — Introduction
+---
+
+# Bodu.Extensions.Configuration.Text
+
+**Bodu.Extensions.Configuration.Text** is the bridge between
+[`Bodu.Text.Configuration`](../text-configuration/index.md) and `Microsoft.Extensions.Configuration`. It exposes a
+single conventional entry point — `IConfigurationBuilder.AddBoduConfiguration(...)` — that adds a Bodu Text
+Configuration file (or stream, or pre-parsed document) as a configuration source alongside JSON, INI, XML, and
+environment variables.
+
+The overload set deliberately mirrors `Microsoft.Extensions.Configuration.Json`'s `AddJsonFile` / `AddJsonStream`
+shape, so consumers familiar with the JSON provider can swap in this provider without learning a new API. Once added,
+keys are exposed in the canonical colon-delimited form that `IConfiguration` consumes:
+
+```csharp
+configuration["logging:level:default"]   // "Warning"
+configuration.GetSection("service")      // a child section that binds to your POCO
+```
+
+## Core mental model
+
+![Configuration flow — builder to provider to IConfiguration to IOptions](../../images/diagrams/extensions-configuration-text-flow.svg)
+
+The provider is a thin host around `Bodu.Text.Configuration`. The builder creates a
+<xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> (or its stream-only sibling
+<xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource>); the source's `Build` method instantiates
+a <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationProvider>; the provider loads the file, parses it with
+the supplied
+<xref:Bodu.Text.Configuration.BoduConfigurationParseOptions>, resolves it for the source's `TargetPath` using the
+supplied <xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions>, and copies the resolved view into
+`IConfiguration.Data` as colon-delimited keys. The DI extensions (`AddBoduConfigurationOptions<T>`) bind a named
+section to an `IOptions<T>` instance.
+
+```
+IConfigurationBuilder
+  ▶ AddBoduConfiguration(path | stream | document, …)
+  ▶ BoduTextConfigurationSource ▶ Build()
+  ▶ BoduTextConfigurationProvider.Load()
+  ▶ Parse + Resolve via Bodu.Text.Configuration
+  ▶ IConfiguration["key:subkey"]
+  ▶ services.AddBoduConfigurationOptions<TOptions>(config, "section")
+  ▶ IOptions<TOptions>
+```
+
+## The shape of the library
+
+Everything lives in the `Bodu.Extensions.Configuration.Text` namespace.
+
+### Builder extensions
+
+*The primary entry point. Mirrors `AddJsonFile` / `AddJsonStream` exactly so call sites stay familiar.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationExtensions> | Static class. Six `AddBoduConfiguration` overloads: file path, file path + file provider, configure callback, conventional probe (`.boduconfig` → `bodu.config`), stream, and pre-parsed `IniDocument`. |
+
+### Sources and providers
+
+*The plumbing — typically not constructed directly. Use the builder extensions instead.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> | `FileConfigurationSource` subclass. Inherits `Path`, `Optional`, `ReloadOnChange`, `FileProvider`; adds `TargetPath`, `ParseOptions`, `ResolveOptions`. |
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationProvider> | `FileConfigurationProvider` subclass. Reads the file via the standard MEC pipeline and projects the resolved view into `Data`. |
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationSource> | `StreamConfigurationSource` subclass. One-shot: no reload-on-change. |
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextStreamConfigurationProvider> | The matching stream provider. |
+| <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationLoader> | Internal helper that parses + resolves a stream into a flat key/value dictionary; reused by both providers. |
+
+### Options binding
+
+*Thin shims over `services.Configure<TOptions>(...)` — there for discoverability.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Extensions.Configuration.Text.BoduConfigurationOptionsExtensions> | Static class. `AddBoduConfigurationOptions<TOptions>(services, configuration, sectionName)` and the section overload `AddBoduConfigurationOptions<TOptions>(services, IConfigurationSection)`. |
+
+## Common scenarios
+
+| Scenario | Reach for |
+|---|---|
+| Add a `.boduconfig` file to the builder | `builder.AddBoduConfiguration(".boduconfig")` |
+| Conventional probe — try `.boduconfig` then `bodu.config` | `builder.AddBoduConfiguration()` (no-arg) |
+| Anchor glob resolution to a specific source path | `builder.AddBoduConfiguration("appsettings.bodu", targetPath: "src/Foo.cs")` |
+| Optional file — do not throw if missing | `builder.AddBoduConfiguration("appsettings.bodu", optional: true)` |
+| Reload-on-change | `builder.AddBoduConfiguration("appsettings.bodu", reloadOnChange: true)` |
+| Use a specific `IFileProvider` | `builder.AddBoduConfiguration(physicalFileProvider, "appsettings.bodu")` |
+| Read from a stream (test fixtures, embedded resources) | `builder.AddBoduConfiguration(stream)` |
+| Wire up everything via a configure callback | `builder.AddBoduConfiguration(src => { src.Path = …; src.TargetPath = …; src.ReloadOnChange = true; })` |
+| Bind a section to an options class | `services.AddBoduConfigurationOptions<MyOptions>(configuration, "service")` |
+| Pre-parsed `IniDocument` (already loaded elsewhere) | `builder.AddBoduConfiguration(document, targetPath: …)` |
+
+## Conventional file probe
+
+The no-argument overload probes the builder's base path for two conventional names:
+
+| Order | File name |
+|---|---|
+| 1 | `.boduconfig` |
+| 2 | `bodu.config` |
+
+The first file found is added as a configuration source. When neither is present and `optional` is `true`, the call is
+a no-op; when `optional` is `false`, the source surfaces as missing per the standard `FileConfigurationProvider`
+contract.
+
+## Reload-on-change
+
+`BoduTextConfigurationSource` inherits the `ReloadOnChange` property from `FileConfigurationSource`. When `true`, the
+provider attaches a file watcher through the configured `IFileProvider`; any change to the underlying file triggers
+a reparse + reload, and any reload tokens issued through `IConfiguration` fire.
+
+`BoduTextStreamConfigurationSource` does **not** support reload-on-change — it parses the stream once when `Build` is
+called, and the stream lifetime ends with that parse. For dynamic stream-backed inputs, rebuild the configuration.
+
+## Where to go next
+
+- **[Core concepts](concepts.md)** — vocabulary: source vs provider, target path, parse / resolve option propagation, reload-on-change, options binding.
+- **[Getting started](getting-started.md)** — install + minimal samples for the file overload, the stream overload, conventional probe, options binding.
+- **[Bodu.Text.Configuration](../text-configuration/index.md)** — the underlying parser, resolver, and view model.
+- **[Bodu.Extensions.Configuration.Text API reference](../../apidoc/Bodu.Extensions.Configuration.Text.md)** — full type-by-type docs.

--- a/docs/docs/formats/concepts.md
+++ b/docs/docs/formats/concepts.md
@@ -165,4 +165,5 @@ Dictionary keys are ordered and compared by raw byte ordinal — *not* by Unicod
 
 - **[Getting started](getting-started.md)** — install + runnable minimal samples.
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — deep-dive walk-throughs for every concept above.
+- **[Bodu.Text.Formats API reference](../../apidoc/Bodu.Text.Formats.md)** — full type-by-type docs.
 - **[Introduction](index.md)** — the high-level shape of the library.

--- a/docs/docs/formats/getting-started.md
+++ b/docs/docs/formats/getting-started.md
@@ -193,3 +193,4 @@ The library passes every positive Known Answer Test vector from BEP 3 in both di
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — per-API deep dives.
 - **[Core concepts](concepts.md)** — vocabulary refresher.
 - **[Introduction](index.md)** — type map and scenario index.
+- **[Bodu.Text.Formats API reference](../../apidoc/Bodu.Text.Formats.md)** — full type-by-type docs.

--- a/docs/docs/formats/index.md
+++ b/docs/docs/formats/index.md
@@ -33,6 +33,10 @@ For the full glossary, see [Core concepts](concepts.md).
 
 Bencode is not a binary-to-text encoding like Base64. It is a **binary serialization grammar**: integers and structure tokens are emitted as ASCII for human readability, but the string payload is raw bytes — a torrent file's `pieces` field is a SHA-1 hash table, not text. Use [`Bodu.Text.Encoding`](../text-encoding/index.md) when you need to convert raw bytes into a printable alphabet; use **Bodu.Text.Formats** when you need to (de)serialize a structured value tree.
 
+### INI as a sibling format
+
+Alongside Bencode, the package ships the **INI primitives** — <xref:Bodu.Text.Formats.IniDocument>, <xref:Bodu.Text.Formats.IniSection>, <xref:Bodu.Text.Formats.IniEntry>, and the static <xref:Bodu.Text.Formats.Ini> codec — used directly by [`Bodu.Text.Configuration`](../text-configuration/index.md) to layer EditorConfig-style configuration on top of the same model. When you need INI parsing without configuration layering, work with <xref:Bodu.Text.Formats.Ini> directly; when you need glob-anchored sections, profile presets, and a flat colon-delimited view, reach for the Configuration package.
+
 ### Canonicality
 
 A bencoded value has exactly one canonical encoding: `i42e`, not `i+42e` or `i042e`; dictionary keys are sorted by raw byte order, not insertion order. The codec produces the canonical form and the parser rejects every non-canonical input. This is a load-bearing property for content-addressed identifiers — the SHA-1 of a torrent's `info` dictionary (the *infohash*) only works because every parser agrees on the canonical bytes.
@@ -97,3 +101,5 @@ The same surface, grouped by what role you're playing rather than by namespace.
 - **[Core concepts](concepts.md)** — full vocabulary: value vs. document, canonical encoding, framing tokens, byte string vs. text, format exception.
 - **[Getting started](getting-started.md)** — install + minimal samples for `Decode`, `Encode`, `Try*`, and the stream overloads.
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — using the Bencode codec, the value model, and stream support.
+- **[Bodu.Text.Formats API reference](../../apidoc/Bodu.Text.Formats.md)** — full type-by-type docs.
+- **For EditorConfig-style configuration layering on `IniDocument`**, see [Bodu.Text.Configuration](../text-configuration/index.md).

--- a/docs/docs/text-configuration/concepts.md
+++ b/docs/docs/text-configuration/concepts.md
@@ -1,0 +1,233 @@
+---
+title: Bodu.Text.Configuration — Core concepts
+---
+
+# Bodu.Text.Configuration — Core concepts
+
+This page is the vocabulary the rest of the documentation assumes. Read it once before the
+[getting-started samples](getting-started.md), and refer back whenever a term feels imprecise.
+
+For the high-level shape of the library and the pipeline diagram, start with the [introduction](index.md).
+
+## Document and view
+
+A **document** is the parsed-but-not-yet-resolved representation of the source text. It is an
+<xref:Bodu.Text.Formats.IniDocument> from <xref:Bodu.Text.Formats> — the same structure the INI codec produces — with a
+preamble (the global section) and zero or more named sections in source order. The document preserves comments,
+ordering, and duplicate-policy decisions, so it can be re-emitted byte-for-byte.
+
+A **view** is the resolved snapshot for one **target path** — a flat dictionary of colon-delimited configuration keys
+to their effective string values. <xref:Bodu.Text.Configuration.BoduConfigurationView> is one-shot: subsequent mutation
+of the originating document does not retroactively update the view. Take a fresh view whenever the document changes or
+the target path changes.
+
+```
+source text ──► BoduConfigurationDocument.Parse ──► IniDocument
+IniDocument ──► .Resolve(targetPath) ───────────► BoduConfigurationView
+BoduConfigurationView ──► .GetXxx(key) ──────────► typed value
+```
+
+## Profile
+
+A **profile** is a named, validated combination of parse, resolve, and write options. Four profiles ship in the box:
+
+| Profile | Intent |
+|---|---|
+| `Bodu` (default) | Permissive Bodu defaults: dotted-to-colon keys, whitespace-introduced inline comments, last-wins duplicates, preamble participates in resolve. |
+| `EditorConfigCompatible` | Strict alignment with EditorConfig 0.17.2: inline comments disabled, identity key mapping, only the `root` key in the preamble takes part in resolve. |
+| `Strict` | Deterministic parsing for generated files: duplicate keys are rejected, key-only properties are not permitted. |
+| `Relaxed` | Permissive parsing of user-authored files: inline comments enabled, duplicates last-wins, diagnostics collected rather than thrown. |
+
+Each option type — <xref:Bodu.Text.Configuration.BoduConfigurationParseOptions>,
+<xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions>,
+<xref:Bodu.Text.Configuration.BoduConfigurationWriteOptions> — has a static `For(profile)` factory plus the four named
+properties `Bodu`, `EditorConfigCompatible`, `Strict`, `Relaxed`. Profiles are starting points, not contracts; every
+property on every options bag is mutable through `init` setters.
+
+## Parse, resolve, and write options
+
+Each option type controls one stage of the pipeline.
+
+**<xref:Bodu.Text.Configuration.BoduConfigurationParseOptions>** controls the reader:
+
+| Property | Role |
+|---|---|
+| `Profile` | The profile this bag represents. |
+| `InlineCommentMode` | Disabled / WhitespaceIntroduced (default) / Always. |
+| `DuplicateKeyMode` | LastWins (default) / Disallowed / FirstWins (from `IniDuplicateKeyBehavior`). |
+| `DuplicateSectionMode` | Preserve / Disallowed / Merge (from `IniDuplicateSectionBehavior`). |
+| `DiagnosticMode` | Throw (default) / Collect / Ignore. |
+| `MaxLineLength` / `MaxKeyLength` | DoS-resistant caps; defaults 8192 / 1024. |
+| `TrimKeysAndValues` | EditorConfig-compatible trimming; default `true`. |
+| `AllowKeyOnlyProperties` | Whether lines without `=` are accepted as boolean-true; default `false`. |
+| `KeyOptions` | The <xref:Bodu.Text.Configuration.BoduConfigurationKeyOptions> applied while reading raw keys. |
+
+**<xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions>** controls the resolver:
+
+| Property | Role |
+|---|---|
+| `PathRoot` | The directory anchor for glob matches. When `null`, the document's load path is used; when neither is available, `MissingPathRootMode` decides. |
+| `MissingPathRootMode` | UseEmptyRoot (default) / Throw / IgnoreAnchoredPatterns. |
+| `ApplyPreambleProperties` | Whether preamble (global section) properties contribute to the view. |
+| `PathComparison` | The <xref:System.StringComparison> used when matching target paths against patterns. |
+| `UnsetValueMode` | TreatAsLiteral (default) / RemoveEffectiveValue (EditorConfig sentinel). |
+| `KeyOptions` | The key options applied when expanding raw keys into colon-delimited form. |
+
+**<xref:Bodu.Text.Configuration.BoduConfigurationWriteOptions>** controls `Save`: encoding, newline style, blank-line
+policy, property layout. Use the static `Bodu` / `EditorConfigCompatible` / `Strict` / `Relaxed` presets, or supply a
+custom bag.
+
+## Key — raw, segments, configuration
+
+A configuration key has three concurrent forms:
+
+| Form | Example | Where used |
+|---|---|---|
+| **Raw key** | `logging.level.default` | The text as authored in the source file. |
+| **Segments** | `["logging", "level", "default"]` | Split on the configured separators. |
+| **Configuration key** | `logging:level:default` | The canonical colon-delimited form stored in the view. |
+
+<xref:Bodu.Text.Configuration.BoduConfigurationKey> is the read-only struct that holds all three.
+`BoduConfigurationKey.Parse(rawKey)` is the entry point; `TryParse` is the non-throwing variant.
+
+Lookups on a <xref:Bodu.Text.Configuration.BoduConfigurationView> accept either the dotted or the colon-delimited form
+— `view["logging.level.default"]` and `view["logging:level:default"]` return the same value. The view stores keys in
+the colon-delimited form to interoperate with `Microsoft.Extensions.Configuration`.
+
+## Key mapping
+
+`BoduConfigurationKey` uses a <xref:Bodu.Text.Configuration.BoduConfigurationKeyOptions> to govern splitting and
+mapping:
+
+| Mapping | Behaviour |
+|---|---|
+| `DotToColon` (default) | Split on `.` and `:`; emit `:`-joined. |
+| `Colon` | Split on `:` only; emit `:`-joined. |
+| `Identity` | Split on the configured separators; rejoin with the first separator (preserves the original delimiter). |
+
+`SegmentSeparators` defaults to `{ '.', ':' }`. `CaseSensitive` defaults to `false`, matching
+`Microsoft.Extensions.Configuration`. `AllowEmptySegments` defaults to `false` — `a..b` is rejected unless the
+property is set explicitly.
+
+## Glob pattern and target path
+
+Section headers are interpreted as **glob patterns** matched against the resolver's target path. The pattern
+language follows EditorConfig:
+
+| Pattern | Matches |
+|---|---|
+| `*` | Any characters except `/`. |
+| `**` | Any characters including `/`. |
+| `?` | Any single character. |
+| `[abc]` / `[!abc]` | Character class / negated character class. |
+| `{a,b,c}` | Alternation. |
+| `[*.cs]` | All `.cs` files at any depth (unanchored). |
+| `[src/**/*.cs]` | All `.cs` files under `src/` (anchored to `PathRoot`). |
+
+The **target path** is the value passed to `document.Resolve(targetPath)`. Anchored patterns (those that contain `/`)
+are tested against `PathRoot + targetPath`. Unanchored patterns are tested against the filename only.
+
+When `PathRoot` is unset and the document was loaded from a string,
+<xref:Bodu.Text.Configuration.BoduConfigurationMissingPathRootMode> decides: `UseEmptyRoot` matches against the bare
+target path, `Throw` rejects anchored patterns at resolve time, `IgnoreAnchoredPatterns` silently skips them.
+
+The pattern compiler is <xref:Bodu.Text.Configuration.BoduConfigurationPattern> — the same engine the resolver uses,
+exposed for callers who want to test pattern matching directly without instantiating a document.
+
+## Preamble
+
+The **preamble** is the EditorConfig name for the file's global section — properties that appear before any `[...]`
+section header. Bodu exposes it as <xref:Bodu.Text.Formats.IniDocument.GlobalSection> and the
+<xref:Bodu.Text.Configuration.BoduConfigurationExtensions.Preamble(Bodu.Text.Formats.IniDocument)> alias.
+
+Under the default `Bodu` profile, the resolver layers the preamble first and then each matching section in source
+order, so preamble properties act as defaults that any matching section can override. Under
+`EditorConfigCompatible`, only the well-known `root` key is honoured from the preamble; every other preamble property
+is ignored during resolve.
+
+## Resolution layering
+
+![Resolution layering — preamble plus matching sections in source order](../../images/diagrams/text-configuration-layering.svg)
+
+The resolver walks the document once:
+
+1. If `ApplyPreambleProperties` is true, copy every preamble property into the working dictionary.
+2. For each named section in source order, test the header pattern against the target path. If it matches, copy each
+   property into the working dictionary, overwriting any earlier value for the same key (**last-wins**).
+3. Apply the `UnsetValueMode` policy to any property whose value is the literal `unset`.
+4. Wrap the working dictionary in a <xref:Bodu.Text.Configuration.BoduConfigurationView>.
+
+The walk is single-pass and source-order — no precedence rule beyond "later wins for a given key". This matches
+EditorConfig semantics; tools that need different precedence rules should layer multiple documents or filter the
+sections before resolving.
+
+## Diagnostic mode
+
+The reader can route recoverable issues three ways:
+
+| Mode | Behaviour |
+|---|---|
+| `Throw` (default) | On the first recoverable error, raise <xref:Bodu.Text.Configuration.BoduConfigurationParseException> and stop. The document is not returned. |
+| `Collect` | Run the parser to completion and attach diagnostics to a <xref:Bodu.Text.Configuration.BoduConfigurationParseResult>. The document is still returned and its valid portions remain usable. |
+| `Ignore` | Discard diagnostics; return the document anyway. |
+
+Use `Throw` for generated files where any deviation is a programmer error; use `Collect` for user-authored files where
+you want to surface every problem at once; use `Ignore` only when you are happy to trust whatever the parser produces.
+<xref:Bodu.Text.Configuration.BoduConfigurationDocument.ParseWithDiagnostics(System.String,Bodu.Text.Configuration.BoduConfigurationParseOptions)>
+returns a <xref:Bodu.Text.Configuration.BoduConfigurationParseResult> directly, even under `Throw` (where the
+diagnostic list is always empty on a successful parse).
+
+## Unset sentinel
+
+EditorConfig defines the literal string `unset` as a directive that *removes* the effective value of a property for
+the matching path — useful when a deeply nested section should opt out of a default established by an earlier
+section.
+
+<xref:Bodu.Text.Configuration.BoduConfigurationUnsetValueMode> controls how the resolver treats it:
+
+| Mode | Behaviour |
+|---|---|
+| `TreatAsLiteral` (default) | The string `"unset"` is preserved verbatim in the view. |
+| `RemoveEffectiveValue` | The key is removed from the working dictionary; it does not appear in the view. |
+
+`Bodu` and `Strict` profiles default to `TreatAsLiteral` so the literal text is not silently dropped. The
+`EditorConfigCompatible` profile defaults to `RemoveEffectiveValue` to match the specification.
+
+## Typed accessors
+
+<xref:Bodu.Text.Configuration.BoduConfigurationView> exposes a family of typed getters built on top of
+<xref:System.ISpanParsable`1>:
+
+| Getter family | Behaviour on missing key | Behaviour on malformed value |
+|---|---|---|
+| `GetString` | Throws `KeyNotFoundException`. | n/a — value is already string. |
+| `GetString(key, fallback)` | Returns the fallback. | n/a. |
+| `TryGetString` | Returns `false`. | n/a. |
+| `GetInt32` / `GetInt64` / `GetBoolean` / `GetEnum<T>` | Throws `KeyNotFoundException`. | Throws `FormatException`. |
+| `GetXxx(key, fallback)` | Returns the fallback. | Throws `FormatException` (malformed values are never silently swallowed). |
+| `TryGetXxx` | Returns `false`. | Returns `false` (never throws on parse failure). |
+| `GetValue<T>(key)` | Throws `KeyNotFoundException`. | Throws `FormatException`. |
+| `TryGetValue<T>(key, out value)` | Returns `false`. | Returns `false`. |
+
+The `GetValue<T>` and `TryGetValue<T>` generics accept any type that implements
+<xref:System.ISpanParsable`1> — `int`, `long`, `double`, `Guid`, `TimeSpan`, `DateTimeOffset`, custom enums, custom
+records, anything with a span-parseable surface. All parsing is done with
+<xref:System.Globalization.CultureInfo.InvariantCulture> to keep behaviour deterministic across locales.
+
+## Saving (round-trip)
+
+<xref:Bodu.Text.Configuration.BoduConfigurationDocument.Save(Bodu.Text.Formats.IniDocument,System.String,Bodu.Text.Configuration.BoduConfigurationWriteOptions)>
+emits the document back to text. The writer preserves comment lines, section ordering, and the original property
+ordering within each section, so a parse-then-save round-trip is byte-stable for any document the library produced.
+The write options control encoding (default UTF-8 without BOM), newline style (default `\n`), and blank-line policy
+between sections.
+
+For documents the library *did not* produce — hand-authored INI files with idiosyncratic whitespace — the writer
+emits canonical formatting, so the round-trip is semantically stable but may rearrange incidental whitespace.
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — install + runnable minimal samples.
+- **[Bodu.Extensions.Configuration.Text](../extensions-configuration-text/index.md)** — `IConfigurationBuilder` integration.
+- **[Bodu.Text.Configuration API reference](../../apidoc/Bodu.Text.Configuration.md)** — full type-by-type docs.
+- **[Introduction](index.md)** — the high-level shape of the library.

--- a/docs/docs/text-configuration/getting-started.md
+++ b/docs/docs/text-configuration/getting-started.md
@@ -1,0 +1,239 @@
+---
+title: Bodu.Text.Configuration — Getting started
+---
+
+# Bodu.Text.Configuration — Getting started
+
+Unfamiliar with terms like *document*, *view*, *profile*, *preamble*, *target path*, *unset*, or *diagnostic mode*?
+Read [Core concepts](concepts.md) first.
+
+## Install
+
+```bash
+dotnet add package Bodu.Text.Configuration
+```
+
+Targets `net8.0`. Depends on `Bodu.Core` (throw helpers) and `Bodu.Text.Formats` (the underlying `IniDocument`). No
+external NuGet references.
+
+For `Microsoft.Extensions.Configuration` integration — `AddBoduConfiguration`, options binding, file-provider
+support — install the sibling [`Bodu.Extensions.Configuration.Text`](../extensions-configuration-text/getting-started.md)
+package on top.
+
+## Minimal samples
+
+### Parse, resolve, read
+
+```csharp
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
+
+const string source = """
+# Bodu configuration sample
+root = true
+
+[*.cs]
+format.indent.style = space
+format.indent.size  = 4
+logging.level.default = Information
+
+[src/**/*.{cs,csproj}]
+format.indent.size = 2
+logging.level.default = Warning
+""";
+
+IniDocument doc = BoduConfigurationDocument.Parse(source);
+
+BoduConfigurationView view = doc.Resolve("src/Bodu.Text.Configuration/src/Foo.cs");
+
+string indentStyle = view.GetString("format:indent:style");           // "space"
+int    indentSize  = view.GetInt32("format:indent:size");             // 2 (last-wins from the [src/**] section)
+string logLevel    = view.GetString("logging:level:default");         // "Warning"
+```
+
+Both the dotted form (`format.indent.style`) and the colon-delimited form (`format:indent:style`) work as lookup keys
+on the view — the library projects raw keys to canonical colon-delimited form during resolve, but the dotted form
+remains a valid alias.
+
+### Read with a fallback
+
+```csharp
+int indent = view.GetInt32("format:indent:size", fallback: 4);        // 4 if the key is missing — but FormatException still fires on malformed values
+string logTo = view.GetString("logging:writeTo", fallback: "console");
+```
+
+`TryGetXxx` never throws — including on malformed values. Use it when you cannot trust the source text and want
+diagnostics on a per-key basis.
+
+```csharp
+if (view.TryGetInt32("format:indent:size", out int size))
+{
+    // size is set
+}
+```
+
+### Generic typed accessor — any `ISpanParsable<T>`
+
+```csharp
+double threshold = view.GetValue<double>("limits:cpu:threshold");
+TimeSpan timeout = view.GetValue<TimeSpan>("network:read:timeout");
+Guid     correlation = view.GetValue<Guid>("trace:correlation:id");
+```
+
+All parsing uses `CultureInfo.InvariantCulture` so behaviour is deterministic across locales.
+
+### Profile presets
+
+```csharp
+// Strict — duplicate keys are rejected, key-only properties forbidden, inline comments off.
+IniDocument generated = BoduConfigurationDocument.Parse(
+    text,
+    BoduConfigurationParseOptions.Strict);
+
+// EditorConfig-compatible — inline comments disabled, identity key mapping, only `root` from preamble.
+IniDocument editorConfig = BoduConfigurationDocument.Parse(
+    text,
+    BoduConfigurationParseOptions.EditorConfigCompatible);
+
+// Pick a profile at runtime.
+BoduConfigurationProfile profile = userProfile;
+BoduConfigurationParseOptions options = BoduConfigurationParseOptions.For(profile);
+```
+
+### Collect diagnostics instead of throwing
+
+```csharp
+BoduConfigurationParseOptions options = BoduConfigurationParseOptions.Relaxed; // DiagnosticMode = Collect
+
+BoduConfigurationParseResult result = BoduConfigurationDocument.ParseWithDiagnostics(text, options);
+
+foreach (BoduConfigurationDiagnostic d in result.Diagnostics)
+{
+    Console.WriteLine($"{d.Severity} {d.Code} at line {d.Location.Line}: {d.Message}");
+}
+
+if (result.Diagnostics.Length == 0)
+{
+    // Clean parse — document is fully usable.
+    BoduConfigurationView view = result.Document.Resolve("src/Foo.cs");
+}
+```
+
+`ParseWithDiagnostics` returns successfully even when the document contains recoverable issues; valid sections remain
+usable in `result.Document`. Under the default `Throw` diagnostic mode, the same method raises
+<xref:Bodu.Text.Configuration.BoduConfigurationParseException> on the first error.
+
+### Load from a file or stream
+
+```csharp
+IniDocument fromPath = BoduConfigurationDocument.Load(".boduconfig");
+
+await using FileStream fs = File.OpenRead("bodu.config");
+IniDocument fromStream = BoduConfigurationDocument.Load(fs);
+```
+
+`Load(path)` records the originating directory so anchored glob patterns (e.g. `[src/**]`) can resolve against the
+correct root without an explicit `PathRoot` setting. `Load(Stream)` and `Parse(string)` produce documents with no
+path context, so anchored globs require `BoduConfigurationResolveOptions.PathRoot` to be set explicitly — or
+`MissingPathRootMode` to opt into the empty-root or ignore behaviour.
+
+### Resolve options — anchor a path root
+
+```csharp
+IniDocument doc = BoduConfigurationDocument.Parse(source);
+
+BoduConfigurationResolveOptions options = new()
+{
+    PathRoot = "/home/user/projects/my-app",
+    ApplyPreambleProperties = true,
+    UnsetValueMode = BoduConfigurationUnsetValueMode.RemoveEffectiveValue, // EditorConfig sentinel
+};
+
+BoduConfigurationView view = doc.Resolve("src/Bodu/Foo.cs", options);
+```
+
+### Save (round-trip)
+
+```csharp
+IniDocument doc = BoduConfigurationDocument.Parse(source);
+
+// Modify a value via the underlying IniDocument API.
+doc.Sections[0].SetEntry("format.indent.size", "8");
+
+BoduConfigurationDocument.Save(doc, "/tmp/output.boduconfig");
+```
+
+The writer emits canonical Bodu formatting by default. Use
+<xref:Bodu.Text.Configuration.BoduConfigurationWriteOptions.EditorConfigCompatible> when round-tripping into an
+EditorConfig-strict toolchain.
+
+### Key parsing
+
+```csharp
+BoduConfigurationKey key = BoduConfigurationKey.Parse("logging.level.default");
+
+string raw      = key.RawKey;             // "logging.level.default"
+string canonical = key.ConfigurationKey;  // "logging:level:default"
+ImmutableArray<string> segments = key.Segments; // ["logging", "level", "default"]
+
+// Non-throwing variant.
+if (BoduConfigurationKey.TryParse(userInput, out BoduConfigurationKey parsed))
+{
+    // parsed.ConfigurationKey is ready for Microsoft.Extensions.Configuration interop
+}
+```
+
+### Iterate the resolved view
+
+```csharp
+BoduConfigurationView view = doc.Resolve("src/Foo.cs");
+
+foreach (KeyValuePair<string, string?> kvp in view)
+{
+    Console.WriteLine($"{kvp.Key} = {kvp.Value}");
+}
+
+// Or directly via the underlying read-only dictionary.
+IReadOnlyDictionary<string, string?> raw = view.Values;
+```
+
+The view implements `IEnumerable<KeyValuePair<string, string?>>` and exposes the underlying dictionary through
+`Values`, `Keys`, and `Count`.
+
+## End-to-end round-trip example
+
+```csharp
+using Bodu.Text.Configuration;
+using Bodu.Text.Formats;
+
+const string source = """
+root = true
+
+[*.cs]
+format.indent.style = space
+format.indent.size  = 4
+""";
+
+// Parse → Resolve → Read.
+IniDocument doc = BoduConfigurationDocument.Parse(source);
+BoduConfigurationView view = doc.Resolve("Bodu/Foo.cs");
+
+string style = view.GetString("format:indent:style");                 // "space"
+int size = view.GetInt32("format:indent:size");                       // 4
+
+// Save → Parse again → Compare.
+using StringWriter sw = new();
+BoduConfigurationDocument.Save(doc, sw);
+
+IniDocument reparsed = BoduConfigurationDocument.Parse(sw.ToString());
+Debug.Assert(reparsed.Sections.Count == doc.Sections.Count);
+Debug.Assert(reparsed.GlobalSection["root"] == doc.GlobalSection["root"]);
+```
+
+## Where to go next
+
+- **[Core concepts](concepts.md)** — vocabulary refresher.
+- **[Introduction](index.md)** — type map, scenario index.
+- **[Bodu.Extensions.Configuration.Text](../extensions-configuration-text/index.md)** — plug into `IConfigurationBuilder`, bind to `IOptions<T>`.
+- **[Bodu.Text.Configuration API reference](../../apidoc/Bodu.Text.Configuration.md)** — full type-by-type docs.
+- **[Bodu.Text.Formats](../formats/index.md)** — the underlying `IniDocument` model.

--- a/docs/docs/text-configuration/index.md
+++ b/docs/docs/text-configuration/index.md
@@ -1,0 +1,146 @@
+---
+title: Bodu.Text.Configuration — Introduction
+---
+
+# Bodu.Text.Configuration
+
+**Bodu.Text.Configuration** is the configuration-layering package of the Bodu suite. It reads a single text file in the
+familiar **INI / EditorConfig** shape — preamble, named sections, `key = value` properties — and projects it into a
+flattened, target-aware **view** keyed by colon-delimited configuration keys. The result drops directly into the same
+shape `Microsoft.Extensions.Configuration` expects, without taking a dependency on that package: the bridge lives in
+the sibling [`Bodu.Extensions.Configuration.Text`](../extensions-configuration-text/index.md) library.
+
+The package is intentionally narrow: parse a document, optionally collect diagnostics, resolve it for a target path,
+and read typed values back out. No reflection, no `dynamic`, no schema, no global state.
+
+## Core mental model
+
+![Configuration pipeline — source text to resolved view](../../images/diagrams/text-configuration-pipeline.svg)
+
+Configuration runs as a four-stage pipeline: the **reader** (`BoduConfigurationReader`) tokenises the source text and
+produces an immutable `IniDocument` from `Bodu.Text.Formats`; the **resolver** layers the document's preamble and
+matching glob-anchored sections in source order to produce a `BoduConfigurationView`; the **getter API** on the view
+returns typed values (`GetString`, `GetInt32`, `GetBoolean`, `GetEnum<T>`, `GetValue<T>` for any `ISpanParsable<T>`).
+Every stage is opt-in: parse without resolving when you just want the document, resolve without typed accessors when
+you only need raw strings.
+
+A configuration file is *not* a snapshot of a single object graph — it is a layered description of how
+properties change as a target path moves through a directory tree. The library's job is to collapse those layers down
+to the right answer for a specific target.
+
+## The shape of the library
+
+The package contains five concept groups, all in the `Bodu.Text.Configuration` namespace.
+
+### Document and view
+
+*The minimal happy-path: `Parse` → `Resolve` → `GetXxx`.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Configuration.BoduConfigurationDocument> | Static façade — `Parse`, `ParseWithDiagnostics`, `Load`, `Save` over strings, streams, paths, and text readers. Backed by <xref:Bodu.Text.Formats.IniDocument>. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationView> | Resolved, flattened snapshot for one target path; implements `IEnumerable<KeyValuePair<string, string?>>`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationExtensions> | Extension methods on `IniDocument`, `IniSection`, `IniEntry` — including the `Resolve(targetPath)` projection. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationParseResult> | The output of `ParseWithDiagnostics` — carries both the document and any diagnostics collected during the parse. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationParseException> | Thrown by the throwing parse / load overloads when `DiagnosticMode` is `Throw`. |
+
+### Profiles and options
+
+*Four named profiles cover the common use cases; everything else is composed from the per-stage option types.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Configuration.BoduConfigurationProfile> | Enum: `Bodu` (default), `EditorConfigCompatible`, `Strict`, `Relaxed`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationParseOptions> | Reader behaviour: inline-comment mode, duplicate-key / -section handling, diagnostic mode, length limits, key options. Static `Bodu` / `EditorConfigCompatible` / `Strict` / `Relaxed` presets. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationResolveOptions> | Resolver behaviour: `PathRoot`, `MissingPathRootMode`, `ApplyPreambleProperties`, `UnsetValueMode`, `PathComparison`, `KeyOptions`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationWriteOptions> | Save behaviour: encoding, newline style, blank-line policy, property formatting. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationKeyOptions> | Key behaviour: segment separators (default `.` and `:`), mapping (`DotToColon` / `Colon` / `Identity`), case sensitivity. |
+
+### Keys
+
+*The library distinguishes the raw key as authored in the file from the canonical colon-delimited form.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Configuration.BoduConfigurationKey> | Read-only struct with `RawKey`, `ConfigurationKey`, `Segments`, and `CaseSensitive`. Static `Parse` / `TryParse` factories. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationKeyMapping> | Enum: `DotToColon` (default), `Colon`, `Identity`. |
+
+### Diagnostics
+
+*When `DiagnosticMode` is `Collect`, the parser runs to completion and lists every recoverable issue.*
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Configuration.BoduConfigurationDiagnostic> | Immutable diagnostic record: severity, code, message, source location. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticSeverity> | Enum: `Warning`, `Error`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticCode> | Enum identifying the diagnostic category (duplicate key, invalid section, unset literal, …). |
+| <xref:Bodu.Text.Configuration.BoduConfigurationDiagnosticMode> | Enum: `Throw` (default), `Collect`, `Ignore`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationSourceLocation> | Line / column metadata pointing into the source text. |
+
+### Resolution modes
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Configuration.BoduConfigurationInlineCommentMode> | Enum: `Disabled` (EditorConfig), `WhitespaceIntroduced` (default), `Always`. |
+| <xref:Bodu.Text.Configuration.BoduConfigurationUnsetValueMode> | Enum: `TreatAsLiteral` (default), `RemoveEffectiveValue` (EditorConfig). |
+| <xref:Bodu.Text.Configuration.BoduConfigurationMissingPathRootMode> | Enum: `UseEmptyRoot` (default), `Throw`, `IgnoreAnchoredPatterns`. |
+
+## Profile presets at a glance
+
+| Profile | Inline comments | Duplicate keys | Diagnostics | Preamble in resolve | Unset semantics |
+|---|---|---|---|---|---|
+| `Bodu` (default) | WhitespaceIntroduced | LastWins | Throw | Applied | Literal |
+| `EditorConfigCompatible` | Disabled | LastWins | Throw | Only `root` | Removes value |
+| `Strict` | Disabled | Disallowed | Throw | Applied | Literal |
+| `Relaxed` | WhitespaceIntroduced | LastWins | Collect | Applied | Literal |
+
+Profiles are not exclusive — every option type is fully mutable through `init` properties, so the presets are
+starting points, not contracts.
+
+## Common scenarios
+
+| Scenario | Reach for |
+|---|---|
+| Parse a file with default behaviour | `BoduConfigurationDocument.Parse(text)` or `Load(path)` |
+| Parse a user-authored file without halting on errors | `BoduConfigurationDocument.ParseWithDiagnostics(text, BoduConfigurationParseOptions.Relaxed)` |
+| Resolve effective settings for one source file | `doc.Resolve("src/Foo.cs").GetString("format:indent:style")` |
+| Read a typed value with a fallback | `view.GetInt32("format:indent:size", fallback: 4)` |
+| Read any `ISpanParsable<T>` | `view.GetValue<double>("limits:cpu:threshold")` |
+| EditorConfig-strict parsing | `BoduConfigurationDocument.Parse(text, BoduConfigurationParseOptions.EditorConfigCompatible)` |
+| Reject any input the parser cannot prove canonical | `BoduConfigurationParseOptions.Strict` |
+| Use dots in keys but project to colon-delimited form | (default — `BoduConfigurationKeyMapping.DotToColon`) |
+| Round-trip a document through save | `BoduConfigurationDocument.Save(doc, path)` |
+| Pick the profile from configuration at runtime | `BoduConfigurationParseOptions.For(profile)` |
+| Plug into <xref:Microsoft.Extensions.Configuration.IConfigurationBuilder> | See [Bodu.Extensions.Configuration.Text](../extensions-configuration-text/index.md). |
+
+## File grammar at a glance
+
+```ini
+# A preamble property — applies before any section opens.
+root = true
+
+# A section: the header is a glob pattern matched against the resolver's target path.
+[*.cs]
+format.indent.style = space
+format.indent.size  = 4
+
+# Later sections override earlier sections for any path they both match (last-wins).
+[src/**/*.{cs,csproj}]
+format.indent.size = 2
+```
+
+The grammar matches **EditorConfig** verbatim with two Bodu-specific extensions:
+
+1. **Inline comments** are recognised when introduced by whitespace (`key = value  # comment`) under the default `Bodu`
+   profile. Set the profile to `EditorConfigCompatible` to disable them.
+2. **Key mapping** projects dotted keys (`logging.level.default`) to colon-delimited configuration keys
+   (`logging:level:default`) for direct interoperability with `Microsoft.Extensions.Configuration`. Both forms work as
+   lookup inputs on the view; the canonical stored form is the colon-delimited one.
+
+## Where to go next
+
+- **[Core concepts](concepts.md)** — vocabulary: document vs view, profile, parse/resolve/write options, key mapping, glob pattern, preamble, target path, diagnostic mode, unset.
+- **[Getting started](getting-started.md)** — install + minimal samples for parse-resolve-read, profile presets, diagnostics, round-trip save.
+- **[Bodu.Extensions.Configuration.Text](../extensions-configuration-text/index.md)** — `IConfigurationBuilder` integration, options binding, file probing.
+- **[Bodu.Text.Configuration API reference](../../apidoc/Bodu.Text.Configuration.md)** — full type-by-type docs.
+- **[Bodu.Text.Formats](../formats/index.md)** — the underlying `IniDocument` model that `BoduConfigurationDocument.Parse` returns.

--- a/docs/docs/text-encoding/concepts.md
+++ b/docs/docs/text-encoding/concepts.md
@@ -190,4 +190,5 @@ needs those should keep using the static classes directly.
 
 - **[Getting started](getting-started.md)** — install + minimal sample per encoding type.
 - **[Bodu.Text.Encoding guides](../../guides/text-encoding/index.md)** — using each encoding, choosing variants, streaming, the `IBinaryEncoding` interface.
+- **[Bodu.Text.Encoding API reference](../../apidoc/Bodu.Text.Encoding.md)** — full type-by-type docs.
 - **[Introduction](index.md)** — type map, scenarios, where each encoding fits.

--- a/docs/docs/text-encoding/getting-started.md
+++ b/docs/docs/text-encoding/getting-started.md
@@ -178,3 +178,4 @@ Debug.Assert(original.SequenceEqual(recovered));
 - **[Bodu.Text.Encoding guides](../../guides/text-encoding/index.md)** — per-encoding deep dives.
 - **[Core concepts](concepts.md)** — vocabulary refresher.
 - **[Introduction](index.md)** — type map and scenario index.
+- **[Bodu.Text.Encoding API reference](../../apidoc/Bodu.Text.Encoding.md)** — full type-by-type docs.

--- a/docs/docs/text-encoding/index.md
+++ b/docs/docs/text-encoding/index.md
@@ -110,3 +110,5 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 - **[Core concepts](concepts.md)** — vocabulary: alphabet, variant, terminal quantum, padding, shortcut, decoration.
 - **[Getting started](getting-started.md)** — install + minimal sample per encoding type.
 - **[Bodu.Text.Encoding guides](../../guides/text-encoding/index.md)** — using each encoding, choosing variants, streaming, the `IBinaryEncoding` interface.
+- **[Bodu.Text.Encoding API reference](../../apidoc/Bodu.Text.Encoding.md)** — full type-by-type docs.
+- **For structured binary serialization formats** (Bencode, INI) with their own self-describing grammar, see [Bodu.Text.Formats](../formats/index.md).

--- a/docs/docs/toc.yml
+++ b/docs/docs/toc.yml
@@ -47,3 +47,19 @@
       href: formats/concepts.md
     - name: Getting started
       href: formats/getting-started.md
+- name: Bodu.Text.Configuration
+  items:
+    - name: Introduction
+      href: text-configuration/index.md
+    - name: Core concepts
+      href: text-configuration/concepts.md
+    - name: Getting started
+      href: text-configuration/getting-started.md
+- name: Bodu.Extensions.Configuration.Text
+  items:
+    - name: Introduction
+      href: extensions-configuration-text/index.md
+    - name: Core concepts
+      href: extensions-configuration-text/concepts.md
+    - name: Getting started
+      href: extensions-configuration-text/getting-started.md

--- a/docs/guides/extensions-configuration-text/index.md
+++ b/docs/guides/extensions-configuration-text/index.md
@@ -1,0 +1,38 @@
+---
+title: Bodu.Extensions.Configuration.Text guides
+---
+
+# Bodu.Extensions.Configuration.Text guides
+
+Recipe-style walk-throughs for **Bodu.Extensions.Configuration.Text** — the bridge between
+[`Bodu.Text.Configuration`](../text-configuration/index.md) and `Microsoft.Extensions.Configuration`.
+
+If you are new to the library, start with the [introduction](../../docs/extensions-configuration-text/index.md), the
+[Core concepts](../../docs/extensions-configuration-text/concepts.md) glossary, and the
+[getting-started page](../../docs/extensions-configuration-text/getting-started.md). The guides below assume you know
+the vocabulary (source, provider, target path, parse / resolve option propagation, reload-on-change, options binding).
+
+## How the library works
+
+![IConfigurationBuilder to IConfiguration to IOptions](../../images/diagrams/extensions-configuration-text-flow.svg)
+
+`AddBoduConfiguration(...)` registers a <xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationSource> on the
+builder. When the builder calls `Build`, the source instantiates a
+<xref:Bodu.Extensions.Configuration.Text.BoduTextConfigurationProvider> that parses the file via
+<xref:Bodu.Text.Configuration.BoduConfigurationDocument>, resolves it for the source's `TargetPath`, and copies the
+flattened view into the inherited `Data` dictionary as colon-delimited keys. The DI options helper binds named
+sections to typed POCO classes through the standard `Microsoft.Extensions.DependencyInjection` shape.
+
+## Namespace map
+
+| Namespace | What lives here | Static docs |
+|---|---|---|
+| `Bodu.Extensions.Configuration.Text` | Builder extensions (`BoduTextConfigurationExtensions`), file source / provider (`BoduTextConfigurationSource`, `BoduTextConfigurationProvider`), stream source / provider (`BoduTextStreamConfigurationSource`, `BoduTextStreamConfigurationProvider`), DI options helpers (`BoduConfigurationOptionsExtensions`). | [Introduction](../../docs/extensions-configuration-text/index.md) · [Core concepts](../../docs/extensions-configuration-text/concepts.md) · [Getting started](../../docs/extensions-configuration-text/getting-started.md) |
+
+## Where to go next
+
+- **[Introduction](../../docs/extensions-configuration-text/index.md)** — namespaces, headline types, scenarios.
+- **[Core concepts](../../docs/extensions-configuration-text/concepts.md)** — full vocabulary.
+- **[Getting started](../../docs/extensions-configuration-text/getting-started.md)** — install + runnable minimal samples.
+- **[Bodu.Extensions.Configuration.Text API reference](../../apidoc/Bodu.Extensions.Configuration.Text.md)** — full type-by-type docs.
+- **[Bodu.Text.Configuration](../text-configuration/index.md)** — the underlying parser, resolver, and view.

--- a/docs/guides/extensions-configuration-text/toc.yml
+++ b/docs/guides/extensions-configuration-text/toc.yml
@@ -1,0 +1,2 @@
+- name: Overview
+  href: index.md

--- a/docs/guides/text-configuration/index.md
+++ b/docs/guides/text-configuration/index.md
@@ -1,0 +1,36 @@
+---
+title: Bodu.Text.Configuration guides
+---
+
+# Bodu.Text.Configuration guides
+
+Recipe-style walk-throughs for **Bodu.Text.Configuration**.
+
+If you are new to the library, start with the [introduction](../../docs/text-configuration/index.md), the
+[Core concepts](../../docs/text-configuration/concepts.md) glossary, and the
+[getting-started page](../../docs/text-configuration/getting-started.md). The guides below assume you know the
+vocabulary (document, view, profile, target path, preamble, glob pattern, key mapping, unset, diagnostic mode).
+
+## How the library works
+
+![Bodu Text Configuration pipeline](../../images/diagrams/text-configuration-pipeline.svg)
+
+A configuration document is parsed once and then projected — through a target path — into a flat
+<xref:Bodu.Text.Configuration.BoduConfigurationView>. The reader produces an immutable
+<xref:Bodu.Text.Formats.IniDocument>; the resolver layers the preamble plus matching glob-anchored sections in source
+order; the view exposes typed accessors that return the effective value for each colon-delimited key.
+
+## Namespace map
+
+| Namespace | What lives here | Static docs |
+|---|---|---|
+| `Bodu.Text.Configuration` | Static façade (`BoduConfigurationDocument`), resolved view (`BoduConfigurationView`), profile and option types (`BoduConfigurationParseOptions`, `BoduConfigurationResolveOptions`, `BoduConfigurationWriteOptions`, `BoduConfigurationKeyOptions`), key model (`BoduConfigurationKey`), diagnostics (`BoduConfigurationDiagnostic`, `BoduConfigurationParseResult`), and the resolver pattern engine (`BoduConfigurationPattern`). | [Introduction](../../docs/text-configuration/index.md) · [Core concepts](../../docs/text-configuration/concepts.md) · [Getting started](../../docs/text-configuration/getting-started.md) |
+
+## Where to go next
+
+- **[Introduction](../../docs/text-configuration/index.md)** — namespaces, headline types, scenarios.
+- **[Core concepts](../../docs/text-configuration/concepts.md)** — full vocabulary.
+- **[Getting started](../../docs/text-configuration/getting-started.md)** — install + runnable minimal samples.
+- **[Bodu.Text.Configuration API reference](../../apidoc/Bodu.Text.Configuration.md)** — full type-by-type docs.
+- **[Bodu.Extensions.Configuration.Text](../extensions-configuration-text/index.md)** — the `Microsoft.Extensions.Configuration` bridge.
+- **[Bodu.Text.Formats](../formats/index.md)** — the underlying `IniDocument` model.

--- a/docs/guides/text-configuration/toc.yml
+++ b/docs/guides/text-configuration/toc.yml
@@ -1,0 +1,2 @@
+- name: Overview
+  href: index.md

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -172,3 +172,13 @@
       items:
         - name: Streams and async I/O
           href: formats/streaming.md
+- name: Bodu.Text.Configuration
+  href: text-configuration/
+  items:
+    - name: Overview
+      href: text-configuration/index.md
+- name: Bodu.Extensions.Configuration.Text
+  href: extensions-configuration-text/
+  items:
+    - name: Overview
+      href: extensions-configuration-text/index.md

--- a/docs/images/diagrams/extensions-configuration-text-flow.svg
+++ b/docs/images/diagrams/extensions-configuration-text-flow.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 280" role="img" aria-labelledby="ef-t ef-d">
+  <title id="ef-t">Bodu.Extensions.Configuration.Text bridge flow</title>
+  <desc id="ef-d">The Bodu Extensions Configuration Text bridge connects Bodu.Text.Configuration to Microsoft.Extensions.Configuration. Calls to IConfigurationBuilder.AddBoduConfiguration register a BoduTextConfigurationSource that carries the path, target path, parse options, and resolve options. When the builder calls Build, the source instantiates a BoduTextConfigurationProvider that parses the file via Bodu.Text.Configuration, resolves it for the target path, and copies the flattened view into the inherited Data dictionary as colon-delimited keys. The resulting IConfiguration is bound to typed POCO options classes through the standard DI Configure helper, surfaced as the AddBoduConfigurationOptions convenience wrapper.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; letter-spacing: 1px; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .src   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .mid   { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .dst   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out   { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .wp    { stroke: #A78BFA; stroke-width: 1.6; fill: none; }
+      .wa    { stroke: #FBBF24; stroke-width: 1.6; fill: none; }
+    </style>
+    <marker id="ef-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="ef-p" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+    <marker id="ef-o" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#FBBF24"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="280"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="260" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">IConfigurationBuilder → IConfiguration → IOptions</text>
+
+    <!-- ===== Top row — LOAD (left-to-right, teal) ===== -->
+    <text class="row" x="20" y="58">LOAD  ▸ register source → parse + resolve → populate Data</text>
+
+    <g transform="translate(20 70)">
+      <rect class="src" width="170" height="50" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="85" y="20">IConfigurationBuilder</text>
+      <text class="mut" x="85" y="36">.AddBoduConfiguration(...)</text>
+    </g>
+
+    <line class="wt" x1="190" y1="95" x2="220" y2="95" marker-end="url(#ef-a)"/>
+
+    <g transform="translate(220 70)">
+      <rect class="mid" width="170" height="50" rx="6"/>
+      <text class="lbl" x="85" y="20">BoduTextConfiguration</text>
+      <text class="lbl" x="85" y="34">Source</text>
+      <text class="mut" x="85" y="46">Path · TargetPath · Options</text>
+    </g>
+
+    <line class="wt" x1="390" y1="95" x2="420" y2="95" marker-end="url(#ef-a)"/>
+
+    <g transform="translate(420 70)">
+      <rect class="dst" width="170" height="50" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="85" y="20">BoduTextConfiguration</text>
+      <text class="lbl" fill="#C4B5FD" x="85" y="34">Provider</text>
+      <text class="mut" x="85" y="46">load → parse → resolve</text>
+    </g>
+
+    <line class="wp" x1="590" y1="95" x2="620" y2="95" marker-end="url(#ef-p)"/>
+
+    <g transform="translate(620 70)">
+      <rect class="out" width="160" height="50" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">IConfiguration</text>
+      <text class="mut" x="80" y="36">colon-delimited keys</text>
+      <text class="mut" x="80" y="48">["logging:level:default"]</text>
+    </g>
+
+    <!-- ===== Middle separator ===== -->
+    <line x1="20" y1="140" x2="780" y2="140" stroke="#334155" stroke-width="1"/>
+
+    <!-- ===== Bottom row — BIND (left-to-right, amber) ===== -->
+    <text class="row" x="20" y="162" fill="#FBBF24">BIND  ▸ section → POCO via DI</text>
+
+    <g transform="translate(20 175)">
+      <rect class="out" width="170" height="48" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="85" y="20">IConfiguration</text>
+      <text class="mut" x="85" y="36">root or GetSection(name)</text>
+    </g>
+
+    <line class="wa" x1="190" y1="199" x2="220" y2="199" marker-end="url(#ef-o)"/>
+
+    <g transform="translate(220 175)">
+      <rect class="mid" width="170" height="48" rx="6"/>
+      <text class="lbl" x="85" y="20">IServiceCollection</text>
+      <text class="mut" x="85" y="36">.AddBoduConfigurationOptions&lt;T&gt;</text>
+    </g>
+
+    <line class="wa" x1="390" y1="199" x2="420" y2="199" marker-end="url(#ef-o)"/>
+
+    <g transform="translate(420 175)">
+      <rect class="dst" width="170" height="48" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="85" y="20">DI container</text>
+      <text class="mut" x="85" y="36">services.Configure&lt;T&gt;(section)</text>
+    </g>
+
+    <line class="wa" x1="590" y1="199" x2="620" y2="199" marker-end="url(#ef-o)"/>
+
+    <g transform="translate(620 175)">
+      <rect class="src" width="160" height="48" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">IOptions&lt;TOptions&gt;</text>
+      <text class="mut" x="80" y="36">strongly typed POCO</text>
+    </g>
+
+    <!-- Footer note -->
+    <text class="mut" x="400" y="248" text-anchor="middle">ReloadOnChange wires up a file watcher; IOptionsMonitor&lt;T&gt; re-binds automatically when the underlying source changes.</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/text-configuration-layering.svg
+++ b/docs/images/diagrams/text-configuration-layering.svg
@@ -1,0 +1,118 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 320" role="img" aria-labelledby="cl-t cl-d">
+  <title id="cl-t">Bodu Text Configuration resolution layering</title>
+  <desc id="cl-d">Resolution layers the document for a target path in source order. The preamble (global section) contributes its properties first, then each named section whose glob header matches the target path contributes in turn. Later matches overwrite earlier values for the same key — last-wins precedence. The unset sentinel removes a key entirely when UnsetValueMode is RemoveEffectiveValue. The resulting BoduConfigurationView is a flat dictionary of colon-delimited keys to effective string values.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .lblL  { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mutL  { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .code  { fill: #CBD5E1; font: 400 11px/1.2 "Cascadia Code","Fira Code",Consolas,monospace; }
+      .codeb { fill: #F8FAFC; font: 700 11px/1.2 "Cascadia Code","Fira Code",Consolas,monospace; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .ambr  { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .teal  { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .blue  { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .purp  { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .arr   { stroke: #94A3B8; stroke-width: 1.2; fill: none; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .strike{ stroke: #F87171; stroke-width: 1.2; }
+    </style>
+    <marker id="cl-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#94A3B8"/>
+    </marker>
+    <marker id="cl-w" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="320"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="300" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Resolution layering — last-wins precedence in source order</text>
+
+    <!-- Target path indicator -->
+    <text class="row" x="20" y="58">TARGET PATH</text>
+    <g transform="translate(120 46)">
+      <rect class="ambr" width="200" height="20" rx="4"/>
+      <text class="codeb" fill="#FBBF24" x="100" y="14" text-anchor="middle">src/MyApp/Program.cs</text>
+    </g>
+    <text class="mutL" x="330" y="60">PathRoot + targetPath; anchored globs match against this</text>
+
+    <!-- ===== Layer 1: Preamble ===== -->
+    <g transform="translate(20 80)">
+      <rect class="teal" width="360" height="46" rx="6"/>
+      <text class="lblL" x="12" y="20">① Preamble (global section)</text>
+      <text class="code" x="12" y="36">root = true   ·   format.indent.style = tab</text>
+    </g>
+
+    <line class="arr" x1="400" y1="103" x2="430" y2="103" marker-end="url(#cl-a)"/>
+    <text class="mutL" x="440" y="98">applies first when</text>
+    <text class="mutL" x="440" y="110">ApplyPreambleProperties = true</text>
+
+    <!-- ===== Layer 2: Matching unanchored ===== -->
+    <g transform="translate(20 134)">
+      <rect class="blue" width="360" height="46" rx="6"/>
+      <text class="lblL" x="12" y="20">② [*.cs]   ← unanchored glob match</text>
+      <text class="code" x="12" y="36">format.indent.style = space   ·   indent.size = 4</text>
+    </g>
+
+    <line class="arr" x1="400" y1="157" x2="430" y2="157" marker-end="url(#cl-a)"/>
+    <text class="mutL" x="440" y="152">overrides preamble for</text>
+    <text class="mutL" x="440" y="164">format.indent.style</text>
+
+    <!-- ===== Layer 3: Matching anchored ===== -->
+    <g transform="translate(20 188)">
+      <rect class="purp" width="360" height="46" rx="6"/>
+      <text class="lblL" x="12" y="20">③ [src/**/*.cs]   ← anchored glob match</text>
+      <text class="code" x="12" y="36">format.indent.size = 2   ·   logging.level.default = Warning</text>
+    </g>
+
+    <line class="arr" x1="400" y1="211" x2="430" y2="211" marker-end="url(#cl-a)"/>
+    <text class="mutL" x="440" y="206">overrides layer ② for</text>
+    <text class="mutL" x="440" y="218">format.indent.size — last-wins</text>
+
+    <!-- ===== Layer 4: non-matching section (skipped) ===== -->
+    <g transform="translate(20 242)">
+      <rect class="pan" stroke="#475569" stroke-dasharray="3 2" width="360" height="46" rx="6"/>
+      <text class="lblL" fill="#94A3B8" x="12" y="20">[*.md]   ← does not match — skipped</text>
+      <text class="code" fill="#64748B" x="12" y="36">word_wrap = true</text>
+    </g>
+
+    <text class="mutL" x="440" y="262">non-matching sections</text>
+    <text class="mutL" x="440" y="274">contribute nothing</text>
+
+    <!-- ===== Effective view (right column) ===== -->
+    <g transform="translate(580 80)">
+      <rect class="ambr" width="200" height="208" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="100" y="22">Effective view</text>
+      <text class="mut" x="100" y="38">BoduConfigurationView</text>
+
+      <line x1="12" y1="48" x2="188" y2="48" stroke="#FBBF24" stroke-opacity="0.4" stroke-width="0.8"/>
+
+      <text class="code" x="12" y="68">format:indent:style</text>
+      <text class="codeb" fill="#FBBF24" x="12" y="84">= "space"   ← ②</text>
+
+      <text class="code" x="12" y="108">format:indent:size</text>
+      <text class="codeb" fill="#FBBF24" x="12" y="124">= "2"   ← ③</text>
+
+      <text class="code" x="12" y="148">logging:level:default</text>
+      <text class="codeb" fill="#FBBF24" x="12" y="164">= "Warning"   ← ③</text>
+
+      <text class="code" x="12" y="188">root</text>
+      <text class="codeb" fill="#FBBF24" x="12" y="204">= "true"   ← ①</text>
+    </g>
+
+    <!-- Bottom note -->
+    <text class="mut" x="400" y="296" text-anchor="middle">The literal value "unset" removes the key entirely when UnsetValueMode = RemoveEffectiveValue (EditorConfig 0.17.2 semantics).</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/text-configuration-pipeline.svg
+++ b/docs/images/diagrams/text-configuration-pipeline.svg
@@ -1,0 +1,111 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 280" role="img" aria-labelledby="cp-t cp-d">
+  <title id="cp-t">Bodu Text Configuration pipeline</title>
+  <desc id="cp-d">The Bodu.Text.Configuration pipeline runs in four stages. Source text is tokenised by BoduConfigurationReader and produces an immutable IniDocument from Bodu.Text.Formats. The IniDocument is projected by BoduConfigurationResolver for a specific target path, layering the preamble plus matching glob-anchored sections in source order to produce a BoduConfigurationView. The view exposes typed accessors — GetString, GetInt32, GetBoolean, GetEnum, and GetValue&lt;T&gt; for any ISpanParsable — that return the effective value for each colon-delimited configuration key.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sub   { fill: #CBD5E1; font: 400 11px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .rowd  { fill: #A78BFA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .src   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .mid   { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .dst   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out   { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .wp    { stroke: #A78BFA; stroke-width: 1.6; fill: none; }
+    </style>
+    <marker id="cpt-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="cpd-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="280"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="260" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Bodu.Text.Configuration pipeline</text>
+
+    <!-- ===== Top row — PARSE (left-to-right, teal) ===== -->
+    <text class="row" x="20" y="58">PARSE  ▸ source text → IniDocument</text>
+
+    <g transform="translate(20 70)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">Source text</text>
+      <text class="mut" x="80" y="36">file · stream · string</text>
+    </g>
+
+    <line class="wt" x1="180" y1="93" x2="220" y2="93" marker-end="url(#cpt-a)"/>
+
+    <g transform="translate(220 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">BoduConfigurationReader</text>
+      <text class="mut" x="80" y="36">tokenise + diagnose</text>
+    </g>
+
+    <line class="wt" x1="380" y1="93" x2="420" y2="93" marker-end="url(#cpt-a)"/>
+
+    <g transform="translate(420 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">ParseOptions / Profile</text>
+      <text class="mut" x="80" y="36">Bodu · Strict · EditorConfig</text>
+    </g>
+
+    <line class="wt" x1="580" y1="93" x2="620" y2="93" marker-end="url(#cpt-a)"/>
+
+    <g transform="translate(620 70)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">IniDocument</text>
+      <text class="mut" x="80" y="36">preamble + sections</text>
+    </g>
+
+    <!-- ===== Middle separator ===== -->
+    <line x1="20" y1="138" x2="780" y2="138" stroke="#334155" stroke-width="1"/>
+
+    <!-- ===== Bottom row — RESOLVE (left-to-right, purple) ===== -->
+    <text class="rowd" x="20" y="160">RESOLVE  ▸ IniDocument + targetPath → typed values</text>
+
+    <g transform="translate(20 172)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">IniDocument</text>
+      <text class="mut" x="80" y="36">+ targetPath</text>
+    </g>
+
+    <line class="wp" x1="180" y1="195" x2="220" y2="195" marker-end="url(#cpd-a)"/>
+
+    <g transform="translate(220 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">BoduConfigurationResolver</text>
+      <text class="mut" x="80" y="36">preamble + matched globs</text>
+    </g>
+
+    <line class="wp" x1="380" y1="195" x2="420" y2="195" marker-end="url(#cpd-a)"/>
+
+    <g transform="translate(420 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">BoduConfigurationView</text>
+      <text class="mut" x="80" y="36">flat colon-delimited keys</text>
+    </g>
+
+    <line class="wp" x1="580" y1="195" x2="620" y2="195" marker-end="url(#cpd-a)"/>
+
+    <g transform="translate(620 172)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">Typed value</text>
+      <text class="mut" x="80" y="36">GetString · GetValue&lt;T&gt;</text>
+    </g>
+
+    <!-- Footer note -->
+    <text class="mut" x="400" y="244" text-anchor="middle">ParseWithDiagnostics returns a BoduConfigurationParseResult under Collect mode; TryGetXxx never throws on missing or malformed values.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for two new packages in the Bodu suite:
- **Bodu.Text.Configuration** — the configuration-layering package that parses INI/EditorConfig-style text, resolves it for target paths, and projects it into a flat colon-delimited view
- **Bodu.Extensions.Configuration.Text** — the bridge that integrates Bodu.Text.Configuration with Microsoft.Extensions.Configuration

## Changes

### Documentation Structure

**Bodu.Text.Configuration**
- `docs/docs/text-configuration/index.md` — Introduction covering the core mental model, pipeline diagram, and shape of the library
- `docs/docs/text-configuration/concepts.md` — Vocabulary reference (document, view, profile, parse/resolve/write options, key mapping, glob patterns, preamble, target path, diagnostic mode, unset)
- `docs/docs/text-configuration/getting-started.md` — Installation and minimal samples (parse-resolve-read, profile presets, diagnostics, round-trip save, file/stream loading, resolve options, save)
- `docs/apidoc/Bodu.Text.Configuration.md` — API documentation index with key types and links to static docs
- `docs/guides/text-configuration/index.md` — Guide overview page
- `docs/guides/text-configuration/toc.yml` — Guide table of contents

**Bodu.Extensions.Configuration.Text**
- `docs/docs/extensions-configuration-text/index.md` — Introduction covering the bridge role, core mental model, and shape of the library
- `docs/docs/extensions-configuration-text/concepts.md` — Vocabulary reference (source vs provider vs loader, file vs stream source, target path, parse/resolve option propagation, reload-on-change, options binding)
- `docs/docs/extensions-configuration-text/getting-started.md` — Installation and minimal samples (add configuration file, conventional probe, anchor glob resolution, configure via callback, load from stream, bind to POCO via DI, combine with other providers)
- `docs/apidoc/Bodu.Extensions.Configuration.Text.md` — API documentation index with key types and links to static docs
- `docs/guides/extensions-configuration-text/index.md` — Guide overview page
- `docs/guides/extensions-configuration-text/toc.yml` — Guide table of contents

### Diagrams

Three SVG diagrams illustrating the architecture:
- `docs/images/diagrams/text-configuration-pipeline.svg` — Four-stage pipeline (reader → document → resolver → view → typed accessors)
- `docs/images/diagrams/text-configuration-layering.svg` — Resolution layering showing how preamble and glob-matched sections combine in source order
- `docs/images/diagrams/extensions-configuration-text-flow.svg` — Bridge flow from IConfigurationBuilder through source/provider to IConfiguration and IOptions

### Navigation Updates

- `docs/docs/toc.yml` — Added Bodu.Text.Configuration section with Introduction, Core concepts, and Getting started links
- `docs/guides/toc.yml` — Added Bodu.Text.Configuration guide section
- Updated cross-references in existing `Bodu.Text.Formats` and `Bodu.Text.Encoding` documentation to link to the new packages

## Implementation Details

- All documentation follows the established pattern: introduction → core concepts → getting started → API index → guides
- Minimal samples are runnable and demonstrate the most common use cases
- Vocabulary is consistent across both packages and cross-referenced appropriately
- Diagrams use the existing Bodu visual style (dark theme, teal/blue/purple/amber color scheme)
- API documentation indexes link to both static docs and key types with cross-references

https://claude.ai/code/session_01DwscDfwBc9SswLb9WwNCKa