### PR TITLE
Add input validation to prevent unsafe indexing and padding operations

### DIFF
--- a/Bodu.Core/src/Collections.Generic/SegmentedBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic/SegmentedBuffer.cs
@@ -101,7 +101,8 @@ public sealed class SegmentedBuffer<T> :
     {
         get
         {
-            ThrowHelper.ThrowIfGreaterThanOther(index, Count - 1);
+            ThrowHelper.ThrowIfLessThan(index, 0);
+            ThrowHelper.ThrowIfGreaterThanOrEqual(index, Count);
 
             var segmentIndex = index / _segmentSize;
             var offset = index % _segmentSize;
@@ -110,7 +111,8 @@ public sealed class SegmentedBuffer<T> :
 
         set
         {
-            ThrowHelper.ThrowIfGreaterThanOther(index, Count);
+            ThrowHelper.ThrowIfLessThan(index, 0);
+            ThrowHelper.ThrowIfGreaterThanOrEqual(index, Count);
 
             var segmentIndex = index / _segmentSize;
             var offset = index % _segmentSize;

--- a/Bodu.Core/test/Collections.Generic/SegmentedBufferTests.cs
+++ b/Bodu.Core/test/Collections.Generic/SegmentedBufferTests.cs
@@ -125,7 +125,7 @@ public sealed class SegmentedBufferTests
     }
 
     /// <summary>
-    /// Verifies that the indexer getter throws <see cref="ArgumentException" /> when the index exceeds the buffer count.
+    /// Verifies that the indexer getter throws <see cref="ArgumentOutOfRangeException" /> when the index exceeds the buffer count.
     /// </summary>
     [TestMethod]
     public void Indexer_Get_WhenIndexIsBeyondCount_ShouldThrowExactly()
@@ -133,9 +133,78 @@ public sealed class SegmentedBufferTests
         var buffer = new SegmentedBuffer<int>(4);
         buffer.Add(0);
 
-        Assert.ThrowsExactly<ArgumentException>(() =>
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
         {
             _ = buffer[1];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer getter throws <see cref="ArgumentOutOfRangeException" /> when the index is negative,
+    /// rather than indexing a backing segment with a negative offset and surfacing an <see cref="IndexOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void Indexer_Get_WhenIndexIsNegative_ShouldThrowExactly(int index)
+    {
+        var buffer = new SegmentedBuffer<int>(4);
+        buffer.Add(0);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = buffer[index];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer setter throws <see cref="ArgumentOutOfRangeException" /> when the index is negative,
+    /// rather than writing to a backing segment at a negative offset.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(int.MinValue)]
+    public void Indexer_Set_WhenIndexIsNegative_ShouldThrowExactly(int index)
+    {
+        var buffer = new SegmentedBuffer<int>(4);
+        buffer.Add(0);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            buffer[index] = 1;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer setter throws <see cref="ArgumentOutOfRangeException" /> when the index equals
+    /// <see cref="SegmentedBuffer{T}.Count" />, which is one position past the last element, rather than silently
+    /// writing into an unused segment slot.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenIndexEqualsCount_ShouldThrowExactly()
+    {
+        var buffer = new SegmentedBuffer<int>(4);
+        buffer.Add(0);
+        buffer.Add(1);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            buffer[buffer.Count] = 99;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer setter throws <see cref="ArgumentOutOfRangeException" /> when the index exceeds the buffer count.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_Set_WhenIndexIsBeyondCount_ShouldThrowExactly()
+    {
+        var buffer = new SegmentedBuffer<int>(4);
+        buffer.Add(0);
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            buffer[5] = 99;
         });
     }
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
@@ -42,7 +42,7 @@ public sealed class AsalhaPujaNotableDateAlgorithm
     /// A <see cref="DateTime" /> representing the date of Asalha Puja, or <see langword="null" /> if the date cannot be
     /// determined. The returned <see cref="DateTime.Kind" /> is always <see cref="DateTimeKind.Unspecified" />.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1 or greater than 9999.</exception>
     /// <exception cref="NotSupportedException">
     /// Thrown when the specified <paramref name="calendar" /> type is unsupported.
     /// </exception>
@@ -50,6 +50,7 @@ public sealed class AsalhaPujaNotableDateAlgorithm
     {
         if (year < 1)
             throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         DateTime? fullMoon = LunarPhaseAlgorithm.GetFullMoonOnOrAfter(new DateTime(year, 6, 15));
         if (fullMoon is null)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
@@ -54,6 +54,7 @@ public sealed class EasterSundayNotableDateAlgorithm
     public DateTime? GetDate(int year, System.Globalization.Calendar? calendar)
     {
         ThrowHelper.ThrowIfLessThan(year, 1);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         return GetOrAddEasterSunday(year, calendar);
     }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase.cs
@@ -83,6 +83,7 @@ public abstract class EasterSundayNotableDateProviderBase
     public IReadOnlyList<NotableDate> GetDates(int year, SysGlobal.Calendar? calendar = null)
     {
         ThrowHelper.ThrowIfLessThan(year, 1);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         ValidateCalendar(calendar);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
@@ -119,7 +119,7 @@ public sealed class HinduLunarNotableDateAlgorithm
     /// date cannot be determined. The returned <see cref="DateTime.Kind" /> is always
     /// <see cref="DateTimeKind.Unspecified" />.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1 or greater than 9999.</exception>
     /// <exception cref="NotSupportedException">
     /// Thrown when the specified <paramref name="calendar" /> type is unsupported.
     /// </exception>
@@ -127,6 +127,7 @@ public sealed class HinduLunarNotableDateAlgorithm
     {
         if (year < 1)
             throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         // Find the new moon that begins the target lunar month.
         var searchMonth = GetSearchMonth(_month);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
@@ -47,7 +47,7 @@ public sealed class LosarNotableDateAlgorithm
     /// cannot be determined. The returned <see cref="DateTime.Kind" /> is always
     /// <see cref="DateTimeKind.Unspecified" />.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1 or greater than 9999.</exception>
     /// <exception cref="NotSupportedException">
     /// Thrown when the specified <paramref name="calendar" /> type is unsupported.
     /// </exception>
@@ -55,6 +55,7 @@ public sealed class LosarNotableDateAlgorithm
     {
         if (year < 1)
             throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         // The Tibetan New Year falls on or shortly after the second new moon after the winter
         // solstice. The winter solstice is approximately 21 December; the second new moon after

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
@@ -69,7 +69,7 @@ public sealed class QingmingNotableDateAlgorithm
     /// A <see cref="DateTime" /> representing the date of Qingming in the specified calendar system. The returned
     /// <see cref="DateTime.Kind" /> is always <see cref="DateTimeKind.Unspecified" />.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1 or greater than 9999.</exception>
     /// <exception cref="NotSupportedException">
     /// Thrown when the specified <paramref name="calendar" /> type is unsupported.
     /// </exception>
@@ -77,6 +77,7 @@ public sealed class QingmingNotableDateAlgorithm
     {
         if (year < 1)
             throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         var equinoxJde = ComputeVernalEquinoxJde(year);
         var qingmingJde = equinoxJde + DegreesToDays15;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
@@ -43,7 +43,7 @@ public sealed class VesakNotableDateAlgorithm
     /// A <see cref="DateTime" /> representing the date of Vesak, or <see langword="null" /> if the date cannot be
     /// determined. The returned <see cref="DateTime.Kind" /> is always <see cref="DateTimeKind.Unspecified" />.
     /// </returns>
-    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="year" /> is less than 1 or greater than 9999.</exception>
     /// <exception cref="NotSupportedException">
     /// Thrown when the specified <paramref name="calendar" /> type is unsupported.
     /// </exception>
@@ -51,6 +51,7 @@ public sealed class VesakNotableDateAlgorithm
     {
         if (year < 1)
             throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
+        ThrowHelper.ThrowIfGreaterThan(year, 9999);
 
         DateTime? fullMoon = LunarPhaseAlgorithm.GetFullMoonOnOrAfter(new DateTime(year, 5, 1));
         return fullMoon is null ? null : ProjectToCalendar(fullMoon.Value, calendar);

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithmTests.cs
@@ -32,6 +32,23 @@ public sealed class AsalhaPujaNotableDateAlgorithmTests
     }
 
     /// <summary>
+    /// Verifies that requesting Asalha Puja with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the <see cref="DateTime" /> constructor.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = _algorithm.GetDate(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that Asalha Puja returns known correct dates for years where the first full moon on or after
     /// 15 June matches the Thai Asanha Bucha public holiday. Years with Thai intercalary months (such as 2023 and
     /// 2024) are excluded because the official observance is moved to the following lunation.

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithmTests.cs
@@ -27,6 +27,23 @@ public sealed class EasterSundayNotableDateAlgorithmTests
 
     public sealed record EasterSundayKnownAnswer { public int Year { get; init; } public DateTime ExpectedDate { get; init; } public EasterCalendarType CalendarType { get; init; } = EasterCalendarType.Default; }
 
+    /// <summary>
+    /// Verifies that requesting Easter Sunday with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the <see cref="DateTime" /> constructor.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = _algorithm.GetDate(year, null);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
     public static IEnumerable<object[]> GetInvalidYearTestData()
     {
         yield return new object[] { new EasterSundayKnownAnswer { Year = 1700, ExpectedDate = new DateTime(1700, 4, 11) } };

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBaseTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBaseTests.cs
@@ -29,6 +29,25 @@ public sealed class EasterSundayNotableDateProviderBaseTests
     }
 
     /// <summary>
+    /// Verifies that requesting dates with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception leaking from the date calculation.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDates_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var provider = new DefaultTestProvider();
+
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = provider.GetDates(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that the default tag set contains the expected Christianity/Easter entries.
     /// </summary>
     [TestMethod]

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithmTests.cs
@@ -88,6 +88,25 @@ public sealed class HinduLunarNotableDateAlgorithmTests
     }
 
     /// <summary>
+    /// Verifies that requesting a date with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the <see cref="DateTime" /> constructor.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var sut = new HinduLunarNotableDateAlgorithm(HinduLunarMonth.Kartik, HinduPaksha.Krishna, 15);
+
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = sut.GetDate(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that Diwali (Amavasya / Krishna Paksha Chaturdashi of Kartik, i.e. the new moon) falls
     /// within ±2 days of the known panchanga date. Only years without an intercalary Kartik month are included;
     /// years 2022 and 2023 are excluded because an intercalary month causes the algorithm to locate the wrong

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithmTests.cs
@@ -40,6 +40,23 @@ public sealed class LosarNotableDateAlgorithmTests
     }
 
     /// <summary>
+    /// Verifies that requesting Losar with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the <see cref="DateTime" /> constructor.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = _algorithm.GetDate(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that Losar returns a date within ±1 day of the known official Tibetan New Year for years where the
     /// algorithm agrees with the Tibetan lunisolar calendar. Years where the Tibetan calendar diverges by a full
     /// intercalary month are excluded.

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithmTests.cs
@@ -32,6 +32,23 @@ public sealed class QingmingNotableDateAlgorithmTests
     }
 
     /// <summary>
+    /// Verifies that requesting Qingming with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the date calculation overflowing <see cref="DateTime" />.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = _algorithm.GetDate(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that Qingming falls within one calendar day of the published astronomical date for years in the range
     /// 2020–2026. The algorithm computes solar-term transitions in Universal Time; published dates in East Asia use
     /// CST (UTC+8) and may differ by one calendar day when the transition falls near local midnight.

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithmTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithmTests.cs
@@ -32,6 +32,23 @@ public sealed class VesakNotableDateAlgorithmTests
     }
 
     /// <summary>
+    /// Verifies that requesting Vesak with a year above 9999 throws <see cref="ArgumentOutOfRangeException" />
+    /// rather than a raw exception from the <see cref="DateTime" /> constructor.
+    /// </summary>
+    [DataRow(10000)]
+    [DataRow(int.MaxValue)]
+    [TestMethod]
+    public void GetDate_WhenYearGreaterThan9999_ShouldThrowArgumentOutOfRangeException(int year)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = _algorithm.GetDate(year);
+        });
+
+        Assert.AreEqual("year", ex.ParamName);
+    }
+
+    /// <summary>
     /// Verifies that Vesak returns known correct dates for recent years. The expected dates match the Thai Visakha
     /// Bucha public holiday, which is the first full moon on or after 1 May.
     /// </summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -273,6 +273,7 @@ public sealed class Crc
     {
         ThrowHelper.ThrowIfNull(previousHash);
         ThrowHelper.ThrowIfNull(newData);
+        ThrowHelper.ThrowIfArrayOffsetOrCountInvalid(newData, offset, length);
 
         return ComputeHashFrom(previousHash.AsSpan(), newData.AsSpan().Slice(offset, length));
     }

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHashFrom.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHashFrom.cs
@@ -64,6 +64,56 @@ public partial class CrcTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> throws
+    /// <see cref="System.ArgumentOutOfRangeException" /> with <c>ParamName</c> equal to <c>offset</c> when the
+    /// offset is negative, rather than surfacing a span-internal exception from the slice operation.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenOffsetIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        var previousHash = new byte[crc.HashLengthInBytes];
+        byte[] newData = [0x01, 0x02, 0x03, 0x04];
+
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<System.ArgumentOutOfRangeException>(
+            () => crc.ComputeHashFrom(previousHash, newData, -1, 4));
+        Assert.AreEqual("offset", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> throws
+    /// <see cref="System.ArgumentOutOfRangeException" /> with <c>ParamName</c> equal to <c>length</c> when the
+    /// length is negative.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenLengthIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        var previousHash = new byte[crc.HashLengthInBytes];
+        byte[] newData = [0x01, 0x02, 0x03, 0x04];
+
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<System.ArgumentOutOfRangeException>(
+            () => crc.ComputeHashFrom(previousHash, newData, 0, -1));
+        Assert.AreEqual("length", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[], int, int)" /> throws
+    /// <see cref="System.ArgumentException" /> when <c>offset + length</c> exceeds the bounds of
+    /// <paramref name="newData" />, rather than surfacing a span-internal slicing exception.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenOffsetPlusLengthExceedsNewData_ShouldThrowArgumentException()
+    {
+        Crc crc = new(CrcStandard.CRC32_ISOHDLC);
+        var previousHash = new byte[crc.HashLengthInBytes];
+        byte[] newData = [0x01, 0x02, 0x03, 0x04];
+
+        Assert.ThrowsExactly<System.ArgumentException>(
+            () => crc.ComputeHashFrom(previousHash, newData, 3, 4));
+    }
+
+    /// <summary>
     /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[])" /> throws
     /// <see cref="System.ArgumentNullException" /> with <c>ParamName</c> equal to <c>previousHash</c> when the
     /// prior-digest argument is <see langword="null" />.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -50,14 +50,11 @@ public sealed class Ansix923Padding
     /// <param name="blockSize">The block size in bits.</param>
     /// <returns>The padded data as a byte array.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="blockSize" /> is less than or equal to zero.
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         var paddingLength = size - (input.Length % size);
@@ -80,16 +77,16 @@ public sealed class Ansix923Padding
     /// <param name="input">The padded data.</param>
     /// <param name="blockSize">The block size in bits.</param>
     /// <returns>The unpadded data as a byte array.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> is empty or not aligned to the block size.
     /// </exception>
     /// <exception cref="CryptographicException">Thrown if the padding is invalid or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         // Constant-time verification to mitigate CBC padding-oracle attacks.
         var size = blockSize / 8;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -50,14 +50,11 @@ public sealed class Iso10126Padding
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The padded data as a byte array.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="blockSize" /> is less than or equal to zero.
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         var paddingLength = size - (input.Length % size);
@@ -88,16 +85,16 @@ public sealed class Iso10126Padding
     /// <param name="input">The padded data.</param>
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The unpadded data as a byte array.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> is empty or not aligned to the block size.
     /// </exception>
     /// <exception cref="CryptographicException">Thrown if the trailing length byte is out of range.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -52,14 +52,11 @@ public sealed class Iso7816_4Padding
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The padded data as a byte array.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="blockSize" /> is less than or equal to zero.
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         var paddingLength = size - (input.Length % size);
@@ -81,16 +78,16 @@ public sealed class Iso7816_4Padding
     /// <param name="input">The padded data.</param>
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The unpadded data as a byte array.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> is empty or not aligned to the block size.
     /// </exception>
     /// <exception cref="CryptographicException">Thrown if the padding terminator is missing or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -48,15 +48,15 @@ public sealed class NoPadding
     /// <param name="input">The input data to validate and return.</param>
     /// <param name="blockSize">The required block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>A new byte array containing the same bytes as <paramref name="input" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if the length of <paramref name="input" /> is not a multiple of <paramref name="blockSize" />.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         if (input.Length % size != 0)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -309,10 +309,15 @@ public sealed class ParallelMerkleTreeHash
     /// computation. Pass <see langword="null" /> to disable diagnostic recording.
     /// </param>
     /// <returns>A byte array containing the Merkle root hash of <paramref name="data" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="data" /> is <see langword="null" />.</exception>
     /// <exception cref="ObjectDisposedException">The instance has been disposed.</exception>
     /// <exception cref="InvalidOperationException">No input data was provided.</exception>
-    public byte[] ComputeHash(byte[] data, MerkleTreeDiagnostics? diagnostics = null) =>
-        this.ComputeHash(new ReadOnlySpan<byte>(data), diagnostics);
+    public byte[] ComputeHash(byte[] data, MerkleTreeDiagnostics? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        return this.ComputeHash(new ReadOnlySpan<byte>(data), diagnostics);
+    }
 
     /// <summary>
     /// Synchronously computes the Merkle root hash of a region within <paramref name="data" />.
@@ -332,8 +337,12 @@ public sealed class ParallelMerkleTreeHash
     /// <paramref name="count" /> exceeds the length of <paramref name="data" />.
     /// </exception>
     /// <exception cref="InvalidOperationException">No input data was provided.</exception>
-    public byte[] ComputeHash(byte[] data, int offset, int count, MerkleTreeDiagnostics? diagnostics = null) =>
-        this.ComputeHash(new ReadOnlySpan<byte>(data, offset, count), diagnostics);
+    public byte[] ComputeHash(byte[] data, int offset, int count, MerkleTreeDiagnostics? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+
+        return this.ComputeHash(new ReadOnlySpan<byte>(data, offset, count), diagnostics);
+    }
 
     // -----------------------------------------------------------------------------------------
     // Reset — restores the instance to a clean state for the next computation

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -55,14 +55,11 @@ public sealed class Pkcs7Padding
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The padded data as a byte array.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="blockSize" /> is less than or equal to zero.
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         var paddingLength = size - (input.Length % size);
@@ -83,16 +80,16 @@ public sealed class Pkcs7Padding
     /// <param name="input">The padded data.</param>
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The unpadded data as a byte array.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
+    /// </exception>
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> is empty or not aligned to the block size.
     /// </exception>
     /// <exception cref="CryptographicException">Thrown if the padding is invalid or malformed.</exception>
     public byte[] Unpad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ZeroPadding.cs
@@ -47,14 +47,11 @@ public sealed class ZeroPadding
     /// <param name="blockSize">The block size in bits. Must be a positive multiple of 8.</param>
     /// <returns>The padded input.</returns>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// Thrown if <paramref name="blockSize" /> is less than or equal to zero.
+    /// Thrown if <paramref name="blockSize" /> is not a positive multiple of 8.
     /// </exception>
     public byte[] Pad(ReadOnlySpan<byte> input, int blockSize)
     {
-        if (blockSize <= 0)
-            throw new ArgumentOutOfRangeException(
-                nameof(blockSize),
-                string.Format(CryptoResourceStrings.Arg_OutOfRange_BlockSizeMustBeGreaterThan, 0));
+        ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8);
 
         var size = blockSize / 8;
         var paddingLength = size - (input.Length % size);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/MerkleTreeHashTestsBase.ComputeHash.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/MerkleTreeHashTestsBase.ComputeHash.cs
@@ -122,6 +122,36 @@ public abstract partial class MerkleTreeHashTestsBase<THasher>
         });
     }
 
+    /// <summary>
+    /// Verifies that passing a <see langword="null" /> byte array to the <c>ComputeHash(byte[])</c>
+    /// overload raises <see cref="ArgumentNullException" /> rather than silently treating the missing
+    /// array as empty input.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenByteArrayIsNull_ShouldThrowArgumentNullException()
+    {
+        using THasher hasher = Construct(Factory, DefaultBlockSize, DefaultFanOut);
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ComputeHash(hasher, (byte[])null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that passing a <see langword="null" /> byte array to the
+    /// <c>ComputeHash(byte[], int, int)</c> overload raises <see cref="ArgumentNullException" />
+    /// rather than a <see cref="ReadOnlySpan{T}" />-constructor exception keyed to the wrong parameter.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenByteArrayIsNullWithOffsetAndCount_ShouldThrowArgumentNullException()
+    {
+        using THasher hasher = Construct(Factory, DefaultBlockSize, DefaultFanOut);
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            ComputeHash(hasher, (byte[])null!, 0, 0);
+        });
+    }
+
     // ═══════════════════════════════════════════════════════════════════════════════════════════
     // ComputeHash — result shape
     // ═══════════════════════════════════════════════════════════════════════════════════════════

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.BlockSizeValidation.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/PaddingStrategyTests.BlockSizeValidation.cs
@@ -9,15 +9,10 @@ namespace Bodu.Security.Cryptography;
 /// <summary>
 /// Pins the <see cref="IPaddingStrategy" /> contract for invalid <c>blockSize</c> values across
 /// both <c>Pad</c> and <c>Unpad</c>. Every implementation must throw
-/// <see cref="ArgumentOutOfRangeException" /> when <c>blockSize &lt;= 0</c> rather than letting the
-/// modulo arithmetic surface a <see cref="DivideByZeroException" /> or silently succeeding for
-/// inputs whose length happens to be a multiple of <c>|blockSize|</c>.
-/// </summary>
-/// Pins the <see cref="IPaddingStrategy" /> contract for invalid <c>blockSize</c> values across
-/// both <c>Pad</c> and <c>Unpad</c>. Every implementation must throw
-/// <see cref="ArgumentOutOfRangeException" /> when <c>blockSize &lt;= 0</c> rather than letting the
-/// modulo arithmetic surface a <see cref="DivideByZeroException" /> or silently succeeding for
-/// inputs whose length happens to be a multiple of <c>|blockSize|</c>.
+/// <see cref="ArgumentOutOfRangeException" /> when <c>blockSize</c> is not a positive multiple of
+/// 8 — rather than letting the <c>blockSize / 8</c> integer division surface a
+/// <see cref="DivideByZeroException" />, or silently succeeding for inputs whose length happens to
+/// be a multiple of <c>|blockSize|</c>.
 /// </summary>
 /// <remarks>
 /// Strategies whose <c>Unpad</c> ignores <c>blockSize</c> (<see cref="NoPadding" />,
@@ -107,6 +102,55 @@ public abstract partial class PaddingStrategyTests<TPadding>
     [DataRow(-16)]
     [DataRow(int.MinValue)]
     public void Unpad_WhenBlockSizeIsNegative_ShouldThrowArgumentOutOfRangeException_fix(int blockSize)
+    {
+        if (!ValidatesBlockSizeOnUnpad)
+        {
+            Assert.Inconclusive($"{typeof(TPadding).Name} ignores the blockSize parameter on Unpad.");
+            return;
+        }
+
+        TPadding padding = CreatePadding();
+        var input = new byte[BlockSize];
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Unpad(input, blockSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IPaddingStrategy.Pad" /> with a positive <c>blockSize</c>
+    /// that is not a multiple of 8 throws <see cref="ArgumentOutOfRangeException" />. Values in the
+    /// range <c>1..7</c> would otherwise drive the <c>blockSize / 8</c> integer division to zero and
+    /// surface a <see cref="DivideByZeroException" /> from the subsequent modulo expression.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(4)]
+    [DataRow(7)]
+    [DataRow(12)]
+    public void Pad_WhenBlockSizeIsNotMultipleOfEight_ShouldThrowArgumentOutOfRangeException(int blockSize)
+    {
+        TPadding padding = CreatePadding();
+        var input = new byte[BlockSize];
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = padding.Pad(input, blockSize);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IPaddingStrategy.Unpad" /> with a positive <c>blockSize</c>
+    /// that is not a multiple of 8 throws <see cref="ArgumentOutOfRangeException" /> rather than
+    /// surfacing a <see cref="DivideByZeroException" /> for values in the range <c>1..7</c>.
+    /// </summary>
+    [TestMethod]
+    [DataRow(1)]
+    [DataRow(4)]
+    [DataRow(7)]
+    [DataRow(12)]
+    public void Unpad_WhenBlockSizeIsNotMultipleOfEight_ShouldThrowArgumentOutOfRangeException(int blockSize)
     {
         if (!ValidatesBlockSizeOnUnpad)
         {

--- a/Bodu.Text.Encoding/src/Text.Encoding/SlicedMemoryOwner.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/SlicedMemoryOwner.cs
@@ -71,7 +71,7 @@ internal sealed class SlicedMemoryOwner<T> : IMemoryOwner<T>
         get
         {
             IMemoryOwner<T> inner = _inner
-                ?? throw new ObjectDisposedException(nameof(SlicedMemoryOwner<>));
+                ?? throw new ObjectDisposedException(nameof(SlicedMemoryOwner<T>));
             return inner.Memory.Slice(0, _length);
         }
     }

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodedList.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodedList.cs
@@ -73,5 +73,16 @@ public sealed class BencodedList
     /// </summary>
     /// <param name="index">The zero-based item index.</param>
     /// <returns>The item at the specified index.</returns>
-    public BencodedValue this[int index] => _items[index];
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="index" /> is less than 0 or greater than or equal to <see cref="Count" />.
+    /// </exception>
+    public BencodedValue this[int index]
+    {
+        get
+        {
+            ThrowHelper.ThrowIfIndexOutOfRange(index, _items);
+
+            return _items[index];
+        }
+    }
 }

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedWriter.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedWriter.cs
@@ -82,13 +82,16 @@ public sealed class DelimitedWriter : IDisposable
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="headers" /> is <see langword="null" />.
     /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="headers" /> contains a <see langword="null" /> element.
+    /// </exception>
     /// <exception cref="ObjectDisposedException">Thrown when the writer has been disposed.</exception>
     public void WriteHeader(IEnumerable<string> headers)
     {
         ThrowHelper.ThrowIfNull(headers);
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        WriteFields(headers);
+        WriteFields(headers, nameof(headers));
     }
 
     /// <summary>
@@ -99,13 +102,16 @@ public sealed class DelimitedWriter : IDisposable
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="fields" /> is <see langword="null" />.
     /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="fields" /> contains a <see langword="null" /> element.
+    /// </exception>
     /// <exception cref="ObjectDisposedException">Thrown when the writer has been disposed.</exception>
     public void WriteRow(IEnumerable<string> fields)
     {
         ThrowHelper.ThrowIfNull(fields);
         ObjectDisposedException.ThrowIf(_disposed, this);
 
-        WriteFields(fields);
+        WriteFields(fields, nameof(fields));
         _rowsWritten++;
     }
 
@@ -126,13 +132,23 @@ public sealed class DelimitedWriter : IDisposable
     /// appending a line feed.
     /// </summary>
     /// <param name="fields">The field values to write.</param>
-    private void WriteFields(IEnumerable<string> fields)
+    /// <param name="paramName">
+    /// The name of the public parameter that supplied <paramref name="fields" />, reported when an element is
+    /// <see langword="null" />.
+    /// </param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="fields" /> contains a <see langword="null" /> element.
+    /// </exception>
+    private void WriteFields(IEnumerable<string> fields, string paramName)
     {
         var delimiter = _options.Delimiter;
         var first = true;
 
         foreach (var field in fields)
         {
+            if (field is null)
+                throw new ArgumentException(FormatsResourceStrings.Arg_Invalid_NullListElement, paramName);
+
             if (!first)
                 _writer.Write(delimiter);
 

--- a/Bodu.Text.Formats/test/Text.Bencode/BencodedListTests.cs
+++ b/Bodu.Text.Formats/test/Text.Bencode/BencodedListTests.cs
@@ -57,6 +57,36 @@ public sealed partial class BencodedListTests
     }
 
     /// <summary>
+    /// Verifies that the indexer throws <see cref="ArgumentOutOfRangeException" /> when the index is negative,
+    /// rather than surfacing an <see cref="IndexOutOfRangeException" /> from the backing array.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        BencodedList list = new(new BencodedValue[] { new BencodedInteger(1) });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = list[-1];
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the indexer throws <see cref="ArgumentOutOfRangeException" /> when the index is greater than
+    /// or equal to <see cref="BencodedList.Count" />.
+    /// </summary>
+    [TestMethod]
+    public void Indexer_WhenIndexIsBeyondCount_ShouldThrowArgumentOutOfRangeException()
+    {
+        BencodedList list = new(new BencodedValue[] { new BencodedInteger(1) });
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = list[1];
+        });
+    }
+
+    /// <summary>
     /// Verifies that <see cref="BencodedValue.Kind" /> returns <see cref="BencodedValueKind.List" />.
     /// </summary>
     [TestMethod]

--- a/Bodu.Text.Formats/test/Text.Delimited/DelimitedWriterTests.WriteRow.cs
+++ b/Bodu.Text.Formats/test/Text.Delimited/DelimitedWriterTests.WriteRow.cs
@@ -25,6 +25,22 @@ public sealed partial class DelimitedWriterTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="DelimitedWriter.WriteRow" /> throws <see cref="ArgumentException" /> when the
+    /// field collection contains a <see langword="null" /> element, rather than a <see cref="NullReferenceException" />.
+    /// </summary>
+    [TestMethod]
+    public void WriteRow_WhenFieldsContainsNullElement_ShouldThrowArgumentException()
+    {
+        using var sw = new StringWriter();
+        using DelimitedWriter writer = new(sw);
+
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            writer.WriteRow(["a", null!, "b"]);
+        });
+    }
+
+    /// <summary>
     /// Verifies that <see cref="DelimitedWriter.WriteRow" /> throws <see cref="ObjectDisposedException" />
     /// after the writer has been disposed.
     /// </summary>
@@ -149,6 +165,22 @@ public sealed partial class DelimitedWriterTests
         _ = Assert.ThrowsExactly<ArgumentNullException>(() =>
         {
             writer.WriteHeader(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="DelimitedWriter.WriteHeader" /> throws <see cref="ArgumentException" /> when the
+    /// header collection contains a <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void WriteHeader_WhenHeadersContainsNullElement_ShouldThrowArgumentException()
+    {
+        using var sw = new StringWriter();
+        using DelimitedWriter writer = new(sw);
+
+        _ = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            writer.WriteHeader(["name", null!, "age"]);
         });
     }
 


### PR DESCRIPTION
## Summary

This PR adds comprehensive input validation across multiple projects to prevent unsafe operations that could otherwise surface internal exceptions or allow out-of-bounds access. The changes enforce stricter contracts on indexers, padding algorithms, and hash computation methods by validating parameters upfront and throwing appropriate, well-documented exceptions.

## Key Changes

### Bodu.Core — SegmentedBuffer Indexer Validation
- **Indexer getter**: Now validates that index is non-negative and less than `Count`, throwing `ArgumentOutOfRangeException` instead of allowing negative indices to wrap around or exceed bounds silently.
- **Indexer setter**: Added validation for negative indices and indices at or beyond `Count`, preventing writes to unintended segment slots.
- Updated test coverage with new test methods for negative indices and out-of-bounds access on both getter and setter.

### Bodu.Security.Cryptography — Padding Algorithm Validation
- **All padding strategies** (`Ansix923Padding`, `Iso10126Padding`, `Iso7816_4Padding`, `Pkcs7Padding`, `ZeroPadding`, `NoPadding`): Replaced loose `blockSize <= 0` checks with `ThrowHelper.ThrowIfNotPositiveMultipleOf(blockSize, 8)` to enforce that `blockSize` must be a positive multiple of 8.
  - This prevents `DivideByZeroException` from `blockSize / 8` integer division when `blockSize` is in the range 1–7.
  - Updated XML documentation to clarify the stricter requirement.
- **Test coverage**: Added `Pad_WhenBlockSizeIsNotMultipleOfEight_ShouldThrowArgumentOutOfRangeException` and `Unpad_WhenBlockSizeIsNotMultipleOfEight_ShouldThrowArgumentOutOfRangeException` test methods with `[DataRow]` for values 1, 4, 7, and 12.
- **ParallelMerkleTreeHash**: Added explicit `ArgumentNullException.ThrowIfNull(data)` check in `ComputeHash(byte[], MerkleTreeDiagnostics?)` overload to validate before constructing `ReadOnlySpan<byte>`.

### Bodu.IO.Hashing — CRC Validation
- **Crc.ComputeHashFrom**: Added validation for negative `offset` and `length` parameters, and for `offset + length` exceeding array bounds.
  - Throws `ArgumentOutOfRangeException` with correct `ParamName` for negative values.
  - Throws `ArgumentException` when slice bounds exceed the input array.
- Added three new test methods: `ComputeHashFrom_WhenOffsetIsNegative_ShouldThrowArgumentOutOfRangeException`, `ComputeHashFrom_WhenLengthIsNegative_ShouldThrowArgumentOutOfRangeException`, and `ComputeHashFrom_WhenOffsetPlusLengthExceedsNewData_ShouldThrowArgumentException`.

### Bodu.Text.Formats — DelimitedWriter and BencodedList Validation
- **DelimitedWriter**: Updated `WriteRow` and `WriteHeader` to validate that field/header collections do not contain `null` elements, throwing `ArgumentException` instead of `NullReferenceException`.
  - Modified `WriteFields` helper to accept a `paramName` parameter for proper error reporting.
  - Updated XML documentation to document the new `ArgumentException` contract.
- **BencodedList indexer**: Added bounds checking to throw `ArgumentOutOfRangeException` for negative indices or indices >= `Count`, preventing `IndexOutOfRangeException` from the backing array.
- Added test methods: `WriteRow_WhenFieldsContainsNullElement_ShouldThrowArgumentException`, `WriteHeader_WhenHeadersContainsNullElement_ShouldThrowArgumentException`, `Indexer_WhenIndexIsNegative_ShouldThrowArgumentOutOfRangeException`, and `Indexer_WhenIndexIsBeyondCount_ShouldThrowArgumentOutOfRangeException`.

https://claude.ai/code/session_014yLT1aBZ3aPY8wnuAS8FJf