### PR TITLE
Add extension methods for enums, streams, dictionaries, and enumerables

### DIFF
--- a/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.AddOrUpdate.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.AddOrUpdate.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IDictionaryExtensions.AddOrUpdate.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IDictionaryExtensions
+{
+    /// <summary>
+    /// Inserts <paramref name="value" /> under <paramref name="key" />, or replaces the existing value when the key is
+    /// already present.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    /// <param name="dictionary">The dictionary to insert into or update.</param>
+    /// <param name="key">The key to insert or update.</param>
+    /// <param name="value">The value to associate with <paramref name="key" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="dictionary" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The operation is unconditional: it has the same effect as the indexer assignment <c>dictionary[key] = value</c>,
+    /// and exists to state the add-or-update intent explicitly at the call site.
+    /// </remarks>
+    public static void AddOrUpdate<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        ThrowHelper.ThrowIfNull(dictionary);
+
+        dictionary[key] = value;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.GetOrAdd.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.GetOrAdd.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IDictionaryExtensions.GetOrAdd.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IDictionaryExtensions
+{
+    /// <summary>
+    /// Returns the value associated with <paramref name="key" />, adding <paramref name="value" /> first when the key
+    /// is not already present.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    /// <param name="dictionary">The dictionary to read from and, when necessary, insert into.</param>
+    /// <param name="key">The key to locate.</param>
+    /// <param name="value">The value to insert when <paramref name="key" /> is not present.</param>
+    /// <returns>
+    /// The existing value when <paramref name="key" /> is already present; otherwise <paramref name="value" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="dictionary" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// The lookup and the conditional insert are performed as two separate operations; the helper provides no atomicity
+    /// guarantee and must not be used as a substitute for
+    /// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}.GetOrAdd(TKey, TValue)" /> on a
+    /// shared instance.
+    /// </remarks>
+    public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue value)
+    {
+        ThrowHelper.ThrowIfNull(dictionary);
+
+        if (dictionary.TryGetValue(key, out TValue? existing))
+            return existing;
+
+        dictionary[key] = value;
+        return value;
+    }
+
+    /// <summary>
+    /// Returns the value associated with <paramref name="key" />, invoking <paramref name="valueFactory" /> to produce
+    /// and insert a value when the key is not already present.
+    /// </summary>
+    /// <typeparam name="TKey">The type of the keys in the dictionary.</typeparam>
+    /// <typeparam name="TValue">The type of the values in the dictionary.</typeparam>
+    /// <param name="dictionary">The dictionary to read from and, when necessary, insert into.</param>
+    /// <param name="key">The key to locate.</param>
+    /// <param name="valueFactory">A delegate that produces the value to insert, given the key.</param>
+    /// <returns>
+    /// The existing value when <paramref name="key" /> is already present; otherwise the value produced by
+    /// <paramref name="valueFactory" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="dictionary" /> or <paramref name="valueFactory" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <paramref name="valueFactory" /> is invoked at most once, and only when <paramref name="key" /> is absent. The
+    /// lookup and insert are not atomic; see the value-argument overload for the concurrency caveat.
+    /// </remarks>
+    public static TValue GetOrAdd<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, Func<TKey, TValue> valueFactory)
+    {
+        ThrowHelper.ThrowIfNull(dictionary);
+        ThrowHelper.ThrowIfNull(valueFactory);
+
+        if (dictionary.TryGetValue(key, out TValue? existing))
+            return existing;
+
+        TValue created = valueFactory(key);
+        dictionary[key] = created;
+        return created;
+    }
+}

--- a/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IDictionaryExtensions.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IDictionaryExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+/// <summary>
+/// Provides retrieval-and-mutation helpers for <see cref="IDictionary{TKey, TValue}" /> — get-or-add and add-or-update
+/// operations modelled on the <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}" /> surface
+/// but available on any dictionary implementation.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="IDictionary{TKey, TValue}" /> exposes only primitive lookup and mutation members, so callers routinely
+/// hand-roll the "return the existing value or insert a new one" pattern. This class collects those patterns behind
+/// verb-led names.
+/// </para>
+/// <para>
+/// These helpers perform no synchronization. On a dictionary shared between threads the caller must provide external
+/// synchronization; they are not a substitute for
+/// <see cref="System.Collections.Concurrent.ConcurrentDictionary{TKey, TValue}" /> when concurrent access is required.
+/// </para>
+/// </remarks>
+public static partial class IDictionaryExtensions
+{
+}

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.ForEach.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.ForEach.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.ForEach.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IEnumerableExtensions
+{
+    /// <summary>
+    /// Invokes <paramref name="action" /> once for each element of <paramref name="source" />, in sequence order.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">The sequence whose elements are passed to <paramref name="action" />.</param>
+    /// <param name="action">The delegate invoked for each element.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="source" /> or <paramref name="action" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Execution is eager: <paramref name="source" /> is enumerated to completion before the method returns, and is
+    /// enumerated exactly once.
+    /// </remarks>
+    public static void ForEach<TSource>(this IEnumerable<TSource> source, Action<TSource> action)
+    {
+        ThrowHelper.ThrowIfNull(source);
+        ThrowHelper.ThrowIfNull(action);
+
+        foreach (TSource item in source)
+            action(item);
+    }
+}

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Index.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Index.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.Index.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+#if !NET9_0_OR_GREATER
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IEnumerableExtensions
+{
+    /// <summary>
+    /// Pairs each element of <paramref name="source" /> with its zero-based position in the sequence.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">The sequence to pair with positional indexes.</param>
+    /// <returns>
+    /// A sequence of tuples, each holding the zero-based index and the element at that position, in order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Execution is deferred: <paramref name="source" /> is not enumerated until the returned sequence is iterated,
+    /// while the <see langword="null" /> argument check runs eagerly.
+    /// </para>
+    /// <para>
+    /// This helper is compiled only for targets earlier than .NET 9, where the runtime introduces an equivalent
+    /// <c>Enumerable.Index</c> method on the standard LINQ surface.
+    /// </para>
+    /// </remarks>
+    public static IEnumerable<(int Index, TSource Item)> Index<TSource>(this IEnumerable<TSource> source)
+    {
+        ThrowHelper.ThrowIfNull(source);
+
+        return Iterator(source);
+
+        static IEnumerable<(int Index, TSource Item)> Iterator(IEnumerable<TSource> sequence)
+        {
+            int index = 0;
+            foreach (TSource item in sequence)
+                yield return (index++, item);
+        }
+    }
+}
+
+#endif

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.IsNullOrEmpty.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.IsNullOrEmpty.cs
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.IsNullOrEmpty.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IEnumerableExtensions
+{
+    /// <summary>
+    /// Determines whether <paramref name="source" /> is <see langword="null" /> or contains no elements.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements of <paramref name="source" />.</typeparam>
+    /// <param name="source">The sequence to test. May be <see langword="null" />.</param>
+    /// <returns>
+    /// <see langword="true" /> when <paramref name="source" /> is <see langword="null" /> or yields no elements;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// When <paramref name="source" /> implements <see cref="ICollection{T}" /> or
+    /// <see cref="IReadOnlyCollection{T}" /> the element count is read directly; otherwise the sequence is probed for a
+    /// single element. A non-counted sequence is advanced by at most one step and is never fully enumerated.
+    /// </remarks>
+    public static bool IsNullOrEmpty<TSource>(this IEnumerable<TSource>? source)
+    {
+        if (source is null)
+            return true;
+
+        if (source is ICollection<TSource> collection)
+            return collection.Count == 0;
+
+        if (source is IReadOnlyCollection<TSource> readOnlyCollection)
+            return readOnlyCollection.Count == 0;
+
+        using IEnumerator<TSource> enumerator = source.GetEnumerator();
+        return !enumerator.MoveNext();
+    }
+}

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.WhereNotNull.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.WhereNotNull.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.WhereNotNull.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+public static partial class IEnumerableExtensions
+{
+    /// <summary>
+    /// Filters a sequence of nullable references, yielding only the elements that are not <see langword="null" />.
+    /// </summary>
+    /// <typeparam name="TSource">The reference type of the elements.</typeparam>
+    /// <param name="source">The sequence of possibly-<see langword="null" /> references to filter.</param>
+    /// <returns>
+    /// A sequence containing the non-<see langword="null" /> elements of <paramref name="source" />, in order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Execution is deferred: <paramref name="source" /> is not enumerated until the returned sequence is iterated,
+    /// while the <see langword="null" /> argument check runs eagerly.
+    /// </remarks>
+    public static IEnumerable<TSource> WhereNotNull<TSource>(this IEnumerable<TSource?> source)
+        where TSource : class
+    {
+        ThrowHelper.ThrowIfNull(source);
+
+        return Iterator(source);
+
+        static IEnumerable<TSource> Iterator(IEnumerable<TSource?> sequence)
+        {
+            foreach (TSource? item in sequence)
+            {
+                if (item is not null)
+                    yield return item;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Filters a sequence of nullable value types, yielding the underlying value of each element that has one.
+    /// </summary>
+    /// <typeparam name="TSource">The value type of the elements.</typeparam>
+    /// <param name="source">The sequence of <see cref="Nullable{T}" /> values to filter.</param>
+    /// <returns>
+    /// A sequence containing the value of every element of <paramref name="source" /> that is not
+    /// <see langword="null" />, in order.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="source" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Execution is deferred: <paramref name="source" /> is not enumerated until the returned sequence is iterated,
+    /// while the <see langword="null" /> argument check runs eagerly.
+    /// </remarks>
+    public static IEnumerable<TSource> WhereNotNull<TSource>(this IEnumerable<TSource?> source)
+        where TSource : struct
+    {
+        ThrowHelper.ThrowIfNull(source);
+
+        return Iterator(source);
+
+        static IEnumerable<TSource> Iterator(IEnumerable<TSource?> sequence)
+        {
+            foreach (TSource? item in sequence)
+            {
+                if (item.HasValue)
+                    yield return item.GetValueOrDefault();
+            }
+        }
+    }
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.BitConversion.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.BitConversion.cs
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.BitConversion.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Reinterprets the bit pattern of <paramref name="value" /> as a 64-bit unsigned integer without boxing.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value whose underlying bits are read.</param>
+    /// <returns>The underlying integer value of <paramref name="value" />, zero-extended to 64 bits.</returns>
+    /// <remarks>
+    /// The enum is read at exactly its declared width (1, 2, 4, or 8 bytes); reading a wider type would observe
+    /// adjacent storage. The width switch is resolved at JIT time for each closed <typeparamref name="TEnum" />, so the
+    /// helper compiles down to a single load.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong ToUInt64<TEnum>(TEnum value)
+        where TEnum : struct, Enum =>
+        Unsafe.SizeOf<TEnum>() switch
+        {
+            1 => Unsafe.As<TEnum, byte>(ref value),
+            2 => Unsafe.As<TEnum, ushort>(ref value),
+            4 => Unsafe.As<TEnum, uint>(ref value),
+            _ => Unsafe.As<TEnum, ulong>(ref value),
+        };
+
+    /// <summary>
+    /// Reinterprets the low bits of <paramref name="value" /> as an enumeration of type <typeparamref name="TEnum" />.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The integer bit pattern to reinterpret.</param>
+    /// <returns>An enumeration value whose underlying bits are the low bits of <paramref name="value" />.</returns>
+    /// <remarks>
+    /// Only the low bytes corresponding to the declared width of <typeparamref name="TEnum" /> are written; the
+    /// remaining bits of <paramref name="value" /> are discarded, which is correct because every bitwise result is
+    /// produced from operands of that same width.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static TEnum FromUInt64<TEnum>(ulong value)
+        where TEnum : struct, Enum
+    {
+        TEnum result = default;
+
+        switch (Unsafe.SizeOf<TEnum>())
+        {
+            case 1:
+                Unsafe.As<TEnum, byte>(ref result) = (byte)value;
+                break;
+            case 2:
+                Unsafe.As<TEnum, ushort>(ref result) = (ushort)value;
+                break;
+            case 4:
+                Unsafe.As<TEnum, uint>(ref result) = (uint)value;
+                break;
+            default:
+                Unsafe.As<TEnum, ulong>(ref result) = value;
+                break;
+        }
+
+        return result;
+    }
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.ClearFlag.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.ClearFlag.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.ClearFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="value" /> with every bit in <paramref name="flags" /> cleared.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value to start from.</param>
+    /// <param name="flags">The flag bits to clear.</param>
+    /// <returns>
+    /// A new enumeration value equal to <paramref name="value" /> with <paramref name="flags" /> removed.
+    /// </returns>
+    /// <remarks>
+    /// Equivalent to <c>value &amp; ~flags</c>. Bits not present in <paramref name="flags" /> are left unchanged, and
+    /// clearing a bit that was not set is a no-op.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static TEnum ClearFlag<TEnum>(this TEnum value, TEnum flags)
+        where TEnum : struct, Enum =>
+        FromUInt64<TEnum>(ToUInt64(value) & ~ToUInt64(flags));
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.HasAllFlags.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.HasAllFlags.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.HasAllFlags.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Determines whether <paramref name="value" /> has every bit set that is set in <paramref name="flags" />.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value to test.</param>
+    /// <param name="flags">The flag bits that must all be present.</param>
+    /// <returns>
+    /// <see langword="true" /> if every bit set in <paramref name="flags" /> is also set in <paramref name="value" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// Equivalent to <c>(value &amp; flags) == flags</c> evaluated on the underlying integer type. When
+    /// <paramref name="flags" /> has no bits set the result is always <see langword="true" />. This is the non-boxing
+    /// counterpart of <see cref="System.Enum.HasFlag(System.Enum)" />.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasAllFlags<TEnum>(this TEnum value, TEnum flags)
+        where TEnum : struct, Enum
+    {
+        ulong mask = ToUInt64(flags);
+        return (ToUInt64(value) & mask) == mask;
+    }
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.HasAnyFlag.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.HasAnyFlag.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.HasAnyFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Determines whether <paramref name="value" /> has at least one of the bits set in <paramref name="flags" />.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value to test.</param>
+    /// <param name="flags">The flag bits to look for.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="value" /> and <paramref name="flags" /> share at least one set bit;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// Equivalent to <c>(value &amp; flags) != 0</c> evaluated on the underlying integer type. When
+    /// <paramref name="flags" /> has no bits set the result is always <see langword="false" />.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasAnyFlag<TEnum>(this TEnum value, TEnum flags)
+        where TEnum : struct, Enum =>
+        (ToUInt64(value) & ToUInt64(flags)) != 0UL;
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.SetFlag.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.SetFlag.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.SetFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="value" /> with every bit in <paramref name="flags" /> set.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value to start from.</param>
+    /// <param name="flags">The flag bits to set.</param>
+    /// <returns>
+    /// A new enumeration value equal to <paramref name="value" /> with <paramref name="flags" /> added.
+    /// </returns>
+    /// <remarks>
+    /// Equivalent to the bitwise OR <c>value | flags</c>. The receiver is not modified; enumerations are value types
+    /// and the result is returned as a new value.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static TEnum SetFlag<TEnum>(this TEnum value, TEnum flags)
+        where TEnum : struct, Enum =>
+        FromUInt64<TEnum>(ToUInt64(value) | ToUInt64(flags));
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.ToggleFlag.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.ToggleFlag.cs
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.ToggleFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Extensions;
+
+public static partial class EnumExtensions
+{
+    /// <summary>
+    /// Returns a copy of <paramref name="value" /> with every bit in <paramref name="flags" /> flipped.
+    /// </summary>
+    /// <typeparam name="TEnum">The enumeration type.</typeparam>
+    /// <param name="value">The enumeration value to start from.</param>
+    /// <param name="flags">The flag bits to toggle.</param>
+    /// <returns>
+    /// A new enumeration value equal to <paramref name="value" /> with <paramref name="flags" /> toggled.
+    /// </returns>
+    /// <remarks>
+    /// Equivalent to the bitwise XOR <c>value ^ flags</c>: bits present in <paramref name="flags" /> are flipped, so
+    /// applying the operation twice with the same <paramref name="flags" /> restores the original value.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static TEnum ToggleFlag<TEnum>(this TEnum value, TEnum flags)
+        where TEnum : struct, Enum =>
+        FromUInt64<TEnum>(ToUInt64(value) ^ ToUInt64(flags));
+}

--- a/Bodu.Core/src/Extensions/EnumExtensions.cs
+++ b/Bodu.Core/src/Extensions/EnumExtensions.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides non-boxing bitwise helpers for flag-style enumerations — membership tests and add, remove, and toggle
+/// operations that work uniformly across every enum underlying type.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The built-in <see cref="System.Enum.HasFlag(System.Enum)" /> boxes both operands on every call, and the bitwise
+/// operators (<c>|</c>, <c>&amp;</c>, <c>^</c>, <c>~</c>) are unavailable on an open generic enum type. This class
+/// supplies generic, allocation-free equivalents constrained to <c>struct, System.Enum</c>.
+/// </para>
+/// <para>
+/// Each operation reinterprets the enum value as its underlying integer, applies the bitwise operation, and — for the
+/// mutating helpers — reinterprets the result back to the enum type. No boxing, reflection, or
+/// <see cref="System.Convert" /> call is involved, so the helpers are safe to use on hot paths.
+/// </para>
+/// <para>
+/// These helpers are intended for enumerations annotated with <see cref="System.FlagsAttribute" />; they operate purely
+/// on the bit pattern and do not validate that the supplied values correspond to declared members.
+/// </para>
+/// </remarks>
+public static partial class EnumExtensions
+{
+}

--- a/Bodu.Core/src/Extensions/StreamExtensions.ReadAllBytes.cs
+++ b/Bodu.Core/src/Extensions/StreamExtensions.ReadAllBytes.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensions.ReadAllBytes.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public static partial class StreamExtensions
+{
+    /// <summary>
+    /// Reads <paramref name="stream" /> from its current position to the end and returns the bytes as an array.
+    /// </summary>
+    /// <param name="stream">The stream to read. Must not be <see langword="null" />.</param>
+    /// <returns>
+    /// A new array containing every byte from the current position to the end of <paramref name="stream" />, or an
+    /// empty array when no bytes remain.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="stream" /> does not support reading.
+    /// </exception>
+    /// <remarks>
+    /// When <paramref name="stream" /> is seekable a single buffer sized to the remaining length is allocated;
+    /// otherwise the content is accumulated through an intermediate <see cref="MemoryStream" />. The read begins at the
+    /// current position and the stream is left open.
+    /// </remarks>
+    public static byte[] ReadAllBytes(this Stream stream)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+
+        if (stream.CanSeek)
+        {
+            long remaining = stream.Length - stream.Position;
+            if (remaining <= 0L)
+                return Array.Empty<byte>();
+
+            if (remaining <= int.MaxValue)
+            {
+                int count = (int)remaining;
+                byte[] buffer = new byte[count];
+                int offset = 0;
+
+                int read;
+                while (offset < count && (read = stream.Read(buffer, offset, count - offset)) > 0)
+                    offset += read;
+
+                if (offset != count)
+                    Array.Resize(ref buffer, offset);
+
+                return buffer;
+            }
+        }
+
+        using MemoryStream memory = new();
+        stream.CopyTo(memory);
+        return memory.ToArray();
+    }
+}

--- a/Bodu.Core/src/Extensions/StreamExtensions.ReadAllBytesAsync.cs
+++ b/Bodu.Core/src/Extensions/StreamExtensions.ReadAllBytesAsync.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensions.ReadAllBytesAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public static partial class StreamExtensions
+{
+    /// <summary>
+    /// Asynchronously reads <paramref name="stream" /> from its current position to the end and returns the bytes as an
+    /// array.
+    /// </summary>
+    /// <param name="stream">The stream to read. Must not be <see langword="null" />.</param>
+    /// <param name="cancellationToken">A token used to observe cancellation requests.</param>
+    /// <returns>
+    /// A task that completes with a new array containing every byte from the current position to the end of
+    /// <paramref name="stream" />, or an empty array when no bytes remain.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Argument validation runs synchronously, so a <see langword="null" /> <paramref name="stream" /> faults at the
+    /// call site rather than on the returned task. See <see cref="ReadAllBytes(Stream)" /> for the buffering strategy.
+    /// </remarks>
+    public static Task<byte[]> ReadAllBytesAsync(this Stream stream, CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+
+        return ReadAllBytesCoreAsync(stream, cancellationToken);
+
+        static async Task<byte[]> ReadAllBytesCoreAsync(Stream source, CancellationToken token)
+        {
+            if (source.CanSeek)
+            {
+                long remaining = source.Length - source.Position;
+                if (remaining <= 0L)
+                    return Array.Empty<byte>();
+
+                if (remaining <= int.MaxValue)
+                {
+                    int count = (int)remaining;
+                    byte[] buffer = new byte[count];
+                    int offset = 0;
+
+                    int read;
+                    while (offset < count &&
+                           (read = await source.ReadAsync(buffer.AsMemory(offset, count - offset), token).ConfigureAwait(false)) > 0)
+                        offset += read;
+
+                    if (offset != count)
+                        Array.Resize(ref buffer, offset);
+
+                    return buffer;
+                }
+            }
+
+            using MemoryStream memory = new();
+            await source.CopyToAsync(memory, token).ConfigureAwait(false);
+            return memory.ToArray();
+        }
+    }
+}

--- a/Bodu.Core/src/Extensions/StreamExtensions.WriteAllBytes.cs
+++ b/Bodu.Core/src/Extensions/StreamExtensions.WriteAllBytes.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensions.WriteAllBytes.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public static partial class StreamExtensions
+{
+    /// <summary>
+    /// Writes the entire contents of <paramref name="bytes" /> to <paramref name="stream" /> at its current position.
+    /// </summary>
+    /// <param name="stream">The stream to write to. Must not be <see langword="null" />.</param>
+    /// <param name="bytes">The bytes to write.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="stream" /> does not support writing.
+    /// </exception>
+    /// <remarks>
+    /// The write begins at the current position; the stream is neither flushed nor closed by this method.
+    /// </remarks>
+    public static void WriteAllBytes(this Stream stream, ReadOnlySpan<byte> bytes)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+
+        stream.Write(bytes);
+    }
+}

--- a/Bodu.Core/src/Extensions/StreamExtensions.WriteAllBytesAsync.cs
+++ b/Bodu.Core/src/Extensions/StreamExtensions.WriteAllBytesAsync.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensions.WriteAllBytesAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public static partial class StreamExtensions
+{
+    /// <summary>
+    /// Asynchronously writes the entire contents of <paramref name="bytes" /> to <paramref name="stream" /> at its
+    /// current position.
+    /// </summary>
+    /// <param name="stream">The stream to write to. Must not be <see langword="null" />.</param>
+    /// <param name="bytes">The bytes to write.</param>
+    /// <param name="cancellationToken">A token used to observe cancellation requests.</param>
+    /// <returns>A task that completes when the write has finished.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="stream" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Argument validation runs synchronously, so a <see langword="null" /> <paramref name="stream" /> faults at the
+    /// call site rather than on the returned task. The stream is neither flushed nor closed by this method.
+    /// </remarks>
+    public static Task WriteAllBytesAsync(this Stream stream, ReadOnlyMemory<byte> bytes, CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNull(stream);
+
+        return stream.WriteAsync(bytes, cancellationToken).AsTask();
+    }
+}

--- a/Bodu.Core/src/Extensions/StreamExtensions.cs
+++ b/Bodu.Core/src/Extensions/StreamExtensions.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Provides whole-payload read and write helpers for <see cref="System.IO.Stream" /> — synchronous and asynchronous
+/// operations that consume or emit an entire byte buffer in a single call.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="System.IO.Stream" /> exposes only incremental, partial-progress primitives: a single
+/// <see cref="System.IO.Stream.Read(byte[], int, int)" /> call may return fewer bytes than requested, so reading a
+/// stream to its end correctly requires a loop. These helpers encapsulate that loop together with the seekable and
+/// non-seekable buffering distinction, so callers can treat a stream as a single byte payload.
+/// </para>
+/// <para>
+/// When the stream is seekable the exact remaining length is used to allocate a single right-sized buffer; when it is
+/// not, the content is accumulated through a growable buffer. Every helper reads from or writes at the current position
+/// and leaves the stream open.
+/// </para>
+/// </remarks>
+public static partial class StreamExtensions
+{
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IDictionaryExtensions.AddOrUpdate.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IDictionaryExtensions.AddOrUpdate.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IDictionaryExtensions.AddOrUpdate.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IDictionaryExtensionsTests_AddOrUpdate
+{
+    /// <summary>
+    /// Verifies that <c>AddOrUpdate</c> inserts the value when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void AddOrUpdate_WhenKeyIsAbsent_ShouldInsertValue()
+    {
+        Dictionary<string, int> dictionary = new();
+
+        dictionary.AddOrUpdate("a", 1);
+
+        Assert.AreEqual(1, dictionary["a"]);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddOrUpdate</c> replaces the value when the key is already present.
+    /// </summary>
+    [TestMethod]
+    public void AddOrUpdate_WhenKeyIsPresent_ShouldReplaceValue()
+    {
+        Dictionary<string, int> dictionary = new() { ["a"] = 1 };
+
+        dictionary.AddOrUpdate("a", 2);
+
+        Assert.AreEqual(2, dictionary["a"]);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddOrUpdate</c> throws <see cref="ArgumentNullException" /> when the dictionary is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOrUpdate_WhenDictionaryIsNull_ShouldThrowArgumentNullException()
+    {
+        IDictionary<string, int> dictionary = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            dictionary.AddOrUpdate("a", 1);
+        });
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IDictionaryExtensions.GetOrAdd.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IDictionaryExtensions.GetOrAdd.cs
@@ -1,0 +1,103 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IDictionaryExtensions.GetOrAdd.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IDictionaryExtensionsTests_GetOrAdd
+{
+    /// <summary>
+    /// Verifies that the value overload adds and returns the value when the key is absent.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void GetOrAdd_WhenKeyIsAbsent_ShouldAddAndReturnValue()
+    {
+        Dictionary<string, int> dictionary = new();
+
+        int result = dictionary.GetOrAdd("a", 1);
+
+        Assert.AreEqual(1, result);
+        Assert.AreEqual(1, dictionary["a"]);
+    }
+
+    /// <summary>
+    /// Verifies that the value overload returns the existing value without overwriting it.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAdd_WhenKeyIsPresent_ShouldReturnExistingValueWithoutOverwriting()
+    {
+        Dictionary<string, int> dictionary = new() { ["a"] = 1 };
+
+        int result = dictionary.GetOrAdd("a", 99);
+
+        Assert.AreEqual(1, result);
+        Assert.AreEqual(1, dictionary["a"]);
+    }
+
+    /// <summary>
+    /// Verifies that the factory overload invokes the factory and adds its result when the key is absent.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAdd_WhenKeyIsAbsent_ForFactoryOverload_ShouldInvokeFactoryAndAdd()
+    {
+        Dictionary<string, int> dictionary = new();
+
+        int result = dictionary.GetOrAdd("key", k => k.Length);
+
+        Assert.AreEqual(3, result);
+        Assert.AreEqual(3, dictionary["key"]);
+    }
+
+    /// <summary>
+    /// Verifies that the factory overload does not invoke the factory when the key is already present.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAdd_WhenKeyIsPresent_ForFactoryOverload_ShouldNotInvokeFactory()
+    {
+        Dictionary<string, int> dictionary = new() { ["a"] = 1 };
+        bool invoked = false;
+
+        int result = dictionary.GetOrAdd("a", _ =>
+        {
+            invoked = true;
+            return 99;
+        });
+
+        Assert.AreEqual(1, result);
+        Assert.IsFalse(invoked);
+    }
+
+    /// <summary>
+    /// Verifies that the value overload throws <see cref="ArgumentNullException" /> when the dictionary is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAdd_WhenDictionaryIsNull_ShouldThrowArgumentNullException()
+    {
+        IDictionary<string, int> dictionary = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = dictionary.GetOrAdd("a", 1);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the factory overload throws <see cref="ArgumentNullException" /> when the factory is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAdd_WhenFactoryIsNull_ShouldThrowArgumentNullException()
+    {
+        Dictionary<string, int> dictionary = new();
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = dictionary.GetOrAdd("a", (Func<string, int>)null!);
+        });
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.ForEach.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.ForEach.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.ForEach.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IEnumerableExtensionsTests_ForEach
+{
+    /// <summary>
+    /// Verifies that <c>ForEach</c> invokes the action once for each element, in sequence order.
+    /// </summary>
+    [TestMethod]
+    public void ForEach_WhenInvoked_ShouldCallActionForEachElementInOrder()
+    {
+        List<int> observed = new();
+
+        new[] { 1, 2, 3 }.ForEach(observed.Add);
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, observed);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ForEach</c> does not invoke the action for an empty sequence.
+    /// </summary>
+    [TestMethod]
+    public void ForEach_WhenSourceIsEmpty_ShouldNotInvokeAction()
+    {
+        int count = 0;
+
+        Array.Empty<int>().ForEach(_ => count++);
+
+        Assert.AreEqual(0, count);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ForEach</c> throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ForEach_WhenSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        IEnumerable<int> source = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            source.ForEach(_ => { });
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <c>ForEach</c> throws <see cref="ArgumentNullException" /> when the action is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ForEach_WhenActionIsNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            new[] { 1, 2, 3 }.ForEach(null!);
+        });
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Index.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.Index.cs
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.Index.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+#if !NET9_0_OR_GREATER
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IEnumerableExtensionsTests_Index
+{
+    /// <summary>
+    /// Verifies that <c>Index</c> pairs each element with its zero-based position, in order.
+    /// </summary>
+    [TestMethod]
+    public void Index_WhenInvoked_ShouldPairEachElementWithItsPosition()
+    {
+        (int Index, string Item)[] result = new[] { "a", "b", "c" }.Index().ToArray();
+
+        CollectionAssert.AreEqual(
+            new[] { (0, "a"), (1, "b"), (2, "c") },
+            result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Index</c> returns an empty sequence for an empty source.
+    /// </summary>
+    [TestMethod]
+    public void Index_WhenSourceIsEmpty_ShouldReturnEmptySequence()
+    {
+        Assert.AreEqual(0, Array.Empty<int>().Index().Count());
+    }
+
+    /// <summary>
+    /// Verifies that <c>Index</c> defers enumeration of the source until the result is iterated.
+    /// </summary>
+    [TestMethod]
+    public void Index_WhenResultNotEnumerated_ShouldNotEnumerateSource()
+    {
+        bool enumerated = false;
+
+        IEnumerable<int> Source()
+        {
+            enumerated = true;
+            yield return 1;
+        }
+
+        _ = Source().Index();
+
+        Assert.IsFalse(enumerated);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Index</c> throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Index_WhenSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        IEnumerable<int> source = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = source.Index();
+        });
+    }
+}
+
+#endif

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.IsNullOrEmpty.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.IsNullOrEmpty.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.IsNullOrEmpty.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IEnumerableExtensionsTests_IsNullOrEmpty
+{
+    /// <summary>
+    /// Verifies that <c>IsNullOrEmpty</c> returns <see langword="true" /> for a <see langword="null" /> sequence.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void IsNullOrEmpty_WhenSourceIsNull_ShouldReturnTrue()
+    {
+        IEnumerable<int>? source = null;
+
+        Assert.IsTrue(source.IsNullOrEmpty());
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsNullOrEmpty</c> returns <see langword="true" /> for an empty counted collection.
+    /// </summary>
+    [TestMethod]
+    public void IsNullOrEmpty_WhenSourceIsEmptyCollection_ShouldReturnTrue()
+    {
+        Assert.IsTrue(Array.Empty<int>().IsNullOrEmpty());
+        Assert.IsTrue(new List<int>().IsNullOrEmpty());
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsNullOrEmpty</c> returns <see langword="false" /> for a non-empty counted collection.
+    /// </summary>
+    [TestMethod]
+    public void IsNullOrEmpty_WhenSourceIsNonEmptyCollection_ShouldReturnFalse()
+    {
+        Assert.IsFalse(new[] { 1 }.IsNullOrEmpty());
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsNullOrEmpty</c> returns <see langword="true" /> for an empty lazy sequence that exposes no
+    /// count.
+    /// </summary>
+    [TestMethod]
+    public void IsNullOrEmpty_WhenSourceIsEmptyLazySequence_ShouldReturnTrue()
+    {
+        Assert.IsTrue(Enumerable.Empty<int>().Where(_ => true).IsNullOrEmpty());
+    }
+
+    /// <summary>
+    /// Verifies that <c>IsNullOrEmpty</c> returns <see langword="false" /> for a non-empty lazy sequence that exposes
+    /// no count.
+    /// </summary>
+    [TestMethod]
+    public void IsNullOrEmpty_WhenSourceIsNonEmptyLazySequence_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Enumerable.Range(1, 3).Where(_ => true).IsNullOrEmpty());
+    }
+}

--- a/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.WhereNotNull.cs
+++ b/Bodu.Core/test/Collections.Generic.Extensions/IEnumerableExtensions.WhereNotNull.cs
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IEnumerableExtensions.WhereNotNull.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Collections.Generic.Extensions;
+
+[TestClass]
+public sealed partial class IEnumerableExtensionsTests_WhereNotNull
+{
+    /// <summary>
+    /// Verifies that <c>WhereNotNull</c> removes <see langword="null" /> references from a reference-type sequence.
+    /// </summary>
+    [TestMethod]
+    public void WhereNotNull_WhenSourceIsReferenceType_ShouldRemoveNulls()
+    {
+        string?[] source = ["a", null, "b", null, "c"];
+
+        CollectionAssert.AreEqual(new[] { "a", "b", "c" }, source.WhereNotNull().ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <c>WhereNotNull</c> removes <see langword="null" /> elements from a nullable value-type sequence
+    /// and unwraps the remaining values.
+    /// </summary>
+    [TestMethod]
+    public void WhereNotNull_WhenSourceIsNullableValueType_ShouldRemoveNullsAndUnwrap()
+    {
+        int?[] source = [1, null, 2, null, 3];
+
+        CollectionAssert.AreEqual(new[] { 1, 2, 3 }, source.WhereNotNull().ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <c>WhereNotNull</c> defers enumeration of the source until the result is iterated.
+    /// </summary>
+    [TestMethod]
+    public void WhereNotNull_WhenResultNotEnumerated_ShouldNotEnumerateSource()
+    {
+        bool enumerated = false;
+
+        IEnumerable<string?> Source()
+        {
+            enumerated = true;
+            yield return "a";
+        }
+
+        _ = Source().WhereNotNull();
+
+        Assert.IsFalse(enumerated);
+    }
+
+    /// <summary>
+    /// Verifies that the reference-type overload throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void WhereNotNull_WhenReferenceSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        IEnumerable<string?> source = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = source.WhereNotNull();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the nullable value-type overload throws <see cref="ArgumentNullException" /> when the source is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void WhereNotNull_WhenValueSourceIsNull_ShouldThrowArgumentNullException()
+    {
+        IEnumerable<int?> source = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = source.WhereNotNull();
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.ClearFlag.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.ClearFlag.cs
@@ -1,0 +1,55 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.ClearFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class EnumExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>ClearFlag</c> returns a value with the requested bits removed.
+    /// </summary>
+    [TestMethod]
+    public void ClearFlag_WhenFlagIsSet_ShouldRemoveTheFlag()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B | IntFlags.C;
+
+        Assert.AreEqual(IntFlags.A | IntFlags.C, value.ClearFlag(IntFlags.B));
+    }
+
+    /// <summary>
+    /// Verifies that <c>ClearFlag</c> leaves the value unchanged when the requested bits are not set.
+    /// </summary>
+    [TestMethod]
+    public void ClearFlag_WhenFlagIsAbsent_ShouldReturnEquivalentValue()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.AreEqual(value, value.ClearFlag(IntFlags.D));
+    }
+
+    /// <summary>
+    /// Verifies that <c>ClearFlag</c> leaves other bits untouched when clearing a single flag.
+    /// </summary>
+    [TestMethod]
+    public void ClearFlag_WhenClearingOneFlag_ShouldPreserveOtherFlags()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B | IntFlags.D;
+
+        Assert.AreEqual(IntFlags.A | IntFlags.D, value.ClearFlag(IntFlags.B));
+    }
+
+    /// <summary>
+    /// Verifies that <c>ClearFlag</c> clears a bit beyond the 32-bit range for a <see cref="long" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void ClearFlag_ForLongBackedEnum_ShouldClearBitAboveInt32()
+    {
+        LongFlags value = LongFlags.A | LongFlags.High;
+
+        Assert.AreEqual(LongFlags.A, value.ClearFlag(LongFlags.High));
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.HasAllFlags.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.HasAllFlags.cs
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.HasAllFlags.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class EnumExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>HasAllFlags</c> returns <see langword="true" /> when every bit in the flags argument is set
+    /// in the value.
+    /// </summary>
+    [TestMethod]
+    public void HasAllFlags_WhenAllFlagsPresent_ShouldReturnTrue()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B | IntFlags.C;
+
+        Assert.IsTrue(value.HasAllFlags(IntFlags.A | IntFlags.C));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAllFlags</c> returns <see langword="false" /> when only some of the requested bits are
+    /// set in the value.
+    /// </summary>
+    [TestMethod]
+    public void HasAllFlags_WhenSomeFlagsMissing_ShouldReturnFalse()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.IsFalse(value.HasAllFlags(IntFlags.A | IntFlags.D));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAllFlags</c> returns <see langword="true" /> when the flags argument has no bits set.
+    /// </summary>
+    [TestMethod]
+    public void HasAllFlags_WhenFlagsIsNone_ShouldReturnTrue()
+    {
+        Assert.IsTrue(IntFlags.A.HasAllFlags(IntFlags.None));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAllFlags</c> evaluates a bit beyond the 32-bit range for a <see cref="long" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void HasAllFlags_ForLongBackedEnum_ShouldEvaluateBitAboveInt32()
+    {
+        LongFlags value = LongFlags.High | LongFlags.A;
+
+        Assert.IsTrue(value.HasAllFlags(LongFlags.High | LongFlags.A));
+        Assert.IsFalse(value.HasAllFlags(LongFlags.High | LongFlags.B));
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.HasAnyFlag.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.HasAnyFlag.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.HasAnyFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class EnumExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>HasAnyFlag</c> returns <see langword="true" /> when the value and the flags share at least
+    /// one set bit.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void HasAnyFlag_WhenValueSharesABit_ShouldReturnTrue()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.IsTrue(value.HasAnyFlag(IntFlags.B | IntFlags.C));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAnyFlag</c> returns <see langword="false" /> when the value and the flags share no bits.
+    /// </summary>
+    [TestMethod]
+    public void HasAnyFlag_WhenValueSharesNoBit_ShouldReturnFalse()
+    {
+        Assert.IsFalse(IntFlags.A.HasAnyFlag(IntFlags.B | IntFlags.C));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAnyFlag</c> returns <see langword="false" /> when the flags argument has no bits set.
+    /// </summary>
+    [TestMethod]
+    public void HasAnyFlag_WhenFlagsIsNone_ShouldReturnFalse()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.IsFalse(value.HasAnyFlag(IntFlags.None));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAnyFlag</c> evaluates the most significant bit of a <see cref="byte" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void HasAnyFlag_ForByteBackedEnum_ShouldEvaluateHighBit()
+    {
+        Assert.IsTrue((ByteFlags.High | ByteFlags.A).HasAnyFlag(ByteFlags.High));
+        Assert.IsFalse((ByteFlags.A | ByteFlags.B).HasAnyFlag(ByteFlags.High));
+    }
+
+    /// <summary>
+    /// Verifies that <c>HasAnyFlag</c> evaluates a bit beyond the 32-bit range for a <see cref="long" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void HasAnyFlag_ForLongBackedEnum_ShouldEvaluateBitAboveInt32()
+    {
+        Assert.IsTrue((LongFlags.High | LongFlags.A).HasAnyFlag(LongFlags.High));
+        Assert.IsFalse((LongFlags.A | LongFlags.B).HasAnyFlag(LongFlags.High));
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.SetFlag.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.SetFlag.cs
@@ -1,0 +1,44 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.SetFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class EnumExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>SetFlag</c> returns a value with the requested bits added to the original.
+    /// </summary>
+    [TestMethod]
+    public void SetFlag_WhenFlagIsAbsent_ShouldAddTheFlag()
+    {
+        IntFlags result = IntFlags.A.SetFlag(IntFlags.C);
+
+        Assert.AreEqual(IntFlags.A | IntFlags.C, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>SetFlag</c> leaves the value unchanged when the requested bits are already set.
+    /// </summary>
+    [TestMethod]
+    public void SetFlag_WhenFlagIsAlreadySet_ShouldReturnEquivalentValue()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.AreEqual(value, value.SetFlag(IntFlags.B));
+    }
+
+    /// <summary>
+    /// Verifies that <c>SetFlag</c> sets a bit beyond the 32-bit range for a <see cref="long" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void SetFlag_ForLongBackedEnum_ShouldSetBitAboveInt32()
+    {
+        LongFlags result = LongFlags.A.SetFlag(LongFlags.High);
+
+        Assert.AreEqual(LongFlags.A | LongFlags.High, result);
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.ToggleFlag.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.ToggleFlag.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.ToggleFlag.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class EnumExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>ToggleFlag</c> sets a bit that was previously clear.
+    /// </summary>
+    [TestMethod]
+    public void ToggleFlag_WhenFlagIsClear_ShouldSetTheFlag()
+    {
+        IntFlags result = IntFlags.A.ToggleFlag(IntFlags.C);
+
+        Assert.AreEqual(IntFlags.A | IntFlags.C, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ToggleFlag</c> clears a bit that was previously set.
+    /// </summary>
+    [TestMethod]
+    public void ToggleFlag_WhenFlagIsSet_ShouldClearTheFlag()
+    {
+        IntFlags value = IntFlags.A | IntFlags.C;
+
+        Assert.AreEqual(IntFlags.A, value.ToggleFlag(IntFlags.C));
+    }
+
+    /// <summary>
+    /// Verifies that toggling the same flags twice restores the original value.
+    /// </summary>
+    [TestMethod]
+    public void ToggleFlag_WhenAppliedTwice_ShouldRestoreOriginalValue()
+    {
+        IntFlags value = IntFlags.A | IntFlags.B;
+
+        Assert.AreEqual(value, value.ToggleFlag(IntFlags.C | IntFlags.D).ToggleFlag(IntFlags.C | IntFlags.D));
+    }
+
+    /// <summary>
+    /// Verifies that <c>ToggleFlag</c> flips a bit beyond the 32-bit range for a <see cref="long" />-backed
+    /// enumeration.
+    /// </summary>
+    [TestMethod]
+    public void ToggleFlag_ForLongBackedEnum_ShouldFlipBitAboveInt32()
+    {
+        Assert.AreEqual(LongFlags.A | LongFlags.High, LongFlags.A.ToggleFlag(LongFlags.High));
+        Assert.AreEqual(LongFlags.A, (LongFlags.A | LongFlags.High).ToggleFlag(LongFlags.High));
+    }
+}

--- a/Bodu.Core/test/Extensions/EnumExtensionsTests.cs
+++ b/Bodu.Core/test/Extensions/EnumExtensionsTests.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="EnumExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Base class for <see cref="EnumExtensions" /> tests. Declares the flag enumerations, of varying underlying
+/// integer width, shared by the bitwise-helper test suites.
+/// </summary>
+[TestClass]
+public partial class EnumExtensionsTests
+{
+    /// <summary>A flag enumeration backed by <see cref="byte" />, exercising the one-byte reinterpretation path.</summary>
+    [Flags]
+    internal enum ByteFlags : byte
+    {
+        /// <summary>No flag bits set.</summary>
+        None = 0,
+
+        /// <summary>The first flag bit.</summary>
+        A = 1,
+
+        /// <summary>The second flag bit.</summary>
+        B = 1 << 1,
+
+        /// <summary>The third flag bit.</summary>
+        C = 1 << 2,
+
+        /// <summary>The most significant bit of the underlying byte.</summary>
+        High = 1 << 7,
+    }
+
+    /// <summary>A flag enumeration backed by the default <see cref="int" /> underlying type.</summary>
+    [Flags]
+    internal enum IntFlags
+    {
+        /// <summary>No flag bits set.</summary>
+        None = 0,
+
+        /// <summary>The first flag bit.</summary>
+        A = 1,
+
+        /// <summary>The second flag bit.</summary>
+        B = 1 << 1,
+
+        /// <summary>The third flag bit.</summary>
+        C = 1 << 2,
+
+        /// <summary>The fourth flag bit.</summary>
+        D = 1 << 3,
+    }
+
+    /// <summary>A flag enumeration backed by <see cref="long" />, exercising the eight-byte reinterpretation path.</summary>
+    [Flags]
+    internal enum LongFlags : long
+    {
+        /// <summary>No flag bits set.</summary>
+        None = 0L,
+
+        /// <summary>The first flag bit.</summary>
+        A = 1L,
+
+        /// <summary>The second flag bit.</summary>
+        B = 1L << 1,
+
+        /// <summary>A flag bit set at position 40, beyond the 32-bit range.</summary>
+        High = 1L << 40,
+    }
+}

--- a/Bodu.Core/test/Extensions/StreamExtensionsTests.ReadAllBytes.cs
+++ b/Bodu.Core/test/Extensions/StreamExtensionsTests.ReadAllBytes.cs
@@ -1,0 +1,82 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensionsTests.ReadAllBytes.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class StreamExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>ReadAllBytes</c> returns the full content of a seekable stream.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void ReadAllBytes_WhenStreamIsSeekable_ShouldReturnAllBytes()
+    {
+        byte[] content = [1, 2, 3, 4, 5];
+        using MemoryStream stream = new(content);
+
+        byte[] result = stream.ReadAllBytes();
+
+        CollectionAssert.AreEqual(content, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytes</c> reads only from the current position onward.
+    /// </summary>
+    [TestMethod]
+    public void ReadAllBytes_WhenPositionIsAdvanced_ShouldReturnRemainingBytes()
+    {
+        using MemoryStream stream = new([1, 2, 3, 4, 5]);
+        stream.Position = 2;
+
+        byte[] result = stream.ReadAllBytes();
+
+        CollectionAssert.AreEqual(new byte[] { 3, 4, 5 }, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytes</c> returns an empty array when no bytes remain.
+    /// </summary>
+    [TestMethod]
+    public void ReadAllBytes_WhenStreamIsAtEnd_ShouldReturnEmptyArray()
+    {
+        using MemoryStream stream = new([1, 2, 3]);
+        stream.Position = stream.Length;
+
+        byte[] result = stream.ReadAllBytes();
+
+        Assert.AreEqual(0, result.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytes</c> reads the full content of a non-seekable stream.
+    /// </summary>
+    [TestMethod]
+    public void ReadAllBytes_WhenStreamIsNotSeekable_ShouldReturnAllBytes()
+    {
+        byte[] content = [10, 20, 30, 40];
+        using NonSeekableMemoryStream stream = new(content);
+
+        byte[] result = stream.ReadAllBytes();
+
+        CollectionAssert.AreEqual(content, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytes</c> throws <see cref="ArgumentNullException" /> when the stream is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ReadAllBytes_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Stream stream = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = stream.ReadAllBytes();
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/StreamExtensionsTests.ReadAllBytesAsync.cs
+++ b/Bodu.Core/test/Extensions/StreamExtensionsTests.ReadAllBytesAsync.cs
@@ -1,0 +1,67 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensionsTests.ReadAllBytesAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class StreamExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>ReadAllBytesAsync</c> returns the full content of a seekable stream.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadAllBytesAsync_WhenStreamIsSeekable_ShouldReturnAllBytes()
+    {
+        byte[] content = [1, 2, 3, 4, 5];
+        using MemoryStream stream = new(content);
+
+        byte[] result = await stream.ReadAllBytesAsync();
+
+        CollectionAssert.AreEqual(content, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytesAsync</c> reads the full content of a non-seekable stream.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadAllBytesAsync_WhenStreamIsNotSeekable_ShouldReturnAllBytes()
+    {
+        byte[] content = [9, 8, 7, 6];
+        using NonSeekableMemoryStream stream = new(content);
+
+        byte[] result = await stream.ReadAllBytesAsync();
+
+        CollectionAssert.AreEqual(content, result);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytesAsync</c> returns an empty array when no bytes remain.
+    /// </summary>
+    [TestMethod]
+    public async Task ReadAllBytesAsync_WhenStreamIsAtEnd_ShouldReturnEmptyArray()
+    {
+        using MemoryStream stream = new([1, 2, 3]);
+        stream.Position = stream.Length;
+
+        byte[] result = await stream.ReadAllBytesAsync();
+
+        Assert.AreEqual(0, result.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <c>ReadAllBytesAsync</c> throws <see cref="ArgumentNullException" /> synchronously when the
+    /// stream is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void ReadAllBytesAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Stream stream = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = stream.ReadAllBytesAsync();
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/StreamExtensionsTests.WriteAllBytes.cs
+++ b/Bodu.Core/test/Extensions/StreamExtensionsTests.WriteAllBytes.cs
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensionsTests.WriteAllBytes.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class StreamExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>WriteAllBytes</c> writes the entire span to the stream.
+    /// </summary>
+    [TestMethod]
+    public void WriteAllBytes_WhenInvoked_ShouldWriteAllBytes()
+    {
+        byte[] content = [1, 2, 3, 4, 5];
+        using MemoryStream stream = new();
+
+        stream.WriteAllBytes(content);
+
+        CollectionAssert.AreEqual(content, stream.ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <c>WriteAllBytes</c> writes nothing when the span is empty.
+    /// </summary>
+    [TestMethod]
+    public void WriteAllBytes_WhenSpanIsEmpty_ShouldWriteNothing()
+    {
+        using MemoryStream stream = new();
+
+        stream.WriteAllBytes(ReadOnlySpan<byte>.Empty);
+
+        Assert.AreEqual(0L, stream.Length);
+    }
+
+    /// <summary>
+    /// Verifies that <c>WriteAllBytes</c> throws <see cref="ArgumentNullException" /> when the stream is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void WriteAllBytes_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Stream stream = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            stream.WriteAllBytes(new byte[] { 1, 2, 3 });
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/StreamExtensionsTests.WriteAllBytesAsync.cs
+++ b/Bodu.Core/test/Extensions/StreamExtensionsTests.WriteAllBytesAsync.cs
@@ -1,0 +1,39 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensionsTests.WriteAllBytesAsync.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+public partial class StreamExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>WriteAllBytesAsync</c> writes the entire buffer to the stream.
+    /// </summary>
+    [TestMethod]
+    public async Task WriteAllBytesAsync_WhenInvoked_ShouldWriteAllBytes()
+    {
+        byte[] content = [1, 2, 3, 4, 5];
+        using MemoryStream stream = new();
+
+        await stream.WriteAllBytesAsync(content);
+
+        CollectionAssert.AreEqual(content, stream.ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <c>WriteAllBytesAsync</c> throws <see cref="ArgumentNullException" /> synchronously when the
+    /// stream is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void WriteAllBytesAsync_WhenStreamIsNull_ShouldThrowArgumentNullException()
+    {
+        Stream stream = null!;
+
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = stream.WriteAllBytesAsync(new byte[] { 1, 2, 3 });
+        });
+    }
+}

--- a/Bodu.Core/test/Extensions/StreamExtensionsTests.cs
+++ b/Bodu.Core/test/Extensions/StreamExtensionsTests.cs
@@ -1,0 +1,34 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Extensions;
+
+/// <summary>
+/// Base class for <see cref="StreamExtensions" /> tests. Provides the non-seekable stream fixture used to exercise
+/// the growable-buffer code path.
+/// </summary>
+[TestClass]
+public partial class StreamExtensionsTests
+{
+    /// <summary>
+    /// A <see cref="MemoryStream" /> that reports itself as non-seekable, forcing the <see cref="StreamExtensions" />
+    /// read helpers down their growable-buffer path while still serving content from memory.
+    /// </summary>
+    private sealed class NonSeekableMemoryStream : MemoryStream
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NonSeekableMemoryStream" /> class over the supplied bytes.
+        /// </summary>
+        /// <param name="buffer">The backing content exposed by the stream.</param>
+        public NonSeekableMemoryStream(byte[] buffer)
+            : base(buffer)
+        {
+        }
+
+        /// <inheritdoc />
+        public override bool CanSeek => false;
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds a comprehensive set of extension methods across four namespaces to improve developer ergonomics and reduce boilerplate:

- **EnumExtensions**: Non-boxing bitwise flag helpers for all enum underlying types
- **StreamExtensions**: Whole-payload read/write helpers (sync and async)
- **IDictionaryExtensions**: Get-or-add and add-or-update operations
- **IEnumerableExtensions**: Filtering, iteration, and utility methods

## Key Changes

### EnumExtensions (Bodu.Core/src/Extensions/)
- `HasAllFlags<TEnum>()` — Tests whether all bits in a flag argument are set
- `HasAnyFlag<TEnum>()` — Tests whether at least one bit in a flag argument is set
- `SetFlag<TEnum>()` — Returns a copy with requested bits set
- `ClearFlag<TEnum>()` — Returns a copy with requested bits cleared
- `ToggleFlag<TEnum>()` — Returns a copy with requested bits flipped
- `BitConversion.cs` — Internal helper for reinterpreting enum bit patterns as `ulong` without boxing, with JIT-time width resolution for 1/2/4/8-byte enums

### StreamExtensions (Bodu.Core/src/Extensions/)
- `ReadAllBytes(Stream)` — Reads from current position to end; uses single-buffer allocation for seekable streams, growable buffer for non-seekable
- `ReadAllBytesAsync(Stream, CancellationToken)` — Async variant
- `WriteAllBytes(Stream, ReadOnlySpan<byte>)` — Writes entire span at current position
- `WriteAllBytesAsync(Stream, byte[], CancellationToken)` — Async variant

### IDictionaryExtensions (Bodu.Core/src/Collections.Generic.Extensions/)
- `GetOrAdd<TKey, TValue>(IDictionary, TKey, TValue)` — Returns existing value or adds and returns the provided value
- `GetOrAdd<TKey, TValue>(IDictionary, TKey, Func<TKey, TValue>)` — Factory overload; factory only invoked if key absent
- `AddOrUpdate<TKey, TValue>(IDictionary, TKey, TValue)` — Inserts or replaces value

### IEnumerableExtensions (Bodu.Core/src/Collections.Generic.Extensions/)
- `WhereNotNull<TSource>()` — Filters nullable references; removes `null` elements
- `WhereNotNull<TSource>()` — Overload for nullable value types; removes `null` and unwraps
- `ForEach<TSource>(IEnumerable, Action)` — Invokes action for each element in sequence
- `IsNullOrEmpty<TSource>(IEnumerable)` — Returns `true` if source is `null` or empty; optimized for counted collections
- `Index<TSource>()` — Pairs each element with its zero-based position (NET9_0_OR_GREATER conditional)

## Implementation Details

- **Enum helpers** use `System.Runtime.CompilerServices.Unsafe` for zero-copy bit reinterpretation; width switching is resolved at JIT time per closed generic type
- **Stream helpers** defer allocation decisions based on seekability; non-seekable streams use `MemoryStream` accumulation
- **Dictionary helpers** follow `ConcurrentDictionary` semantics but provide no atomicity guarantee (two-phase lookup + insert)
- **Enumerable helpers** use deferred execution (iterator pattern) where appropriate; `IsNullOrEmpty` fast-paths `ICollection<T>` and `IReadOnlyCollection<T>`
- All methods include comprehensive XML documentation and null-argument validation via `ThrowHelper`
- Full test coverage with smoke, boundary, and exception-handling scenarios per test convention

https://claude.ai/code/session_014iCeLg1AwCfFk4pdhsd3r9