### PR TITLE
Add code examples to String extension method documentation

### DIFF
--- a/Bodu.Core/src/Extensions/StringExtensions.After.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.After.cs
@@ -26,6 +26,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="marker" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user@example.com".After("@");  // "example.com"
+    /// "no-delimiter".After("@");      // null
+    ///]]>
+    /// </code>
+    /// </example>
     public static string? After(
         this string value,
         string marker,

--- a/Bodu.Core/src/Extensions/StringExtensions.AfterLast.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.AfterLast.cs
@@ -26,6 +26,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="marker" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a/b/c/file.txt".AfterLast("/");  // "file.txt"
+    /// "no-slash".AfterLast("/");        // null
+    ///]]>
+    /// </code>
+    /// </example>
     public static string? AfterLast(
         this string value,
         string marker,

--- a/Bodu.Core/src/Extensions/StringExtensions.Before.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Before.cs
@@ -26,6 +26,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="marker" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user@example.com".Before("@");  // "user"
+    /// "no-delimiter".Before("@");      // null
+    ///]]>
+    /// </code>
+    /// </example>
     public static string? Before(
         this string value,
         string marker,

--- a/Bodu.Core/src/Extensions/StringExtensions.BeforeLast.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.BeforeLast.cs
@@ -26,6 +26,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="marker" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a.b.c.txt".BeforeLast(".");  // "a.b.c"
+    /// "no-dot".BeforeLast(".");     // null
+    ///]]>
+    /// </code>
+    /// </example>
     public static string? BeforeLast(
         this string value,
         string marker,

--- a/Bodu.Core/src/Extensions/StringExtensions.Between.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Between.cs
@@ -28,6 +28,14 @@ public static partial class StringExtensions
     /// Thrown when <paramref name="value" />, <paramref name="start" />, or <paramref name="end" /> is
     /// <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "<title>Hello</title>".Between("<title>", "</title>");  // "Hello"
+    /// "key=[value]".Between("[", "]");                        // "value"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string? Between(
         this string value,
         string start,

--- a/Bodu.Core/src/Extensions/StringExtensions.CollapseWhitespace.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.CollapseWhitespace.cs
@@ -29,6 +29,13 @@ public static partial class StringExtensions
     /// strip the edges. White-space is detected via <see cref="char.IsWhiteSpace(char)" /> so Unicode separators (NBSP,
     /// EN SPACE, line terminators, tab) all collapse to a single ASCII space.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "  too   many\t\nspaces ".CollapseWhitespace();  // " too many spaces "
+    ///]]>
+    /// </code>
+    /// </example>
     public static string CollapseWhitespace(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.EnsureEndsWith.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.EnsureEndsWith.cs
@@ -28,6 +28,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="suffix" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "report".EnsureEndsWith(".txt");      // "report.txt"
+    /// "report.txt".EnsureEndsWith(".txt");  // "report.txt" (suffix already present)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string EnsureEndsWith(
         this string value,
         string suffix,

--- a/Bodu.Core/src/Extensions/StringExtensions.EnsureStartsWith.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.EnsureStartsWith.cs
@@ -28,6 +28,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="prefix" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "api/users".EnsureStartsWith("/");   // "/api/users"
+    /// "/api/users".EnsureStartsWith("/");  // "/api/users" (prefix already present)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string EnsureStartsWith(
         this string value,
         string prefix,

--- a/Bodu.Core/src/Extensions/StringExtensions.EnsureTrailingNewLine.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.EnsureTrailingNewLine.cs
@@ -31,6 +31,14 @@ public static partial class StringExtensions
     /// terminated. A value ending in <c>"\r\n"</c> is not considered to end in <c>"\n"</c> for the purposes of this
     /// method.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "line".EnsureTrailingNewLine();    // "line\n"
+    /// "line\n".EnsureTrailingNewLine();  // "line\n" (already terminated)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string EnsureTrailingNewLine(this string value, string newline = "\n")
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.FromBase64ToString.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.FromBase64ToString.cs
@@ -32,6 +32,13 @@ public static partial class StringExtensions
     /// Named <c>FromBase64ToString</c> rather than <c>FromBase64String</c> to avoid colliding with the existing
     /// byte-returning helpers in <c>Bodu.Text.Encoding.BinaryEncodingExtensions</c>.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "SGVsbG8gd29ybGQ=".FromBase64ToString();  // "Hello world"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string FromBase64ToString(this string value, Encoding? encoding = null)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.Indent.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Indent.cs
@@ -28,6 +28,13 @@ public static partial class StringExtensions
     /// newline followed by nothing) are not indented. When <paramref name="count" /> is zero the input is returned
     /// unchanged.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "line1\nline2".Indent(2);  // "  line1\n  line2"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Indent(this string value, int count, char indentChar = ' ')
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.IsOneOf.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.IsOneOf.cs
@@ -27,6 +27,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="values" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "GET".IsOneOf("GET", "POST", "PUT");  // true
+    /// "Trace".IsOneOf("GET", "POST");       // false
+    ///]]>
+    /// </code>
+    /// </example>
     public static bool IsOneOf(this string value, params string[] values)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.IsValidIdentifier.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.IsValidIdentifier.cs
@@ -35,6 +35,16 @@ public static partial class StringExtensions
     /// The empty string returns <see langword="false" /> because an identifier must contain at least one character.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "userName".IsValidIdentifier();  // true
+    /// "_count".IsValidIdentifier();    // true
+    /// "2fast".IsValidIdentifier();     // false (starts with a digit)
+    /// "has-dash".IsValidIdentifier();  // false
+    ///]]>
+    /// </code>
+    /// </example>
     public static bool IsValidIdentifier(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.KeepDigits.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.KeepDigits.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// Membership is determined via <see cref="char.IsDigit(char)" />, which recognises every Unicode digit (Nd)
     /// character — not just ASCII <c>0–9</c>.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Order #12345 (paid)".KeepDigits();  // "12345"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string KeepDigits(this string value) =>
         value.KeepWhere(char.IsDigit);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.KeepLetters.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.KeepLetters.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// Membership is determined via <see cref="char.IsLetter(char)" />, which recognises every Unicode letter category
     /// (Lu, Ll, Lt, Lm, Lo). ASCII digits, punctuation, whitespace, and control characters are stripped.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "abc123 def!".KeepLetters();  // "abcdef"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string KeepLetters(this string value) =>
         value.KeepWhere(char.IsLetter);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.KeepLettersAndDigits.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.KeepLettersAndDigits.cs
@@ -18,6 +18,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user_name-42!".KeepLettersAndDigits();  // "username42"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string KeepLettersAndDigits(this string value) =>
         value.KeepWhere(char.IsLetterOrDigit);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.KeepWhere.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.KeepWhere.cs
@@ -24,6 +24,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="predicate" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a1-b2-c3".KeepWhere(char.IsLetter);  // "abc"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string KeepWhere(this string value, Func<char, bool> predicate)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.NormalizeLineEndings.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.NormalizeLineEndings.cs
@@ -32,6 +32,14 @@ public static partial class StringExtensions
     /// CRLF pairs are treated as a single line ending and replaced by exactly one <paramref name="newline" />. Other
     /// Unicode line separators (U+2028, U+2029, NEL U+0085) are not touched.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a\r\nb\rc\n".NormalizeLineEndings();    // "a\nb\nc\n"
+    /// "a\nb".NormalizeLineEndings("\r\n");      // "a\r\nb"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string NormalizeLineEndings(this string value, string newline = "\n")
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.Outdent.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Outdent.cs
@@ -31,6 +31,13 @@ public static partial class StringExtensions
     /// raised. Line boundaries follow the same rules as <see cref="Indent(string, int, char)" /> (<c>\r\n</c>,
     /// <c>\n</c>, bare <c>\r</c>).
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "    line1\n    line2".Outdent(2);  // "  line1\n  line2"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Outdent(this string value, int count, char indentChar = ' ')
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.Parse.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Parse.cs
@@ -33,6 +33,14 @@ public static partial class StringExtensions
     /// static <c>T.Parse</c> factory. The invariant culture is used by default to keep behaviour stable across machines
     /// and locales.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// int count = "42".Parse<int>();                 // 42
+    /// DateTime due = "2025-01-31".Parse<DateTime>(); // 2025-01-31
+    ///]]>
+    /// </code>
+    /// </example>
     public static T Parse<T>(this string value)
         where T : IParsable<T>
     {
@@ -57,6 +65,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "42".TryParse<int>(out int n);   // returns true,  n == 42
+    /// "abc".TryParse<int>(out int m);  // returns false, m == 0
+    ///]]>
+    /// </code>
+    /// </example>
     public static bool TryParse<T>(this string value, out T result)
         where T : IParsable<T>
     {

--- a/Bodu.Core/src/Extensions/StringExtensions.PrefixLines.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.PrefixLines.cs
@@ -23,6 +23,13 @@ public static partial class StringExtensions
     /// <paramref name="prefix" /> returns the input unchanged. Commonly used to add a comment marker to a block of
     /// source — e.g. <c>"line1\nline2".PrefixLines("// ")</c>.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "name\nvalue".PrefixLines("// ");  // "// name\n// value"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string PrefixLines(this string value, string prefix)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.Remove.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Remove.cs
@@ -34,6 +34,14 @@ public static partial class StringExtensions
     /// <see cref="string.TrimStart(char[])" />/<see cref="string.TrimEnd(char[])" /> when the goal is to strip
     /// individual characters.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a-b-c".Remove("-");    // "abc"
+    /// "Hello".Remove("xyz");  // "Hello" (substring absent)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Remove(
         this string value,
         string valueToRemove,

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveControlCharacters.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveControlCharacters.cs
@@ -23,6 +23,13 @@ public static partial class StringExtensions
     /// (U+0000–U+001F), DEL (U+007F), and the C1 control range (U+0080–U+009F). Tab, CR and LF count as control
     /// characters and are also removed.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "tab\there\nend".RemoveControlCharacters();  // "tabhereend"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveControlCharacters(this string value) =>
         value.RemoveWhere(char.IsControl);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveDiacritics.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveDiacritics.cs
@@ -34,6 +34,13 @@ public static partial class StringExtensions
     /// search normalisation combine this with <c>ToLowerInvariant</c> and <see cref="CollapseWhitespace(string)" />.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "café crème brûlée".RemoveDiacritics();  // "cafe creme brulee"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveDiacritics(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveDigits.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveDigits.cs
@@ -18,6 +18,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "abc123def".RemoveDigits();  // "abcdef"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveDigits(this string value) =>
         value.RemoveWhere(char.IsDigit);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveLineEndings.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveLineEndings.cs
@@ -29,6 +29,13 @@ public static partial class StringExtensions
     /// U+000B, form feed U+000C) are preserved. Use <see cref="NormalizeLineEndings(string, string)" /> with an empty
     /// string when stripping all newline-equivalent characters is required.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "line1\r\nline2\n".RemoveLineEndings();  // "line1line2"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveLineEndings(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveMany.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveMany.cs
@@ -30,6 +30,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentException">
     /// Thrown when any element of <paramref name="valuesToRemove" /> is the empty string.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "(555) 123-4567".RemoveMany("(", ")", " ", "-");  // "5551234567"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveMany(this string value, params string[] valuesToRemove)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.RemovePrefix.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemovePrefix.cs
@@ -31,6 +31,14 @@ public static partial class StringExtensions
     /// Removes at most one occurrence of <paramref name="prefix" />. Use the BCL
     /// <see cref="string.TrimStart(char[])" /> when greedy removal of character-level prefixes is required.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Mr. Smith".RemovePrefix("Mr. ");  // "Smith"
+    /// "Dr. Smith".RemovePrefix("Mr. ");  // "Dr. Smith" (prefix absent)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemovePrefix(
         this string value,
         string prefix,

--- a/Bodu.Core/src/Extensions/StringExtensions.RemovePunctuation.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemovePunctuation.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// Membership is determined via <see cref="char.IsPunctuation(char)" /> which covers the Unicode punctuation
     /// categories (Pc, Pd, Pe, Pf, Pi, Po, Ps).
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello, world!".RemovePunctuation();  // "Hello world"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemovePunctuation(this string value) =>
         value.RemoveWhere(char.IsPunctuation);
 }

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveSuffix.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveSuffix.cs
@@ -31,6 +31,14 @@ public static partial class StringExtensions
     /// Removes at most one occurrence of <paramref name="suffix" />. Use the BCL <see cref="string.TrimEnd(char[])" />
     /// when greedy removal of character-level suffixes is required.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "report.txt".RemoveSuffix(".txt");  // "report"
+    /// "report.csv".RemoveSuffix(".txt");  // "report.csv" (suffix absent)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveSuffix(
         this string value,
         string suffix,

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveTrailingNewLine.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveTrailingNewLine.cs
@@ -25,6 +25,14 @@ public static partial class StringExtensions
     /// Only one trailing line terminator is removed. Repeated trailing newlines are intentionally preserved — use
     /// <see cref="string.TrimEnd(char[])" /> with <c>'\r','\n'</c> when greedy stripping is required.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "line\r\n".RemoveTrailingNewLine();  // "line"
+    /// "line\n\n".RemoveTrailingNewLine();  // "line\n" (only one terminator removed)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveTrailingNewLine(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveWhere.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveWhere.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> or <paramref name="predicate" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a1b2c3".RemoveWhere(char.IsDigit);  // "abc"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveWhere(this string value, Func<char, bool> predicate)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.RemoveWhitespace.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.RemoveWhitespace.cs
@@ -26,6 +26,13 @@ public static partial class StringExtensions
     /// White-space is detected via <see cref="char.IsWhiteSpace(char)" /> so Unicode separators (NBSP, line
     /// terminators, tab) are all removed.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "  spaced \t out\n".RemoveWhitespace();  // "spacedout"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string RemoveWhitespace(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ReplaceMany.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ReplaceMany.cs
@@ -35,6 +35,14 @@ public static partial class StringExtensions
     /// Replacements are applied sequentially — output of an earlier replacement is visible to a later one. Pre-order
     /// keys to avoid cascading substitutions when independence is required.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var map = new Dictionary<string, string> { ["{name}"] = "Sam", ["{role}"] = "admin" };
+    /// "Hi {name}, role={role}".ReplaceMany(map);  // "Hi Sam, role=admin"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ReplaceMany(this string value, IReadOnlyDictionary<string, string> replacements)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ReplaceOrdinalIgnoreCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ReplaceOrdinalIgnoreCase.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// Thrown when <paramref name="value" /> or <paramref name="oldValue" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentException">Thrown when <paramref name="oldValue" /> is the empty string.</exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello HELLO hello".ReplaceOrdinalIgnoreCase("hello", "hi");  // "hi hi hi"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ReplaceOrdinalIgnoreCase(this string value, string oldValue, string? newValue)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.SliceSafe.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.SliceSafe.cs
@@ -24,6 +24,15 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "hello".SliceSafe(2);   // "llo"
+    /// "hello".SliceSafe(99);  // "" (start past end)
+    /// "hello".SliceSafe(-3);  // "hello" (negative start clamped)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string SliceSafe(this string value, int startIndex)
     {
         ThrowHelper.ThrowIfNull(value);
@@ -50,6 +59,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "hello world".SliceSafe(6, 99);  // "world" (length clamped to remainder)
+    /// "hello".SliceSafe(-2, 3);        // "hel" (start clamped to 0)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string SliceSafe(this string value, int startIndex, int length)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.SplitLines.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.SplitLines.cs
@@ -30,6 +30,14 @@ public static partial class StringExtensions
     /// CRLF is treated as a single line ending. Unlike <see cref="string.Split(char[])" />, a trailing line terminator
     /// does not produce a final empty line — the contract matches typical "lines in a file" reading semantics.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "a\r\nb\nc".SplitLines();                     // yields "a", "b", "c"
+    /// "a\n\nb".SplitLines(removeEmptyLines: true);  // yields "a", "b"
+    ///]]>
+    /// </code>
+    /// </example>
     public static IEnumerable<string> SplitLines(this string value, bool removeEmptyLines = false)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ToBase64.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToBase64.cs
@@ -30,6 +30,13 @@ public static partial class StringExtensions
     /// the string to bytes manually. Pair with <see cref="FromBase64ToString(string, Encoding)" /> for the inverse
     /// operation.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello world".ToBase64();  // "SGVsbG8gd29ybGQ="
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToBase64(this string value, Encoding? encoding = null)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ToCamelCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToCamelCase.cs
@@ -26,6 +26,14 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Casing changes use the configured culture.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user_account_id".ToCamelCase();  // "userAccountId"
+    /// "Hello World".ToCamelCase();      // "helloWorld"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToCamelCase(this string value) =>
         ToCamelCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToConstantCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToConstantCase.cs
@@ -24,6 +24,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Every word is upper-cased.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "userAccountId".ToConstantCase();  // "USER_ACCOUNT_ID"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToConstantCase(this string value) =>
         ToConstantCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToDotCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToDotCase.cs
@@ -24,6 +24,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Every word, including acronyms, is lower-cased.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "UserAccountId".ToDotCase();  // "user.account.id"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToDotCase(this string value) =>
         ToDotCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToIdentifier.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToIdentifier.cs
@@ -29,6 +29,14 @@ public static partial class StringExtensions
     /// Equivalent to <c>value.ToIdentifier(IdentifierCase.Preserve)</c>. When the input contains no valid identifier
     /// characters at all, a single underscore is returned so the result is still a valid identifier.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "123 Main St.".ToIdentifier();  // "_123MainSt" (digit start guarded)
+    /// "my-variable!".ToIdentifier();  // "myvariable"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToIdentifier(this string value) =>
         value.ToIdentifier(IdentifierCase.Preserve);
 
@@ -53,6 +61,14 @@ public static partial class StringExtensions
     /// <see cref="EnumerateWords(string)" />). Non-letter / non-digit / non-underscore characters are treated as
     /// separators and discarded.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user name".ToIdentifier(IdentifierCase.Pascal);  // "UserName"
+    /// "2 cool".ToIdentifier(IdentifierCase.Camel);      // "_2Cool"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToIdentifier(this string value, IdentifierCase identifierCase)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ToKebabCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToKebabCase.cs
@@ -23,6 +23,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Every word, including acronyms, is lower-cased.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "UserAccountId".ToKebabCase();  // "user-account-id"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToKebabCase(this string value) =>
         ToKebabCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToPascalCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToPascalCase.cs
@@ -26,6 +26,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Casing changes use the configured culture.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user_account_id".ToPascalCase();  // "UserAccountId"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToPascalCase(this string value) =>
         ToPascalCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToSafeFileName.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToSafeFileName.cs
@@ -29,6 +29,13 @@ public static partial class StringExtensions
     /// Callers writing files for a known target platform should construct the invalid set explicitly rather than
     /// relying on the current platform's defaults.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "year/month".ToSafeFileName();  // "year_month"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToSafeFileName(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ToSafePathSegment.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToSafePathSegment.cs
@@ -30,6 +30,13 @@ public static partial class StringExtensions
     /// separators. For a full file name (no embedded separators required as a rule), prefer
     /// <see cref="ToSafeFileName(string)" /> — the two differ only in whether path separators are stripped.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "docs/2025".ToSafePathSegment();  // "docs_2025" (path separator replaced)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToSafePathSegment(this string value)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.ToSentenceCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToSentenceCase.cs
@@ -22,6 +22,13 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "the QUICK brown fox. and more".ToSentenceCase();  // "The quick brown fox. And more"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToSentenceCase(this string value) =>
         ToSentenceCase(value, SentenceCaseOptions.None);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToSlug.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToSlug.cs
@@ -25,6 +25,13 @@ public static partial class StringExtensions
     /// <remarks>
     /// Equivalent to calling <see cref="ToSlug(string, SlugOptions)" /> with <see cref="SlugOptions.Default" />.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello, World! — Café".ToSlug();  // "hello-world-cafe"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToSlug(this string value) =>
         ToSlug(value, SlugOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToSnakeCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToSnakeCase.cs
@@ -23,6 +23,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Every word, including acronyms, is lower-cased.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "UserAccountId".ToSnakeCase();  // "user_account_id"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToSnakeCase(this string value) =>
         ToSnakeCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToTitleCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToTitleCase.cs
@@ -38,6 +38,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "the lord of the rings".ToTitleCase();  // "The Lord Of The Rings"
+    /// "the lord of the rings".ToTitleCase(TitleCaseOptions.LowerCaseSmallWords);  // "The Lord of the Rings"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToTitleCase(this string value) =>
         ToTitleCase(value, TitleCaseOptions.None);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.ToTrainCase.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.ToTrainCase.cs
@@ -26,6 +26,13 @@ public static partial class StringExtensions
     /// Word boundaries follow <see cref="EnumerateWords(string, WordCasingOptions)" /> using
     /// <see cref="WordCasingOptions.Default" />. Casing changes use the configured culture.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "user_account_id".ToTrainCase();  // "User-Account-Id"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string ToTrainCase(this string value) =>
         ToTrainCase(value, WordCasingOptions.Default);
 

--- a/Bodu.Core/src/Extensions/StringExtensions.Truncate.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Truncate.cs
@@ -23,6 +23,14 @@ public static partial class StringExtensions
     /// Thrown when <paramref name="value" /> is <see langword="null" />.
     /// </exception>
     /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="maxLength" /> is negative.</exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello, world".Truncate(5);  // "Hello"
+    /// "Hi".Truncate(5);            // "Hi" (already within limit)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Truncate(this string value, int maxLength)
     {
         ThrowHelper.ThrowIfNull(value);
@@ -51,6 +59,14 @@ public static partial class StringExtensions
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown when <paramref name="maxLength" /> is smaller than <paramref name="ellipsis" />.Length.
     /// </exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "Hello, world".Truncate(8, "…");    // "Hello, …"
+    /// "Hello, world".Truncate(9, "...");  // "Hello,..."
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Truncate(this string value, int maxLength, string ellipsis)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.TruncateMiddle.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.TruncateMiddle.cs
@@ -36,10 +36,12 @@ public static partial class StringExtensions
     /// Thrown when <paramref name="maxLength" /> is smaller than <paramref name="separator" />.Length.
     /// </exception>
     /// <example>
+    /// <code language="csharp">
     ///<![CDATA[
     /// "hello-world-foo-bar".TruncateMiddle(11);          // "hello…o-bar"
     /// "abcdefghij".TruncateMiddle(7, "...");             // "ab...ij"
     ///]]>
+    /// </code>
     /// </example>
     public static string TruncateMiddle(this string value, int maxLength, string separator = "…")
     {

--- a/Bodu.Core/src/Extensions/StringExtensions.UnprefixLines.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.UnprefixLines.cs
@@ -24,6 +24,13 @@ public static partial class StringExtensions
     /// <paramref name="prefix" /> are emitted unchanged. Comparison is ordinal. Line boundaries follow the usual
     /// <c>\r\n</c> / <c>\n</c> / <c>\r</c> recognition.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "// name\n// value".UnprefixLines("// ");  // "name\nvalue"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string UnprefixLines(this string value, string prefix)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.Unwrap.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Unwrap.cs
@@ -24,6 +24,14 @@ public static partial class StringExtensions
     /// <see cref="Wrap(string, string, string)" />.
     /// </returns>
     /// <exception cref="ArgumentNullException">Thrown when any string argument is <see langword="null" />.</exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "(content)".Unwrap("(", ")");  // "content"
+    /// "(content".Unwrap("(", ")");   // "(content" (both ends must match)
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Unwrap(
         this string value,
         string prefix,

--- a/Bodu.Core/src/Extensions/StringExtensions.Wrap.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.Wrap.cs
@@ -19,6 +19,14 @@ public static partial class StringExtensions
     /// <param name="suffix">The string to append. Must not be <see langword="null" />.</param>
     /// <returns>The wrapped string.</returns>
     /// <exception cref="ArgumentNullException">Thrown when any argument is <see langword="null" />.</exception>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// "content".Wrap("[", "]");    // "[content]"
+    /// "name".Wrap("<b>", "</b>");  // "<b>name</b>"
+    ///]]>
+    /// </code>
+    /// </example>
     public static string Wrap(this string value, string prefix, string suffix)
     {
         ThrowHelper.ThrowIfNull(value);

--- a/Bodu.Core/src/Extensions/StringExtensions.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.cs
@@ -30,6 +30,7 @@ namespace Bodu.Extensions;
 /// </para>
 /// </remarks>
 /// <example>
+/// <code language="csharp">
 ///<![CDATA[
 /// // Sanitise then truncate user input for a log line.
 /// string? raw = request?.Title;
@@ -42,6 +43,7 @@ namespace Bodu.Extensions;
 /// string pascal = "user_account_id".ToPascalCase(); // "UserAccountId"
 /// string snake  = "UserAccountId".ToSnakeCase();    // "user_account_id"
 ///]]>
+/// </code>
 /// </example>
 public static partial class StringExtensions
 {


### PR DESCRIPTION
Add <example> code blocks to 55 StringExtensions methods where a worked
input/output pair clarifies non-obvious behaviour: substring windowing,
affix management, case conversion, character filtering, slug/identifier
generation, base64, and truncation. Trivial affix wrappers and
self-describing comparison predicates are intentionally left unchanged.

Examples use <code language="csharp"> with CDATA, matching the sibling
DateTimeExtensions and NumericExtensions files. The two pre-existing
StringExtensions examples (root file and TruncateMiddle) are converted
to the same form so the partial class is consistent.

https://claude.ai/code/session_01WLFH9KTLHaKs7igqE129W9