### PR TITLE
Add XML documentation to public and internal APIs

### DIFF
--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDiagnostic.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDiagnostic.cs
@@ -47,7 +47,8 @@ namespace Bodu.Text.Configuration;
 public sealed class ConfigurationDiagnostic
 {
     /// <summary>
-    /// Initializes a new diagnostic with the specified severity, code, message, and location.
+    /// Initializes a new instance of the <see cref="ConfigurationDiagnostic" /> class with the specified severity,
+    /// code, message, and location.
     /// </summary>
     /// <param name="severity">The severity classification.</param>
     /// <param name="code">The stable code identifying the diagnostic category.</param>

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocument.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocument.cs
@@ -212,7 +212,9 @@ public static class ConfigurationDocument
     /// <param name="document">The document to save.</param>
     /// <param name="path">The destination file path.</param>
     /// <param name="options">The write options, or <see langword="null" /> for the defaults.</param>
-    /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="document" /> or <paramref name="path" /> is <see langword="null" />.
+    /// </exception>
     /// <exception cref="ArgumentException"><paramref name="path" /> is empty or whitespace.</exception>
     public static void Save(IniDocument document, string path, ConfigurationWriteOptions? options = null)
     {
@@ -232,6 +234,10 @@ public static class ConfigurationDocument
     /// <param name="stream">The destination stream. Must support writing.</param>
     /// <param name="options">The write options, or <see langword="null" /> for the defaults.</param>
     /// <param name="leaveOpen">When <see langword="true" />, the stream remains open after writing.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="document" /> or <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="stream" /> does not support writing.</exception>
     public static void Save(IniDocument document, Stream stream, ConfigurationWriteOptions? options = null, bool leaveOpen = false)
     {
         ThrowHelper.ThrowIfNull(document);
@@ -249,6 +255,9 @@ public static class ConfigurationDocument
     /// <param name="document">The document to save.</param>
     /// <param name="writer">The destination writer.</param>
     /// <param name="options">The write options, or <see langword="null" /> for the defaults.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="document" /> or <paramref name="writer" /> is <see langword="null" />.
+    /// </exception>
     public static void Save(IniDocument document, TextWriter writer, ConfigurationWriteOptions? options = null)
     {
         ThrowHelper.ThrowIfNull(document);
@@ -272,10 +281,11 @@ public static class ConfigurationDocument
 public sealed class ConfigurationParseResult
 {
     /// <summary>
-    /// Initializes a new <see cref="ConfigurationParseResult" />.
+    /// Initializes a new instance of the <see cref="ConfigurationParseResult" /> class.
     /// </summary>
     /// <param name="document">The parsed document.</param>
     /// <param name="diagnostics">The diagnostics collected during the parse.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
     public ConfigurationParseResult(IniDocument document, ImmutableArray<ConfigurationDiagnostic> diagnostics)
     {
         ThrowHelper.ThrowIfNull(document);

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocumentWriter.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocumentWriter.cs
@@ -16,13 +16,20 @@ namespace Bodu.Text.Configuration;
 /// </summary>
 /// <remarks>
 /// Unlike <see cref="Bodu.Text.Ini.Ini.Format(IniDocument)" /> — which always emits trivia using the INI defaults —
-/// this writer honors the Bodu-specific options: <see cref="ConfigurationWriteOptions.KeyValueSeparator" />,
-/// <see cref="ConfigurationWriteOptions.NewLine" />, <see cref="ConfigurationWriteOptions.PreserveComments" />,
-/// <see cref="ConfigurationWriteOptions.WriteInlineComments" />, and
-/// <see cref="ConfigurationWriteOptions.InsertBlankLineBetweenSections" />.
+/// this writer honors the Bodu-specific formatting options exposed by <see cref="ConfigurationWriteOptions" />.
 /// </remarks>
 internal static class ConfigurationDocumentWriter
 {
+    /// <summary>
+    /// Writes <paramref name="document" /> to <paramref name="writer" /> according to <paramref name="options" />.
+    /// </summary>
+    /// <param name="document">The document to emit.</param>
+    /// <param name="writer">The destination writer.</param>
+    /// <param name="options">The write options that govern separators, comments, and section spacing.</param>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="document" />, <paramref name="writer" />, or <paramref name="options" /> is
+    /// <see langword="null" />.
+    /// </exception>
     internal static void Write(IniDocument document, TextWriter writer, ConfigurationWriteOptions options)
     {
         ThrowHelper.ThrowIfNull(document);
@@ -40,6 +47,18 @@ internal static class ConfigurationDocumentWriter
         }
     }
 
+    /// <summary>
+    /// Writes a single section — its leading comments, header line, and entries — and reports whether any output was
+    /// produced.
+    /// </summary>
+    /// <param name="section">The section to emit.</param>
+    /// <param name="writer">The destination writer.</param>
+    /// <param name="options">The write options that govern separators, comments, and section spacing.</param>
+    /// <param name="isGlobal">
+    /// <see langword="true" /> when <paramref name="section" /> is the document's global section, whose header line is
+    /// suppressed.
+    /// </param>
+    /// <returns><see langword="true" /> when any line was written; otherwise, <see langword="false" />.</returns>
     private static bool WriteSection(IniSection section, TextWriter writer, ConfigurationWriteOptions options, bool isGlobal)
     {
         var wroteAny = false;

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationKey.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationKey.cs
@@ -70,6 +70,13 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
         CaseSensitive = effective.CaseSensitive;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationKey" /> struct from already-validated components.
+    /// </summary>
+    /// <param name="rawKey">The raw key as authored in the configuration source.</param>
+    /// <param name="segments">The pre-split, pre-validated key segments.</param>
+    /// <param name="path">The canonical colon-delimited key path.</param>
+    /// <param name="caseSensitive">Whether equality and hashing use ordinal case-sensitive comparison.</param>
     private ConfigurationKey(string rawKey, ImmutableArray<string> segments, string path, bool caseSensitive)
     {
         _rawKey = rawKey;
@@ -182,6 +189,14 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
     /// <inheritdoc />
     public override string ToString() => Path;
 
+    /// <summary>
+    /// Splits <paramref name="rawKey" /> into segments on the separator characters configured by
+    /// <paramref name="options" />.
+    /// </summary>
+    /// <param name="rawKey">The raw key to split.</param>
+    /// <param name="options">The key options supplying the recognised separators.</param>
+    /// <returns>The ordered segments produced by the split.</returns>
+    /// <exception cref="ArgumentException">A segment was empty and empty segments are not permitted.</exception>
     private static ImmutableArray<string> SplitSegments(string rawKey, ConfigurationKeyOptions options)
     {
         IReadOnlyList<char> separators = options.SegmentSeparators;
@@ -203,6 +218,16 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
         return builder.ToImmutable();
     }
 
+    /// <summary>
+    /// Appends <paramref name="segment" /> to <paramref name="builder" />, enforcing the empty-segment policy.
+    /// </summary>
+    /// <param name="builder">The builder accumulating the key segments.</param>
+    /// <param name="segment">The candidate segment span.</param>
+    /// <param name="options">The key options that determine whether empty segments are permitted.</param>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="segment" /> is empty and <see cref="ConfigurationKeyOptions.AllowEmptySegments" /> is
+    /// <see langword="false" />.
+    /// </exception>
     private static void AddSegment(ImmutableArray<string>.Builder builder, ReadOnlySpan<char> segment, ConfigurationKeyOptions options)
     {
         if (segment.IsEmpty)
@@ -216,9 +241,20 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
         builder.Add(segment.ToString());
     }
 
+    /// <summary>
+    /// Throws when <paramref name="rawKey" /> contains a control character.
+    /// </summary>
+    /// <param name="rawKey">The raw key to scan.</param>
+    /// <exception cref="ArgumentException"><paramref name="rawKey" /> contains a control character.</exception>
     private static void RejectControlCharacters(string rawKey) =>
         ConfigurationThrowHelper.ThrowIfConfigKeyContainsControlChar(rawKey);
 
+    /// <summary>
+    /// Determines whether <paramref name="c" /> is one of the configured segment separators.
+    /// </summary>
+    /// <param name="c">The character to test.</param>
+    /// <param name="separators">The recognised separator characters.</param>
+    /// <returns><see langword="true" /> when <paramref name="c" /> matches a separator.</returns>
     private static bool IsSeparator(char c, IReadOnlyList<char> separators)
     {
         for (var i = 0; i < separators.Count; i++)
@@ -230,6 +266,12 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
         return false;
     }
 
+    /// <summary>
+    /// Joins <paramref name="segments" /> into a canonical key path according to the configured mapping.
+    /// </summary>
+    /// <param name="segments">The key segments to join.</param>
+    /// <param name="options">The key options supplying the mapping policy.</param>
+    /// <returns>The canonical configuration key path.</returns>
     private static string ComposePath(ImmutableArray<string> segments, ConfigurationKeyOptions options) =>
         options.Mapping switch
         {
@@ -239,6 +281,11 @@ public readonly partial struct ConfigurationKey : IEquatable<ConfigurationKey>
             _ => string.Join(':', segments),
         };
 
+    /// <summary>
+    /// Gets the first configured segment separator, falling back to <c>'.'</c> when none are configured.
+    /// </summary>
+    /// <param name="options">The key options supplying the separator set.</param>
+    /// <returns>The first separator character, or <c>'.'</c> when the set is empty.</returns>
     private static char GetFirstSeparator(ConfigurationKeyOptions options) =>
         options.SegmentSeparators.Count > 0 ? options.SegmentSeparators[0] : '.';
 }

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationParseException.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationParseException.cs
@@ -105,7 +105,9 @@ public sealed class ConfigurationParseException : FormatException
     }
 
 #if !NET8_0_OR_GREATER
-    /// <summary>Serialization constructor.</summary>
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationParseException" /> class from serialized data.
+    /// </summary>
     /// <param name="info">The serialization information.</param>
     /// <param name="context">The streaming context.</param>
     private ConfigurationParseException(SerializationInfo info, StreamingContext context)
@@ -132,18 +134,30 @@ public sealed class ConfigurationParseException : FormatException
     /// Gets the location in the source document that triggered the exception.
     /// </summary>
     /// <returns>
-    /// The associated <see cref="ConfigurationSourceLocation" />, or
-    /// <see cref="ConfigurationSourceLocation.None" /> when no primary diagnostic is available.
+    /// The associated <see cref="ConfigurationSourceLocation" />, or <see cref="ConfigurationSourceLocation.None" />
+    /// when no primary diagnostic is available.
     /// </returns>
     public ConfigurationSourceLocation Location =>
         Diagnostic?.Location ?? ConfigurationSourceLocation.None;
 
+    /// <summary>
+    /// Derives the exception message from a single diagnostic.
+    /// </summary>
+    /// <param name="diagnostic">The diagnostic that triggered the failure.</param>
+    /// <returns>The diagnostic's message text.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="diagnostic" /> is <see langword="null" />.</exception>
     private static string GetMessage(ConfigurationDiagnostic diagnostic)
     {
         ThrowHelper.ThrowIfNull(diagnostic);
         return diagnostic.Message;
     }
 
+    /// <summary>
+    /// Derives the exception message from a set of collected diagnostics.
+    /// </summary>
+    /// <param name="diagnostics">The diagnostics gathered before the failure.</param>
+    /// <returns>The first diagnostic's message, or a default message when the set is empty.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="diagnostics" /> is <see langword="null" />.</exception>
     private static string GetMessage(IReadOnlyList<ConfigurationDiagnostic> diagnostics)
     {
         ThrowHelper.ThrowIfNull(diagnostics);

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.Compile.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.Compile.cs
@@ -37,6 +37,13 @@ public sealed partial class ConfigurationPattern
         return sb.ToString();
     }
 
+    /// <summary>
+    /// Translates the glob expression <paramref name="pattern" /> into regex syntax, appending the result to
+    /// <paramref name="sb" />.
+    /// </summary>
+    /// <param name="pattern">The glob expression to translate.</param>
+    /// <param name="sb">The buffer that receives the translated regex.</param>
+    /// <exception cref="ConfigurationParseException">The pattern contains an unbalanced brace or bracket.</exception>
     private static void TranslateExpression(string pattern, StringBuilder sb)
     {
         for (var i = 0; i < pattern.Length;)
@@ -107,6 +114,14 @@ public sealed partial class ConfigurationPattern
         }
     }
 
+    /// <summary>
+    /// Translates the bracket character class beginning at <paramref name="start" /> into a regex set.
+    /// </summary>
+    /// <param name="pattern">The glob expression being translated.</param>
+    /// <param name="start">The index of the opening <c>[</c>.</param>
+    /// <param name="sb">The buffer that receives the translated regex.</param>
+    /// <returns>The index immediately following the closing <c>]</c>.</returns>
+    /// <exception cref="ConfigurationParseException">The bracket is unbalanced.</exception>
     private static int TranslateCharClass(string pattern, int start, StringBuilder sb)
     {
         var close = FindClosingBracket(pattern, start);
@@ -148,6 +163,12 @@ public sealed partial class ConfigurationPattern
         return close + 1;
     }
 
+    /// <summary>
+    /// Finds the index of the <c>]</c> that closes the character class opened at <paramref name="start" />.
+    /// </summary>
+    /// <param name="pattern">The glob expression to scan.</param>
+    /// <param name="start">The index of the opening <c>[</c>.</param>
+    /// <returns>The index of the closing <c>]</c>, or <c>-1</c> when none is found.</returns>
     private static int FindClosingBracket(string pattern, int start)
     {
         for (var i = start + 1; i < pattern.Length; i++)
@@ -165,6 +186,15 @@ public sealed partial class ConfigurationPattern
         return -1;
     }
 
+    /// <summary>
+    /// Translates the brace group beginning at <paramref name="start" /> — an alternation or a numeric range — into
+    /// regex syntax.
+    /// </summary>
+    /// <param name="pattern">The glob expression being translated.</param>
+    /// <param name="start">The index of the opening <c>{</c>.</param>
+    /// <param name="sb">The buffer that receives the translated regex.</param>
+    /// <returns>The index immediately following the closing <c>}</c>.</returns>
+    /// <exception cref="ConfigurationParseException">The brace is unbalanced.</exception>
     private static int TranslateBraceGroup(string pattern, int start, StringBuilder sb)
     {
         var close = FindMatchingBrace(pattern, start);
@@ -194,6 +224,13 @@ public sealed partial class ConfigurationPattern
         return close + 1;
     }
 
+    /// <summary>
+    /// Finds the index of the <c>}</c> that closes the brace group opened at <paramref name="start" />, accounting for
+    /// nesting.
+    /// </summary>
+    /// <param name="pattern">The glob expression to scan.</param>
+    /// <param name="start">The index of the opening <c>{</c>.</param>
+    /// <returns>The index of the matching <c>}</c>, or <c>-1</c> when none is found.</returns>
     private static int FindMatchingBrace(string pattern, int start)
     {
         var depth = 0;
@@ -218,6 +255,11 @@ public sealed partial class ConfigurationPattern
         return -1;
     }
 
+    /// <summary>
+    /// Splits a brace-group body on commas that are not nested inside an inner brace group.
+    /// </summary>
+    /// <param name="body">The brace-group body, excluding the surrounding braces.</param>
+    /// <returns>The top-level comma-separated alternatives.</returns>
     private static List<string> SplitTopLevelCommas(string body)
     {
         List<string> result = new();
@@ -247,6 +289,16 @@ public sealed partial class ConfigurationPattern
         return result;
     }
 
+    /// <summary>
+    /// Attempts to translate a brace-group body of the form <c>n1..n2</c> into a regex alternation over the inclusive
+    /// integer range.
+    /// </summary>
+    /// <param name="body">The brace-group body, excluding the surrounding braces.</param>
+    /// <param name="sb">The buffer that receives the translated regex when the body is a numeric range.</param>
+    /// <returns>
+    /// <see langword="true" /> when <paramref name="body" /> was a numeric range and was translated; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
     private static bool TryTranslateNumericRange(string body, StringBuilder sb)
     {
         var dot = body.IndexOf("..", StringComparison.Ordinal);

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.cs
@@ -78,6 +78,12 @@ public sealed partial class ConfigurationPattern
 {
     private readonly Regex _regex;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationPattern" /> class with the supplied source and
+    /// compiled regular expression.
+    /// </summary>
+    /// <param name="source">The glob expression as authored.</param>
+    /// <param name="regex">The compiled regular expression equivalent to <paramref name="source" />.</param>
     private ConfigurationPattern(string source, Regex regex)
     {
         Source = source;

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationReader.Helpers.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationReader.Helpers.cs
@@ -15,6 +15,14 @@ internal sealed partial class ConfigurationReader
     /// <see cref="ConfigurationDiagnosticMode.Throw" /> and retaining it on the local diagnostic list only when the
     /// mode is <see cref="ConfigurationDiagnosticMode.Collect" />.
     /// </summary>
+    /// <param name="severity">The severity classification of the diagnostic.</param>
+    /// <param name="code">The stable code identifying the diagnostic category.</param>
+    /// <param name="message">The human-readable message text.</param>
+    /// <param name="location">The source location the diagnostic refers to.</param>
+    /// <exception cref="ConfigurationParseException">
+    /// The configured mode is <see cref="ConfigurationDiagnosticMode.Throw" /> and <paramref name="severity" /> is
+    /// <see cref="ConfigurationDiagnosticSeverity.Error" />.
+    /// </exception>
     private void EmitDiagnostic(
         ConfigurationDiagnosticSeverity severity,
         ConfigurationDiagnosticCode code,
@@ -41,9 +49,20 @@ internal sealed partial class ConfigurationReader
         }
     }
 
+    /// <summary>
+    /// Gets the section a property should attach to — the most recently declared section, or the global section when
+    /// none have been declared.
+    /// </summary>
+    /// <param name="document">The document being populated.</param>
+    /// <returns>The current target section.</returns>
     private static IniSection GetCurrentSection(IniDocument document) =>
         document.Sections.Count > 0 ? document.Sections[^1] : document.GlobalSection;
 
+    /// <summary>
+    /// Attaches every comment in <paramref name="pending" /> to <paramref name="section" /> and clears the list.
+    /// </summary>
+    /// <param name="section">The section the comments are attached to.</param>
+    /// <param name="pending">The pending leading comments; emptied by this call.</param>
     private static void AttachPendingComments(IniSection section, List<IniComment> pending)
     {
         foreach (IniComment c in pending)
@@ -51,6 +70,11 @@ internal sealed partial class ConfigurationReader
         pending.Clear();
     }
 
+    /// <summary>
+    /// Finds the index of the first non-whitespace character in <paramref name="line" />.
+    /// </summary>
+    /// <param name="line">The line to scan.</param>
+    /// <returns>The zero-based index, or <c>-1</c> when the line is blank.</returns>
     private static int FindFirstNonWhitespace(string line)
     {
         for (var i = 0; i < line.Length; i++)
@@ -62,6 +86,12 @@ internal sealed partial class ConfigurationReader
         return -1;
     }
 
+    /// <summary>
+    /// Finds the index of the last <c>]</c> on <paramref name="line" />, scanning back past trailing whitespace.
+    /// </summary>
+    /// <param name="line">The line to scan.</param>
+    /// <param name="firstNonWs">The index of the first non-whitespace character on the line.</param>
+    /// <returns>The index of the closing <c>]</c>, or <c>-1</c> when none is found.</returns>
     private static int FindLastClosingBracket(string line, int firstNonWs)
     {
         for (var i = line.Length - 1; i > firstNonWs; i--)
@@ -76,6 +106,14 @@ internal sealed partial class ConfigurationReader
         return -1;
     }
 
+    /// <summary>
+    /// Finds the index of the first unescaped occurrence of <paramref name="target" /> at or after
+    /// <paramref name="from" />.
+    /// </summary>
+    /// <param name="line">The line to scan.</param>
+    /// <param name="target">The character to search for.</param>
+    /// <param name="from">The index to begin scanning from.</param>
+    /// <returns>The zero-based index, or <c>-1</c> when no unescaped occurrence is found.</returns>
     private static int FindFirstUnescaped(string line, char target, int from)
     {
         for (var i = from; i < line.Length; i++)
@@ -93,6 +131,13 @@ internal sealed partial class ConfigurationReader
         return -1;
     }
 
+    /// <summary>
+    /// Returns the substring of <paramref name="line" /> from <paramref name="firstNonWs" /> with trailing whitespace
+    /// removed.
+    /// </summary>
+    /// <param name="line">The line to trim.</param>
+    /// <param name="firstNonWs">The index of the first non-whitespace character on the line.</param>
+    /// <returns>The trimmed substring.</returns>
     private static string TrimTrailing(string line, int firstNonWs)
     {
         var end = line.Length - 1;
@@ -101,6 +146,15 @@ internal sealed partial class ConfigurationReader
         return line.Substring(firstNonWs, end - firstNonWs + 1);
     }
 
+    /// <summary>
+    /// Attempts to split an inline comment from the end of <paramref name="value" /> under the supplied comment mode.
+    /// </summary>
+    /// <param name="value">
+    /// The property value to scan; trimmed of the comment and trailing whitespace when one is found.
+    /// </param>
+    /// <param name="mode">The inline comment mode that decides when a comment prefix is recognized.</param>
+    /// <param name="lineNumber">The 1-based line number recorded on the extracted comment.</param>
+    /// <returns>The extracted inline comment, or <see langword="null" /> when none is present.</returns>
     private static IniComment? TryExtractInlineComment(
         ref string value,
         ConfigurationInlineCommentMode mode,

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationReader.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationReader.cs
@@ -25,6 +25,10 @@ internal sealed partial class ConfigurationReader
     private readonly List<ConfigurationDiagnostic> _diagnostics = [];
     private readonly List<IniComment> _pendingLeadingComments = [];
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationReader" /> class with the supplied parse options.
+    /// </summary>
+    /// <param name="options">The parse options that govern comment, duplicate, and diagnostic handling.</param>
     internal ConfigurationReader(ConfigurationParseOptions options)
     {
         _options = options;
@@ -36,8 +40,8 @@ internal sealed partial class ConfigurationReader
     /// <param name="reader">The source of configuration text.</param>
     /// <param name="path">The optional file path used when emitting source locations.</param>
     /// <returns>
-    /// A <see cref="ConfigurationParseResult" /> carrying the populated <see cref="IniDocument" /> and any
-    /// diagnostics collected.
+    /// A <see cref="ConfigurationParseResult" /> carrying the populated <see cref="IniDocument" /> and any diagnostics
+    /// collected.
     /// </returns>
     internal ConfigurationParseResult Read(TextReader reader, string? path)
     {
@@ -63,6 +67,15 @@ internal sealed partial class ConfigurationReader
         return new ConfigurationParseResult(document, [.. _diagnostics]);
     }
 
+    /// <summary>
+    /// Processes a single input line, dispatching to comment, section-header, or property handling.
+    /// </summary>
+    /// <param name="document">The document being populated.</param>
+    /// <param name="currentSection">The section that subsequent properties are added to.</param>
+    /// <param name="line">The raw line text.</param>
+    /// <param name="lineNumber">The 1-based number of <paramref name="line" />.</param>
+    /// <param name="path">The optional source file path used when emitting source locations.</param>
+    /// <returns>The section current after the line has been processed.</returns>
     private IniSection ProcessLine(
         IniDocument document,
         IniSection currentSection,
@@ -103,6 +116,15 @@ internal sealed partial class ConfigurationReader
             : ProcessPropertyLine(currentSection, line, firstNonWs, lineNumber, path);
     }
 
+    /// <summary>
+    /// Processes a section-header line, registering the section and attaching any pending leading comments.
+    /// </summary>
+    /// <param name="document">The document being populated.</param>
+    /// <param name="line">The raw line text containing the section header.</param>
+    /// <param name="firstNonWs">The index of the first non-whitespace character on the line.</param>
+    /// <param name="lineNumber">The 1-based number of <paramref name="line" />.</param>
+    /// <param name="path">The optional source file path used when emitting source locations.</param>
+    /// <returns>The section that subsequent properties are added to.</returns>
     private IniSection ProcessSectionHeader(
         IniDocument document,
         string line,
@@ -144,6 +166,13 @@ internal sealed partial class ConfigurationReader
         return section;
     }
 
+    /// <summary>
+    /// Resolves the section that a header names, honoring the configured duplicate-section behaviour.
+    /// </summary>
+    /// <param name="document">The document being populated.</param>
+    /// <param name="name">The section name parsed from the header.</param>
+    /// <param name="headerLoc">The source location of the header, used when emitting diagnostics.</param>
+    /// <returns>The existing or newly created section that subsequent properties are added to.</returns>
     private IniSection ResolveSectionTarget(IniDocument document, string name, ConfigurationSourceLocation headerLoc)
     {
         // Detect duplicates by scanning the existing sections list rather than a separate lookup, so that
@@ -188,6 +217,15 @@ internal sealed partial class ConfigurationReader
         return created;
     }
 
+    /// <summary>
+    /// Processes a property line, splitting it into a key and value and appending the resulting entry.
+    /// </summary>
+    /// <param name="currentSection">The section the entry is added to.</param>
+    /// <param name="line">The raw line text containing the property.</param>
+    /// <param name="firstNonWs">The index of the first non-whitespace character on the line.</param>
+    /// <param name="lineNumber">The 1-based number of <paramref name="line" />.</param>
+    /// <param name="path">The optional source file path used when emitting source locations.</param>
+    /// <returns>The unchanged <paramref name="currentSection" />.</returns>
     private IniSection ProcessPropertyLine(
         IniSection currentSection,
         string line,
@@ -256,6 +294,17 @@ internal sealed partial class ConfigurationReader
         return currentSection;
     }
 
+    /// <summary>
+    /// Appends a property entry to <paramref name="section" />, validating the key and honoring the configured
+    /// duplicate-key behaviour.
+    /// </summary>
+    /// <param name="section">The section the entry is added to.</param>
+    /// <param name="rawKey">The raw property key.</param>
+    /// <param name="value">The property value.</param>
+    /// <param name="lineNumber">The 1-based line number the entry was read from.</param>
+    /// <param name="linePosition">The zero-based index of the key on the line.</param>
+    /// <param name="path">The optional source file path used when emitting source locations.</param>
+    /// <param name="inlineComment">The inline comment trailing the value, or <see langword="null" />.</param>
     private void AppendEntry(
         IniSection section,
         string rawKey,

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationResolver.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationResolver.cs
@@ -16,11 +16,27 @@ internal sealed class ConfigurationResolver
 {
     private readonly ConfigurationResolveOptions _options;
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationResolver" /> class with the supplied resolve options.
+    /// </summary>
+    /// <param name="options">The resolve options that govern glob matching and preamble layering.</param>
     internal ConfigurationResolver(ConfigurationResolveOptions options)
     {
         _options = options;
     }
 
+    /// <summary>
+    /// Projects <paramref name="document" /> into a resolved <see cref="ConfigurationView" /> for
+    /// <paramref name="targetPath" />.
+    /// </summary>
+    /// <param name="document">The document to resolve.</param>
+    /// <param name="targetPath">The target path the view is evaluated for, or <see langword="null" />.</param>
+    /// <returns>The resolved view for <paramref name="targetPath" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="document" /> is <see langword="null" />.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// The configured options require a path root, the document was parsed without one, and no target path was
+    /// supplied.
+    /// </exception>
     internal ConfigurationView Resolve(IniDocument document, string? targetPath)
     {
         ThrowHelper.ThrowIfNull(document);
@@ -52,6 +68,12 @@ internal sealed class ConfigurationResolver
         return new ConfigurationView(values);
     }
 
+    /// <summary>
+    /// Applies the entries of <paramref name="section" /> to <paramref name="values" />, honoring the EditorConfig
+    /// <c>unset</c> sentinel.
+    /// </summary>
+    /// <param name="section">The section whose entries are layered onto the resolved values.</param>
+    /// <param name="values">The accumulating dictionary of resolved values.</param>
     private void ApplySection(IniSection section, Dictionary<string, string?> values)
     {
         foreach (IniEntry entry in section.Entries)
@@ -70,6 +92,13 @@ internal sealed class ConfigurationResolver
         }
     }
 
+    /// <summary>
+    /// Normalizes <paramref name="targetPath" /> to forward slashes and rebases it relative to
+    /// <paramref name="pathRoot" />.
+    /// </summary>
+    /// <param name="targetPath">The target path to normalize.</param>
+    /// <param name="pathRoot">The path root the result is made relative to, or <see langword="null" />.</param>
+    /// <returns>The normalized, root-relative path.</returns>
     private static string NormalizePath(string targetPath, string? pathRoot)
     {
         var normalizedTarget = targetPath.Replace('\\', '/');

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationSourceLocation.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationSourceLocation.cs
@@ -55,7 +55,7 @@ namespace Bodu.Text.Configuration;
 public readonly struct ConfigurationSourceLocation : IEquatable<ConfigurationSourceLocation>
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ConfigurationSourceLocation" /> struct. with the specified line
+    /// Initializes a new instance of the <see cref="ConfigurationSourceLocation" /> struct with the specified line
     /// number, column, span length, and optional file path.
     /// </summary>
     /// <param name="lineNumber">The 1-based line number.</param>

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationView.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationView.cs
@@ -49,6 +49,10 @@ namespace Bodu.Text.Configuration;
 /// </example>
 public sealed partial class ConfigurationView : IEnumerable<KeyValuePair<string, string?>>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConfigurationView" /> class over the supplied resolved values.
+    /// </summary>
+    /// <param name="values">The resolved configuration values, keyed by canonical configuration key.</param>
     internal ConfigurationView(IReadOnlyDictionary<string, string?> values)
     {
         Values = values;
@@ -114,5 +118,6 @@ public sealed partial class ConfigurationView : IEnumerable<KeyValuePair<string,
     public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() =>
         Values.GetEnumerator();
 
+    /// <inheritdoc />
     IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }


### PR DESCRIPTION
## Summary

This change adds comprehensive XML documentation comments to public and internal APIs across the `Bodu.Text.Configuration` namespace. The documentation covers method parameters, return values, exception conditions, and type initialization, improving IDE IntelliSense support and enabling DocFX documentation generation.

## Key Changes

- **ConfigurationReader.cs & ConfigurationReader.Helpers.cs**: Added XML docs to the constructor and all helper methods (`EmitDiagnostic`, `GetCurrentSection`, `AttachPendingComments`, `FindFirstNonWhitespace`, `FindLastClosingBracket`, `FindFirstUnescaped`, `TrimTrailing`, `TryExtractInlineComment`, `ProcessLine`, `ProcessSectionHeader`, `ResolveSectionTarget`, `ProcessPropertyLine`, `AppendEntry`)

- **ConfigurationPattern.Compile.cs**: Added XML docs to pattern compilation methods (`TranslateExpression`, `TranslateCharClass`, `FindClosingBracket`, `TranslateBraceGroup`, `FindMatchingBrace`, `SplitTopLevelCommas`, `TryTranslateNumericRange`)

- **ConfigurationKey.cs**: Added XML docs to the private constructor and all helper methods (`SplitSegments`, `AddSegment`, `RejectControlCharacters`, `IsSeparator`, `ComposePath`, `GetFirstSeparator`)

- **ConfigurationResolver.cs**: Added XML docs to the constructor and helper methods (`Resolve`, `ApplySection`, `NormalizePath`)

- **ConfigurationDocumentWriter.cs**: Added XML docs to the `Write` method and `WriteSection` helper, updated remarks to reference `ConfigurationWriteOptions` more concisely

- **ConfigurationParseException.cs**: Added XML docs to the serialization constructor and helper methods (`GetMessage` overloads), improved existing documentation formatting

- **ConfigurationDocument.cs**: Enhanced XML docs for `Save` overloads to clarify null-check and exception conditions

- **ConfigurationPattern.cs**: Added XML docs to the private constructor

- **ConfigurationView.cs**: Added XML docs to the internal constructor

- **ConfigurationDiagnostic.cs**: Improved constructor documentation formatting

- **ConfigurationSourceLocation.cs**: Improved documentation formatting

## Notable Details

- All documentation follows the existing style: concise summaries, explicit `<param>`, `<returns>`, and `<exception>` tags
- Private and internal members are documented to support maintainability and IDE support within the assembly
- Exception documentation is precise about conditions and parameter names
- Return value documentation clarifies special cases (e.g., `-1` for "not found" indices, `null` for optional results)

https://claude.ai/code/session_012ZXro19x9ubQnEBzkPTBor