### PR TITLE
Add AVX-512 vectorized implementations for Threefish ciphers

### DIFF
--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.Avx512.cs
@@ -1,0 +1,182 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake2b.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of the BLAKE2b compression function. The 16-element working vector
+/// <c>v</c> is laid out as four <see cref="Vector256{T}" /> rows (<c>a, b, c, d</c>), so the four parallel
+/// <c>G</c> calls in each column step collapse into a single SIMD <c>G</c> operation. The diagonal step
+/// reuses the same kernel by shifting the <c>b, c, d</c> rows by 1/2/3 lanes via <c>VPERMQ</c>, running
+/// <c>G</c>, then shifting back — the canonical ChaCha-style vectorisation pattern Blake2 was designed
+/// around.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated on <see cref="Avx512F.VL.IsSupported" /> because the rotations use the AVX-512VL VPRORQ variant
+/// on <see cref="Vector256{T}" />. Every modern Intel/AMD CPU that ships AVX-512F also ships VL, so the
+/// gate is effectively equivalent to "any AVX-512 host".
+/// </para>
+/// </remarks>
+public sealed partial class Blake2b
+{
+    // The four rotation amounts used by Blake2b's G function (RFC 7693 §3.1). Encoded as broadcast
+    // vectors so that Avx512F.VL.RotateRightVariable lowers each rotate to a single VPRORQ instruction.
+    private static readonly Vector256<ulong> s_ror32 = Vector256.Create((ulong)32);
+    private static readonly Vector256<ulong> s_ror24 = Vector256.Create((ulong)24);
+    private static readonly Vector256<ulong> s_ror16 = Vector256.Create((ulong)16);
+    private static readonly Vector256<ulong> s_ror63 = Vector256.Create((ulong)63);
+
+    /// <summary>
+    /// Compresses a single 128-byte block using the AVX-512 vectorised BLAKE2b compression function.
+    /// </summary>
+    /// <param name="block">The 128-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">The cumulative byte count including this block.</param>
+    /// <param name="isFinal"><see langword="true" /> if this is the final block (inverts the f0 flag).</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void ProcessBlockAvx512(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
+    {
+        // Load the 16 message words. Used to build the per-step (mx, my) gather vectors below.
+        Span<ulong> m = stackalloc ulong[16];
+        ref byte blockRef = ref MemoryMarshal.GetReference(block);
+        if (BitConverter.IsLittleEndian)
+        {
+            ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref blockRef);
+            for (var i = 0; i < 16; i++)
+                m[i] = Unsafe.Add(ref wordRef, i);
+        }
+        else
+        {
+            for (var i = 0; i < 16; i++)
+                m[i] = BinaryPrimitives.ReadUInt64LittleEndian(block.Slice(i * 8, 8));
+        }
+
+        ref ulong mRef = ref MemoryMarshal.GetReference(m);
+
+        // Build the four rows of the working vector. a/b come from the chaining state; c/d come from the
+        // IV with the counter XORed into lane 0 of d (= v[12]) and the finalization flag conditionally
+        // inverting lane 2 of d (= v[14]).
+        ref ulong hRef = ref MemoryMarshal.GetArrayDataReference(this._h);
+        Vector256<ulong> a = Vector256.Create(
+            Unsafe.Add(ref hRef, 0),
+            Unsafe.Add(ref hRef, 1),
+            Unsafe.Add(ref hRef, 2),
+            Unsafe.Add(ref hRef, 3));
+        Vector256<ulong> b = Vector256.Create(
+            Unsafe.Add(ref hRef, 4),
+            Unsafe.Add(ref hRef, 5),
+            Unsafe.Add(ref hRef, 6),
+            Unsafe.Add(ref hRef, 7));
+        Vector256<ulong> c = Vector256.Create(s_iv[0], s_iv[1], s_iv[2], s_iv[3]);
+        Vector256<ulong> d = Vector256.Create(
+            s_iv[4] ^ totalBytesIncludingThisBlock,
+            s_iv[5],
+            isFinal ? ~s_iv[6] : s_iv[6],
+            s_iv[7]);
+
+        // 12 rounds, each consisting of a column step followed by a diagonal step. Each step applies the
+        // SIMD G kernel once across all four columns / diagonals in parallel.
+        for (var r = 0; r < 12; r++)
+        {
+            var s = Blake2Constants.Sigma[r % 10];
+
+            // Column step: G applied to columns (0,4,8,12), (1,5,9,13), (2,6,10,14), (3,7,11,15) — i.e.
+            // each column of the 4x4 v matrix. With a/b/c/d holding rows, lane i of each row is column i,
+            // so a single SIMD G covers all four columns.
+            Vector256<ulong> mx = Vector256.Create(
+                Unsafe.Add(ref mRef, s[0]),
+                Unsafe.Add(ref mRef, s[2]),
+                Unsafe.Add(ref mRef, s[4]),
+                Unsafe.Add(ref mRef, s[6]));
+            Vector256<ulong> my = Vector256.Create(
+                Unsafe.Add(ref mRef, s[1]),
+                Unsafe.Add(ref mRef, s[3]),
+                Unsafe.Add(ref mRef, s[5]),
+                Unsafe.Add(ref mRef, s[7]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Diagonalize: shift b left by 1 lane, c left by 2, d left by 3 so that what was the i-th
+            // diagonal of the original matrix becomes the i-th column of the shuffled layout. The same
+            // SIMD G then handles the four diagonals.
+            b = Avx2.Permute4x64(b, 0x39);  // lanes (1, 2, 3, 0) — left rotate by 1
+            c = Avx2.Permute4x64(c, 0x4E);  // lanes (2, 3, 0, 1) — left rotate by 2 (self-inverse)
+            d = Avx2.Permute4x64(d, 0x93);  // lanes (3, 0, 1, 2) — left rotate by 3
+
+            mx = Vector256.Create(
+                Unsafe.Add(ref mRef, s[8]),
+                Unsafe.Add(ref mRef, s[10]),
+                Unsafe.Add(ref mRef, s[12]),
+                Unsafe.Add(ref mRef, s[14]));
+            my = Vector256.Create(
+                Unsafe.Add(ref mRef, s[9]),
+                Unsafe.Add(ref mRef, s[11]),
+                Unsafe.Add(ref mRef, s[13]),
+                Unsafe.Add(ref mRef, s[15]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Undiagonalize: invert the lane shifts to restore canonical row layout for the next round.
+            b = Avx2.Permute4x64(b, 0x93);  // left rotate by 3 = right rotate by 1
+            c = Avx2.Permute4x64(c, 0x4E);  // self-inverse
+            d = Avx2.Permute4x64(d, 0x39);  // left rotate by 1 = right rotate by 3
+        }
+
+        // Fold the working vector back into the chaining state: h[i] ^= v[i] ^ v[i + 8]. With a holding
+        // v[0..3], b holding v[4..7], c holding v[8..11], and d holding v[12..15], the fold reduces to
+        // h[0..3] ^= a ^ c and h[4..7] ^= b ^ d.
+        Vector256<ulong> hLo = Vector256.Create(
+            Unsafe.Add(ref hRef, 0),
+            Unsafe.Add(ref hRef, 1),
+            Unsafe.Add(ref hRef, 2),
+            Unsafe.Add(ref hRef, 3));
+        Vector256<ulong> hHi = Vector256.Create(
+            Unsafe.Add(ref hRef, 4),
+            Unsafe.Add(ref hRef, 5),
+            Unsafe.Add(ref hRef, 6),
+            Unsafe.Add(ref hRef, 7));
+        hLo ^= a ^ c;
+        hHi ^= b ^ d;
+
+        Unsafe.Add(ref hRef, 0) = hLo.GetElement(0);
+        Unsafe.Add(ref hRef, 1) = hLo.GetElement(1);
+        Unsafe.Add(ref hRef, 2) = hLo.GetElement(2);
+        Unsafe.Add(ref hRef, 3) = hLo.GetElement(3);
+        Unsafe.Add(ref hRef, 4) = hHi.GetElement(0);
+        Unsafe.Add(ref hRef, 5) = hHi.GetElement(1);
+        Unsafe.Add(ref hRef, 6) = hHi.GetElement(2);
+        Unsafe.Add(ref hRef, 7) = hHi.GetElement(3);
+    }
+
+    /// <summary>
+    /// Applies the BLAKE2b <c>G</c> mixing function in parallel across four columns (or four diagonals,
+    /// after the caller has applied the appropriate lane shifts).
+    /// </summary>
+    /// <param name="a">The top row of the working vector, updated in place.</param>
+    /// <param name="b">The second row of the working vector, updated in place.</param>
+    /// <param name="c">The third row of the working vector, updated in place.</param>
+    /// <param name="d">The bottom row of the working vector, updated in place.</param>
+    /// <param name="mx">The four <c>x</c> message words for this step, one per column.</param>
+    /// <param name="my">The four <c>y</c> message words for this step, one per column.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void GSimd(
+        ref Vector256<ulong> a, ref Vector256<ulong> b, ref Vector256<ulong> c, ref Vector256<ulong> d,
+        Vector256<ulong> mx, Vector256<ulong> my)
+    {
+        a += b + mx;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror32);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror24);
+        a += b + my;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror16);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror63);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -6,6 +6,7 @@
 
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Security.Cryptography;
 using Bodu.Extensions;
 
@@ -81,7 +82,7 @@ namespace Bodu.Security.Cryptography;
 /// </code>
 /// </example>
 /// <seealso cref="Blake2s"/> <seealso cref="Blake3"/>
-public sealed class Blake2b
+public sealed partial class Blake2b
     : KeyedDeferredFinalBlockHashAlgorithm<Blake2b>
 {
     /// <summary>
@@ -247,7 +248,35 @@ public sealed class Blake2b
     /// <param name="isFinal">
     /// <see langword="true" /> if this is the final block; causes the finalization flag word to be inverted.
     /// </param>
+    /// <remarks>
+    /// Dispatches to an AVX-512 vectorised implementation when supported by the host, falling back to a
+    /// scalar reference implementation otherwise. <see cref="Avx512F.VL.IsSupported" /> is a JIT intrinsic
+    /// that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     protected override void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
+    {
+        if (Avx512F.VL.IsSupported)
+        {
+            this.ProcessBlockAvx512(block, totalBytesIncludingThisBlock, isFinal);
+            return;
+        }
+
+        this.ProcessBlockScalar(block, totalBytesIncludingThisBlock, isFinal);
+    }
+
+    /// <summary>
+    /// Compresses a single 128-byte block using the scalar reference BLAKE2b implementation.
+    /// </summary>
+    /// <param name="block">The 128-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">The cumulative byte count including this block.</param>
+    /// <param name="isFinal"><see langword="true" /> if this is the final block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="ProcessBlock" /> on hosts without AVX-512 + VL support. Implements the
+    /// reference 16-element working-vector form of the BLAKE2b <c>F</c> compression function directly
+    /// from RFC 7693.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void ProcessBlockScalar(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
     {
         // Read the 16 message words in little-endian order.
         Span<ulong> m = stackalloc ulong[16];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.Avx512.cs
@@ -1,0 +1,176 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake2s.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Buffers.Binary;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of the BLAKE2s compression function. The 16-element working vector
+/// <c>v</c> is laid out as four <see cref="Vector128{T}" /> rows (<c>a, b, c, d</c>), so the four parallel
+/// <c>G</c> calls in each column step collapse into a single SIMD <c>G</c> operation. The diagonal step
+/// reuses the same kernel by shifting the <c>b, c, d</c> rows by 1/2/3 lanes via <c>PSHUFD</c>, running
+/// <c>G</c>, then shifting back — the canonical ChaCha-style vectorisation pattern Blake2 was designed
+/// around, mirroring the BLAKE2b path with 32-bit lanes in 128-bit registers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated on <see cref="Avx512F.VL.IsSupported" /> because the rotations use the AVX-512VL VPRORD variant
+/// on <see cref="Vector128{T}" />. Every modern Intel/AMD CPU that ships AVX-512F also ships VL, so the
+/// gate is effectively equivalent to "any AVX-512 host".
+/// </para>
+/// </remarks>
+public sealed partial class Blake2s
+{
+    // The four rotation amounts used by Blake2s's G function (RFC 7693 §3.1). Encoded as broadcast
+    // vectors so that Avx512F.VL.RotateRightVariable lowers each rotate to a single VPRORD instruction.
+    private static readonly Vector128<uint> s_ror16 = Vector128.Create((uint)16);
+    private static readonly Vector128<uint> s_ror12 = Vector128.Create((uint)12);
+    private static readonly Vector128<uint> s_ror8 = Vector128.Create((uint)8);
+    private static readonly Vector128<uint> s_ror7 = Vector128.Create((uint)7);
+
+    /// <summary>
+    /// Compresses a single 64-byte block using the AVX-512 vectorised BLAKE2s compression function.
+    /// </summary>
+    /// <param name="block">The 64-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">The cumulative byte count including this block.</param>
+    /// <param name="isFinal"><see langword="true" /> if this is the final block (inverts the f0 flag).</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void ProcessBlockAvx512(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
+    {
+        // Load the 16 message words. Used to build the per-step (mx, my) gather vectors below.
+        Span<uint> m = stackalloc uint[16];
+        ref byte blockRef = ref MemoryMarshal.GetReference(block);
+        if (BitConverter.IsLittleEndian)
+        {
+            ref uint wordRef = ref Unsafe.As<byte, uint>(ref blockRef);
+            for (var i = 0; i < 16; i++)
+                m[i] = Unsafe.Add(ref wordRef, i);
+        }
+        else
+        {
+            for (var i = 0; i < 16; i++)
+                m[i] = BinaryPrimitives.ReadUInt32LittleEndian(block.Slice(i * 4, 4));
+        }
+
+        ref uint mRef = ref MemoryMarshal.GetReference(m);
+
+        // Build the four rows of the working vector. a/b come from the chaining state; c/d come from the
+        // IV with the 64-bit counter XORed into lanes 0 and 1 of d (= v[12] and v[13]) and the
+        // finalization flag conditionally inverting lane 2 of d (= v[14]).
+        ref uint hRef = ref MemoryMarshal.GetArrayDataReference(this._h);
+        Vector128<uint> a = Vector128.Create(
+            Unsafe.Add(ref hRef, 0),
+            Unsafe.Add(ref hRef, 1),
+            Unsafe.Add(ref hRef, 2),
+            Unsafe.Add(ref hRef, 3));
+        Vector128<uint> b = Vector128.Create(
+            Unsafe.Add(ref hRef, 4),
+            Unsafe.Add(ref hRef, 5),
+            Unsafe.Add(ref hRef, 6),
+            Unsafe.Add(ref hRef, 7));
+        Vector128<uint> c = Vector128.Create(s_iv[0], s_iv[1], s_iv[2], s_iv[3]);
+        Vector128<uint> d = Vector128.Create(
+            s_iv[4] ^ (uint)(totalBytesIncludingThisBlock & 0xFFFFFFFFUL),
+            s_iv[5] ^ (uint)(totalBytesIncludingThisBlock >> 32),
+            isFinal ? ~s_iv[6] : s_iv[6],
+            s_iv[7]);
+
+        // 10 rounds, each consisting of a column step followed by a diagonal step. Each step applies the
+        // SIMD G kernel once across all four columns / diagonals in parallel.
+        for (var r = 0; r < 10; r++)
+        {
+            var s = Blake2Constants.Sigma[r];
+
+            // Column step.
+            Vector128<uint> mx = Vector128.Create(
+                Unsafe.Add(ref mRef, s[0]),
+                Unsafe.Add(ref mRef, s[2]),
+                Unsafe.Add(ref mRef, s[4]),
+                Unsafe.Add(ref mRef, s[6]));
+            Vector128<uint> my = Vector128.Create(
+                Unsafe.Add(ref mRef, s[1]),
+                Unsafe.Add(ref mRef, s[3]),
+                Unsafe.Add(ref mRef, s[5]),
+                Unsafe.Add(ref mRef, s[7]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Diagonalize: shift b left by 1 lane, c left by 2, d left by 3 so diagonals become columns.
+            b = Sse2.Shuffle(b.AsInt32(), 0x39).AsUInt32();  // lanes (1, 2, 3, 0)
+            c = Sse2.Shuffle(c.AsInt32(), 0x4E).AsUInt32();  // lanes (2, 3, 0, 1)
+            d = Sse2.Shuffle(d.AsInt32(), 0x93).AsUInt32();  // lanes (3, 0, 1, 2)
+
+            mx = Vector128.Create(
+                Unsafe.Add(ref mRef, s[8]),
+                Unsafe.Add(ref mRef, s[10]),
+                Unsafe.Add(ref mRef, s[12]),
+                Unsafe.Add(ref mRef, s[14]));
+            my = Vector128.Create(
+                Unsafe.Add(ref mRef, s[9]),
+                Unsafe.Add(ref mRef, s[11]),
+                Unsafe.Add(ref mRef, s[13]),
+                Unsafe.Add(ref mRef, s[15]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Undiagonalize: invert the lane shifts to restore canonical row layout for the next round.
+            b = Sse2.Shuffle(b.AsInt32(), 0x93).AsUInt32();
+            c = Sse2.Shuffle(c.AsInt32(), 0x4E).AsUInt32();
+            d = Sse2.Shuffle(d.AsInt32(), 0x39).AsUInt32();
+        }
+
+        // Fold the working vector back into the chaining state: h[i] ^= v[i] ^ v[i + 8].
+        Vector128<uint> hLo = Vector128.Create(
+            Unsafe.Add(ref hRef, 0),
+            Unsafe.Add(ref hRef, 1),
+            Unsafe.Add(ref hRef, 2),
+            Unsafe.Add(ref hRef, 3));
+        Vector128<uint> hHi = Vector128.Create(
+            Unsafe.Add(ref hRef, 4),
+            Unsafe.Add(ref hRef, 5),
+            Unsafe.Add(ref hRef, 6),
+            Unsafe.Add(ref hRef, 7));
+        hLo ^= a ^ c;
+        hHi ^= b ^ d;
+
+        Unsafe.Add(ref hRef, 0) = hLo.GetElement(0);
+        Unsafe.Add(ref hRef, 1) = hLo.GetElement(1);
+        Unsafe.Add(ref hRef, 2) = hLo.GetElement(2);
+        Unsafe.Add(ref hRef, 3) = hLo.GetElement(3);
+        Unsafe.Add(ref hRef, 4) = hHi.GetElement(0);
+        Unsafe.Add(ref hRef, 5) = hHi.GetElement(1);
+        Unsafe.Add(ref hRef, 6) = hHi.GetElement(2);
+        Unsafe.Add(ref hRef, 7) = hHi.GetElement(3);
+    }
+
+    /// <summary>
+    /// Applies the BLAKE2s <c>G</c> mixing function in parallel across four columns (or four diagonals,
+    /// after the caller has applied the appropriate lane shifts).
+    /// </summary>
+    /// <param name="a">The top row of the working vector, updated in place.</param>
+    /// <param name="b">The second row of the working vector, updated in place.</param>
+    /// <param name="c">The third row of the working vector, updated in place.</param>
+    /// <param name="d">The bottom row of the working vector, updated in place.</param>
+    /// <param name="mx">The four <c>x</c> message words for this step, one per column.</param>
+    /// <param name="my">The four <c>y</c> message words for this step, one per column.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void GSimd(
+        ref Vector128<uint> a, ref Vector128<uint> b, ref Vector128<uint> c, ref Vector128<uint> d,
+        Vector128<uint> mx, Vector128<uint> my)
+    {
+        a += b + mx;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror16);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror12);
+        a += b + my;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror8);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror7);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -6,6 +6,7 @@
 
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Security.Cryptography;
 using Bodu.Extensions;
 
@@ -80,7 +81,7 @@ namespace Bodu.Security.Cryptography;
 /// </code>
 /// </example>
 /// <seealso cref="Blake2b"/> <seealso cref="Blake3"/>
-public sealed class Blake2s
+public sealed partial class Blake2s
     : KeyedDeferredFinalBlockHashAlgorithm<Blake2s>
 {
     /// <summary>
@@ -244,7 +245,35 @@ public sealed class Blake2s
     /// <param name="isFinal">
     /// <see langword="true" /> if this is the final block; causes the finalization flag word to be inverted.
     /// </param>
+    /// <remarks>
+    /// Dispatches to an AVX-512 vectorised implementation when supported by the host, falling back to a
+    /// scalar reference implementation otherwise. <see cref="Avx512F.VL.IsSupported" /> is a JIT intrinsic
+    /// that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     protected override void ProcessBlock(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
+    {
+        if (Avx512F.VL.IsSupported)
+        {
+            this.ProcessBlockAvx512(block, totalBytesIncludingThisBlock, isFinal);
+            return;
+        }
+
+        this.ProcessBlockScalar(block, totalBytesIncludingThisBlock, isFinal);
+    }
+
+    /// <summary>
+    /// Compresses a single 64-byte block using the scalar reference BLAKE2s implementation.
+    /// </summary>
+    /// <param name="block">The 64-byte block to compress.</param>
+    /// <param name="totalBytesIncludingThisBlock">The cumulative byte count including this block.</param>
+    /// <param name="isFinal"><see langword="true" /> if this is the final block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="ProcessBlock" /> on hosts without AVX-512 + VL support. Implements the
+    /// reference 16-element working-vector form of the BLAKE2s <c>F</c> compression function directly
+    /// from RFC 7693.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void ProcessBlockScalar(ReadOnlySpan<byte> block, ulong totalBytesIncludingThisBlock, bool isFinal)
     {
         // Read the 16 message words in little-endian order.
         Span<uint> m = stackalloc uint[16];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.Avx512.cs
@@ -1,0 +1,180 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Blake3.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of the BLAKE3 compression function. The 16-word working state is
+/// laid out as four <see cref="Vector128{T}" /> rows (<c>a, b, c, d</c>), so the four parallel <c>G</c>
+/// calls in each column step collapse into a single SIMD <c>G</c> operation. The diagonal step reuses
+/// the same kernel by shifting the <c>b, c, d</c> rows by 1/2/3 lanes via <c>PSHUFD</c>, running
+/// <c>G</c>, then shifting back — the canonical ChaCha-style vectorisation pattern that BLAKE3 inherits
+/// from BLAKE2.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Gated on <see cref="Avx512F.VL.IsSupported" /> because the rotations use the AVX-512VL VPRORD variant
+/// on <see cref="Vector128{T}" />. The SIMD <c>G</c> kernel is identical to <see cref="Blake2s" />'s
+/// because BLAKE3 reuses the same four rotation amounts (16, 12, 8, 7); only the round count, message
+/// schedule, and finalization differ.
+/// </para>
+/// </remarks>
+public sealed partial class Blake3
+{
+    // The four rotation amounts used by Blake3's G function (§2.4 of the BLAKE3 specification). Encoded
+    // as broadcast vectors so that Avx512F.VL.RotateRightVariable lowers each rotate to a single
+    // VPRORD instruction. Values match Blake2s.
+    private static readonly Vector128<uint> s_ror16 = Vector128.Create((uint)16);
+    private static readonly Vector128<uint> s_ror12 = Vector128.Create((uint)12);
+    private static readonly Vector128<uint> s_ror8 = Vector128.Create((uint)8);
+    private static readonly Vector128<uint> s_ror7 = Vector128.Create((uint)7);
+
+    /// <summary>
+    /// AVX-512 vectorised implementation of the BLAKE3 compression function used when the host supports
+    /// AVX-512F + VL. Returns the same 16-word post-compression state as <see cref="CompressScalar" />.
+    /// </summary>
+    /// <param name="cv">The 8-word input chaining value.</param>
+    /// <param name="blockWords">The 16-word message block.</param>
+    /// <param name="counter">The 64-bit chunk counter.</param>
+    /// <param name="blockLen">The valid byte length of the message block (≤ 64).</param>
+    /// <param name="flags">The 32-bit domain-separation flags.</param>
+    /// <returns>A 16-element array holding the post-compression state.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static uint[] CompressAvx512(uint[] cv, uint[] blockWords, ulong counter, uint blockLen, uint flags)
+    {
+        ref uint cvRef = ref MemoryMarshal.GetArrayDataReference(cv);
+        ref uint mRef = ref MemoryMarshal.GetArrayDataReference(blockWords);
+
+        // Build the four rows of the working state.
+        //   a = cv[0..3], b = cv[4..7] (upper half: chaining value)
+        //   c = IV[0..3] (lower half row 0: IV)
+        //   d = (counter_lo, counter_hi, blockLen, flags) (lower half row 1: domain)
+        Vector128<uint> a = Vector128.Create(
+            Unsafe.Add(ref cvRef, 0),
+            Unsafe.Add(ref cvRef, 1),
+            Unsafe.Add(ref cvRef, 2),
+            Unsafe.Add(ref cvRef, 3));
+        Vector128<uint> b = Vector128.Create(
+            Unsafe.Add(ref cvRef, 4),
+            Unsafe.Add(ref cvRef, 5),
+            Unsafe.Add(ref cvRef, 6),
+            Unsafe.Add(ref cvRef, 7));
+        Vector128<uint> c = Vector128.Create(s_iv[0], s_iv[1], s_iv[2], s_iv[3]);
+        Vector128<uint> d = Vector128.Create((uint)counter, (uint)(counter >> 32), blockLen, flags);
+
+        // Seven rounds, each consisting of a column step followed by a diagonal step. Each step applies
+        // the SIMD G kernel once across all four columns / diagonals in parallel.
+        for (var round = 0; round < 7; round++)
+        {
+            // Column step.
+            Vector128<uint> mx = Vector128.Create(
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 0]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 2]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 4]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 6]));
+            Vector128<uint> my = Vector128.Create(
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 1]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 3]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 5]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 7]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Diagonalize: shift b left by 1 lane, c left by 2, d left by 3 so diagonals become columns.
+            b = Sse2.Shuffle(b.AsInt32(), 0x39).AsUInt32();  // lanes (1, 2, 3, 0)
+            c = Sse2.Shuffle(c.AsInt32(), 0x4E).AsUInt32();  // lanes (2, 3, 0, 1)
+            d = Sse2.Shuffle(d.AsInt32(), 0x93).AsUInt32();  // lanes (3, 0, 1, 2)
+
+            mx = Vector128.Create(
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 8]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 10]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 12]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 14]));
+            my = Vector128.Create(
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 9]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 11]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 13]),
+                Unsafe.Add(ref mRef, s_msgSchedule[round, 15]));
+            GSimd(ref a, ref b, ref c, ref d, mx, my);
+
+            // Undiagonalize: invert the lane shifts to restore canonical row layout for the next round.
+            b = Sse2.Shuffle(b.AsInt32(), 0x93).AsUInt32();
+            c = Sse2.Shuffle(c.AsInt32(), 0x4E).AsUInt32();
+            d = Sse2.Shuffle(d.AsInt32(), 0x39).AsUInt32();
+        }
+
+        // BLAKE3 finalization differs from BLAKE2: the upper half of the output also has the input
+        // chaining value mixed in, so that callers reading state[8..16] get an extended-output stream
+        // distinct from a plain BLAKE2 fold.
+        //   state[i]     ^= state[i + 8]   for i in 0..7  →  a ^= c, b ^= d
+        //   state[i + 8] ^= cv[i]          for i in 0..7  →  c ^= cv_lo, d ^= cv_hi
+        Vector128<uint> cvLo = Vector128.Create(
+            Unsafe.Add(ref cvRef, 0),
+            Unsafe.Add(ref cvRef, 1),
+            Unsafe.Add(ref cvRef, 2),
+            Unsafe.Add(ref cvRef, 3));
+        Vector128<uint> cvHi = Vector128.Create(
+            Unsafe.Add(ref cvRef, 4),
+            Unsafe.Add(ref cvRef, 5),
+            Unsafe.Add(ref cvRef, 6),
+            Unsafe.Add(ref cvRef, 7));
+        a ^= c;
+        b ^= d;
+        c ^= cvLo;
+        d ^= cvHi;
+
+        // Materialise the 16-word output state in canonical row order.
+        var state = new uint[16];
+        ref uint outRef = ref MemoryMarshal.GetArrayDataReference(state);
+        Unsafe.Add(ref outRef, 0) = a.GetElement(0);
+        Unsafe.Add(ref outRef, 1) = a.GetElement(1);
+        Unsafe.Add(ref outRef, 2) = a.GetElement(2);
+        Unsafe.Add(ref outRef, 3) = a.GetElement(3);
+        Unsafe.Add(ref outRef, 4) = b.GetElement(0);
+        Unsafe.Add(ref outRef, 5) = b.GetElement(1);
+        Unsafe.Add(ref outRef, 6) = b.GetElement(2);
+        Unsafe.Add(ref outRef, 7) = b.GetElement(3);
+        Unsafe.Add(ref outRef, 8) = c.GetElement(0);
+        Unsafe.Add(ref outRef, 9) = c.GetElement(1);
+        Unsafe.Add(ref outRef, 10) = c.GetElement(2);
+        Unsafe.Add(ref outRef, 11) = c.GetElement(3);
+        Unsafe.Add(ref outRef, 12) = d.GetElement(0);
+        Unsafe.Add(ref outRef, 13) = d.GetElement(1);
+        Unsafe.Add(ref outRef, 14) = d.GetElement(2);
+        Unsafe.Add(ref outRef, 15) = d.GetElement(3);
+        return state;
+    }
+
+    /// <summary>
+    /// Applies the BLAKE3 <c>G</c> mixing function in parallel across four columns (or four diagonals,
+    /// after the caller has applied the appropriate lane shifts). Identical kernel shape to
+    /// <see cref="Blake2s" /> since BLAKE3 reuses BLAKE2s's rotation amounts.
+    /// </summary>
+    /// <param name="a">The top row of the working state, updated in place.</param>
+    /// <param name="b">The second row of the working state, updated in place.</param>
+    /// <param name="c">The third row of the working state, updated in place.</param>
+    /// <param name="d">The bottom row of the working state, updated in place.</param>
+    /// <param name="mx">The four <c>x</c> message words for this step, one per column.</param>
+    /// <param name="my">The four <c>y</c> message words for this step, one per column.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void GSimd(
+        ref Vector128<uint> a, ref Vector128<uint> b, ref Vector128<uint> c, ref Vector128<uint> d,
+        Vector128<uint> mx, Vector128<uint> my)
+    {
+        a += b + mx;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror16);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror12);
+        a += b + my;
+        d = Avx512F.VL.RotateRightVariable(d ^ a, s_ror8);
+        c += d;
+        b = Avx512F.VL.RotateRightVariable(b ^ c, s_ror7);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -6,6 +6,7 @@
 
 using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
+using System.Runtime.Intrinsics.X86;
 using System.Security.Cryptography;
 using Bodu.Extensions;
 
@@ -81,7 +82,7 @@ namespace Bodu.Security.Cryptography;
 /// </code>
 /// </example>
 /// <seealso cref="Blake2b"/> <seealso cref="Blake2s"/>
-public sealed class Blake3
+public sealed partial class Blake3
     : DeferredFinalBlockHashAlgorithm<Blake3>
 {
 
@@ -353,8 +354,27 @@ public sealed class Blake3
     /// A 16-element array containing the post-compression state, whose first eight words form the updated chaining
     /// value.
     /// </returns>
+    /// <remarks>
+    /// Dispatches to an AVX-512 vectorised implementation when supported by the host, falling back to a
+    /// scalar reference implementation otherwise. <see cref="Avx512F.VL.IsSupported" /> is a JIT intrinsic
+    /// that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static uint[] Compress(uint[] cv, uint[] blockWords, ulong counter, uint blockLen, uint flags)
+    {
+        if (Avx512F.VL.IsSupported)
+            return CompressAvx512(cv, blockWords, counter, blockLen, flags);
+
+        return CompressScalar(cv, blockWords, counter, blockLen, flags);
+    }
+
+    /// <summary>
+    /// Scalar reference implementation of the BLAKE3 compression function used as a fallback on hosts
+    /// without AVX-512 + VL support. Implements §2.4 of the BLAKE3 specification directly on a 16-element
+    /// <see cref="uint" /> array.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private static uint[] CompressScalar(uint[] cv, uint[] blockWords, ulong counter, uint blockLen, uint flags)
     {
         var state = new uint[16];
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Buffers.Binary;
 using System.Runtime.CompilerServices;
 
 namespace Bodu.Security.Cryptography;
@@ -415,10 +416,10 @@ public sealed class SkipjackBlockCipher
 
         // Ciphertext is emitted by encryption as w1,w2,w3,w4. The inverse formulation loads it as
         // w2,w1,w4,w3 so that the following reverse Rule B/Rule A operations mirror the reference implementation.
-        var w2 = (input[0] << 8) + (input[1] & 0xff);
-        var w1 = (input[2] << 8) + (input[3] & 0xff);
-        var w4 = (input[4] << 8) + (input[5] & 0xff);
-        var w3 = (input[6] << 8) + (input[7] & 0xff);
+        var w2 = (int)BinaryPrimitives.ReadUInt16BigEndian(input);
+        var w1 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[2..]);
+        var w4 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[4..]);
+        var w3 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[6..]);
 
         // Start from round 32. The round counter k is zero-based internally, while the Skipjack counter value
         // inserted into Rule A/Rule B is k + 1.
@@ -452,14 +453,10 @@ public sealed class SkipjackBlockCipher
         }
 
         // Store the recovered plaintext in the Skipjack 4-word big-endian block order.
-        output[0] = (byte)(w2 >> 8);
-        output[1] = (byte)w2;
-        output[2] = (byte)(w1 >> 8);
-        output[3] = (byte)w1;
-        output[4] = (byte)(w4 >> 8);
-        output[5] = (byte)w4;
-        output[6] = (byte)(w3 >> 8);
-        output[7] = (byte)w3;
+        BinaryPrimitives.WriteUInt16BigEndian(output, (ushort)w2);
+        BinaryPrimitives.WriteUInt16BigEndian(output[2..], (ushort)w1);
+        BinaryPrimitives.WriteUInt16BigEndian(output[4..], (ushort)w4);
+        BinaryPrimitives.WriteUInt16BigEndian(output[6..], (ushort)w3);
     }
 
     /// <summary>
@@ -499,10 +496,10 @@ public sealed class SkipjackBlockCipher
 
         // Split the 64-bit plaintext block into four big-endian 16-bit words W1..W4, matching the Skipjack
         // reference algorithm's word-oriented round descriptions.
-        var w1 = (input[0] << 8) + (input[1] & 0xff);
-        var w2 = (input[2] << 8) + (input[3] & 0xff);
-        var w3 = (input[4] << 8) + (input[5] & 0xff);
-        var w4 = (input[6] << 8) + (input[7] & 0xff);
+        var w1 = (int)BinaryPrimitives.ReadUInt16BigEndian(input);
+        var w2 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[2..]);
+        var w3 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[4..]);
+        var w4 = (int)BinaryPrimitives.ReadUInt16BigEndian(input[6..]);
 
         // k is the zero-based round-key index. The Skipjack rule counter value used by the round equations is k + 1.
         var k = 0;
@@ -538,14 +535,10 @@ public sealed class SkipjackBlockCipher
         }
 
         // Store the ciphertext as four big-endian 16-bit words in W1..W4 order.
-        output[0] = (byte)(w1 >> 8);
-        output[1] = (byte)w1;
-        output[2] = (byte)(w2 >> 8);
-        output[3] = (byte)w2;
-        output[4] = (byte)(w3 >> 8);
-        output[5] = (byte)w3;
-        output[6] = (byte)(w4 >> 8);
-        output[7] = (byte)w4;
+        BinaryPrimitives.WriteUInt16BigEndian(output, (ushort)w1);
+        BinaryPrimitives.WriteUInt16BigEndian(output[2..], (ushort)w2);
+        BinaryPrimitives.WriteUInt16BigEndian(output[4..], (ushort)w3);
+        BinaryPrimitives.WriteUInt16BigEndian(output[6..], (ushort)w4);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.Avx512.cs
@@ -1,0 +1,320 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThreefishBlockCipher.1024.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of <see cref="Threefish1024Cipher" />. The sixteen 64-bit state words
+/// are split across two <see cref="Vector512{T}" /> registers — <c>loVec</c> holds the eight even-position
+/// words <c>(x0, x2, x4, x6, x8, x10, x12, x14)</c> and <c>hiVec</c> the eight odd-position words
+/// <c>(x1, x3, x5, x7, x9, x11, x13, x15)</c>. Each round performs a vector add, a per-lane variable rotate
+/// (<c>VPROLVQ</c>), an XOR, and a pair of single-source <c>VPERMQ</c> shuffles that realign the registers
+/// for the next round's MIX pairing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The per-round word permutation has a uniform 4-round cycle: the same two lane-shuffle vectors realign
+/// both registers for every inter-round transition within a group, and after four shuffles both registers
+/// return to canonical layout — exactly where the subkey injection lands.
+/// </para>
+/// <para>
+/// Gated on <see cref="Avx512F.IsSupported" /> directly because the implementation operates on
+/// <see cref="Vector512{T}" /> rather than <see cref="Vector256{T}" />, so the Vector Length extensions are
+/// not required.
+/// </para>
+/// </remarks>
+public sealed partial class Threefish1024Cipher
+{
+    // Per-round rotation vectors. Each Vector512<ulong> packs eight spec-defined rotation amounts (the
+    // eight MIX rotations for one round) at lane positions matching the hi register's lane layout when
+    // the round executes.
+    private static readonly Vector512<ulong> s_rotVec0 = Vector512.Create((ulong)R0, R1, R2, R3, R4, R5, R6, R7);
+    private static readonly Vector512<ulong> s_rotVec1 = Vector512.Create((ulong)R8, R9, R10, R11, R12, R13, R14, R15);
+    private static readonly Vector512<ulong> s_rotVec2 = Vector512.Create((ulong)R16, R17, R18, R19, R20, R21, R22, R23);
+    private static readonly Vector512<ulong> s_rotVec3 = Vector512.Create((ulong)R24, R25, R26, R27, R28, R29, R30, R31);
+    private static readonly Vector512<ulong> s_rotVec4 = Vector512.Create((ulong)R32, R33, R34, R35, R36, R37, R38, R39);
+    private static readonly Vector512<ulong> s_rotVec5 = Vector512.Create((ulong)R40, R41, R42, R43, R44, R45, R46, R47);
+    private static readonly Vector512<ulong> s_rotVec6 = Vector512.Create((ulong)R48, R49, R50, R51, R52, R53, R54, R55);
+    private static readonly Vector512<ulong> s_rotVec7 = Vector512.Create((ulong)R56, R57, R58, R59, R60, R61, R62, R63);
+
+    // Inter-round lane-shuffle vectors. Forward shuffle takes canonical lane order to the round-1 layout
+    // (and applied four times in a row cycles back to canonical); inverse shuffle takes canonical back to
+    // the round-3 post-MIX layout that Decrypt's first UNMIX operates on.
+    private static readonly Vector512<ulong> s_loShuffleForward = Vector512.Create(0UL, 1, 3, 2, 5, 6, 7, 4);
+    private static readonly Vector512<ulong> s_hiShuffleForward = Vector512.Create(4UL, 6, 5, 7, 3, 1, 2, 0);
+    private static readonly Vector512<ulong> s_loShuffleInverse = Vector512.Create(0UL, 1, 3, 2, 7, 4, 5, 6);
+    private static readonly Vector512<ulong> s_hiShuffleInverse = Vector512.Create(7UL, 5, 6, 4, 0, 2, 1, 3);
+
+    // Deinterleave indices for the initial block load: separate the canonical-byte-order block into the
+    // even-position loVec and odd-position hiVec via a single VPERMI2Q each (indices 0-7 select from the
+    // first source vector, 8-15 from the second).
+    private static readonly Vector512<ulong> s_evenWordIndices = Vector512.Create(0UL, 2, 4, 6, 8, 10, 12, 14);
+    private static readonly Vector512<ulong> s_oddWordIndices = Vector512.Create(1UL, 3, 5, 7, 9, 11, 13, 15);
+
+    // Reinterleave indices for the final block store: combine UnpackLow / UnpackHigh of (loVec, hiVec)
+    // into the canonical-byte-order halves of the output block.
+    private static readonly Vector512<ulong> s_outFirstHalfIndices = Vector512.Create(0UL, 1, 8, 9, 2, 3, 10, 11);
+    private static readonly Vector512<ulong> s_outSecondHalfIndices = Vector512.Create(4UL, 5, 12, 13, 6, 7, 14, 15);
+
+    /// <summary>
+    /// Encrypts a single 128-byte block using the AVX-512 vectorised Threefish-1024 implementation.
+    /// </summary>
+    /// <param name="input">The 128-byte plaintext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 128-byte buffer that receives the ciphertext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Load both halves of the plaintext block and deinterleave into the (lo, hi) lane layout.
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        Vector512<ulong> vec0 = Vector512.LoadUnsafe(ref wordRef);
+        Vector512<ulong> vec1 = Vector512.LoadUnsafe(ref wordRef, 8);
+        Vector512<ulong> loVec = Avx512F.PermuteVar8x64x2(vec0, s_evenWordIndices, vec1);
+        Vector512<ulong> hiVec = Avx512F.PermuteVar8x64x2(vec0, s_oddWordIndices, vec1);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        // Initial subkey injection. Tweak applies at positions 13 (hiVec lane 6) and 14 (loVec lane 7).
+        loVec += Vector512.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2),
+            Unsafe.Add(ref keyRef, 4),
+            Unsafe.Add(ref keyRef, 6),
+            Unsafe.Add(ref keyRef, 8),
+            Unsafe.Add(ref keyRef, 10),
+            Unsafe.Add(ref keyRef, 12),
+            Unsafe.Add(ref keyRef, 14) + Unsafe.Add(ref tweakRef, 1));
+        hiVec += Vector512.Create(
+            Unsafe.Add(ref keyRef, 1),
+            Unsafe.Add(ref keyRef, 3),
+            Unsafe.Add(ref keyRef, 5),
+            Unsafe.Add(ref keyRef, 7),
+            Unsafe.Add(ref keyRef, 9),
+            Unsafe.Add(ref keyRef, 11),
+            Unsafe.Add(ref keyRef, 13) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 15));
+
+        for (var d = 1; d < 80 / 4; d += 2)
+        {
+            int dm17 = d % 17, dm3 = d % 3;
+
+            // First 4 rounds (R0..R31). Four forward shuffles cycle the registers back to canonical layout.
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec0);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec1);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec2);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec3);
+
+            // Mid subkey injection at canonical layout.
+            loVec += Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17),
+                Unsafe.Add(ref keyRef, dm17 + 2),
+                Unsafe.Add(ref keyRef, dm17 + 4),
+                Unsafe.Add(ref keyRef, dm17 + 6),
+                Unsafe.Add(ref keyRef, dm17 + 8),
+                Unsafe.Add(ref keyRef, dm17 + 10),
+                Unsafe.Add(ref keyRef, dm17 + 12),
+                Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hiVec += Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 3),
+                Unsafe.Add(ref keyRef, dm17 + 5),
+                Unsafe.Add(ref keyRef, dm17 + 7),
+                Unsafe.Add(ref keyRef, dm17 + 9),
+                Unsafe.Add(ref keyRef, dm17 + 11),
+                Unsafe.Add(ref keyRef, dm17 + 13) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm17 + 15) + (ulong)d);
+
+            // Second 4 rounds (R32..R63), again returning to canonical layout.
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec4);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec5);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec6);
+            SimdRoundForward(ref loVec, ref hiVec, s_rotVec7);
+
+            // Post subkey injection at canonical layout.
+            loVec += Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 3),
+                Unsafe.Add(ref keyRef, dm17 + 5),
+                Unsafe.Add(ref keyRef, dm17 + 7),
+                Unsafe.Add(ref keyRef, dm17 + 9),
+                Unsafe.Add(ref keyRef, dm17 + 11),
+                Unsafe.Add(ref keyRef, dm17 + 13),
+                Unsafe.Add(ref keyRef, dm17 + 15) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hiVec += Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 2),
+                Unsafe.Add(ref keyRef, dm17 + 4),
+                Unsafe.Add(ref keyRef, dm17 + 6),
+                Unsafe.Add(ref keyRef, dm17 + 8),
+                Unsafe.Add(ref keyRef, dm17 + 10),
+                Unsafe.Add(ref keyRef, dm17 + 12),
+                Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 16) + (ulong)(d + 1));
+        }
+
+        // Reinterleave (loVec, hiVec) back into canonical byte order and commit to the output buffer.
+        StoreStateBlock(ref MemoryMarshal.GetReference(output), loVec, hiVec);
+    }
+
+    /// <summary>
+    /// Decrypts a single 128-byte block using the AVX-512 vectorised Threefish-1024 implementation.
+    /// </summary>
+    /// <param name="input">The 128-byte ciphertext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 128-byte buffer that receives the plaintext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        Vector512<ulong> vec0 = Vector512.LoadUnsafe(ref wordRef);
+        Vector512<ulong> vec1 = Vector512.LoadUnsafe(ref wordRef, 8);
+        Vector512<ulong> loVec = Avx512F.PermuteVar8x64x2(vec0, s_evenWordIndices, vec1);
+        Vector512<ulong> hiVec = Avx512F.PermuteVar8x64x2(vec0, s_oddWordIndices, vec1);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        for (var d = (80 / 4) - 1; d >= 1; d -= 2)
+        {
+            int dm17 = d % 17, dm3 = d % 3;
+
+            // Reverse the post subkey injection.
+            loVec -= Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 3),
+                Unsafe.Add(ref keyRef, dm17 + 5),
+                Unsafe.Add(ref keyRef, dm17 + 7),
+                Unsafe.Add(ref keyRef, dm17 + 9),
+                Unsafe.Add(ref keyRef, dm17 + 11),
+                Unsafe.Add(ref keyRef, dm17 + 13),
+                Unsafe.Add(ref keyRef, dm17 + 15) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hiVec -= Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 2),
+                Unsafe.Add(ref keyRef, dm17 + 4),
+                Unsafe.Add(ref keyRef, dm17 + 6),
+                Unsafe.Add(ref keyRef, dm17 + 8),
+                Unsafe.Add(ref keyRef, dm17 + 10),
+                Unsafe.Add(ref keyRef, dm17 + 12),
+                Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 16) + (ulong)(d + 1));
+
+            // Reverse the second 4 rounds (rotations R56..R63, R48..R55, R40..R47, R32..R39).
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec7);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec6);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec5);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec4);
+
+            // Reverse the mid subkey injection.
+            loVec -= Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17),
+                Unsafe.Add(ref keyRef, dm17 + 2),
+                Unsafe.Add(ref keyRef, dm17 + 4),
+                Unsafe.Add(ref keyRef, dm17 + 6),
+                Unsafe.Add(ref keyRef, dm17 + 8),
+                Unsafe.Add(ref keyRef, dm17 + 10),
+                Unsafe.Add(ref keyRef, dm17 + 12),
+                Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hiVec -= Vector512.Create(
+                Unsafe.Add(ref keyRef, dm17 + 1),
+                Unsafe.Add(ref keyRef, dm17 + 3),
+                Unsafe.Add(ref keyRef, dm17 + 5),
+                Unsafe.Add(ref keyRef, dm17 + 7),
+                Unsafe.Add(ref keyRef, dm17 + 9),
+                Unsafe.Add(ref keyRef, dm17 + 11),
+                Unsafe.Add(ref keyRef, dm17 + 13) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm17 + 15) + (ulong)d);
+
+            // Reverse the first 4 rounds (rotations R24..R31, R16..R23, R8..R15, R0..R7).
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec3);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec2);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec1);
+            SimdRoundInverse(ref loVec, ref hiVec, s_rotVec0);
+        }
+
+        // Reverse the initial subkey injection.
+        loVec -= Vector512.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2),
+            Unsafe.Add(ref keyRef, 4),
+            Unsafe.Add(ref keyRef, 6),
+            Unsafe.Add(ref keyRef, 8),
+            Unsafe.Add(ref keyRef, 10),
+            Unsafe.Add(ref keyRef, 12),
+            Unsafe.Add(ref keyRef, 14) + Unsafe.Add(ref tweakRef, 1));
+        hiVec -= Vector512.Create(
+            Unsafe.Add(ref keyRef, 1),
+            Unsafe.Add(ref keyRef, 3),
+            Unsafe.Add(ref keyRef, 5),
+            Unsafe.Add(ref keyRef, 7),
+            Unsafe.Add(ref keyRef, 9),
+            Unsafe.Add(ref keyRef, 11),
+            Unsafe.Add(ref keyRef, 13) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 15));
+
+        StoreStateBlock(ref MemoryMarshal.GetReference(output), loVec, hiVec);
+    }
+
+    /// <summary>
+    /// Executes one forward Threefish-1024 round on the vectorised state and applies the inter-round
+    /// shuffle that realigns the registers for the next round's MIX pairing.
+    /// </summary>
+    /// <param name="loVec">The even-position state register, updated in place.</param>
+    /// <param name="hiVec">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The eight per-lane rotation amounts for this round.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundForward(ref Vector512<ulong> loVec, ref Vector512<ulong> hiVec, Vector512<ulong> rotation)
+    {
+        loVec += hiVec;
+        hiVec = Avx512F.RotateLeftVariable(hiVec, rotation) ^ loVec;
+        loVec = Avx512F.PermuteVar8x64(loVec, s_loShuffleForward);
+        hiVec = Avx512F.PermuteVar8x64(hiVec, s_hiShuffleForward);
+    }
+
+    /// <summary>
+    /// Executes one inverse Threefish-1024 round on the vectorised state. The inverse shuffle runs before
+    /// the UNMIX so it undoes the previous forward shuffle, restoring the layout the original MIX operated
+    /// on.
+    /// </summary>
+    /// <param name="loVec">The even-position state register, updated in place.</param>
+    /// <param name="hiVec">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The eight per-lane rotation amounts originally applied in the forward round.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundInverse(ref Vector512<ulong> loVec, ref Vector512<ulong> hiVec, Vector512<ulong> rotation)
+    {
+        loVec = Avx512F.PermuteVar8x64(loVec, s_loShuffleInverse);
+        hiVec = Avx512F.PermuteVar8x64(hiVec, s_hiShuffleInverse);
+        hiVec ^= loVec;
+        hiVec = Avx512F.RotateRightVariable(hiVec, rotation);
+        loVec -= hiVec;
+    }
+
+    /// <summary>
+    /// Reinterleaves the <c>(loVec, hiVec)</c> vectorised state back into the canonical sixteen-word byte
+    /// order and writes it to the destination buffer as two unaligned 512-bit stores.
+    /// </summary>
+    /// <param name="destination">A reference to the first byte of the destination buffer.</param>
+    /// <param name="loVec">The even-position state register.</param>
+    /// <param name="hiVec">The odd-position state register.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreStateBlock(ref byte destination, Vector512<ulong> loVec, Vector512<ulong> hiVec)
+    {
+        // UnpackLow / UnpackHigh on Vector512 interleave within each 128-bit lane, producing:
+        //   unLow  = (x0, x1, x4, x5, x8, x9, x12, x13)
+        //   unHigh = (x2, x3, x6, x7, x10, x11, x14, x15)
+        // PermuteVar8x64x2 then combines them into the natural (x0..x7) and (x8..x15) halves.
+        Vector512<ulong> unLow = Avx512F.UnpackLow(loVec, hiVec);
+        Vector512<ulong> unHigh = Avx512F.UnpackHigh(loVec, hiVec);
+        Vector512<ulong> outFirst = Avx512F.PermuteVar8x64x2(unLow, s_outFirstHalfIndices, unHigh);
+        Vector512<ulong> outSecond = Avx512F.PermuteVar8x64x2(unLow, s_outSecondHalfIndices, unHigh);
+
+        ref ulong outRef = ref Unsafe.As<byte, ulong>(ref destination);
+        outFirst.StoreUnsafe(ref outRef);
+        outSecond.StoreUnsafe(ref outRef, 8);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
@@ -6,6 +6,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace Bodu.Security.Cryptography;
 
@@ -47,7 +48,7 @@ namespace Bodu.Security.Cryptography;
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.
 /// SymmetricAlgorithm</seealso> <seealso cref="Threefish1024"/>
-public sealed class Threefish1024Cipher
+public sealed partial class Threefish1024Cipher
     : ThreefishBlockCipher
 {
     /// <summary>
@@ -118,6 +119,11 @@ public sealed class Threefish1024Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 128 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512F vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -127,10 +133,30 @@ public sealed class Threefish1024Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 128));
         }
 
-        // Load the ciphertext block as sixteen 64-bit little-endian words into locals. The Threefish-1024
-        // working set exceeds the x64 general-purpose register file, so the JIT will spill some words to
-        // stack — but the elimination of bounds-checked Span indexing on every Mix/key access is still a net
-        // win versus the prior stackalloc + MemoryMarshal.Cast approach.
+        if (Avx512F.IsSupported)
+        {
+            this.DecryptAvx512(input, output);
+            return;
+        }
+
+        this.DecryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Decrypts a single 128-byte ciphertext block using the scalar register-resident Threefish-1024 implementation.
+    /// </summary>
+    /// <param name="input">The 128-byte ciphertext block to decrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 128-byte buffer to receive the decrypted plaintext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Decrypt" /> on hosts without AVX-512F support. Operates on sixteen 64-bit words
+    /// held in stack-resident locals — note that the working set exceeds the x64 general-purpose register
+    /// file, so the JIT will spill some words to stack. Even with spills, the elimination of bounds-checked
+    /// Span indexing on every Mix/key access remains a net win versus the prior stackalloc-based path.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Load the ciphertext block as sixteen 64-bit little-endian words into locals.
         ref byte inputRef = ref MemoryMarshal.GetReference(input);
         ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
         ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
@@ -309,6 +335,11 @@ public sealed class Threefish1024Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 128 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512F vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -318,6 +349,27 @@ public sealed class Threefish1024Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 128));
         }
 
+        if (Avx512F.IsSupported)
+        {
+            this.EncryptAvx512(input, output);
+            return;
+        }
+
+        this.EncryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Encrypts a single 128-byte plaintext block using the scalar register-resident Threefish-1024 implementation.
+    /// </summary>
+    /// <param name="input">The 128-byte plaintext block to encrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 128-byte buffer to receive the encrypted ciphertext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Encrypt" /> on hosts without AVX-512F support. See <see cref="DecryptScalar" />
+    /// for register-pressure notes that apply to the 16-word working set.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
         ref byte inputRef = ref MemoryMarshal.GetReference(input);
         ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
         ulong b1 = LoadWordLittleEndian(ref inputRef, 8);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
@@ -1,9 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="ThreefishBlockCipher.1024.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Bodu.Security.Cryptography;
@@ -62,6 +63,38 @@ public sealed class Threefish1024Cipher
     /// </summary>
     public const int KeySize = 1024;
 
+    // Spec-defined rotation constants for Threefish-1024. Declared as named const ints so the JIT can
+    // fold each Mix/Unmix call to a ROL/ROR with an immediate count, and so all 64 values live in one
+    // place rather than being duplicated between Encrypt, Decrypt, and the public RotationSchedule.
+    private const int R0 = 24, R1 = 13, R2 = 8, R3 = 47;
+    private const int R4 = 8, R5 = 17, R6 = 22, R7 = 37;
+    private const int R8 = 38, R9 = 19, R10 = 10, R11 = 55;
+    private const int R12 = 49, R13 = 18, R14 = 23, R15 = 52;
+    private const int R16 = 33, R17 = 4, R18 = 51, R19 = 13;
+    private const int R20 = 34, R21 = 41, R22 = 59, R23 = 17;
+    private const int R24 = 5, R25 = 20, R26 = 48, R27 = 41;
+    private const int R28 = 47, R29 = 28, R30 = 16, R31 = 25;
+    private const int R32 = 41, R33 = 9, R34 = 37, R35 = 31;
+    private const int R36 = 12, R37 = 47, R38 = 44, R39 = 30;
+    private const int R40 = 16, R41 = 34, R42 = 56, R43 = 51;
+    private const int R44 = 4, R45 = 53, R46 = 42, R47 = 41;
+    private const int R48 = 31, R49 = 44, R50 = 47, R51 = 46;
+    private const int R52 = 19, R53 = 42, R54 = 44, R55 = 25;
+    private const int R56 = 9, R57 = 48, R58 = 35, R59 = 52;
+    private const int R60 = 23, R61 = 31, R62 = 37, R63 = 20;
+
+    private static readonly int[] s_rotationSchedule =
+    [
+        R0, R1, R2, R3, R4, R5, R6, R7,
+        R8, R9, R10, R11, R12, R13, R14, R15,
+        R16, R17, R18, R19, R20, R21, R22, R23,
+        R24, R25, R26, R27, R28, R29, R30, R31,
+        R32, R33, R34, R35, R36, R37, R38, R39,
+        R40, R41, R42, R43, R44, R45, R46, R47,
+        R48, R49, R50, R51, R52, R53, R54, R55,
+        R56, R57, R58, R59, R60, R61, R62, R63,
+    ];
+
     /// <inheritdoc />
     /// <value>Length of the Threefish-1024 block is 1024 bits (128 bytes).</value>
     public override int BlockSize => 1024;
@@ -70,75 +103,7 @@ public sealed class Threefish1024Cipher
     protected override int BlockWords => 16;
 
     /// <inheritdoc />
-#pragma warning disable SA1137 // Elements should have the same indentation
-    protected override int[] RotationSchedule =>
-    [
-        24,
-        13,
-        8,
-        47,
-        8,
-        17,
-        22,
-        37,
-        38,
-        19,
-        10,
-        55,
-        49,
-        18,
-        23,
-        52,
-        33,
-        4,
-        51,
-        13,
-        34,
-        41,
-        59,
-        17,
-        5,
-        20,
-        48,
-        41,
-        47,
-        28,
-        16,
-        25,
-        41,
-        9,
-        37,
-        31,
-        12,
-        47,
-        44,
-        30,
-        16,
-        34,
-        56,
-        51,
-        4,
-        53,
-        42,
-        41,
-        31,
-        44,
-        47,
-        46,
-        19,
-        42,
-        44,
-        25,
-        9,
-        48,
-        35,
-        52,
-        23,
-        31,
-        37,
-        20
-    ];
-#pragma warning restore SA1137 // Elements should have the same indentation
+    protected override int[] RotationSchedule => s_rotationSchedule;
 
     /// <inheritdoc />
     protected override int Rounds => 80;
@@ -156,148 +121,182 @@ public sealed class Threefish1024Cipher
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 128 || output.Length != 128)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 128));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        // Load the ciphertext block as sixteen 64-bit little-endian words into locals. The Threefish-1024
+        // working set exceeds the x64 general-purpose register file, so the JIT will spill some words to
+        // stack — but the elimination of bounds-checked Span indexing on every Mix/key access is still a net
+        // win versus the prior stackalloc + MemoryMarshal.Cast approach.
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
+        ulong b4 = LoadWordLittleEndian(ref inputRef, 32);
+        ulong b5 = LoadWordLittleEndian(ref inputRef, 40);
+        ulong b6 = LoadWordLittleEndian(ref inputRef, 48);
+        ulong b7 = LoadWordLittleEndian(ref inputRef, 56);
+        ulong b8 = LoadWordLittleEndian(ref inputRef, 64);
+        ulong b9 = LoadWordLittleEndian(ref inputRef, 72);
+        ulong b10 = LoadWordLittleEndian(ref inputRef, 80);
+        ulong b11 = LoadWordLittleEndian(ref inputRef, 88);
+        ulong b12 = LoadWordLittleEndian(ref inputRef, 96);
+        ulong b13 = LoadWordLittleEndian(ref inputRef, 104);
+        ulong b14 = LoadWordLittleEndian(ref inputRef, 112);
+        ulong b15 = LoadWordLittleEndian(ref inputRef, 120);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule;
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
-        for (var d = (this.Rounds / 4) - 1; d >= 1; d -= 2)
+        for (var d = (80 / 4) - 1; d >= 1; d -= 2)
         {
             int dm17 = d % 17, dm3 = d % 3;
 
-            block[0] -= key[dm17 + 1];
-            block[1] -= key[dm17 + 2];
-            block[2] -= key[dm17 + 3];
-            block[3] -= key[dm17 + 4];
-            block[4] -= key[dm17 + 5];
-            block[5] -= key[dm17 + 6];
-            block[6] -= key[dm17 + 7];
-            block[7] -= key[dm17 + 8];
-            block[8] -= key[dm17 + 9];
-            block[9] -= key[dm17 + 10];
-            block[10] -= key[dm17 + 11];
-            block[11] -= key[dm17 + 12];
-            block[12] -= key[dm17 + 13];
-            block[13] -= key[dm17 + 14] + tweak[dm3 + 1];
-            block[14] -= key[dm17 + 15] + tweak[dm3 + 2];
-            block[15] -= key[dm17 + 16] + (uint)d + 1;
+            b0 -= Unsafe.Add(ref keyRef, dm17 + 1);
+            b1 -= Unsafe.Add(ref keyRef, dm17 + 2);
+            b2 -= Unsafe.Add(ref keyRef, dm17 + 3);
+            b3 -= Unsafe.Add(ref keyRef, dm17 + 4);
+            b4 -= Unsafe.Add(ref keyRef, dm17 + 5);
+            b5 -= Unsafe.Add(ref keyRef, dm17 + 6);
+            b6 -= Unsafe.Add(ref keyRef, dm17 + 7);
+            b7 -= Unsafe.Add(ref keyRef, dm17 + 8);
+            b8 -= Unsafe.Add(ref keyRef, dm17 + 9);
+            b9 -= Unsafe.Add(ref keyRef, dm17 + 10);
+            b10 -= Unsafe.Add(ref keyRef, dm17 + 11);
+            b11 -= Unsafe.Add(ref keyRef, dm17 + 12);
+            b12 -= Unsafe.Add(ref keyRef, dm17 + 13);
+            b13 -= Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b14 -= Unsafe.Add(ref keyRef, dm17 + 15) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b15 -= Unsafe.Add(ref keyRef, dm17 + 16) + (uint)d + 1;
 
-            Unmix(ref block[12], ref block[7], rot[63]);
-            Unmix(ref block[10], ref block[3], rot[62]);
-            Unmix(ref block[8], ref block[5], rot[61]);
-            Unmix(ref block[14], ref block[1], rot[60]);
-            Unmix(ref block[4], ref block[9], rot[59]);
-            Unmix(ref block[6], ref block[13], rot[58]);
-            Unmix(ref block[2], ref block[11], rot[57]);
-            Unmix(ref block[0], ref block[15], rot[56]);
+            Unmix(ref b12, ref b7, R63);
+            Unmix(ref b10, ref b3, R62);
+            Unmix(ref b8, ref b5, R61);
+            Unmix(ref b14, ref b1, R60);
+            Unmix(ref b4, ref b9, R59);
+            Unmix(ref b6, ref b13, R58);
+            Unmix(ref b2, ref b11, R57);
+            Unmix(ref b0, ref b15, R56);
 
-            Unmix(ref block[10], ref block[9], rot[55]);
-            Unmix(ref block[8], ref block[11], rot[54]);
-            Unmix(ref block[14], ref block[13], rot[53]);
-            Unmix(ref block[12], ref block[15], rot[52]);
-            Unmix(ref block[6], ref block[1], rot[51]);
-            Unmix(ref block[4], ref block[3], rot[50]);
-            Unmix(ref block[2], ref block[5], rot[49]);
-            Unmix(ref block[0], ref block[7], rot[48]);
+            Unmix(ref b10, ref b9, R55);
+            Unmix(ref b8, ref b11, R54);
+            Unmix(ref b14, ref b13, R53);
+            Unmix(ref b12, ref b15, R52);
+            Unmix(ref b6, ref b1, R51);
+            Unmix(ref b4, ref b3, R50);
+            Unmix(ref b2, ref b5, R49);
+            Unmix(ref b0, ref b7, R48);
 
-            Unmix(ref block[8], ref block[1], rot[47]);
-            Unmix(ref block[14], ref block[5], rot[46]);
-            Unmix(ref block[12], ref block[3], rot[45]);
-            Unmix(ref block[10], ref block[7], rot[44]);
-            Unmix(ref block[4], ref block[15], rot[43]);
-            Unmix(ref block[6], ref block[11], rot[42]);
-            Unmix(ref block[2], ref block[13], rot[41]);
-            Unmix(ref block[0], ref block[9], rot[40]);
+            Unmix(ref b8, ref b1, R47);
+            Unmix(ref b14, ref b5, R46);
+            Unmix(ref b12, ref b3, R45);
+            Unmix(ref b10, ref b7, R44);
+            Unmix(ref b4, ref b15, R43);
+            Unmix(ref b6, ref b11, R42);
+            Unmix(ref b2, ref b13, R41);
+            Unmix(ref b0, ref b9, R40);
 
-            Unmix(ref block[14], ref block[15], rot[39]);
-            Unmix(ref block[12], ref block[13], rot[38]);
-            Unmix(ref block[10], ref block[11], rot[37]);
-            Unmix(ref block[8], ref block[9], rot[36]);
-            Unmix(ref block[6], ref block[7], rot[35]);
-            Unmix(ref block[4], ref block[5], rot[34]);
-            Unmix(ref block[2], ref block[3], rot[33]);
-            Unmix(ref block[0], ref block[1], rot[32]);
+            Unmix(ref b14, ref b15, R39);
+            Unmix(ref b12, ref b13, R38);
+            Unmix(ref b10, ref b11, R37);
+            Unmix(ref b8, ref b9, R36);
+            Unmix(ref b6, ref b7, R35);
+            Unmix(ref b4, ref b5, R34);
+            Unmix(ref b2, ref b3, R33);
+            Unmix(ref b0, ref b1, R32);
 
-            block[0] -= key[dm17];
-            block[1] -= key[dm17 + 1];
-            block[2] -= key[dm17 + 2];
-            block[3] -= key[dm17 + 3];
-            block[4] -= key[dm17 + 4];
-            block[5] -= key[dm17 + 5];
-            block[6] -= key[dm17 + 6];
-            block[7] -= key[dm17 + 7];
-            block[8] -= key[dm17 + 8];
-            block[9] -= key[dm17 + 9];
-            block[10] -= key[dm17 + 10];
-            block[11] -= key[dm17 + 11];
-            block[12] -= key[dm17 + 12];
-            block[13] -= key[dm17 + 13] + tweak[dm3];
-            block[14] -= key[dm17 + 14] + tweak[dm3 + 1];
-            block[15] -= key[dm17 + 15] + (uint)d;
+            b0 -= Unsafe.Add(ref keyRef, dm17);
+            b1 -= Unsafe.Add(ref keyRef, dm17 + 1);
+            b2 -= Unsafe.Add(ref keyRef, dm17 + 2);
+            b3 -= Unsafe.Add(ref keyRef, dm17 + 3);
+            b4 -= Unsafe.Add(ref keyRef, dm17 + 4);
+            b5 -= Unsafe.Add(ref keyRef, dm17 + 5);
+            b6 -= Unsafe.Add(ref keyRef, dm17 + 6);
+            b7 -= Unsafe.Add(ref keyRef, dm17 + 7);
+            b8 -= Unsafe.Add(ref keyRef, dm17 + 8);
+            b9 -= Unsafe.Add(ref keyRef, dm17 + 9);
+            b10 -= Unsafe.Add(ref keyRef, dm17 + 10);
+            b11 -= Unsafe.Add(ref keyRef, dm17 + 11);
+            b12 -= Unsafe.Add(ref keyRef, dm17 + 12);
+            b13 -= Unsafe.Add(ref keyRef, dm17 + 13) + Unsafe.Add(ref tweakRef, dm3);
+            b14 -= Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b15 -= Unsafe.Add(ref keyRef, dm17 + 15) + (uint)d;
 
-            Unmix(ref block[12], ref block[7], rot[31]);
-            Unmix(ref block[10], ref block[3], rot[30]);
-            Unmix(ref block[8], ref block[5], rot[29]);
-            Unmix(ref block[14], ref block[1], rot[28]);
-            Unmix(ref block[4], ref block[9], rot[27]);
-            Unmix(ref block[6], ref block[13], rot[26]);
-            Unmix(ref block[2], ref block[11], rot[25]);
-            Unmix(ref block[0], ref block[15], rot[24]);
+            Unmix(ref b12, ref b7, R31);
+            Unmix(ref b10, ref b3, R30);
+            Unmix(ref b8, ref b5, R29);
+            Unmix(ref b14, ref b1, R28);
+            Unmix(ref b4, ref b9, R27);
+            Unmix(ref b6, ref b13, R26);
+            Unmix(ref b2, ref b11, R25);
+            Unmix(ref b0, ref b15, R24);
 
-            Unmix(ref block[10], ref block[9], rot[23]);
-            Unmix(ref block[8], ref block[11], rot[22]);
-            Unmix(ref block[14], ref block[13], rot[21]);
-            Unmix(ref block[12], ref block[15], rot[20]);
-            Unmix(ref block[6], ref block[1], rot[19]);
-            Unmix(ref block[4], ref block[3], rot[18]);
-            Unmix(ref block[2], ref block[5], rot[17]);
-            Unmix(ref block[0], ref block[7], rot[16]);
+            Unmix(ref b10, ref b9, R23);
+            Unmix(ref b8, ref b11, R22);
+            Unmix(ref b14, ref b13, R21);
+            Unmix(ref b12, ref b15, R20);
+            Unmix(ref b6, ref b1, R19);
+            Unmix(ref b4, ref b3, R18);
+            Unmix(ref b2, ref b5, R17);
+            Unmix(ref b0, ref b7, R16);
 
-            Unmix(ref block[8], ref block[1], rot[15]);
-            Unmix(ref block[14], ref block[5], rot[14]);
-            Unmix(ref block[12], ref block[3], rot[13]);
-            Unmix(ref block[10], ref block[7], rot[12]);
-            Unmix(ref block[4], ref block[15], rot[11]);
-            Unmix(ref block[6], ref block[11], rot[10]);
-            Unmix(ref block[2], ref block[13], rot[9]);
-            Unmix(ref block[0], ref block[9], rot[8]);
+            Unmix(ref b8, ref b1, R15);
+            Unmix(ref b14, ref b5, R14);
+            Unmix(ref b12, ref b3, R13);
+            Unmix(ref b10, ref b7, R12);
+            Unmix(ref b4, ref b15, R11);
+            Unmix(ref b6, ref b11, R10);
+            Unmix(ref b2, ref b13, R9);
+            Unmix(ref b0, ref b9, R8);
 
-            Unmix(ref block[14], ref block[15], rot[7]);
-            Unmix(ref block[12], ref block[13], rot[6]);
-            Unmix(ref block[10], ref block[11], rot[5]);
-            Unmix(ref block[8], ref block[9], rot[4]);
-            Unmix(ref block[6], ref block[7], rot[3]);
-            Unmix(ref block[4], ref block[5], rot[2]);
-            Unmix(ref block[2], ref block[3], rot[1]);
-            Unmix(ref block[0], ref block[1], rot[0]);
+            Unmix(ref b14, ref b15, R7);
+            Unmix(ref b12, ref b13, R6);
+            Unmix(ref b10, ref b11, R5);
+            Unmix(ref b8, ref b9, R4);
+            Unmix(ref b6, ref b7, R3);
+            Unmix(ref b4, ref b5, R2);
+            Unmix(ref b2, ref b3, R1);
+            Unmix(ref b0, ref b1, R0);
         }
 
-        block[0] -= key[0];
-        block[1] -= key[1];
-        block[2] -= key[2];
-        block[3] -= key[3];
-        block[4] -= key[4];
-        block[5] -= key[5];
-        block[6] -= key[6];
-        block[7] -= key[7];
-        block[8] -= key[8];
-        block[9] -= key[9];
-        block[10] -= key[10];
-        block[11] -= key[11];
-        block[12] -= key[12];
-        block[13] -= key[13] + tweak[0];
-        block[14] -= key[14] + tweak[1];
-        block[15] -= key[15];
+        b0 -= Unsafe.Add(ref keyRef, 0);
+        b1 -= Unsafe.Add(ref keyRef, 1);
+        b2 -= Unsafe.Add(ref keyRef, 2);
+        b3 -= Unsafe.Add(ref keyRef, 3);
+        b4 -= Unsafe.Add(ref keyRef, 4);
+        b5 -= Unsafe.Add(ref keyRef, 5);
+        b6 -= Unsafe.Add(ref keyRef, 6);
+        b7 -= Unsafe.Add(ref keyRef, 7);
+        b8 -= Unsafe.Add(ref keyRef, 8);
+        b9 -= Unsafe.Add(ref keyRef, 9);
+        b10 -= Unsafe.Add(ref keyRef, 10);
+        b11 -= Unsafe.Add(ref keyRef, 11);
+        b12 -= Unsafe.Add(ref keyRef, 12);
+        b13 -= Unsafe.Add(ref keyRef, 13) + Unsafe.Add(ref tweakRef, 0);
+        b14 -= Unsafe.Add(ref keyRef, 14) + Unsafe.Add(ref tweakRef, 1);
+        b15 -= Unsafe.Add(ref keyRef, 15);
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
+        StoreWordLittleEndian(ref outputRef, 32, b4);
+        StoreWordLittleEndian(ref outputRef, 40, b5);
+        StoreWordLittleEndian(ref outputRef, 48, b6);
+        StoreWordLittleEndian(ref outputRef, 56, b7);
+        StoreWordLittleEndian(ref outputRef, 64, b8);
+        StoreWordLittleEndian(ref outputRef, 72, b9);
+        StoreWordLittleEndian(ref outputRef, 80, b10);
+        StoreWordLittleEndian(ref outputRef, 88, b11);
+        StoreWordLittleEndian(ref outputRef, 96, b12);
+        StoreWordLittleEndian(ref outputRef, 104, b13);
+        StoreWordLittleEndian(ref outputRef, 112, b14);
+        StoreWordLittleEndian(ref outputRef, 120, b15);
     }
 
     /// <summary>
@@ -313,141 +312,171 @@ public sealed class Threefish1024Cipher
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 128 || output.Length != 128)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 128));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
+        ulong b4 = LoadWordLittleEndian(ref inputRef, 32);
+        ulong b5 = LoadWordLittleEndian(ref inputRef, 40);
+        ulong b6 = LoadWordLittleEndian(ref inputRef, 48);
+        ulong b7 = LoadWordLittleEndian(ref inputRef, 56);
+        ulong b8 = LoadWordLittleEndian(ref inputRef, 64);
+        ulong b9 = LoadWordLittleEndian(ref inputRef, 72);
+        ulong b10 = LoadWordLittleEndian(ref inputRef, 80);
+        ulong b11 = LoadWordLittleEndian(ref inputRef, 88);
+        ulong b12 = LoadWordLittleEndian(ref inputRef, 96);
+        ulong b13 = LoadWordLittleEndian(ref inputRef, 104);
+        ulong b14 = LoadWordLittleEndian(ref inputRef, 112);
+        ulong b15 = LoadWordLittleEndian(ref inputRef, 120);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule;
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
-        block[0] += key[0];
-        block[1] += key[1];
-        block[2] += key[2];
-        block[3] += key[3];
-        block[4] += key[4];
-        block[5] += key[5];
-        block[6] += key[6];
-        block[7] += key[7];
-        block[8] += key[8];
-        block[9] += key[9];
-        block[10] += key[10];
-        block[11] += key[11];
-        block[12] += key[12];
-        block[13] += key[13] + tweak[0];
-        block[14] += key[14] + tweak[1];
-        block[15] += key[15];
+        b0 += Unsafe.Add(ref keyRef, 0);
+        b1 += Unsafe.Add(ref keyRef, 1);
+        b2 += Unsafe.Add(ref keyRef, 2);
+        b3 += Unsafe.Add(ref keyRef, 3);
+        b4 += Unsafe.Add(ref keyRef, 4);
+        b5 += Unsafe.Add(ref keyRef, 5);
+        b6 += Unsafe.Add(ref keyRef, 6);
+        b7 += Unsafe.Add(ref keyRef, 7);
+        b8 += Unsafe.Add(ref keyRef, 8);
+        b9 += Unsafe.Add(ref keyRef, 9);
+        b10 += Unsafe.Add(ref keyRef, 10);
+        b11 += Unsafe.Add(ref keyRef, 11);
+        b12 += Unsafe.Add(ref keyRef, 12);
+        b13 += Unsafe.Add(ref keyRef, 13) + Unsafe.Add(ref tweakRef, 0);
+        b14 += Unsafe.Add(ref keyRef, 14) + Unsafe.Add(ref tweakRef, 1);
+        b15 += Unsafe.Add(ref keyRef, 15);
 
-        for (var d = 1; d < this.Rounds / 4; d += 2)
+        for (var d = 1; d < 80 / 4; d += 2)
         {
             int dm17 = d % 17, dm3 = d % 3;
 
-            Mix(ref block[0], ref block[1], rot[0]);
-            Mix(ref block[2], ref block[3], rot[1]);
-            Mix(ref block[4], ref block[5], rot[2]);
-            Mix(ref block[6], ref block[7], rot[3]);
-            Mix(ref block[8], ref block[9], rot[4]);
-            Mix(ref block[10], ref block[11], rot[5]);
-            Mix(ref block[12], ref block[13], rot[6]);
-            Mix(ref block[14], ref block[15], rot[7]);
-            Mix(ref block[0], ref block[9], rot[8]);
-            Mix(ref block[2], ref block[13], rot[9]);
-            Mix(ref block[6], ref block[11], rot[10]);
-            Mix(ref block[4], ref block[15], rot[11]);
-            Mix(ref block[10], ref block[7], rot[12]);
-            Mix(ref block[12], ref block[3], rot[13]);
-            Mix(ref block[14], ref block[5], rot[14]);
-            Mix(ref block[8], ref block[1], rot[15]);
-            Mix(ref block[0], ref block[7], rot[16]);
-            Mix(ref block[2], ref block[5], rot[17]);
-            Mix(ref block[4], ref block[3], rot[18]);
-            Mix(ref block[6], ref block[1], rot[19]);
-            Mix(ref block[12], ref block[15], rot[20]);
-            Mix(ref block[14], ref block[13], rot[21]);
-            Mix(ref block[8], ref block[11], rot[22]);
-            Mix(ref block[10], ref block[9], rot[23]);
-            Mix(ref block[0], ref block[15], rot[24]);
-            Mix(ref block[2], ref block[11], rot[25]);
-            Mix(ref block[6], ref block[13], rot[26]);
-            Mix(ref block[4], ref block[9], rot[27]);
-            Mix(ref block[14], ref block[1], rot[28]);
-            Mix(ref block[8], ref block[5], rot[29]);
-            Mix(ref block[10], ref block[3], rot[30]);
-            Mix(ref block[12], ref block[7], rot[31]);
+            Mix(ref b0, ref b1, R0);
+            Mix(ref b2, ref b3, R1);
+            Mix(ref b4, ref b5, R2);
+            Mix(ref b6, ref b7, R3);
+            Mix(ref b8, ref b9, R4);
+            Mix(ref b10, ref b11, R5);
+            Mix(ref b12, ref b13, R6);
+            Mix(ref b14, ref b15, R7);
+            Mix(ref b0, ref b9, R8);
+            Mix(ref b2, ref b13, R9);
+            Mix(ref b6, ref b11, R10);
+            Mix(ref b4, ref b15, R11);
+            Mix(ref b10, ref b7, R12);
+            Mix(ref b12, ref b3, R13);
+            Mix(ref b14, ref b5, R14);
+            Mix(ref b8, ref b1, R15);
+            Mix(ref b0, ref b7, R16);
+            Mix(ref b2, ref b5, R17);
+            Mix(ref b4, ref b3, R18);
+            Mix(ref b6, ref b1, R19);
+            Mix(ref b12, ref b15, R20);
+            Mix(ref b14, ref b13, R21);
+            Mix(ref b8, ref b11, R22);
+            Mix(ref b10, ref b9, R23);
+            Mix(ref b0, ref b15, R24);
+            Mix(ref b2, ref b11, R25);
+            Mix(ref b6, ref b13, R26);
+            Mix(ref b4, ref b9, R27);
+            Mix(ref b14, ref b1, R28);
+            Mix(ref b8, ref b5, R29);
+            Mix(ref b10, ref b3, R30);
+            Mix(ref b12, ref b7, R31);
 
-            block[0] += key[dm17];
-            block[1] += key[dm17 + 1];
-            block[2] += key[dm17 + 2];
-            block[3] += key[dm17 + 3];
-            block[4] += key[dm17 + 4];
-            block[5] += key[dm17 + 5];
-            block[6] += key[dm17 + 6];
-            block[7] += key[dm17 + 7];
-            block[8] += key[dm17 + 8];
-            block[9] += key[dm17 + 9];
-            block[10] += key[dm17 + 10];
-            block[11] += key[dm17 + 11];
-            block[12] += key[dm17 + 12];
-            block[13] += key[dm17 + 13] + tweak[dm3];
-            block[14] += key[dm17 + 14] + tweak[dm3 + 1];
-            block[15] += key[dm17 + 15] + (uint)d;
+            b0 += Unsafe.Add(ref keyRef, dm17);
+            b1 += Unsafe.Add(ref keyRef, dm17 + 1);
+            b2 += Unsafe.Add(ref keyRef, dm17 + 2);
+            b3 += Unsafe.Add(ref keyRef, dm17 + 3);
+            b4 += Unsafe.Add(ref keyRef, dm17 + 4);
+            b5 += Unsafe.Add(ref keyRef, dm17 + 5);
+            b6 += Unsafe.Add(ref keyRef, dm17 + 6);
+            b7 += Unsafe.Add(ref keyRef, dm17 + 7);
+            b8 += Unsafe.Add(ref keyRef, dm17 + 8);
+            b9 += Unsafe.Add(ref keyRef, dm17 + 9);
+            b10 += Unsafe.Add(ref keyRef, dm17 + 10);
+            b11 += Unsafe.Add(ref keyRef, dm17 + 11);
+            b12 += Unsafe.Add(ref keyRef, dm17 + 12);
+            b13 += Unsafe.Add(ref keyRef, dm17 + 13) + Unsafe.Add(ref tweakRef, dm3);
+            b14 += Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b15 += Unsafe.Add(ref keyRef, dm17 + 15) + (uint)d;
 
-            Mix(ref block[0], ref block[1], rot[32]);
-            Mix(ref block[2], ref block[3], rot[33]);
-            Mix(ref block[4], ref block[5], rot[34]);
-            Mix(ref block[6], ref block[7], rot[35]);
-            Mix(ref block[8], ref block[9], rot[36]);
-            Mix(ref block[10], ref block[11], rot[37]);
-            Mix(ref block[12], ref block[13], rot[38]);
-            Mix(ref block[14], ref block[15], rot[39]);
-            Mix(ref block[0], ref block[9], rot[40]);
-            Mix(ref block[2], ref block[13], rot[41]);
-            Mix(ref block[6], ref block[11], rot[42]);
-            Mix(ref block[4], ref block[15], rot[43]);
-            Mix(ref block[10], ref block[7], rot[44]);
-            Mix(ref block[12], ref block[3], rot[45]);
-            Mix(ref block[14], ref block[5], rot[46]);
-            Mix(ref block[8], ref block[1], rot[47]);
-            Mix(ref block[0], ref block[7], rot[48]);
-            Mix(ref block[2], ref block[5], rot[49]);
-            Mix(ref block[4], ref block[3], rot[50]);
-            Mix(ref block[6], ref block[1], rot[51]);
-            Mix(ref block[12], ref block[15], rot[52]);
-            Mix(ref block[14], ref block[13], rot[53]);
-            Mix(ref block[8], ref block[11], rot[54]);
-            Mix(ref block[10], ref block[9], rot[55]);
-            Mix(ref block[0], ref block[15], rot[56]);
-            Mix(ref block[2], ref block[11], rot[57]);
-            Mix(ref block[6], ref block[13], rot[58]);
-            Mix(ref block[4], ref block[9], rot[59]);
-            Mix(ref block[14], ref block[1], rot[60]);
-            Mix(ref block[8], ref block[5], rot[61]);
-            Mix(ref block[10], ref block[3], rot[62]);
-            Mix(ref block[12], ref block[7], rot[63]);
+            Mix(ref b0, ref b1, R32);
+            Mix(ref b2, ref b3, R33);
+            Mix(ref b4, ref b5, R34);
+            Mix(ref b6, ref b7, R35);
+            Mix(ref b8, ref b9, R36);
+            Mix(ref b10, ref b11, R37);
+            Mix(ref b12, ref b13, R38);
+            Mix(ref b14, ref b15, R39);
+            Mix(ref b0, ref b9, R40);
+            Mix(ref b2, ref b13, R41);
+            Mix(ref b6, ref b11, R42);
+            Mix(ref b4, ref b15, R43);
+            Mix(ref b10, ref b7, R44);
+            Mix(ref b12, ref b3, R45);
+            Mix(ref b14, ref b5, R46);
+            Mix(ref b8, ref b1, R47);
+            Mix(ref b0, ref b7, R48);
+            Mix(ref b2, ref b5, R49);
+            Mix(ref b4, ref b3, R50);
+            Mix(ref b6, ref b1, R51);
+            Mix(ref b12, ref b15, R52);
+            Mix(ref b14, ref b13, R53);
+            Mix(ref b8, ref b11, R54);
+            Mix(ref b10, ref b9, R55);
+            Mix(ref b0, ref b15, R56);
+            Mix(ref b2, ref b11, R57);
+            Mix(ref b6, ref b13, R58);
+            Mix(ref b4, ref b9, R59);
+            Mix(ref b14, ref b1, R60);
+            Mix(ref b8, ref b5, R61);
+            Mix(ref b10, ref b3, R62);
+            Mix(ref b12, ref b7, R63);
 
-            block[0] += key[dm17 + 1];
-            block[1] += key[dm17 + 2];
-            block[2] += key[dm17 + 3];
-            block[3] += key[dm17 + 4];
-            block[4] += key[dm17 + 5];
-            block[5] += key[dm17 + 6];
-            block[6] += key[dm17 + 7];
-            block[7] += key[dm17 + 8];
-            block[8] += key[dm17 + 9];
-            block[9] += key[dm17 + 10];
-            block[10] += key[dm17 + 11];
-            block[11] += key[dm17 + 12];
-            block[12] += key[dm17 + 13];
-            block[13] += key[dm17 + 14] + tweak[dm3 + 1];
-            block[14] += key[dm17 + 15] + tweak[dm3 + 2];
-            block[15] += key[dm17 + 16] + (uint)d + 1;
+            b0 += Unsafe.Add(ref keyRef, dm17 + 1);
+            b1 += Unsafe.Add(ref keyRef, dm17 + 2);
+            b2 += Unsafe.Add(ref keyRef, dm17 + 3);
+            b3 += Unsafe.Add(ref keyRef, dm17 + 4);
+            b4 += Unsafe.Add(ref keyRef, dm17 + 5);
+            b5 += Unsafe.Add(ref keyRef, dm17 + 6);
+            b6 += Unsafe.Add(ref keyRef, dm17 + 7);
+            b7 += Unsafe.Add(ref keyRef, dm17 + 8);
+            b8 += Unsafe.Add(ref keyRef, dm17 + 9);
+            b9 += Unsafe.Add(ref keyRef, dm17 + 10);
+            b10 += Unsafe.Add(ref keyRef, dm17 + 11);
+            b11 += Unsafe.Add(ref keyRef, dm17 + 12);
+            b12 += Unsafe.Add(ref keyRef, dm17 + 13);
+            b13 += Unsafe.Add(ref keyRef, dm17 + 14) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b14 += Unsafe.Add(ref keyRef, dm17 + 15) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b15 += Unsafe.Add(ref keyRef, dm17 + 16) + (uint)d + 1;
         }
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
+        StoreWordLittleEndian(ref outputRef, 32, b4);
+        StoreWordLittleEndian(ref outputRef, 40, b5);
+        StoreWordLittleEndian(ref outputRef, 48, b6);
+        StoreWordLittleEndian(ref outputRef, 56, b7);
+        StoreWordLittleEndian(ref outputRef, 64, b8);
+        StoreWordLittleEndian(ref outputRef, 72, b9);
+        StoreWordLittleEndian(ref outputRef, 80, b10);
+        StoreWordLittleEndian(ref outputRef, 88, b11);
+        StoreWordLittleEndian(ref outputRef, 96, b12);
+        StoreWordLittleEndian(ref outputRef, 104, b13);
+        StoreWordLittleEndian(ref outputRef, 112, b14);
+        StoreWordLittleEndian(ref outputRef, 120, b15);
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.Avx512.cs
@@ -1,0 +1,220 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThreefishBlockCipher.256.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of <see cref="Threefish256Cipher" />. The four 64-bit state words
+/// are split across two <see cref="Vector128{T}" /> registers — <c>lo</c> holds the even-position words
+/// <c>(b0, b2)</c> and <c>hi</c> the odd-position words <c>(b1, b3)</c>. Each round performs a vector add,
+/// a per-lane variable rotate (<c>VPROLVQ</c>), an XOR, and a single 64-bit lane swap on <c>hi</c> that
+/// realigns it for the next round's MIX pairing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Threefish-256 alternates between two MIX pair patterns within a 4-round group: <c>(0,1)(2,3)</c> at
+/// rounds 0 and 2, and <c>(0,3)(2,1)</c> at rounds 1 and 3. With the state split into even/odd halves,
+/// the alternation reduces to a single swap of <c>hi</c>'s two lanes — applied four times in a row, the
+/// swaps cycle back to canonical layout, which is exactly where the subkey injection lands.
+/// </para>
+/// <para>
+/// Gated on <see cref="Avx512F.VL.IsSupported" /> because the per-lane variable rotate runs on
+/// <see cref="Vector128{T}" />. SIMD gain on Threefish-256 is the smallest of the three variants — the
+/// 128-bit working width matches scalar register count and the per-instruction overhead is high relative
+/// to the work — but the implementation keeps the family pattern consistent and provides a measured
+/// reduction in scalar instruction count per round.
+/// </para>
+/// </remarks>
+public sealed partial class Threefish256Cipher
+{
+    // Per-round rotation vectors. Each Vector128<ulong> packs the two MIX rotations for one round at
+    // lane positions matching the hi register's lane layout when the round executes.
+    private static readonly Vector128<ulong> s_rotVec0 = Vector128.Create((ulong)R0, R1);
+    private static readonly Vector128<ulong> s_rotVec1 = Vector128.Create((ulong)R2, R3);
+    private static readonly Vector128<ulong> s_rotVec2 = Vector128.Create((ulong)R4, R5);
+    private static readonly Vector128<ulong> s_rotVec3 = Vector128.Create((ulong)R6, R7);
+    private static readonly Vector128<ulong> s_rotVec4 = Vector128.Create((ulong)R8, R9);
+    private static readonly Vector128<ulong> s_rotVec5 = Vector128.Create((ulong)R10, R11);
+    private static readonly Vector128<ulong> s_rotVec6 = Vector128.Create((ulong)R12, R13);
+    private static readonly Vector128<ulong> s_rotVec7 = Vector128.Create((ulong)R14, R15);
+
+    // Lane-swap index vector: swaps the two 64-bit lanes of a Vector128<ulong>. The swap is its own
+    // inverse, so the same vector serves both the forward (Encrypt) and inverse (Decrypt) directions.
+    private static readonly Vector128<ulong> s_hiSwapIndices = Vector128.Create(1UL, 0);
+
+    /// <summary>
+    /// Encrypts a single 32-byte block using the AVX-512 vectorised Threefish-256 implementation.
+    /// </summary>
+    /// <param name="input">The 32-byte plaintext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 32-byte buffer that receives the ciphertext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        ulong b0 = Unsafe.Add(ref wordRef, 0);
+        ulong b1 = Unsafe.Add(ref wordRef, 1);
+        ulong b2 = Unsafe.Add(ref wordRef, 2);
+        ulong b3 = Unsafe.Add(ref wordRef, 3);
+        Vector128<ulong> lo = Vector128.Create(b0, b2);
+        Vector128<ulong> hi = Vector128.Create(b1, b3);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        // Initial subkey injection. Tweak applies at positions 1 (hi lane 0) and 2 (lo lane 1).
+        lo += Vector128.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2) + Unsafe.Add(ref tweakRef, 1));
+        hi += Vector128.Create(
+            Unsafe.Add(ref keyRef, 1) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 3));
+
+        for (var d = 1; d < 72 / 4; d += 2)
+        {
+            var dm5 = d % 5;
+            var dm3 = d % 3;
+
+            // First 4 rounds (R0..R7). Four hi-swaps cycle the layout back to canonical.
+            SimdRoundForward(ref lo, ref hi, s_rotVec0);
+            SimdRoundForward(ref lo, ref hi, s_rotVec1);
+            SimdRoundForward(ref lo, ref hi, s_rotVec2);
+            SimdRoundForward(ref lo, ref hi, s_rotVec3);
+
+            // Mid subkey injection at canonical layout.
+            lo += Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5),
+                Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hi += Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 1) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm5 + 3) + (ulong)d);
+
+            // Second 4 rounds (R8..R15), again returning to canonical layout.
+            SimdRoundForward(ref lo, ref hi, s_rotVec4);
+            SimdRoundForward(ref lo, ref hi, s_rotVec5);
+            SimdRoundForward(ref lo, ref hi, s_rotVec6);
+            SimdRoundForward(ref lo, ref hi, s_rotVec7);
+
+            // Post subkey injection at canonical layout.
+            lo += Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 1),
+                Unsafe.Add(ref keyRef, dm5 + 3) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hi += Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm5 + 4) + (ulong)d + 1);
+        }
+
+        ref ulong outWordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(output));
+        Unsafe.Add(ref outWordRef, 0) = lo.GetElement(0);
+        Unsafe.Add(ref outWordRef, 1) = hi.GetElement(0);
+        Unsafe.Add(ref outWordRef, 2) = lo.GetElement(1);
+        Unsafe.Add(ref outWordRef, 3) = hi.GetElement(1);
+    }
+
+    /// <summary>
+    /// Decrypts a single 32-byte block using the AVX-512 vectorised Threefish-256 implementation.
+    /// </summary>
+    /// <param name="input">The 32-byte ciphertext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 32-byte buffer that receives the plaintext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        ulong b0 = Unsafe.Add(ref wordRef, 0);
+        ulong b1 = Unsafe.Add(ref wordRef, 1);
+        ulong b2 = Unsafe.Add(ref wordRef, 2);
+        ulong b3 = Unsafe.Add(ref wordRef, 3);
+        Vector128<ulong> lo = Vector128.Create(b0, b2);
+        Vector128<ulong> hi = Vector128.Create(b1, b3);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        for (var d = (72 / 4) - 1; d >= 1; d -= 2)
+        {
+            var dm5 = d % 5;
+            var dm3 = d % 3;
+
+            // Reverse the post subkey injection.
+            lo -= Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 1),
+                Unsafe.Add(ref keyRef, dm5 + 3) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hi -= Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm5 + 4) + (ulong)d + 1);
+
+            // Reverse the second 4 rounds (R14..R15, R12..R13, R10..R11, R8..R9).
+            SimdRoundInverse(ref lo, ref hi, s_rotVec7);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec6);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec5);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec4);
+
+            // Reverse the mid subkey injection.
+            lo -= Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5),
+                Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hi -= Vector128.Create(
+                Unsafe.Add(ref keyRef, dm5 + 1) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm5 + 3) + (ulong)d);
+
+            // Reverse the first 4 rounds (R6..R7, R4..R5, R2..R3, R0..R1).
+            SimdRoundInverse(ref lo, ref hi, s_rotVec3);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec2);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec1);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec0);
+        }
+
+        // Reverse the initial subkey injection.
+        lo -= Vector128.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2) + Unsafe.Add(ref tweakRef, 1));
+        hi -= Vector128.Create(
+            Unsafe.Add(ref keyRef, 1) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 3));
+
+        ref ulong outWordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(output));
+        Unsafe.Add(ref outWordRef, 0) = lo.GetElement(0);
+        Unsafe.Add(ref outWordRef, 1) = hi.GetElement(0);
+        Unsafe.Add(ref outWordRef, 2) = lo.GetElement(1);
+        Unsafe.Add(ref outWordRef, 3) = hi.GetElement(1);
+    }
+
+    /// <summary>
+    /// Executes one forward Threefish-256 round on the vectorised state and applies the inter-round
+    /// lane swap that realigns <c>hi</c> for the next round's MIX pairing.
+    /// </summary>
+    /// <param name="lo">The even-position state register, updated in place.</param>
+    /// <param name="hi">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The two per-lane rotation amounts for this round, packed into a Vector128.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundForward(ref Vector128<ulong> lo, ref Vector128<ulong> hi, Vector128<ulong> rotation)
+    {
+        lo += hi;
+        hi = Avx512F.VL.RotateLeftVariable(hi, rotation) ^ lo;
+        hi = Vector128.Shuffle(hi, s_hiSwapIndices);
+    }
+
+    /// <summary>
+    /// Executes one inverse Threefish-256 round on the vectorised state. The inverse lane swap is applied
+    /// before the UNMIX so it undoes the previous forward swap, restoring the layout the original MIX
+    /// operated on.
+    /// </summary>
+    /// <param name="lo">The even-position state register, updated in place.</param>
+    /// <param name="hi">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The two per-lane rotation amounts originally applied in the forward round.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundInverse(ref Vector128<ulong> lo, ref Vector128<ulong> hi, Vector128<ulong> rotation)
+    {
+        hi = Vector128.Shuffle(hi, s_hiSwapIndices);
+        hi ^= lo;
+        hi = Avx512F.VL.RotateRightVariable(hi, rotation);
+        lo -= hi;
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
@@ -6,6 +6,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace Bodu.Security.Cryptography;
 
@@ -47,7 +48,7 @@ namespace Bodu.Security.Cryptography;
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.
 /// SymmetricAlgorithm</seealso> <seealso cref="Threefish256"/>
-public sealed class Threefish256Cipher
+public sealed partial class Threefish256Cipher
     : ThreefishBlockCipher
 {
     /// <summary>
@@ -100,6 +101,11 @@ public sealed class Threefish256Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 32 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512 vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.VL.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -109,6 +115,28 @@ public sealed class Threefish256Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 32));
         }
 
+        if (Avx512F.VL.IsSupported)
+        {
+            this.DecryptAvx512(input, output);
+            return;
+        }
+
+        this.DecryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Decrypts a single 32-byte ciphertext block using the scalar register-resident Threefish-256 implementation.
+    /// </summary>
+    /// <param name="input">The 32-byte ciphertext block to decrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 32-byte buffer to receive the decrypted plaintext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Decrypt" /> on hosts without AVX-512 + VL support. Operates on four 64-bit words
+    /// held in stack-resident locals, with the key/tweak schedule accessed via interior refs so subkey
+    /// injections skip per-element bounds checks.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
         // Load the ciphertext block as four 64-bit little-endian words into registers, skipping the
         // intermediate stackalloc + MemoryMarshal.Cast + CopyTo trip through the stack the prior
         // implementation used.
@@ -185,6 +213,11 @@ public sealed class Threefish256Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 32 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512 vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.VL.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -194,6 +227,27 @@ public sealed class Threefish256Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 32));
         }
 
+        if (Avx512F.VL.IsSupported)
+        {
+            this.EncryptAvx512(input, output);
+            return;
+        }
+
+        this.EncryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Encrypts a single 32-byte plaintext block using the scalar register-resident Threefish-256 implementation.
+    /// </summary>
+    /// <param name="input">The 32-byte plaintext block to encrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 32-byte buffer to receive the encrypted ciphertext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Encrypt" /> on hosts without AVX-512 + VL support. See <see cref="DecryptScalar" />
+    /// for the local-resident state strategy this method mirrors.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
         // Load the plaintext block as four 64-bit little-endian words into registers.
         ref byte inputRef = ref MemoryMarshal.GetReference(input);
         ulong b0 = LoadWordLittleEndian(ref inputRef, 0);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
@@ -1,9 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="ThreefishBlockCipher.256.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Bodu.Security.Cryptography;
@@ -62,6 +63,20 @@ public sealed class Threefish256Cipher
     /// </summary>
     public const int KeySize = 256;
 
+    // Spec-defined rotation constants for Threefish-256. Declared as named const ints so the JIT can
+    // fold each Mix/Unmix call to a ROL/ROR with an immediate count, and so all 16 values live in one
+    // place rather than being duplicated between Encrypt, Decrypt, and the public RotationSchedule.
+    private const int R0 = 14, R1 = 16, R2 = 52, R3 = 57;
+    private const int R4 = 23, R5 = 40, R6 = 5, R7 = 37;
+    private const int R8 = 25, R9 = 33, R10 = 46, R11 = 12;
+    private const int R12 = 58, R13 = 22, R14 = 32, R15 = 32;
+
+    private static readonly int[] s_rotationSchedule =
+    [
+        R0, R1, R2, R3, R4, R5, R6, R7,
+        R8, R9, R10, R11, R12, R13, R14, R15,
+    ];
+
     /// <inheritdoc />
     /// <value>Length of the Threefish-256 block is 256 bits (32 bytes).</value>
     public override int BlockSize => 256;
@@ -70,25 +85,7 @@ public sealed class Threefish256Cipher
     protected override int BlockWords => 4;
 
     /// <inheritdoc />
-    protected override int[] RotationSchedule =>
-    [
-        14,
-        16,
-        52,
-        57,
-        23,
-        40,
-        5,
-        37,
-        25,
-        33,
-        46,
-        12,
-        58,
-        22,
-        32,
-        32
-    ];
+    protected override int[] RotationSchedule => s_rotationSchedule;
 
     /// <inheritdoc />
     protected override int Rounds => 72;
@@ -106,64 +103,76 @@ public sealed class Threefish256Cipher
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 32 || output.Length != 32)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 32));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        // Load the ciphertext block as four 64-bit little-endian words into registers, skipping the
+        // intermediate stackalloc + MemoryMarshal.Cast + CopyTo trip through the stack the prior
+        // implementation used.
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule; // Use indexed rotation constants
+        // Capture interior refs to the key and tweak schedule arrays so each subkey-injection access
+        // skips the per-element bounds check that ulong[] indexing would otherwise emit.
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
-        for (var d = (this.Rounds / 4) - 1; d >= 1; d -= 2)
+        for (var d = (72 / 4) - 1; d >= 1; d -= 2)
         {
             var dm5 = d % 5;
             var dm3 = d % 3;
 
             // Reverse post-round subkey injection
-            block[0] -= key[dm5 + 1];
-            block[1] -= key[dm5 + 2] + tweak[dm3 + 1];
-            block[2] -= key[dm5 + 3] + tweak[dm3 + 2];
-            block[3] -= key[dm5 + 4] + (uint)(d + 1);
+            b0 -= Unsafe.Add(ref keyRef, dm5 + 1);
+            b1 -= Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b2 -= Unsafe.Add(ref keyRef, dm5 + 3) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b3 -= Unsafe.Add(ref keyRef, dm5 + 4) + (uint)(d + 1);
 
             // Reverse second 4 rounds
-            Unmix(ref block[2], ref block[1], rot[15]);
-            Unmix(ref block[0], ref block[3], rot[14]);
-            Unmix(ref block[2], ref block[3], rot[13]);
-            Unmix(ref block[0], ref block[1], rot[12]);
-            Unmix(ref block[2], ref block[1], rot[11]);
-            Unmix(ref block[0], ref block[3], rot[10]);
-            Unmix(ref block[2], ref block[3], rot[9]);
-            Unmix(ref block[0], ref block[1], rot[8]);
+            Unmix(ref b2, ref b1, R15);
+            Unmix(ref b0, ref b3, R14);
+            Unmix(ref b2, ref b3, R13);
+            Unmix(ref b0, ref b1, R12);
+            Unmix(ref b2, ref b1, R11);
+            Unmix(ref b0, ref b3, R10);
+            Unmix(ref b2, ref b3, R9);
+            Unmix(ref b0, ref b1, R8);
 
             // Reverse mid-round subkey injection
-            block[0] -= key[dm5];
-            block[1] -= key[dm5 + 1] + tweak[dm3];
-            block[2] -= key[dm5 + 2] + tweak[dm3 + 1];
-            block[3] -= key[dm5 + 3] + (uint)d;
+            b0 -= Unsafe.Add(ref keyRef, dm5);
+            b1 -= Unsafe.Add(ref keyRef, dm5 + 1) + Unsafe.Add(ref tweakRef, dm3);
+            b2 -= Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b3 -= Unsafe.Add(ref keyRef, dm5 + 3) + (uint)d;
 
             // Reverse first 4 rounds
-            Unmix(ref block[2], ref block[1], rot[7]);
-            Unmix(ref block[0], ref block[3], rot[6]);
-            Unmix(ref block[2], ref block[3], rot[5]);
-            Unmix(ref block[0], ref block[1], rot[4]);
-            Unmix(ref block[2], ref block[1], rot[3]);
-            Unmix(ref block[0], ref block[3], rot[2]);
-            Unmix(ref block[2], ref block[3], rot[1]);
-            Unmix(ref block[0], ref block[1], rot[0]);
+            Unmix(ref b2, ref b1, R7);
+            Unmix(ref b0, ref b3, R6);
+            Unmix(ref b2, ref b3, R5);
+            Unmix(ref b0, ref b1, R4);
+            Unmix(ref b2, ref b1, R3);
+            Unmix(ref b0, ref b3, R2);
+            Unmix(ref b2, ref b3, R1);
+            Unmix(ref b0, ref b1, R0);
         }
 
         // Final subkey removal (round 0)
-        block[0] -= key[0];
-        block[1] -= key[1] + tweak[0];
-        block[2] -= key[2] + tweak[1];
-        block[3] -= key[3];
+        b0 -= Unsafe.Add(ref keyRef, 0);
+        b1 -= Unsafe.Add(ref keyRef, 1) + Unsafe.Add(ref tweakRef, 0);
+        b2 -= Unsafe.Add(ref keyRef, 2) + Unsafe.Add(ref tweakRef, 1);
+        b3 -= Unsafe.Add(ref keyRef, 3);
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        // Commit the four plaintext words to the output buffer in little-endian byte order.
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
     }
 
     /// <summary>
@@ -179,63 +188,70 @@ public sealed class Threefish256Cipher
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 32 || output.Length != 32)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 32));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        // Load the plaintext block as four 64-bit little-endian words into registers.
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule;
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
         // Initial key injection (round 0)
-        block[0] += key[0x00];
-        block[1] += key[0x01] + tweak[0x00];
-        block[2] += key[0x02] + tweak[0x01];
-        block[3] += key[0x03];
+        b0 += Unsafe.Add(ref keyRef, 0);
+        b1 += Unsafe.Add(ref keyRef, 1) + Unsafe.Add(ref tweakRef, 0);
+        b2 += Unsafe.Add(ref keyRef, 2) + Unsafe.Add(ref tweakRef, 1);
+        b3 += Unsafe.Add(ref keyRef, 3);
 
-        for (var d = 1; d < this.Rounds / 4; d += 2)
+        for (var d = 1; d < 72 / 4; d += 2)
         {
             var dm5 = d % 5;
             var dm3 = d % 3;
 
             // First 4 MIX rounds
-            Mix(ref block[0], ref block[1], rot[0]);
-            Mix(ref block[2], ref block[3], rot[1]);
-            Mix(ref block[0], ref block[3], rot[2]);
-            Mix(ref block[2], ref block[1], rot[3]);
-            Mix(ref block[0], ref block[1], rot[4]);
-            Mix(ref block[2], ref block[3], rot[5]);
-            Mix(ref block[0], ref block[3], rot[6]);
-            Mix(ref block[2], ref block[1], rot[7]);
+            Mix(ref b0, ref b1, R0);
+            Mix(ref b2, ref b3, R1);
+            Mix(ref b0, ref b3, R2);
+            Mix(ref b2, ref b1, R3);
+            Mix(ref b0, ref b1, R4);
+            Mix(ref b2, ref b3, R5);
+            Mix(ref b0, ref b3, R6);
+            Mix(ref b2, ref b1, R7);
 
             // Mid-round subkey injection
-            block[0] += key[dm5];
-            block[1] += key[dm5 + 1] + tweak[dm3];
-            block[2] += key[dm5 + 2] + tweak[dm3 + 1];
-            block[3] += key[dm5 + 3] + (ulong)d;
+            b0 += Unsafe.Add(ref keyRef, dm5);
+            b1 += Unsafe.Add(ref keyRef, dm5 + 1) + Unsafe.Add(ref tweakRef, dm3);
+            b2 += Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b3 += Unsafe.Add(ref keyRef, dm5 + 3) + (ulong)d;
 
             // Second 4 MIX rounds
-            Mix(ref block[0], ref block[1], rot[8]);
-            Mix(ref block[2], ref block[3], rot[9]);
-            Mix(ref block[0], ref block[3], rot[10]);
-            Mix(ref block[2], ref block[1], rot[11]);
-            Mix(ref block[0], ref block[1], rot[12]);
-            Mix(ref block[2], ref block[3], rot[13]);
-            Mix(ref block[0], ref block[3], rot[14]);
-            Mix(ref block[2], ref block[1], rot[15]);
+            Mix(ref b0, ref b1, R8);
+            Mix(ref b2, ref b3, R9);
+            Mix(ref b0, ref b3, R10);
+            Mix(ref b2, ref b1, R11);
+            Mix(ref b0, ref b1, R12);
+            Mix(ref b2, ref b3, R13);
+            Mix(ref b0, ref b3, R14);
+            Mix(ref b2, ref b1, R15);
 
             // Post-round subkey injection
-            block[0] += key[dm5 + 1];
-            block[1] += key[dm5 + 2] + tweak[dm3 + 1];
-            block[2] += key[dm5 + 3] + tweak[dm3 + 2];
-            block[3] += key[dm5 + 4] + (ulong)d + 1;
+            b0 += Unsafe.Add(ref keyRef, dm5 + 1);
+            b1 += Unsafe.Add(ref keyRef, dm5 + 2) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b2 += Unsafe.Add(ref keyRef, dm5 + 3) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b3 += Unsafe.Add(ref keyRef, dm5 + 4) + (ulong)d + 1;
         }
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.Avx512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.Avx512.cs
@@ -1,0 +1,269 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ThreefishBlockCipher.512.Avx512.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics;
+using System.Runtime.Intrinsics.X86;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// AVX-512 vectorised implementation of <see cref="Threefish512Cipher" />. The eight 64-bit state words are
+/// split across two <see cref="Vector256{T}" /> registers — <c>lo</c> holds the even-position words
+/// <c>(x0, x2, x4, x6)</c> and <c>hi</c> the odd-position words <c>(x1, x3, x5, x7)</c> — and each round
+/// applies a vector add, a per-lane variable rotate (<c>VPROLVQ</c>), an XOR, and a pair of lane shuffles
+/// that realign the registers for the next round's MIX pairing.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The per-round word permutation in Threefish-512 has a 4-round cycle: between rounds, the even-position
+/// register rotates its four lanes left by one (<c>VPERMQ</c> with control <c>0x39</c>) and the odd-position
+/// register swaps lanes 1 and 3 (<c>VPERMQ</c> with control <c>0x6C</c>). After four such shuffles both
+/// registers return to canonical layout, which is exactly the layout the subkey injection expects.
+/// </para>
+/// <para>
+/// Gated on <see cref="Avx512F.VL.IsSupported" /> rather than <see cref="Avx512F.IsSupported" /> because the
+/// variable rotate is invoked on <see cref="Vector256{T}" /> rather than <see cref="Vector512{T}" />, which
+/// requires the AVX-512 Vector Length extensions. AVX-512VL has been bundled with AVX-512F on every
+/// mainstream Intel/AMD CPU shipping it (the only AVX-512F-without-VL parts were the discontinued
+/// Knights Landing / Knights Mill server processors).
+/// </para>
+/// </remarks>
+public sealed partial class Threefish512Cipher
+{
+    // Per-round rotation vectors. Each Vector256<ulong> packs four spec-defined rotation amounts (the four
+    // MIX rotations for one round) at lane positions matching the hi register's lane layout when the round
+    // executes.
+    private static readonly Vector256<ulong> s_rotVec0 = Vector256.Create((ulong)R0, R1, R2, R3);
+    private static readonly Vector256<ulong> s_rotVec1 = Vector256.Create((ulong)R4, R5, R6, R7);
+    private static readonly Vector256<ulong> s_rotVec2 = Vector256.Create((ulong)R8, R9, R10, R11);
+    private static readonly Vector256<ulong> s_rotVec3 = Vector256.Create((ulong)R12, R13, R14, R15);
+    private static readonly Vector256<ulong> s_rotVec4 = Vector256.Create((ulong)R16, R17, R18, R19);
+    private static readonly Vector256<ulong> s_rotVec5 = Vector256.Create((ulong)R20, R21, R22, R23);
+    private static readonly Vector256<ulong> s_rotVec6 = Vector256.Create((ulong)R24, R25, R26, R27);
+    private static readonly Vector256<ulong> s_rotVec7 = Vector256.Create((ulong)R28, R29, R30, R31);
+
+    // VPERMQ control bytes used by the inter-round shuffle. ShuffleLoForward rotates lo's four lanes left
+    // by one position; ShuffleHiSwap13 swaps hi's lanes 1 and 3 (an involution, so the same byte serves
+    // both the forward and inverse direction). ShuffleLoInverse rotates lo's lanes right by one for the
+    // Decrypt pass.
+    private const byte ShuffleLoForward = 0x39;  // lanes (1, 2, 3, 0) — left-rotate by 1
+    private const byte ShuffleLoInverse = 0x93;  // lanes (3, 0, 1, 2) — right-rotate by 1
+    private const byte ShuffleHiSwap13 = 0x6C;   // lanes (0, 3, 2, 1) — swap 1 and 3 (self-inverse)
+
+    /// <summary>
+    /// Encrypts a single 64-byte block using the AVX-512 vectorised Threefish-512 implementation.
+    /// </summary>
+    /// <param name="input">The 64-byte plaintext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 64-byte buffer that receives the ciphertext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Load the plaintext block as eight 64-bit words held across two Vector256 registers, then
+        // deinterleave into lo = (x0, x2, x4, x6) and hi = (x1, x3, x5, x7).
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        Vector256<ulong> low4 = Vector256.LoadUnsafe(ref wordRef);
+        Vector256<ulong> high4 = Vector256.LoadUnsafe(ref wordRef, 4);
+        Vector256<ulong> lo = Avx2.Permute4x64(Avx2.UnpackLow(low4, high4), 0xD8);
+        Vector256<ulong> hi = Avx2.Permute4x64(Avx2.UnpackHigh(low4, high4), 0xD8);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        // Initial subkey injection. In canonical layout, lo lanes correspond to state positions
+        // (0, 2, 4, 6) and hi lanes to (1, 3, 5, 7); the tweak applies at positions 5 and 6.
+        lo += Vector256.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2),
+            Unsafe.Add(ref keyRef, 4),
+            Unsafe.Add(ref keyRef, 6) + Unsafe.Add(ref tweakRef, 1));
+        hi += Vector256.Create(
+            Unsafe.Add(ref keyRef, 1),
+            Unsafe.Add(ref keyRef, 3),
+            Unsafe.Add(ref keyRef, 5) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 7));
+
+        for (var d = 1; d < 72 / 4; d += 2)
+        {
+            int dm9 = d % 9, dm3 = d % 3;
+
+            // First 4 rounds (R0..R15). After four forward shuffles both registers cycle back to
+            // canonical layout, where the mid subkey injection lands.
+            SimdRoundForward(ref lo, ref hi, s_rotVec0);
+            SimdRoundForward(ref lo, ref hi, s_rotVec1);
+            SimdRoundForward(ref lo, ref hi, s_rotVec2);
+            SimdRoundForward(ref lo, ref hi, s_rotVec3);
+
+            // Mid subkey injection at canonical layout.
+            lo += Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9),
+                Unsafe.Add(ref keyRef, dm9 + 2),
+                Unsafe.Add(ref keyRef, dm9 + 4),
+                Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hi += Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 3),
+                Unsafe.Add(ref keyRef, dm9 + 5) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm9 + 7) + (ulong)d);
+
+            // Second 4 rounds (R16..R31), again returning to canonical layout.
+            SimdRoundForward(ref lo, ref hi, s_rotVec4);
+            SimdRoundForward(ref lo, ref hi, s_rotVec5);
+            SimdRoundForward(ref lo, ref hi, s_rotVec6);
+            SimdRoundForward(ref lo, ref hi, s_rotVec7);
+
+            // Post subkey injection at canonical layout.
+            lo += Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 3),
+                Unsafe.Add(ref keyRef, dm9 + 5),
+                Unsafe.Add(ref keyRef, dm9 + 7) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hi += Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 2),
+                Unsafe.Add(ref keyRef, dm9 + 4),
+                Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 8) + (ulong)(d + 1));
+        }
+
+        // Reinterleave (lo, hi) back into byte-order halves and commit to the output buffer.
+        StoreStateBlock(ref MemoryMarshal.GetReference(output), lo, hi);
+    }
+
+    /// <summary>
+    /// Decrypts a single 64-byte block using the AVX-512 vectorised Threefish-512 implementation.
+    /// </summary>
+    /// <param name="input">The 64-byte ciphertext block. Caller is responsible for length validation.</param>
+    /// <param name="output">The 64-byte buffer that receives the plaintext block.</param>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptAvx512(ReadOnlySpan<byte> input, Span<byte> output)
+    {
+        // Load the ciphertext block in the same canonical layout the Encrypt path produces.
+        ref ulong wordRef = ref Unsafe.As<byte, ulong>(ref MemoryMarshal.GetReference(input));
+        Vector256<ulong> low4 = Vector256.LoadUnsafe(ref wordRef);
+        Vector256<ulong> high4 = Vector256.LoadUnsafe(ref wordRef, 4);
+        Vector256<ulong> lo = Avx2.Permute4x64(Avx2.UnpackLow(low4, high4), 0xD8);
+        Vector256<ulong> hi = Avx2.Permute4x64(Avx2.UnpackHigh(low4, high4), 0xD8);
+
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
+
+        // Walk the subkey-injection / round groups in reverse. Each inverse-round applies the inverse
+        // shuffle first to undo the previous forward shuffle, then UNMIX with the rotation that round
+        // used originally — so the loop body mirrors EncryptAvx512 in reverse order.
+        for (var d = (72 / 4) - 1; d >= 1; d -= 2)
+        {
+            int dm9 = d % 9, dm3 = d % 3;
+
+            // Reverse the post subkey injection.
+            lo -= Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 3),
+                Unsafe.Add(ref keyRef, dm9 + 5),
+                Unsafe.Add(ref keyRef, dm9 + 7) + Unsafe.Add(ref tweakRef, dm3 + 2));
+            hi -= Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 2),
+                Unsafe.Add(ref keyRef, dm9 + 4),
+                Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 8) + (ulong)(d + 1));
+
+            // Reverse the second 4 rounds (rotations R28..R31, R24..R27, R20..R23, R16..R19) — four
+            // inverse shuffles cycle the registers back through layouts L3, L2, L1, L0 = canonical.
+            SimdRoundInverse(ref lo, ref hi, s_rotVec7);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec6);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec5);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec4);
+
+            // Reverse the mid subkey injection.
+            lo -= Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9),
+                Unsafe.Add(ref keyRef, dm9 + 2),
+                Unsafe.Add(ref keyRef, dm9 + 4),
+                Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1));
+            hi -= Vector256.Create(
+                Unsafe.Add(ref keyRef, dm9 + 1),
+                Unsafe.Add(ref keyRef, dm9 + 3),
+                Unsafe.Add(ref keyRef, dm9 + 5) + Unsafe.Add(ref tweakRef, dm3),
+                Unsafe.Add(ref keyRef, dm9 + 7) + (ulong)d);
+
+            // Reverse the first 4 rounds (rotations R12..R15, R8..R11, R4..R7, R0..R3).
+            SimdRoundInverse(ref lo, ref hi, s_rotVec3);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec2);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec1);
+            SimdRoundInverse(ref lo, ref hi, s_rotVec0);
+        }
+
+        // Reverse the initial subkey injection.
+        lo -= Vector256.Create(
+            Unsafe.Add(ref keyRef, 0),
+            Unsafe.Add(ref keyRef, 2),
+            Unsafe.Add(ref keyRef, 4),
+            Unsafe.Add(ref keyRef, 6) + Unsafe.Add(ref tweakRef, 1));
+        hi -= Vector256.Create(
+            Unsafe.Add(ref keyRef, 1),
+            Unsafe.Add(ref keyRef, 3),
+            Unsafe.Add(ref keyRef, 5) + Unsafe.Add(ref tweakRef, 0),
+            Unsafe.Add(ref keyRef, 7));
+
+        StoreStateBlock(ref MemoryMarshal.GetReference(output), lo, hi);
+    }
+
+    /// <summary>
+    /// Executes one forward Threefish-512 round on the vectorised state and applies the inter-round shuffle
+    /// that realigns the registers for the next round's MIX pairing.
+    /// </summary>
+    /// <param name="lo">The even-position state register, updated in place.</param>
+    /// <param name="hi">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The four per-lane rotation amounts for this round, packed into a Vector256.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundForward(ref Vector256<ulong> lo, ref Vector256<ulong> hi, Vector256<ulong> rotation)
+    {
+        lo += hi;
+        hi = Avx512F.VL.RotateLeftVariable(hi, rotation) ^ lo;
+        lo = Avx2.Permute4x64(lo, ShuffleLoForward);
+        hi = Avx2.Permute4x64(hi, ShuffleHiSwap13);
+    }
+
+    /// <summary>
+    /// Executes one inverse Threefish-512 round on the vectorised state. The inverse shuffle is applied
+    /// before the UNMIX so it undoes the previous forward shuffle, restoring the layout that the original
+    /// MIX operated on.
+    /// </summary>
+    /// <param name="lo">The even-position state register, updated in place.</param>
+    /// <param name="hi">The odd-position state register, updated in place.</param>
+    /// <param name="rotation">The four per-lane rotation amounts originally applied in the forward round.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void SimdRoundInverse(ref Vector256<ulong> lo, ref Vector256<ulong> hi, Vector256<ulong> rotation)
+    {
+        lo = Avx2.Permute4x64(lo, ShuffleLoInverse);
+        hi = Avx2.Permute4x64(hi, ShuffleHiSwap13);
+        hi ^= lo;
+        hi = Avx512F.VL.RotateRightVariable(hi, rotation);
+        lo -= hi;
+    }
+
+    /// <summary>
+    /// Reinterleaves the <c>(lo, hi)</c> vectorised state back into the canonical eight-word byte order and
+    /// writes it to the destination buffer as two unaligned 256-bit stores.
+    /// </summary>
+    /// <param name="destination">A reference to the first byte of the destination buffer.</param>
+    /// <param name="lo">The even-position state register holding <c>(x0, x2, x4, x6)</c>.</param>
+    /// <param name="hi">The odd-position state register holding <c>(x1, x3, x5, x7)</c>.</param>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static void StoreStateBlock(ref byte destination, Vector256<ulong> lo, Vector256<ulong> hi)
+    {
+        // UnpackLow/High split the registers into per-128-bit-lane interleavings; Permute2x128 then
+        // recombines the lower-half and upper-half pieces into the natural (x0..x3) and (x4..x7) order.
+        Vector256<ulong> unLow = Avx2.UnpackLow(lo, hi);       // (x0, x1, x4, x5)
+        Vector256<ulong> unHigh = Avx2.UnpackHigh(lo, hi);     // (x2, x3, x6, x7)
+        Vector256<ulong> outLow4 = Avx2.Permute2x128(unLow, unHigh, 0x20);   // (x0, x1, x2, x3)
+        Vector256<ulong> outHigh4 = Avx2.Permute2x128(unLow, unHigh, 0x31);  // (x4, x5, x6, x7)
+
+        ref ulong outRef = ref Unsafe.As<byte, ulong>(ref destination);
+        outLow4.StoreUnsafe(ref outRef);
+        outHigh4.StoreUnsafe(ref outRef, 4);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
@@ -6,6 +6,7 @@
 
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.X86;
 
 namespace Bodu.Security.Cryptography;
 
@@ -47,7 +48,7 @@ namespace Bodu.Security.Cryptography;
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.
 /// SymmetricAlgorithm</seealso> <seealso cref="Threefish512"/>
-public sealed class Threefish512Cipher
+public sealed partial class Threefish512Cipher
     : ThreefishBlockCipher
 {
     /// <summary>
@@ -65,7 +66,8 @@ public sealed class Threefish512Cipher
 
     // Spec-defined rotation constants for Threefish-512. Declared as named const ints so the JIT can
     // fold each Mix/Unmix call to a ROL/ROR with an immediate count, and so all 32 values live in one
-    // place rather than being duplicated between Encrypt, Decrypt, and the public RotationSchedule.
+    // place rather than being duplicated between Encrypt, Decrypt, the AVX-512 rotation vectors, and
+    // the public RotationSchedule.
     private const int R0 = 46, R1 = 36, R2 = 19, R3 = 37;
     private const int R4 = 33, R5 = 27, R6 = 14, R7 = 42;
     private const int R8 = 17, R9 = 49, R10 = 36, R11 = 39;
@@ -106,6 +108,11 @@ public sealed class Threefish512Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 64 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512F vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -115,6 +122,28 @@ public sealed class Threefish512Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 64));
         }
 
+        if (Avx512F.IsSupported)
+        {
+            this.DecryptAvx512(input, output);
+            return;
+        }
+
+        this.DecryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Decrypts a single 64-byte ciphertext block using the scalar register-resident Threefish-512 implementation.
+    /// </summary>
+    /// <param name="input">The 64-byte ciphertext block to decrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 64-byte buffer to receive the decrypted plaintext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Decrypt" /> on hosts without AVX-512F support. Operates on eight 64-bit words held
+    /// in stack-resident locals, with the key/tweak schedule accessed via interior refs so subkey injections
+    /// skip per-element bounds checks.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void DecryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
         // Load the ciphertext block as eight 64-bit little-endian words into registers, skipping the
         // intermediate stackalloc + MemoryMarshal.Cast + CopyTo trip through the stack the prior
         // implementation used.
@@ -222,6 +251,11 @@ public sealed class Threefish512Cipher
     /// <exception cref="ArgumentException">
     /// Thrown if <paramref name="input" /> or <paramref name="output" /> is not 64 bytes.
     /// </exception>
+    /// <remarks>
+    /// Dispatches to an AVX-512F vectorised implementation when supported by the host, falling back to a
+    /// scalar register-resident implementation otherwise. <see cref="Avx512F.IsSupported" /> is a JIT
+    /// intrinsic that folds to a compile-time constant, so the branch carries no runtime cost.
+    /// </remarks>
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
@@ -231,6 +265,28 @@ public sealed class Threefish512Cipher
                 string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 64));
         }
 
+        if (Avx512F.IsSupported)
+        {
+            this.EncryptAvx512(input, output);
+            return;
+        }
+
+        this.EncryptScalar(input, output);
+    }
+
+    /// <summary>
+    /// Encrypts a single 64-byte plaintext block using the scalar register-resident Threefish-512 implementation.
+    /// </summary>
+    /// <param name="input">The 64-byte plaintext block to encrypt. Caller is responsible for length validation.</param>
+    /// <param name="output">The 64-byte buffer to receive the encrypted ciphertext block.</param>
+    /// <remarks>
+    /// Invoked by <see cref="Encrypt" /> on hosts without AVX-512F support. Operates on eight 64-bit words held
+    /// in stack-resident locals, with the key/tweak schedule accessed via interior refs so subkey injections
+    /// skip per-element bounds checks.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+    private void EncryptScalar(ReadOnlySpan<byte> input, Span<byte> output)
+    {
         // Load the plaintext block as eight 64-bit little-endian words into registers.
         ref byte inputRef = ref MemoryMarshal.GetReference(input);
         ulong b0 = LoadWordLittleEndian(ref inputRef, 0);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
@@ -1,9 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="ThreefishBlockCipher.512.cs" company="PlaceholderCompany">
 //     Copyright (c) PlaceholderCompany. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 namespace Bodu.Security.Cryptography;
@@ -62,6 +63,26 @@ public sealed class Threefish512Cipher
     /// </summary>
     public const int KeySize = 512;
 
+    // Spec-defined rotation constants for Threefish-512. Declared as named const ints so the JIT can
+    // fold each Mix/Unmix call to a ROL/ROR with an immediate count, and so all 32 values live in one
+    // place rather than being duplicated between Encrypt, Decrypt, and the public RotationSchedule.
+    private const int R0 = 46, R1 = 36, R2 = 19, R3 = 37;
+    private const int R4 = 33, R5 = 27, R6 = 14, R7 = 42;
+    private const int R8 = 17, R9 = 49, R10 = 36, R11 = 39;
+    private const int R12 = 44, R13 = 9, R14 = 54, R15 = 56;
+    private const int R16 = 39, R17 = 30, R18 = 34, R19 = 24;
+    private const int R20 = 13, R21 = 50, R22 = 10, R23 = 17;
+    private const int R24 = 25, R25 = 29, R26 = 39, R27 = 43;
+    private const int R28 = 8, R29 = 35, R30 = 56, R31 = 22;
+
+    private static readonly int[] s_rotationSchedule =
+    [
+        R0, R1, R2, R3, R4, R5, R6, R7,
+        R8, R9, R10, R11, R12, R13, R14, R15,
+        R16, R17, R18, R19, R20, R21, R22, R23,
+        R24, R25, R26, R27, R28, R29, R30, R31,
+    ];
+
     /// <inheritdoc />
     /// <value>Length of the Threefish-512 block is 512 bits (64 bytes).</value>
     public override int BlockSize => 512;
@@ -70,41 +91,7 @@ public sealed class Threefish512Cipher
     protected override int BlockWords => 8;
 
     /// <inheritdoc />
-    protected override int[] RotationSchedule =>
-    [
-        46,
-        36,
-        19,
-        37,
-        33,
-        27,
-        14,
-        42,
-        17,
-        49,
-        36,
-        39,
-        44,
-        9,
-        54,
-        56,
-        39,
-        30,
-        34,
-        24,
-        13,
-        50,
-        10,
-        17,
-        25,
-        29,
-        39,
-        43,
-        8,
-        35,
-        56,
-        22
-    ];
+    protected override int[] RotationSchedule => s_rotationSchedule;
 
     /// <inheritdoc />
     protected override int Rounds => 72;
@@ -122,86 +109,107 @@ public sealed class Threefish512Cipher
     public override void Decrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 64 || output.Length != 64)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 64));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        // Load the ciphertext block as eight 64-bit little-endian words into registers, skipping the
+        // intermediate stackalloc + MemoryMarshal.Cast + CopyTo trip through the stack the prior
+        // implementation used.
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
+        ulong b4 = LoadWordLittleEndian(ref inputRef, 32);
+        ulong b5 = LoadWordLittleEndian(ref inputRef, 40);
+        ulong b6 = LoadWordLittleEndian(ref inputRef, 48);
+        ulong b7 = LoadWordLittleEndian(ref inputRef, 56);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule;
+        // Capture interior refs to the key and tweak schedule arrays so each subkey-injection access
+        // skips the per-element bounds check that ulong[] indexing would otherwise emit.
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
-        for (var d = (this.Rounds / 4) - 1; d >= 1; d -= 2)
+        for (var d = (72 / 4) - 1; d >= 1; d -= 2)
         {
             int dm9 = d % 9, dm3 = d % 3;
 
-            block[0] -= key[dm9 + 1];
-            block[1] -= key[dm9 + 2];
-            block[2] -= key[dm9 + 3];
-            block[3] -= key[dm9 + 4];
-            block[4] -= key[dm9 + 5];
-            block[5] -= key[dm9 + 6] + tweak[dm3 + 1];
-            block[6] -= key[dm9 + 7] + tweak[dm3 + 2];
-            block[7] -= key[dm9 + 8] + (ulong)(d + 1);
+            b0 -= Unsafe.Add(ref keyRef, dm9 + 1);
+            b1 -= Unsafe.Add(ref keyRef, dm9 + 2);
+            b2 -= Unsafe.Add(ref keyRef, dm9 + 3);
+            b3 -= Unsafe.Add(ref keyRef, dm9 + 4);
+            b4 -= Unsafe.Add(ref keyRef, dm9 + 5);
+            b5 -= Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b6 -= Unsafe.Add(ref keyRef, dm9 + 7) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b7 -= Unsafe.Add(ref keyRef, dm9 + 8) + (ulong)(d + 1);
 
-            Unmix(ref block[4], ref block[3], rot[31]);
-            Unmix(ref block[2], ref block[5], rot[30]);
-            Unmix(ref block[0], ref block[7], rot[29]);
-            Unmix(ref block[6], ref block[1], rot[28]);
-            Unmix(ref block[2], ref block[7], rot[27]);
-            Unmix(ref block[0], ref block[5], rot[26]);
-            Unmix(ref block[6], ref block[3], rot[25]);
-            Unmix(ref block[4], ref block[1], rot[24]);
-            Unmix(ref block[0], ref block[3], rot[23]);
-            Unmix(ref block[6], ref block[5], rot[22]);
-            Unmix(ref block[4], ref block[7], rot[21]);
-            Unmix(ref block[2], ref block[1], rot[20]);
-            Unmix(ref block[6], ref block[7], rot[19]);
-            Unmix(ref block[4], ref block[5], rot[18]);
-            Unmix(ref block[2], ref block[3], rot[17]);
-            Unmix(ref block[0], ref block[1], rot[16]);
+            Unmix(ref b4, ref b3, R31);
+            Unmix(ref b2, ref b5, R30);
+            Unmix(ref b0, ref b7, R29);
+            Unmix(ref b6, ref b1, R28);
+            Unmix(ref b2, ref b7, R27);
+            Unmix(ref b0, ref b5, R26);
+            Unmix(ref b6, ref b3, R25);
+            Unmix(ref b4, ref b1, R24);
+            Unmix(ref b0, ref b3, R23);
+            Unmix(ref b6, ref b5, R22);
+            Unmix(ref b4, ref b7, R21);
+            Unmix(ref b2, ref b1, R20);
+            Unmix(ref b6, ref b7, R19);
+            Unmix(ref b4, ref b5, R18);
+            Unmix(ref b2, ref b3, R17);
+            Unmix(ref b0, ref b1, R16);
 
-            block[0] -= key[dm9];
-            block[1] -= key[dm9 + 1];
-            block[2] -= key[dm9 + 2];
-            block[3] -= key[dm9 + 3];
-            block[4] -= key[dm9 + 4];
-            block[5] -= key[dm9 + 5] + tweak[dm3];
-            block[6] -= key[dm9 + 6] + tweak[dm3 + 1];
-            block[7] -= key[dm9 + 7] + (ulong)d;
+            b0 -= Unsafe.Add(ref keyRef, dm9);
+            b1 -= Unsafe.Add(ref keyRef, dm9 + 1);
+            b2 -= Unsafe.Add(ref keyRef, dm9 + 2);
+            b3 -= Unsafe.Add(ref keyRef, dm9 + 3);
+            b4 -= Unsafe.Add(ref keyRef, dm9 + 4);
+            b5 -= Unsafe.Add(ref keyRef, dm9 + 5) + Unsafe.Add(ref tweakRef, dm3);
+            b6 -= Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b7 -= Unsafe.Add(ref keyRef, dm9 + 7) + (ulong)d;
 
-            Unmix(ref block[4], ref block[3], rot[15]);
-            Unmix(ref block[2], ref block[5], rot[14]);
-            Unmix(ref block[0], ref block[7], rot[13]);
-            Unmix(ref block[6], ref block[1], rot[12]);
-            Unmix(ref block[2], ref block[7], rot[11]);
-            Unmix(ref block[0], ref block[5], rot[10]);
-            Unmix(ref block[6], ref block[3], rot[9]);
-            Unmix(ref block[4], ref block[1], rot[8]);
-            Unmix(ref block[0], ref block[3], rot[7]);
-            Unmix(ref block[6], ref block[5], rot[6]);
-            Unmix(ref block[4], ref block[7], rot[5]);
-            Unmix(ref block[2], ref block[1], rot[4]);
-            Unmix(ref block[6], ref block[7], rot[3]);
-            Unmix(ref block[4], ref block[5], rot[2]);
-            Unmix(ref block[2], ref block[3], rot[1]);
-            Unmix(ref block[0], ref block[1], rot[0]);
+            Unmix(ref b4, ref b3, R15);
+            Unmix(ref b2, ref b5, R14);
+            Unmix(ref b0, ref b7, R13);
+            Unmix(ref b6, ref b1, R12);
+            Unmix(ref b2, ref b7, R11);
+            Unmix(ref b0, ref b5, R10);
+            Unmix(ref b6, ref b3, R9);
+            Unmix(ref b4, ref b1, R8);
+            Unmix(ref b0, ref b3, R7);
+            Unmix(ref b6, ref b5, R6);
+            Unmix(ref b4, ref b7, R5);
+            Unmix(ref b2, ref b1, R4);
+            Unmix(ref b6, ref b7, R3);
+            Unmix(ref b4, ref b5, R2);
+            Unmix(ref b2, ref b3, R1);
+            Unmix(ref b0, ref b1, R0);
         }
 
-        block[0] -= key[0];
-        block[1] -= key[1];
-        block[2] -= key[2];
-        block[3] -= key[3];
-        block[4] -= key[4];
-        block[5] -= key[5] + tweak[0];
-        block[6] -= key[6] + tweak[1];
-        block[7] -= key[7];
+        b0 -= Unsafe.Add(ref keyRef, 0);
+        b1 -= Unsafe.Add(ref keyRef, 1);
+        b2 -= Unsafe.Add(ref keyRef, 2);
+        b3 -= Unsafe.Add(ref keyRef, 3);
+        b4 -= Unsafe.Add(ref keyRef, 4);
+        b5 -= Unsafe.Add(ref keyRef, 5) + Unsafe.Add(ref tweakRef, 0);
+        b6 -= Unsafe.Add(ref keyRef, 6) + Unsafe.Add(ref tweakRef, 1);
+        b7 -= Unsafe.Add(ref keyRef, 7);
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        // Commit the eight plaintext words to the output buffer in little-endian byte order. On LE
+        // hosts each call lowers to a single unaligned store.
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
+        StoreWordLittleEndian(ref outputRef, 32, b4);
+        StoreWordLittleEndian(ref outputRef, 40, b5);
+        StoreWordLittleEndian(ref outputRef, 48, b6);
+        StoreWordLittleEndian(ref outputRef, 56, b7);
     }
 
     /// <summary>
@@ -217,85 +225,101 @@ public sealed class Threefish512Cipher
     public override void Encrypt(ReadOnlySpan<byte> input, Span<byte> output)
     {
         this.ThrowIfDisposed();
-        if (input.Length != this.BlockSize / 8 || output.Length != this.BlockSize / 8)
+        if (input.Length != 64 || output.Length != 64)
         {
             throw new ArgumentException(
-                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, this.BlockSize / 8));
+                string.Format(CryptoResourceStrings.Crypt_Invalid_BlockLength, 64));
         }
 
-        Span<ulong> block = stackalloc ulong[this.BlockWords];
-        MemoryMarshal.Cast<byte, ulong>(input).CopyTo(block);
+        // Load the plaintext block as eight 64-bit little-endian words into registers.
+        ref byte inputRef = ref MemoryMarshal.GetReference(input);
+        ulong b0 = LoadWordLittleEndian(ref inputRef, 0);
+        ulong b1 = LoadWordLittleEndian(ref inputRef, 8);
+        ulong b2 = LoadWordLittleEndian(ref inputRef, 16);
+        ulong b3 = LoadWordLittleEndian(ref inputRef, 24);
+        ulong b4 = LoadWordLittleEndian(ref inputRef, 32);
+        ulong b5 = LoadWordLittleEndian(ref inputRef, 40);
+        ulong b6 = LoadWordLittleEndian(ref inputRef, 48);
+        ulong b7 = LoadWordLittleEndian(ref inputRef, 56);
 
-        var key = this._keySchedule;
-        var tweak = this._tweakSchedule;
-        var rot = this.RotationSchedule;
+        ref ulong keyRef = ref MemoryMarshal.GetArrayDataReference(this._keySchedule);
+        ref ulong tweakRef = ref MemoryMarshal.GetArrayDataReference(this._tweakSchedule);
 
-        block[0] += key[0];
-        block[1] += key[1];
-        block[2] += key[2];
-        block[3] += key[3];
-        block[4] += key[4];
-        block[5] += key[5] + tweak[0];
-        block[6] += key[6] + tweak[1];
-        block[7] += key[7];
+        // Initial key injection (round 0)
+        b0 += Unsafe.Add(ref keyRef, 0);
+        b1 += Unsafe.Add(ref keyRef, 1);
+        b2 += Unsafe.Add(ref keyRef, 2);
+        b3 += Unsafe.Add(ref keyRef, 3);
+        b4 += Unsafe.Add(ref keyRef, 4);
+        b5 += Unsafe.Add(ref keyRef, 5) + Unsafe.Add(ref tweakRef, 0);
+        b6 += Unsafe.Add(ref keyRef, 6) + Unsafe.Add(ref tweakRef, 1);
+        b7 += Unsafe.Add(ref keyRef, 7);
 
-        for (var d = 1; d < this.Rounds / 4; d += 2)
+        for (var d = 1; d < 72 / 4; d += 2)
         {
             int dm9 = d % 9, dm3 = d % 3;
 
-            Mix(ref block[0], ref block[1], rot[0]);
-            Mix(ref block[2], ref block[3], rot[1]);
-            Mix(ref block[4], ref block[5], rot[2]);
-            Mix(ref block[6], ref block[7], rot[3]);
-            Mix(ref block[2], ref block[1], rot[4]);
-            Mix(ref block[4], ref block[7], rot[5]);
-            Mix(ref block[6], ref block[5], rot[6]);
-            Mix(ref block[0], ref block[3], rot[7]);
-            Mix(ref block[4], ref block[1], rot[8]);
-            Mix(ref block[6], ref block[3], rot[9]);
-            Mix(ref block[0], ref block[5], rot[10]);
-            Mix(ref block[2], ref block[7], rot[11]);
-            Mix(ref block[6], ref block[1], rot[12]);
-            Mix(ref block[0], ref block[7], rot[13]);
-            Mix(ref block[2], ref block[5], rot[14]);
-            Mix(ref block[4], ref block[3], rot[15]);
+            Mix(ref b0, ref b1, R0);
+            Mix(ref b2, ref b3, R1);
+            Mix(ref b4, ref b5, R2);
+            Mix(ref b6, ref b7, R3);
+            Mix(ref b2, ref b1, R4);
+            Mix(ref b4, ref b7, R5);
+            Mix(ref b6, ref b5, R6);
+            Mix(ref b0, ref b3, R7);
+            Mix(ref b4, ref b1, R8);
+            Mix(ref b6, ref b3, R9);
+            Mix(ref b0, ref b5, R10);
+            Mix(ref b2, ref b7, R11);
+            Mix(ref b6, ref b1, R12);
+            Mix(ref b0, ref b7, R13);
+            Mix(ref b2, ref b5, R14);
+            Mix(ref b4, ref b3, R15);
 
-            block[0] += key[dm9];
-            block[1] += key[dm9 + 1];
-            block[2] += key[dm9 + 2];
-            block[3] += key[dm9 + 3];
-            block[4] += key[dm9 + 4];
-            block[5] += key[dm9 + 5] + tweak[dm3];
-            block[6] += key[dm9 + 6] + tweak[dm3 + 1];
-            block[7] += key[dm9 + 7] + (ulong)d;
+            b0 += Unsafe.Add(ref keyRef, dm9);
+            b1 += Unsafe.Add(ref keyRef, dm9 + 1);
+            b2 += Unsafe.Add(ref keyRef, dm9 + 2);
+            b3 += Unsafe.Add(ref keyRef, dm9 + 3);
+            b4 += Unsafe.Add(ref keyRef, dm9 + 4);
+            b5 += Unsafe.Add(ref keyRef, dm9 + 5) + Unsafe.Add(ref tweakRef, dm3);
+            b6 += Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b7 += Unsafe.Add(ref keyRef, dm9 + 7) + (ulong)d;
 
-            Mix(ref block[0], ref block[1], rot[16]);
-            Mix(ref block[2], ref block[3], rot[17]);
-            Mix(ref block[4], ref block[5], rot[18]);
-            Mix(ref block[6], ref block[7], rot[19]);
-            Mix(ref block[2], ref block[1], rot[20]);
-            Mix(ref block[4], ref block[7], rot[21]);
-            Mix(ref block[6], ref block[5], rot[22]);
-            Mix(ref block[0], ref block[3], rot[23]);
-            Mix(ref block[4], ref block[1], rot[24]);
-            Mix(ref block[6], ref block[3], rot[25]);
-            Mix(ref block[0], ref block[5], rot[26]);
-            Mix(ref block[2], ref block[7], rot[27]);
-            Mix(ref block[6], ref block[1], rot[28]);
-            Mix(ref block[0], ref block[7], rot[29]);
-            Mix(ref block[2], ref block[5], rot[30]);
-            Mix(ref block[4], ref block[3], rot[31]);
+            Mix(ref b0, ref b1, R16);
+            Mix(ref b2, ref b3, R17);
+            Mix(ref b4, ref b5, R18);
+            Mix(ref b6, ref b7, R19);
+            Mix(ref b2, ref b1, R20);
+            Mix(ref b4, ref b7, R21);
+            Mix(ref b6, ref b5, R22);
+            Mix(ref b0, ref b3, R23);
+            Mix(ref b4, ref b1, R24);
+            Mix(ref b6, ref b3, R25);
+            Mix(ref b0, ref b5, R26);
+            Mix(ref b2, ref b7, R27);
+            Mix(ref b6, ref b1, R28);
+            Mix(ref b0, ref b7, R29);
+            Mix(ref b2, ref b5, R30);
+            Mix(ref b4, ref b3, R31);
 
-            block[0] += key[dm9 + 1];
-            block[1] += key[dm9 + 2];
-            block[2] += key[dm9 + 3];
-            block[3] += key[dm9 + 4];
-            block[4] += key[dm9 + 5];
-            block[5] += key[dm9 + 6] + tweak[dm3 + 1];
-            block[6] += key[dm9 + 7] + tweak[dm3 + 2];
-            block[7] += key[dm9 + 8] + (ulong)(d + 1);
+            b0 += Unsafe.Add(ref keyRef, dm9 + 1);
+            b1 += Unsafe.Add(ref keyRef, dm9 + 2);
+            b2 += Unsafe.Add(ref keyRef, dm9 + 3);
+            b3 += Unsafe.Add(ref keyRef, dm9 + 4);
+            b4 += Unsafe.Add(ref keyRef, dm9 + 5);
+            b5 += Unsafe.Add(ref keyRef, dm9 + 6) + Unsafe.Add(ref tweakRef, dm3 + 1);
+            b6 += Unsafe.Add(ref keyRef, dm9 + 7) + Unsafe.Add(ref tweakRef, dm3 + 2);
+            b7 += Unsafe.Add(ref keyRef, dm9 + 8) + (ulong)(d + 1);
         }
 
-        MemoryMarshal.Cast<ulong, byte>(block).CopyTo(output);
+        ref byte outputRef = ref MemoryMarshal.GetReference(output);
+        StoreWordLittleEndian(ref outputRef, 0, b0);
+        StoreWordLittleEndian(ref outputRef, 8, b1);
+        StoreWordLittleEndian(ref outputRef, 16, b2);
+        StoreWordLittleEndian(ref outputRef, 24, b3);
+        StoreWordLittleEndian(ref outputRef, 32, b4);
+        StoreWordLittleEndian(ref outputRef, 40, b5);
+        StoreWordLittleEndian(ref outputRef, 48, b6);
+        StoreWordLittleEndian(ref outputRef, 56, b7);
     }
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Buffers.Binary;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -214,6 +215,46 @@ public abstract partial class ThreefishBlockCipher
         b ^= a;
         b = BitOperations.RotateRight(b, rotation);
         a -= b;
+    }
+
+    /// <summary>
+    /// Loads a 64-bit little-endian word from <paramref name="source" /> at <paramref name="byteOffset" /> bytes from
+    /// the reference, without bounds-checking or alignment requirements on the source buffer.
+    /// </summary>
+    /// <param name="source">A reference to the first byte of the source buffer.</param>
+    /// <param name="byteOffset">The byte offset within the buffer at which to read.</param>
+    /// <returns>The 64-bit unsigned integer read from the source, with little-endian semantics.</returns>
+    /// <remarks>
+    /// On little-endian hosts (the common case for .NET 8 targets) the byte-swap branch folds away and the call
+    /// compiles to a single unaligned 64-bit load. Used by the Threefish variants to materialise block words
+    /// directly into stack-local registers, eliminating the intermediate <c>stackalloc</c> + <c>CopyTo</c> staging
+    /// buffer in the per-block hot path.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected static ulong LoadWordLittleEndian(ref byte source, nint byteOffset)
+    {
+        ulong value = Unsafe.ReadUnaligned<ulong>(ref Unsafe.AddByteOffset(ref source, byteOffset));
+        return BitConverter.IsLittleEndian ? value : BinaryPrimitives.ReverseEndianness(value);
+    }
+
+    /// <summary>
+    /// Stores a 64-bit unsigned integer into <paramref name="destination" /> at <paramref name="byteOffset" /> bytes
+    /// from the reference using little-endian byte order, without bounds-checking or alignment requirements.
+    /// </summary>
+    /// <param name="destination">A reference to the first byte of the destination buffer.</param>
+    /// <param name="byteOffset">The byte offset within the buffer at which to write.</param>
+    /// <param name="value">The 64-bit unsigned integer to store.</param>
+    /// <remarks>
+    /// On little-endian hosts the byte-swap branch folds away and the call compiles to a single unaligned 64-bit
+    /// store. Mirrors <see cref="LoadWordLittleEndian" /> on the output side, allowing the per-block hot path to
+    /// commit cipher state to the output buffer straight from registers.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected static void StoreWordLittleEndian(ref byte destination, nint byteOffset, ulong value)
+    {
+        if (!BitConverter.IsLittleEndian)
+            value = BinaryPrimitives.ReverseEndianness(value);
+        Unsafe.WriteUnaligned(ref Unsafe.AddByteOffset(ref destination, byteOffset), value);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Adds high-performance AVX-512 vectorized implementations for all three Threefish cipher variants (256, 512, 1024) while maintaining scalar fallbacks for hosts without AVX-512 support. The changes refactor rotation constants into named `const int` fields to enable JIT constant-folding and reduce duplication across implementations.

## Key Changes

- **Rotation constant refactoring**: Extracted all spec-defined rotation amounts into named `private const int` fields (R0–R63 for Threefish-1024, R0–R31 for others) and a static `s_rotationSchedule` array. This allows the JIT to fold each Mix/Unmix call to a ROL/ROR with an immediate count and centralizes the values.

- **AVX-512 vectorized implementations**: Added three new partial files:
  - `ThreefishBlockCipher.256.Avx512.cs`: Uses Vector128<ulong> (two 64-bit lanes) with lane-swap shuffles
  - `ThreefishBlockCipher.512.Avx512.cs`: Uses Vector256<ulong> (four 64-bit lanes) with VPERMQ shuffles
  - `ThreefishBlockCipher.1024.Avx512.cs`: Uses Vector512<ulong> (eight 64-bit lanes) with VPERMI2Q deinterleaving

- **Scalar register-resident implementations**: Refactored `Decrypt` methods to load ciphertext blocks directly into local `ulong` variables instead of stackalloc'd spans, eliminating bounds-checked indexing on every Mix/key access. Added `[MethodImpl(MethodImplOptions.AggressiveOptimization)]` to encourage inlining and register allocation.

- **Runtime dispatch**: Each cipher's `Decrypt` method now checks `Avx512F.IsSupported` (or `Avx512F.VL.IsSupported` for 256-bit) and dispatches to the vectorized path when available. The check is a JIT intrinsic that folds to a compile-time constant, incurring no runtime cost.

- **Helper method**: Added `LoadWordLittleEndian(ref byte source, int byteOffset)` to `ThreefishBlockCipher` base class to load 64-bit little-endian words without bounds checks or alignment requirements.

- **Code cleanup**: Replaced magic numbers (e.g., `this.BlockSize / 8`) with literal constants (e.g., `128`, `64`, `32`) in length validation, improving clarity and reducing redundant property lookups.

- **Partial class declarations**: Changed all three cipher classes from `sealed` to `sealed partial` to accommodate the new AVX-512 implementation files.

## Implementation Details

- **Threefish-256**: The four-word state is split into `lo = (b0, b2)` and `hi = (b1, b3)` across two Vector128 registers. A single lane-swap on `hi` (via `VPSHUFB` or equivalent) realigns the state for each round's MIX pairing.

- **Threefish-512**: The eight-word state is split into `lo = (x0, x2, x4, x6)` and `hi = (x1, x3, x5, x7)` across two Vector256 registers. Inter-round shuffles use VPERMQ with fixed control bytes (0x39 for lo, 0x6C for hi) to rotate/swap lanes; the 4-round cycle returns both registers to canonical layout.

- **Threefish-1024**: The sixteen-word state is split into `lo = (x0, x2, …, x14)` and `hi = (x1, x3, …, x15)` across two Vector512 registers. Deinterleaving uses VPERMI2Q with index vectors; inter-round shuffles apply the same pair of VPERMQ operations four times per subkey-injection cycle.

- **Rotation vectors**: Each round's per-lane variable rotations are precomputed as static Vector128/256/512 constants, enabling

https://claude.ai/code/session_013E9kESUyu44Eo1FA1dqh8B