### PR TITLE
Move hard-coded exception messages to resource strings

### DIFF
--- a/Bodu.Core/src/Extensions/StringExtensions.EnsureTrailingNewLine.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.EnsureTrailingNewLine.cs
@@ -35,7 +35,7 @@ public static partial class StringExtensions
     {
         ThrowHelper.ThrowIfNull(value);
         ThrowHelper.ThrowIfNull(newline);
-        if (newline.Length == 0) throw new ArgumentException("Newline must not be empty.", nameof(newline));
+        if (newline.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_StringIsEmpty, nameof(newline));
 
         return value.EndsWith(newline, StringComparison.Ordinal) ? value : value + newline;
     }

--- a/Bodu.Core/src/Extensions/StringExtensions.Remove.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Remove.cs
@@ -41,7 +41,7 @@ public static partial class StringExtensions
     {
         ThrowHelper.ThrowIfNull(value);
         ThrowHelper.ThrowIfNull(valueToRemove);
-        if (valueToRemove.Length == 0) throw new ArgumentException("valueToRemove must not be empty.", nameof(valueToRemove));
+        if (valueToRemove.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_StringIsEmpty, nameof(valueToRemove));
 
         return value.Replace(valueToRemove, string.Empty, comparison);
     }

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveMany.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveMany.cs
@@ -42,7 +42,7 @@ public static partial class StringExtensions
         {
             string item = valuesToRemove[i];
             ThrowHelper.ThrowIfNull(item);
-            if (item.Length == 0) throw new ArgumentException("Entries of valuesToRemove must not be empty.", nameof(valuesToRemove));
+            if (item.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_EmptyCollectionElement, nameof(valuesToRemove));
             current = current.Replace(item, string.Empty, StringComparison.Ordinal);
         }
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ReplaceMany.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ReplaceMany.cs
@@ -46,7 +46,7 @@ public static partial class StringExtensions
         foreach (KeyValuePair<string, string> pair in replacements)
         {
             ThrowHelper.ThrowIfNull(pair.Key);
-            if (pair.Key.Length == 0) throw new ArgumentException("Replacement keys must not be empty.", nameof(replacements));
+            if (pair.Key.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_EmptyDictionaryKey, nameof(replacements));
             current = current.Replace(pair.Key, pair.Value, StringComparison.Ordinal);
         }
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ReplaceOrdinalIgnoreCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ReplaceOrdinalIgnoreCase.cs
@@ -26,7 +26,7 @@ public static partial class StringExtensions
     {
         ThrowHelper.ThrowIfNull(value);
         ThrowHelper.ThrowIfNull(oldValue);
-        if (oldValue.Length == 0) throw new ArgumentException("oldValue must not be empty.", nameof(oldValue));
+        if (oldValue.Length == 0) throw new ArgumentException(ResourceStrings.Arg_Invalid_StringIsEmpty, nameof(oldValue));
 
         return value.Replace(oldValue, newValue, StringComparison.OrdinalIgnoreCase);
     }

--- a/Bodu.Core/src/Extensions/StringExtensions.Truncate.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Truncate.cs
@@ -55,7 +55,7 @@ public static partial class StringExtensions
     {
         ThrowHelper.ThrowIfNull(value);
         ThrowHelper.ThrowIfNull(ellipsis);
-        if (maxLength < ellipsis.Length) throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "maxLength must be at least ellipsis.Length.");
+        if (maxLength < ellipsis.Length) throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, ResourceStrings.Arg_OutOfRange_MaxLengthLessThanMarker);
 
         if (value.Length <= maxLength) return value;
         return string.Concat(value.AsSpan(0, maxLength - ellipsis.Length), ellipsis);

--- a/Bodu.Core/src/Extensions/StringExtensions.TruncateMiddle.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.TruncateMiddle.cs
@@ -45,7 +45,7 @@ public static partial class StringExtensions
     {
         ThrowHelper.ThrowIfNull(value);
         ThrowHelper.ThrowIfNull(separator);
-        if (maxLength < separator.Length) throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "maxLength must be at least separator.Length.");
+        if (maxLength < separator.Length) throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, ResourceStrings.Arg_OutOfRange_MaxLengthLessThanMarker);
 
         if (value.Length <= maxLength) return value;
 

--- a/Bodu.Core/src/ResourceStrings.Designer.cs
+++ b/Bodu.Core/src/ResourceStrings.Designer.cs
@@ -232,6 +232,24 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The collection cannot contain empty elements..
+        /// </summary>
+        internal static string Arg_Invalid_EmptyCollectionElement {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_EmptyCollectionElement", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The dictionary cannot contain empty keys..
+        /// </summary>
+        internal static string Arg_Invalid_EmptyDictionaryKey {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_EmptyDictionaryKey", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to The format string is invalid..
         /// </summary>
         internal static string Arg_Invalid_FormatString {
@@ -509,7 +527,16 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_Invalid_StringEmptyOrWhitespace", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The value must not be empty..
+        /// </summary>
+        internal static string Arg_Invalid_StringIsEmpty {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_StringIsEmpty", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The string length must be exactly {0} characters..
         /// </summary>
@@ -689,7 +716,16 @@ namespace Bodu {
                 return ResourceManager.GetString("Arg_OutOfRange_InvalidQuarterNumber", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to The maximum length must be at least the length of the truncation marker..
+        /// </summary>
+        internal static string Arg_OutOfRange_MaxLengthLessThanMarker {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_MaxLengthLessThanMarker", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The value cannot be greater than the value of &apos;{0}&apos;..
         /// </summary>

--- a/Bodu.Core/src/ResourceStrings.resx
+++ b/Bodu.Core/src/ResourceStrings.resx
@@ -174,6 +174,12 @@
   <data name="Arg_Invalid_DuplicateSetValue" xml:space="preserve">
     <value>The set already contains the specified value.</value>
   </data>
+  <data name="Arg_Invalid_EmptyCollectionElement" xml:space="preserve">
+    <value>The collection cannot contain empty elements.</value>
+  </data>
+  <data name="Arg_Invalid_EmptyDictionaryKey" xml:space="preserve">
+    <value>The dictionary cannot contain empty keys.</value>
+  </data>
   <data name="Arg_Invalid_FormatString" xml:space="preserve">
     <value>The format string is invalid.</value>
   </data>
@@ -267,6 +273,9 @@
   <data name="Arg_Invalid_StringEmptyOrWhitespace" xml:space="preserve">
     <value>The value cannot be empty or consist only of white-space characters.</value>
   </data>
+  <data name="Arg_Invalid_StringIsEmpty" xml:space="preserve">
+    <value>The value must not be empty.</value>
+  </data>
   <data name="Arg_Invalid_StringLength" xml:space="preserve">
     <value>The string length must be exactly {0} characters.</value>
   </data>
@@ -326,6 +335,9 @@
   </data>
   <data name="Arg_OutOfRange_InvalidQuarterNumber" xml:space="preserve">
     <value>The quarter number must be between 1 and 4.</value>
+  </data>
+  <data name="Arg_OutOfRange_MaxLengthLessThanMarker" xml:space="preserve">
+    <value>The maximum length must be at least the length of the truncation marker.</value>
   </data>
   <data name="Arg_OutOfRange_MinCannotExceedMax" xml:space="preserve">
     <value>The value cannot be greater than the value of '{0}'.</value>

--- a/Bodu.Text.Encoding/src/EncodingResourceStrings.Designer.cs
+++ b/Bodu.Text.Encoding/src/EncodingResourceStrings.Designer.cs
@@ -237,11 +237,74 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Input contains a character outside the variant alphabet: &apos;{0}&apos;..
+        /// </summary>
+        internal static string Format_Invalid_Base32CharacterNotInAlphabet {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32CharacterNotInAlphabet", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input length is not a multiple of 8 and AllowMissingPadding is not set..
+        /// </summary>
+        internal static string Format_Invalid_Base32LengthNotMultipleOfEight {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32LengthNotMultipleOfEight", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Base32 input is not in canonical form — unused trailing bits are non-zero..
+        /// </summary>
+        internal static string Format_Invalid_Base32NonCanonical {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32NonCanonical", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Expected {0} padding character(s) but found {1}..
+        /// </summary>
+        internal static string Format_Invalid_Base32PaddingCount {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32PaddingCount", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Padding characters may only appear at the end of the input..
+        /// </summary>
+        internal static string Format_Invalid_Base32PaddingNotAtEnd {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32PaddingNotAtEnd", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Base32 input has an invalid number of data characters for the final quantum..
+        /// </summary>
+        internal static string Format_Invalid_Base32TerminalQuantum {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base32TerminalQuantum", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Input contains characters outside the Base32 variant alphabet..
         /// </summary>
         internal static string Format_Invalid_Base32VariantAlphabet {
             get {
                 return ResourceManager.GetString("Format_Invalid_Base32VariantAlphabet", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input contains a character outside the Base58 variant alphabet: &apos;{0}&apos;..
+        /// </summary>
+        internal static string Format_Invalid_Base58CharacterNotInAlphabet {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base58CharacterNotInAlphabet", resourceCulture);
             }
         }
 
@@ -296,6 +359,60 @@ namespace Bodu {
         internal static string Format_Invalid_Base64VariantAlphabet {
             get {
                 return ResourceManager.GetString("Format_Invalid_Base64VariantAlphabet", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Input contains a character outside the Base85 variant alphabet: &apos;{0}&apos;..
+        /// </summary>
+        internal static string Format_Invalid_Base85CharacterNotInAlphabet {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85CharacterNotInAlphabet", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Base85 group exceeds the maximum 32-bit value..
+        /// </summary>
+        internal static string Format_Invalid_Base85GroupOverflow {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85GroupOverflow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The &apos;z&apos; shortcut may only appear at the start of a five-character group..
+        /// </summary>
+        internal static string Format_Invalid_Base85ShortcutPosition {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85ShortcutPosition", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to A single trailing Base85 character cannot decode to a complete byte..
+        /// </summary>
+        internal static string Format_Invalid_Base85SingleTrailingCharacter {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85SingleTrailingCharacter", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Trailing Base85 group overflows the 32-bit accumulator after padding..
+        /// </summary>
+        internal static string Format_Invalid_Base85TrailingGroupOverflow {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85TrailingGroupOverflow", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Z85 input length must be a multiple of five characters..
+        /// </summary>
+        internal static string Format_Invalid_Base85Z85LengthNotMultipleOfFive {
+            get {
+                return ResourceManager.GetString("Format_Invalid_Base85Z85LengthNotMultipleOfFive", resourceCulture);
             }
         }
 

--- a/Bodu.Text.Encoding/src/EncodingResourceStrings.resx
+++ b/Bodu.Text.Encoding/src/EncodingResourceStrings.resx
@@ -118,8 +118,29 @@
   <data name="Format_Invalid_Ascii85" xml:space="preserve">
     <value>Input is not valid Ascii85.</value>
   </data>
+  <data name="Format_Invalid_Base32CharacterNotInAlphabet" xml:space="preserve">
+    <value>Input contains a character outside the variant alphabet: '{0}'.</value>
+  </data>
+  <data name="Format_Invalid_Base32LengthNotMultipleOfEight" xml:space="preserve">
+    <value>Input length is not a multiple of 8 and AllowMissingPadding is not set.</value>
+  </data>
+  <data name="Format_Invalid_Base32NonCanonical" xml:space="preserve">
+    <value>Base32 input is not in canonical form — unused trailing bits are non-zero.</value>
+  </data>
+  <data name="Format_Invalid_Base32PaddingCount" xml:space="preserve">
+    <value>Expected {0} padding character(s) but found {1}.</value>
+  </data>
+  <data name="Format_Invalid_Base32PaddingNotAtEnd" xml:space="preserve">
+    <value>Padding characters may only appear at the end of the input.</value>
+  </data>
+  <data name="Format_Invalid_Base32TerminalQuantum" xml:space="preserve">
+    <value>Base32 input has an invalid number of data characters for the final quantum.</value>
+  </data>
   <data name="Format_Invalid_Base32VariantAlphabet" xml:space="preserve">
     <value>Input contains characters outside the Base32 variant alphabet.</value>
+  </data>
+  <data name="Format_Invalid_Base58CharacterNotInAlphabet" xml:space="preserve">
+    <value>Input contains a character outside the Base58 variant alphabet: '{0}'.</value>
   </data>
   <data name="Format_Invalid_Base58CheckChecksumFailed" xml:space="preserve">
     <value>Base58Check checksum verification failed.</value>
@@ -138,6 +159,24 @@
   </data>
   <data name="Format_Invalid_Base64VariantAlphabet" xml:space="preserve">
     <value>Input contains characters outside the Base64 variant alphabet.</value>
+  </data>
+  <data name="Format_Invalid_Base85CharacterNotInAlphabet" xml:space="preserve">
+    <value>Input contains a character outside the Base85 variant alphabet: '{0}'.</value>
+  </data>
+  <data name="Format_Invalid_Base85GroupOverflow" xml:space="preserve">
+    <value>Base85 group exceeds the maximum 32-bit value.</value>
+  </data>
+  <data name="Format_Invalid_Base85ShortcutPosition" xml:space="preserve">
+    <value>The 'z' shortcut may only appear at the start of a five-character group.</value>
+  </data>
+  <data name="Format_Invalid_Base85SingleTrailingCharacter" xml:space="preserve">
+    <value>A single trailing Base85 character cannot decode to a complete byte.</value>
+  </data>
+  <data name="Format_Invalid_Base85TrailingGroupOverflow" xml:space="preserve">
+    <value>Trailing Base85 group overflows the 32-bit accumulator after padding.</value>
+  </data>
+  <data name="Format_Invalid_Base85Z85LengthNotMultipleOfFive" xml:space="preserve">
+    <value>Z85 input length must be a multiple of five characters.</value>
   </data>
   <data name="Format_Invalid_BitcoinFlickrBase58" xml:space="preserve">
     <value>Input is not valid Bitcoin/Flickr Base58.</value>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base32.Decode.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base32.Decode.cs
@@ -179,14 +179,14 @@ public static partial class Base32
 
             if (paddingSeen > 0)
             {
-                error = "Padding characters may only appear at the end of the input.";
+                error = EncodingResourceStrings.Format_Invalid_Base32PaddingNotAtEnd;
                 bytesWritten = 0;
                 return false;
             }
 
             if ((uint)c >= (uint)lookup.Length)
             {
-                error = $"Input contains a character outside the variant alphabet: '{c}'.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base32CharacterNotInAlphabet, c);
                 bytesWritten = 0;
                 return false;
             }
@@ -194,7 +194,7 @@ public static partial class Base32
             int value = lookup[c];
             if (value < 0)
             {
-                error = $"Input contains a character outside the variant alphabet: '{c}'.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base32CharacterNotInAlphabet, c);
                 bytesWritten = 0;
                 return false;
             }
@@ -219,7 +219,7 @@ public static partial class Base32
         var totalSymbols = symbolsConsumed + paddingSeen;
         if (requireExactPadding && (totalSymbols % 8) != 0)
         {
-            error = "Input length is not a multiple of 8 and AllowMissingPadding is not set.";
+            error = EncodingResourceStrings.Format_Invalid_Base32LengthNotMultipleOfEight;
             bytesWritten = 0;
             return false;
         }
@@ -229,7 +229,7 @@ public static partial class Base32
             var expectedPadding = (8 - (symbolsConsumed % 8)) % 8;
             if (paddingSeen != expectedPadding)
             {
-                error = $"Expected {expectedPadding} padding character(s) but found {paddingSeen}.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base32PaddingCount, expectedPadding, paddingSeen);
                 bytesWritten = 0;
                 return false;
             }
@@ -240,7 +240,7 @@ public static partial class Base32
         var dataMod = symbolsConsumed % 8;
         if (strictQuantum && dataMod is 1 or 3 or 6)
         {
-            error = "Base32 input has an invalid number of data characters for the final quantum.";
+            error = EncodingResourceStrings.Format_Invalid_Base32TerminalQuantum;
             bytesWritten = 0;
             return false;
         }
@@ -252,7 +252,7 @@ public static partial class Base32
             var leftoverMask = (1 << bitsAccumulated) - 1;
             if ((accumulator & leftoverMask) != 0)
             {
-                error = "Base32 input is not in canonical form — unused trailing bits are non-zero.";
+                error = EncodingResourceStrings.Format_Invalid_Base32NonCanonical;
                 bytesWritten = 0;
                 return false;
             }

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base58.Decode.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base58.Decode.cs
@@ -141,14 +141,14 @@ public static partial class Base58
 
             if (c >= lookup.Length)
             {
-                error = $"Input contains a character outside the Base58 variant alphabet: '{c}'.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base58CharacterNotInAlphabet, c);
                 return false;
             }
 
             int symbolValue = lookup[c];
             if (symbolValue < 0)
             {
-                error = $"Input contains a character outside the Base58 variant alphabet: '{c}'.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base58CharacterNotInAlphabet, c);
                 return false;
             }
 

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base85.Decode.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base85.Decode.cs
@@ -153,7 +153,7 @@ public static partial class Base85
             {
                 if (charsAccumulated != 0)
                 {
-                    error = "The 'z' shortcut may only appear at the start of a five-character group.";
+                    error = EncodingResourceStrings.Format_Invalid_Base85ShortcutPosition;
                     written = 0;
                     return false;
                 }
@@ -167,7 +167,7 @@ public static partial class Base85
 
             if (c >= lookup.Length || lookup[c] < 0)
             {
-                error = $"Input contains a character outside the Base85 variant alphabet: '{c}'.";
+                error = string.Format(System.Globalization.CultureInfo.InvariantCulture, EncodingResourceStrings.Format_Invalid_Base85CharacterNotInAlphabet, c);
                 written = 0;
                 return false;
             }
@@ -179,7 +179,7 @@ public static partial class Base85
             var next = ((ulong)accumulator * 85) + (uint)symbolValue;
             if (next > uint.MaxValue)
             {
-                error = "Base85 group exceeds the maximum 32-bit value.";
+                error = EncodingResourceStrings.Format_Invalid_Base85GroupOverflow;
                 written = 0;
                 return false;
             }
@@ -203,14 +203,14 @@ public static partial class Base85
 
         if (requireFullGroups)
         {
-            error = "Z85 input length must be a multiple of five characters.";
+            error = EncodingResourceStrings.Format_Invalid_Base85Z85LengthNotMultipleOfFive;
             written = 0;
             return false;
         }
 
         if (charsAccumulated == 1)
         {
-            error = "A single trailing Base85 character cannot decode to a complete byte.";
+            error = EncodingResourceStrings.Format_Invalid_Base85SingleTrailingCharacter;
             written = 0;
             return false;
         }
@@ -221,7 +221,7 @@ public static partial class Base85
             var next = ((ulong)accumulator * 85) + 84;
             if (next > uint.MaxValue)
             {
-                error = "Trailing Base85 group overflows the 32-bit accumulator after padding.";
+                error = EncodingResourceStrings.Format_Invalid_Base85TrailingGroupOverflow;
                 written = 0;
                 return false;
             }


### PR DESCRIPTION
Replaces literal exception message strings in StringExtensions and the
Base32/58/85 decoders with EncodingResourceStrings/ResourceStrings
entries, following the existing <Category>_<Subcategory>_<Description>
naming convention.

https://claude.ai/code/session_01TSk1UGWvao6exkQiqGSi8t