### PR TITLE
Add fluent extension methods over Text.Formats types

### DIFF
--- a/Bodu.Text.Formats/src/Text.Formats.Extensions/BencodeExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Formats.Extensions/BencodeExtensions.cs
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BencodeExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Provides fluent extension methods on <see cref="byte" /> arrays, <see cref="ReadOnlySpan{T}" /> of byte, and
+/// <see cref="BencodedValue" /> that route through the canonical <see cref="Bencode" /> decoder and encoder.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These extensions exist purely for ergonomic discoverability — typing <c>bytes.</c> in an editor brings up
+/// <c>ParseBencode</c> and <c>TryParseBencode</c>, and typing <c>value.</c> on a <see cref="BencodedValue" /> brings up
+/// <c>FormatBencode</c>, <c>TryFormatBencode</c>, and <c>GetBencodedLength</c>. They delegate without overhead to the
+/// static <see cref="Bencode" /> class.
+/// </para>
+/// </remarks>
+/// <example>
+///<![CDATA[
+/// // Parse and round-trip via the receiver-typed extensions.
+/// byte[] payload = File.ReadAllBytes("example.torrent");
+/// BencodedValue root = payload.ParseBencode();
+/// byte[] reencoded = root.FormatBencode();
+///]]>
+/// </example>
+public static class BencodeExtensions
+{
+    /// <summary>
+    /// Decodes a complete bencoded document from the specified byte span.
+    /// </summary>
+    /// <param name="source">The bencoded source bytes.</param>
+    /// <returns>The decoded value.</returns>
+    /// <exception cref="BencodeFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or contains trailing bytes.
+    /// </exception>
+    public static BencodedValue ParseBencode(this ReadOnlySpan<byte> source) =>
+        Bencode.Decode(source);
+
+    /// <summary>
+    /// Decodes a complete bencoded document from the specified byte array.
+    /// </summary>
+    /// <param name="source">The bencoded source bytes.</param>
+    /// <returns>The decoded value.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="BencodeFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or contains trailing bytes.
+    /// </exception>
+    public static BencodedValue ParseBencode(this byte[] source) =>
+        Bencode.Decode(source);
+
+    /// <summary>
+    /// Attempts to decode a single bencoded value from the specified byte span.
+    /// </summary>
+    /// <param name="source">The bencoded source bytes.</param>
+    /// <param name="value">When this method returns, contains the decoded value, when successful.</param>
+    /// <param name="bytesConsumed">When this method returns, contains the number of bytes consumed.</param>
+    /// <returns><see langword="true" /> when a value was decoded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseBencode(
+        this ReadOnlySpan<byte> source,
+        [NotNullWhen(true)] out BencodedValue? value,
+        out int bytesConsumed) =>
+        Bencode.TryDecode(source, out value, out bytesConsumed);
+
+    /// <summary>
+    /// Encodes the specified bencoded value into a new byte array.
+    /// </summary>
+    /// <param name="value">The value to encode.</param>
+    /// <returns>The encoded bytes.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OverflowException">
+    /// Thrown when the encoded length exceeds <see cref="int.MaxValue" />.
+    /// </exception>
+    public static byte[] FormatBencode(this BencodedValue value) =>
+        Bencode.Encode(value);
+
+    /// <summary>
+    /// Attempts to encode the specified bencoded value into the supplied destination buffer.
+    /// </summary>
+    /// <param name="value">The value to encode.</param>
+    /// <param name="destination">The destination buffer.</param>
+    /// <param name="bytesWritten">When this method returns, contains the number of bytes written.</param>
+    /// <returns>
+    /// <see langword="true" /> when the value was encoded; otherwise, <see langword="false" /> when the destination
+    /// buffer is too small.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OverflowException">
+    /// Thrown when the encoded length exceeds <see cref="int.MaxValue" />.
+    /// </exception>
+    public static bool TryFormatBencode(
+        this BencodedValue value,
+        Span<byte> destination,
+        out int bytesWritten) =>
+        Bencode.TryEncode(value, destination, out bytesWritten);
+
+    /// <summary>
+    /// Gets the exact number of bytes required to encode the specified value.
+    /// </summary>
+    /// <param name="value">The value to measure.</param>
+    /// <returns>The exact encoded length, in bytes.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="value" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="OverflowException">
+    /// Thrown when the encoded length exceeds <see cref="int.MaxValue" />.
+    /// </exception>
+    public static int GetBencodedLength(this BencodedValue value) =>
+        Bencode.GetEncodedLength(value);
+}

--- a/Bodu.Text.Formats/src/Text.Formats.Extensions/DelimitedExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Formats.Extensions/DelimitedExtensions.cs
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DelimitedExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Provides fluent extension methods on <see cref="string" />, <see cref="ReadOnlySpan{T}" /> of <see cref="char" />,
+/// and <see cref="DelimitedDocument" /> that route through the canonical <see cref="Delimited" /> parser and formatter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These extensions exist purely for ergonomic discoverability — typing <c>text.</c> in an editor brings up
+/// <c>ParseDelimited</c> and <c>TryParseDelimited</c>, and typing <c>document.</c> on a
+/// <see cref="DelimitedDocument" /> brings up <c>FormatDelimited</c>. They delegate without overhead to the static
+/// <see cref="Delimited" /> class.
+/// </para>
+/// </remarks>
+/// <example>
+///<![CDATA[
+/// // Parse a CSV document and round-trip back to text via the receiver-typed extensions.
+/// DelimitedDocument doc = "name,age\nAda,42".ParseDelimited();
+/// string text = doc.FormatDelimited();
+///]]>
+/// </example>
+public static class DelimitedExtensions
+{
+    /// <summary>
+    /// Parses a delimited-text document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <returns>The parsed <see cref="DelimitedDocument" />.</returns>
+    /// <exception cref="DelimitedFormatException">
+    /// Thrown when <paramref name="source" /> contains a structural error, such as an unterminated quoted field.
+    /// </exception>
+    public static DelimitedDocument ParseDelimited(this ReadOnlySpan<char> source) =>
+        Delimited.Parse(source);
+
+    /// <summary>
+    /// Parses a delimited-text document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="DelimitedDocument" />.</returns>
+    /// <exception cref="DelimitedFormatException">
+    /// Thrown when <paramref name="source" /> contains a structural error.
+    /// </exception>
+    public static DelimitedDocument ParseDelimited(this ReadOnlySpan<char> source, DelimitedParseOptions options) =>
+        Delimited.Parse(source, options);
+
+    /// <summary>
+    /// Parses a delimited-text document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <returns>The parsed <see cref="DelimitedDocument" />.</returns>
+    /// <exception cref="DelimitedFormatException">
+    /// Thrown when <paramref name="source" /> contains a structural error, such as an unterminated quoted field.
+    /// </exception>
+    public static DelimitedDocument ParseDelimited(this string source) =>
+        Delimited.Parse(source);
+
+    /// <summary>
+    /// Parses a delimited-text document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="DelimitedDocument" />.</returns>
+    /// <exception cref="DelimitedFormatException">
+    /// Thrown when <paramref name="source" /> contains a structural error.
+    /// </exception>
+    public static DelimitedDocument ParseDelimited(this string source, DelimitedParseOptions options) =>
+        Delimited.Parse(source, options);
+
+    /// <summary>
+    /// Attempts to parse a delimited-text document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDelimited(
+        this ReadOnlySpan<char> source,
+        [NotNullWhen(true)] out DelimitedDocument? document) =>
+        Delimited.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse a delimited-text document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDelimited(
+        this ReadOnlySpan<char> source,
+        DelimitedParseOptions options,
+        [NotNullWhen(true)] out DelimitedDocument? document) =>
+        Delimited.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Attempts to parse a delimited-text document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDelimited(
+        this string source,
+        [NotNullWhen(true)] out DelimitedDocument? document) =>
+        Delimited.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse a delimited-text document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The delimited source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDelimited(
+        this string source,
+        DelimitedParseOptions options,
+        [NotNullWhen(true)] out DelimitedDocument? document) =>
+        Delimited.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Renders the specified <see cref="DelimitedDocument" /> back to delimited text using default options.
+    /// </summary>
+    /// <param name="document">The document to format.</param>
+    /// <returns>A string containing the formatted representation of <paramref name="document" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="document" /> is <see langword="null" />.
+    /// </exception>
+    public static string FormatDelimited(this DelimitedDocument document) =>
+        Delimited.Format(document);
+
+    /// <summary>
+    /// Renders the specified <see cref="DelimitedDocument" /> back to delimited text using the supplied options.
+    /// </summary>
+    /// <param name="document">The document to format.</param>
+    /// <param name="options">
+    /// Options whose <see cref="DelimitedParseOptions.Delimiter" /> and <see cref="DelimitedParseOptions.Quote" />
+    /// properties govern the output format.
+    /// </param>
+    /// <returns>A string containing the formatted representation of <paramref name="document" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="document" /> is <see langword="null" />.
+    /// </exception>
+    public static string FormatDelimited(this DelimitedDocument document, DelimitedParseOptions options) =>
+        Delimited.Format(document, options);
+}

--- a/Bodu.Text.Formats/src/Text.Formats.Extensions/DotEnvExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Formats.Extensions/DotEnvExtensions.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DotEnvExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Provides fluent extension methods on <see cref="string" />, <see cref="ReadOnlySpan{T}" /> of <see cref="char" />,
+/// and <see cref="DotEnvDocument" /> that route through the canonical <see cref="DotEnv" /> parser and formatter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These extensions exist purely for ergonomic discoverability — typing <c>text.</c> in an editor brings up
+/// <c>ParseDotEnv</c> and <c>TryParseDotEnv</c>, and typing <c>document.</c> on a <see cref="DotEnvDocument" /> brings
+/// up <c>FormatDotEnv</c>. They delegate without overhead to the static <see cref="DotEnv" /> class.
+/// </para>
+/// </remarks>
+/// <example>
+///<![CDATA[
+/// // Parse and round-trip via the receiver-typed extensions.
+/// DotEnvDocument doc = "PORT=8080\nHOST=localhost".ParseDotEnv();
+/// string text = doc.FormatDotEnv();
+///]]>
+/// </example>
+public static class DotEnvExtensions
+{
+    /// <summary>
+    /// Parses a DotEnv document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <returns>The parsed <see cref="DotEnvDocument" />.</returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static DotEnvDocument ParseDotEnv(this ReadOnlySpan<char> source) =>
+        DotEnv.Parse(source);
+
+    /// <summary>
+    /// Parses a DotEnv document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="DotEnvDocument" />.</returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static DotEnvDocument ParseDotEnv(this ReadOnlySpan<char> source, DotEnvParseOptions options) =>
+        DotEnv.Parse(source, options);
+
+    /// <summary>
+    /// Parses a DotEnv document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <returns>The parsed <see cref="DotEnvDocument" />.</returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static DotEnvDocument ParseDotEnv(this string source) =>
+        DotEnv.Parse(source);
+
+    /// <summary>
+    /// Parses a DotEnv document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="DotEnvDocument" />.</returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static DotEnvDocument ParseDotEnv(this string source, DotEnvParseOptions options) =>
+        DotEnv.Parse(source, options);
+
+    /// <summary>
+    /// Attempts to parse a DotEnv document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDotEnv(
+        this ReadOnlySpan<char> source,
+        [NotNullWhen(true)] out DotEnvDocument? document) =>
+        DotEnv.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse a DotEnv document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDotEnv(
+        this ReadOnlySpan<char> source,
+        DotEnvParseOptions options,
+        [NotNullWhen(true)] out DotEnvDocument? document) =>
+        DotEnv.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Attempts to parse a DotEnv document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDotEnv(
+        this string source,
+        [NotNullWhen(true)] out DotEnvDocument? document) =>
+        DotEnv.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse a DotEnv document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The DotEnv source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseDotEnv(
+        this string source,
+        DotEnvParseOptions options,
+        [NotNullWhen(true)] out DotEnvDocument? document) =>
+        DotEnv.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Renders the specified <see cref="DotEnvDocument" /> back to DotEnv text.
+    /// </summary>
+    /// <param name="document">The document to format.</param>
+    /// <returns>A string containing the formatted DotEnv representation of <paramref name="document" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="document" /> is <see langword="null" />.
+    /// </exception>
+    public static string FormatDotEnv(this DotEnvDocument document) =>
+        DotEnv.Format(document);
+}

--- a/Bodu.Text.Formats/src/Text.Formats.Extensions/IniExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Formats.Extensions/IniExtensions.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IniExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Provides fluent extension methods on <see cref="string" />, <see cref="ReadOnlySpan{T}" /> of <see cref="char" />,
+/// and <see cref="IniDocument" /> that route through the canonical <see cref="Ini" /> parser and formatter.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These extensions exist purely for ergonomic discoverability — typing <c>text.</c> in an editor brings up
+/// <c>ParseIni</c> and <c>TryParseIni</c>, and typing <c>document.</c> on an <see cref="IniDocument" /> brings up
+/// <c>FormatIni</c>. They delegate without overhead to the static <see cref="Ini" /> class.
+/// </para>
+/// </remarks>
+/// <example>
+///<![CDATA[
+/// // Parse and round-trip via the receiver-typed extensions.
+/// IniDocument doc = "[database]\nhost=localhost".ParseIni();
+/// string text = doc.FormatIni();
+///
+/// // Non-throwing variant.
+/// if (source.ParseIni() is { Sections.Count: > 0 } parsed) { /* ... */ }
+///]]>
+/// </example>
+public static class IniExtensions
+{
+    /// <summary>
+    /// Parses an INI document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <returns>The parsed <see cref="IniDocument" />.</returns>
+    /// <exception cref="IniFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static IniDocument ParseIni(this ReadOnlySpan<char> source) =>
+        Ini.Parse(source);
+
+    /// <summary>
+    /// Parses an INI document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="IniDocument" />.</returns>
+    /// <exception cref="IniFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static IniDocument ParseIni(this ReadOnlySpan<char> source, IniParseOptions options) =>
+        Ini.Parse(source, options);
+
+    /// <summary>
+    /// Parses an INI document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <returns>The parsed <see cref="IniDocument" />.</returns>
+    /// <exception cref="IniFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static IniDocument ParseIni(this string source) =>
+        Ini.Parse(source);
+
+    /// <summary>
+    /// Parses an INI document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <returns>The parsed <see cref="IniDocument" />.</returns>
+    /// <exception cref="IniFormatException">
+    /// Thrown when <paramref name="source" /> is malformed or violates the configured parsing policy.
+    /// </exception>
+    public static IniDocument ParseIni(this string source, IniParseOptions options) =>
+        Ini.Parse(source, options);
+
+    /// <summary>
+    /// Attempts to parse an INI document from the specified character span using default options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseIni(
+        this ReadOnlySpan<char> source,
+        [NotNullWhen(true)] out IniDocument? document) =>
+        Ini.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse an INI document from the specified character span using the supplied options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseIni(
+        this ReadOnlySpan<char> source,
+        IniParseOptions options,
+        [NotNullWhen(true)] out IniDocument? document) =>
+        Ini.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Attempts to parse an INI document from the specified string using default options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseIni(
+        this string source,
+        [NotNullWhen(true)] out IniDocument? document) =>
+        Ini.TryParse(source, out document);
+
+    /// <summary>
+    /// Attempts to parse an INI document from the specified string using the supplied options.
+    /// </summary>
+    /// <param name="source">The INI source text.</param>
+    /// <param name="options">Options that control how the source is interpreted.</param>
+    /// <param name="document">
+    /// When this method returns <see langword="true" />, contains the parsed document; otherwise,
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns><see langword="true" /> when parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParseIni(
+        this string source,
+        IniParseOptions options,
+        [NotNullWhen(true)] out IniDocument? document) =>
+        Ini.TryParse(source, options, out document);
+
+    /// <summary>
+    /// Renders the specified <see cref="IniDocument" /> back to INI text.
+    /// </summary>
+    /// <param name="document">The document to format.</param>
+    /// <returns>A string containing the formatted INI representation of <paramref name="document" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="document" /> is <see langword="null" />.
+    /// </exception>
+    public static string FormatIni(this IniDocument document) =>
+        Ini.Format(document);
+}

--- a/Bodu.Text.Formats/test/Text.Formats.Extensions/BencodeExtensionsTests.cs
+++ b/Bodu.Text.Formats/test/Text.Formats.Extensions/BencodeExtensionsTests.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BencodeExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Behavioural tests for <see cref="BencodeExtensions" />.
+/// </summary>
+[TestClass]
+public sealed class BencodeExtensionsTests
+{
+    private static readonly byte[] CanonicalEncodedInteger = "i42e"u8.ToArray();
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.ParseBencode(ReadOnlySpan{byte})" /> produces the same value as the
+    /// canonical <see cref="Bencode.Decode(ReadOnlySpan{byte})" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseBencode_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        BencodedValue fromExtension = ((ReadOnlySpan<byte>)CanonicalEncodedInteger).ParseBencode();
+        BencodedValue fromStatic = Bencode.Decode(CanonicalEncodedInteger);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.ParseBencode(byte[])" /> produces the same value as the canonical
+    /// static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseBencode_OnByteArray_ShouldMatchStaticCanonical()
+    {
+        BencodedValue fromExtension = CanonicalEncodedInteger.ParseBencode();
+        BencodedValue fromStatic = Bencode.Decode(CanonicalEncodedInteger);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.ParseBencode(byte[])" /> throws
+    /// <see cref="ArgumentNullException" /> when the receiver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ParseBencode_OnByteArray_WhenSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ((byte[])null!).ParseBencode();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.TryParseBencode(ReadOnlySpan{byte}, out BencodedValue?, out int)" />
+    /// returns <see langword="true" /> and yields the same value and consumed-byte count as the canonical static
+    /// <see cref="Bencode.TryDecode(ReadOnlySpan{byte}, out BencodedValue?, out int)" /> method.
+    /// </summary>
+    [TestMethod]
+    public void TryParseBencode_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        var extSuccess = ((ReadOnlySpan<byte>)CanonicalEncodedInteger)
+            .TryParseBencode(out BencodedValue? extValue, out var extBytesConsumed);
+        var staticSuccess = Bencode.TryDecode(
+            CanonicalEncodedInteger, out BencodedValue? staticValue, out var staticBytesConsumed);
+
+        Assert.AreEqual(staticSuccess, extSuccess);
+        Assert.AreEqual(staticBytesConsumed, extBytesConsumed);
+        Assert.AreEqual(staticValue, extValue);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.FormatBencode(BencodedValue)" /> returns the same bytes as the
+    /// canonical <see cref="Bencode.Encode(BencodedValue)" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void FormatBencode_OnBencodedValue_ShouldMatchStaticCanonical()
+    {
+        BencodedValue value = new BencodedInteger(42);
+
+        var fromExtension = value.FormatBencode();
+        var fromStatic = Bencode.Encode(value);
+
+        CollectionAssert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.TryFormatBencode(BencodedValue, Span{byte}, out int)" /> matches the
+    /// canonical static <see cref="Bencode.TryEncode(BencodedValue, Span{byte}, out int)" /> method.
+    /// </summary>
+    [TestMethod]
+    public void TryFormatBencode_OnBencodedValue_ShouldMatchStaticCanonical()
+    {
+        BencodedValue value = new BencodedInteger(42);
+        Span<byte> extBuffer = stackalloc byte[16];
+        Span<byte> staticBuffer = stackalloc byte[16];
+
+        var extSuccess = value.TryFormatBencode(extBuffer, out var extWritten);
+        var staticSuccess = Bencode.TryEncode(value, staticBuffer, out var staticWritten);
+
+        Assert.AreEqual(staticSuccess, extSuccess);
+        Assert.AreEqual(staticWritten, extWritten);
+        Assert.IsTrue(extBuffer[..extWritten].SequenceEqual(staticBuffer[..staticWritten]));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.GetBencodedLength(BencodedValue)" /> matches the canonical static
+    /// <see cref="Bencode.GetEncodedLength(BencodedValue)" /> method.
+    /// </summary>
+    [TestMethod]
+    public void GetBencodedLength_OnBencodedValue_ShouldMatchStaticCanonical()
+    {
+        BencodedValue value = new BencodedInteger(42);
+
+        var fromExtension = value.GetBencodedLength();
+        var fromStatic = Bencode.GetEncodedLength(value);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ParseBencode</c> followed by <c>FormatBencode</c> round-trips a value through the extension
+    /// surface.
+    /// </summary>
+    [TestMethod]
+    public void ParseBencodeThenFormatBencode_ShouldRoundTrip()
+    {
+        BencodedValue first = CanonicalEncodedInteger.ParseBencode();
+        var emitted = first.FormatBencode();
+        BencodedValue second = emitted.ParseBencode();
+
+        Assert.AreEqual(first, second);
+        CollectionAssert.AreEqual(CanonicalEncodedInteger, emitted);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BencodeExtensions.FormatBencode(BencodedValue)" /> throws
+    /// <see cref="ArgumentNullException" /> when the receiver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void FormatBencode_WhenValueIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ((BencodedValue)null!).FormatBencode();
+        });
+    }
+}

--- a/Bodu.Text.Formats/test/Text.Formats.Extensions/DelimitedExtensionsTests.cs
+++ b/Bodu.Text.Formats/test/Text.Formats.Extensions/DelimitedExtensionsTests.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DelimitedExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Behavioural tests for <see cref="DelimitedExtensions" />.
+/// </summary>
+[TestClass]
+public sealed class DelimitedExtensionsTests
+{
+    private const string CanonicalSource = "name,age\nAda,42\nLinus,55";
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.ParseDelimited(ReadOnlySpan{char})" /> produces the same document
+    /// as the canonical <see cref="Delimited.Parse(ReadOnlySpan{char})" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseDelimited_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        DelimitedDocument fromExtension = CanonicalSource.AsSpan().ParseDelimited();
+        DelimitedDocument fromStatic = Delimited.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic.Rows.Count, fromExtension.Rows.Count);
+        Assert.AreEqual(fromStatic.Headers.Count, fromExtension.Headers.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.ParseDelimited(string)" /> produces the same document as the
+    /// canonical static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseDelimited_OnString_ShouldMatchStaticCanonical()
+    {
+        DelimitedDocument fromExtension = CanonicalSource.ParseDelimited();
+        DelimitedDocument fromStatic = Delimited.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic.Rows.Count, fromExtension.Rows.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.ParseDelimited(string, DelimitedParseOptions)" /> respects the
+    /// supplied options.
+    /// </summary>
+    [TestMethod]
+    public void ParseDelimited_OnStringWithOptions_ShouldRespectOptions()
+    {
+        DelimitedParseOptions options = new() { Delimiter = '\t', HasHeader = false };
+        const string tsv = "Ada\t42\nLinus\t55";
+
+        DelimitedDocument fromExtension = tsv.ParseDelimited(options);
+        DelimitedDocument fromStatic = Delimited.Parse(tsv, options);
+
+        Assert.AreEqual(fromStatic.Rows.Count, fromExtension.Rows.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.TryParseDelimited(string, out DelimitedDocument?)" /> returns
+    /// <see langword="true" /> and produces a document for valid input.
+    /// </summary>
+    [TestMethod]
+    public void TryParseDelimited_OnString_WhenInputIsValid_ShouldReturnTrue()
+    {
+        var success = CanonicalSource.TryParseDelimited(out DelimitedDocument? document);
+
+        Assert.IsTrue(success);
+        Assert.IsNotNull(document);
+        Assert.AreEqual(2, document.Rows.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.TryParseDelimited(ReadOnlySpan{char}, out DelimitedDocument?)" />
+    /// matches the canonical static
+    /// <see cref="Delimited.TryParse(ReadOnlySpan{char}, out DelimitedDocument?)" /> outcome.
+    /// </summary>
+    [TestMethod]
+    public void TryParseDelimited_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        var extSuccess = CanonicalSource.AsSpan().TryParseDelimited(out DelimitedDocument? extDocument);
+        var staticSuccess = Delimited.TryParse(CanonicalSource, out DelimitedDocument? staticDocument);
+
+        Assert.AreEqual(staticSuccess, extSuccess);
+        Assert.AreEqual(staticDocument!.Rows.Count, extDocument!.Rows.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.FormatDelimited(DelimitedDocument)" /> returns the same text as the
+    /// canonical <see cref="Delimited.Format(DelimitedDocument)" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void FormatDelimited_OnDelimitedDocument_ShouldMatchStaticCanonical()
+    {
+        DelimitedDocument document = Delimited.Parse(CanonicalSource);
+
+        var fromExtension = document.FormatDelimited();
+        var fromStatic = Delimited.Format(document);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.FormatDelimited(DelimitedDocument, DelimitedParseOptions)" />
+    /// matches the canonical static method when options are supplied.
+    /// </summary>
+    [TestMethod]
+    public void FormatDelimited_OnDelimitedDocumentWithOptions_ShouldMatchStaticCanonical()
+    {
+        DelimitedDocument document = Delimited.Parse(CanonicalSource);
+        DelimitedParseOptions options = new() { Delimiter = '\t' };
+
+        var fromExtension = document.FormatDelimited(options);
+        var fromStatic = Delimited.Format(document, options);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ParseDelimited</c> followed by <c>FormatDelimited</c> round-trips a delimited document through
+    /// the extension surface.
+    /// </summary>
+    [TestMethod]
+    public void ParseDelimitedThenFormatDelimited_ShouldRoundTrip()
+    {
+        DelimitedDocument first = CanonicalSource.ParseDelimited();
+        var emitted = first.FormatDelimited();
+        DelimitedDocument second = emitted.ParseDelimited();
+
+        Assert.AreEqual(first.Rows.Count, second.Rows.Count);
+        Assert.AreEqual(first.Headers.Count, second.Headers.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedExtensions.FormatDelimited(DelimitedDocument)" /> throws
+    /// <see cref="ArgumentNullException" /> when the receiver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void FormatDelimited_WhenDocumentIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ((DelimitedDocument)null!).FormatDelimited();
+        });
+    }
+}

--- a/Bodu.Text.Formats/test/Text.Formats.Extensions/DotEnvExtensionsTests.cs
+++ b/Bodu.Text.Formats/test/Text.Formats.Extensions/DotEnvExtensionsTests.cs
@@ -1,0 +1,129 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DotEnvExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Behavioural tests for <see cref="DotEnvExtensions" />.
+/// </summary>
+[TestClass]
+public sealed class DotEnvExtensionsTests
+{
+    private const string CanonicalSource = "PORT=8080\nHOST=localhost";
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.ParseDotEnv(ReadOnlySpan{char})" /> produces the same document as the
+    /// canonical <see cref="DotEnv.Parse(ReadOnlySpan{char})" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseDotEnv_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        DotEnvDocument fromExtension = CanonicalSource.AsSpan().ParseDotEnv();
+        DotEnvDocument fromStatic = DotEnv.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic["PORT"], fromExtension["PORT"]);
+        Assert.AreEqual(fromStatic["HOST"], fromExtension["HOST"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.ParseDotEnv(string)" /> produces the same document as the canonical
+    /// static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseDotEnv_OnString_ShouldMatchStaticCanonical()
+    {
+        DotEnvDocument fromExtension = CanonicalSource.ParseDotEnv();
+        DotEnvDocument fromStatic = DotEnv.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic["PORT"], fromExtension["PORT"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.ParseDotEnv(string, DotEnvParseOptions)" /> respects the supplied
+    /// options.
+    /// </summary>
+    [TestMethod]
+    public void ParseDotEnv_OnStringWithOptions_ShouldRespectOptions()
+    {
+        DotEnvParseOptions options = new();
+
+        DotEnvDocument fromExtension = CanonicalSource.ParseDotEnv(options);
+        DotEnvDocument fromStatic = DotEnv.Parse(CanonicalSource, options);
+
+        Assert.AreEqual(fromStatic.Entries.Count, fromExtension.Entries.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.TryParseDotEnv(string, out DotEnvDocument?)" /> returns
+    /// <see langword="true" /> and produces a document for valid input.
+    /// </summary>
+    [TestMethod]
+    public void TryParseDotEnv_OnString_WhenInputIsValid_ShouldReturnTrue()
+    {
+        var success = CanonicalSource.TryParseDotEnv(out DotEnvDocument? document);
+
+        Assert.IsTrue(success);
+        Assert.IsNotNull(document);
+        Assert.AreEqual("8080", document["PORT"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.TryParseDotEnv(ReadOnlySpan{char}, out DotEnvDocument?)" /> matches
+    /// the canonical static <see cref="DotEnv.TryParse(ReadOnlySpan{char}, out DotEnvDocument?)" /> outcome.
+    /// </summary>
+    [TestMethod]
+    public void TryParseDotEnv_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        var extSuccess = CanonicalSource.AsSpan().TryParseDotEnv(out DotEnvDocument? extDocument);
+        var staticSuccess = DotEnv.TryParse(CanonicalSource, out DotEnvDocument? staticDocument);
+
+        Assert.AreEqual(staticSuccess, extSuccess);
+        Assert.AreEqual(staticDocument!["PORT"], extDocument!["PORT"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.FormatDotEnv(DotEnvDocument)" /> returns the same text as the
+    /// canonical <see cref="DotEnv.Format(DotEnvDocument)" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void FormatDotEnv_OnDotEnvDocument_ShouldMatchStaticCanonical()
+    {
+        DotEnvDocument document = DotEnv.Parse(CanonicalSource);
+
+        var fromExtension = document.FormatDotEnv();
+        var fromStatic = DotEnv.Format(document);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ParseDotEnv</c> followed by <c>FormatDotEnv</c> round-trips a DotEnv document through the
+    /// extension surface.
+    /// </summary>
+    [TestMethod]
+    public void ParseDotEnvThenFormatDotEnv_ShouldRoundTrip()
+    {
+        DotEnvDocument first = CanonicalSource.ParseDotEnv();
+        var emitted = first.FormatDotEnv();
+        DotEnvDocument second = emitted.ParseDotEnv();
+
+        Assert.AreEqual(first["PORT"], second["PORT"]);
+        Assert.AreEqual(first["HOST"], second["HOST"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DotEnvExtensions.FormatDotEnv(DotEnvDocument)" /> throws
+    /// <see cref="ArgumentNullException" /> when the receiver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void FormatDotEnv_WhenDocumentIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ((DotEnvDocument)null!).FormatDotEnv();
+        });
+    }
+}

--- a/Bodu.Text.Formats/test/Text.Formats.Extensions/IniExtensionsTests.cs
+++ b/Bodu.Text.Formats/test/Text.Formats.Extensions/IniExtensionsTests.cs
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IniExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Text.Formats;
+
+/// <summary>
+/// Behavioural tests for <see cref="IniExtensions" />.
+/// </summary>
+[TestClass]
+public sealed class IniExtensionsTests
+{
+    private const string CanonicalSource = "[database]\nhost=localhost\nport=5432";
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.ParseIni(ReadOnlySpan{char})" /> produces the same document as the
+    /// canonical <see cref="Ini.Parse(ReadOnlySpan{char})" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void ParseIni_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        IniDocument fromExtension = CanonicalSource.AsSpan().ParseIni();
+        IniDocument fromStatic = Ini.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic.Sections.Count, fromExtension.Sections.Count);
+        Assert.AreEqual(fromStatic.GetSection("database")!["host"], fromExtension.GetSection("database")!["host"]);
+        Assert.AreEqual(fromStatic.GetSection("database")!["port"], fromExtension.GetSection("database")!["port"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.ParseIni(string)" /> produces the same document as the canonical static
+    /// method.
+    /// </summary>
+    [TestMethod]
+    public void ParseIni_OnString_ShouldMatchStaticCanonical()
+    {
+        IniDocument fromExtension = CanonicalSource.ParseIni();
+        IniDocument fromStatic = Ini.Parse(CanonicalSource);
+
+        Assert.AreEqual(fromStatic.GetSection("database")!["host"], fromExtension.GetSection("database")!["host"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.ParseIni(string, IniParseOptions)" /> respects the supplied options.
+    /// </summary>
+    [TestMethod]
+    public void ParseIni_OnStringWithOptions_ShouldRespectOptions()
+    {
+        IniParseOptions options = new() { CaseSensitiveSections = true };
+
+        IniDocument fromExtension = CanonicalSource.ParseIni(options);
+        IniDocument fromStatic = Ini.Parse(CanonicalSource, options);
+
+        Assert.AreEqual(fromStatic.Sections.Count, fromExtension.Sections.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.TryParseIni(string, out IniDocument?)" /> returns <see langword="true" />
+    /// and produces a document for valid input.
+    /// </summary>
+    [TestMethod]
+    public void TryParseIni_OnString_WhenInputIsValid_ShouldReturnTrue()
+    {
+        var success = CanonicalSource.TryParseIni(out IniDocument? document);
+
+        Assert.IsTrue(success);
+        Assert.IsNotNull(document);
+        Assert.AreEqual("localhost", document.GetSection("database")!["host"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.TryParseIni(ReadOnlySpan{char}, out IniDocument?)" /> matches the
+    /// canonical static <see cref="Ini.TryParse(ReadOnlySpan{char}, out IniDocument?)" /> outcome.
+    /// </summary>
+    [TestMethod]
+    public void TryParseIni_OnReadOnlySpan_ShouldMatchStaticCanonical()
+    {
+        var extSuccess = CanonicalSource.AsSpan().TryParseIni(out IniDocument? extDocument);
+        var staticSuccess = Ini.TryParse(CanonicalSource, out IniDocument? staticDocument);
+
+        Assert.AreEqual(staticSuccess, extSuccess);
+        Assert.AreEqual(
+            staticDocument!.GetSection("database")!["host"],
+            extDocument!.GetSection("database")!["host"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.FormatIni(IniDocument)" /> returns the same text as the canonical
+    /// <see cref="Ini.Format(IniDocument)" /> static method.
+    /// </summary>
+    [TestMethod]
+    public void FormatIni_OnIniDocument_ShouldMatchStaticCanonical()
+    {
+        IniDocument document = Ini.Parse(CanonicalSource);
+
+        var fromExtension = document.FormatIni();
+        var fromStatic = Ini.Format(document);
+
+        Assert.AreEqual(fromStatic, fromExtension);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ParseIni</c> followed by <c>FormatIni</c> round-trips an INI document through the extension
+    /// surface.
+    /// </summary>
+    [TestMethod]
+    public void ParseIniThenFormatIni_ShouldRoundTrip()
+    {
+        IniDocument first = CanonicalSource.ParseIni();
+        var emitted = first.FormatIni();
+        IniDocument second = emitted.ParseIni();
+
+        Assert.AreEqual(first.GetSection("database")!["host"], second.GetSection("database")!["host"]);
+        Assert.AreEqual(first.GetSection("database")!["port"], second.GetSection("database")!["port"]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IniExtensions.FormatIni(IniDocument)" /> throws
+    /// <see cref="ArgumentNullException" /> when the receiver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void FormatIni_WhenDocumentIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ((IniDocument)null!).FormatIni();
+        });
+    }
+}


### PR DESCRIPTION
Closes a consistency gap with Bodu.Text.Encoding (which already ships BinaryEncodingExtensions): Bencode, Delimited, Ini, and DotEnv now have parallel Parse/TryParse/Format extension surfaces on string, ReadOnlySpan<char>/byte, and the respective document types. The extensions are thin delegates to the canonical static factories and exist for ergonomic IntelliSense discoverability via receiver typing.