### PR TITLE
Add Bodu.Numerics with Fraction<T> exact-rational type

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -22,6 +22,7 @@ jobs:
     env:
       TEST_PROJECTS: >-
         Bodu.Core/test/Bodu.Core.Test.csproj
+        Bodu.Numerics/test/Bodu.Numerics.Test.csproj
         Bodu.Security.Cryptography/test/Bodu.Security.Cryptography.Test.csproj
         Bodu.IO.Hashing/test/Bodu.IO.Hashing.Test.csproj
         Bodu.Globalization.Calendar/test/Bodu.Globalization.Calendar.Test.csproj

--- a/Bodu.Numerics/src/Bodu.Numerics.csproj
+++ b/Bodu.Numerics/src/Bodu.Numerics.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Library</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
+    <Version>1.0.0</Version>
+    <Description>Numeric value primitives for .NET. Provides Fraction&lt;T&gt;, a generic exact-rational number type backed by any IBinaryInteger&lt;T&gt;.</Description>
+    <PackageTags>bodu;numerics;fraction;rational;ratio;bigrational;math</PackageTags>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Bodu.Numerics.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Numerics/src/Numerics/Fraction.Arithmetic.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Arithmetic.cs
@@ -1,0 +1,143 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Arithmetic.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T>
+{
+    /// <summary>
+    /// Adds two rational values.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>The canonical sum of <paramref name="left" /> and <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> Add(Fraction<T> left, Fraction<T> right) =>
+        left + right;
+
+    /// <summary>
+    /// Subtracts one rational value from another.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns>The canonical difference <paramref name="left" /> minus <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> Subtract(Fraction<T> left, Fraction<T> right) =>
+        left - right;
+
+    /// <summary>
+    /// Multiplies two rational values.
+    /// </summary>
+    /// <param name="left">The first factor.</param>
+    /// <param name="right">The second factor.</param>
+    /// <returns>The canonical product of <paramref name="left" /> and <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> Multiply(Fraction<T> left, Fraction<T> right) =>
+        left * right;
+
+    /// <summary>
+    /// Divides one rational value by another.
+    /// </summary>
+    /// <param name="left">The dividend.</param>
+    /// <param name="right">The divisor.</param>
+    /// <returns>The canonical quotient <paramref name="left" /> divided by <paramref name="right" />.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="right" /> is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> Divide(Fraction<T> left, Fraction<T> right) =>
+        left / right;
+
+    /// <summary>
+    /// Returns the additive inverse of this rational value.
+    /// </summary>
+    /// <returns>The canonical value with its sign reversed.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the negated numerator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public Fraction<T> Negate() =>
+        -this;
+
+    /// <summary>
+    /// Returns the absolute value of this rational value.
+    /// </summary>
+    /// <returns>The canonical magnitude of this value.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the magnitude of the numerator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public Fraction<T> Abs() =>
+        Sign < 0 ? FromBigInteger(-BigNumerator, BigDenominator) : this;
+
+    /// <summary>
+    /// Returns the multiplicative inverse of this rational value.
+    /// </summary>
+    /// <returns>The canonical value with its numerator and denominator exchanged.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if this value is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the reciprocal cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public Fraction<T> Reciprocal()
+    {
+        if (IsZero)
+            throw new DivideByZeroException("Cannot compute the reciprocal of zero.");
+
+        return FromBigInteger(BigDenominator, BigNumerator);
+    }
+
+    /// <summary>
+    /// Raises this rational value to the specified integer power.
+    /// </summary>
+    /// <param name="exponent">
+    /// The exponent. A negative value raises the reciprocal to the corresponding magnitude.
+    /// </param>
+    /// <returns>The canonical value of this rational raised to <paramref name="exponent" />.</returns>
+    /// <exception cref="DivideByZeroException">
+    /// Thrown if <paramref name="exponent" /> is negative and this value is zero.
+    /// </exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public Fraction<T> Pow(int exponent)
+    {
+        if (exponent == 0)
+            return One;
+
+        if (exponent < 0)
+        {
+            if (IsZero)
+                throw new DivideByZeroException("Cannot raise zero to a negative power.");
+
+            int magnitude = -exponent;
+            return FromBigInteger(
+                BigInteger.Pow(BigDenominator, magnitude),
+                BigInteger.Pow(BigNumerator, magnitude));
+        }
+
+        return FromBigInteger(
+            BigInteger.Pow(BigNumerator, exponent),
+            BigInteger.Pow(BigDenominator, exponent));
+    }
+
+    /// <summary>
+    /// Returns the remainder produced by dividing this rational value by another, with the sign of the dividend.
+    /// </summary>
+    /// <param name="divisor">The value to divide by.</param>
+    /// <returns>The canonical remainder of this value divided by <paramref name="divisor" />.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="divisor" /> is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public Fraction<T> Remainder(Fraction<T> divisor) =>
+        this % divisor;
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.ContinuedFraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.ContinuedFraction.cs
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.ContinuedFraction.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T>
+{
+    /// <summary>
+    /// Expands this rational value into the coefficients of its simple continued fraction.
+    /// </summary>
+    /// <returns>
+    /// The continued-fraction coefficients <c>[a0; a1, a2, ...]</c>, where the leading coefficient carries the sign and
+    /// every following coefficient is strictly positive.
+    /// </returns>
+    public T[] ToContinuedFraction()
+    {
+        List<T> coefficients = new List<T>();
+
+        BigInteger n = BigNumerator;
+        BigInteger d = BigDenominator;
+
+        while (!d.IsZero)
+        {
+            BigInteger a = FloorDivide(n, d);
+            coefficients.Add(T.CreateChecked(a));
+            (n, d) = (d, n - (a * d));
+        }
+
+        return coefficients.ToArray();
+    }
+
+    /// <summary>
+    /// Reconstructs a rational value from the coefficients of a simple continued fraction.
+    /// </summary>
+    /// <param name="coefficients">
+    /// The continued-fraction coefficients. The leading coefficient may carry any sign; every following coefficient
+    /// must be strictly positive.
+    /// </param>
+    /// <returns>The canonical rational value the coefficients describe.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="coefficients" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="coefficients" /> is empty.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if a coefficient after the first is not strictly positive.
+    /// </exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> FromContinuedFraction(params T[] coefficients)
+    {
+        ThrowHelper.ThrowIfNull(coefficients);
+        if (coefficients.Length == 0)
+            throw new ArgumentException("At least one coefficient is required.", nameof(coefficients));
+
+        for (int i = 1; i < coefficients.Length; i++)
+        {
+            if (T.IsZero(coefficients[i]) || T.IsNegative(coefficients[i]))
+                throw new ArgumentOutOfRangeException(nameof(coefficients), "Coefficients after the first must be strictly positive.");
+        }
+
+        Fraction<T> result = new Fraction<T>(coefficients[^1]);
+        for (int i = coefficients.Length - 2; i >= 0; i--)
+        {
+            result = new Fraction<T>(coefficients[i]) + result.Reciprocal();
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Returns the closest rational value whose denominator does not exceed the specified limit.
+    /// </summary>
+    /// <param name="maxDenominator">The largest denominator the approximation may use.</param>
+    /// <returns>
+    /// The best rational approximation of this value with a denominator no greater than
+    /// <paramref name="maxDenominator" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="maxDenominator" /> is less than one.
+    /// </exception>
+    /// <remarks>
+    /// The approximation is derived from the convergents of the continued-fraction expansion and is the closest
+    /// rational value subject to the denominator bound, matching the behaviour of the best-approximation algorithm used
+    /// by other rational-number libraries.
+    /// </remarks>
+    public Fraction<T> LimitDenominator(T maxDenominator)
+    {
+        if (T.IsZero(maxDenominator) || T.IsNegative(maxDenominator))
+            throw new ArgumentOutOfRangeException(nameof(maxDenominator), "The denominator limit must be at least one.");
+
+        BigInteger limit = BigInteger.CreateChecked(maxDenominator);
+        if (BigDenominator <= limit)
+            return this;
+
+        BigInteger p0 = BigInteger.Zero, q0 = BigInteger.One;
+        BigInteger p1 = BigInteger.One, q1 = BigInteger.Zero;
+        BigInteger n = BigNumerator, d = BigDenominator;
+
+        while (true)
+        {
+            BigInteger a = FloorDivide(n, d);
+            BigInteger q2 = q0 + (a * q1);
+            if (q2 > limit)
+                break;
+
+            (p0, q0, p1, q1) = (p1, q1, p0 + (a * p1), q2);
+            (n, d) = (d, n - (a * d));
+        }
+
+        BigInteger k = (limit - q0) / q1;
+        Fraction<T> bound1 = FromBigInteger(p0 + (k * p1), q0 + (k * q1));
+        Fraction<T> bound2 = FromBigInteger(p1, q1);
+
+        return (bound2 - this).Abs() <= (bound1 - this).Abs() ? bound2 : bound1;
+    }
+
+    /// <summary>
+    /// Divides one integer by another, rounding the quotient toward negative infinity.
+    /// </summary>
+    /// <param name="dividend">The value being divided.</param>
+    /// <param name="divisor">The strictly positive value to divide by.</param>
+    /// <returns>The floored quotient of <paramref name="dividend" /> divided by <paramref name="divisor" />.</returns>
+    private static BigInteger FloorDivide(BigInteger dividend, BigInteger divisor)
+    {
+        BigInteger quotient = BigInteger.DivRem(dividend, divisor, out BigInteger remainder);
+        if (!remainder.IsZero && remainder.Sign != divisor.Sign)
+            quotient -= BigInteger.One;
+
+        return quotient;
+    }
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Conversions.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Conversions.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Conversions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T>
+{
+    /// <summary>
+    /// Converts an integer of the backing type to a whole-number <see cref="Fraction{T}" />.
+    /// </summary>
+    /// <param name="value">The integer value to lift into a rational value.</param>
+    /// <returns>A <see cref="Fraction{T}" /> with denominator one.</returns>
+    public static implicit operator Fraction<T>(T value) =>
+        new Fraction<T>(value);
+
+    /// <summary>
+    /// Converts a <see cref="decimal" /> to its exact rational representation.
+    /// </summary>
+    /// <param name="value">The decimal value to convert.</param>
+    /// <returns>A <see cref="Fraction{T}" /> equal to <paramref name="value" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static explicit operator Fraction<T>(decimal value) =>
+        FromDecimal(value);
+
+    /// <summary>
+    /// Converts a finite <see cref="double" /> to its exact rational representation.
+    /// </summary>
+    /// <param name="value">The double-precision value to convert.</param>
+    /// <returns>A <see cref="Fraction{T}" /> equal to <paramref name="value" />.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value" /> is not a finite number.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static explicit operator Fraction<T>(double value) =>
+        FromDouble(value);
+
+    /// <summary>
+    /// Converts a rational value to the nearest <see cref="decimal" />.
+    /// </summary>
+    /// <param name="value">The rational value to convert.</param>
+    /// <returns>The decimal approximation of <paramref name="value" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if <paramref name="value" /> lies outside the range of <see cref="decimal" />.
+    /// </exception>
+    public static explicit operator decimal(Fraction<T> value) =>
+        value.ToDecimal();
+
+    /// <summary>
+    /// Converts a rational value to the nearest <see cref="double" />.
+    /// </summary>
+    /// <param name="value">The rational value to convert.</param>
+    /// <returns>The double-precision approximation of <paramref name="value" />.</returns>
+    public static explicit operator double(Fraction<T> value) =>
+        value.ToDouble();
+
+    /// <summary>
+    /// Converts a <see cref="decimal" /> to its exact rational representation.
+    /// </summary>
+    /// <param name="value">The decimal value to convert.</param>
+    /// <returns>A <see cref="Fraction{T}" /> equal to <paramref name="value" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> FromDecimal(decimal value)
+    {
+        int[] bits = decimal.GetBits(value);
+        BigInteger mantissa = (new BigInteger((uint)bits[2]) << 64)
+            | (new BigInteger((uint)bits[1]) << 32)
+            | new BigInteger((uint)bits[0]);
+
+        bool negative = (bits[3] & unchecked((int)0x80000000)) != 0;
+        int scale = (bits[3] >> 16) & 0xFF;
+
+        if (negative)
+            mantissa = -mantissa;
+
+        return FromBigInteger(mantissa, BigInteger.Pow(10, scale));
+    }
+
+    /// <summary>
+    /// Converts a finite <see cref="double" /> to its exact rational representation.
+    /// </summary>
+    /// <param name="value">The double-precision value to convert.</param>
+    /// <returns>A <see cref="Fraction{T}" /> equal to <paramref name="value" />.</returns>
+    /// <exception cref="ArgumentException">Thrown if <paramref name="value" /> is not a finite number.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> FromDouble(double value)
+    {
+        if (!double.IsFinite(value))
+            throw new ArgumentException("Only finite values can be converted to a fraction.", nameof(value));
+
+        long bits = BitConverter.DoubleToInt64Bits(value);
+        bool negative = bits < 0;
+        int exponent = (int)((bits >> 52) & 0x7FF);
+        long mantissa = bits & 0xFFFFFFFFFFFFF;
+
+        if (exponent == 0)
+            exponent++;
+        else
+            mantissa |= 0x10000000000000;
+
+        exponent -= 1075;
+
+        BigInteger numerator = mantissa;
+        if (negative)
+            numerator = -numerator;
+
+        return exponent >= 0
+            ? FromBigInteger(numerator << exponent, BigInteger.One)
+            : FromBigInteger(numerator, BigInteger.One << -exponent);
+    }
+
+    /// <summary>
+    /// Converts this rational value to the nearest <see cref="decimal" />.
+    /// </summary>
+    /// <returns>The decimal approximation of this value.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if this value lies outside the range of <see cref="decimal" />.
+    /// </exception>
+    public decimal ToDecimal() =>
+        (decimal)BigNumerator / (decimal)BigDenominator;
+
+    /// <summary>
+    /// Converts this rational value to the nearest <see cref="double" />.
+    /// </summary>
+    /// <returns>The double-precision approximation of this value.</returns>
+    public double ToDouble() =>
+        (double)BigNumerator / (double)BigDenominator;
+
+    /// <summary>
+    /// Converts this rational value to an equivalent <see cref="Fraction{T}" /> over a different backing integer type.
+    /// </summary>
+    /// <typeparam name="TOther">The backing integer type of the result.</typeparam>
+    /// <returns>A <see cref="Fraction{TOther}" /> with the same canonical value.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="TOther" />.
+    /// </exception>
+    public Fraction<TOther> As<TOther>()
+        where TOther : IBinaryInteger<TOther> =>
+        new Fraction<TOther>(TOther.CreateChecked(_numerator), TOther.CreateChecked(Denominator));
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Formatting.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Formatting.cs
@@ -1,0 +1,210 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Formatting.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+using System.Text;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IFormattable,
+    ISpanFormattable,
+    IUtf8SpanFormattable
+{
+    /// <summary>
+    /// Maps a proper-fraction numerator and denominator to its Unicode vulgar-fraction glyph.
+    /// </summary>
+    private static readonly Dictionary<(int Numerator, int Denominator), char> s_vulgarFractions = new()
+    {
+        [(1, 2)] = '½',
+        [(1, 3)] = '⅓',
+        [(2, 3)] = '⅔',
+        [(1, 4)] = '¼',
+        [(3, 4)] = '¾',
+        [(1, 5)] = '⅕',
+        [(2, 5)] = '⅖',
+        [(3, 5)] = '⅗',
+        [(4, 5)] = '⅘',
+        [(1, 6)] = '⅙',
+        [(5, 6)] = '⅚',
+        [(1, 7)] = '⅐',
+        [(1, 8)] = '⅛',
+        [(3, 8)] = '⅜',
+        [(5, 8)] = '⅝',
+        [(7, 8)] = '⅞',
+        [(1, 9)] = '⅑',
+        [(1, 10)] = '⅒',
+    };
+
+    /// <summary>
+    /// Returns the default string representation of this rational value.
+    /// </summary>
+    /// <returns>The value formatted as <c>numerator/denominator</c>, or as a bare integer when whole.</returns>
+    public override string ToString() =>
+        Format(default, null);
+
+    /// <summary>
+    /// Returns a string representation of this rational value using the specified format.
+    /// </summary>
+    /// <param name="format">The format specifier: <c>G</c>, <c>M</c>, <c>U</c>, or <c>P</c>.</param>
+    /// <returns>The value formatted according to <paramref name="format" />.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="format" /> is not a supported specifier.</exception>
+    public string ToString(string? format) =>
+        Format(format, null);
+
+    /// <summary>
+    /// Returns a string representation of this rational value using the specified format and culture.
+    /// </summary>
+    /// <param name="format">The format specifier: <c>G</c>, <c>M</c>, <c>U</c>, or <c>P</c>.</param>
+    /// <param name="formatProvider">The culture used to render the numeric components.</param>
+    /// <returns>The value formatted according to <paramref name="format" />.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="format" /> is not a supported specifier.</exception>
+    public string ToString(string? format, IFormatProvider? formatProvider) =>
+        Format(format, formatProvider);
+
+    /// <summary>
+    /// Attempts to format this rational value into the provided character span.
+    /// </summary>
+    /// <param name="destination">The span that receives the formatted characters.</param>
+    /// <param name="charsWritten">When this method returns, contains the number of characters written.</param>
+    /// <param name="format">The format specifier.</param>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns><see langword="true" /> if formatting succeeded; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="format" /> is not a supported specifier.</exception>
+    public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        string text = Format(format, provider);
+        if (text.Length <= destination.Length)
+        {
+            text.CopyTo(destination);
+            charsWritten = text.Length;
+            return true;
+        }
+
+        charsWritten = 0;
+        return false;
+    }
+
+    /// <summary>
+    /// Attempts to format this rational value into the provided UTF-8 byte span.
+    /// </summary>
+    /// <param name="utf8Destination">The span that receives the formatted UTF-8 bytes.</param>
+    /// <param name="bytesWritten">When this method returns, contains the number of bytes written.</param>
+    /// <param name="format">The format specifier.</param>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns><see langword="true" /> if formatting succeeded; otherwise, <see langword="false" />.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="format" /> is not a supported specifier.</exception>
+    public bool TryFormat(Span<byte> utf8Destination, out int bytesWritten, ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        string text = Format(format, provider);
+        return Encoding.UTF8.TryGetBytes(text, utf8Destination, out bytesWritten);
+    }
+
+    /// <summary>
+    /// Formats this rational value according to the specified format specifier.
+    /// </summary>
+    /// <param name="format">The format specifier; an empty span selects the general format.</param>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns>The formatted string representation.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="format" /> is not a supported specifier.</exception>
+    private string Format(ReadOnlySpan<char> format, IFormatProvider? provider)
+    {
+        char specifier = format.IsEmpty ? 'G' : char.ToUpperInvariant(format[0]);
+
+        return specifier switch
+        {
+            'G' => FormatGeneral(provider),
+            'M' => FormatMixed(provider),
+            'U' => FormatUnicode(provider),
+            'P' => FormatPercent(provider),
+            _ => throw new FormatException($"The format string '{format.ToString()}' is not supported."),
+        };
+    }
+
+    /// <summary>
+    /// Formats this value as <c>numerator/denominator</c>, or as a bare integer when whole.
+    /// </summary>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns>The general string representation.</returns>
+    private string FormatGeneral(IFormatProvider? provider) =>
+        BigDenominator.IsOne
+            ? BigNumerator.ToString(provider)
+            : $"{BigNumerator.ToString(provider)}/{BigDenominator.ToString(provider)}";
+
+    /// <summary>
+    /// Formats this value as a mixed number, separating the whole and fractional parts.
+    /// </summary>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns>The mixed-number string representation.</returns>
+    private string FormatMixed(IFormatProvider? provider)
+    {
+        BigInteger numerator = BigNumerator;
+        BigInteger denominator = BigDenominator;
+
+        if (denominator.IsOne)
+            return numerator.ToString(provider);
+
+        BigInteger magnitude = BigInteger.Abs(numerator);
+        if (magnitude < denominator)
+            return $"{numerator.ToString(provider)}/{denominator.ToString(provider)}";
+
+        BigInteger whole = numerator / denominator;
+        BigInteger remainder = magnitude - (BigInteger.Abs(whole) * denominator);
+
+        return $"{whole.ToString(provider)} {remainder.ToString(provider)}/{denominator.ToString(provider)}";
+    }
+
+    /// <summary>
+    /// Formats this value using a Unicode vulgar-fraction glyph when one exists, otherwise as a mixed number.
+    /// </summary>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns>The Unicode string representation.</returns>
+    private string FormatUnicode(IFormatProvider? provider)
+    {
+        BigInteger numerator = BigNumerator;
+        BigInteger denominator = BigDenominator;
+
+        if (denominator.IsOne)
+            return numerator.ToString(provider);
+
+        BigInteger magnitude = BigInteger.Abs(numerator);
+        BigInteger whole = magnitude / denominator;
+        BigInteger remainder = magnitude % denominator;
+
+        if (denominator <= 16
+            && remainder >= BigInteger.One
+            && s_vulgarFractions.TryGetValue(((int)remainder, (int)denominator), out char glyph))
+        {
+            string sign = numerator.Sign < 0 ? "-" : string.Empty;
+            string wholePart = whole.IsZero ? string.Empty : whole.ToString(provider);
+            return $"{sign}{wholePart}{glyph}";
+        }
+
+        return FormatMixed(provider);
+    }
+
+    /// <summary>
+    /// Formats this value as a percentage by scaling it by one hundred and appending a percent sign.
+    /// </summary>
+    /// <param name="provider">The culture used to render the numeric components.</param>
+    /// <returns>The percentage string representation.</returns>
+    private string FormatPercent(IFormatProvider? provider)
+    {
+        BigInteger scaledNumerator = BigNumerator * 100;
+        BigInteger denominator = BigDenominator;
+
+        BigInteger divisor = BigInteger.GreatestCommonDivisor(BigInteger.Abs(scaledNumerator), denominator);
+        if (divisor > BigInteger.One)
+        {
+            scaledNumerator /= divisor;
+            denominator /= divisor;
+        }
+
+        return denominator.IsOne
+            ? $"{scaledNumerator.ToString(provider)}%"
+            : $"{scaledNumerator.ToString(provider)}/{denominator.ToString(provider)}%";
+    }
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.GenericMath.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.GenericMath.cs
@@ -1,0 +1,274 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.GenericMath.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+// StyleCop's SA1648 does not recognize <inheritdoc /> on explicit implementations of static abstract interface
+// members; the documentation is correctly inherited from the System.Numerics generic-math interfaces.
+#pragma warning disable SA1648 // inheritdoc should be used with inheriting class
+
+public readonly partial struct Fraction<T> :
+    INumber<Fraction<T>>,
+    ISignedNumber<Fraction<T>>
+{
+    /// <inheritdoc />
+    static Fraction<T> IAdditiveIdentity<Fraction<T>, Fraction<T>>.AdditiveIdentity => Zero;
+
+    /// <inheritdoc />
+    static Fraction<T> IMultiplicativeIdentity<Fraction<T>, Fraction<T>>.MultiplicativeIdentity => One;
+
+    /// <inheritdoc />
+    static Fraction<T> ISignedNumber<Fraction<T>>.NegativeOne => MinusOne;
+
+    /// <inheritdoc />
+    static int INumberBase<Fraction<T>>.Radix => 2;
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.Abs(Fraction<T> value) =>
+        value.Abs();
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsCanonical(Fraction<T> value) =>
+        true;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsComplexNumber(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsEvenInteger(Fraction<T> value) =>
+        value.IsInteger && value.BigNumerator.IsEven;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsFinite(Fraction<T> value) =>
+        true;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsImaginaryNumber(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsInfinity(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsInteger(Fraction<T> value) =>
+        value.IsInteger;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsNaN(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsNegative(Fraction<T> value) =>
+        value.IsNegative;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsNegativeInfinity(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsNormal(Fraction<T> value) =>
+        !value.IsZero;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsOddInteger(Fraction<T> value) =>
+        value.IsInteger && !value.BigNumerator.IsEven;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsPositive(Fraction<T> value) =>
+        value.IsPositive;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsPositiveInfinity(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsRealNumber(Fraction<T> value) =>
+        true;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsSubnormal(Fraction<T> value) =>
+        false;
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.IsZero(Fraction<T> value) =>
+        value.IsZero;
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.MaxMagnitude(Fraction<T> x, Fraction<T> y) =>
+        MaxMagnitudeInternal(x, y);
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.MaxMagnitudeNumber(Fraction<T> x, Fraction<T> y) =>
+        MaxMagnitudeInternal(x, y);
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.MinMagnitude(Fraction<T> x, Fraction<T> y) =>
+        MinMagnitudeInternal(x, y);
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.MinMagnitudeNumber(Fraction<T> x, Fraction<T> y) =>
+        MinMagnitudeInternal(x, y);
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider) =>
+        Parse(s, provider);
+
+    /// <inheritdoc />
+    static Fraction<T> INumberBase<Fraction<T>>.Parse(string s, NumberStyles style, IFormatProvider? provider) =>
+        Parse(s, provider);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, out Fraction<T> result) =>
+        TryParse(s, provider, out result);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryParse(string? s, NumberStyles style, IFormatProvider? provider, out Fraction<T> result) =>
+        TryParse(s, provider, out result);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertFromChecked<TOther>(TOther value, out Fraction<T> result) =>
+        TryConvertFrom(value, out result);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertFromSaturating<TOther>(TOther value, out Fraction<T> result) =>
+        TryConvertFrom(value, out result);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertFromTruncating<TOther>(TOther value, out Fraction<T> result) =>
+        TryConvertFrom(value, out result);
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertToChecked<TOther>(Fraction<T> value, out TOther result)
+    {
+        result = value.IsInteger
+            ? TOther.CreateChecked(value.BigNumerator)
+            : TOther.CreateChecked(value.ToDouble());
+        return true;
+    }
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertToSaturating<TOther>(Fraction<T> value, out TOther result)
+    {
+        result = value.IsInteger
+            ? TOther.CreateSaturating(value.BigNumerator)
+            : TOther.CreateSaturating(value.ToDouble());
+        return true;
+    }
+
+    /// <inheritdoc />
+    static bool INumberBase<Fraction<T>>.TryConvertToTruncating<TOther>(Fraction<T> value, out TOther result)
+    {
+        result = value.IsInteger
+            ? TOther.CreateTruncating(value.BigNumerator)
+            : TOther.CreateTruncating(value.ToDouble());
+        return true;
+    }
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.Clamp(Fraction<T> value, Fraction<T> min, Fraction<T> max)
+    {
+        if (Compare(min, max) > 0)
+            throw new ArgumentException("The minimum bound must not exceed the maximum bound.", nameof(min));
+
+        if (Compare(value, min) < 0)
+            return min;
+
+        return Compare(value, max) > 0 ? max : value;
+    }
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.CopySign(Fraction<T> value, Fraction<T> sign) =>
+        sign.IsNegative ? -value.Abs() : value.Abs();
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.Max(Fraction<T> x, Fraction<T> y) =>
+        Compare(x, y) >= 0 ? x : y;
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.MaxNumber(Fraction<T> x, Fraction<T> y) =>
+        Compare(x, y) >= 0 ? x : y;
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.Min(Fraction<T> x, Fraction<T> y) =>
+        Compare(x, y) <= 0 ? x : y;
+
+    /// <inheritdoc />
+    static Fraction<T> INumber<Fraction<T>>.MinNumber(Fraction<T> x, Fraction<T> y) =>
+        Compare(x, y) <= 0 ? x : y;
+
+    /// <inheritdoc />
+    static int INumber<Fraction<T>>.Sign(Fraction<T> value) =>
+        value.Sign;
+
+    /// <summary>
+    /// Converts a value of an arbitrary numeric type to a <see cref="Fraction{T}" />.
+    /// </summary>
+    /// <typeparam name="TOther">The source numeric type.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="result">When this method returns, contains the converted value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if the value was converted; otherwise, <see langword="false" />.</returns>
+    private static bool TryConvertFrom<TOther>(TOther value, out Fraction<T> result)
+        where TOther : INumberBase<TOther>
+    {
+        if (TOther.IsInteger(value))
+        {
+            result = FromBigInteger(BigInteger.CreateChecked(value), BigInteger.One);
+            return true;
+        }
+
+        if (!TOther.IsFinite(value))
+        {
+            result = default;
+            return false;
+        }
+
+        result = FromDouble(double.CreateChecked(value));
+        return true;
+    }
+
+    /// <summary>
+    /// Returns whichever argument has the greater magnitude, preferring the positive value on a tie.
+    /// </summary>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The argument with the greater magnitude.</returns>
+    private static Fraction<T> MaxMagnitudeInternal(Fraction<T> x, Fraction<T> y)
+    {
+        int comparison = Compare(x.Abs(), y.Abs());
+        if (comparison > 0)
+            return x;
+
+        if (comparison < 0)
+            return y;
+
+        return x.Sign >= y.Sign ? x : y;
+    }
+
+    /// <summary>
+    /// Returns whichever argument has the smaller magnitude, preferring the negative value on a tie.
+    /// </summary>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The argument with the smaller magnitude.</returns>
+    private static Fraction<T> MinMagnitudeInternal(Fraction<T> x, Fraction<T> y)
+    {
+        int comparison = Compare(x.Abs(), y.Abs());
+        if (comparison < 0)
+            return x;
+
+        if (comparison > 0)
+            return y;
+
+        return x.Sign <= y.Sign ? x : y;
+    }
+}
+
+#pragma warning restore SA1648 // inheritdoc should be used with inheriting class

--- a/Bodu.Numerics/src/Numerics/Fraction.IComparable.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.IComparable.cs
@@ -1,0 +1,57 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.IComparable.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IComparable,
+    IComparable<Fraction<T>>
+{
+    /// <summary>
+    /// Compares this rational value with another and indicates their relative order.
+    /// </summary>
+    /// <param name="other">The value to compare with this value.</param>
+    /// <returns>
+    /// A negative number if this value precedes <paramref name="other" />, zero if they are equal, and a positive
+    /// number if this value follows <paramref name="other" />.
+    /// </returns>
+    public int CompareTo(Fraction<T> other) =>
+        Compare(this, other);
+
+    /// <summary>
+    /// Compares this rational value with the specified object and indicates their relative order.
+    /// </summary>
+    /// <param name="obj">The object to compare with this value.</param>
+    /// <returns>
+    /// A negative number if this value precedes <paramref name="obj" />, zero if they are equal, and a positive number
+    /// if this value follows <paramref name="obj" />. A <see langword="null" /> object sorts before any value.
+    /// </returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="obj" /> is not a <see cref="Fraction{T}" />.
+    /// </exception>
+    public int CompareTo(object? obj)
+    {
+        if (obj is null)
+            return 1;
+
+        if (obj is Fraction<T> other)
+            return Compare(this, other);
+
+        throw new ArgumentException($"Object must be of type {typeof(Fraction<T>)}.", nameof(obj));
+    }
+
+    /// <summary>
+    /// Compares two rational values and indicates their relative order.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>
+    /// A negative number if <paramref name="left" /> precedes <paramref name="right" />, zero if they are equal, and a
+    /// positive number if <paramref name="left" /> follows <paramref name="right" />.
+    /// </returns>
+    private static int Compare(Fraction<T> left, Fraction<T> right) =>
+        (left.BigNumerator * right.BigDenominator).CompareTo(right.BigNumerator * left.BigDenominator);
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.IEquatable.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.IEquatable.cs
@@ -1,0 +1,40 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.IEquatable.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IEquatable<Fraction<T>>
+{
+    /// <summary>
+    /// Determines whether the specified object is a <see cref="Fraction{T}" /> equal to this value.
+    /// </summary>
+    /// <param name="obj">The object to compare with this value.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="obj" /> is a <see cref="Fraction{T}" /> with the same canonical
+    /// value; otherwise, <see langword="false" />.
+    /// </returns>
+    public override bool Equals(object? obj) =>
+        obj is Fraction<T> other && Equals(other);
+
+    /// <summary>
+    /// Determines whether the specified <see cref="Fraction{T}" /> is equal to this value.
+    /// </summary>
+    /// <param name="other">The value to compare with this value.</param>
+    /// <returns>
+    /// <see langword="true" /> if both values share the same canonical numerator and denominator; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    public bool Equals(Fraction<T> other) =>
+        _numerator == other._numerator && Denominator == other.Denominator;
+
+    /// <summary>
+    /// Returns a hash code for this rational value.
+    /// </summary>
+    /// <returns>A hash code derived from the canonical numerator and denominator.</returns>
+    public override int GetHashCode() =>
+        HashCode.Combine(_numerator, Denominator);
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Operators.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Operators.cs
@@ -1,0 +1,220 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Operators.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T>
+{
+    /// <summary>
+    /// Gets the canonical numerator promoted to <see cref="BigInteger" /> precision.
+    /// </summary>
+    /// <returns>The numerator as a <see cref="BigInteger" />.</returns>
+    private BigInteger BigNumerator =>
+        BigInteger.CreateChecked(_numerator);
+
+    /// <summary>
+    /// Gets the canonical denominator promoted to <see cref="BigInteger" /> precision.
+    /// </summary>
+    /// <returns>The denominator as a <see cref="BigInteger" />.</returns>
+    private BigInteger BigDenominator =>
+        BigInteger.CreateChecked(Denominator);
+
+    /// <summary>
+    /// Adds two rational values.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>The canonical sum of <paramref name="left" /> and <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator +(Fraction<T> left, Fraction<T> right) =>
+        FromBigInteger(
+            (left.BigNumerator * right.BigDenominator) + (right.BigNumerator * left.BigDenominator),
+            left.BigDenominator * right.BigDenominator);
+
+    /// <summary>
+    /// Subtracts one rational value from another.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns>The canonical difference <paramref name="left" /> minus <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator -(Fraction<T> left, Fraction<T> right) =>
+        FromBigInteger(
+            (left.BigNumerator * right.BigDenominator) - (right.BigNumerator * left.BigDenominator),
+            left.BigDenominator * right.BigDenominator);
+
+    /// <summary>
+    /// Multiplies two rational values.
+    /// </summary>
+    /// <param name="left">The first factor.</param>
+    /// <param name="right">The second factor.</param>
+    /// <returns>The canonical product of <paramref name="left" /> and <paramref name="right" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator *(Fraction<T> left, Fraction<T> right) =>
+        FromBigInteger(
+            left.BigNumerator * right.BigNumerator,
+            left.BigDenominator * right.BigDenominator);
+
+    /// <summary>
+    /// Divides one rational value by another.
+    /// </summary>
+    /// <param name="left">The dividend.</param>
+    /// <param name="right">The divisor.</param>
+    /// <returns>The canonical quotient <paramref name="left" /> divided by <paramref name="right" />.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="right" /> is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator /(Fraction<T> left, Fraction<T> right)
+    {
+        if (right.IsZero)
+            throw new DivideByZeroException("Cannot divide a fraction by zero.");
+
+        return FromBigInteger(
+            left.BigNumerator * right.BigDenominator,
+            left.BigDenominator * right.BigNumerator);
+    }
+
+    /// <summary>
+    /// Returns the remainder produced by dividing one rational value by another, with the sign of the dividend.
+    /// </summary>
+    /// <param name="left">The dividend.</param>
+    /// <param name="right">The divisor.</param>
+    /// <returns>The canonical remainder of <paramref name="left" /> divided by <paramref name="right" />.</returns>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="right" /> is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator %(Fraction<T> left, Fraction<T> right)
+    {
+        if (right.IsZero)
+            throw new DivideByZeroException("Cannot take the remainder of a fraction divided by zero.");
+
+        BigInteger ln = left.BigNumerator;
+        BigInteger ld = left.BigDenominator;
+        BigInteger rn = right.BigNumerator;
+        BigInteger rd = right.BigDenominator;
+
+        BigInteger quotient = (ln * rd) / (ld * rn);
+
+        return FromBigInteger((ln * rd) - (quotient * rn * ld), ld * rd);
+    }
+
+    /// <summary>
+    /// Returns the additive inverse of a rational value.
+    /// </summary>
+    /// <param name="value">The value to negate.</param>
+    /// <returns>The canonical value with its sign reversed.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the negated numerator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator -(Fraction<T> value) =>
+        FromBigInteger(-value.BigNumerator, value.BigDenominator);
+
+    /// <summary>
+    /// Returns the rational value unchanged.
+    /// </summary>
+    /// <param name="value">The value to return.</param>
+    /// <returns>The unmodified <paramref name="value" />.</returns>
+    public static Fraction<T> operator +(Fraction<T> value) =>
+        value;
+
+    /// <summary>
+    /// Returns the rational value increased by one.
+    /// </summary>
+    /// <param name="value">The value to increment.</param>
+    /// <returns>The canonical value of <paramref name="value" /> plus one.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator ++(Fraction<T> value) =>
+        value + One;
+
+    /// <summary>
+    /// Returns the rational value decreased by one.
+    /// </summary>
+    /// <param name="value">The value to decrement.</param>
+    /// <returns>The canonical value of <paramref name="value" /> minus one.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical result does not fit <typeparamref name="T" />.
+    /// </exception>
+    public static Fraction<T> operator --(Fraction<T> value) =>
+        value - One;
+
+    /// <summary>
+    /// Determines whether two rational values are equal.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> if the values are equal; otherwise, <see langword="false" />.</returns>
+    public static bool operator ==(Fraction<T> left, Fraction<T> right) =>
+        left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two rational values are unequal.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> if the values are unequal; otherwise, <see langword="false" />.</returns>
+    public static bool operator !=(Fraction<T> left, Fraction<T> right) =>
+        !left.Equals(right);
+
+    /// <summary>
+    /// Determines whether one rational value is less than another.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is less than <paramref name="right" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    public static bool operator <(Fraction<T> left, Fraction<T> right) =>
+        Compare(left, right) < 0;
+
+    /// <summary>
+    /// Determines whether one rational value is less than or equal to another.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is less than or equal to <paramref name="right" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool operator <=(Fraction<T> left, Fraction<T> right) =>
+        Compare(left, right) <= 0;
+
+    /// <summary>
+    /// Determines whether one rational value is greater than another.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is greater than <paramref name="right" />; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    public static bool operator >(Fraction<T> left, Fraction<T> right) =>
+        Compare(left, right) > 0;
+
+    /// <summary>
+    /// Determines whether one rational value is greater than or equal to another.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="left" /> is greater than or equal to <paramref name="right" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    public static bool operator >=(Fraction<T> left, Fraction<T> right) =>
+        Compare(left, right) >= 0;
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Parse.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Parse.cs
@@ -1,0 +1,229 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Parse.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IParsable<Fraction<T>>,
+    ISpanParsable<Fraction<T>>
+{
+    /// <summary>
+    /// Maps a Unicode vulgar-fraction glyph to its proper-fraction numerator and denominator.
+    /// </summary>
+    private static readonly Dictionary<char, (int Numerator, int Denominator)> s_vulgarGlyphs = new()
+    {
+        ['½'] = (1, 2),
+        ['⅓'] = (1, 3),
+        ['⅔'] = (2, 3),
+        ['¼'] = (1, 4),
+        ['¾'] = (3, 4),
+        ['⅕'] = (1, 5),
+        ['⅖'] = (2, 5),
+        ['⅗'] = (3, 5),
+        ['⅘'] = (4, 5),
+        ['⅙'] = (1, 6),
+        ['⅚'] = (5, 6),
+        ['⅐'] = (1, 7),
+        ['⅛'] = (1, 8),
+        ['⅜'] = (3, 8),
+        ['⅝'] = (5, 8),
+        ['⅞'] = (7, 8),
+        ['⅑'] = (1, 9),
+        ['⅒'] = (1, 10),
+    };
+
+    /// <summary>
+    /// Parses a string into a <see cref="Fraction{T}" />.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <returns>The rational value the string represents.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="s" /> is <see langword="null" />.</exception>
+    /// <exception cref="FormatException">Thrown if <paramref name="s" /> is not a valid fraction.</exception>
+    public static Fraction<T> Parse(string s) =>
+        Parse(s, null);
+
+    /// <summary>
+    /// Parses a string into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <returns>The rational value the string represents.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="s" /> is <see langword="null" />.</exception>
+    /// <exception cref="FormatException">Thrown if <paramref name="s" /> is not a valid fraction.</exception>
+    public static Fraction<T> Parse(string s, IFormatProvider? provider)
+    {
+        ThrowHelper.ThrowIfNull(s);
+
+        return Parse(s.AsSpan(), provider);
+    }
+
+    /// <summary>
+    /// Parses a character span into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="s">The span to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <returns>The rational value the span represents.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="s" /> is not a valid fraction.</exception>
+    public static Fraction<T> Parse(ReadOnlySpan<char> s, IFormatProvider? provider)
+    {
+        if (!TryParseCore(s, provider, out Fraction<T> result))
+            throw new FormatException($"The input string '{s.ToString()}' was not in a correct fraction format.");
+
+        return result;
+    }
+
+    /// <summary>
+    /// Attempts to parse a string into a <see cref="Fraction{T}" />.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <param name="result">When this method returns, contains the parsed value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParse(string? s, out Fraction<T> result) =>
+        TryParse(s, null, out result);
+
+    /// <summary>
+    /// Attempts to parse a string into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="s">The string to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <param name="result">When this method returns, contains the parsed value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParse(string? s, IFormatProvider? provider, out Fraction<T> result)
+    {
+        if (s is null)
+        {
+            result = default;
+            return false;
+        }
+
+        return TryParseCore(s.AsSpan(), provider, out result);
+    }
+
+    /// <summary>
+    /// Attempts to parse a character span into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="s">The span to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <param name="result">When this method returns, contains the parsed value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, out Fraction<T> result) =>
+        TryParseCore(s, provider, out result);
+
+    /// <summary>
+    /// Performs the shared parsing logic for every string and span entry point.
+    /// </summary>
+    /// <param name="s">The text to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <param name="result">When this method returns, contains the parsed value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
+    private static bool TryParseCore(ReadOnlySpan<char> s, IFormatProvider? provider, out Fraction<T> result)
+    {
+        result = default;
+
+        s = s.Trim();
+        if (s.IsEmpty)
+            return false;
+
+        bool percent = s[^1] == '%';
+        if (percent)
+        {
+            s = s[..^1].Trim();
+            if (s.IsEmpty)
+                return false;
+        }
+
+        bool negative = false;
+        if (s[0] == '-')
+        {
+            negative = true;
+            s = s[1..].TrimStart();
+        }
+        else if (s[0] == '+')
+        {
+            s = s[1..].TrimStart();
+        }
+
+        if (s.IsEmpty)
+            return false;
+
+        if (!TryParseMagnitude(s, provider, out BigInteger numerator, out BigInteger denominator))
+            return false;
+
+        if (denominator.IsZero)
+            return false;
+
+        if (negative)
+            numerator = -numerator;
+
+        if (percent)
+            denominator *= 100;
+
+        try
+        {
+            result = FromBigInteger(numerator, denominator);
+            return true;
+        }
+        catch (OverflowException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Parses the unsigned magnitude of a fraction expressed as an integer, a ratio, a mixed number, or a Unicode
+    /// vulgar fraction.
+    /// </summary>
+    /// <param name="s">The non-empty, sign-stripped text to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <param name="numerator">When this method returns, contains the parsed numerator.</param>
+    /// <param name="denominator">When this method returns, contains the parsed denominator.</param>
+    /// <returns><see langword="true" /> if the magnitude was parsed; otherwise, <see langword="false" />.</returns>
+    private static bool TryParseMagnitude(ReadOnlySpan<char> s, IFormatProvider? provider, out BigInteger numerator, out BigInteger denominator)
+    {
+        numerator = BigInteger.Zero;
+        denominator = BigInteger.One;
+
+        if (s_vulgarGlyphs.TryGetValue(s[^1], out (int Numerator, int Denominator) glyph))
+        {
+            ReadOnlySpan<char> wholeText = s[..^1].Trim();
+            BigInteger whole = BigInteger.Zero;
+            if (!wholeText.IsEmpty && !BigInteger.TryParse(wholeText, NumberStyles.None, provider, out whole))
+                return false;
+
+            denominator = glyph.Denominator;
+            numerator = (whole * denominator) + glyph.Numerator;
+            return true;
+        }
+
+        int slash = s.IndexOf('/');
+        if (slash < 0)
+            return BigInteger.TryParse(s, NumberStyles.None, provider, out numerator);
+
+        ReadOnlySpan<char> leftText = s[..slash].Trim();
+        ReadOnlySpan<char> rightText = s.Slice(slash + 1).Trim();
+        if (leftText.IsEmpty || rightText.IsEmpty)
+            return false;
+
+        if (!BigInteger.TryParse(rightText, NumberStyles.None, provider, out denominator))
+            return false;
+
+        int space = leftText.IndexOfAny(' ', '\t');
+        if (space < 0)
+            return BigInteger.TryParse(leftText, NumberStyles.None, provider, out numerator);
+
+        ReadOnlySpan<char> wholePart = leftText[..space].Trim();
+        ReadOnlySpan<char> fractionPart = leftText.Slice(space + 1).Trim();
+        if (!BigInteger.TryParse(wholePart, NumberStyles.None, provider, out BigInteger mixedWhole)
+            || !BigInteger.TryParse(fractionPart, NumberStyles.None, provider, out BigInteger mixedNumerator))
+            return false;
+
+        numerator = (mixedWhole * denominator) + mixedNumerator;
+        return true;
+    }
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Properties.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Properties.cs
@@ -1,0 +1,61 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Properties.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T>
+{
+    /// <summary>
+    /// Gets a value indicating whether this rational value is zero.
+    /// </summary>
+    /// <returns><see langword="true" /> if this value equals zero; otherwise, <see langword="false" />.</returns>
+    public bool IsZero =>
+        T.IsZero(_numerator);
+
+    /// <summary>
+    /// Gets a value indicating whether this rational value is an exact integer.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> if the canonical denominator is one; otherwise, <see langword="false" />.
+    /// </returns>
+    public bool IsInteger =>
+        Denominator == T.One;
+
+    /// <summary>
+    /// Gets a value indicating whether this rational value is a proper fraction.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> if the magnitude of this value is strictly less than one; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
+    public bool IsProper =>
+        Abs(_numerator) < Denominator;
+
+    /// <summary>
+    /// Gets a value indicating whether this rational value is a unit fraction.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> if the numerator has a magnitude of one; otherwise, <see langword="false" />.
+    /// </returns>
+    public bool IsUnit =>
+        Abs(_numerator) == T.One;
+
+    /// <summary>
+    /// Gets a value indicating whether this rational value is negative.
+    /// </summary>
+    /// <returns><see langword="true" /> if this value is less than zero; otherwise, <see langword="false" />.</returns>
+    public bool IsNegative =>
+        T.IsNegative(_numerator);
+
+    /// <summary>
+    /// Gets a value indicating whether this rational value is positive.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> if this value is greater than zero; otherwise, <see langword="false" />.
+    /// </returns>
+    public bool IsPositive =>
+        !T.IsZero(_numerator) && !T.IsNegative(_numerator);
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Serialization.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Serialization.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Serialization.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using System.Xml;
+using System.Xml.Schema;
+using System.Xml.Serialization;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IXmlSerializable
+{
+    /// <inheritdoc />
+    XmlSchema? IXmlSerializable.GetSchema() =>
+        null;
+
+    /// <inheritdoc />
+    void IXmlSerializable.ReadXml(XmlReader reader)
+    {
+        ThrowHelper.ThrowIfNull(reader);
+
+        string content = reader.ReadElementContentAsString();
+
+        // The struct is immutable, so deserialization rebuilds the value and writes it back through a mutable
+        // reference to the boxed instance the serializer passes as the receiver.
+        Unsafe.AsRef(in this) = Parse(content, CultureInfo.InvariantCulture);
+    }
+
+    /// <inheritdoc />
+    void IXmlSerializable.WriteXml(XmlWriter writer)
+    {
+        ThrowHelper.ThrowIfNull(writer);
+
+        writer.WriteString(ToString(null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.Utf8.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.Utf8.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.Utf8.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Bodu.Numerics;
+
+public readonly partial struct Fraction<T> :
+    IUtf8SpanParsable<Fraction<T>>
+{
+    /// <summary>
+    /// Parses a UTF-8 byte span into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="utf8Text">The UTF-8 encoded text to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <returns>The rational value the text represents.</returns>
+    /// <exception cref="FormatException">Thrown if <paramref name="utf8Text" /> is not a valid fraction.</exception>
+    public static Fraction<T> Parse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider) =>
+        Parse(Encoding.UTF8.GetString(utf8Text), provider);
+
+    /// <summary>
+    /// Attempts to parse a UTF-8 byte span into a <see cref="Fraction{T}" /> using the specified culture.
+    /// </summary>
+    /// <param name="utf8Text">The UTF-8 encoded text to parse.</param>
+    /// <param name="provider">The culture used to interpret the numeric components.</param>
+    /// <param name="result">When this method returns, contains the parsed value, or zero on failure.</param>
+    /// <returns><see langword="true" /> if parsing succeeded; otherwise, <see langword="false" />.</returns>
+    public static bool TryParse(ReadOnlySpan<byte> utf8Text, IFormatProvider? provider, out Fraction<T> result) =>
+        TryParse(Encoding.UTF8.GetString(utf8Text), provider, out result);
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.cs
@@ -138,7 +138,7 @@ public readonly partial struct Fraction<T>
     /// Thrown if <typeparamref name="T" /> is an unsigned type and cannot represent <c>-1</c>.
     /// </exception>
     public static Fraction<T> MinusOne =>
-        new Fraction<T>(-T.One, T.One, canonical: true);
+        FromBigInteger(BigInteger.MinusOne, BigInteger.One);
 
     /// <summary>
     /// Gets the numerator of the rational value in canonical form.

--- a/Bodu.Numerics/src/Numerics/Fraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.cs
@@ -1,0 +1,259 @@
+﻿// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Fraction.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Numerics;
+
+/// <summary>
+/// Represents an immutable exact rational number — a ratio of two integers — backed by an arbitrary
+/// <see cref="IBinaryInteger{TSelf}" /> component type.
+/// </summary>
+/// <typeparam name="T">
+/// The integer type used to store the numerator and denominator. Use a fixed-width type such as <see cref="int" /> or
+/// <see cref="long" /> for compact storage, or <see cref="BigInteger" /> for arithmetic that never overflows.
+/// </typeparam>
+/// <remarks>
+/// <para>
+/// A <see cref="Fraction{T}" /> is always held in canonical form: the denominator is strictly positive, the numerator
+/// carries the sign, and the two components share no common factor other than one. Equal rational values therefore have
+/// identical components and compare and hash equally.
+/// </para>
+/// <para>
+/// Arithmetic is exact. Intermediate results are evaluated with <see cref="BigInteger" /> precision and the canonical
+/// result is narrowed back to <typeparamref name="T" />; when the narrowed component does not fit a fixed-width
+/// <typeparamref name="T" /> an <see cref="OverflowException" /> is thrown. Selecting <see cref="BigInteger" /> as
+/// <typeparamref name="T" /> removes that limit entirely.
+/// </para>
+/// <para>
+/// When <typeparamref name="T" /> is an unsigned integer type, negative rationals cannot be represented; operations
+/// that would produce a negative component — such as negating a non-zero value — throw an
+/// <see cref="OverflowException" /> at run time.
+/// </para>
+/// </remarks>
+[Serializable]
+[DebuggerDisplay("{ToString(),nq}")]
+public readonly partial struct Fraction<T>
+    where T : IBinaryInteger<T>
+{
+    /// <summary>
+    /// The canonical numerator. Carries the sign of the rational value.
+    /// </summary>
+    private readonly T _numerator;
+
+    /// <summary>
+    /// The canonical denominator. A stored value of zero occurs only for a default-initialized instance and is
+    /// interpreted as one by <see cref="Denominator" />.
+    /// </summary>
+    private readonly T _denominator;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Fraction{T}" /> struct representing the whole number
+    /// <paramref name="value" />.
+    /// </summary>
+    /// <param name="value">The integer value the fraction represents.</param>
+    public Fraction(T value)
+    {
+        _numerator = value;
+        _denominator = T.One;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Fraction{T}" /> struct from the specified numerator and
+    /// denominator, reducing the result to canonical form.
+    /// </summary>
+    /// <param name="numerator">The numerator of the rational value.</param>
+    /// <param name="denominator">The denominator of the rational value.</param>
+    /// <exception cref="DivideByZeroException">Thrown if <paramref name="denominator" /> is zero.</exception>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public Fraction(T numerator, T denominator)
+    {
+        if (T.IsZero(denominator))
+            throw new DivideByZeroException("The denominator of a fraction must not be zero.");
+
+        BigInteger n = BigInteger.CreateChecked(numerator);
+        BigInteger d = BigInteger.CreateChecked(denominator);
+
+        if (d.Sign < 0)
+        {
+            n = -n;
+            d = -d;
+        }
+
+        BigInteger g = BigInteger.GreatestCommonDivisor(n, d);
+        if (g > BigInteger.One)
+        {
+            n /= g;
+            d /= g;
+        }
+
+        _numerator = T.CreateChecked(n);
+        _denominator = T.CreateChecked(d);
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="Fraction{T}" /> struct from components that are already in
+    /// canonical form, bypassing reduction.
+    /// </summary>
+    /// <param name="numerator">The canonical numerator.</param>
+    /// <param name="denominator">The canonical, strictly positive denominator.</param>
+    /// <param name="canonical">
+    /// A discriminator that selects the no-reduction initialization path. The value itself is not inspected.
+    /// </param>
+    private Fraction(T numerator, T denominator, bool canonical)
+    {
+        _ = canonical;
+        _numerator = numerator;
+        _denominator = denominator;
+    }
+
+    /// <summary>
+    /// Gets a <see cref="Fraction{T}" /> representing the value zero.
+    /// </summary>
+    /// <returns>The rational value <c>0/1</c>.</returns>
+    public static Fraction<T> Zero =>
+        new Fraction<T>(T.Zero, T.One, canonical: true);
+
+    /// <summary>
+    /// Gets a <see cref="Fraction{T}" /> representing the value one.
+    /// </summary>
+    /// <returns>The rational value <c>1/1</c>.</returns>
+    public static Fraction<T> One =>
+        new Fraction<T>(T.One, T.One, canonical: true);
+
+    /// <summary>
+    /// Gets a <see cref="Fraction{T}" /> representing the value negative one.
+    /// </summary>
+    /// <returns>The rational value <c>-1/1</c>.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if <typeparamref name="T" /> is an unsigned type and cannot represent <c>-1</c>.
+    /// </exception>
+    public static Fraction<T> MinusOne =>
+        new Fraction<T>(-T.One, T.One, canonical: true);
+
+    /// <summary>
+    /// Gets the numerator of the rational value in canonical form.
+    /// </summary>
+    /// <returns>The signed numerator.</returns>
+    public T Numerator => _numerator;
+
+    /// <summary>
+    /// Gets the denominator of the rational value in canonical form.
+    /// </summary>
+    /// <returns>The strictly positive denominator.</returns>
+    /// <value>
+    /// A value of one is reported for a default-initialized instance so that <c>default(Fraction&lt;T&gt;)</c> behaves
+    /// as the rational value zero.
+    /// </value>
+    public T Denominator =>
+        T.IsZero(_denominator) ? T.One : _denominator;
+
+    /// <summary>
+    /// Gets the sign of the rational value.
+    /// </summary>
+    /// <returns>
+    /// <c>-1</c> if the value is negative, <c>0</c> if the value is zero, and <c>1</c> if the value is positive.
+    /// </returns>
+    public int Sign =>
+        T.IsZero(_numerator) ? 0 : (T.IsNegative(_numerator) ? -1 : 1);
+
+    /// <summary>
+    /// Deconstructs the rational value into its canonical numerator and denominator.
+    /// </summary>
+    /// <param name="numerator">When this method returns, contains the canonical numerator.</param>
+    /// <param name="denominator">When this method returns, contains the canonical denominator.</param>
+    public void Deconstruct(out T numerator, out T denominator)
+    {
+        numerator = Numerator;
+        denominator = Denominator;
+    }
+
+    /// <summary>
+    /// Computes the greatest common divisor of two integers.
+    /// </summary>
+    /// <param name="left">The first integer.</param>
+    /// <param name="right">The second integer.</param>
+    /// <returns>
+    /// The largest non-negative integer that divides both <paramref name="left" /> and <paramref name="right" />, or
+    /// zero when both arguments are zero.
+    /// </returns>
+    public static T GreatestCommonDivisor(T left, T right)
+    {
+        T a = Abs(left);
+        T b = Abs(right);
+
+        while (!T.IsZero(b))
+        {
+            (a, b) = (b, a % b);
+        }
+
+        return a;
+    }
+
+    /// <summary>
+    /// Computes the least common multiple of two integers.
+    /// </summary>
+    /// <param name="left">The first integer.</param>
+    /// <param name="right">The second integer.</param>
+    /// <returns>
+    /// The smallest non-negative integer that is a multiple of both arguments, or zero when either argument is zero.
+    /// </returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the least common multiple cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    public static T LeastCommonMultiple(T left, T right)
+    {
+        if (T.IsZero(left) || T.IsZero(right))
+            return T.Zero;
+
+        BigInteger a = BigInteger.Abs(BigInteger.CreateChecked(left));
+        BigInteger b = BigInteger.Abs(BigInteger.CreateChecked(right));
+        BigInteger result = a / BigInteger.GreatestCommonDivisor(a, b) * b;
+
+        return T.CreateChecked(result);
+    }
+
+    /// <summary>
+    /// Returns the absolute value of an integer.
+    /// </summary>
+    /// <param name="value">The integer whose magnitude is required.</param>
+    /// <returns>The magnitude of <paramref name="value" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static T Abs(T value) =>
+        T.IsNegative(value) ? -value : value;
+
+    /// <summary>
+    /// Creates a canonical <see cref="Fraction{T}" /> from a numerator and denominator evaluated with
+    /// <see cref="BigInteger" /> precision.
+    /// </summary>
+    /// <param name="numerator">The unreduced numerator.</param>
+    /// <param name="denominator">The unreduced, non-zero denominator.</param>
+    /// <returns>The reduced rational value narrowed to <typeparamref name="T" />.</returns>
+    /// <exception cref="OverflowException">
+    /// Thrown if the canonical numerator or denominator cannot be represented by <typeparamref name="T" />.
+    /// </exception>
+    private static Fraction<T> FromBigInteger(BigInteger numerator, BigInteger denominator)
+    {
+        if (denominator.Sign < 0)
+        {
+            numerator = -numerator;
+            denominator = -denominator;
+        }
+
+        BigInteger g = BigInteger.GreatestCommonDivisor(numerator, denominator);
+        if (g > BigInteger.One)
+        {
+            numerator /= g;
+            denominator /= g;
+        }
+
+        return new Fraction<T>(T.CreateChecked(numerator), T.CreateChecked(denominator), canonical: true);
+    }
+}

--- a/Bodu.Numerics/src/Numerics/Fraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.cs
@@ -7,6 +7,7 @@
 using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Text.Json.Serialization;
 
 namespace Bodu.Numerics;
 
@@ -38,6 +39,7 @@ namespace Bodu.Numerics;
 /// </remarks>
 [Serializable]
 [DebuggerDisplay("{ToString(),nq}")]
+[JsonConverter(typeof(FractionJsonConverterFactory))]
 public readonly partial struct Fraction<T>
     where T : IBinaryInteger<T>
 {

--- a/Bodu.Numerics/src/Numerics/FractionJsonConverter.cs
+++ b/Bodu.Numerics/src/Numerics/FractionJsonConverter.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionJsonConverter.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Bodu.Numerics;
+
+/// <summary>
+/// Converts a <see cref="Fraction{T}" /> to and from its JSON string representation.
+/// </summary>
+/// <typeparam name="T">The backing integer type of the fraction.</typeparam>
+/// <remarks>
+/// The fraction is serialized as a JSON string in <c>numerator/denominator</c> form using the invariant culture,
+/// matching the round-trip contract of <see cref="Fraction{T}.ToString()" /> and
+/// <see cref="Fraction{T}.Parse(string)" />.
+/// </remarks>
+public sealed class FractionJsonConverter<T> : JsonConverter<Fraction<T>>
+    where T : IBinaryInteger<T>
+{
+    /// <summary>
+    /// Reads a <see cref="Fraction{T}" /> from its JSON string representation.
+    /// </summary>
+    /// <param name="reader">The reader positioned at the value to convert.</param>
+    /// <param name="typeToConvert">The type being converted.</param>
+    /// <param name="options">The serializer options in effect.</param>
+    /// <returns>The deserialized rational value.</returns>
+    /// <exception cref="JsonException">
+    /// Thrown if the current token is not a string or does not represent a valid fraction.
+    /// </exception>
+    public override Fraction<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.String)
+            throw new JsonException("Expected a JSON string containing a fraction.");
+
+        string text = reader.GetString() ?? throw new JsonException("Expected a non-null fraction string.");
+
+        try
+        {
+            return Fraction<T>.Parse(text, CultureInfo.InvariantCulture);
+        }
+        catch (FormatException ex)
+        {
+            throw new JsonException($"The value '{text}' is not a valid fraction.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Writes a <see cref="Fraction{T}" /> as its JSON string representation.
+    /// </summary>
+    /// <param name="writer">The writer that receives the value.</param>
+    /// <param name="value">The rational value to write.</param>
+    /// <param name="options">The serializer options in effect.</param>
+    public override void Write(Utf8JsonWriter writer, Fraction<T> value, JsonSerializerOptions options)
+    {
+        ThrowHelper.ThrowIfNull(writer);
+
+        writer.WriteStringValue(value.ToString(null, CultureInfo.InvariantCulture));
+    }
+}

--- a/Bodu.Numerics/src/Numerics/FractionJsonConverterFactory.cs
+++ b/Bodu.Numerics/src/Numerics/FractionJsonConverterFactory.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionJsonConverterFactory.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Bodu.Numerics;
+
+/// <summary>
+/// Creates <see cref="FractionJsonConverter{T}" /> instances for closed <see cref="Fraction{T}" /> types.
+/// </summary>
+/// <remarks>
+/// This factory is referenced by the <see cref="JsonConverterAttribute" /> applied to <see cref="Fraction{T}" />, so
+/// <see cref="Fraction{T}" /> values serialize through <see cref="System.Text.Json" /> without any explicit converter
+/// registration.
+/// </remarks>
+public sealed class FractionJsonConverterFactory : JsonConverterFactory
+{
+    /// <summary>
+    /// Determines whether this factory can create a converter for the specified type.
+    /// </summary>
+    /// <param name="typeToConvert">The candidate type.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="typeToConvert" /> is a closed <see cref="Fraction{T}" /> type;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert is { IsGenericType: true }
+        && typeToConvert.GetGenericTypeDefinition() == typeof(Fraction<>);
+
+    /// <summary>
+    /// Creates a converter for the specified closed <see cref="Fraction{T}" /> type.
+    /// </summary>
+    /// <param name="typeToConvert">The closed <see cref="Fraction{T}" /> type to convert.</param>
+    /// <param name="options">The serializer options in effect.</param>
+    /// <returns>A converter for <paramref name="typeToConvert" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="typeToConvert" /> is <see langword="null" />.
+    /// </exception>
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        ThrowHelper.ThrowIfNull(typeToConvert);
+
+        Type componentType = typeToConvert.GetGenericArguments()[0];
+        Type converterType = typeof(FractionJsonConverter<>).MakeGenericType(componentType);
+        object converter = Activator.CreateInstance(converterType)
+            ?? throw new InvalidOperationException($"Unable to create a JSON converter for '{typeToConvert}'.");
+
+        return (JsonConverter)converter;
+    }
+}

--- a/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
+++ b/Bodu.Numerics/test/Bodu.Numerics.Test.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Test\src\Bodu.Test.csproj" />
+    <ProjectReference Include="..\src\Bodu.Numerics.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Numerics/test/Numerics/FractionTests.Arithmetic.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Arithmetic.cs
@@ -1,0 +1,133 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Arithmetic.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that the named arithmetic methods agree with the arithmetic operators.
+    /// </summary>
+    [TestMethod]
+    public void NamedArithmeticMethods_WhenInvoked_ShouldMatchOperators()
+    {
+        Fraction<int> a = new Fraction<int>(3, 4);
+        Fraction<int> b = new Fraction<int>(1, 6);
+
+        Assert.AreEqual(a + b, Fraction<int>.Add(a, b));
+        Assert.AreEqual(a - b, Fraction<int>.Subtract(a, b));
+        Assert.AreEqual(a * b, Fraction<int>.Multiply(a, b));
+        Assert.AreEqual(a / b, Fraction<int>.Divide(a, b));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Abs" /> returns the magnitude of the value.
+    /// </summary>
+    [TestMethod]
+    public void Abs_WhenValueIsNegative_ShouldReturnMagnitude()
+    {
+        Assert.AreEqual(new Fraction<int>(3, 4), new Fraction<int>(-3, 4).Abs());
+        Assert.AreEqual(new Fraction<int>(3, 4), new Fraction<int>(3, 4).Abs());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Reciprocal" /> exchanges the numerator and denominator.
+    /// </summary>
+    [TestMethod]
+    public void Reciprocal_WhenValueIsNonZero_ShouldExchangeComponents()
+    {
+        Assert.AreEqual(new Fraction<int>(4, 3), new Fraction<int>(3, 4).Reciprocal());
+        Assert.AreEqual(new Fraction<int>(-2, 1), new Fraction<int>(-1, 2).Reciprocal());
+    }
+
+    /// <summary>
+    /// Verifies that taking the reciprocal of zero throws <see cref="DivideByZeroException" />.
+    /// </summary>
+    [TestMethod]
+    public void Reciprocal_WhenValueIsZero_ShouldThrowDivideByZeroException()
+    {
+        _ = Assert.ThrowsExactly<DivideByZeroException>(() =>
+        {
+            _ = Fraction<int>.Zero.Reciprocal();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Pow" /> raises the value to integer powers.
+    /// </summary>
+    [TestMethod]
+    [DataRow(2, 3, 2, 4, 9)]
+    [DataRow(2, 3, 0, 1, 1)]
+    [DataRow(2, 3, -2, 9, 4)]
+    public void Pow_WhenRaisedToInteger_ShouldReturnExpectedValue(int numerator, int denominator, int exponent, int expectedNumerator, int expectedDenominator)
+    {
+        Fraction<int> result = new Fraction<int>(numerator, denominator).Pow(exponent);
+
+        Assert.AreEqual(new Fraction<int>(expectedNumerator, expectedDenominator), result);
+    }
+
+    /// <summary>
+    /// Verifies that raising zero to a negative power throws <see cref="DivideByZeroException" />.
+    /// </summary>
+    [TestMethod]
+    public void Pow_WhenZeroRaisedToNegativePower_ShouldThrowDivideByZeroException()
+    {
+        _ = Assert.ThrowsExactly<DivideByZeroException>(() =>
+        {
+            _ = Fraction<int>.Zero.Pow(-1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Remainder" /> matches the modulus operator.
+    /// </summary>
+    [TestMethod]
+    public void Remainder_WhenInvoked_ShouldMatchModulusOperator()
+    {
+        Fraction<int> value = new Fraction<int>(7, 4);
+
+        Assert.AreEqual(value % Fraction<int>.One, value.Remainder(Fraction<int>.One));
+    }
+
+    /// <summary>
+    /// Verifies that arithmetic overflowing a fixed-width component throws <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Addition_WhenResultExceedsFixedWidthRange_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(int.MaxValue) + new Fraction<int>(int.MaxValue);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the same arithmetic succeeds without overflow when backed by <see cref="BigInteger" />.
+    /// </summary>
+    [TestMethod]
+    public void Addition_WhenBackedByBigInteger_ShouldNotOverflow()
+    {
+        Fraction<BigInteger> result = new Fraction<BigInteger>(int.MaxValue) + new Fraction<BigInteger>(int.MaxValue);
+
+        Assert.AreEqual((BigInteger)int.MaxValue * 2, result.Numerator);
+        Assert.AreEqual(BigInteger.One, result.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that the greatest common divisor and least common multiple helpers compute known answers.
+    /// </summary>
+    [TestMethod]
+    [DataRow(12, 18, 6, 36)]
+    [DataRow(17, 5, 1, 85)]
+    [DataRow(0, 9, 9, 0)]
+    public void GcdAndLcm_WhenComputed_ShouldReturnKnownAnswers(int left, int right, int expectedGcd, int expectedLcm)
+    {
+        Assert.AreEqual(expectedGcd, Fraction<int>.GreatestCommonDivisor(left, right));
+        Assert.AreEqual(expectedLcm, Fraction<int>.LeastCommonMultiple(left, right));
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Arithmetic.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Arithmetic.cs
@@ -130,4 +130,161 @@ public partial class FractionTests
         Assert.AreEqual(expectedGcd, Fraction<int>.GreatestCommonDivisor(left, right));
         Assert.AreEqual(expectedLcm, Fraction<int>.LeastCommonMultiple(left, right));
     }
+
+    /// <summary>
+    /// Verifies that addition produces the canonical sum for a table of known operands.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 2, 1, 3, 5, 6)]
+    [DataRow(1, 2, 1, 2, 1, 1)]
+    [DataRow(3, 4, -1, 4, 1, 2)]
+    [DataRow(-1, 3, -1, 6, -1, 2)]
+    [DataRow(0, 1, 5, 7, 5, 7)]
+    [DataRow(2, 3, 1, 3, 1, 1)]
+    [DataRow(7, 10, 3, 10, 1, 1)]
+    [DataRow(1, 6, 1, 6, 1, 3)]
+    [DataRow(5, 8, -5, 8, 0, 1)]
+    public void Addition_WhenGivenKnownOperands_ShouldReturnCanonicalSum(int an, int ad, int bn, int bd, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(an, ad) + new Fraction<int>(bn, bd));
+    }
+
+    /// <summary>
+    /// Verifies that subtraction produces the canonical difference for a table of known operands.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(5, 6, 1, 3, 1, 2)]
+    [DataRow(1, 2, 1, 2, 0, 1)]
+    [DataRow(1, 3, 2, 3, -1, 3)]
+    [DataRow(0, 1, 1, 4, -1, 4)]
+    [DataRow(-1, 2, 1, 2, -1, 1)]
+    [DataRow(3, 4, -1, 4, 1, 1)]
+    public void Subtraction_WhenGivenKnownOperands_ShouldReturnCanonicalDifference(int an, int ad, int bn, int bd, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(an, ad) - new Fraction<int>(bn, bd));
+    }
+
+    /// <summary>
+    /// Verifies that multiplication produces the canonical product for a table of known operands.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(2, 3, 3, 4, 1, 2)]
+    [DataRow(1, 2, 0, 1, 0, 1)]
+    [DataRow(-2, 3, 3, 5, -2, 5)]
+    [DataRow(-1, 2, -1, 2, 1, 4)]
+    [DataRow(5, 6, 6, 5, 1, 1)]
+    [DataRow(3, 7, 14, 9, 2, 3)]
+    public void Multiplication_WhenGivenKnownOperands_ShouldReturnCanonicalProduct(int an, int ad, int bn, int bd, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(an, ad) * new Fraction<int>(bn, bd));
+    }
+
+    /// <summary>
+    /// Verifies that division produces the canonical quotient for a table of known operands.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 2, 1, 4, 2, 1)]
+    [DataRow(2, 3, 4, 3, 1, 2)]
+    [DataRow(-3, 4, 1, 2, -3, 2)]
+    [DataRow(5, 6, 5, 6, 1, 1)]
+    [DataRow(0, 1, 3, 4, 0, 1)]
+    [DataRow(3, 4, -3, 8, -2, 1)]
+    public void Division_WhenGivenKnownOperands_ShouldReturnCanonicalQuotient(int an, int ad, int bn, int bd, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(an, ad) / new Fraction<int>(bn, bd));
+    }
+
+    /// <summary>
+    /// Verifies that the remainder operation returns the signed remainder for a table of known operands.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(7, 4, 1, 1, 3, 4)]
+    [DataRow(-7, 4, 1, 1, -3, 4)]
+    [DataRow(5, 2, 1, 2, 0, 1)]
+    [DataRow(7, 3, 2, 3, 1, 3)]
+    [DataRow(1, 2, 1, 3, 1, 6)]
+    [DataRow(-1, 2, 1, 3, -1, 6)]
+    [DataRow(10, 3, 1, 1, 1, 3)]
+    public void Remainder_WhenGivenKnownOperands_ShouldReturnSignedRemainder(int an, int ad, int bn, int bd, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(an, ad).Remainder(new Fraction<int>(bn, bd)));
+    }
+
+    /// <summary>
+    /// Verifies that exponentiation returns known answers across positive, zero, and negative exponents.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(2, 3, 1, 2, 3)]
+    [DataRow(2, 3, 3, 8, 27)]
+    [DataRow(-2, 3, 2, 4, 9)]
+    [DataRow(-2, 3, 3, -8, 27)]
+    [DataRow(3, 4, -1, 4, 3)]
+    [DataRow(1, 1, 100, 1, 1)]
+    [DataRow(2, 1, 5, 32, 1)]
+    [DataRow(-1, 2, -2, 4, 1)]
+    [DataRow(5, 7, 0, 1, 1)]
+    public void Pow_WhenGivenKnownOperands_ShouldReturnKnownAnswers(int numerator, int denominator, int exponent, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), new Fraction<int>(numerator, denominator).Pow(exponent));
+    }
+
+    /// <summary>
+    /// Verifies that multiplication overflowing a fixed-width component throws <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Multiplication_WhenResultExceedsFixedWidthRange_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(int.MaxValue, 1) * new Fraction<int>(2, 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that exponentiation overflowing a fixed-width component throws <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Pow_WhenResultExceedsFixedWidthRange_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(2, 1).Pow(40);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that negating or taking the magnitude of the most-negative value throws
+    /// <see cref="OverflowException" /> because the result cannot be represented.
+    /// </summary>
+    [TestMethod]
+    public void NegateAndAbs_WhenMagnitudeExceedsFixedWidthRange_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(int.MinValue).Abs();
+        });
+
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(int.MinValue).Negate();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the most-negative fixed-width value negates without overflow when widened to
+    /// <see cref="long" />.
+    /// </summary>
+    [TestMethod]
+    public void Negate_WhenMagnitudeFitsWiderType_ShouldNotOverflow()
+    {
+        Fraction<long> result = new Fraction<long>(int.MinValue).Negate();
+
+        Assert.AreEqual(-(long)int.MinValue, result.Numerator);
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Comparison.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Comparison.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Comparison.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.CompareTo(Fraction{T})" /> orders values across sign boundaries.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_WhenOrderingAcrossSigns_ShouldReturnExpectedRelativeOrder()
+    {
+        Fraction<int> negative = new Fraction<int>(-1, 2);
+        Fraction<int> zero = Fraction<int>.Zero;
+        Fraction<int> positive = new Fraction<int>(1, 3);
+
+        Assert.IsTrue(negative.CompareTo(zero) < 0);
+        Assert.IsTrue(zero.CompareTo(positive) < 0);
+        Assert.IsTrue(positive.CompareTo(negative) > 0);
+        Assert.AreEqual(0, positive.CompareTo(new Fraction<int>(2, 6)));
+    }
+
+    /// <summary>
+    /// Verifies that comparing with a <see langword="null" /> object sorts the value after <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_WhenComparedWithNullObject_ShouldReturnPositive()
+    {
+        Assert.IsTrue(new Fraction<int>(1, 2).CompareTo(null) > 0);
+    }
+
+    /// <summary>
+    /// Verifies that comparing with an object of a foreign type throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_WhenComparedWithForeignType_ShouldThrowArgumentException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = new Fraction<int>(1, 2).CompareTo("1/2");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that sorting a sequence of fractions yields ascending numeric order.
+    /// </summary>
+    [TestMethod]
+    public void CompareTo_WhenUsedToSort_ShouldYieldAscendingOrder()
+    {
+        Fraction<int>[] values =
+        [
+            new Fraction<int>(3, 4),
+            new Fraction<int>(-1, 2),
+            new Fraction<int>(1, 8),
+            new Fraction<int>(2, 3),
+        ];
+
+        Array.Sort(values);
+
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                new Fraction<int>(-1, 2),
+                new Fraction<int>(1, 8),
+                new Fraction<int>(2, 3),
+                new Fraction<int>(3, 4),
+            },
+            values);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.ContinuedFraction.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.ContinuedFraction.cs
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.ContinuedFraction.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.ToContinuedFraction" /> expands a value into its expected
+    /// coefficients.
+    /// </summary>
+    [TestMethod]
+    public void ToContinuedFraction_WhenExpanded_ShouldProduceExpectedCoefficients()
+    {
+        CollectionAssert.AreEqual(new[] { 0, 1, 3 }, new Fraction<int>(3, 4).ToContinuedFraction());
+        CollectionAssert.AreEqual(new[] { 3, 7 }, new Fraction<int>(22, 7).ToContinuedFraction());
+    }
+
+    /// <summary>
+    /// Verifies that expanding then reconstructing a value reproduces the original fraction.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 4)]
+    [DataRow(22, 7)]
+    [DataRow(-5, 8)]
+    [DataRow(355, 113)]
+    public void ContinuedFraction_WhenRoundTripped_ShouldReproduceOriginal(int numerator, int denominator)
+    {
+        Fraction<int> original = new Fraction<int>(numerator, denominator);
+
+        Fraction<int> roundTripped = Fraction<int>.FromContinuedFraction(original.ToContinuedFraction());
+
+        Assert.AreEqual(original, roundTripped);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromContinuedFraction" /> rejects an empty coefficient set.
+    /// </summary>
+    [TestMethod]
+    public void FromContinuedFraction_WhenGivenNoCoefficients_ShouldThrowArgumentException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Fraction<int>.FromContinuedFraction();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromContinuedFraction" /> rejects a non-positive trailing
+    /// coefficient.
+    /// </summary>
+    [TestMethod]
+    public void FromContinuedFraction_WhenTrailingCoefficientIsNotPositive_ShouldThrowArgumentOutOfRangeException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = Fraction<int>.FromContinuedFraction(1, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromContinuedFraction" /> rejects a <see langword="null" /> array.
+    /// </summary>
+    [TestMethod]
+    public void FromContinuedFraction_WhenGivenNullArray_ShouldThrowArgumentNullException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = Fraction<int>.FromContinuedFraction(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.LimitDenominator" /> returns the known best approximation of pi.
+    /// </summary>
+    [TestMethod]
+    public void LimitDenominator_WhenApproximatingPi_ShouldReturnKnownConvergents()
+    {
+        Fraction<long> pi = Fraction<long>.FromDouble(Math.PI);
+
+        Assert.AreEqual(new Fraction<long>(22, 7), pi.LimitDenominator(10));
+        Assert.AreEqual(new Fraction<long>(311, 99), pi.LimitDenominator(100));
+        Assert.AreEqual(new Fraction<long>(355, 113), pi.LimitDenominator(113));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.LimitDenominator" /> returns the value unchanged when its
+    /// denominator is already within the limit.
+    /// </summary>
+    [TestMethod]
+    public void LimitDenominator_WhenDenominatorWithinLimit_ShouldReturnSameValue()
+    {
+        Fraction<int> value = new Fraction<int>(1, 2);
+
+        Assert.AreEqual(value, value.LimitDenominator(10));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.LimitDenominator" /> rejects a limit below one.
+    /// </summary>
+    [TestMethod]
+    public void LimitDenominator_WhenLimitIsLessThanOne_ShouldThrowArgumentOutOfRangeException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new Fraction<int>(3, 4).LimitDenominator(0);
+        });
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.ContinuedFraction.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.ContinuedFraction.cs
@@ -109,4 +109,81 @@ public partial class FractionTests
             _ = new Fraction<int>(3, 4).LimitDenominator(0);
         });
     }
+
+    /// <summary>
+    /// Verifies that continued-fraction expansion yields known coefficient sequences.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(3, 4, "0,1,3")]
+    [DataRow(22, 7, "3,7")]
+    [DataRow(1, 1, "1")]
+    [DataRow(0, 1, "0")]
+    [DataRow(7, 4, "1,1,3")]
+    [DataRow(-5, 8, "-1,2,1,2")]
+    [DataRow(355, 113, "3,7,16")]
+    [DataRow(43, 19, "2,3,1,4")]
+    [DataRow(5, 1, "5")]
+    [DataRow(-3, 1, "-3")]
+    public void ToContinuedFraction_WhenExpanded_ShouldYieldKnownCoefficients(int numerator, int denominator, string expected)
+    {
+        int[] coefficients = new Fraction<int>(numerator, denominator).ToContinuedFraction();
+
+        CollectionAssert.AreEqual(ParseCoefficients(expected), coefficients);
+    }
+
+    /// <summary>
+    /// Verifies that reconstructing a fraction from known coefficients yields the expected value.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow("0,1,3", 3, 4)]
+    [DataRow("3,7", 22, 7)]
+    [DataRow("1,1,3", 7, 4)]
+    [DataRow("-1,2,1,2", -5, 8)]
+    [DataRow("-2,3", -5, 3)]
+    [DataRow("3,7,16", 355, 113)]
+    [DataRow("5", 5, 1)]
+    public void FromContinuedFraction_WhenGivenKnownCoefficients_ShouldReturnExpectedValue(string coefficients, int en, int ed)
+    {
+        Fraction<int> value = Fraction<int>.FromContinuedFraction(ParseCoefficients(coefficients));
+
+        Assert.AreEqual(new Fraction<int>(en, ed), value);
+    }
+
+    /// <summary>
+    /// Verifies that a single-coefficient continued fraction reconstructs a whole number.
+    /// </summary>
+    [TestMethod]
+    public void FromContinuedFraction_WhenGivenSingleCoefficient_ShouldReturnWholeNumber()
+    {
+        Assert.AreEqual(new Fraction<int>(-3, 1), Fraction<int>.FromContinuedFraction(-3));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.LimitDenominator" /> returns an exact rational unchanged when its
+    /// denominator does not exceed the limit.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 7, 10)]
+    [DataRow(355, 113, 200)]
+    [DataRow(-5, 8, 8)]
+    public void LimitDenominator_WhenDenominatorDoesNotExceedLimit_ShouldReturnInputValue(int numerator, int denominator, int limit)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(value, value.LimitDenominator(limit));
+    }
+
+    /// <summary>
+    /// Splits a comma-separated coefficient string into an array of integers.
+    /// </summary>
+    /// <param name="text">The comma-separated coefficients.</param>
+    /// <returns>The parsed coefficient array.</returns>
+    private static int[] ParseCoefficients(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+
+        return text.Split(',').Select(int.Parse).ToArray();
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Conversions.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Conversions.cs
@@ -1,0 +1,110 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Conversions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that an integer of the backing type implicitly converts to a whole-number fraction.
+    /// </summary>
+    [TestMethod]
+    public void ImplicitConversion_WhenFromBackingInteger_ShouldProduceWholeNumber()
+    {
+        Fraction<int> value = 5;
+
+        Assert.AreEqual(new Fraction<int>(5, 1), value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDecimal" /> produces the exact rational value.
+    /// </summary>
+    [TestMethod]
+    [DataRow("0.75", 3, 4)]
+    [DataRow("0.25", 1, 4)]
+    [DataRow("-0.5", -1, 2)]
+    [DataRow("2.5", 5, 2)]
+    public void FromDecimal_WhenGivenDecimal_ShouldProduceExactValue(string text, int expectedNumerator, int expectedDenominator)
+    {
+        decimal input = decimal.Parse(text, System.Globalization.CultureInfo.InvariantCulture);
+
+        Fraction<int> value = Fraction<int>.FromDecimal(input);
+
+        Assert.AreEqual(new Fraction<int>(expectedNumerator, expectedDenominator), value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDouble" /> produces the exact rational value for binary fractions.
+    /// </summary>
+    [TestMethod]
+    public void FromDouble_WhenGivenBinaryFraction_ShouldProduceExactValue()
+    {
+        Assert.AreEqual(new Fraction<int>(1, 2), Fraction<int>.FromDouble(0.5));
+        Assert.AreEqual(new Fraction<int>(-3, 8), Fraction<int>.FromDouble(-0.375));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDouble" /> rejects non-finite values.
+    /// </summary>
+    [TestMethod]
+    public void FromDouble_WhenGivenNonFiniteValue_ShouldThrowArgumentException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Fraction<int>.FromDouble(double.NaN);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that conversion to <see cref="double" /> and <see cref="decimal" /> yields the expected value.
+    /// </summary>
+    [TestMethod]
+    public void ToDoubleAndToDecimal_WhenConverted_ShouldYieldExpectedValue()
+    {
+        Fraction<int> value = new Fraction<int>(3, 4);
+
+        Assert.AreEqual(0.75, value.ToDouble());
+        Assert.AreEqual(0.75m, value.ToDecimal());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.As{TOther}" /> retypes the fraction onto a different backing type.
+    /// </summary>
+    [TestMethod]
+    public void As_WhenRetypingBackingComponent_ShouldPreserveValue()
+    {
+        Fraction<long> value = new Fraction<int>(3, 4).As<long>();
+
+        Assert.AreEqual(3L, value.Numerator);
+        Assert.AreEqual(4L, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that retyping onto a backing type too small to hold the value throws
+    /// <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void As_WhenComponentDoesNotFitTargetType_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<int>(1, 1000).As<byte>();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the explicit decimal conversion operator matches <see cref="Fraction{T}.FromDecimal" />.
+    /// </summary>
+    [TestMethod]
+    public void ExplicitDecimalOperator_WhenConverting_ShouldMatchFromDecimal()
+    {
+        Fraction<BigInteger> value = (Fraction<BigInteger>)1.5m;
+
+        Assert.AreEqual(new Fraction<BigInteger>(3, 2), value);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Conversions.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Conversions.cs
@@ -107,4 +107,96 @@ public partial class FractionTests
 
         Assert.AreEqual(new Fraction<BigInteger>(3, 2), value);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDecimal" /> produces exact values for a table of known decimals.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow("0.5", 1, 2)]
+    [DataRow("0.25", 1, 4)]
+    [DataRow("0.75", 3, 4)]
+    [DataRow("0.1", 1, 10)]
+    [DataRow("0.125", 1, 8)]
+    [DataRow("0.05", 1, 20)]
+    [DataRow("0.2", 1, 5)]
+    [DataRow("1.0", 1, 1)]
+    [DataRow("2.5", 5, 2)]
+    [DataRow("-1.25", -5, 4)]
+    [DataRow("3", 3, 1)]
+    [DataRow("0", 0, 1)]
+    [DataRow("100", 100, 1)]
+    public void FromDecimal_WhenGivenKnownValues_ShouldProduceExactValue(string text, int en, int ed)
+    {
+        decimal input = decimal.Parse(text, System.Globalization.CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(new Fraction<int>(en, ed), Fraction<int>.FromDecimal(input));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDouble" /> produces exact values for a table of binary
+    /// fractions.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(0.5, 1, 2)]
+    [DataRow(0.25, 1, 4)]
+    [DataRow(0.75, 3, 4)]
+    [DataRow(0.125, 1, 8)]
+    [DataRow(0.625, 5, 8)]
+    [DataRow(-0.375, -3, 8)]
+    [DataRow(1.0, 1, 1)]
+    [DataRow(2.0, 2, 1)]
+    [DataRow(3.0, 3, 1)]
+    [DataRow(0.0, 0, 1)]
+    [DataRow(-2.5, -5, 2)]
+    public void FromDouble_WhenGivenKnownValues_ShouldProduceExactValue(double input, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), Fraction<int>.FromDouble(input));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.FromDouble" /> rejects every non-finite value.
+    /// </summary>
+    [TestMethod]
+    [DataRow(double.NaN)]
+    [DataRow(double.PositiveInfinity)]
+    [DataRow(double.NegativeInfinity)]
+    public void FromDouble_WhenGivenNonFiniteValue_ShouldThrowArgumentExceptionForEachCase(double input)
+    {
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Fraction<int>.FromDouble(input);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that conversion to <see cref="double" /> returns known answers.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 2, 0.5)]
+    [DataRow(3, 4, 0.75)]
+    [DataRow(-1, 4, -0.25)]
+    [DataRow(5, 1, 5.0)]
+    [DataRow(0, 1, 0.0)]
+    [DataRow(-7, 2, -3.5)]
+    public void ToDouble_WhenConverted_ShouldReturnKnownAnswers(int numerator, int denominator, double expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToDouble());
+    }
+
+    /// <summary>
+    /// Verifies that an exact binary fraction round-trips through <see cref="double" /> conversion.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0.5)]
+    [DataRow(0.25)]
+    [DataRow(-0.375)]
+    [DataRow(123.0)]
+    [DataRow(0.0)]
+    public void FromDouble_WhenRoundTrippedThroughToDouble_ShouldReproduceValue(double input)
+    {
+        Assert.AreEqual(input, Fraction<long>.FromDouble(input).ToDouble());
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Ctors.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Ctors.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Ctors.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that the constructor reduces a non-canonical fraction to its lowest terms.
+    /// </summary>
+    [TestMethod]
+    [DataRow(2, 4, 1, 2)]
+    [DataRow(6, 8, 3, 4)]
+    [DataRow(100, 10, 10, 1)]
+    [DataRow(9, 6, 3, 2)]
+    public void Constructor_WhenGivenReducibleComponents_ShouldNormalizeToLowestTerms(int numerator, int denominator, int expectedNumerator, int expectedDenominator)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(expectedNumerator, value.Numerator);
+        Assert.AreEqual(expectedDenominator, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that a negative denominator is canonicalized so the numerator carries the sign.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, -2, -1, 2)]
+    [DataRow(-1, -2, 1, 2)]
+    [DataRow(-3, 4, -3, 4)]
+    public void Constructor_WhenGivenNegativeDenominator_ShouldMoveSignToNumerator(int numerator, int denominator, int expectedNumerator, int expectedDenominator)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(expectedNumerator, value.Numerator);
+        Assert.AreEqual(expectedDenominator, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that a zero numerator is reduced to the canonical zero <c>0/1</c>.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenNumeratorIsZero_ShouldProduceCanonicalZero()
+    {
+        Fraction<int> value = new Fraction<int>(0, 5);
+
+        Assert.AreEqual(0, value.Numerator);
+        Assert.AreEqual(1, value.Denominator);
+        Assert.IsTrue(value.IsZero);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a fraction with a zero denominator throws
+    /// <see cref="DivideByZeroException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenDenominatorIsZero_ShouldThrowDivideByZeroException()
+    {
+        _ = Assert.ThrowsExactly<DivideByZeroException>(() =>
+        {
+            _ = new Fraction<int>(1, 0);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the single-argument constructor produces a whole-number fraction.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenGivenSingleInteger_ShouldProduceWholeNumber()
+    {
+        Fraction<int> value = new Fraction<int>(7);
+
+        Assert.AreEqual(7, value.Numerator);
+        Assert.AreEqual(1, value.Denominator);
+        Assert.IsTrue(value.IsInteger);
+    }
+
+    /// <summary>
+    /// Verifies that a default-initialized fraction behaves as the rational value zero.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenDefaultInitialized_ShouldBehaveAsZero()
+    {
+        Fraction<int> value = default;
+
+        Assert.AreEqual(0, value.Numerator);
+        Assert.AreEqual(1, value.Denominator);
+        Assert.IsTrue(value.IsZero);
+        Assert.AreEqual(Fraction<int>.Zero, value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="BigInteger" /> components support construction beyond fixed-width ranges.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenBackedByBigInteger_ShouldNormalizeLargeComponents()
+    {
+        BigInteger large = BigInteger.Pow(10, 40);
+        Fraction<BigInteger> value = new Fraction<BigInteger>(large * 2, large * 4);
+
+        Assert.AreEqual(BigInteger.One, value.Numerator);
+        Assert.AreEqual((BigInteger)2, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Deconstruct" /> yields the canonical components.
+    /// </summary>
+    [TestMethod]
+    public void Deconstruct_WhenCalled_ShouldYieldCanonicalComponents()
+    {
+        (int numerator, int denominator) = new Fraction<int>(6, 8);
+
+        Assert.AreEqual(3, numerator);
+        Assert.AreEqual(4, denominator);
+    }
+
+    /// <summary>
+    /// Verifies that the <c>Sign</c> property reflects the sign of the rational value.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-3, 4, -1)]
+    [DataRow(0, 4, 0)]
+    [DataRow(3, 4, 1)]
+    public void Sign_WhenInspected_ShouldReflectTheValueSign(int numerator, int denominator, int expectedSign)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(expectedSign, value.Sign);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Ctors.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Ctors.cs
@@ -132,4 +132,46 @@ public partial class FractionTests
 
         Assert.AreEqual(expectedSign, value.Sign);
     }
+
+    /// <summary>
+    /// Verifies that construction reduces a wide table of components to their canonical form.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(2, 4, 1, 2)]
+    [DataRow(6, 8, 3, 4)]
+    [DataRow(-2, 4, -1, 2)]
+    [DataRow(2, -4, -1, 2)]
+    [DataRow(-2, -4, 1, 2)]
+    [DataRow(0, 5, 0, 1)]
+    [DataRow(0, -5, 0, 1)]
+    [DataRow(10, 5, 2, 1)]
+    [DataRow(100, 10, 10, 1)]
+    [DataRow(7, 7, 1, 1)]
+    [DataRow(-7, 7, -1, 1)]
+    [DataRow(15, 25, 3, 5)]
+    [DataRow(-15, 25, -3, 5)]
+    [DataRow(9, -6, -3, 2)]
+    [DataRow(12, 18, 2, 3)]
+    [DataRow(-12, -18, 2, 3)]
+    [DataRow(17, 19, 17, 19)]
+    [DataRow(1000000, 1, 1000000, 1)]
+    public void Constructor_WhenGivenComponents_ShouldNormalizeToKnownAnswer(int numerator, int denominator, int expectedNumerator, int expectedDenominator)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(expectedNumerator, value.Numerator);
+        Assert.AreEqual(expectedDenominator, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that the most-negative and most-positive fixed-width values construct without overflow.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenGivenFixedWidthExtremes_ShouldConstructWithoutOverflow()
+    {
+        Assert.AreEqual(int.MinValue, new Fraction<int>(int.MinValue).Numerator);
+        Assert.AreEqual(int.MaxValue, new Fraction<int>(int.MaxValue).Numerator);
+        Assert.AreEqual(1, new Fraction<int>(int.MaxValue).Denominator);
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.DefaultValue.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.DefaultValue.cs
@@ -1,0 +1,74 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.DefaultValue.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that a default-initialized fraction exposes the canonical components of zero.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenInspected_ShouldExposeCanonicalZeroComponents()
+    {
+        Fraction<int> value = default;
+
+        Assert.AreEqual(0, value.Numerator);
+        Assert.AreEqual(1, value.Denominator);
+        Assert.AreEqual(0, value.Sign);
+        Assert.IsTrue(value.IsZero);
+        Assert.IsTrue(value.IsInteger);
+    }
+
+    /// <summary>
+    /// Verifies that a default-initialized fraction behaves as zero through arithmetic operators.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenUsedInArithmetic_ShouldBehaveAsZero()
+    {
+        Fraction<int> half = new Fraction<int>(1, 2);
+
+        Assert.AreEqual(half, default(Fraction<int>) + half);
+        Assert.AreEqual(-half, default(Fraction<int>) - half);
+        Assert.AreEqual(Fraction<int>.Zero, default(Fraction<int>) * half);
+    }
+
+    /// <summary>
+    /// Verifies that a default-initialized fraction formats, hashes, and compares as zero.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenFormattedHashedOrCompared_ShouldMatchZero()
+    {
+        Fraction<int> value = default;
+
+        Assert.AreEqual("0", value.ToString());
+        Assert.AreEqual(Fraction<int>.Zero.GetHashCode(), value.GetHashCode());
+        Assert.AreEqual(0, value.CompareTo(Fraction<int>.Zero));
+        Assert.IsTrue(value == Fraction<int>.Zero);
+    }
+
+    /// <summary>
+    /// Verifies that expanding a default-initialized fraction yields the continued fraction of zero.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenExpandedToContinuedFraction_ShouldYieldZero()
+    {
+        CollectionAssert.AreEqual(new[] { 0 }, default(Fraction<int>).ToContinuedFraction());
+    }
+
+    /// <summary>
+    /// Verifies that taking the reciprocal of a default-initialized fraction throws
+    /// <see cref="DivideByZeroException" />.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenReciprocalRequested_ShouldThrowDivideByZeroException()
+    {
+        _ = Assert.ThrowsExactly<DivideByZeroException>(() =>
+        {
+            _ = default(Fraction<int>).Reciprocal();
+        });
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Equality.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Equality.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Equality.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that fractions reduced from different components compare equal and hash equally.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenValuesReduceToSameCanonicalForm_ShouldBeEqualAndShareHashCode()
+    {
+        Fraction<int> a = new Fraction<int>(1, 2);
+        Fraction<int> b = new Fraction<int>(50, 100);
+
+        Assert.IsTrue(a.Equals(b));
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that the object overload of <c>Equals</c> recognizes a boxed fraction of the same value.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparedWithBoxedFraction_ShouldReturnTrue()
+    {
+        object boxed = new Fraction<int>(3, 4);
+
+        Assert.IsTrue(new Fraction<int>(3, 4).Equals(boxed));
+    }
+
+    /// <summary>
+    /// Verifies that the object overload of <c>Equals</c> rejects <see langword="null" /> and foreign types.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparedWithNullOrForeignType_ShouldReturnFalse()
+    {
+        Fraction<int> value = new Fraction<int>(3, 4);
+
+        Assert.IsFalse(value.Equals(null));
+        Assert.IsFalse(value.Equals("3/4"));
+    }
+
+    /// <summary>
+    /// Verifies that a default-initialized fraction is equal to zero.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenComparingDefaultWithZero_ShouldReturnTrue()
+    {
+        Assert.IsTrue(default(Fraction<int>).Equals(Fraction<int>.Zero));
+    }
+
+    /// <summary>
+    /// Verifies that unequal fractions are reported as unequal.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenValuesDiffer_ShouldReturnFalse()
+    {
+        Assert.IsFalse(new Fraction<int>(1, 2).Equals(new Fraction<int>(1, 3)));
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Formatting.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Formatting.cs
@@ -111,4 +111,83 @@ public partial class FractionTests
 
         Assert.AreEqual(value, Fraction<int>.Parse(text, CultureInfo.InvariantCulture));
     }
+
+    /// <summary>
+    /// Verifies that the default format renders known answers for a wide table of values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(0, 1, "0")]
+    [DataRow(1, 1, "1")]
+    [DataRow(-1, 1, "-1")]
+    [DataRow(3, 4, "3/4")]
+    [DataRow(-3, 4, "-3/4")]
+    [DataRow(100, 7, "100/7")]
+    [DataRow(-100, 7, "-100/7")]
+    [DataRow(6, 3, "2")]
+    public void ToString_WhenUsingDefaultFormat_ShouldRenderKnownAnswers(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString());
+    }
+
+    /// <summary>
+    /// Verifies that the mixed-number format renders known answers for a wide table of values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(7, 4, "1 3/4")]
+    [DataRow(-7, 4, "-1 3/4")]
+    [DataRow(11, 4, "2 3/4")]
+    [DataRow(-11, 4, "-2 3/4")]
+    [DataRow(3, 4, "3/4")]
+    [DataRow(5, 3, "1 2/3")]
+    [DataRow(-5, 3, "-1 2/3")]
+    [DataRow(4, 1, "4")]
+    [DataRow(0, 1, "0")]
+    public void ToString_WhenUsingMixedFormat_ShouldRenderKnownAnswers(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("M"));
+    }
+
+    /// <summary>
+    /// Verifies that the Unicode format renders known answers for a wide table of values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 2, "½")]
+    [DataRow(1, 3, "⅓")]
+    [DataRow(2, 3, "⅔")]
+    [DataRow(1, 4, "¼")]
+    [DataRow(3, 4, "¾")]
+    [DataRow(1, 8, "⅛")]
+    [DataRow(5, 8, "⅝")]
+    [DataRow(7, 4, "1¾")]
+    [DataRow(-1, 2, "-½")]
+    [DataRow(5, 2, "2½")]
+    [DataRow(3, 1, "3")]
+    [DataRow(5, 9, "5/9")]
+    public void ToString_WhenUsingUnicodeFormat_ShouldRenderKnownAnswers(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("U"));
+    }
+
+    /// <summary>
+    /// Verifies that the percent format renders known answers for a wide table of values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 1, "100%")]
+    [DataRow(1, 2, "50%")]
+    [DataRow(1, 4, "25%")]
+    [DataRow(3, 4, "75%")]
+    [DataRow(2, 1, "200%")]
+    [DataRow(-3, 4, "-75%")]
+    [DataRow(0, 1, "0%")]
+    [DataRow(1, 8, "25/2%")]
+    [DataRow(1, 3, "100/3%")]
+    [DataRow(1, 6, "50/3%")]
+    public void ToString_WhenUsingPercentFormat_ShouldRenderKnownAnswers(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("P"));
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Formatting.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Formatting.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Formatting.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that the default format renders a ratio, or a bare integer when the value is whole.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 4, "3/4")]
+    [DataRow(-3, 4, "-3/4")]
+    [DataRow(6, 2, "3")]
+    [DataRow(0, 5, "0")]
+    public void ToString_WhenUsingDefaultFormat_ShouldRenderRatioOrInteger(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString());
+    }
+
+    /// <summary>
+    /// Verifies that the mixed-number format separates the whole and fractional parts.
+    /// </summary>
+    [TestMethod]
+    [DataRow(7, 4, "1 3/4")]
+    [DataRow(-7, 4, "-1 3/4")]
+    [DataRow(3, 4, "3/4")]
+    public void ToString_WhenUsingMixedFormat_ShouldSeparateWholeAndFraction(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("M"));
+    }
+
+    /// <summary>
+    /// Verifies that the Unicode format renders a vulgar-fraction glyph when one exists.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 4, "¾")]
+    [DataRow(1, 2, "½")]
+    [DataRow(7, 4, "1¾")]
+    [DataRow(-3, 4, "-¾")]
+    public void ToString_WhenUsingUnicodeFormat_ShouldRenderVulgarGlyph(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("U"));
+    }
+
+    /// <summary>
+    /// Verifies that the Unicode format falls back to the mixed-number form when no glyph exists.
+    /// </summary>
+    [TestMethod]
+    public void ToString_WhenUsingUnicodeFormatWithoutGlyph_ShouldFallBackToMixed()
+    {
+        Assert.AreEqual("5/9", new Fraction<int>(5, 9).ToString("U"));
+    }
+
+    /// <summary>
+    /// Verifies that the percent format scales the value by one hundred and appends a percent sign.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 4, "75%")]
+    [DataRow(1, 3, "100/3%")]
+    public void ToString_WhenUsingPercentFormat_ShouldScaleByOneHundred(int numerator, int denominator, string expected)
+    {
+        Assert.AreEqual(expected, new Fraction<int>(numerator, denominator).ToString("P"));
+    }
+
+    /// <summary>
+    /// Verifies that an unsupported format specifier throws <see cref="FormatException" />.
+    /// </summary>
+    [TestMethod]
+    public void ToString_WhenFormatIsUnsupported_ShouldThrowFormatException()
+    {
+        _ = Assert.ThrowsExactly<FormatException>(() =>
+        {
+            _ = new Fraction<int>(3, 4).ToString("Z");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.TryFormat(Span{char}, out int, ReadOnlySpan{char}, IFormatProvider?)" />
+    /// writes the formatted value into a character span.
+    /// </summary>
+    [TestMethod]
+    public void TryFormat_WhenDestinationIsLargeEnough_ShouldWriteFormattedValue()
+    {
+        Span<char> buffer = stackalloc char[16];
+
+        bool formatted = new Fraction<int>(3, 4).TryFormat(buffer, out int written, default, null);
+
+        Assert.IsTrue(formatted);
+        Assert.AreEqual("3/4", new string(buffer[..written]));
+    }
+
+    /// <summary>
+    /// Verifies that every format specifier round-trips through <see cref="Fraction{T}.Parse(string)" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow("G")]
+    [DataRow("M")]
+    [DataRow("U")]
+    [DataRow("P")]
+    public void ToString_WhenRoundTrippedThroughParse_ShouldReproduceValue(string format)
+    {
+        Fraction<int> value = new Fraction<int>(7, 4);
+
+        string text = value.ToString(format, CultureInfo.InvariantCulture);
+
+        Assert.AreEqual(value, Fraction<int>.Parse(text, CultureInfo.InvariantCulture));
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.GenericMath.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.GenericMath.cs
@@ -118,4 +118,147 @@ public partial class FractionTests
     private static TNumber CreateFromInt32<TNumber>(int value)
         where TNumber : INumberBase<TNumber> =>
         TNumber.CreateChecked(value);
+
+    /// <summary>
+    /// Verifies that the generic-math classification predicates report known answers.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(4, 1, true, true, false, false)]
+    [DataRow(3, 1, true, false, true, false)]
+    [DataRow(3, 4, false, false, false, false)]
+    [DataRow(0, 1, true, true, false, false)]
+    [DataRow(-2, 1, true, true, false, true)]
+    [DataRow(-3, 1, true, false, true, true)]
+    [DataRow(-3, 4, false, false, false, true)]
+    public void GenericMath_WhenClassifyingValue_ShouldReportKnownAnswers(
+        int numerator,
+        int denominator,
+        bool isInteger,
+        bool isEvenInteger,
+        bool isOddInteger,
+        bool isNegative)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(isInteger, IsIntegerOf(value), nameof(isInteger));
+        Assert.AreEqual(isEvenInteger, IsEvenIntegerOf(value), nameof(isEvenInteger));
+        Assert.AreEqual(isOddInteger, IsOddIntegerOf(value), nameof(isOddInteger));
+        Assert.AreEqual(isNegative, IsNegativeOf(value), nameof(isNegative));
+    }
+
+    /// <summary>
+    /// Verifies that the generic-math minimum, maximum, and magnitude selectors return expected values.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenSelectingExtremes_ShouldReturnExpectedValues()
+    {
+        Assert.AreEqual(new Fraction<int>(1, 2), MaxOf(new Fraction<int>(1, 3), new Fraction<int>(1, 2)));
+        Assert.AreEqual(new Fraction<int>(1, 3), MinOf(new Fraction<int>(1, 3), new Fraction<int>(1, 2)));
+        Assert.AreEqual(new Fraction<int>(-1, 3), MaxOf(new Fraction<int>(-1, 2), new Fraction<int>(-1, 3)));
+        Assert.AreEqual(new Fraction<int>(-3, 4), MaxMagnitudeOf(new Fraction<int>(-3, 4), new Fraction<int>(1, 2)));
+        Assert.AreEqual(new Fraction<int>(1, 2), MinMagnitudeOf(new Fraction<int>(-3, 4), new Fraction<int>(1, 2)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}" /> reports a radix of two through the generic-math contract.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenQueryingRadix_ShouldReturnTwo()
+    {
+        Assert.AreEqual(2, RadixOf<Fraction<int>>());
+    }
+
+    /// <summary>
+    /// Determines whether a number is an integer using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to classify.</param>
+    /// <returns><see langword="true" /> if the value is an integer; otherwise, <see langword="false" />.</returns>
+    private static bool IsIntegerOf<TNumber>(TNumber value)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.IsInteger(value);
+
+    /// <summary>
+    /// Determines whether a number is an even integer using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to classify.</param>
+    /// <returns><see langword="true" /> if the value is an even integer; otherwise, <see langword="false" />.</returns>
+    private static bool IsEvenIntegerOf<TNumber>(TNumber value)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.IsEvenInteger(value);
+
+    /// <summary>
+    /// Determines whether a number is an odd integer using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to classify.</param>
+    /// <returns><see langword="true" /> if the value is an odd integer; otherwise, <see langword="false" />.</returns>
+    private static bool IsOddIntegerOf<TNumber>(TNumber value)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.IsOddInteger(value);
+
+    /// <summary>
+    /// Determines whether a number is negative using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to classify.</param>
+    /// <returns><see langword="true" /> if the value is negative; otherwise, <see langword="false" />.</returns>
+    private static bool IsNegativeOf<TNumber>(TNumber value)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.IsNegative(value);
+
+    /// <summary>
+    /// Returns the larger of two numbers using the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The larger of the two values.</returns>
+    private static TNumber MaxOf<TNumber>(TNumber x, TNumber y)
+        where TNumber : INumber<TNumber> =>
+        TNumber.Max(x, y);
+
+    /// <summary>
+    /// Returns the smaller of two numbers using the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The smaller of the two values.</returns>
+    private static TNumber MinOf<TNumber>(TNumber x, TNumber y)
+        where TNumber : INumber<TNumber> =>
+        TNumber.Min(x, y);
+
+    /// <summary>
+    /// Returns the number with the greater magnitude using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The value with the greater magnitude.</returns>
+    private static TNumber MaxMagnitudeOf<TNumber>(TNumber x, TNumber y)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.MaxMagnitude(x, y);
+
+    /// <summary>
+    /// Returns the number with the smaller magnitude using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="x">The first value.</param>
+    /// <param name="y">The second value.</param>
+    /// <returns>The value with the smaller magnitude.</returns>
+    private static TNumber MinMagnitudeOf<TNumber>(TNumber x, TNumber y)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.MinMagnitude(x, y);
+
+    /// <summary>
+    /// Returns the radix of a number type using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <returns>The radix reported by <typeparamref name="TNumber" />.</returns>
+    private static int RadixOf<TNumber>()
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.Radix;
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.GenericMath.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.GenericMath.cs
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.GenericMath.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Numerics;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}" /> can substitute for a type parameter constrained to
+    /// <see cref="INumber{TSelf}" />.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenUsedAsINumber_ShouldComposeWithConstrainedCode()
+    {
+        Fraction<int> total = SumValues(
+            new Fraction<int>(1, 2),
+            new Fraction<int>(1, 3),
+            new Fraction<int>(1, 6));
+
+        Assert.AreEqual(Fraction<int>.One, total);
+    }
+
+    /// <summary>
+    /// Verifies that the generic-math absolute value and sign operations behave correctly.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenComputingAbsAndSign_ShouldReturnExpectedValues()
+    {
+        Assert.AreEqual(new Fraction<int>(3, 4), AbsoluteValue(new Fraction<int>(-3, 4)));
+        Assert.AreEqual(-1, SignOf(new Fraction<int>(-3, 4)));
+        Assert.AreEqual(1, SignOf(new Fraction<int>(3, 4)));
+    }
+
+    /// <summary>
+    /// Verifies that the generic-math clamp operation constrains a value to an inclusive range.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenClampingValue_ShouldConstrainToRange()
+    {
+        Fraction<int> low = Fraction<int>.Zero;
+        Fraction<int> high = Fraction<int>.One;
+
+        Assert.AreEqual(high, Clamp(new Fraction<int>(2, 1), low, high));
+        Assert.AreEqual(low, Clamp(new Fraction<int>(-1, 1), low, high));
+        Assert.AreEqual(new Fraction<int>(1, 2), Clamp(new Fraction<int>(1, 2), low, high));
+    }
+
+    /// <summary>
+    /// Verifies that the generic-math creation routine converts an integer into a <see cref="Fraction{T}" />.
+    /// </summary>
+    [TestMethod]
+    public void GenericMath_WhenCreatingFromInteger_ShouldProduceWholeNumber()
+    {
+        Assert.AreEqual(new Fraction<int>(5, 1), CreateFromInt32<Fraction<int>>(5));
+    }
+
+    /// <summary>
+    /// Sums a sequence of numbers using only the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="values">The values to sum.</param>
+    /// <returns>The total of <paramref name="values" />.</returns>
+    private static TNumber SumValues<TNumber>(params TNumber[] values)
+        where TNumber : INumber<TNumber>
+    {
+        TNumber total = TNumber.Zero;
+        foreach (TNumber value in values)
+        {
+            total += value;
+        }
+
+        return total;
+    }
+
+    /// <summary>
+    /// Returns the absolute value of a number using the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value whose magnitude is required.</param>
+    /// <returns>The magnitude of <paramref name="value" />.</returns>
+    private static TNumber AbsoluteValue<TNumber>(TNumber value)
+        where TNumber : INumber<TNumber> =>
+        TNumber.Abs(value);
+
+    /// <summary>
+    /// Returns the sign of a number using the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to inspect.</param>
+    /// <returns>The sign of <paramref name="value" />.</returns>
+    private static int SignOf<TNumber>(TNumber value)
+        where TNumber : INumber<TNumber> =>
+        TNumber.Sign(value);
+
+    /// <summary>
+    /// Clamps a number to an inclusive range using the <see cref="INumber{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The value to clamp.</param>
+    /// <param name="min">The inclusive lower bound.</param>
+    /// <param name="max">The inclusive upper bound.</param>
+    /// <returns>The clamped value.</returns>
+    private static TNumber Clamp<TNumber>(TNumber value, TNumber min, TNumber max)
+        where TNumber : INumber<TNumber> =>
+        TNumber.Clamp(value, min, max);
+
+    /// <summary>
+    /// Creates a number from an <see cref="int" /> using the <see cref="INumberBase{TSelf}" /> contract.
+    /// </summary>
+    /// <typeparam name="TNumber">The number type.</typeparam>
+    /// <param name="value">The integer to convert.</param>
+    /// <returns>The created value.</returns>
+    private static TNumber CreateFromInt32<TNumber>(int value)
+        where TNumber : INumberBase<TNumber> =>
+        TNumber.CreateChecked(value);
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Operators.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Operators.cs
@@ -85,4 +85,50 @@ public partial class FractionTests
         Assert.IsTrue(small != large);
         Assert.IsTrue(small == new Fraction<int>(2, 6));
     }
+
+    /// <summary>
+    /// Verifies that comparison yields the expected relative order for a table of known operand pairs.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(1, 3, 1, 2, -1)]
+    [DataRow(1, 2, 1, 3, 1)]
+    [DataRow(2, 4, 1, 2, 0)]
+    [DataRow(-1, 2, 1, 2, -1)]
+    [DataRow(-1, 2, -1, 3, -1)]
+    [DataRow(0, 1, 0, 1, 0)]
+    [DataRow(3, 4, 3, 4, 0)]
+    [DataRow(-3, 4, -3, 4, 0)]
+    [DataRow(100, 1, 99, 1, 1)]
+    [DataRow(1, 1000000, 0, 1, 1)]
+    [DataRow(-1, 1000000, 0, 1, -1)]
+    public void Comparison_WhenGivenKnownOperands_ShouldYieldExpectedOrder(int an, int ad, int bn, int bd, int expectedSign)
+    {
+        Fraction<int> a = new Fraction<int>(an, ad);
+        Fraction<int> b = new Fraction<int>(bn, bd);
+
+        Assert.AreEqual(expectedSign, Math.Sign(a.CompareTo(b)));
+    }
+
+    /// <summary>
+    /// Verifies that the relational operators agree with the result of <c>CompareTo</c>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1, 3, 1, 2)]
+    [DataRow(1, 2, 1, 2)]
+    [DataRow(3, 2, 1, 2)]
+    [DataRow(-1, 2, 1, 4)]
+    public void RelationalOperators_WhenCompared_ShouldAgreeWithCompareTo(int an, int ad, int bn, int bd)
+    {
+        Fraction<int> a = new Fraction<int>(an, ad);
+        Fraction<int> b = new Fraction<int>(bn, bd);
+        int order = a.CompareTo(b);
+
+        Assert.AreEqual(order < 0, a < b);
+        Assert.AreEqual(order <= 0, a <= b);
+        Assert.AreEqual(order > 0, a > b);
+        Assert.AreEqual(order >= 0, a >= b);
+        Assert.AreEqual(order == 0, a == b);
+        Assert.AreEqual(order != 0, a != b);
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Operators.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Operators.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Operators.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that the arithmetic operators produce the expected canonical results.
+    /// </summary>
+    [TestMethod]
+    public void Operators_WhenCombiningFractions_ShouldProduceCanonicalResults()
+    {
+        Fraction<int> a = new Fraction<int>(2, 3);
+        Fraction<int> b = new Fraction<int>(1, 6);
+
+        Assert.AreEqual(new Fraction<int>(5, 6), a + b);
+        Assert.AreEqual(new Fraction<int>(1, 2), a - b);
+        Assert.AreEqual(new Fraction<int>(1, 9), a * b);
+        Assert.AreEqual(new Fraction<int>(4, 1), a / b);
+    }
+
+    /// <summary>
+    /// Verifies that dividing a fraction by zero throws <see cref="DivideByZeroException" />.
+    /// </summary>
+    [TestMethod]
+    public void DivisionOperator_WhenDividingByZero_ShouldThrowDivideByZeroException()
+    {
+        _ = Assert.ThrowsExactly<DivideByZeroException>(() =>
+        {
+            _ = new Fraction<int>(1, 2) / Fraction<int>.Zero;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the unary negation operator reverses the sign of the value.
+    /// </summary>
+    [TestMethod]
+    public void UnaryNegationOperator_WhenApplied_ShouldReverseSign()
+    {
+        Assert.AreEqual(new Fraction<int>(-3, 4), -new Fraction<int>(3, 4));
+        Assert.AreEqual(new Fraction<int>(3, 4), -new Fraction<int>(-3, 4));
+    }
+
+    /// <summary>
+    /// Verifies that the increment and decrement operators change the value by one.
+    /// </summary>
+    [TestMethod]
+    public void IncrementAndDecrementOperators_WhenApplied_ShouldChangeValueByOne()
+    {
+        Fraction<int> value = new Fraction<int>(1, 2);
+        value++;
+        Assert.AreEqual(new Fraction<int>(3, 2), value);
+
+        value--;
+        Assert.AreEqual(new Fraction<int>(1, 2), value);
+    }
+
+    /// <summary>
+    /// Verifies that the modulus operator returns a remainder with the sign of the dividend.
+    /// </summary>
+    [TestMethod]
+    public void ModulusOperator_WhenApplied_ShouldReturnSignedRemainder()
+    {
+        Assert.AreEqual(new Fraction<int>(3, 4), new Fraction<int>(7, 4) % Fraction<int>.One);
+        Assert.AreEqual(new Fraction<int>(-3, 4), new Fraction<int>(-7, 4) % Fraction<int>.One);
+    }
+
+    /// <summary>
+    /// Verifies that the comparison operators order rational values correctly.
+    /// </summary>
+    [TestMethod]
+    public void ComparisonOperators_WhenComparingValues_ShouldOrderCorrectly()
+    {
+        Fraction<int> small = new Fraction<int>(1, 3);
+        Fraction<int> large = new Fraction<int>(1, 2);
+
+        Assert.IsTrue(small < large);
+        Assert.IsTrue(small <= large);
+        Assert.IsTrue(large > small);
+        Assert.IsTrue(large >= small);
+        Assert.IsTrue(small != large);
+        Assert.IsTrue(small == new Fraction<int>(2, 6));
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Parse.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Parse.cs
@@ -95,4 +95,101 @@ public partial class FractionTests
 
         Assert.IsFalse(parsed);
     }
+
+    /// <summary>
+    /// Verifies that parsing accepts a wide table of valid textual forms.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow("0", 0, 1)]
+    [DataRow("+3/4", 3, 4)]
+    [DataRow("+3", 3, 1)]
+    [DataRow("10/20", 1, 2)]
+    [DataRow("2 1/2", 5, 2)]
+    [DataRow("-0 3/4", -3, 4)]
+    [DataRow("2⅓", 7, 3)]
+    [DataRow("-2⅓", -7, 3)]
+    [DataRow("150%", 3, 2)]
+    [DataRow("0%", 0, 1)]
+    [DataRow("  -3 / 4  ", -3, 4)]
+    [DataRow("100/300", 1, 3)]
+    public void Parse_WhenGivenKnownForm_ShouldReturnExpectedValue(string text, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), Fraction<int>.Parse(text));
+    }
+
+    /// <summary>
+    /// Verifies that every supported Unicode vulgar-fraction glyph parses to its rational value.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow("½", 1, 2)]
+    [DataRow("⅓", 1, 3)]
+    [DataRow("⅔", 2, 3)]
+    [DataRow("¼", 1, 4)]
+    [DataRow("¾", 3, 4)]
+    [DataRow("⅕", 1, 5)]
+    [DataRow("⅖", 2, 5)]
+    [DataRow("⅗", 3, 5)]
+    [DataRow("⅘", 4, 5)]
+    [DataRow("⅙", 1, 6)]
+    [DataRow("⅚", 5, 6)]
+    [DataRow("⅐", 1, 7)]
+    [DataRow("⅛", 1, 8)]
+    [DataRow("⅜", 3, 8)]
+    [DataRow("⅝", 5, 8)]
+    [DataRow("⅞", 7, 8)]
+    [DataRow("⅑", 1, 9)]
+    [DataRow("⅒", 1, 10)]
+    public void Parse_WhenGivenVulgarGlyph_ShouldReturnExpectedValue(string text, int en, int ed)
+    {
+        Assert.AreEqual(new Fraction<int>(en, ed), Fraction<int>.Parse(text));
+    }
+
+    /// <summary>
+    /// Verifies that parsing rejects a wide table of malformed input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow("abc")]
+    [DataRow("")]
+    [DataRow("   ")]
+    [DataRow("1/0")]
+    [DataRow("/4")]
+    [DataRow("3/")]
+    [DataRow("3/4/5")]
+    [DataRow("--3")]
+    [DataRow("3.5")]
+    [DataRow("%")]
+    [DataRow("1 2 3/4")]
+    [DataRow("0/0")]
+    public void Parse_WhenGivenMalformedInput_ShouldThrowFormatExceptionForEachCase(string text)
+    {
+        _ = Assert.ThrowsExactly<FormatException>(() =>
+        {
+            _ = Fraction<int>.Parse(text);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that formatting and parsing round-trip exactly across a table of values and format specifiers.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(3, 4)]
+    [DataRow(-7, 4)]
+    [DataRow(5, 1)]
+    [DataRow(0, 1)]
+    [DataRow(1, 3)]
+    [DataRow(-11, 8)]
+    public void Parse_WhenRoundTrippingEveryFormat_ShouldReproduceValue(int numerator, int denominator)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        foreach (string format in new[] { "G", "M", "U", "P" })
+        {
+            string text = value.ToString(format, System.Globalization.CultureInfo.InvariantCulture);
+            Assert.AreEqual(value, Fraction<int>.Parse(text, System.Globalization.CultureInfo.InvariantCulture), format);
+        }
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Parse.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Parse.cs
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Parse.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Parse(string)" /> accepts the supported textual forms.
+    /// </summary>
+    [TestMethod]
+    [DataRow("3/4", 3, 4)]
+    [DataRow("3", 3, 1)]
+    [DataRow("-3/4", -3, 4)]
+    [DataRow("  3 / 4  ", 3, 4)]
+    [DataRow("1 3/4", 7, 4)]
+    [DataRow("-1 3/4", -7, 4)]
+    [DataRow("¾", 3, 4)]
+    [DataRow("1½", 3, 2)]
+    [DataRow("-1½", -3, 2)]
+    [DataRow("75%", 3, 4)]
+    public void Parse_WhenGivenSupportedForm_ShouldReturnExpectedValue(string text, int expectedNumerator, int expectedDenominator)
+    {
+        Fraction<int> value = Fraction<int>.Parse(text);
+
+        Assert.AreEqual(new Fraction<int>(expectedNumerator, expectedDenominator), value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Parse(string)" /> rejects malformed input.
+    /// </summary>
+    [TestMethod]
+    [DataRow("abc")]
+    [DataRow("")]
+    [DataRow("1/0")]
+    [DataRow("/4")]
+    [DataRow("3/")]
+    public void Parse_WhenGivenInvalidInput_ShouldThrowFormatException(string text)
+    {
+        _ = Assert.ThrowsExactly<FormatException>(() =>
+        {
+            _ = Fraction<int>.Parse(text);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.Parse(string)" /> rejects a <see langword="null" /> string.
+    /// </summary>
+    [TestMethod]
+    public void Parse_WhenGivenNull_ShouldThrowArgumentNullException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = Fraction<int>.Parse(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.TryParse(string?, out Fraction{T})" /> succeeds for valid input.
+    /// </summary>
+    [TestMethod]
+    public void TryParse_WhenGivenValidInput_ShouldReturnTrueAndValue()
+    {
+        bool parsed = Fraction<int>.TryParse("5/8", out Fraction<int> value);
+
+        Assert.IsTrue(parsed);
+        Assert.AreEqual(new Fraction<int>(5, 8), value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.TryParse(string?, out Fraction{T})" /> fails gracefully for
+    /// invalid or <see langword="null" /> input.
+    /// </summary>
+    [TestMethod]
+    [DataRow("not a fraction")]
+    [DataRow(null)]
+    public void TryParse_WhenGivenInvalidInput_ShouldReturnFalse(string? text)
+    {
+        bool parsed = Fraction<int>.TryParse(text, out Fraction<int> value);
+
+        Assert.IsFalse(parsed);
+        Assert.AreEqual(Fraction<int>.Zero, value);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Fraction{T}.TryParse(string?, out Fraction{T})" /> reports overflow as failure.
+    /// </summary>
+    [TestMethod]
+    public void TryParse_WhenValueExceedsFixedWidthRange_ShouldReturnFalse()
+    {
+        bool parsed = Fraction<int>.TryParse("9999999999/1", out _);
+
+        Assert.IsFalse(parsed);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Properties.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Properties.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Properties.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that the classification properties report known answers for a range of canonical values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(0, 1, true, true, true, false, false, false)]
+    [DataRow(1, 1, false, true, false, true, false, true)]
+    [DataRow(-1, 1, false, true, false, true, true, false)]
+    [DataRow(1, 2, false, false, true, true, false, true)]
+    [DataRow(-1, 2, false, false, true, true, true, false)]
+    [DataRow(3, 4, false, false, true, false, false, true)]
+    [DataRow(-3, 4, false, false, true, false, true, false)]
+    [DataRow(7, 4, false, false, false, false, false, true)]
+    [DataRow(-7, 4, false, false, false, false, true, false)]
+    [DataRow(5, 1, false, true, false, false, false, true)]
+    [DataRow(-5, 1, false, true, false, false, true, false)]
+    public void Properties_WhenInspected_ShouldReportKnownAnswers(
+        int numerator,
+        int denominator,
+        bool isZero,
+        bool isInteger,
+        bool isProper,
+        bool isUnit,
+        bool isNegative,
+        bool isPositive)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        Assert.AreEqual(isZero, value.IsZero, nameof(value.IsZero));
+        Assert.AreEqual(isInteger, value.IsInteger, nameof(value.IsInteger));
+        Assert.AreEqual(isProper, value.IsProper, nameof(value.IsProper));
+        Assert.AreEqual(isUnit, value.IsUnit, nameof(value.IsUnit));
+        Assert.AreEqual(isNegative, value.IsNegative, nameof(value.IsNegative));
+        Assert.AreEqual(isPositive, value.IsPositive, nameof(value.IsPositive));
+    }
+
+    /// <summary>
+    /// Verifies that exactly one of <c>IsZero</c>, <c>IsNegative</c>, and <c>IsPositive</c> holds for any value.
+    /// </summary>
+    [TestMethod]
+    [DataRow(0, 1)]
+    [DataRow(3, 4)]
+    [DataRow(-3, 4)]
+    [DataRow(9, 2)]
+    public void Properties_WhenInspectingSign_ShouldBeMutuallyExclusive(int numerator, int denominator)
+    {
+        Fraction<int> value = new Fraction<int>(numerator, denominator);
+
+        int trueCount = (value.IsZero ? 1 : 0) + (value.IsNegative ? 1 : 0) + (value.IsPositive ? 1 : 0);
+
+        Assert.AreEqual(1, trueCount);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Serialization.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Serialization.cs
@@ -84,4 +84,40 @@ public partial class FractionTests
 
         Assert.AreEqual(original, restored);
     }
+
+    /// <summary>
+    /// Verifies that deserializing a non-string JSON token throws <see cref="JsonException" />.
+    /// </summary>
+    [TestMethod]
+    public void JsonSerialization_WhenTokenIsNotString_ShouldThrowJsonException()
+    {
+        _ = Assert.ThrowsExactly<JsonException>(() =>
+        {
+            _ = JsonSerializer.Deserialize<Fraction<int>>("123");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a table of values round-trips through XML serialization.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Regression)]
+    [DataRow(3, 4)]
+    [DataRow(-7, 8)]
+    [DataRow(5, 1)]
+    [DataRow(0, 1)]
+    [DataRow(-11, 3)]
+    public void XmlSerialization_WhenRoundTrippingKnownValues_ShouldPreserveValue(int numerator, int denominator)
+    {
+        Fraction<int> original = new Fraction<int>(numerator, denominator);
+        XmlSerializer serializer = new XmlSerializer(typeof(Fraction<int>));
+
+        using StringWriter writer = new StringWriter();
+        serializer.Serialize(writer, original);
+
+        using StringReader reader = new StringReader(writer.ToString());
+        Fraction<int> restored = (Fraction<int>)serializer.Deserialize(reader)!;
+
+        Assert.AreEqual(original, restored);
+    }
 }

--- a/Bodu.Numerics/test/Numerics/FractionTests.Serialization.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Serialization.cs
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Serialization.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO;
+using System.Numerics;
+using System.Text.Json;
+using System.Xml.Serialization;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that JSON serialization writes a fraction as its string representation.
+    /// </summary>
+    [TestMethod]
+    public void JsonSerialization_WhenSerializing_ShouldWriteStringForm()
+    {
+        string json = JsonSerializer.Serialize(new Fraction<int>(3, 4));
+
+        Assert.AreEqual("\"3/4\"", json);
+    }
+
+    /// <summary>
+    /// Verifies that a fraction round-trips through JSON serialization.
+    /// </summary>
+    [TestMethod]
+    [DataRow(3, 4)]
+    [DataRow(-7, 2)]
+    [DataRow(5, 1)]
+    public void JsonSerialization_WhenRoundTripped_ShouldPreserveValue(int numerator, int denominator)
+    {
+        Fraction<int> original = new Fraction<int>(numerator, denominator);
+
+        string json = JsonSerializer.Serialize(original);
+        Fraction<int> restored = JsonSerializer.Deserialize<Fraction<int>>(json);
+
+        Assert.AreEqual(original, restored);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="BigInteger" />-backed fraction round-trips through JSON serialization.
+    /// </summary>
+    [TestMethod]
+    public void JsonSerialization_WhenBackedByBigInteger_ShouldPreserveValue()
+    {
+        Fraction<BigInteger> original = new Fraction<BigInteger>(BigInteger.Pow(10, 30), 3);
+
+        string json = JsonSerializer.Serialize(original);
+        Fraction<BigInteger> restored = JsonSerializer.Deserialize<Fraction<BigInteger>>(json);
+
+        Assert.AreEqual(original, restored);
+    }
+
+    /// <summary>
+    /// Verifies that deserializing a malformed JSON fraction string throws <see cref="JsonException" />.
+    /// </summary>
+    [TestMethod]
+    public void JsonSerialization_WhenStringIsMalformed_ShouldThrowJsonException()
+    {
+        _ = Assert.ThrowsExactly<JsonException>(() =>
+        {
+            _ = JsonSerializer.Deserialize<Fraction<int>>("\"not a fraction\"");
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a fraction round-trips through XML serialization.
+    /// </summary>
+    [TestMethod]
+    public void XmlSerialization_WhenRoundTripped_ShouldPreserveValue()
+    {
+        Fraction<int> original = new Fraction<int>(-7, 8);
+        XmlSerializer serializer = new XmlSerializer(typeof(Fraction<int>));
+
+        using StringWriter writer = new StringWriter();
+        serializer.Serialize(writer, original);
+
+        using StringReader reader = new StringReader(writer.ToString());
+        Fraction<int> restored = (Fraction<int>)serializer.Deserialize(reader)!;
+
+        Assert.AreEqual(original, restored);
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.UnsignedBackingType.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.UnsignedBackingType.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.UnsignedBackingType.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that a fraction backed by an unsigned integer type reduces non-negative components.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenBackedByUnsignedType_ShouldNormalizeNonNegativeComponents()
+    {
+        Fraction<uint> value = new Fraction<uint>(6, 8);
+
+        Assert.AreEqual(3u, value.Numerator);
+        Assert.AreEqual(4u, value.Denominator);
+    }
+
+    /// <summary>
+    /// Verifies that the zero and one constants are available for an unsigned backing type.
+    /// </summary>
+    [TestMethod]
+    public void ZeroAndOne_WhenBackedByUnsignedType_ShouldBeAvailable()
+    {
+        Assert.IsTrue(Fraction<byte>.Zero.IsZero);
+        Assert.IsTrue(Fraction<byte>.One.IsInteger);
+        Assert.AreEqual(1u, Fraction<uint>.One.Numerator);
+    }
+
+    /// <summary>
+    /// Verifies that requesting negative one for an unsigned backing type throws
+    /// <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void MinusOne_WhenBackedByUnsignedType_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = Fraction<uint>.MinusOne;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that negating a non-zero unsigned-backed fraction throws <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Negate_WhenBackedByUnsignedTypeAndNonZero_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<uint>(3, 4).Negate();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that negating zero is permitted even for an unsigned backing type.
+    /// </summary>
+    [TestMethod]
+    public void Negate_WhenBackedByUnsignedTypeAndZero_ShouldReturnZero()
+    {
+        Assert.AreEqual(Fraction<uint>.Zero, Fraction<uint>.Zero.Negate());
+    }
+
+    /// <summary>
+    /// Verifies that subtraction producing a negative result throws <see cref="OverflowException" /> for an
+    /// unsigned backing type.
+    /// </summary>
+    [TestMethod]
+    public void Subtraction_WhenBackedByUnsignedTypeAndResultIsNegative_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<uint>(1, 4) - new Fraction<uint>(1, 2);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an unsigned-backed fraction is never reported as negative.
+    /// </summary>
+    [TestMethod]
+    public void IsNegative_WhenBackedByUnsignedType_ShouldAlwaysBeFalse()
+    {
+        Assert.IsFalse(new Fraction<uint>(3, 4).IsNegative);
+        Assert.IsFalse(Fraction<uint>.Zero.IsNegative);
+    }
+
+    /// <summary>
+    /// Verifies that arithmetic overflowing an unsigned fixed-width component throws
+    /// <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Addition_WhenBackedByByteAndResultExceedsRange_ShouldThrowOverflowException()
+    {
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = new Fraction<byte>(200) + new Fraction<byte>(100);
+        });
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.Utf8.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.Utf8.cs
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.Utf8.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace Bodu.Numerics;
+
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that a <see cref="Fraction{T}" /> can be parsed from a UTF-8 byte span.
+    /// </summary>
+    [TestMethod]
+    public void Parse_WhenGivenUtf8Bytes_ShouldReturnExpectedValue()
+    {
+        Fraction<int> value = Fraction<int>.Parse("3/4"u8, null);
+
+        Assert.AreEqual(new Fraction<int>(3, 4), value);
+    }
+
+    /// <summary>
+    /// Verifies that <c>TryParse</c> succeeds for a valid UTF-8 byte span.
+    /// </summary>
+    [TestMethod]
+    public void TryParse_WhenGivenValidUtf8Bytes_ShouldReturnTrueAndValue()
+    {
+        bool parsed = Fraction<int>.TryParse("5/8"u8, null, out Fraction<int> value);
+
+        Assert.IsTrue(parsed);
+        Assert.AreEqual(new Fraction<int>(5, 8), value);
+    }
+
+    /// <summary>
+    /// Verifies that <c>TryParse</c> fails gracefully for an invalid UTF-8 byte span.
+    /// </summary>
+    [TestMethod]
+    public void TryParse_WhenGivenInvalidUtf8Bytes_ShouldReturnFalse()
+    {
+        bool parsed = Fraction<int>.TryParse("bad"u8, null, out _);
+
+        Assert.IsFalse(parsed);
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="Fraction{T}" /> formats into a UTF-8 byte span.
+    /// </summary>
+    [TestMethod]
+    public void TryFormat_WhenWritingUtf8Bytes_ShouldWriteFormattedValue()
+    {
+        Span<byte> buffer = stackalloc byte[16];
+
+        bool formatted = new Fraction<int>(3, 4).TryFormat(buffer, out int written, default, null);
+
+        Assert.IsTrue(formatted);
+        Assert.AreEqual("3/4", Encoding.UTF8.GetString(buffer[..written]));
+    }
+}

--- a/Bodu.Numerics/test/Numerics/FractionTests.cs
+++ b/Bodu.Numerics/test/Numerics/FractionTests.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FractionTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Numerics;
+
+/// <summary>
+/// Contains the unit tests for the <see cref="Fraction{T}" /> rational number type.
+/// </summary>
+[TestClass]
+public partial class FractionTests
+{
+    /// <summary>
+    /// Verifies that adding two fractions produces the expected canonical sum.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(Bodu.Test.TestCategories.Smoke)]
+    public void Add_WhenAddingTwoFractions_ShouldReturnCanonicalSum()
+    {
+        Fraction<int> result = new Fraction<int>(1, 2) + new Fraction<int>(1, 3);
+
+        Assert.AreEqual(new Fraction<int>(5, 6), result);
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/
 
 ## [Unreleased]
 
+### Bodu.Numerics — 1.0.0
+
+Initial release of a new numeric-primitives library. Ships `Fraction<T>`, an immutable exact-rational value type generic over any `IBinaryInteger<T>` backing component — use a fixed-width type such as `int` or `long` for compact storage, or `BigInteger` for arithmetic that never overflows.
+
+#### Added
+
+- `Fraction<T>` is always held in canonical form (strictly positive denominator, sign on the numerator, fully reduced). Arithmetic is exact: intermediate results are evaluated with `BigInteger` precision and narrowed back to `T`, throwing `OverflowException` when a fixed-width component cannot represent the canonical result.
+- Arithmetic and comparison operators, named arithmetic methods (`Add`, `Negate`, `Abs`, `Reciprocal`, `Pow`, `Remainder`), and `GreatestCommonDivisor` / `LeastCommonMultiple` helpers.
+- Conversions to and from `decimal` and `double` with exact `FromDecimal` / `FromDouble` factories, plus `As<TOther>()` for retyping the backing component.
+- Continued-fraction expansion (`ToContinuedFraction`, `FromContinuedFraction`) and bounded best-rational approximation (`LimitDenominator`).
+- Parsing of integer, ratio, mixed-number, Unicode vulgar-fraction, and percent forms across `string`, `ReadOnlySpan<char>`, and UTF-8 inputs (`IParsable`, `ISpanParsable`, `IUtf8SpanParsable`); formatting with general, mixed (`M`), Unicode (`U`), and percent (`P`) specifiers (`IFormattable`, `ISpanFormattable`, `IUtf8SpanFormattable`).
+- The full generic-math surface — `INumber<Fraction<T>>`, `INumberBase<Fraction<T>>`, `ISignedNumber<Fraction<T>>` — so `Fraction<T>` composes with `INumber<T>`-constrained code.
+- XML serialization (`IXmlSerializable`) and `System.Text.Json` support through a converter that round-trips the value as its `numerator/denominator` string form.
+
 ### Bodu.Globalization.Calendar — 1.1.0
 
 #### Added


### PR DESCRIPTION
Introduces a new `Bodu.Numerics` project shipping `Fraction<T>`, an immutable exact-rational value type backed by an arbitrary `IBinaryInteger<T>` component type.

## Summary

This PR adds the initial release of `Bodu.Numerics` (v1.0.0), a numeric-primitives library providing exact rational arithmetic. The `Fraction<T>` struct represents a ratio of two integers in canonical form (lowest terms, positive denominator, sign on numerator) and supports:

- **Exact arithmetic**: Addition, subtraction, multiplication, division with `BigInteger` precision intermediates
- **Generic-math interfaces**: Implements `INumber<Fraction<T>>` and `ISignedNumber<Fraction<T>>` for use in generic algorithms
- **Parsing and formatting**: Multiple input formats (ratio, mixed number, vulgar glyphs, percentage) and output formats (general, mixed, Unicode, percentage)
- **Continued fractions**: Expansion and reconstruction via simple continued-fraction coefficients
- **JSON serialization**: Custom converter for round-trip serialization
- **Type flexibility**: Works with fixed-width types (`int`, `long`) for compact storage or `BigInteger` for unbounded arithmetic

## Key Changes

- **New project structure**: `Bodu.Numerics/src/` and `Bodu.Numerics/test/` following repository conventions
- **Core type**: `Fraction<T>` struct with:
  - Canonical normalization in constructor (GCD reduction, sign normalization)
  - Arithmetic operators and named methods (`Add`, `Subtract`, `Multiply`, `Divide`)
  - Unary operations (`Abs`, `Reciprocal`, `Pow`)
  - Comparison and equality (`IComparable<T>`, `IEquatable<T>`)
  - Classification properties (`IsZero`, `IsPositive`, `IsNegative`, `IsInteger`, etc.)
- **Parsing**: `IParsable<T>` and `ISpanParsable<T>` implementations supporting:
  - Simple ratios: `"3/4"`
  - Mixed numbers: `"1 3/4"`
  - Vulgar fractions: `"¾"`
  - Percentages: `"75%"`
  - Whitespace tolerance and culture-aware numeric parsing
- **Formatting**: `IFormattable`, `ISpanFormattable`, `IUtf8SpanFormattable` with format specifiers:
  - `G` (general): `"3/4"` or bare integer
  - `M` (mixed): `"1 3/4"` for improper fractions
  - `U` (Unicode): Vulgar glyphs where available, fallback to mixed form
  - `P` (percentage): `"75%"`
- **Generic-math support**: Full implementation of `INumberBase<T>` static abstract members for constraint-based generic programming
- **Conversions**: Implicit from backing integer type; explicit from `decimal` and `double` (finite values only)
- **Continued fractions**: `ToContinuedFraction()` and `FromContinuedFraction()` for rational approximation and analysis
- **Comprehensive test suite**: 20+ partial test files covering constructors, arithmetic, operators, parsing, formatting, conversions, generic-math, serialization, edge cases, and unsigned backing types

## Notable Implementation Details

- Arithmetic uses `BigInteger` intermediates to avoid overflow, then narrows back to `T` with overflow checking
- Unsigned backing types (`uint`, `ulong`) cannot represent negative rationals; operations that would produce negative components throw `OverflowException`
- Default-initialized `Fraction<T>` is interpreted as zero (denominator 0 → 1 via property)
- Vulgar-fraction glyphs and percentage parsing use static dictionaries for efficient lookup
- JSON serialization delegates to the string representation for human readability
- All partial-class files follow `.filenameesting.json` nesting convention

## CI Integration

Updated `.github/workflows/build-test.yml` to include `Bodu.Numerics/test/Bodu.

https://claude.ai/code/session_019bfXREXDwfg4TJevXyK33v