### PR TITLE
Reformat XML documentation code examples for readability

### DIFF
--- a/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.cs
+++ b/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.cs
@@ -32,11 +32,16 @@ namespace Bodu.Collections.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ // Cheap count when the source already exposes ICollection — falls back to enumeration
-/// otherwise. System.Collections.IEnumerable boxed = new ArrayList { 1, 2, 3, 4 }; int count = boxed.CountOrDefault();
-/// // => 4 // Walk a heterogeneous control tree without committing to a generic type. System.Collections.IEnumerable
-/// controls = root.GetChildren(); foreach (object node in controls.RecursiveSelect(c =&gt; ((Control)c).GetChildren()))
-/// Console.WriteLine(node); ]]>
+///<![CDATA[
+/// // Cheap count when the source already exposes ICollection — falls back to enumeration otherwise.
+/// System.Collections.IEnumerable boxed = new ArrayList { 1, 2, 3, 4 };
+/// int count = boxed.CountOrDefault(); // => 4
+///
+/// // Walk a heterogeneous control tree without committing to a generic type.
+/// System.Collections.IEnumerable controls = root.GetChildren();
+/// foreach (object node in controls.RecursiveSelect(c => ((Control)c).GetChildren()))
+///     Console.WriteLine(node);
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Farey.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Farey.cs
@@ -38,8 +38,10 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (var (num, den) in SequenceGenerator.Farey(5)) Console.Write($"{num}/{den} ");
-    /// // => 0/1 1/5 1/4 1/3 2/5 1/2 3/5 2/3 3/4 4/5 1/1 ]]>
+    ///<![CDATA[
+    /// foreach (var (num, den) in SequenceGenerator.Farey(5))
+    ///     Console.Write($"{num}/{den} "); // => 0/1 1/5 1/4 1/3 2/5 1/2 3/5 2/3 3/4 4/5 1/1
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<(int Numerator, int Denominator)> Farey(int order)

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Fibonacci.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Fibonacci.cs
@@ -47,9 +47,12 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (long f in SequenceGenerator.Fibonacci(10, 1000)) Console.Write($"{f} "); // =>
-    /// 13 21 34 55 89 144 233 377 610 987 var none = SequenceGenerator.Fibonacci(50, 54).ToArray(); // => empty (no
-    /// Fibonacci numbers between 50 and 54). ]]>
+    ///<![CDATA[
+    /// foreach (long f in SequenceGenerator.Fibonacci(10, 1000))
+    ///     Console.Write($"{f} "); // => 13 21 34 55 89 144 233 377 610 987
+    ///
+    /// var none = SequenceGenerator.Fibonacci(50, 54).ToArray(); // => empty (no Fibonacci numbers between 50 and 54).
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<long> Fibonacci(long min, long max)

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Leibniz.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Leibniz.cs
@@ -51,9 +51,14 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Approximate π by summing the first hundred terms whose magnitude is at least 1e-3.
-    /// double partial = 0; foreach (double term in SequenceGenerator.Leibniz(1e-3, 1.1).Take(100)) partial += term;
-    /// double pi = partial * 4; // => pi ≈ 3.139... (slow convergence, expected) ]]>
+    ///<![CDATA[
+    /// // Approximate π by summing the first hundred terms whose magnitude is at least 1e-3.
+    /// double partial = 0;
+    /// foreach (double term in SequenceGenerator.Leibniz(1e-3, 1.1).Take(100))
+    ///     partial += term;
+    ///
+    /// double pi = partial * 4; // => pi ≈ 3.139... (slow convergence, expected)
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<double> Leibniz(double min, double max)

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.LookAndSay.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.LookAndSay.cs
@@ -40,8 +40,16 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (string term in SequenceGenerator.LookAndSay(6)) Console.WriteLine(term); // =>
-    /// 1 // => 11 // => 21 // => 1211 // => 111221 // => 312211 ]]>
+    ///<![CDATA[
+    /// foreach (string term in SequenceGenerator.LookAndSay(6))
+    ///     Console.WriteLine(term);
+    /// // => 1
+    /// // => 11
+    /// // => 21
+    /// // => 1211
+    /// // => 111221
+    /// // => 312211
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<string> LookAndSay(int count)

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.ThueMorse.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.ThueMorse.cs
@@ -33,9 +33,12 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ var prefix = SequenceGenerator.ThueMorse(16).ToArray(); // => [0, 1, 1, 0, 1, 0, 0, 1,
-    /// 1, 0, 0, 1, 0, 1, 1, 0] // Convenient as the schedule for a fair turn-taking algorithm: // player A goes on 0,
-    /// player B goes on 1. ]]>
+    ///<![CDATA[
+    /// var prefix = SequenceGenerator.ThueMorse(16).ToArray(); // => [0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
+    ///
+    /// // Convenient as the schedule for a fair turn-taking algorithm:
+    /// // player A goes on 0, player B goes on 1.
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<int> ThueMorse(int count)

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Aggregate.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Aggregate.cs
@@ -170,9 +170,13 @@ public static partial class IEnumerableExtensions
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ var (min, max) = new[] { 3, 1, 4, 1, 5, 9, 2, 6 }.Aggregate( seed1: int.MaxValue,
-    /// seed2: int.MinValue, func1: (acc, x) => Math.Min(acc, x), func2: (acc, x) => Math.Max(acc, x)); // min == 1, max
-    /// == 9 ]]>
+    ///<![CDATA[
+    /// var (min, max) = new[] { 3, 1, 4, 1, 5, 9, 2, 6 }.Aggregate(
+    ///     seed1: int.MaxValue,
+    ///     seed2: int.MinValue,
+    ///     func1: (acc, x) => Math.Min(acc, x),
+    ///     func2: (acc, x) => Math.Max(acc, x)); // min == 1, max == 9
+    ///]]>
     /// </code>
     /// </example>
     public static (T1, T2) Aggregate<TSource, T1, T2>(
@@ -360,9 +364,15 @@ public static partial class IEnumerableExtensions
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ var (sum, count, max) = new[] { 3, 1, 4, 1, 5, 9, 2, 6 }.Aggregate( seed1: 0, seed2: 0,
-    /// seed3: int.MinValue, func1: (acc, x) => acc + x, func2: (acc, _) => acc + 1, func3: (acc, x) => Math.Max(acc,
-    /// x)); // sum == 31, count == 8, max == 9 ]]>
+    ///<![CDATA[
+    /// var (sum, count, max) = new[] { 3, 1, 4, 1, 5, 9, 2, 6 }.Aggregate(
+    ///     seed1: 0,
+    ///     seed2: 0,
+    ///     seed3: int.MinValue,
+    ///     func1: (acc, x) => acc + x,
+    ///     func2: (acc, _) => acc + 1,
+    ///     func3: (acc, x) => Math.Max(acc, x)); // sum == 31, count == 8, max == 9
+    ///]]>
     /// </code>
     /// </example>
     public static (T1, T2, T3) Aggregate<TSource, T1, T2, T3>(

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Batch.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Batch.cs
@@ -245,9 +245,21 @@ public static partial class IEnumerableExtensions
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ Input: Enumerable.Range(1, 9) Batch size: 3 Expected output: Batch 1: 1, 2, 3 Batch 2:
-    /// 4, 5, 6 Batch 3: 7, 8, 9 var source = Enumerable.Range(1, 9); foreach (var batch in source.BatchPooled(3)) {
-    /// Console.WriteLine(string.Join(", ", batch.ToArray())); } ]]>
+    ///<![CDATA[
+    /// Input:  Enumerable.Range(1, 9)
+    /// Batch size: 3
+    ///
+    /// Expected output:
+    /// Batch 1: 1, 2, 3
+    /// Batch 2: 4, 5, 6
+    /// Batch 3: 7, 8, 9
+    ///
+    /// var source = Enumerable.Range(1, 9);
+    /// foreach (var batch in source.BatchPooled(3))
+    /// {
+    ///     Console.WriteLine(string.Join(", ", batch.ToArray()));
+    /// }
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<ReadOnlyMemory<TSource>> BatchPooled<TSource>(

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.cs
@@ -36,12 +36,27 @@ namespace Bodu.Collections.Generic.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ IEnumerable&lt;int&gt; source = Enumerable.Range(1, 9); // Chunk into windows of three.
-/// foreach (var window in source.Batch(3)) Console.WriteLine(string.Join(", ", window)); // => 1, 2, 3 // => 4, 5, 6 //
-/// => 7, 8, 9 // Compute count and sum in a single pass. var (count, sum) = source.Aggregate( seed1: 0, seed2: 0L,
-/// func1: (c, _) =&gt; c + 1, func2: (s, x) =&gt; s + x); // => count == 9, sum == 45 // Predicate-style set check
-/// using a custom comparer. bool anyMatch = new[] { "FOO", "bar" } .ContainsAny(new[] { "foo", "baz" },
-/// StringComparer.OrdinalIgnoreCase); // => true ]]>
+///<![CDATA[
+/// IEnumerable<int> source = Enumerable.Range(1, 9);
+///
+/// // Chunk into windows of three.
+/// foreach (var window in source.Batch(3))
+///     Console.WriteLine(string.Join(", ", window));
+/// // => 1, 2, 3
+/// // => 4, 5, 6
+/// // => 7, 8, 9
+///
+/// // Compute count and sum in a single pass.
+/// var (count, sum) = source.Aggregate(
+///     seed1: 0,
+///     seed2: 0L,
+///     func1: (c, _) => c + 1,
+///     func2: (s, x) => s + x); // => count == 9, sum == 45
+///
+/// // Predicate-style set check using a custom comparer.
+/// bool anyMatch = new[] { "FOO", "bar" }
+///     .ContainsAny(new[] { "foo", "baz" }, StringComparer.OrdinalIgnoreCase); // => true
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Factory.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Factory.cs
@@ -44,10 +44,17 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Adapt an external pull-style API into an IEnumerable&lt;T&gt; pipeline.
-    /// IEnumerable&lt;int&gt; randomBytes = SequenceGenerator.Factory(() =&gt; { var rng = new Random(42); return
-    /// Enumerable.Range(0, 4).Select(_ =&gt; rng.Next(0, 256)).GetEnumerator(); }); foreach (int b in randomBytes)
-    /// Console.Write($"{b} "); // => 79 235 64 230 (a deterministic run with seed 42) ]]>
+    ///<![CDATA[
+    /// // Adapt an external pull-style API into an IEnumerable<T> pipeline.
+    /// IEnumerable<int> randomBytes = SequenceGenerator.Factory(() =>
+    /// {
+    ///     var rng = new Random(42);
+    ///     return Enumerable.Range(0, 4).Select(_ => rng.Next(0, 256)).GetEnumerator();
+    /// });
+    ///
+    /// foreach (int b in randomBytes)
+    ///     Console.Write($"{b} "); // => 79 235 64 230 (a deterministic run with seed 42)
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<TResult> Factory<TResult>(Func<IEnumerator<TResult>> enumeratorFactory)

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.NextWhile.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.NextWhile.cs
@@ -47,10 +47,13 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Halving sequence — terminates when the value drops to zero. var halves =
-    /// SequenceGenerator.NextWhile(64, v =&gt; v &gt; 0, v =&gt; v / 2); // => 64, 32, 16, 8, 4, 2, 1 // Empty result
-    /// when the seed already fails the predicate. var none = SequenceGenerator.NextWhile(0, v =&gt; v &gt; 0, v =&gt; v
-    /// - 1); // => (empty) ]]>
+    ///<![CDATA[
+    /// // Halving sequence — terminates when the value drops to zero.
+    /// var halves = SequenceGenerator.NextWhile(64, v => v > 0, v => v / 2); // => 64, 32, 16, 8, 4, 2, 1
+    ///
+    /// // Empty result when the seed already fails the predicate.
+    /// var none = SequenceGenerator.NextWhile(0, v => v > 0, v => v - 1); // => (empty)
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<TResult> NextWhile<TResult>(
@@ -109,8 +112,10 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Triangular numbers up to 100: 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91.
-    /// var triangular = SequenceGenerator.NextWhile(0, v =&gt; v &lt;= 100, (v, i) =&gt; v + (i + 1)); ]]>
+    ///<![CDATA[
+    /// // Triangular numbers up to 100: 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91.
+    /// var triangular = SequenceGenerator.NextWhile(0, v => v <= 100, (v, i) => v + (i + 1));
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<TResult> NextWhile<TResult>(
@@ -173,10 +178,14 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Fibonacci numbers below 100, tracked through a (prev, curr) state record. var fib =
-    /// SequenceGenerator.NextWhile( initialState: (Prev: 0, Curr: 1), conditionHandler: s =&gt; s.Curr &lt; 100,
-    /// iterateFunction: s =&gt; (s.Curr, s.Prev + s.Curr), resultSelector: s =&gt; s.Curr); // => 1, 1, 2, 3, 5, 8, 13,
-    /// 21, 34, 55, 89 ]]>
+    ///<![CDATA[
+    /// // Fibonacci numbers below 100, tracked through a (prev, curr) state record.
+    /// var fib = SequenceGenerator.NextWhile(
+    ///     initialState: (Prev: 0, Curr: 1),
+    ///     conditionHandler: s => s.Curr < 100,
+    ///     iterateFunction: s => (s.Curr, s.Prev + s.Curr),
+    ///     resultSelector: s => s.Curr); // => 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<TResult> NextWhile<TState, TResult>(

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Range.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Range.cs
@@ -35,8 +35,13 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (int n in SequenceGenerator.Range(10, 14)) Console.Write($"{n} "); // => 10 11
-    /// 12 13 14 foreach (int n in SequenceGenerator.Range(3, -2)) Console.Write($"{n} "); // => 3 2 1 0 -1 -2 ]]>
+    ///<![CDATA[
+    /// foreach (int n in SequenceGenerator.Range(10, 14))
+    ///     Console.Write($"{n} "); // => 10 11 12 13 14
+    ///
+    /// foreach (int n in SequenceGenerator.Range(3, -2))
+    ///     Console.Write($"{n} "); // => 3 2 1 0 -1 -2
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<int> Range(int start, int stop) => SequenceGenerator.Range(start, stop, start < stop ? 1 : -1);
@@ -79,10 +84,16 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (int n in SequenceGenerator.Range(0, 20, 5)) Console.Write($"{n} "); // => 0 5
-    /// 10 15 20 foreach (int n in SequenceGenerator.Range(10, 1, -3)) Console.Write($"{n} "); // => 10 7 4 1 // Step of
-    /// zero yields an unbounded sequence — bound it with Take. var heartbeat = SequenceGenerator.Range(42, 0,
-    /// 0).Take(3); // => 42, 42, 42 ]]>
+    ///<![CDATA[
+    /// foreach (int n in SequenceGenerator.Range(0, 20, 5))
+    ///     Console.Write($"{n} "); // => 0 5 10 15 20
+    ///
+    /// foreach (int n in SequenceGenerator.Range(10, 1, -3))
+    ///     Console.Write($"{n} "); // => 10 7 4 1
+    ///
+    /// // Step of zero yields an unbounded sequence — bound it with Take.
+    /// var heartbeat = SequenceGenerator.Range(42, 0, 0).Take(3); // => 42, 42, 42
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<int> Range(int start, int stop, int step)
@@ -139,9 +150,12 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ foreach (long n in SequenceGenerator.Range(1_000_000_000_000L, 4)) Console.Write($"{n}
-    /// "); // => 1000000000000 1000000000001 1000000000002 1000000000003 var empty = SequenceGenerator.Range(0L,
-    /// 0).ToArray(); // => empty.Length == 0 ]]>
+    ///<![CDATA[
+    /// foreach (long n in SequenceGenerator.Range(1_000_000_000_000L, 4))
+    ///     Console.Write($"{n} "); // => 1000000000000 1000000000001 1000000000002 1000000000003
+    ///
+    /// var empty = SequenceGenerator.Range(0L, 0).ToArray(); // => empty.Length == 0
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<long> Range(long start, int count)

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Repeat.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Repeat.cs
@@ -38,9 +38,11 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ // Generate the first five powers of two by zipping a counter against a constant feed.
-    /// var powers = SequenceGenerator.Repeat(2) .Zip(SequenceGenerator.Range(0, 4), (b, e) =&gt; (long)Math.Pow(b, e));
-    /// // => 1, 2, 4, 8, 16 ]]>
+    ///<![CDATA[
+    /// // Generate the first five powers of two by zipping a counter against a constant feed.
+    /// var powers = SequenceGenerator.Repeat(2)
+    ///     .Zip(SequenceGenerator.Range(0, 4), (b, e) => (long)Math.Pow(b, e)); // => 1, 2, 4, 8, 16
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<T> Repeat<T>(T value)
@@ -79,8 +81,10 @@ public static partial class SequenceGenerator
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ var dashes = string.Concat(SequenceGenerator.Repeat('-', 5)); // => "-----" var padding
-    /// = SequenceGenerator.Repeat&lt;string?&gt;(null, 3).ToArray(); // => [null, null, null] ]]>
+    ///<![CDATA[
+    /// var dashes = string.Concat(SequenceGenerator.Repeat('-', 5)); // => "-----"
+    /// var padding = SequenceGenerator.Repeat<string?>(null, 3).ToArray(); // => [null, null, null]
+    ///]]>
     /// </code>
     /// </example>
     public static IEnumerable<T> Repeat<T>(T value, int count)

--- a/Bodu.Core/src/Extensions/ArrayExtensions.Reverse.cs
+++ b/Bodu.Core/src/Extensions/ArrayExtensions.Reverse.cs
@@ -75,8 +75,11 @@ public static partial class ArrayExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    ///<![CDATA[ int[] data = { 1, 2, 3, 4, 5 }; int[] full = data.Reverse(); // [ 5, 4, 3, 2, 1 ] int[] partial =
-    /// data.Reverse(index: 1, count: 3); // [ 1, 4, 3, 2, 5 ] ]]>
+    ///<![CDATA[
+    /// int[] data = { 1, 2, 3, 4, 5 };
+    /// int[] full = data.Reverse(); // [ 5, 4, 3, 2, 1 ]
+    /// int[] partial = data.Reverse(index: 1, count: 3); // [ 1, 4, 3, 2, 5 ]
+    ///]]>
     /// </code>
     /// </example>
     public static T[] Reverse<T>(this T[] source, int index, int count)
@@ -116,8 +119,11 @@ public static partial class ArrayExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    ///<![CDATA[ int[] data = { 1, 2, 3, 4, 5 }; int[] fromStart = data.Reverse(1..4); // [ 1, 4, 3, 2, 5 ] int[] fromEnd
-    /// = data.Reverse(^4..^1); // [ 1, 4, 3, 2, 5 ] ]]>
+    ///<![CDATA[
+    /// int[] data = { 1, 2, 3, 4, 5 };
+    /// int[] fromStart = data.Reverse(1..4); // [ 1, 4, 3, 2, 5 ]
+    /// int[] fromEnd = data.Reverse(^4..^1); // [ 1, 4, 3, 2, 5 ]
+    ///]]>
     /// </code>
     /// </example>
     public static T[] Reverse<T>(this T[] source, Range range)

--- a/Bodu.Core/src/Extensions/ArrayExtensions.cs
+++ b/Bodu.Core/src/Extensions/ArrayExtensions.cs
@@ -34,10 +34,18 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ int[] source = { 1, 2, 3, 4, 5, 6 }; // Reverse only the middle window — in place.
-/// source.Reverse(1, 4); // => source is now { 1, 5, 4, 3, 2, 6 } // Take a freshly allocated slice using a Range
-/// expression. int[] tail = source.Slice(2..); // => { 4, 3, 2, 6 } // Clear the prefix without touching the tail.
-/// source.Clear(0, 3); // => source is now { 0, 0, 0, 3, 2, 6 } ]]>
+///<![CDATA[
+/// int[] source = { 1, 2, 3, 4, 5, 6 };
+///
+/// // Reverse only the middle window — in place.
+/// source.Reverse(1, 4); // => source is now { 1, 5, 4, 3, 2, 6 }
+///
+/// // Take a freshly allocated slice using a Range expression.
+/// int[] tail = source.Slice(2..); // => { 4, 3, 2, 6 }
+///
+/// // Clear the prefix without touching the tail.
+/// source.Clear(0, 3); // => source is now { 0, 0, 0, 3, 2, 6 }
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.cs
@@ -37,11 +37,18 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ var date = new DateOnly(2025, 4, 30); // Anchor to the first Monday in this month. DateOnly
-/// firstMonday = date.FirstDateOfWeekInMonth(DayOfWeek.Monday); // => 2025-04-07 // Walk to the previous Friday, even
-/// if today is already a Friday. DateOnly priorFriday = date.PreviousDateOfWeek(DayOfWeek.Friday); // => 2025-04-25 //
-/// Compute the calendar week within the month using ISO rules. int weekOfMonth =
-/// date.WeekOfMonth(CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday); // => 5 ]]>
+///<![CDATA[
+/// var date = new DateOnly(2025, 4, 30);
+///
+/// // Anchor to the first Monday in this month.
+/// DateOnly firstMonday = date.FirstDateOfWeekInMonth(DayOfWeek.Monday); // => 2025-04-07
+///
+/// // Walk to the previous Friday, even if today is already a Friday.
+/// DateOnly priorFriday = date.PreviousDateOfWeek(DayOfWeek.Friday); // => 2025-04-25
+///
+/// // Compute the calendar week within the month using ISO rules.
+/// int weekOfMonth = date.WeekOfMonth(CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday); // => 5
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.cs
@@ -43,11 +43,20 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ var dt = new DateTime(2025, 4, 30, 14, 35, 0, DateTimeKind.Utc); // Snap to the start and
-/// end of the same day, preserving Kind. DateTime startOfDay = dt.StartOfDay(); // 2025-04-30T00:00:00Z DateTime
-/// endOfDay = dt.EndOfDay(); // 2025-04-30T23:59:59.9999999Z // ISO 8601 week-of-year and matching ISO year. int
-/// isoWeek = dt.IsoWeekOfYear(); // 18 int isoYear = dt.IsoYear(); // 2025 // Walk to the first Monday strictly after
-/// this date. DateTime nextMonday = dt.NextDateOfWeek(DayOfWeek.Monday); // 2025-05-05T14:35:00Z ]]>
+///<![CDATA[
+/// var dt = new DateTime(2025, 4, 30, 14, 35, 0, DateTimeKind.Utc);
+///
+/// // Snap to the start and end of the same day, preserving Kind.
+/// DateTime startOfDay = dt.StartOfDay(); // 2025-04-30T00:00:00Z
+/// DateTime endOfDay = dt.EndOfDay(); // 2025-04-30T23:59:59.9999999Z
+///
+/// // ISO 8601 week-of-year and matching ISO year.
+/// int isoWeek = dt.IsoWeekOfYear(); // 18
+/// int isoYear = dt.IsoYear(); // 2025
+///
+/// // Walk to the first Monday strictly after this date.
+/// DateTime nextMonday = dt.NextDateOfWeek(DayOfWeek.Monday); // 2025-05-05T14:35:00Z
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Extensions/IComparableExtensions.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.cs
@@ -36,10 +36,18 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ int volume = 11; // Replace explicit min/max calls with a fluent clamp. int safeVolume =
-/// volume.Clamp(0, 10); // => 10 // Inclusive "between" predicate, ideal in guard clauses. bool inDecimalDigits =
-/// '7'.IsBetween('0', '9'); // => true // Custom comparer for case-insensitive string ranges. bool inMidAlphabet =
-/// "Mango".IsBetween("apple", "orange", StringComparer.OrdinalIgnoreCase); // => true ]]>
+///<![CDATA[
+/// int volume = 11;
+///
+/// // Replace explicit min/max calls with a fluent clamp.
+/// int safeVolume = volume.Clamp(0, 10); // => 10
+///
+/// // Inclusive "between" predicate, ideal in guard clauses.
+/// bool inDecimalDigits = '7'.IsBetween('0', '9'); // => true
+///
+/// // Custom comparer for case-insensitive string ranges.
+/// bool inMidAlphabet = "Mango".IsBetween("apple", "orange", StringComparer.OrdinalIgnoreCase); // => true
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Extensions/NumericExtensions.RoundToSignificantDigits.cs
+++ b/Bodu.Core/src/Extensions/NumericExtensions.RoundToSignificantDigits.cs
@@ -30,8 +30,10 @@ public static partial class NumericExtensions
     /// </remarks>
     /// <example>
     /// <code language="csharp">
-    ///<![CDATA[ 12345.6789.RoundToSignificantDigits(3); // => 12300
-    /// 0.0012345.RoundToSignificantDigits(2); // => 0.0012 ]]>
+    ///<![CDATA[
+    /// 12345.6789.RoundToSignificantDigits(3); // => 12300
+    /// 0.0012345.RoundToSignificantDigits(2); // => 0.0012
+    ///]]>
     /// </code>
     /// </example>
     public static double RoundToSignificantDigits(this double value, int digits)

--- a/Bodu.Core/src/Extensions/NumericExtensions.cs
+++ b/Bodu.Core/src/Extensions/NumericExtensions.cs
@@ -35,10 +35,18 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ // Swap byte order for big-endian wire encoding. uint host = 0x11_22_33_44u; uint network =
-/// host.ReverseBytes(); // => 0x44_33_22_11 // Bit reversal — useful in CRC and DSP code. byte mask = 0b1011_0001; byte
-/// mirrored = mask.ReverseBits(); // => 0b1000_1101 // Cyclic bit rotation — common in hashing primitives. uint rotated
-/// = 0x0000_00FFu.RotateBitsLeft(8); // => 0x0000_FF00 ]]>
+///<![CDATA[
+/// // Swap byte order for big-endian wire encoding.
+/// uint host = 0x11_22_33_44u;
+/// uint network = host.ReverseBytes(); // => 0x44_33_22_11
+///
+/// // Bit reversal — useful in CRC and DSP code.
+/// byte mask = 0b1011_0001;
+/// byte mirrored = mask.ReverseBits(); // => 0b1000_1101
+///
+/// // Cyclic bit rotation — common in hashing primitives.
+/// uint rotated = 0x0000_00FFu.RotateBitsLeft(8); // => 0x0000_FF00
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Extensions/SpanExtensions.Reverse.cs
+++ b/Bodu.Core/src/Extensions/SpanExtensions.Reverse.cs
@@ -65,8 +65,12 @@ public static partial class SpanExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    ///<![CDATA[ int[] data = { 1, 2, 3, 4, 5 }; // Reverse a middle section; first and last elements are untouched.
-    /// Span&lt;int&gt; result = data.AsSpan().Reverse(start: 1, length: 3); // [ 1, 4, 3, 2, 5 ] ]]>
+    ///<![CDATA[
+    /// int[] data = { 1, 2, 3, 4, 5 };
+    ///
+    /// // Reverse a middle section; first and last elements are untouched.
+    /// Span<int> result = data.AsSpan().Reverse(start: 1, length: 3); // [ 1, 4, 3, 2, 5 ]
+    ///]]>
     /// </code>
     /// </example>
     public static Span<T> Reverse<T>(this ReadOnlySpan<T> source, int index, int count)
@@ -111,8 +115,11 @@ public static partial class SpanExtensions
     /// </remarks>
     /// <example>
     /// <code>
-    ///<![CDATA[ int[] data = { 1, 2, 3, 4, 5 }; Span&lt;int&gt; fromStart = data.AsSpan().Reverse(1..4); // [ 1, 4, 3, 2,
-    /// 5 ] Span&lt;int&gt; fromEnd = data.AsSpan().Reverse(^4..^1); // [ 1, 4, 3, 2, 5 ] ]]>
+    ///<![CDATA[
+    /// int[] data = { 1, 2, 3, 4, 5 };
+    /// Span<int> fromStart = data.AsSpan().Reverse(1..4); // [ 1, 4, 3, 2, 5 ]
+    /// Span<int> fromEnd = data.AsSpan().Reverse(^4..^1); // [ 1, 4, 3, 2, 5 ]
+    ///]]>
     /// </code>
     /// </example>
     public static Span<T> Reverse<T>(this ReadOnlySpan<T> source, Range range)

--- a/Bodu.Core/src/Extensions/SpanExtensions.cs
+++ b/Bodu.Core/src/Extensions/SpanExtensions.cs
@@ -32,10 +32,18 @@ namespace Bodu.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ Span&lt;int&gt; buffer = stackalloc int[] { 1, 2, 3, 4, 5, 6 }; // Reverse only the
-/// trailing window using a Range. buffer.Reverse(2..); // => buffer is now { 1, 2, 6, 5, 4, 3 } // Narrow the surface
-/// before handing the span to a read-only consumer. ReadOnlySpan&lt;int&gt; view = buffer.AsReadOnly(); // Reverse the
-/// full span back to its original ordering. buffer.Reverse(); // => buffer is now { 3, 4, 5, 6, 2, 1 } ]]>
+///<![CDATA[
+/// Span<int> buffer = stackalloc int[] { 1, 2, 3, 4, 5, 6 };
+///
+/// // Reverse only the trailing window using a Range.
+/// buffer.Reverse(2..); // => buffer is now { 1, 2, 6, 5, 4, 3 }
+///
+/// // Narrow the surface before handing the span to a read-only consumer.
+/// ReadOnlySpan<int> view = buffer.AsReadOnly();
+///
+/// // Reverse the full span back to its original ordering.
+/// buffer.Reverse(); // => buffer is now { 3, 4, 5, 6, 2, 1 }
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Core/src/Globalization.Extensions/DateTimeFormatInfoExtensions.cs
+++ b/Bodu.Core/src/Globalization.Extensions/DateTimeFormatInfoExtensions.cs
@@ -32,10 +32,16 @@ namespace Bodu.Globalization.Extensions;
 /// </para>
 /// <example>
 /// <code language="csharp">
-///<![CDATA[ var enGb = CultureInfo.GetCultureInfo("en-GB").DateTimeFormat; var enUs =
-/// CultureInfo.GetCultureInfo("en-US").DateTimeFormat; DayOfWeek lastInBritain = enGb.LastDayOfWeek(); // =>
-/// DayOfWeek.Sunday (en-GB starts on Monday, so the week ends on Sunday) DayOfWeek lastInAmerica =
-/// enUs.LastDayOfWeek(); // => DayOfWeek.Saturday (en-US starts on Sunday, so the week ends on Saturday) ]]>
+///<![CDATA[
+/// var enGb = CultureInfo.GetCultureInfo("en-GB").DateTimeFormat;
+/// var enUs = CultureInfo.GetCultureInfo("en-US").DateTimeFormat;
+///
+/// DayOfWeek lastInBritain = enGb.LastDayOfWeek();
+/// // => DayOfWeek.Sunday (en-GB starts on Monday, so the week ends on Sunday)
+///
+/// DayOfWeek lastInAmerica = enUs.LastDayOfWeek();
+/// // => DayOfWeek.Saturday (en-US starts on Sunday, so the week ends on Saturday)
+///]]>
 /// </code>
 /// </example>
 /// </remarks>

--- a/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
@@ -27,8 +27,9 @@ namespace Bodu.Globalization.Calendar.Data.Americas;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// var service = new NotableDateService( ruleProviders: AmericasCalendarData.CreateProviders(),
-/// workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+/// var service = new NotableDateService(
+///     ruleProviders: AmericasCalendarData.CreateProviders(),
+///     workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
@@ -29,8 +29,9 @@ namespace Bodu.Globalization.Calendar.Data.AsiaPacific;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// var service = new NotableDateService( ruleProviders: AsiaPacificCalendarData.CreateProviders(),
-/// workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+/// var service = new NotableDateService(
+///     ruleProviders: AsiaPacificCalendarData.CreateProviders(),
+///     workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
@@ -27,8 +27,9 @@ namespace Bodu.Globalization.Calendar.Data.Europe;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// var service = new NotableDateService( ruleProviders: EuropeCalendarData.CreateProviders(), workingDaysOfWeek:
-/// WorkingDaysOfWeek.MondayToFriday);
+/// var service = new NotableDateService(
+///     ruleProviders: EuropeCalendarData.CreateProviders(),
+///     workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/DefaultNotableDateCollisionResolver.cs
@@ -30,7 +30,7 @@ namespace Bodu.Globalization.Calendar;
 /// </para>
 /// <code>
 ///<![CDATA[
-/// IReadOnlyList&lt;NotableDate&gt; resolved = new DefaultNotableDateCollisionResolver().Resolve(
+/// IReadOnlyList<NotableDate> resolved = new DefaultNotableDateCollisionResolver().Resolve(
 ///     new DateTime(2027, 4, 25),
 ///     new[]
 ///     {

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateAlgorithm.cs
@@ -54,7 +54,7 @@ namespace Bodu.Globalization.Calendar;
 /// {
 ///     public DateTime? GetDate(int year, System.Globalization.Calendar? calendar = null)
 ///     {
-///         if (year &lt; 1) throw new ArgumentOutOfRangeException(nameof(year));
+///         if (year < 1) throw new ArgumentOutOfRangeException(nameof(year));
 ///
 ///         DateTime firstOfNovember = new(year, 11, 1);
 ///         int offset = ((int)DayOfWeek.Tuesday - (int)firstOfNovember.DayOfWeek + 7) % 7;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateCollisionResolver.cs
@@ -31,7 +31,7 @@ namespace Bodu.Globalization.Calendar;
 ///<![CDATA[
 /// public sealed class HighestPriorityCollisionResolver : INotableDateCollisionResolver
 /// {
-///     public IReadOnlyList&lt;NotableDate&gt; Resolve(DateTime date, IReadOnlyList&lt;NotableDate&gt; overlapping)
+///     public IReadOnlyList<NotableDate> Resolve(DateTime date, IReadOnlyList<NotableDate> overlapping)
 ///     {
 ///         NotableDate winner = overlapping
 ///             .OrderBy(d => (int)d.Category)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleOverrideProvider.cs
@@ -26,13 +26,13 @@ namespace Bodu.Globalization.Calendar;
 ///<![CDATA[
 /// public sealed class CompanyCalendarOverrides : INotableDateRuleOverrideProvider
 /// {
-///     public IEnumerable&lt;RuleRemoval&gt; GetRemovals()
+///     public IEnumerable<RuleRemoval> GetRemovals()
 ///     {
 ///         // Remove Boxing Day for 2026 only:
 ///         yield return new RuleRemoval("Boxing Day", FromYear: 2026, ToYear: 2026);
 ///     }
 ///
-///     public IEnumerable&lt;NotableDateRule&gt; GetAdditions()
+///     public IEnumerable<NotableDateRule> GetAdditions()
 ///     {
 ///         yield return new NotableDateRule
 ///         {

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateRuleProvider.cs
@@ -29,11 +29,11 @@ namespace Bodu.Globalization.Calendar;
 ///<![CDATA[
 /// public sealed class InMemoryRuleProvider : INotableDateRuleProvider
 /// {
-///     private readonly IReadOnlyList&lt;NotableDateRule&gt; _rules;
+///     private readonly IReadOnlyList<NotableDateRule> _rules;
 ///
-///     public InMemoryRuleProvider(IReadOnlyList&lt;NotableDateRule&gt; rules) =&gt; _rules = rules;
+///     public InMemoryRuleProvider(IReadOnlyList<NotableDateRule> rules) => _rules = rules;
 ///
-///     public IEnumerable&lt;NotableDateRule&gt; LoadRules() =&gt; _rules;
+///     public IEnumerable<NotableDateRule> LoadRules() => _rules;
 /// }
 ///]]>
 /// </code>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -33,14 +33,14 @@ namespace Bodu.Globalization.Calendar;
 /// INotableDateService service = new NotableDateService();
 ///
 /// // All notable dates for Australia in 2026, ordered by date:
-/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU");
+/// IReadOnlyList<NotableDate> dates = service.GetNotableDates(2026, territoryCode: "AU");
 ///
 /// // Only non-working public holidays in Australia:
 /// NotableDateFilter filter = NotableDateFilter
 ///     .ForCategory(NotableDateCategory.Public)
 ///     .And(NotableDateFilter.IsNonWorkingDay());
 ///
-/// IReadOnlyList&lt;NotableDate&gt; holidays = service.GetNotableDates(2026, filter, "AU");
+/// IReadOnlyList<NotableDate> holidays = service.GetNotableDates(2026, filter, "AU");
 ///
 /// // Test whether Christmas Day 2026 is a non-working day for New South Wales:
 /// bool isNonWorking = service.IsNonWorkingDay(new DateTime(2026, 12, 25), "AU-NSW");

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
@@ -32,7 +32,7 @@ namespace Bodu.Globalization.Calendar;
 /// <code>
 ///<![CDATA[
 /// INotableDateService service = new NotableDateService();
-/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU");
+/// IReadOnlyList<NotableDate> dates = service.GetNotableDates(2026, territoryCode: "AU");
 ///
 /// foreach (NotableDate date in dates)
 /// {

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -55,7 +55,7 @@ namespace Bodu.Globalization.Calendar;
 ///     .ForCategory(NotableDateCategory.Public)
 ///     .And(NotableDateFilter.IsNonWorkingDay());
 ///
-/// IReadOnlyList&lt;NotableDate&gt; holidays = service.GetNotableDates(2026, filter, "AU-NSW");
+/// IReadOnlyList<NotableDate> holidays = service.GetNotableDates(2026, filter, "AU-NSW");
 ///
 /// // Public or cultural dates tagged "Christian":
 /// NotableDateFilter christian = NotableDateFilter

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -47,27 +47,27 @@ namespace Bodu.Globalization.Calendar;
 /// <code>
 ///<![CDATA[
 /// const string xml = """
-///     &lt;NotableDates xmlns="urn:bodu:globalization:calendar"&gt;
-///       &lt;Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true"&gt;
-///         &lt;Fixed month="1" day="26" /&gt;
-///         &lt;Adjustment key="weekend-roll"
+///     <NotableDates xmlns="urn:bodu:globalization:calendar">
+///       <Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true">
+///         <Fixed month="1" day="26" />
+///         <Adjustment key="weekend-roll"
 ///                     trigger="IfWeekend"
 ///                     action="MoveToNextMonday"
-///                     isNonWorkingDay="true" /&gt;
-///       &lt;/Rule&gt;
-///       &lt;Rule name="Easter Sunday" category="Religious"&gt;
-///         &lt;Algorithm key="easter-sunday" /&gt;
-///       &lt;/Rule&gt;
-///     &lt;/NotableDates&gt;
+///                     isNonWorkingDay="true" />
+///       </Rule>
+///       <Rule name="Easter Sunday" category="Religious">
+///         <Algorithm key="easter-sunday" />
+///       </Rule>
+///     </NotableDates>
 ///     """;
 ///
-/// List&lt;NotableDateRule&gt; rules = NotableDateRuleParser.ParseXml(xml);
+/// List<NotableDateRule> rules = NotableDateRuleParser.ParseXml(xml);
 /// // rules[0] is the Fixed Australia Day rule with one weekend-roll adjustment.
 /// // rules[1] is the Algorithm-backed Easter Sunday rule.
 ///
-/// // When &lt;Use&gt; directives also matter, parse the full document instead:
+/// // When <Use> directives also matter, parse the full document instead:
 /// ParsedNotableDateDocument document = NotableDateRuleParser.ParseDocument(xml);
-/// IReadOnlyList&lt;NotableDateRuleUseGroup&gt; imports = document.UseGroups;
+/// IReadOnlyList<NotableDateRuleUseGroup> imports = document.UseGroups;
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseDirective.cs
@@ -81,11 +81,11 @@ namespace Bodu.Globalization.Calendar;
 ///     });
 ///
 /// // Equivalent XML:
-/// // &lt;Use source="Bodu/Globalization/Calendar/Resources/au-public.xml"&gt;
-/// //   &lt;Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true"&gt;
-/// //     &lt;Adjustment key="weekend-roll" trigger="IfWeekend" action="AddDays" offsetDays="2" isNonWorkingDay="true" /&gt;
-/// //   &lt;/Rule&gt;
-/// // &lt;/Use&gt;
+/// // <Use source="Bodu/Globalization/Calendar/Resources/au-public.xml">
+/// //   <Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true">
+/// //     <Adjustment key="weekend-roll" trigger="IfWeekend" action="AddDays" offsetDays="2" isNonWorkingDay="true" />
+/// //   </Rule>
+/// // </Use>
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseGroup.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleUseGroup.cs
@@ -39,7 +39,7 @@ namespace Bodu.Globalization.Calendar;
 /// NotableDateRuleUseGroup global = new NotableDateRuleUseGroup(
 ///     SourceResource: "Bodu/Globalization/Calendar/Resources/global-public.xml",
 ///     UseAll: true,
-///     Uses: ImmutableArray&lt;NotableDateRuleUseDirective&gt;.Empty);
+///     Uses: ImmutableArray<NotableDateRuleUseDirective>.Empty);
 ///
 /// // From the AU public-holidays resource, pull only Anzac Day, retargeted to Western Australia:
 /// NotableDateRuleUseGroup australia = new NotableDateRuleUseGroup(
@@ -52,10 +52,10 @@ namespace Bodu.Globalization.Calendar;
 ///             IsNonWorkingDay: true)));
 ///
 /// // Equivalent XML:
-/// // &lt;Use source="...global-public.xml" useAll="true" /&gt;
-/// // &lt;Use source="...au-public.xml"&gt;
-/// //   &lt;Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true" /&gt;
-/// // &lt;/Use&gt;
+/// // <Use source="...global-public.xml" useAll="true" />
+/// // <Use source="...au-public.xml">
+/// //   <Rule sourceName="Anzac Day" territoryCode="AU-WA" isNonWorkingDay="true" />
+/// // </Use>
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -99,7 +99,7 @@ namespace Bodu.Globalization.Calendar;
 /// NotableDateService service = new NotableDateService();
 ///
 /// // All notable dates for New South Wales in 2026 (requires the Asia-Pacific data pack):
-/// IReadOnlyList&lt;NotableDate&gt; dates = service.GetNotableDates(2026, territoryCode: "AU-NSW");
+/// IReadOnlyList<NotableDate> dates = service.GetNotableDates(2026, territoryCode: "AU-NSW");
 ///
 /// // Full construction with a custom XML rule file and algorithm registry:
 /// var registry = new NotableDateAlgorithmRegistry()

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ParsedNotableDateDocument.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ParsedNotableDateDocument.cs
@@ -40,14 +40,14 @@ namespace Bodu.Globalization.Calendar;
 /// <code>
 ///<![CDATA[
 /// const string xml = """
-///     &lt;NotableDates xmlns="urn:bodu:globalization:calendar"&gt;
-///       &lt;Use source="Bodu/Globalization/Calendar/Resources/global-public.xml"&gt;
-///         &lt;Rule sourceName="New Year's Day" territoryCode="AU" /&gt;
-///       &lt;/Use&gt;
-///       &lt;Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true"&gt;
-///         &lt;Fixed month="1" day="26" /&gt;
-///       &lt;/Rule&gt;
-///     &lt;/NotableDates&gt;
+///     <NotableDates xmlns="urn:bodu:globalization:calendar">
+///       <Use source="Bodu/Globalization/Calendar/Resources/global-public.xml">
+///         <Rule sourceName="New Year's Day" territoryCode="AU" />
+///       </Use>
+///       <Rule name="Australia Day" category="Public" territoryCode="AU" isNonWorkingDay="true">
+///         <Fixed month="1" day="26" />
+///       </Rule>
+///     </NotableDates>
 ///     """;
 ///
 /// ParsedNotableDateDocument document = NotableDateRuleParser.ParseDocument(xml);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleRemoval.cs
@@ -41,7 +41,7 @@ namespace Bodu.Globalization.Calendar;
 ///     TerritoryCode: "AU-NT");
 ///
 /// // Returned from an INotableDateRuleOverrideProvider:
-/// public IEnumerable&lt;RuleRemoval&gt; GetRemovals()
+/// public IEnumerable<RuleRemoval> GetRemovals()
 /// {
 ///     yield return boxingDay2026;
 ///     yield return picnicDayNT;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
@@ -45,7 +45,7 @@ namespace Bodu.Globalization.Calendar;
 /// Console.WriteLine(nsw.Contains(australia));      // false
 ///
 /// // Parse a comma-separated list (invalid entries are silently skipped):
-/// IReadOnlyList&lt;TerritoryCode&gt; codes = TerritoryCode.ParseList("AU, AU-NSW, AU-VIC");
+/// IReadOnlyList<TerritoryCode> codes = TerritoryCode.ParseList("AU, AU-NSW, AU-VIC");
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/XmlResourceNotableDateRuleProvider.cs
@@ -75,7 +75,7 @@ namespace Bodu.Globalization.Calendar;
 ///     new ResourcePathResolver(),
 ///     assembly: resourceAssembly);
 ///
-/// // Load from a chain of assemblies (data pack first, main library as fallback for &lt;UseFrom&gt; targets):
+/// // Load from a chain of assemblies (data pack first, main library as fallback for <UseFrom> targets):
 /// var packProvider = new XmlResourceNotableDateRuleProvider(
 ///     "MyApp/Calendar/Resources/region-us.xml",
 ///     new ResourcePathResolver(),

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
@@ -48,8 +48,12 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; // zlib-compatible
-/// Adler-32 of a deflate payload. var adler = new Adler32(); byte[] checksum = adler.ComputeHash(deflateBlock);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // zlib-compatible Adler-32 of a deflate payload.
+/// var adler = new Adler32();
+/// byte[] checksum = adler.ComputeHash(deflateBlock);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
@@ -47,9 +47,12 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; // SIMD-friendly Adler
-/// variant for high-throughput internal pipelines. var adler = new Adler32C(); byte[] checksum =
-/// adler.ComputeHash(largeBlock);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // SIMD-friendly Adler variant for high-throughput internal pipelines.
+/// var adler = new Adler32C();
+/// byte[] checksum = adler.ComputeHash(largeBlock);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64.cs
@@ -46,8 +46,11 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; var adler = new
-/// Adler64(); byte[] checksum = adler.ComputeHash(largePayload);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var adler = new Adler64();
+/// byte[] checksum = adler.ComputeHash(largePayload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
@@ -45,8 +45,12 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; // zlib-compatible
-/// Adler-32 of a deflate payload. var adler = new Adler32(); byte[] checksum = adler.ComputeHash(deflateBlock);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // zlib-compatible Adler-32 of a deflate payload.
+/// var adler = new Adler32();
+/// byte[] checksum = adler.ComputeHash(deflateBlock);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -85,14 +85,25 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.IO.Hashing; using Bodu.IO.Hashing; using Bodu.IO.Hashing.Checksums; using
-/// Bodu.IO.Hashing.Extensions; // 1. Standard PKZIP / Ethernet CRC-32 of a buffer. var crc32 = new
-/// Crc(CrcStandard.CRC32_ISOHDLC); byte[] digest = crc32.ComputeHash(File.ReadAllBytes("payload.bin")); // 2. Modbus
-/// RTU — different polynomial/init/reflect choices, same engine. var modbus = new Crc(CrcStandard.CRC16_MODBUS);
-/// modbus.Append(frameHeader); modbus.Append(framePayload); byte[] frameCrc = modbus.GetCurrentHash(); //
-/// non-destructive snapshot // 3. Resumption — fold an appended log segment into yesterday's digest without re-reading
-/// the original bytes. var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC); byte[] updated =
-/// resumable.ComputeHashFrom(digest, File.ReadAllBytes("payload.appended.bin"));
+/// using System.IO.Hashing;
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 1. Standard PKZIP / Ethernet CRC-32 of a buffer.
+/// var crc32 = new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] digest = crc32.ComputeHash(File.ReadAllBytes("payload.bin"));
+///
+/// // 2. Modbus RTU — different polynomial/init/reflect choices, same engine.
+/// var modbus = new Crc(CrcStandard.CRC16_MODBUS);
+/// modbus.Append(frameHeader);
+/// modbus.Append(framePayload);
+/// byte[] frameCrc = modbus.GetCurrentHash(); // non-destructive snapshot
+///
+/// // 3. Resumption — fold an appended log segment into yesterday's digest without re-reading
+/// // the original bytes.
+/// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] updated = resumable.ComputeHashFrom(digest, File.ReadAllBytes("payload.appended.bin"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
@@ -37,11 +37,22 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; // Most callers do not interact with the cache directly —
-/// Crc resolves it through Crc.GlobalCache. var crc = new Crc(CrcStandard.CRC32_ISOHDLC); // Use a scoped cache for an
-/// isolated test, then restore the default. CrcLookupTableCache previous = Crc.GlobalCache; try { Crc.GlobalCache = new
-/// CrcLookupTableCache(); // ... run isolated tests against a fresh cache ... } finally { Crc.GlobalCache = previous; }
+/// using Bodu.IO.Hashing.Checksums;
 ///
+/// // Most callers do not interact with the cache directly — Crc resolves it through Crc.GlobalCache.
+/// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+///
+/// // Use a scoped cache for an isolated test, then restore the default.
+/// CrcLookupTableCache previous = Crc.GlobalCache;
+/// try
+/// {
+///     Crc.GlobalCache = new CrcLookupTableCache();
+///     // ... run isolated tests against a fresh cache ...
+/// }
+/// finally
+/// {
+///     Crc.GlobalCache = previous;
+/// }
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.16.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.16.cs
@@ -49,8 +49,11 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; var f16 = new
-/// Fletcher16(); byte[] checksum = f16.ComputeHash(framePayload);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f16 = new Fletcher16();
+/// byte[] checksum = f16.ComputeHash(framePayload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.32.cs
@@ -49,8 +49,11 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; var f32 = new
-/// Fletcher32(); byte[] checksum = f32.ComputeHash(payload);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f32 = new Fletcher32();
+/// byte[] checksum = f32.ComputeHash(payload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.64.cs
@@ -49,8 +49,11 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; var f64 = new
-/// Fletcher64(); byte[] checksum = f64.ComputeHash(largePayload);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var f64 = new Fletcher64();
+/// byte[] checksum = f64.ComputeHash(largePayload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
@@ -43,9 +43,12 @@ namespace Bodu.IO.Hashing.Checksums;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing.Checksums; using Bodu.IO.Hashing.Extensions; // 32-bit Fletcher
-/// checksum of a packet payload. var fletcher = new Fletcher32(); byte[] checksum = fletcher.ComputeHash(payload);
+/// using Bodu.IO.Hashing.Checksums;
+/// using Bodu.IO.Hashing.Extensions;
 ///
+/// // 32-bit Fletcher checksum of a packet payload.
+/// var fletcher = new Fletcher32();
+/// byte[] checksum = fletcher.ComputeHash(payload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
@@ -40,9 +40,12 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // Default seed (131); appropriate
-/// for short identifier keys. var bkdr = new BKDR(); byte[] digest =
-/// bkdr.ComputeHash(System.Text.Encoding.UTF8.GetBytes("Identifier"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default seed (131); appropriate for short identifier keys.
+/// var bkdr = new BKDR();
+/// byte[] digest = bkdr.ComputeHash(System.Text.Encoding.UTF8.GetBytes("Identifier"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
@@ -44,11 +44,16 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // Default djb2 with the canonical
-/// 5381 seed. var djb2 = new Bernstein(); byte[] digest =
-/// djb2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol")); // XOR-modified djb2a, generally better
-/// distribution. var djb2a = new Bernstein { UseModifiedAlgorithm = true }; byte[] digestA =
-/// djb2a.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default djb2 with the canonical 5381 seed.
+/// var djb2 = new Bernstein();
+/// byte[] digest = djb2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
+///
+/// // XOR-modified djb2a, generally better distribution.
+/// var djb2a = new Bernstein { UseModifiedAlgorithm = true };
+/// byte[] digestA = djb2a.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
@@ -62,9 +62,12 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var city = new CityHash128();
-/// byte[] fingerprint = city.ComputeHash(blob); // fingerprint = [low 64 bits || high 64 bits], each little-endian.
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
 ///
+/// var city = new CityHash128();
+/// byte[] fingerprint = city.ComputeHash(blob);
+/// // fingerprint = [low 64 bits || high 64 bits], each little-endian.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
@@ -56,7 +56,10 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var city = new CityHash32();
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var city = new CityHash32();
 /// byte[] digest = city.ComputeHash(System.Text.Encoding.UTF8.GetBytes("session-key"));
 ///]]>
 /// </code>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.64.cs
@@ -57,7 +57,10 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var city = new CityHash64();
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var city = new CityHash64();
 /// byte[] fingerprint = city.ComputeHash(blob);
 ///]]>
 /// </code>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
@@ -56,10 +56,17 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // 64-bit fingerprint of a content
-/// blob — typical use case. var city = new CityHash64(); byte[] fingerprint = city.ComputeHash(blob); // Stream-hash a
-/// moderately sized file. Note: CityHash buffers fully — prefer Crc / xxHash for very large streams. using FileStream
-/// fs = File.OpenRead("payload.bin"); byte[] streamDigest = city.ComputeHash(fs);
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 64-bit fingerprint of a content blob — typical use case.
+/// var city = new CityHash64();
+/// byte[] fingerprint = city.ComputeHash(blob);
+///
+/// // Stream-hash a moderately sized file.
+/// // Note: CityHash buffers fully — prefer Crc / xxHash for very large streams.
+/// using FileStream fs = File.OpenRead("payload.bin");
+/// byte[] streamDigest = city.ComputeHash(fs);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
@@ -40,8 +40,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var elf = new Elf64(); byte[]
-/// digest = elf.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var elf = new Elf64();
+/// byte[] digest = elf.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv132.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv132.cs
@@ -49,8 +49,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var fnv = new Fnv132(); byte[]
-/// digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv132();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv164.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv164.cs
@@ -49,8 +49,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var fnv = new Fnv164(); byte[]
-/// digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv164();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a32.cs
@@ -51,8 +51,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var fnv = new Fnv1a32(); byte[]
-/// digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv1a32();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.Fnv1a64.cs
@@ -51,8 +51,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var fnv = new Fnv1a64(); byte[]
-/// digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var fnv = new Fnv1a64();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
@@ -58,9 +58,12 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // Pick a width and variant;
-/// FNV-1a is the recommended default. var fnv = new Fnv1a64(); byte[] digest =
-/// fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Pick a width and variant; FNV-1a is the recommended default.
+/// var fnv = new Fnv1a64();
+/// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
@@ -62,12 +62,21 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Checksums; // 1. Compute a baseline digest of
-/// a file's first segment. var crc = new Crc(CrcStandard.CRC32_ISOHDLC); crc.Append(File.ReadAllBytes("part-1.bin"));
-/// byte[] digest1 = crc.GetCurrentHash(); // 2. Hours (or processes) later, fold an additional segment into the same
-/// digest using only `digest1`. var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC); byte[]
-/// digest2 = resumable.ComputeHashFrom(digest1, File.ReadAllBytes("part-2.bin")); // 3. Same result as if both segments
-/// had been appended in one session — without holding the running state.
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Checksums;
+///
+/// // 1. Compute a baseline digest of a file's first segment.
+/// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
+/// crc.Append(File.ReadAllBytes("part-1.bin"));
+/// byte[] digest1 = crc.GetCurrentHash();
+///
+/// // 2. Hours (or processes) later, fold an additional segment into the same
+/// // digest using only `digest1`.
+/// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
+/// byte[] digest2 = resumable.ComputeHashFrom(digest1, File.ReadAllBytes("part-2.bin"));
+///
+/// // 3. Same result as if both segments had been appended in one session — without
+/// // holding the running state.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/JSHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/JSHash.cs
@@ -35,8 +35,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var js = new JSHash(); byte[]
-/// digest = js.ComputeHash(System.Text.Encoding.UTF8.GetBytes("input-key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var js = new JSHash();
+/// byte[] digest = js.ComputeHash(System.Text.Encoding.UTF8.GetBytes("input-key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
@@ -61,9 +61,15 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // 128-bit fingerprint of a
-/// content blob. var m = new MurmurHash3_128(); byte[] fingerprint = m.ComputeHash(blob); // Custom seed to isolate a
-/// second hash family for cuckoo / bloom-filter use. var m2 = new MurmurHash3_128(seed: 0xC2B2AE35u);
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 128-bit fingerprint of a content blob.
+/// var m = new MurmurHash3_128();
+/// byte[] fingerprint = m.ComputeHash(blob);
+///
+/// // Custom seed to isolate a second hash family for cuckoo / bloom-filter use.
+/// var m2 = new MurmurHash3_128(seed: 0xC2B2AE35u);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
@@ -59,11 +59,16 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // Default seed, suitable for an
-/// in-memory hash table. var m = new MurmurHash3_32(); byte[] digest =
-/// m.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key")); // Custom seed for a second, independent hash
-/// family (useful in bloom filters). var m2 = new MurmurHash3_32(seed: 0x9E3779B1u); byte[] digest2 =
-/// m2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Default seed, suitable for an in-memory hash table.
+/// var m = new MurmurHash3_32();
+/// byte[] digest = m.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
+///
+/// // Custom seed for a second, independent hash family (useful in bloom filters).
+/// var m2 = new MurmurHash3_32(seed: 0x9E3779B1u);
+/// byte[] digest2 = m2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
@@ -53,11 +53,16 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // 32-bit hash, default seed,
-/// suitable for in-memory hash tables. var m32 = new MurmurHash3_32(); uint h32 =
-/// BinaryPrimitives.ReadUInt32LittleEndian(m32.ComputeHash(keyBytes)); // 128-bit hash, custom seed for shard isolation
-/// across services. var m128 = new MurmurHash3_128(seed: 0xC2B2AE35u); byte[] fingerprint = m128.ComputeHash(payload);
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
 ///
+/// // 32-bit hash, default seed, suitable for in-memory hash tables.
+/// var m32 = new MurmurHash3_32();
+/// uint h32 = BinaryPrimitives.ReadUInt32LittleEndian(m32.ComputeHash(keyBytes));
+///
+/// // 128-bit hash, custom seed for shard isolation across services.
+/// var m128 = new MurmurHash3_128(seed: 0xC2B2AE35u);
+/// byte[] fingerprint = m128.ComputeHash(payload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
@@ -42,10 +42,13 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // 8-byte (64-bit) Pearson digest
-/// assembled from eight permutation passes, // using one of the canonical lookup tables. var pearson = new
-/// Pearson(hashSizeBits: 64, PearsonTableType.Pearson); byte[] digest =
-/// pearson.ComputeHash(System.Text.Encoding.UTF8.GetBytes("payload"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // 8-byte (64-bit) Pearson digest assembled from eight permutation passes,
+/// // using one of the canonical lookup tables.
+/// var pearson = new Pearson(hashSizeBits: 64, PearsonTableType.Pearson);
+/// byte[] digest = pearson.ComputeHash(System.Text.Encoding.UTF8.GetBytes("payload"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Pjw32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Pjw32.cs
@@ -36,8 +36,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var pjw = new Pjw32(); byte[]
-/// digest = pjw.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var pjw = new Pjw32();
+/// byte[] digest = pjw.ComputeHash(System.Text.Encoding.ASCII.GetBytes("symbol_name"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/SDBM.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SDBM.cs
@@ -37,8 +37,11 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; var sdbm = new SDBM(); byte[]
-/// digest = sdbm.ComputeHash(System.Text.Encoding.UTF8.GetBytes("dbm-key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// var sdbm = new SDBM();
+/// byte[] digest = sdbm.ComputeHash(System.Text.Encoding.UTF8.GetBytes("dbm-key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
@@ -42,9 +42,12 @@ namespace Bodu.IO.Hashing;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.IO.Hashing; using Bodu.IO.Hashing.Extensions; // Suited to short keys; avoid for
-/// multi-megabyte streams (the input is fully buffered). var sfh = new SuperFastHash(); byte[] digest =
-/// sfh.ComputeHash(System.Text.Encoding.UTF8.GetBytes("short-key"));
+/// using Bodu.IO.Hashing;
+/// using Bodu.IO.Hashing.Extensions;
+///
+/// // Suited to short keys; avoid for multi-megabyte streams (the input is fully buffered).
+/// var sfh = new SuperFastHash();
+/// byte[] digest = sfh.ComputeHash(System.Text.Encoding.UTF8.GetBytes("short-key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -68,16 +68,26 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using System.Text; using Bodu.Security.Cryptography;
-/// using Bodu.Security.Cryptography.Extensions; byte[] key = RandomNumberGenerator.GetBytes(32); byte[] nonce =
-/// RandomNumberGenerator.GetBytes(12); byte[] header = Encoding.UTF8.GetBytes("v=1;msg=42"); // 1. Encrypt with
-/// associated data; receive ciphertext + tag in a single buffer. using IAeadBlockCipherModeTransform enc = new
-/// GcmModeTransform(key, nonce); byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header); // 2. Decrypt and
-/// verify in one call. A tampered tag or header throws CryptographicException. using IAeadBlockCipherModeTransform dec
-/// = new GcmModeTransform(key, nonce); byte[] recovered = dec.Decrypt(sealed_, associatedData: header); // 3. Same
-/// shape with a different mode — Ascon, EAX, GCM-SIV all interchange behind IAeadBlockCipherModeTransform. using
-/// IAeadBlockCipherModeTransform enc2 = new AsconAead128(key, nonce); byte[] sealedAscon = enc2.Encrypt(plaintext);
+/// using System.Security.Cryptography;
+/// using System.Text;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
 ///
+/// byte[] key = RandomNumberGenerator.GetBytes(32);
+/// byte[] nonce = RandomNumberGenerator.GetBytes(12);
+/// byte[] header = Encoding.UTF8.GetBytes("v=1;msg=42");
+///
+/// // 1. Encrypt with associated data; receive ciphertext + tag in a single buffer.
+/// using IAeadBlockCipherModeTransform enc = new GcmModeTransform(key, nonce);
+/// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header);
+///
+/// // 2. Decrypt and verify in one call. A tampered tag or header throws CryptographicException.
+/// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(key, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+///
+/// // 3. Same shape with a different mode — Ascon, EAX, GCM-SIV all interchange behind IAeadBlockCipherModeTransform.
+/// using IAeadBlockCipherModeTransform enc2 = new AsconAead128(key, nonce);
+/// byte[] sealedAscon = enc2.Encrypt(plaintext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
@@ -69,15 +69,24 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using System.Text; using
-/// Bodu.Security.Cryptography.Extensions; using var sha = SHA256.Create(); // 1. Verify a UTF-8 string against an
-/// expected digest, throwing if anything is wrong. byte[] expected =
-/// Convert.FromHexString("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f"); bool match =
-/// sha.VerifyHash("Hello, World!", Encoding.UTF8, expected); // 2. Stream-verify a downloaded file against a hex
-/// digest, without throwing on malformed hex. using FileStream fs = File.OpenRead("payload.bin"); bool ok =
-/// sha.TryVerifyHash(fs, expectedHex: "ba7816bf..."); // 3. Cancellable async verification of a network stream against
-/// a known digest. await using Stream net = response.Content.ReadAsStream(); bool verified = await
-/// sha.VerifyHashAsync(net, expected, cancellationToken);
+/// using System.Security.Cryptography;
+/// using System.Text;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var sha = SHA256.Create();
+///
+/// // 1. Verify a UTF-8 string against an expected digest, throwing if anything is wrong.
+/// byte[] expected =
+///     Convert.FromHexString("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
+/// bool match = sha.VerifyHash("Hello, World!", Encoding.UTF8, expected);
+///
+/// // 2. Stream-verify a downloaded file against a hex digest, without throwing on malformed hex.
+/// using FileStream fs = File.OpenRead("payload.bin");
+/// bool ok = sha.TryVerifyHash(fs, expectedHex: "ba7816bf...");
+///
+/// // 3. Cancellable async verification of a network stream against a known digest.
+/// await using Stream net = response.Content.ReadAsStream();
+/// bool verified = await sha.VerifyHashAsync(net, expected, cancellationToken);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
@@ -67,14 +67,26 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography.Extensions; using Aes
-/// aes = Aes.Create(); aes.Key = key; aes.IV = iv; // 1. One-shot encrypt of a span into a new byte[]. using
-/// ICryptoTransform encryptor = aes.CreateEncryptor(); byte[] ciphertext = encryptor.Transform(plaintext.AsSpan()); //
-/// 2. Stream-encrypt a large file end to end with a 64 KiB buffer. using FileStream src = File.OpenRead("plain.bin");
-/// using FileStream dst = File.Create("cipher.bin"); using ICryptoTransform e2 = aes.CreateEncryptor(); int written =
-/// e2.Transform(src, dst, bufferSize: 64 * 1024); // 3. Cancellable async stream transform, e.g. when piping HTTP
-/// content. using ICryptoTransform e3 = aes.CreateEncryptor(); await e3.TransformAsync(networkStream, output,
-/// bufferSize: 16 * 1024, cancellationToken);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using Aes aes = Aes.Create();
+/// aes.Key = key;
+/// aes.IV = iv;
+///
+/// // 1. One-shot encrypt of a span into a new byte[].
+/// using ICryptoTransform encryptor = aes.CreateEncryptor();
+/// byte[] ciphertext = encryptor.Transform(plaintext.AsSpan());
+///
+/// // 2. Stream-encrypt a large file end to end with a 64 KiB buffer.
+/// using FileStream src = File.OpenRead("plain.bin");
+/// using FileStream dst = File.Create("cipher.bin");
+/// using ICryptoTransform e2 = aes.CreateEncryptor();
+/// int written = e2.Transform(src, dst, bufferSize: 64 * 1024);
+///
+/// // 3. Cancellable async stream transform, e.g. when piping HTTP content.
+/// using ICryptoTransform e3 = aes.CreateEncryptor();
+/// await e3.TransformAsync(networkStream, output, bufferSize: 16 * 1024, cancellationToken);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
@@ -62,14 +62,26 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography.Extensions; using Aes
-/// aes = Aes.Create(); aes.Key = key; aes.IV = iv; // 1. One-shot encrypt of an in-memory span; one-shot decrypt back.
-/// byte[] ciphertext = aes.Encrypt(plaintext.AsSpan()); byte[] roundTrip = aes.Decrypt(ciphertext); // 2.
-/// Stream-encrypt a large file with the default 80 KiB buffer. using FileStream src = File.OpenRead("plain.bin"); using
-/// FileStream dst = File.Create("cipher.bin"); int bytesWritten = aes.Encrypt(src, dst); // 3. Validate caller-supplied
-/// key material without catching CryptographicException. if (!aes.TryCreateDecryptor(suppliedKey, suppliedIv, out
-/// ICryptoTransform? decryptor)) return BadRequest("invalid key/iv combination"); using (decryptor) { /* … decrypt with
-/// the validated transform … */ }
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using Aes aes = Aes.Create();
+/// aes.Key = key;
+/// aes.IV = iv;
+///
+/// // 1. One-shot encrypt of an in-memory span; one-shot decrypt back.
+/// byte[] ciphertext = aes.Encrypt(plaintext.AsSpan());
+/// byte[] roundTrip = aes.Decrypt(ciphertext);
+///
+/// // 2. Stream-encrypt a large file with the default 80 KiB buffer.
+/// using FileStream src = File.OpenRead("plain.bin");
+/// using FileStream dst = File.Create("cipher.bin");
+/// int bytesWritten = aes.Encrypt(src, dst);
+///
+/// // 3. Validate caller-supplied key material without catching CryptographicException.
+/// if (!aes.TryCreateDecryptor(suppliedKey, suppliedIv, out ICryptoTransform? decryptor))
+///     return BadRequest("invalid key/iv combination");
+/// using (decryptor) { /* … decrypt with the validated transform … */ }
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
@@ -49,13 +49,22 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using TweakableSymmetricAlgorithm tf = new Threefish256(); // 1. Validate
-/// user-supplied key/IV/tweak without catching CryptographicException. if (!tf.TryCreateEncryptor(suppliedKey,
-/// suppliedIv, suppliedTweak, out ICryptoTransform? encryptor)) return BadRequest("invalid key, iv, or tweak"); using
-/// (encryptor) { /* … encrypt with the validated transform … */ } // 2. Round-trip pairing — same try-pattern shape for
-/// the decryptor. if (tf.TryCreateDecryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? decryptor)) {
-/// using (decryptor) { /* … decrypt … */ } }
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using TweakableSymmetricAlgorithm tf = new Threefish256();
+///
+/// // 1. Validate user-supplied key/IV/tweak without catching CryptographicException.
+/// if (!tf.TryCreateEncryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? encryptor))
+///     return BadRequest("invalid key, iv, or tweak");
+/// using (encryptor) { /* … encrypt with the validated transform … */ }
+///
+/// // 2. Round-trip pairing — same try-pattern shape for the decryptor.
+/// if (tf.TryCreateDecryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? decryptor))
+/// {
+///     using (decryptor) { /* … decrypt … */ }
+/// }
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
@@ -34,8 +34,11 @@ namespace Bodu.Security.Cryptography;
 /// <code language="csharp">
 ///<![CDATA[
 /// // Encrypt a single 16-byte block (typically used indirectly via an AEAD mode transform).
-/// byte[] key = RandomNumberGenerator.GetBytes(16); using var cipher = new AesBlockCipher(key); Span&lt;byte&gt; block
-/// = stackalloc byte[16]; Span&lt;byte&gt; output = stackalloc byte[16]; cipher.Encrypt(block, output);
+/// byte[] key = RandomNumberGenerator.GetBytes(16);
+/// using var cipher = new AesBlockCipher(key);
+/// Span<byte> block = stackalloc byte[16];
+/// Span<byte> output = stackalloc byte[16];
+/// cipher.Encrypt(block, output);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -27,9 +27,13 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; IPaddingStrategy padding = new Ansix923Padding(); byte[]
-/// padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes // padded ends with N-1 zero bytes followed
-/// by a single byte holding N. byte[] recovered = padding.Unpad(padded, blockSize: 128);
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Ansix923Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
+///
+/// // padded ends with N-1 zero bytes followed by a single byte holding N.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
@@ -100,11 +100,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; using Bodu.Security.Cryptography.Extensions; // Most
-/// callers should reach for the AeadBlockCipherModeTransformExtensions helpers, // which size the output buffer and
-/// return a single freshly allocated array. using IAeadBlockCipherModeTransform enc = new AsconAead128(key, nonce);
-/// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header); using IAeadBlockCipherModeTransform dec = new
-/// AsconAead128(key, nonce); byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // Most callers should reach for the AeadBlockCipherModeTransformExtensions helpers,
+/// // which size the output buffer and return a single freshly allocated array.
+/// using IAeadBlockCipherModeTransform enc = new AsconAead128(key, nonce);
+/// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new AsconAead128(key, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconCxof128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconCxof128.cs
@@ -89,8 +89,10 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var cxof = new AsconCxof128(); cxof.Customize(Encoding.UTF8.GetBytes("my-app-v1"));
-/// cxof.Absorb(message); byte[] output = cxof.GetHash(32);
+/// using var cxof = new AsconCxof128();
+/// cxof.Customize(Encoding.UTF8.GetBytes("my-app-v1"));
+/// cxof.Absorb(message);
+/// byte[] output = cxof.GetHash(32);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHash256.cs
@@ -58,7 +58,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var hash = new AsconHash256(); byte[] digest = hash.ComputeHash(message);
+/// using var hash = new AsconHash256();
+/// byte[] digest = hash.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHashA256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconHashA256.cs
@@ -57,7 +57,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var hash = new AsconHashA256(); byte[] digest = hash.ComputeHash(message);
+/// using var hash = new AsconHashA256();
+/// byte[] digest = hash.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof128.cs
@@ -64,8 +64,9 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var xof = new AsconXof128(); xof.Absorb(message); byte[] output = xof.GetHash(64); //
-/// Produce 64 bytes of output
+/// using var xof = new AsconXof128();
+/// xof.Absorb(message);
+/// byte[] output = xof.GetHash(64); // Produce 64 bytes of output
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -70,8 +70,12 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// // Unkeyed hash using var blake2b = new Blake2b(512); byte[] digest =
-/// blake2b.ComputeHash(message); // Keyed MAC (BLAKE2b-MAC-512) using var mac = new Blake2b(512) { Key = myKey };
+/// // Unkeyed hash
+/// using var blake2b = new Blake2b(512);
+/// byte[] digest = blake2b.ComputeHash(message);
+///
+/// // Keyed MAC (BLAKE2b-MAC-512)
+/// using var mac = new Blake2b(512) { Key = myKey };
 /// byte[] tag = mac.ComputeHash(message);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -69,8 +69,12 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// // Unkeyed hash using var blake2s = new Blake2s(256); byte[] digest =
-/// blake2s.ComputeHash(message); // Keyed MAC (BLAKE2s-MAC-256) using var mac = new Blake2s(256) { Key = myKey };
+/// // Unkeyed hash
+/// using var blake2s = new Blake2s(256);
+/// byte[] digest = blake2s.ComputeHash(message);
+///
+/// // Keyed MAC (BLAKE2s-MAC-256)
+/// using var mac = new Blake2s(256) { Key = myKey };
 /// byte[] tag = mac.ComputeHash(message);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -75,7 +75,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var blake3 = new Blake3(); byte[] digest = blake3.ComputeHash(message);
+/// using var blake3 = new Blake3();
+/// byte[] digest = blake3.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherModeFactory.cs
@@ -26,7 +26,8 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// </remarks>
 /// <example>
-/// The following example composes a block cipher, a CBC mode transform, and PKCS#7 padding to encrypt a message: <code>
+/// The following example composes a block cipher, a CBC mode transform, and PKCS#7 padding to encrypt a message:
+/// <code>
 ///<![CDATA[
 /// using IBlockCipher cipher = /* construct an IBlockCipher, e.g. an AES wrapper */;
 /// IBlockCipherModeTransform mode = BlockCipherModeFactory.Create(CipherBlockMode.CBC, cipher, iv);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
@@ -66,10 +66,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; // Legacy interop only. using var blowfish = new Blowfish(); blowfish.Key =
-/// legacyKeyMaterial; // 4–56 bytes blowfish.IV = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block byte[]
-/// ciphertext = blowfish.Encrypt(legacyPlaintext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // Legacy interop only.
+/// using var blowfish = new Blowfish();
+/// blowfish.Key = legacyKeyMaterial; // 4–56 bytes
+/// blowfish.IV = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block
+/// byte[] ciphertext = blowfish.Encrypt(legacyPlaintext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
@@ -62,10 +62,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var camellia = new Camellia(); camellia.GenerateKey(); // 256-bit by
-/// default camellia.GenerateIV(); byte[] ciphertext = camellia.Encrypt(plaintext); byte[] roundTrip =
-/// camellia.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var camellia = new Camellia();
+/// camellia.GenerateKey(); // 256-bit by default
+/// camellia.GenerateIV();
+/// byte[] ciphertext = camellia.Encrypt(plaintext);
+/// byte[] roundTrip = camellia.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
@@ -41,11 +41,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should set SymmetricAlgorithm.Mode = CipherBlockMode.CBC instead of using this directly. using IBlockCipher cipher =
-/// new AesBlockCipher(key); byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
-/// IBlockCipherModeTransform cbc = new CbcModeTransform(cipher, iv); byte[] ciphertext = new
-/// byte[paddedPlaintext.Length]; int written = cbc.Transform(paddedPlaintext, ciphertext, encrypt: true);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CBC instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
+/// IBlockCipherModeTransform cbc = new CbcModeTransform(cipher, iv);
+/// byte[] ciphertext = new byte[paddedPlaintext.Length];
+/// int written = cbc.Transform(paddedPlaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -59,12 +59,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using IBlockCipher cipher = new AesBlockCipher(key); byte[] iv =
-/// BuildCcmIv(nonce); // 12-byte nonce in the first 12 bytes of the IV using IAeadBlockCipherModeTransform ccm = new
-/// CcmModeTransform(cipher, iv); byte[] sealed_ = ccm.Encrypt(plaintext, associatedData: header); using
-/// IAeadBlockCipherModeTransform dec = new CcmModeTransform(cipher, iv); byte[] recovered = dec.Decrypt(sealed_,
-/// associatedData: header);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = BuildCcmIv(nonce); // 12-byte nonce in the first 12 bytes of the IV
+/// using IAeadBlockCipherModeTransform ccm = new CcmModeTransform(cipher, iv);
+/// byte[] sealed_ = ccm.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new CcmModeTransform(cipher, iv);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -40,11 +40,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should set SymmetricAlgorithm.Mode = CipherBlockMode.CFB instead of using this directly. using IBlockCipher cipher =
-/// new AesBlockCipher(key); byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); IBlockCipherModeTransform
-/// cfb = new CfbModeTransform(cipher, iv); byte[] ciphertext = new byte[plaintext.Length]; int written =
-/// cfb.Transform(plaintext, ciphertext, encrypt: true);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CFB instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8);
+/// IBlockCipherModeTransform cfb = new CfbModeTransform(cipher, iv);
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = cfb.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
@@ -45,13 +45,19 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should set SymmetricAlgorithm.Mode = CipherBlockMode.CTR instead of using this directly. using IBlockCipher cipher =
-/// new AesBlockCipher(key); // Initial counter is typically `nonce || zero-counter`; the nonce must never repeat under
-/// one key. byte[] initialCounter = BuildInitialCounter(nonce); IBlockCipherModeTransform ctr = new
-/// CtrModeTransform(cipher, initialCounter); byte[] ciphertext = new byte[plaintext.Length]; int written =
-/// ctr.Transform(plaintext, ciphertext, encrypt: true); // The same call shape decrypts: encrypt: true / encrypt: false
-/// produce identical results.
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTR instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+///
+/// // Initial counter is typically `nonce || zero-counter`; the nonce must never repeat under one key.
+/// byte[] initialCounter = BuildInitialCounter(nonce);
+/// IBlockCipherModeTransform ctr = new CtrModeTransform(cipher, initialCounter);
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = ctr.Transform(plaintext, ciphertext, encrypt: true);
+///
+/// // The same call shape decrypts: encrypt: true / encrypt: false produce identical results.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
@@ -54,12 +54,17 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should set SymmetricAlgorithm.Mode = CipherBlockMode.CTS instead of using this directly. using IBlockCipher cipher =
-/// new AesBlockCipher(key); byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); IBlockCipherModeTransform
-/// cts = new CtsModeTransform(cipher, iv); // CTS preserves length: plaintext.Length == ciphertext.Length, no padding
-/// required. byte[] ciphertext = new byte[plaintext.Length]; int written = cts.Transform(plaintext, ciphertext,
-/// encrypt: true);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTS instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8);
+/// IBlockCipherModeTransform cts = new CtsModeTransform(cipher, iv);
+///
+/// // CTS preserves length: plaintext.Length == ciphertext.Length, no padding required.
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = cts.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -59,8 +59,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; // Default parameters: 512-bit output, 32-byte input
-/// block, 16/16/32 rounds. using var cube = new CubeHash(); byte[] digest = cube.ComputeHash(message);
+/// using Bodu.Security.Cryptography;
+///
+/// // Default parameters: 512-bit output, 32-byte input block, 16/16/32 rounds.
+/// using var cube = new CubeHash();
+/// byte[] digest = cube.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -63,12 +63,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using IBlockCipher cipher = new AesBlockCipher(key); byte[] nonce =
-/// RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message using IAeadBlockCipherModeTransform eax
-/// = new EaxModeTransform(cipher, nonce); byte[] sealed_ = eax.Encrypt(plaintext, associatedData: header); using
-/// IAeadBlockCipherModeTransform dec = new EaxModeTransform(cipher, nonce); byte[] recovered = dec.Decrypt(sealed_,
-/// associatedData: header);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] nonce = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
+/// using IAeadBlockCipherModeTransform eax = new EaxModeTransform(cipher, nonce);
+/// byte[] sealed_ = eax.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new EaxModeTransform(cipher, nonce);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -39,11 +39,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should reach for SymmetricAlgorithm.Mode = ECB instead of constructing this directly. // Direct use is appropriate
-/// only inside larger primitives (e.g. wide-block constructions, KDFs). using IBlockCipher cipher = new
-/// AesBlockCipher(key); IBlockCipherModeTransform ecb = new EcbModeTransform(cipher); byte[] ciphertext = new
-/// byte[plaintext.Length]; int written = ecb.Transform(plaintext, ciphertext, encrypt: true);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should reach for SymmetricAlgorithm.Mode = ECB instead of constructing this directly.
+/// // Direct use is appropriate only inside larger primitives (e.g. wide-block constructions, KDFs).
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// IBlockCipherModeTransform ecb = new EcbModeTransform(cipher);
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = ecb.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
@@ -78,12 +78,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using IBlockCipher cipher = new AesBlockCipher(key); byte[] iv =
-/// BuildGcmIv(nonce); // standard 96-bit nonce padded to the cipher block size using IAeadBlockCipherModeTransform gcm
-/// = new GcmModeTransform(cipher, iv); byte[] sealed_ = gcm.Encrypt(plaintext, associatedData: header); using
-/// IAeadBlockCipherModeTransform dec = new GcmModeTransform(cipher, iv); byte[] recovered = dec.Decrypt(sealed_,
-/// associatedData: header);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = BuildGcmIv(nonce); // standard 96-bit nonce padded to the cipher block size
+/// using IAeadBlockCipherModeTransform gcm = new GcmModeTransform(cipher, iv);
+/// byte[] sealed_ = gcm.Encrypt(plaintext, associatedData: header);
+/// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(cipher, iv);
+/// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -24,7 +24,8 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// <para>
 /// GCM-SIV derives per-message authentication and encryption keys from the master key and a 12-byte nonce using four
-/// cipher calls with little-endian counters (RFC 8452 Section 4): <code>
+/// cipher calls with little-endian counters (RFC 8452 Section 4):
+/// <code>
 ///<![CDATA[
 /// K_auth = E_K(LE32(0) || nonce)[0..7] || E_K(LE32(1) || nonce)[0..7]   (16 bytes)
 /// K_enc  = E_K(LE32(2) || nonce)[0..7] || E_K(LE32(3) || nonce)[0..7]   (16 bytes)
@@ -58,11 +59,17 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using IBlockCipher master = new AesBlockCipher(masterKey); byte[] iv =
-/// BuildSivIv(nonce); // 12-byte nonce padded to the cipher block size using IAeadBlockCipherModeTransform sivlike =
-/// new GcmSivModeTransform( masterCipher: master, cipherFactory: derivedKey =&gt; new AesBlockCipher(derivedKey), iv:
-/// iv); byte[] sealed_ = sivlike.Encrypt(plaintext, associatedData: header);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using IBlockCipher master = new AesBlockCipher(masterKey);
+/// byte[] iv = BuildSivIv(nonce); // 12-byte nonce padded to the cipher block size
+/// using IAeadBlockCipherModeTransform sivlike = new GcmSivModeTransform(
+///     masterCipher: master,
+///     cipherFactory: derivedKey => new AesBlockCipher(derivedKey),
+///     iv: iv);
+/// byte[] sealed_ = sivlike.Encrypt(plaintext, associatedData: header);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
@@ -20,12 +20,15 @@ namespace Bodu.Security.Cryptography;
 /// the ciphertext and AAD together.
 /// </para>
 /// <para>
-/// Usage pattern for encryption: <code>
+/// Usage pattern for encryption:
+/// <code>
 ///<![CDATA[
 /// transform.ProcessAssociatedData(aad);
 /// int written = transform.Encrypt(plaintext, output); // output = ciphertext || tag
 ///]]>
-/// </code> Usage pattern for decryption: <code>
+/// </code>
+/// Usage pattern for decryption:
+/// <code>
 ///<![CDATA[
 /// transform.ProcessAssociatedData(aad);
 /// int written = transform.Decrypt(ciphertextWithTag, output); // throws if tag invalid

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -28,10 +28,12 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; // Legacy interop only — padding bytes are random; only
-/// the final length byte is validated. IPaddingStrategy padding = new Iso10126Padding(); byte[] padded =
-/// padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes byte[] recovered = padding.Unpad(padded, blockSize:
-/// 128);
+/// using Bodu.Security.Cryptography;
+///
+/// // Legacy interop only — padding bytes are random; only the final length byte is validated.
+/// IPaddingStrategy padding = new Iso10126Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
+/// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -29,9 +29,13 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; IPaddingStrategy padding = new Iso7816_4Padding(); byte[]
-/// padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes // padded ends with 0x80 followed by zero or
-/// more 0x00 bytes. byte[] recovered = padding.Unpad(padded, blockSize: 128);
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Iso7816_4Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
+///
+/// // padded ends with 0x80 followed by zero or more 0x00 bytes.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -76,9 +76,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // SHA-256 leaves, 4
-/// KiB blocks, fan-out of 4. using var merkle = new MerkleTreeHash( algorithmFactory: () =&gt; SHA256.Create(),
-/// blockSize: 4096, fanOut: 4); byte[] root = merkle.ComputeHash(payload);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // SHA-256 leaves, 4 KiB blocks, fan-out of 4.
+/// using var merkle = new MerkleTreeHash(
+///     algorithmFactory: () => SHA256.Create(),
+///     blockSize: 4096,
+///     fanOut: 4);
+/// byte[] root = merkle.ComputeHash(payload);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -27,9 +27,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; // Caller guarantees that `plaintext.Length` is a
-/// multiple of the block size. IPaddingStrategy padding = new NoPadding(); byte[] aligned = padding.Pad(plaintext,
-/// blockSize: 128); // 128 bits = 16 bytes; throws if not aligned
+/// using Bodu.Security.Cryptography;
+///
+/// // Caller guarantees that `plaintext.Length` is a multiple of the block size.
+/// IPaddingStrategy padding = new NoPadding();
+/// byte[] aligned = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes; throws if not aligned
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -30,14 +30,15 @@ namespace Bodu.Security.Cryptography;
 /// bytes).
 /// </para>
 /// <para>
-/// Offset initialization uses the RFC 7253 §2.4 K_top stretch: <code>
+/// Offset initialization uses the RFC 7253 §2.4 K_top stretch:
+/// <code>
 ///<![CDATA[
 ///   Nonce  = num2str(TAGLEN mod 128, 7) || zeros(120-bitlen(N)) || 1 || N
 ///   bottom = str2num(Nonce[123..128])
 ///   K_top  = ENCIPHER(K, Nonce[1..122] || zeros(6))
 ///   Stretch = K_top || (K_top[1..64] XOR K_top[9..72])   -- adjacent-byte XOR
 ///   Offset_0 = Stretch[1+bottom..128+bottom]
-///  ]]>
+///]]>
 /// </code>
 /// </para>
 /// <para>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -41,10 +41,14 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // Most callers
-/// should set SymmetricAlgorithm.Mode = CipherBlockMode.OFB instead of using this directly. using IBlockCipher cipher =
-/// new AesBlockCipher(key); byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
-/// IBlockCipherModeTransform ofb = new OfbModeTransform(cipher, iv); byte[] ciphertext = new byte[plaintext.Length];
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.OFB instead of using this directly.
+/// using IBlockCipher cipher = new AesBlockCipher(key);
+/// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
+/// IBlockCipherModeTransform ofb = new OfbModeTransform(cipher, iv);
+/// byte[] ciphertext = new byte[plaintext.Length];
 /// int written = ofb.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -100,10 +100,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // SHA-256 leaves, 64
-/// KiB blocks, fan-out of 4 — a typical large-content configuration. using var merkle = new ParallelMerkleTreeHash(
-/// algorithmFactory: () =&gt; SHA256.Create(), blockSize: 64 * 1024, fanOut: 4); using FileStream fs =
-/// File.OpenRead("very-large.bin"); byte[] root = await merkle.ComputeHashAsync(fs, cancellationToken);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // SHA-256 leaves, 64 KiB blocks, fan-out of 4 — a typical large-content configuration.
+/// using var merkle = new ParallelMerkleTreeHash(
+///     algorithmFactory: () => SHA256.Create(),
+///     blockSize: 64 * 1024,
+///     fanOut: 4);
+/// using FileStream fs = File.OpenRead("very-large.bin");
+/// byte[] root = await merkle.ComputeHashAsync(fs, cancellationToken);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -32,9 +32,13 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; IPaddingStrategy padding = new Pkcs7Padding(); byte[]
-/// padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes // padded.Length is a multiple of 16; the
-/// trailing N bytes each equal N. byte[] recovered = padding.Unpad(padded, blockSize: 128);
+/// using Bodu.Security.Cryptography;
+///
+/// IPaddingStrategy padding = new Pkcs7Padding();
+/// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
+///
+/// // padded.Length is a multiple of 16; the trailing N bytes each equal N.
+/// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -79,10 +79,13 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // The 32-byte key
-/// MUST be unique per message — typically derived from a stream cipher's keystream. byte[] oneTimeKey =
-/// DerivePoly1305KeyFromChaCha20(sessionKey, nonce); using var poly = new Poly1305 { Key = oneTimeKey }; byte[] tag =
-/// poly.ComputeHash(message);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // The 32-byte key MUST be unique per message — typically derived from a stream cipher's keystream.
+/// byte[] oneTimeKey = DerivePoly1305KeyFromChaCha20(sessionKey, nonce);
+/// using var poly = new Poly1305 { Key = oneTimeKey };
+/// byte[] tag = poly.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.1024.cs
@@ -65,11 +65,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var serpent = Serpent1024.Create(); serpent.Key =
-/// RandomNumberGenerator.GetBytes(128); // 1024-bit key serpent.IV = RandomNumberGenerator.GetBytes(128); // matches
-/// the 1024-bit block serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// serpent.Encrypt(plaintext); byte[] roundTrip = serpent.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent1024.Create();
+/// serpent.Key = RandomNumberGenerator.GetBytes(128); // 1024-bit key
+/// serpent.IV = RandomNumberGenerator.GetBytes(128); // matches the 1024-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip = serpent.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.256.cs
@@ -65,11 +65,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var serpent = Serpent256.Create(); serpent.Key =
-/// RandomNumberGenerator.GetBytes(32); // 256-bit key serpent.IV = RandomNumberGenerator.GetBytes(32); // matches the
-/// 256-bit block serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// serpent.Encrypt(plaintext); byte[] roundTrip = serpent.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent256.Create();
+/// serpent.Key = RandomNumberGenerator.GetBytes(32); // 256-bit key
+/// serpent.IV = RandomNumberGenerator.GetBytes(32); // matches the 256-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip = serpent.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.512.cs
@@ -65,11 +65,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var serpent = Serpent512.Create(); serpent.Key =
-/// RandomNumberGenerator.GetBytes(64); // 512-bit key serpent.IV = RandomNumberGenerator.GetBytes(64); // matches the
-/// 512-bit block serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// serpent.Encrypt(plaintext); byte[] roundTrip = serpent.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = Serpent512.Create();
+/// serpent.Key = RandomNumberGenerator.GetBytes(64); // 512-bit key
+/// serpent.IV = RandomNumberGenerator.GetBytes(64); // matches the 512-bit block
+/// serpent.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip = serpent.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
@@ -67,10 +67,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var serpent = new Serpent128(); serpent.GenerateKey(); // 256-bit by
-/// default serpent.GenerateIV(); byte[] ciphertext = serpent.Encrypt(plaintext); byte[] roundTrip =
-/// serpent.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var serpent = new Serpent128();
+/// serpent.GenerateKey(); // 256-bit by default
+/// serpent.GenerateIV();
+/// byte[] ciphertext = serpent.Encrypt(plaintext);
+/// byte[] roundTrip = serpent.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -84,9 +84,13 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// // SHAKE128 producing 256-bit output. using var shake = new Shake(256, 128); byte[] digest
-/// = shake.ComputeHash(Encoding.UTF8.GetBytes("hello")); // SHAKE256 producing 512-bit output. using var shake256 = new
-/// Shake(512, 256); byte[] longer = shake256.ComputeHash(message);
+/// // SHAKE128 producing 256-bit output.
+/// using var shake = new Shake(256, 128);
+/// byte[] digest = shake.ComputeHash(Encoding.UTF8.GetBytes("hello"));
+///
+/// // SHAKE256 producing 512-bit output.
+/// using var shake256 = new Shake(512, 256);
+/// byte[] longer = shake256.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.128.cs
@@ -56,7 +56,9 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; using var sip = new SipHash128 { Key = sessionKey };
+/// using Bodu.Security.Cryptography;
+///
+/// using var sip = new SipHash128 { Key = sessionKey };
 /// byte[] tag = sip.ComputeHash(message);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
@@ -58,10 +58,12 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; // 16-byte secret key — keep it private to your process;
-/// SipHash assumes attackers cannot guess it. byte[] hashTableKey = RandomNumberGenerator.GetBytes(16); using var sip =
-/// new SipHash64 { Key = hashTableKey }; byte[] tag =
-/// sip.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user-supplied-key"));
+/// using Bodu.Security.Cryptography;
+///
+/// // 16-byte secret key — keep it private to your process; SipHash assumes attackers cannot guess it.
+/// byte[] hashTableKey = RandomNumberGenerator.GetBytes(16);
+/// using var sip = new SipHash64 { Key = hashTableKey };
+/// byte[] tag = sip.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user-supplied-key"));
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -57,10 +57,16 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 /// The following example configures a <see cref="SipHash64" /> instance to use the stronger <c>SipHash-4-8</c>
-/// parameter set. <code language="csharp">
+/// parameter set.
+/// <code language="csharp">
 ///<![CDATA[
-/// using var sipHash = new SipHash64 { Key = myKey, CompressionRounds = 4,
-/// FinalizationRounds = 8, }; byte[] tag = sipHash.ComputeHash(message);
+/// using var sipHash = new SipHash64
+/// {
+///     Key = myKey,
+///     CompressionRounds = 4,
+///     FinalizationRounds = 8,
+/// };
+/// byte[] tag = sipHash.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -41,10 +41,11 @@ namespace Bodu.Security.Cryptography;
 /// </para>
 /// <para>
 /// The S2V algorithm (RFC 5297 Section 2.4) accumulates all associated data blocks and the plaintext into a single
-/// 128-bit tag using CMAC: <code>
+/// 128-bit tag using CMAC:
+/// <code>
 ///<![CDATA[
 /// D ← CMAC(K₁, 0^128)
-/// for each AD block Sᵢ (i &lt; n): D ← dbl(D) ⊕ CMAC(K₁, Sᵢ)
+/// for each AD block Sᵢ (i < n): D ← dbl(D) ⊕ CMAC(K₁, Sᵢ)
 /// if |Sₙ| ≥ 128: T ← CMAC(K₁, xorend(Sₙ, D))
 /// else:            T ← CMAC(K₁, dbl(D) ⊕ pad(Sₙ))
 /// SIV ← T

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.1024.cs
@@ -56,8 +56,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var skein = new Skein1024(); // Skein-1024-1024 byte[] digest =
-/// skein.ComputeHash(message);
+/// using var skein = new Skein1024(); // Skein-1024-1024
+/// byte[] digest = skein.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.256.cs
@@ -56,9 +56,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var skein = new Skein256(); // Skein-256-256 byte[] digest =
-/// skein.ComputeHash(message); using var skeinMac = new Skein256 { Key = key }; // Skein-MAC-256-256 byte[] tag =
-/// skeinMac.ComputeHash(message);
+/// using var skein = new Skein256(); // Skein-256-256
+/// byte[] digest = skein.ComputeHash(message);
+///
+/// using var skeinMac = new Skein256 { Key = key }; // Skein-MAC-256-256
+/// byte[] tag = skeinMac.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skein.512.cs
@@ -56,9 +56,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var skein = new Skein512(); // Skein-512-512 (the canonical configuration) byte[]
-/// digest = skein.ComputeHash(message); using var skeinMac = new Skein512 { Key = key }; // Skein-MAC-512-512 byte[]
-/// tag = skeinMac.ComputeHash(message);
+/// using var skein = new Skein512(); // Skein-512-512 (the canonical configuration)
+/// byte[] digest = skein.ComputeHash(message);
+///
+/// using var skeinMac = new Skein512 { Key = key }; // Skein-MAC-512-512
+/// byte[] tag = skeinMac.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -64,11 +64,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; // Legacy interop only — do not use Skipjack to protect new data. using var
-/// skipjack = new Skipjack(); skipjack.Key = legacyKeyMaterial; // exactly 10 bytes skipjack.IV =
-/// RandomNumberGenerator.GetBytes(8); // matches the 64-bit block byte[] ciphertext =
-/// skipjack.Encrypt(legacyPlaintext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// // Legacy interop only — do not use Skipjack to protect new data.
+/// using var skipjack = new Skipjack();
+/// skipjack.Key = legacyKeyMaterial; // exactly 10 bytes
+/// skipjack.IV = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block
+/// byte[] ciphertext = skipjack.Encrypt(legacyPlaintext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.128.cs
@@ -48,8 +48,10 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; using var snefru = new Snefru128(); byte[] digest =
-/// snefru.ComputeHash(legacyMessage);
+/// using Bodu.Security.Cryptography;
+///
+/// using var snefru = new Snefru128();
+/// byte[] digest = snefru.ComputeHash(legacyMessage);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Snefru.256.cs
@@ -48,8 +48,10 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; using var snefru = new Snefru256(); byte[] digest =
-/// snefru.ComputeHash(legacyMessage);
+/// using Bodu.Security.Cryptography;
+///
+/// using var snefru = new Snefru256();
+/// byte[] digest = snefru.ComputeHash(legacyMessage);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.1024.cs
@@ -56,11 +56,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var tf = Threefish1024.Create(); tf.Key =
-/// RandomNumberGenerator.GetBytes(128); // 1024-bit key tf.IV = RandomNumberGenerator.GetBytes(128); // matches the
-/// 1024-bit block tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// tf.Encrypt(plaintext); byte[] roundTrip = tf.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish1024.Create();
+/// tf.Key = RandomNumberGenerator.GetBytes(128); // 1024-bit key
+/// tf.IV = RandomNumberGenerator.GetBytes(128); // matches the 1024-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip = tf.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.256.cs
@@ -58,11 +58,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var tf = Threefish256.Create(); tf.Key =
-/// RandomNumberGenerator.GetBytes(32); // 256-bit key tf.IV = RandomNumberGenerator.GetBytes(32); // matches the
-/// 256-bit block tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// tf.Encrypt(plaintext); byte[] roundTrip = tf.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish256.Create();
+/// tf.Key = RandomNumberGenerator.GetBytes(32); // 256-bit key
+/// tf.IV = RandomNumberGenerator.GetBytes(32); // matches the 256-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip = tf.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.512.cs
@@ -57,11 +57,16 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var tf = Threefish512.Create(); tf.Key =
-/// RandomNumberGenerator.GetBytes(64); // 512-bit key tf.IV = RandomNumberGenerator.GetBytes(64); // matches the
-/// 512-bit block tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak byte[] ciphertext =
-/// tf.Encrypt(plaintext); byte[] roundTrip = tf.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var tf = Threefish512.Create();
+/// tf.Key = RandomNumberGenerator.GetBytes(64); // 512-bit key
+/// tf.IV = RandomNumberGenerator.GetBytes(64); // matches the 512-bit block
+/// tf.Tweak = RandomNumberGenerator.GetBytes(16); // 128-bit tweak
+/// byte[] ciphertext = tf.Encrypt(plaintext);
+/// byte[] roundTrip = tf.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Tiger.cs
@@ -69,8 +69,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var tiger = new Tiger(192) { Variant = TigerHashingVariant.Tiger2 }; byte[] digest =
-/// tiger.ComputeHash(message);
+/// using var tiger = new Tiger(192) { Variant = TigerHashingVariant.Tiger2 };
+/// byte[] digest = tiger.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
@@ -64,10 +64,15 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; using
-/// Bodu.Security.Cryptography.Extensions; using var twofish = new Twofish(); twofish.GenerateKey(); // 256-bit by
-/// default twofish.GenerateIV(); byte[] ciphertext = twofish.Encrypt(plaintext); byte[] roundTrip =
-/// twofish.Decrypt(ciphertext);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+/// using Bodu.Security.Cryptography.Extensions;
+///
+/// using var twofish = new Twofish();
+/// twofish.GenerateKey(); // 256-bit by default
+/// twofish.GenerateIV();
+/// byte[] ciphertext = twofish.Encrypt(plaintext);
+/// byte[] roundTrip = twofish.Decrypt(ciphertext);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Whirlpool.cs
@@ -66,8 +66,8 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using var whirlpool = new Whirlpool { Version = WhirlpoolVersion.WhirlpoolInfo3 }; byte[]
-/// digest = whirlpool.ComputeHash(message);
+/// using var whirlpool = new Whirlpool { Version = WhirlpoolVersion.WhirlpoolInfo3 };
+/// byte[] digest = whirlpool.ComputeHash(message);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
@@ -31,13 +31,15 @@ namespace Bodu.Security.Cryptography;
 /// Using the same key for both reduces XTS to a single-key construction and weakens security.
 /// </para>
 /// <para>
-/// For each 128-bit block j in a sector, the XEX construction is: <code>
+/// For each 128-bit block j in a sector, the XEX construction is:
+/// <code>
 ///<![CDATA[
 /// T_j  = α^j ⊗ tweakCipher.Encrypt(tweak)     // Galois field multiplication
 /// C_j  = dataCipher.Encrypt(P_j ⊕ T_j) ⊕ T_j  // encrypt
 /// P_j  = dataCipher.Decrypt(C_j ⊕ T_j) ⊕ T_j  // decrypt
 ///]]>
-/// </code> The horizontal tweak bus in the diagram corresponds to this successive <c>·α</c> multiplication: each <b>·α
+/// </code>
+/// The horizontal tweak bus in the diagram corresponds to this successive <c>·α</c> multiplication: each <b>·α
 /// </b> box doubles the tweak in GF(2¹²⁸) so the Tⱼ arriving at cell <em>j</em> is αʲ times the base tweak. The two XOR
 /// nodes inside each cell — before and after the data cipher — realize the <c>⊕ T_j</c> pairs in the equation above.
 /// </para>
@@ -58,12 +60,17 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using System.Security.Cryptography; using Bodu.Security.Cryptography; // XTS uses two
-/// independent keys — Key1 for data, Key2 for the tweak. Never share keys. using IBlockCipher data = new
-/// AesBlockCipher(key1); using IBlockCipher tweak = new AesBlockCipher(key2); byte[] sectorNumber =
-/// BitConverter.GetBytes((long)42); // little-endian sector number, padded to block size Array.Resize(ref sectorNumber,
-/// data.BlockSize / 8); IBlockCipherModeTransform xts = new XtsModeTransform(data, tweak, sectorNumber); byte[]
-/// ciphertext = new byte[plaintext.Length]; int written = xts.Transform(plaintext, ciphertext, encrypt: true);
+/// using System.Security.Cryptography;
+/// using Bodu.Security.Cryptography;
+///
+/// // XTS uses two independent keys — Key1 for data, Key2 for the tweak. Never share keys.
+/// using IBlockCipher data = new AesBlockCipher(key1);
+/// using IBlockCipher tweak = new AesBlockCipher(key2);
+/// byte[] sectorNumber = BitConverter.GetBytes((long)42); // little-endian sector number, padded to block size
+/// Array.Resize(ref sectorNumber, data.BlockSize / 8);
+/// IBlockCipherModeTransform xts = new XtsModeTransform(data, tweak, sectorNumber);
+/// byte[] ciphertext = new byte[plaintext.Length];
+/// int written = xts.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
@@ -25,8 +25,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// using Bodu.Security.Cryptography; // Caller is responsible for tracking the original
-/// plaintext length — // Unpad here returns the padded buffer unchanged. IPaddingStrategy padding = new ZeroPadding();
+/// using Bodu.Security.Cryptography;
+///
+/// // Caller is responsible for tracking the original plaintext length —
+/// // Unpad here returns the padded buffer unchanged.
+/// IPaddingStrategy padding = new ZeroPadding();
 /// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
 ///]]>
 /// </code>

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedReader.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedReader.cs
@@ -26,8 +26,12 @@ namespace Bodu.Text.Delimited;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// using var reader = Delimited.CreateReader(File.OpenText("data.csv")); while (reader.Read()) { string name =
-/// reader.Fields[0]; string age = reader.Fields[1]; }
+/// using var reader = Delimited.CreateReader(File.OpenText("data.csv"));
+/// while (reader.Read())
+/// {
+///     string name = reader.Fields[0];
+///     string age = reader.Fields[1];
+/// }
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedWriter.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedWriter.cs
@@ -24,8 +24,10 @@ namespace Bodu.Text.Delimited;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// using var writer = Delimited.CreateWriter(File.CreateText("out.csv")); writer.WriteHeader(["name", "age"]);
-/// writer.WriteRow(["Alice", "30"]); writer.WriteRow(["Bob", "25"]);
+/// using var writer = Delimited.CreateWriter(File.CreateText("out.csv"));
+/// writer.WriteHeader(["name", "age"]);
+/// writer.WriteRow(["Alice", "30"]);
+/// writer.WriteRow(["Bob", "25"]);
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Text.Formats/src/Text.Ini/IniParseOptions.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniParseOptions.cs
@@ -18,8 +18,11 @@ namespace Bodu.Text.Ini;
 /// <example>
 /// <code>
 ///<![CDATA[
-/// IniParseOptions options = new IniParseOptions { AllowGlobalSection = false, DuplicateKeyBehavior =
-/// IniDuplicateKeyBehavior.FirstWins, };
+/// IniParseOptions options = new IniParseOptions
+/// {
+///     AllowGlobalSection = false,
+///     DuplicateKeyBehavior = IniDuplicateKeyBehavior.FirstWins,
+/// };
 ///]]>
 /// </code>
 /// </example>


### PR DESCRIPTION
## Summary

This change reformats XML documentation `<code>` examples across the codebase to improve readability and consistency. The examples are restructured to use proper line breaks and indentation instead of being collapsed onto single lines, making them easier to read in both source and generated documentation.

## Key Changes

- **SequenceGenerator examples**: Reformatted `Range`, `Repeat`, and `NextWhile` examples to use multi-line formatting with proper indentation
- **Extension method examples**: Updated examples in `IEnumerableExtensions`, `ArrayExtensions`, `SpanExtensions`, `DateTimeExtensions`, `DateOnlyExtensions`, `IComparableExtensions`, and `NumericExtensions` to break long lines and improve visual structure
- **Cryptography examples**: Reformatted examples in cipher mode transforms (`CtrModeTransform`, `CtsModeTransform`, `CbcModeTransform`, `CfbModeTransform`, `EcbModeTransform`, `OfbModeTransform`, `CcmModeTransform`, `EaxModeTransform`, `GcmModeTransform`, `XtsModeTransform`, `GcmSivModeTransform`, `OcbModeTransform`, `SivModeTransform`) and extension classes (`AeadBlockCipherModeTransformExtensions`, `ICryptoTransformExtensions`, `SymmetricAlgorithmExtensions`, `HashAlgorithmExtensions`, `TweakableSymmetricAlgorithmExtensions`)
- **Hashing examples**: Updated examples in `Crc`, `IResumableHashAlgorithm`, `CrcLookupTableCache`, `Bernstein`, `CityHash`, `MurmurHash3`, and other hash algorithm classes
- **Calendar examples**: Reformatted XML examples in `NotableDateRuleParser` and `ParsedNotableDateDocument` to use proper XML tag formatting instead of HTML entities
- **Padding and utility examples**: Updated examples in padding strategies, `Poly1305`, `SipHash`, and other utility classes
- **Aggregate examples**: Reformatted the `Aggregate` overload example in `IEnumerableExtensions.Aggregate.cs`

## Implementation Details

- Examples now consistently use multi-line formatting with each logical statement on its own line
- Indentation is preserved to show code structure clearly
- HTML entity escaping (e.g., `&lt;`, `&gt;`) is replaced with actual XML tags where appropriate in calendar-related documentation
- The `<code>` tag placement is adjusted to accommodate the reformatted content
- All changes are documentation-only; no functional code modifications

https://claude.ai/code/session_01UeRWWfno3QWxwpBdaV48sH