### PR TITLE
Add DI sub-package and runtime-mutable overrides for NotableDateService

### DIFF
--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Bodu.Globalization.Calendar.DependencyInjection.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Library</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Bodu.Globalization.Calendar.DependencyInjection.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
+    <ProjectReference Include="..\..\Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/DependencyInjectionResourceStrings.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/DependencyInjectionResourceStrings.cs
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DependencyInjectionResourceStrings.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Centralizes the exception message templates used by the dependency-injection extension surface so that wording
+/// remains consistent across <see cref="ServiceCollectionExtensions" /> and
+/// <see cref="NotableDateServiceBuilderExtensions" />.
+/// </summary>
+/// <remarks>
+/// Messages are exposed as <see langword="const" /> strings rather than via a RESX-backed resource manager — matching
+/// the <c>BuilderResourceStrings</c> convention used by <c>Bodu.Globalization.Calendar.Builder</c>. Key names follow
+/// the <c>&lt;Group&gt;_&lt;ExceptionTypeShort&gt;_&lt;Condition&gt;</c> convention used by every RESX-backed
+/// counterpart elsewhere in the solution. If localization is later added, callers can replace this class without
+/// affecting public API.
+/// </remarks>
+[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Resource string identifiers follow the diagnostic-class_subject convention used by RESX-generated equivalents elsewhere in the solution.")]
+internal static class DependencyInjectionResourceStrings
+{
+    /// <summary>
+    /// A sequence-typed parameter (for example, the <c>providers</c> argument to
+    /// <see cref="NotableDateServiceBuilderExtensions.AddRuleProviders" />) contained a <see langword="null" /> element.
+    /// </summary>
+    internal const string Arg_Invalid_ProviderSequenceContainsNullElement = "The provider sequence must not contain null elements.";
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/INotableDateServiceBuilder.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/INotableDateServiceBuilder.cs
@@ -23,6 +23,21 @@ namespace Bodu.Globalization.Calendar.DependencyInjection;
 /// minimal while remaining trivially extensible by third-party packages.
 /// </para>
 /// </remarks>
+/// <example>
+/// <para>
+/// A typical end-to-end registration with a data pack, runtime overrides, and ambient-default assignment:
+/// </para>
+/// <code>
+///<![CDATA[
+/// services
+///     .AddNotableDates(configuration)
+///     .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+///     .AddOverrideProvider(new MutableNotableDateRuleOverrideProvider())
+///     .UseWorkingDays(WorkingDaysOfWeek.MondayToFriday)
+///     .RegisterAsAmbientDefault();
+///]]>
+/// </code>
+/// </example>
 public interface INotableDateServiceBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/INotableDateServiceBuilder.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/INotableDateServiceBuilder.cs
@@ -1,0 +1,36 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="INotableDateServiceBuilder.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Defines the fluent registration surface returned by
+/// <see cref="ServiceCollectionExtensions.AddNotableDates(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />
+/// so that consumers can register rule providers, override providers, and supporting services on the same
+/// <see cref="IServiceCollection" /> in a discoverable manner.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The interface exposes a single <see cref="Services" /> property that returns the underlying
+/// <see cref="IServiceCollection" />. All fluent functionality is provided through extension methods defined in
+/// <see cref="NotableDateServiceBuilderExtensions" />, mirroring the pattern used by <c>IHttpClientBuilder</c>,
+/// <c>IMvcBuilder</c>, and <c>IAuthenticationBuilder</c> in <c>Microsoft.Extensions.*</c>. This keeps the abstraction
+/// minimal while remaining trivially extensible by third-party packages.
+/// </para>
+/// </remarks>
+public interface INotableDateServiceBuilder
+{
+    /// <summary>
+    /// Gets the <see cref="IServiceCollection" /> that the builder is composing into.
+    /// </summary>
+    /// <returns>
+    /// The service collection passed to
+    /// <see cref="ServiceCollectionExtensions.AddNotableDates(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />.
+    /// </returns>
+    IServiceCollection Services { get; }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateOptions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateOptions.cs
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateOptions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Provides the bindable options bag consumed by
+/// <see cref="ServiceCollectionExtensions.AddNotableDates(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This type is intentionally composed of primitives and enums so that the entire surface can be populated from an
+/// <c>appsettings.json</c> section via <see cref="Microsoft.Extensions.Configuration.IConfiguration" /> binding. It is
+/// distinct from <see cref="NotableDateServiceOptions" />, which carries non-bindable interface-typed dependencies
+/// (algorithm registries, collision resolvers, name localisers, plugins). Use <see cref="NotableDateOptions" /> for
+/// values shaped by app configuration, and the builder's fluent extension methods for everything else.
+/// </para>
+/// <para>
+/// The default values match the parameterless <see cref="NotableDateService" /> constructor:
+/// <see cref="WorkingDaysOfWeek.MondayToFriday" /> working week, no preferred territory, no preferred calendar, no
+/// ambient default assignment. Consumers can override any subset via configuration binding, an explicit
+/// <c>Configure(o =&gt; ...)</c> callback, or the <c>PostConfigure((sp, o) =&gt; ...)</c> hook for projecting from
+/// custom POCOs.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// Binding from <c>appsettings.json</c>:
+/// </para>
+/// <code language="json">
+/// {
+///   "NotableDates": {
+///     "WorkingDays": "MondayToFriday",
+///     "DefaultTerritoryCode": "AU-NSW",
+///     "RegisterAsAmbientDefault": true
+///   }
+/// }
+/// </code>
+/// </example>
+public sealed class NotableDateOptions
+{
+    /// <summary>
+    /// Gets or sets the named working-week pattern applied when classifying dates as working or non-working.
+    /// </summary>
+    /// <value>
+    /// A <see cref="WorkingDaysOfWeek" /> value. Defaults to <see cref="WorkingDaysOfWeek.MondayToFriday" />.
+    /// </value>
+    /// <returns>The configured working-week preset.</returns>
+    /// <remarks>
+    /// Translated to a <see cref="WeekPattern" /> by <see cref="WorkingDaysOfWeek" />'s extension methods before being
+    /// passed to the <see cref="NotableDateService" /> constructor. The value
+    /// <see cref="WorkingDaysOfWeek.Custom" /> has no canonical pattern and will trigger an
+    /// <see cref="ArgumentException" /> during registration — use a builder-supplied <see cref="WeekPattern" /> via
+    /// <c>UseWorkingWeek</c> instead.
+    /// </remarks>
+    public WorkingDaysOfWeek WorkingDays { get; set; } = WorkingDaysOfWeek.MondayToFriday;
+
+    /// <summary>
+    /// Gets or sets the default territory code applied by extension methods that omit an explicit territory argument.
+    /// </summary>
+    /// <value>
+    /// A territory code (e.g. <c>"AU"</c>, <c>"AU-NSW"</c>, <c>"US"</c>), or <see langword="null" /> for no preferred
+    /// territory.
+    /// </value>
+    /// <returns>The configured default territory, or <see langword="null" /> when none is set.</returns>
+    /// <remarks>
+    /// <para>
+    /// This value is exposed to consumers via <see cref="Microsoft.Extensions.Options.IOptions{TOptions}" />; it is not
+    /// pushed into the <see cref="NotableDateService" /> itself because the service supports per-call territory
+    /// scoping. Hosts that wish to thread the default territory through every call site should resolve
+    /// <c>IOptions&lt;NotableDateOptions&gt;</c> and pass <see cref="DefaultTerritoryCode" /> explicitly.
+    /// </para>
+    /// </remarks>
+    public string? DefaultTerritoryCode { get; set; }
+
+    /// <summary>
+    /// Gets or sets the assembly-qualified name of the default calendar type applied by extension methods that omit an
+    /// explicit calendar argument.
+    /// </summary>
+    /// <value>
+    /// An assembly-qualified type name resolvable by <see cref="Type.GetType(string)" /> (for example
+    /// <c>"System.Globalization.GregorianCalendar"</c>), or <see langword="null" /> for no preferred calendar.
+    /// </value>
+    /// <returns>The configured default calendar type name, or <see langword="null" /> when none is set.</returns>
+    /// <remarks>
+    /// Stored as a string so that the value can be bound from configuration. Consumers that need the resolved
+    /// <see cref="Type" /> should call <see cref="Type.GetType(string)" /> against this value and fall back to
+    /// <see langword="null" /> when the type cannot be resolved at runtime.
+    /// </remarks>
+    public string? DefaultCalendarTypeName { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the resolved <see cref="INotableDateService" /> should also be assigned
+    /// to <see cref="NotableDateContext.Default" /> so that extension-method overloads without an explicit service
+    /// argument resolve through the DI-registered instance.
+    /// </summary>
+    /// <value>
+    /// <see langword="true" /> to assign the resolved service to the ambient context; otherwise
+    /// <see langword="false" />. Defaults to <see langword="false" />.
+    /// </value>
+    /// <returns>
+    /// The configured ambient-default toggle.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Assignment happens exactly once, the first time the <see cref="INotableDateService" /> singleton is resolved
+    /// from the container. Assigning <see langword="false" /> after a previous assignment does not unassign — call
+    /// <see cref="NotableDateContext.Reset" /> explicitly in tests if you need to restore the ambient default.
+    /// </para>
+    /// </remarks>
+    public bool RegisterAsAmbientDefault { get; set; }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilder.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilder.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilder.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Provides the default <see cref="INotableDateServiceBuilder" /> implementation, a thin wrapper around an
+/// <see cref="IServiceCollection" /> that the fluent extension methods in
+/// <see cref="NotableDateServiceBuilderExtensions" /> operate against.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The type is internal to the assembly — consumers see only the <see cref="INotableDateServiceBuilder" /> interface
+/// returned from <see cref="ServiceCollectionExtensions.AddNotableDates(IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />.
+/// </para>
+/// </remarks>
+internal sealed class NotableDateServiceBuilder : INotableDateServiceBuilder
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NotableDateServiceBuilder" /> class wrapping the supplied service
+    /// collection.
+    /// </summary>
+    /// <param name="services">The service collection that subsequent registrations contribute into.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="services" /> is <see langword="null" />.
+    /// </exception>
+    public NotableDateServiceBuilder(IServiceCollection services)
+    {
+        ThrowHelper.ThrowIfNull(services);
+
+        Services = services;
+    }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
@@ -151,7 +151,7 @@ public static class NotableDateServiceBuilderExtensions
 
         foreach (INotableDateRuleProvider provider in providers)
         {
-            if (provider is null) throw new ArgumentException("Provider sequence must not contain null elements.", nameof(providers));
+            if (provider is null) throw new ArgumentException(DependencyInjectionResourceStrings.Arg_Invalid_ProviderSequenceContainsNullElement, nameof(providers));
             builder.Services.AddSingleton(provider);
         }
 

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
@@ -58,6 +58,16 @@ public static class NotableDateServiceBuilderExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="builder" /> or <paramref name="provider" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// services.AddNotableDates()
+    ///     .AddRuleProvider(new XmlResourceNotableDateRuleProvider(
+    ///         "MyApp/Calendar/Resources/holidays.xml",
+    ///         new ResourcePathResolver()));
+    ///]]>
+    /// </code>
+    /// </example>
     public static INotableDateServiceBuilder AddRuleProvider(this INotableDateServiceBuilder builder, INotableDateRuleProvider provider)
     {
         ThrowHelper.ThrowIfNull(builder);
@@ -123,6 +133,15 @@ public static class NotableDateServiceBuilderExtensions
     /// Thrown when <paramref name="builder" /> or <paramref name="providers" /> is <see langword="null" />, or when
     /// any element of <paramref name="providers" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// services.AddNotableDates()
+    ///     .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    ///     .AddRuleProviders(EuropeCalendarData.CreateProviders());
+    ///]]>
+    /// </code>
+    /// </example>
     public static INotableDateServiceBuilder AddRuleProviders(
         this INotableDateServiceBuilder builder,
         IEnumerable<INotableDateRuleProvider> providers)
@@ -157,6 +176,31 @@ public static class NotableDateServiceBuilderExtensions
     /// effect without further intervention.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <para>
+    /// Register a runtime-mutable override and mutate it at any point during the application's lifetime — the
+    /// resolved service auto-reloads on every change.
+    /// </para>
+    /// <code>
+    ///<![CDATA[
+    /// var overrides = new MutableNotableDateRuleOverrideProvider();
+    /// services.AddNotableDates()
+    ///     .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    ///     .AddOverrideProvider(overrides);
+    ///
+    /// // Later, anywhere in the application:
+    /// overrides.AddRule(new NotableDateRule
+    /// {
+    ///     Name = "Company Founding Day",
+    ///     Strategy = DateResolutionStrategy.Fixed,
+    ///     Category = NotableDateCategory.Observance,
+    ///     Month = 6,
+    ///     Day = 15,
+    ///     IsNonWorkingDay = true,
+    /// });
+    ///]]>
+    /// </code>
+    /// </example>
     public static INotableDateServiceBuilder AddOverrideProvider(this INotableDateServiceBuilder builder, INotableDateRuleOverrideProvider provider)
     {
         ThrowHelper.ThrowIfNull(builder);
@@ -315,6 +359,18 @@ public static class NotableDateServiceBuilderExtensions
     /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="builder" /> or <paramref name="configure" /> is <see langword="null" />.
     /// </exception>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// services.AddNotableDates()
+    ///     .Configure(opts =>
+    ///     {
+    ///         opts.DefaultTerritoryCode = "AU-NSW";
+    ///         opts.WorkingDays = WorkingDaysOfWeek.MondayToFriday;
+    ///     });
+    ///]]>
+    /// </code>
+    /// </example>
     public static INotableDateServiceBuilder Configure(this INotableDateServiceBuilder builder, Action<NotableDateOptions> configure)
     {
         ThrowHelper.ThrowIfNull(builder);

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensions.cs
@@ -1,0 +1,456 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Provides fluent extension methods that contribute rule providers, override providers, plugins, and supporting
+/// services into an <see cref="INotableDateServiceBuilder" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each method returns the same <see cref="INotableDateServiceBuilder" /> instance so that contributions can be
+/// chained. The extensions are split into three categories:
+/// </para>
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <b>Provider registration</b> — <c>AddRuleProvider</c>, <c>AddRuleProviders</c>, <c>AddOverrideProvider</c>,
+/// <c>AddPlugin</c> register collaborators that will be resolved via <see cref="IEnumerable{T}" /> injection at
+/// service construction time. Multiple calls accumulate.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <b>Single-instance registration</b> — <c>UseAlgorithmRegistry</c>, <c>UseCollisionResolver</c>,
+/// <c>UseNameLocalizer</c>, <c>UseAdjustmentHandlers</c>, <c>UseResourcePathResolver</c> register singletons of
+/// optional collaborator interfaces. Later calls overwrite earlier ones.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <b>Options shaping</b> — <c>Configure</c> and <c>PostConfigure</c> shape the bindable
+/// <see cref="NotableDateOptions" /> instance. <c>PostConfigure</c> is the hook for projecting from
+/// consumer-defined POCOs registered separately through the standard
+/// <see cref="OptionsServiceCollectionExtensions.Configure{TOptions}(IServiceCollection, Action{TOptions})" />
+/// surface.
+/// </description>
+/// </item>
+/// </list>
+/// </remarks>
+public static class NotableDateServiceBuilderExtensions
+{
+    /// <summary>
+    /// Adds an <see cref="INotableDateRuleProvider" /> instance to the builder so that it contributes base rules to
+    /// the resolved <see cref="INotableDateService" />.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="provider">The rule provider. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddRuleProvider(this INotableDateServiceBuilder builder, INotableDateRuleProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(provider);
+
+        builder.Services.AddSingleton(provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="INotableDateRuleProvider" /> type as a singleton so that it is materialised lazily by the
+    /// container.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider type to register.</typeparam>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddRuleProvider<TProvider>(this INotableDateServiceBuilder builder)
+        where TProvider : class, INotableDateRuleProvider
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.AddSingleton<INotableDateRuleProvider, TProvider>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="INotableDateRuleProvider" /> registered via a factory delegate so that it is constructed with
+    /// access to the host's <see cref="IServiceProvider" />.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="factory">
+    /// The factory invoked once when the singleton is resolved. Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="factory" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddRuleProvider(
+        this INotableDateServiceBuilder builder,
+        Func<IServiceProvider, INotableDateRuleProvider> factory)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(factory);
+
+        builder.Services.AddSingleton(factory);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds a sequence of <see cref="INotableDateRuleProvider" /> instances — typically the result of a data pack's
+    /// <c>CreateProviders()</c> factory — to the builder.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="providers">
+    /// The providers to register. Must not be <see langword="null" />; individual elements must not be
+    /// <see langword="null" />.
+    /// </param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="providers" /> is <see langword="null" />, or when
+    /// any element of <paramref name="providers" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddRuleProviders(
+        this INotableDateServiceBuilder builder,
+        IEnumerable<INotableDateRuleProvider> providers)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(providers);
+
+        foreach (INotableDateRuleProvider provider in providers)
+        {
+            if (provider is null) throw new ArgumentException("Provider sequence must not contain null elements.", nameof(providers));
+            builder.Services.AddSingleton(provider);
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="INotableDateRuleOverrideProvider" /> instance to the builder so that its additions and
+    /// removals layer on top of the base rule set.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="provider">The override provider. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// When <paramref name="provider" /> is a <see cref="MutableNotableDateRuleOverrideProvider" />, the resolved
+    /// <see cref="INotableDateService" /> factory subscribes <see cref="INotableDateService.Reload" /> to the
+    /// provider's <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> event so that runtime mutations take
+    /// effect without further intervention.
+    /// </para>
+    /// </remarks>
+    public static INotableDateServiceBuilder AddOverrideProvider(this INotableDateServiceBuilder builder, INotableDateRuleOverrideProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(provider);
+
+        builder.Services.AddSingleton(provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="INotableDateRuleOverrideProvider" /> type as a singleton so that it is materialised lazily
+    /// by the container.
+    /// </summary>
+    /// <typeparam name="TOverride">The override provider type to register.</typeparam>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddOverrideProvider<TOverride>(this INotableDateServiceBuilder builder)
+        where TOverride : class, INotableDateRuleOverrideProvider
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.AddSingleton<INotableDateRuleOverrideProvider, TOverride>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Adds an <see cref="INotableDatePlugin" /> instance to the builder so that its rule providers and algorithm
+    /// contributions participate in the resolved service.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="plugin">The plugin. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="plugin" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddPlugin(this INotableDateServiceBuilder builder, INotableDatePlugin plugin)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(plugin);
+
+        builder.Services.AddSingleton(plugin);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="INotableDateAlgorithmRegistry" /> singleton consulted by the resolved service when
+    /// dispatching <see cref="DateResolutionStrategy.Algorithm" /> rules.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="registry">The algorithm registry. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="registry" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// A subsequent call replaces a previously registered registry. Pair with <see cref="AddPlugin" /> to compose
+    /// algorithm contributions from multiple sources.
+    /// </remarks>
+    public static INotableDateServiceBuilder UseAlgorithmRegistry(this INotableDateServiceBuilder builder, INotableDateAlgorithmRegistry registry)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(registry);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton(registry));
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="INotableDateCollisionResolver" /> singleton that arbitrates same-day rule collisions.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="resolver">The collision resolver. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="resolver" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder UseCollisionResolver(this INotableDateServiceBuilder builder, INotableDateCollisionResolver resolver)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(resolver);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton(resolver));
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="INotableDateNameLocalizer" /> singleton that translates notable-date names into the
+    /// active culture.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="localizer">The name localiser. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="localizer" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder UseNameLocalizer(this INotableDateServiceBuilder builder, INotableDateNameLocalizer localizer)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(localizer);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton(localizer));
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IAdjustmentHandlerRegistry" /> singleton that supplies custom observance-adjustment
+    /// handlers.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="registry">The adjustment-handler registry. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="registry" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder UseAdjustmentHandlers(this INotableDateServiceBuilder builder, IAdjustmentHandlerRegistry registry)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(registry);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton(registry));
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IResourcePathResolver" /> singleton that locates embedded XML rule files for resource
+    /// providers.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="resolver">The resource-path resolver. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="resolver" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder UseResourcePathResolver(this INotableDateServiceBuilder builder, IResourcePathResolver resolver)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(resolver);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton(resolver));
+        return builder;
+    }
+
+    /// <summary>
+    /// Layers an additional configuration callback onto <see cref="NotableDateOptions" /> so that programmatic
+    /// settings overlay any value bound from <see cref="Microsoft.Extensions.Configuration.IConfiguration" />.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="configure">
+    /// The configuration callback. Invoked with the <see cref="NotableDateOptions" /> instance about to be resolved.
+    /// Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="configure" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder Configure(this INotableDateServiceBuilder builder, Action<NotableDateOptions> configure)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(configure);
+
+        builder.Services.Configure(configure);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IPostConfigureOptions{TOptions}" /> callback that runs after every other configuration
+    /// source has populated <see cref="NotableDateOptions" /> and has access to the host's
+    /// <see cref="IServiceProvider" />.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="configure">
+    /// The post-configure callback. Receives the resolved <see cref="IServiceProvider" /> and the populated
+    /// <see cref="NotableDateOptions" /> instance. Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> or <paramref name="configure" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// This is the consumer-defined-options hook. A consumer who has their own bindable POCO can register it normally
+    /// via <see cref="OptionsServiceCollectionExtensions.Configure{TOptions}(IServiceCollection, Action{TOptions})" />
+    /// and then project values into <see cref="NotableDateOptions" /> from inside this callback. The same pattern is
+    /// used by EF Core (<c>AddDbContext((sp, builder) =&gt; ...)</c>), ASP.NET Core authentication, and
+    /// <c>AddHttpClient</c>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// services.Configure<MyAppCalendarSettings>(configuration.GetSection("MyApp:Calendar"));
+    /// services.AddNotableDates()
+    ///     .PostConfigure((sp, opts) =>
+    ///     {
+    ///         MyAppCalendarSettings custom = sp.GetRequiredService<IOptions<MyAppCalendarSettings>>().Value;
+    ///         opts.DefaultTerritoryCode = custom.RegionCode;
+    ///         opts.WorkingDays = custom.WorkWeek;
+    ///     });
+    ///]]>
+    /// </code>
+    /// </example>
+    public static INotableDateServiceBuilder PostConfigure(
+        this INotableDateServiceBuilder builder,
+        Action<IServiceProvider, NotableDateOptions> configure)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(configure);
+
+        builder.Services.AddSingleton<IPostConfigureOptions<NotableDateOptions>>(sp =>
+            new PostConfigureOptionsWithProvider(sp, configure));
+        return builder;
+    }
+
+    /// <summary>
+    /// Overrides the working-week preset that the resolved <see cref="INotableDateService" /> classifies dates
+    /// against.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <param name="workingDays">The working-week preset.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder UseWorkingDays(this INotableDateServiceBuilder builder, WorkingDaysOfWeek workingDays)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.Configure<NotableDateOptions>(opts => opts.WorkingDays = workingDays);
+        return builder;
+    }
+
+    /// <summary>
+    /// Toggles whether the resolved <see cref="INotableDateService" /> is also assigned to
+    /// <see cref="NotableDateContext.Default" />.
+    /// </summary>
+    /// <param name="builder">The builder. Must not be <see langword="null" />.</param>
+    /// <returns>The same builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="builder" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// Equivalent to <c>builder.Configure(opts =&gt; opts.RegisterAsAmbientDefault = true)</c>. The ambient assignment
+    /// is performed lazily the first time the singleton is resolved.
+    /// </remarks>
+    public static INotableDateServiceBuilder RegisterAsAmbientDefault(this INotableDateServiceBuilder builder)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.Configure<NotableDateOptions>(opts => opts.RegisterAsAmbientDefault = true);
+        return builder;
+    }
+
+    /// <summary>
+    /// Closure-bearing adapter that lets <see cref="PostConfigure" /> register an
+    /// <see cref="IPostConfigureOptions{TOptions}" /> backed by a delegate that needs both an
+    /// <see cref="IServiceProvider" /> and the <see cref="NotableDateOptions" /> instance.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="IPostConfigureOptions{TOptions}" /> has no built-in IServiceProvider-aware overload, so we capture
+    /// the provider at registration time (via the factory invoked when the adapter singleton is materialised) and
+    /// hand it to the consumer callback on each post-configure invocation.
+    /// </para>
+    /// </remarks>
+    private sealed class PostConfigureOptionsWithProvider : IPostConfigureOptions<NotableDateOptions>
+    {
+        /// <summary>
+        /// The service provider captured at registration time.
+        /// </summary>
+        private readonly IServiceProvider _serviceProvider;
+
+        /// <summary>
+        /// The consumer-supplied callback invoked on every post-configure pass.
+        /// </summary>
+        private readonly Action<IServiceProvider, NotableDateOptions> _configure;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PostConfigureOptionsWithProvider" /> class.
+        /// </summary>
+        /// <param name="serviceProvider">The captured service provider.</param>
+        /// <param name="configure">The consumer-supplied post-configure callback.</param>
+        public PostConfigureOptionsWithProvider(IServiceProvider serviceProvider, Action<IServiceProvider, NotableDateOptions> configure)
+        {
+            _serviceProvider = serviceProvider;
+            _configure = configure;
+        }
+
+        /// <inheritdoc />
+        public void PostConfigure(string? name, NotableDateOptions options)
+        {
+            _configure(_serviceProvider, options);
+        }
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensions.cs
@@ -94,7 +94,7 @@ public static class ServiceCollectionExtensions
         string sectionName = DefaultConfigurationSection)
     {
         ThrowHelper.ThrowIfNull(services);
-        if (string.IsNullOrWhiteSpace(sectionName)) throw new ArgumentException("Section name must not be blank.", nameof(sectionName));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(sectionName);
 
         services.AddOptions();
 

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Globalization.Calendar.DependencyInjection;
+
+/// <summary>
+/// Provides the <c>AddNotableDates</c> entry points that register an <see cref="INotableDateService" /> singleton and
+/// its supporting infrastructure into an <see cref="IServiceCollection" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The extensions follow the conventions established by <c>Microsoft.Extensions.*</c> packages: registration returns a
+/// builder (<see cref="INotableDateServiceBuilder" />) that exposes a fluent surface for layering in rule providers,
+/// override providers, plugins, algorithm registries, collision resolvers, name localisers, and options projection.
+/// All collaborator interfaces are registered via <c>IEnumerable&lt;T&gt;</c> injection so that consumers can compose
+/// contributions from multiple data packs without overwriting earlier registrations.
+/// </para>
+/// <para>
+/// Two registration shapes are supported: configuration-driven (binds an <see cref="IConfiguration" /> section into
+/// <see cref="NotableDateOptions" />) and builder-callback driven (programmatic composition). Both return the same
+/// <see cref="INotableDateServiceBuilder" /> so registrations remain chainable regardless of entry point.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// Idiomatic ASP.NET Core registration with an Asia-Pacific data pack and runtime overrides:
+/// </para>
+/// <code>
+///<![CDATA[
+/// builder.Services
+///     .AddNotableDates(builder.Configuration)
+///     .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+///     .AddOverrideProvider(new MutableNotableDateRuleOverrideProvider())
+///     .RegisterAsAmbientDefault();
+///]]>
+/// </code>
+/// </example>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// The default <see cref="IConfiguration" /> section name read by
+    /// <see cref="AddNotableDates(IServiceCollection, IConfiguration?, string)" /> when no override is supplied.
+    /// </summary>
+    public const string DefaultConfigurationSection = "NotableDates";
+
+    /// <summary>
+    /// Registers an <see cref="INotableDateService" /> singleton and its supporting infrastructure into
+    /// <paramref name="services" />, optionally binding <see cref="NotableDateOptions" /> from
+    /// <paramref name="configuration" />.
+    /// </summary>
+    /// <param name="services">The service collection to register into. Must not be <see langword="null" />.</param>
+    /// <param name="configuration">
+    /// Optional <see cref="IConfiguration" /> root or section. When supplied, the section identified by
+    /// <paramref name="sectionName" /> is bound into <see cref="NotableDateOptions" />. When <see langword="null" />,
+    /// only programmatic configuration (via the returned builder) populates the options.
+    /// </param>
+    /// <param name="sectionName">
+    /// The configuration section name to bind from <paramref name="configuration" />. Ignored when
+    /// <paramref name="configuration" /> is <see langword="null" />. Defaults to
+    /// <see cref="DefaultConfigurationSection" />.
+    /// </param>
+    /// <returns>
+    /// An <see cref="INotableDateServiceBuilder" /> for further registration via the fluent extension methods in
+    /// <see cref="NotableDateServiceBuilderExtensions" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="services" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="sectionName" /> is empty or whitespace.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Repeated calls to <see cref="AddNotableDates(IServiceCollection, IConfiguration?, string)" /> are safe: the
+    /// underlying <see cref="INotableDateService" /> factory is registered idempotently via
+    /// <see cref="ServiceCollectionDescriptorExtensions.TryAddSingleton{TService}(IServiceCollection, Func{IServiceProvider, TService})" />,
+    /// so the singleton resolves to the same instance regardless of how many times the method is called. Repeated
+    /// calls layer additional configuration binding sources onto <see cref="NotableDateOptions" />.
+    /// </para>
+    /// </remarks>
+    public static INotableDateServiceBuilder AddNotableDates(
+        this IServiceCollection services,
+        IConfiguration? configuration = null,
+        string sectionName = DefaultConfigurationSection)
+    {
+        ThrowHelper.ThrowIfNull(services);
+        if (string.IsNullOrWhiteSpace(sectionName)) throw new ArgumentException("Section name must not be blank.", nameof(sectionName));
+
+        services.AddOptions();
+
+        if (configuration is not null)
+        {
+            services
+                .AddOptions<NotableDateOptions>()
+                .Bind(configuration.GetSection(sectionName));
+        }
+
+        RegisterServiceFactory(services);
+
+        return new NotableDateServiceBuilder(services);
+    }
+
+    /// <summary>
+    /// Registers an <see cref="INotableDateService" /> singleton into <paramref name="services" /> and invokes the
+    /// supplied builder callback for programmatic composition.
+    /// </summary>
+    /// <param name="services">The service collection to register into. Must not be <see langword="null" />.</param>
+    /// <param name="configure">
+    /// A callback invoked with the <see cref="INotableDateServiceBuilder" /> for fluent registration of rule
+    /// providers, override providers, and supporting services. Must not be <see langword="null" />.
+    /// </param>
+    /// <returns>
+    /// The same <see cref="INotableDateServiceBuilder" /> the callback received, returned for callers that wish to
+    /// continue chaining outside the callback.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="services" /> or <paramref name="configure" /> is <see langword="null" />.
+    /// </exception>
+    public static INotableDateServiceBuilder AddNotableDates(
+        this IServiceCollection services,
+        Action<INotableDateServiceBuilder> configure)
+    {
+        ThrowHelper.ThrowIfNull(services);
+        ThrowHelper.ThrowIfNull(configure);
+
+        INotableDateServiceBuilder builder = services.AddNotableDates();
+        configure(builder);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers the <see cref="INotableDateService" /> singleton factory exactly once, regardless of how many times
+    /// <see cref="AddNotableDates(IServiceCollection, IConfiguration?, string)" /> is called.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <remarks>
+    /// <para>
+    /// The factory composes a <see cref="NotableDateService" /> from the registered <see cref="IEnumerable{T}" /> of
+    /// rule providers, override providers, and plugins, augmented with optional single-instance registrations of
+    /// <see cref="INotableDateAlgorithmRegistry" />, <see cref="INotableDateCollisionResolver" />,
+    /// <see cref="INotableDateNameLocalizer" />, <see cref="IAdjustmentHandlerRegistry" />, and
+    /// <see cref="IResourcePathResolver" />.
+    /// </para>
+    /// <para>
+    /// When <see cref="NotableDateOptions.RegisterAsAmbientDefault" /> is <see langword="true" />, the resolved service
+    /// is also assigned to <see cref="NotableDateContext.Default" /> the first time the singleton is resolved. The
+    /// assignment is performed under the singleton factory's intrinsic single-execution semantics and so happens at
+    /// most once.
+    /// </para>
+    /// </remarks>
+    private static void RegisterServiceFactory(IServiceCollection services)
+    {
+        services.TryAddSingleton<INotableDateService>(provider =>
+        {
+            NotableDateOptions opts = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+            IEnumerable<INotableDateRuleProvider> ruleProviders =
+                provider.GetServices<INotableDateRuleProvider>();
+            IEnumerable<INotableDateRuleOverrideProvider> overrideProviders =
+                provider.GetServices<INotableDateRuleOverrideProvider>();
+            IEnumerable<INotableDatePlugin> plugins =
+                provider.GetServices<INotableDatePlugin>();
+
+            NotableDateServiceOptions serviceOptions = new()
+            {
+                OverrideProviders = overrideProviders.ToArray(),
+                AlgorithmRegistry = provider.GetService<INotableDateAlgorithmRegistry>(),
+                AdjustmentHandlers = provider.GetService<IAdjustmentHandlerRegistry>(),
+                CollisionResolver = provider.GetService<INotableDateCollisionResolver>(),
+                NameLocalizer = provider.GetService<INotableDateNameLocalizer>(),
+                ResourcePathResolver = provider.GetService<IResourcePathResolver>(),
+                Plugins = plugins.ToArray(),
+            };
+
+            WeekPattern workingWeek = opts.WorkingDays.ToWeekPattern();
+
+            NotableDateService service = new(ruleProviders.ToArray(), workingWeek, serviceOptions);
+
+            foreach (INotableDateRuleOverrideProvider op in overrideProviders)
+            {
+                if (op is MutableNotableDateRuleOverrideProvider mutable)
+                {
+                    mutable.Changed += (_, _) => service.Reload();
+                }
+            }
+
+            if (opts.RegisterAsAmbientDefault)
+            {
+                NotableDateContext.Default = service;
+            }
+
+            return service;
+        });
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Bodu.Globalization.Calendar.DependencyInjection.Test.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
+    <ProjectReference Include="..\..\Bodu.Globalization.Calendar.Data.AsiaPacific\src\Bodu.Globalization.Calendar.Data.AsiaPacific.csproj" />
+    <ProjectReference Include="..\src\Bodu.Globalization.Calendar.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/IntegrationTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/IntegrationTests.cs
@@ -1,0 +1,94 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IntegrationTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Data.AsiaPacific;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+/// <summary>
+/// Verifies the end-to-end composition path of the DI package — registering an Asia-Pacific data pack, querying
+/// notable dates, enumerating supported territories, and exercising the runtime-mutable override workflow against the
+/// resolved service.
+/// </summary>
+[TestClass]
+public sealed class IntegrationTests
+{
+    /// <summary>
+    /// Verifies that registering the Asia-Pacific data pack surfaces an Australian holiday for the New South Wales
+    /// territory in the resolved service.
+    /// </summary>
+    [TestMethod]
+    public void EndToEnd_WhenAsiaPacificDataPackRegistered_ShouldResolveAuNswHolidays()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .AddRuleProviders(AsiaPacificCalendarData.CreateProviders());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        IReadOnlyList<NotableDate> dates2026 = service.GetNotableDates(2026, territoryCode: "AU-NSW");
+
+        Assert.IsTrue(dates2026.Count > 0, "Expected at least one notable date for AU-NSW in 2026.");
+        Assert.IsTrue(dates2026.Any(n => n.Date == new DateTime(2026, 1, 1)), "Expected New Year's Day in the AU-NSW set for 2026.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="INotableDateService.GetSupportedTerritories" /> exposes Asia-Pacific country codes
+    /// after the data pack is registered.
+    /// </summary>
+    [TestMethod]
+    public void EndToEnd_WhenAsiaPacificDataPackRegistered_ShouldReportSupportedTerritories()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .AddRuleProviders(AsiaPacificCalendarData.CreateProviders());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        IReadOnlyCollection<string> territories = service.GetSupportedTerritories();
+
+        Assert.IsTrue(territories.Any(t => t.StartsWith("AU", StringComparison.OrdinalIgnoreCase)), "Expected at least one AU-* territory.");
+        Assert.IsTrue(territories.Any(t => t.StartsWith("NZ", StringComparison.OrdinalIgnoreCase)), "Expected at least one NZ-* territory.");
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="MutableNotableDateRuleOverrideProvider" /> registered through the builder applies
+    /// runtime mutations to the resolved service end-to-end.
+    /// </summary>
+    [TestMethod]
+    public void EndToEnd_WhenMutableOverrideAddsRuleAtRuntime_ShouldReflectChangeInService()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+            .AddOverrideProvider(overrides);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsFalse(service.GetNotableDates(2026, "AU-NSW").Any(n => n.Name == "Company Day"));
+
+        overrides.AddRule(new NotableDateRule
+        {
+            Name = "Company Day",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Observance,
+            Month = 6,
+            Day = 15,
+            IsNonWorkingDay = true,
+            TerritoryCode = "AU-NSW",
+        });
+
+        Assert.IsTrue(service.GetNotableDates(2026, "AU-NSW").Any(n => n.Name == "Company Day" && n.Date == new DateTime(2026, 6, 15)));
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateOptionsTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateOptionsTests.cs
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateOptionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.DependencyInjection;
+
+/// <summary>
+/// Verifies the defaults and <see cref="IConfiguration" />-binding round-trip semantics of
+/// <see cref="NotableDateOptions" />.
+/// </summary>
+[TestClass]
+public sealed class NotableDateOptionsTests
+{
+    /// <summary>
+    /// Verifies that a freshly constructed <see cref="NotableDateOptions" /> uses Monday–Friday as the default working
+    /// week.
+    /// </summary>
+    [TestMethod]
+    public void DefaultConstruction_ShouldUseMondayToFridayAsWorkingDays()
+    {
+        NotableDateOptions options = new();
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToFriday, options.WorkingDays);
+    }
+
+    /// <summary>
+    /// Verifies that every optional property is <see langword="null" /> or <see langword="false" /> by default.
+    /// </summary>
+    [TestMethod]
+    public void DefaultConstruction_ShouldHaveAllOptionalPropertiesUnset()
+    {
+        NotableDateOptions options = new();
+
+        Assert.IsNull(options.DefaultTerritoryCode);
+        Assert.IsNull(options.DefaultCalendarTypeName);
+        Assert.IsFalse(options.RegisterAsAmbientDefault);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration" /> binding populates every property when each key is present.
+    /// </summary>
+    [TestMethod]
+    public void Binding_WhenAllPropertiesProvided_ShouldPopulateEveryField()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:WorkingDays"] = "MondayToSaturday",
+                ["NotableDates:DefaultTerritoryCode"] = "AU-NSW",
+                ["NotableDates:DefaultCalendarTypeName"] = "System.Globalization.GregorianCalendar",
+                ["NotableDates:RegisterAsAmbientDefault"] = "true",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
+        Assert.AreEqual("AU-NSW", resolved.DefaultTerritoryCode);
+        Assert.AreEqual("System.Globalization.GregorianCalendar", resolved.DefaultCalendarTypeName);
+        Assert.IsTrue(resolved.RegisterAsAmbientDefault);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration" /> binding from an empty section produces an options instance whose
+    /// values match the defaults.
+    /// </summary>
+    [TestMethod]
+    public void Binding_WhenSectionMissing_ShouldReturnDefaults()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToFriday, resolved.WorkingDays);
+        Assert.IsNull(resolved.DefaultTerritoryCode);
+        Assert.IsNull(resolved.DefaultCalendarTypeName);
+        Assert.IsFalse(resolved.RegisterAsAmbientDefault);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration" /> binding tolerates a custom section name passed through
+    /// <see cref="ServiceCollectionExtensions.AddNotableDates(IServiceCollection, IConfiguration?, string)" />.
+    /// </summary>
+    [TestMethod]
+    public void Binding_WhenCustomSectionNameSupplied_ShouldBindFromCustomSection()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Calendar:WorkingDays"] = "MondayToSaturday",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration, sectionName: "Calendar");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateOptionsTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateOptionsTests.cs
@@ -117,4 +117,55 @@ public sealed class NotableDateOptionsTests
 
         Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
     }
+
+    /// <summary>
+    /// Verifies that <see cref="IConfiguration" />-bound boolean values for
+    /// <see cref="NotableDateOptions.RegisterAsAmbientDefault" /> are accepted across the case forms supported by
+    /// the configuration binder.
+    /// </summary>
+    /// <param name="value">The string value in the configuration.</param>
+    /// <param name="expected">The bound boolean value.</param>
+    [TestMethod]
+    [DataRow("true", true)]
+    [DataRow("True", true)]
+    [DataRow("TRUE", true)]
+    [DataRow("false", false)]
+    [DataRow("False", false)]
+    public void Binding_WhenAmbientDefaultFlagSupplied_ShouldHonourEveryCaseForm(string value, bool expected)
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:RegisterAsAmbientDefault"] = value,
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(expected, resolved.RegisterAsAmbientDefault);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOptions" /> setters accept and persist mutations after construction — the
+    /// type is a plain mutable POCO and supports programmatic configuration via <c>Configure(opts =&gt; …)</c>.
+    /// </summary>
+    [TestMethod]
+    public void Properties_WhenMutatedAfterConstruction_ShouldPersistAssignedValues()
+    {
+        NotableDateOptions options = new();
+
+        options.WorkingDays = WorkingDaysOfWeek.MondayToSaturday;
+        options.DefaultTerritoryCode = "AU-NSW";
+        options.DefaultCalendarTypeName = "System.Globalization.GregorianCalendar";
+        options.RegisterAsAmbientDefault = true;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, options.WorkingDays);
+        Assert.AreEqual("AU-NSW", options.DefaultTerritoryCode);
+        Assert.AreEqual("System.Globalization.GregorianCalendar", options.DefaultCalendarTypeName);
+        Assert.IsTrue(options.RegisterAsAmbientDefault);
+    }
 }

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddOverrideProvider.cs
@@ -103,6 +103,67 @@ public partial class NotableDateServiceBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that the typed <c>AddOverrideProvider&lt;TOverride&gt;()</c> overload throws when the builder is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProviderTyped_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.AddOverrideProvider<EmptyOverrideProvider>(null!);
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the typed <c>AddOverrideProvider&lt;TOverride&gt;()</c> overload registers the provider as a
+    /// singleton resolvable through the container, and that additions surface via the resolved service.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProviderTyped_WhenInvoked_ShouldRegisterProviderResolvedFromContainer()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider<EmptyOverrideProvider>();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        // The override provider contributes nothing; the base rule should still resolve unaffected.
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Base"));
+    }
+
+    /// <summary>
+    /// Verifies that two <see cref="MutableNotableDateRuleOverrideProvider" /> instances registered via the builder
+    /// are both auto-wired to <see cref="INotableDateService.Reload" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenMultipleMutableProvidersRegistered_ShouldAutoReloadOnEachProvidersChange()
+    {
+        MutableNotableDateRuleOverrideProvider a = new();
+        MutableNotableDateRuleOverrideProvider b = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider(a)
+            .AddOverrideProvider(b);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        a.AddRule(Fixed("From A", 7, 1));
+        b.AddRule(Fixed("From B", 8, 1));
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsTrue(emitted.Any(n => n.Name == "From A"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "From B"));
+    }
+
+    /// <summary>
     /// Verifies that a <see cref="MutableNotableDateRuleOverrideProvider" /> registered through the builder gets its
     /// <c>Changed</c> event automatically wired to <see cref="INotableDateService.Reload" />.
     /// </summary>
@@ -124,5 +185,18 @@ public partial class NotableDateServiceBuilderExtensionsTests
         overrides.AddRule(Fixed("Live", 9, 9));
 
         Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Live"));
+    }
+
+    /// <summary>
+    /// A degenerate <see cref="INotableDateRuleOverrideProvider" /> used by the typed-registration test above. The
+    /// container must be able to instantiate it via its parameterless constructor.
+    /// </summary>
+    private sealed class EmptyOverrideProvider : INotableDateRuleOverrideProvider
+    {
+        /// <inheritdoc />
+        public IEnumerable<NotableDateRule> GetAdditions() => [];
+
+        /// <inheritdoc />
+        public IEnumerable<RuleRemoval> GetRemovals() => [];
     }
 }

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddOverrideProvider.cs
@@ -1,0 +1,128 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.AddOverrideProvider.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>AddOverrideProvider</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.AddOverrideProvider(null!, new MutableNotableDateRuleOverrideProvider());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddOverrideProvider</c> throws when the provider is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddOverrideProvider((INotableDateRuleOverrideProvider)null!);
+        });
+
+        Assert.AreEqual("provider", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that an authored override addition surfaces through the resolved service when registered via
+    /// <c>AddOverrideProvider</c>.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenStaticProviderSupplied_ShouldSurfaceAdditionInService()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider(new StaticOverrideProvider(
+                additions: new[] { Fixed("Override Add", 7, 1) },
+                removals: Array.Empty<RuleRemoval>()));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Override Add"));
+    }
+
+    /// <summary>
+    /// Verifies that an authored override removal surfaces through the resolved service when registered via
+    /// <c>AddOverrideProvider</c>.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenRemovalAuthored_ShouldSuppressBaseRule()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Suppress Me", 6, 1)))
+            .AddOverrideProvider(new StaticOverrideProvider(
+                additions: Array.Empty<NotableDateRule>(),
+                removals: new[] { new RuleRemoval("Suppress Me") }));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Suppress Me"));
+    }
+
+    /// <summary>
+    /// Verifies that successive <c>AddOverrideProvider</c> calls accumulate so that contributions compose.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenCalledMultipleTimes_ShouldAccumulateProviders()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider(new StaticOverrideProvider(new[] { Fixed("First Override", 7, 1) }, Array.Empty<RuleRemoval>()))
+            .AddOverrideProvider(new StaticOverrideProvider(new[] { Fixed("Second Override", 8, 1) }, Array.Empty<RuleRemoval>()));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsTrue(emitted.Any(n => n.Name == "First Override"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "Second Override"));
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="MutableNotableDateRuleOverrideProvider" /> registered through the builder gets its
+    /// <c>Changed</c> event automatically wired to <see cref="INotableDateService.Reload" />.
+    /// </summary>
+    [TestMethod]
+    public void AddOverrideProvider_WhenMutableProviderRegistered_ShouldAutoReloadOnChange()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider(overrides);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Live"));
+
+        overrides.AddRule(Fixed("Live", 9, 9));
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Live"));
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddPlugin.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddPlugin.cs
@@ -1,0 +1,117 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.AddPlugin.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Bodu.Globalization.Calendar.Plugins;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>AddPlugin</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddPlugin_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.AddPlugin(null!, new StubPlugin());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddPlugin</c> throws when the plugin is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddPlugin_WhenPluginIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddPlugin(null!);
+        });
+
+        Assert.AreEqual("plugin", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="INotableDateRulePlugin" /> registered via <c>AddPlugin</c> contributes its rules to
+    /// the resolved <see cref="INotableDateService" />.
+    /// </summary>
+    [TestMethod]
+    public void AddPlugin_WhenRulePluginRegistered_ShouldContributePluginRulesToService()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddPlugin(new StubRulePlugin(Fixed("Plugin Day", 4, 4)));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Plugin Day"));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddPlugin</c> returns the same builder instance so calls can be chained.
+    /// </summary>
+    [TestMethod]
+    public void AddPlugin_WhenCalled_ShouldReturnSameBuilderInstance()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        INotableDateServiceBuilder returned = builder.AddPlugin(new StubPlugin());
+
+        Assert.AreSame(builder, returned);
+    }
+
+    /// <summary>
+    /// A minimal <see cref="INotableDatePlugin" /> stub that contributes neither rules nor algorithms — used to verify
+    /// the registration path without affecting service output.
+    /// </summary>
+    private sealed class StubPlugin : INotableDatePlugin
+    {
+        /// <inheritdoc />
+        public string Name => "Stub";
+
+        /// <inheritdoc />
+        public Version Version { get; } = new(1, 0, 0);
+    }
+
+    /// <summary>
+    /// A stub plugin that contributes a single in-memory rule provider so that registration can be verified through
+    /// the resolved service surface.
+    /// </summary>
+    private sealed class StubRulePlugin : INotableDatePlugin, INotableDateRulePlugin
+    {
+        /// <summary>
+        /// The rule providers contributed by this plugin.
+        /// </summary>
+        private readonly INotableDateRuleProvider[] _providers;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StubRulePlugin" /> class with the supplied rules.
+        /// </summary>
+        /// <param name="rules">The rules wrapped in a single in-memory provider.</param>
+        public StubRulePlugin(params NotableDateRule[] rules)
+        {
+            _providers = new INotableDateRuleProvider[] { new InMemoryRuleProvider(rules) };
+        }
+
+        /// <inheritdoc />
+        public string Name => "Stub Rule Plugin";
+
+        /// <inheritdoc />
+        public Version Version { get; } = new(1, 0, 0);
+
+        /// <inheritdoc />
+        public IEnumerable<INotableDateRuleProvider> GetRuleProviders() => _providers;
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddRuleProvider.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddRuleProvider.cs
@@ -180,6 +180,22 @@ public partial class NotableDateServiceBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that <c>AddRuleProviders</c> with an empty sequence is a no-op — the resolved service still functions
+    /// and returns no notable dates.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProviders_WhenSequenceIsEmpty_ShouldResolveServiceWithNoRules()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddRuleProviders(Array.Empty<INotableDateRuleProvider>());
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.AreEqual(0, service.GetNotableDates(2026).Count);
+    }
+
+    /// <summary>
     /// A degenerate <see cref="INotableDateRuleProvider" /> used by <c>AddRuleProvider&lt;TProvider&gt;</c> tests.
     /// </summary>
     private sealed class EmptyRuleProvider : INotableDateRuleProvider

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddRuleProvider.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.AddRuleProvider.cs
@@ -1,0 +1,190 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.AddRuleProvider.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// Verifies that the instance overload of <c>AddRuleProvider</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.AddRuleProvider(null!, new InMemoryRuleProvider());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the instance overload of <c>AddRuleProvider</c> throws when the provider is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddRuleProvider((INotableDateRuleProvider)null!);
+        });
+
+        Assert.AreEqual("provider", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the factory overload of <c>AddRuleProvider</c> throws when the factory is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenFactoryIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddRuleProvider((Func<IServiceProvider, INotableDateRuleProvider>)null!);
+        });
+
+        Assert.AreEqual("factory", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the factory overload of <c>AddRuleProvider</c> resolves the provider lazily from the container.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenFactorySupplied_ShouldResolveProviderFromContainer()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddRuleProvider(_ => new InMemoryRuleProvider(Fixed("Lazy", 7, 1)));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Lazy"));
+    }
+
+    /// <summary>
+    /// Verifies that the typed overload of <c>AddRuleProvider</c> resolves the provider via the container.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenTypedRegistrationUsed_ShouldResolveProviderViaContainer()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddRuleProvider<EmptyRuleProvider>();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        // The resolved service composes the empty provider — query must succeed and return no rules.
+        Assert.AreEqual(0, service.GetNotableDates(2026).Count);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddRuleProviders</c> accepts a sequence and registers every element.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProviders_WhenSequenceSupplied_ShouldRegisterEveryProvider()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddRuleProviders(new INotableDateRuleProvider[]
+        {
+            new InMemoryRuleProvider(Fixed("From A", 1, 1)),
+            new InMemoryRuleProvider(Fixed("From B", 2, 1)),
+            new InMemoryRuleProvider(Fixed("From C", 3, 1)),
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsTrue(emitted.Any(n => n.Name == "From A"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "From B"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "From C"));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddRuleProviders</c> throws when the providers sequence is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProviders_WhenSequenceIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.AddRuleProviders(null!);
+        });
+
+        Assert.AreEqual("providers", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddRuleProviders</c> throws when the sequence contains a <see langword="null" /> element.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProviders_WhenSequenceContainsNullElement_ShouldThrowArgumentException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = builder.AddRuleProviders(new INotableDateRuleProvider[]
+            {
+                new InMemoryRuleProvider(Fixed("X")),
+                null!,
+            });
+        });
+
+        Assert.AreEqual("providers", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that successive <c>AddRuleProvider</c> calls accumulate rather than overwrite.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenCalledMultipleTimes_ShouldAccumulateProviders()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.AddRuleProvider(new InMemoryRuleProvider(Fixed("First", 1, 1)));
+        builder.AddRuleProvider(new InMemoryRuleProvider(Fixed("Second", 2, 1)));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsTrue(emitted.Any(n => n.Name == "First"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "Second"));
+    }
+
+    /// <summary>
+    /// Verifies that fluent extension calls return the same builder instance so calls can be chained.
+    /// </summary>
+    [TestMethod]
+    public void AddRuleProvider_WhenCalled_ShouldReturnSameBuilderInstance()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        INotableDateServiceBuilder returned = builder.AddRuleProvider(new InMemoryRuleProvider());
+
+        Assert.AreSame(builder, returned);
+    }
+
+    /// <summary>
+    /// A degenerate <see cref="INotableDateRuleProvider" /> used by <c>AddRuleProvider&lt;TProvider&gt;</c> tests.
+    /// </summary>
+    private sealed class EmptyRuleProvider : INotableDateRuleProvider
+    {
+        /// <inheritdoc />
+        public IEnumerable<NotableDateRule> LoadRules() => [];
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.Configure.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.Configure.cs
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.Configure.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>Configure</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Configure_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.Configure(null!, _ => { });
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Configure</c> throws when the configure callback is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Configure_WhenCallbackIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.Configure(null!);
+        });
+
+        Assert.AreEqual("configure", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>Configure</c> applies its mutation to the materialised <see cref="NotableDateOptions" />.
+    /// </summary>
+    [TestMethod]
+    public void Configure_WhenCallbackMutatesOptions_ShouldBeReflectedInResolvedOptions()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.Configure(opts =>
+        {
+            opts.DefaultTerritoryCode = "AU-NSW";
+            opts.WorkingDays = WorkingDaysOfWeek.MondayToSaturday;
+        });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("AU-NSW", resolved.DefaultTerritoryCode);
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
+    }
+
+    /// <summary>
+    /// Verifies that successive <c>Configure</c> callbacks compose so that later mutations win on the same property.
+    /// </summary>
+    [TestMethod]
+    public void Configure_WhenCalledMultipleTimes_ShouldComposeInRegistrationOrder()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .Configure(opts => opts.DefaultTerritoryCode = "First")
+            .Configure(opts => opts.DefaultTerritoryCode = "Last");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("Last", resolved.DefaultTerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseWorkingDays</c> overrides any previously bound or configured working-days value.
+    /// </summary>
+    [TestMethod]
+    public void UseWorkingDays_WhenInvokedAfterBinding_ShouldOverrideBoundValue()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:WorkingDays"] = "MondayToFriday",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration).UseWorkingDays(WorkingDaysOfWeek.MondayToSaturday);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
+    }
+
+    /// <summary>
+    /// Verifies that <c>RegisterAsAmbientDefault</c> sets the bound flag on <see cref="NotableDateOptions" />.
+    /// </summary>
+    [TestMethod]
+    public void RegisterAsAmbientDefault_WhenCalled_ShouldSetOptionsFlag()
+    {
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.RegisterAsAmbientDefault();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.IsTrue(resolved.RegisterAsAmbientDefault);
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.PostConfigure.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.PostConfigure.cs
@@ -1,0 +1,156 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.PostConfigure.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// A consumer-defined POCO used to exercise the <c>PostConfigure</c> projection hook end-to-end.
+    /// </summary>
+    private sealed class CustomCalendarSettings
+    {
+        /// <summary>
+        /// Gets or sets the region code the consumer wants projected into
+        /// <see cref="NotableDateOptions.DefaultTerritoryCode" />.
+        /// </summary>
+        public string? RegionCode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the working-week preset the consumer wants projected into
+        /// <see cref="NotableDateOptions.WorkingDays" />.
+        /// </summary>
+        public WorkingDaysOfWeek WorkWeek { get; set; } = WorkingDaysOfWeek.MondayToFriday;
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.PostConfigure(null!, (_, _) => { });
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> throws when the configure callback is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenCallbackIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.PostConfigure(null!);
+        });
+
+        Assert.AreEqual("configure", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> projects values from a consumer-defined POCO into
+    /// <see cref="NotableDateOptions" /> after the binding stage has completed.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenProjectingFromCustomPoco_ShouldOverlayValuesIntoNotableDateOptions()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["MyApp:Calendar:RegionCode"] = "AU-NSW",
+                ["MyApp:Calendar:WorkWeek"] = "MondayToSaturday",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.Configure<CustomCalendarSettings>(configuration.GetSection("MyApp:Calendar"));
+        services.AddNotableDates()
+            .PostConfigure((sp, opts) =>
+            {
+                CustomCalendarSettings custom = sp.GetRequiredService<IOptions<CustomCalendarSettings>>().Value;
+                opts.DefaultTerritoryCode = custom.RegionCode;
+                opts.WorkingDays = custom.WorkWeek;
+            });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("AU-NSW", resolved.DefaultTerritoryCode);
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday, resolved.WorkingDays);
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> runs after both <see cref="IConfiguration" /> binding and
+    /// <c>Configure(...)</c> callbacks, so post-configure callbacks always win on the same property.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenCombinedWithBindAndConfigure_ShouldWinOnOverlappingProperty()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:DefaultTerritoryCode"] = "FromConfig",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration)
+            .Configure(opts => opts.DefaultTerritoryCode = "FromConfigure")
+            .PostConfigure((_, opts) => opts.DefaultTerritoryCode = "FromPostConfigure");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("FromPostConfigure", resolved.DefaultTerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> receives the host's <see cref="IServiceProvider" /> so that the callback can
+    /// resolve arbitrary services.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenInvoked_ShouldReceiveHostServiceProvider()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddSingleton<MarkerService>();
+        services.AddNotableDates()
+            .PostConfigure((sp, _) =>
+            {
+                MarkerService marker = sp.GetRequiredService<MarkerService>();
+                marker.Observed = true;
+            });
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        _ = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+        MarkerService marker = provider.GetRequiredService<MarkerService>();
+
+        Assert.IsTrue(marker.Observed);
+    }
+
+    /// <summary>
+    /// A marker class used by <c>PostConfigure</c> tests to confirm the callback received an
+    /// <see cref="IServiceProvider" />.
+    /// </summary>
+    private sealed class MarkerService
+    {
+        /// <summary>
+        /// Gets or sets a value indicating whether the marker has been observed by a post-configure callback.
+        /// </summary>
+        public bool Observed { get; set; }
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.PostConfigure.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.PostConfigure.cs
@@ -143,6 +143,42 @@ public partial class NotableDateServiceBuilderExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that multiple <c>PostConfigure</c> callbacks compose in registration order — each callback runs and
+    /// later callbacks observe earlier callbacks' mutations.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenCalledMultipleTimes_ShouldComposeInRegistrationOrder()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .PostConfigure((_, opts) => opts.DefaultTerritoryCode = "First")
+            .PostConfigure((_, opts) => opts.DefaultTerritoryCode += "+Second")
+            .PostConfigure((_, opts) => opts.DefaultTerritoryCode += "+Third");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("First+Second+Third", resolved.DefaultTerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <c>PostConfigure</c> runs even when no <see cref="Microsoft.Extensions.Configuration.IConfiguration" />
+    /// is supplied — the hook is independent of configuration binding.
+    /// </summary>
+    [TestMethod]
+    public void PostConfigure_WhenNoConfigurationSupplied_ShouldStillRun()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .PostConfigure((_, opts) => opts.DefaultTerritoryCode = "Set-by-postconfigure");
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        NotableDateOptions resolved = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual("Set-by-postconfigure", resolved.DefaultTerritoryCode);
+    }
+
+    /// <summary>
     /// A marker class used by <c>PostConfigure</c> tests to confirm the callback received an
     /// <see cref="IServiceProvider" />.
     /// </summary>

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.UseSingletons.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.UseSingletons.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.UseSingletons.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+public partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>UseAlgorithmRegistry</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseAlgorithmRegistry_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.UseAlgorithmRegistry(null!, new NotableDateAlgorithmRegistry());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseAlgorithmRegistry</c> throws when the registry is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseAlgorithmRegistry_WhenRegistryIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.UseAlgorithmRegistry(null!);
+        });
+
+        Assert.AreEqual("registry", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseAlgorithmRegistry</c> registers the supplied registry so it is resolvable from the
+    /// container.
+    /// </summary>
+    [TestMethod]
+    public void UseAlgorithmRegistry_WhenInvoked_ShouldRegisterRegistryAsResolvableSingleton()
+    {
+        NotableDateAlgorithmRegistry registry = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.UseAlgorithmRegistry(registry);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(registry, provider.GetRequiredService<INotableDateAlgorithmRegistry>());
+    }
+
+    /// <summary>
+    /// Verifies that successive <c>UseAlgorithmRegistry</c> calls replace rather than accumulate.
+    /// </summary>
+    [TestMethod]
+    public void UseAlgorithmRegistry_WhenCalledTwice_ShouldReplaceFirstRegistration()
+    {
+        NotableDateAlgorithmRegistry first = new();
+        NotableDateAlgorithmRegistry second = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder
+            .UseAlgorithmRegistry(first)
+            .UseAlgorithmRegistry(second);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(second, provider.GetRequiredService<INotableDateAlgorithmRegistry>());
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.UseSingletons.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.UseSingletons.cs
@@ -75,4 +75,199 @@ public partial class NotableDateServiceBuilderExtensionsTests
         using ServiceProvider provider = services.BuildServiceProvider();
         Assert.AreSame(second, provider.GetRequiredService<INotableDateAlgorithmRegistry>());
     }
+
+    /// <summary>
+    /// Verifies that <c>UseCollisionResolver</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseCollisionResolver_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.UseCollisionResolver(null!, new DefaultNotableDateCollisionResolver());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseCollisionResolver</c> throws when the resolver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseCollisionResolver_WhenResolverIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.UseCollisionResolver(null!);
+        });
+
+        Assert.AreEqual("resolver", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseCollisionResolver</c> registers the supplied instance and that successive calls replace.
+    /// </summary>
+    [TestMethod]
+    public void UseCollisionResolver_WhenCalledTwice_ShouldReplaceFirstRegistration()
+    {
+        DefaultNotableDateCollisionResolver first = new();
+        DefaultNotableDateCollisionResolver second = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.UseCollisionResolver(first).UseCollisionResolver(second);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(second, provider.GetRequiredService<INotableDateCollisionResolver>());
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseNameLocalizer</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseNameLocalizer_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.UseNameLocalizer(null!, new StubNameLocalizer());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseNameLocalizer</c> throws when the localizer is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseNameLocalizer_WhenLocalizerIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.UseNameLocalizer(null!);
+        });
+
+        Assert.AreEqual("localizer", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseNameLocalizer</c> registers the supplied instance and that successive calls replace.
+    /// </summary>
+    [TestMethod]
+    public void UseNameLocalizer_WhenCalledTwice_ShouldReplaceFirstRegistration()
+    {
+        StubNameLocalizer first = new();
+        StubNameLocalizer second = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.UseNameLocalizer(first).UseNameLocalizer(second);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(second, provider.GetRequiredService<INotableDateNameLocalizer>());
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseAdjustmentHandlers</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseAdjustmentHandlers_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.UseAdjustmentHandlers(null!, new AdjustmentHandlerRegistry());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseAdjustmentHandlers</c> throws when the registry is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseAdjustmentHandlers_WhenRegistryIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.UseAdjustmentHandlers(null!);
+        });
+
+        Assert.AreEqual("registry", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseAdjustmentHandlers</c> registers the supplied registry and that successive calls replace.
+    /// </summary>
+    [TestMethod]
+    public void UseAdjustmentHandlers_WhenCalledTwice_ShouldReplaceFirstRegistration()
+    {
+        AdjustmentHandlerRegistry first = new();
+        AdjustmentHandlerRegistry second = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.UseAdjustmentHandlers(first).UseAdjustmentHandlers(second);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(second, provider.GetRequiredService<IAdjustmentHandlerRegistry>());
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseResourcePathResolver</c> throws when the builder is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseResourcePathResolver_WhenBuilderIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = NotableDateServiceBuilderExtensions.UseResourcePathResolver(null!, new ResourcePathResolver());
+        });
+
+        Assert.AreEqual("builder", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseResourcePathResolver</c> throws when the resolver is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void UseResourcePathResolver_WhenResolverIsNull_ShouldThrowArgumentNullException()
+    {
+        (_, INotableDateServiceBuilder builder) = NewBuilder();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = builder.UseResourcePathResolver(null!);
+        });
+
+        Assert.AreEqual("resolver", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <c>UseResourcePathResolver</c> registers the supplied resolver and that successive calls replace.
+    /// </summary>
+    [TestMethod]
+    public void UseResourcePathResolver_WhenCalledTwice_ShouldReplaceFirstRegistration()
+    {
+        ResourcePathResolver first = new();
+        ResourcePathResolver second = new();
+
+        (IServiceCollection services, INotableDateServiceBuilder builder) = NewBuilder();
+        builder.UseResourcePathResolver(first).UseResourcePathResolver(second);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        Assert.AreSame(second, provider.GetRequiredService<IResourcePathResolver>());
+    }
+
+    /// <summary>
+    /// A trivial <see cref="INotableDateNameLocalizer" /> used only as an identity sentinel for the registration
+    /// tests above.
+    /// </summary>
+    private sealed class StubNameLocalizer : INotableDateNameLocalizer
+    {
+        /// <inheritdoc />
+        public string GetDisplayName(NotableDate notableDate, System.Globalization.CultureInfo? culture = null) =>
+            notableDate?.Name ?? string.Empty;
+    }
 }

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/NotableDateServiceBuilderExtensionsTests.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceBuilderExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+/// <summary>
+/// Verifies the registration semantics of every extension method declared on
+/// <see cref="NotableDateServiceBuilderExtensions" />, including argument validation, accumulation, and effective
+/// surfacing on the resolved <see cref="INotableDateService" />.
+/// </summary>
+[TestClass]
+public sealed partial class NotableDateServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// A trivial in-memory <see cref="INotableDateRuleProvider" /> used to compose isolated tests.
+    /// </summary>
+    private sealed class InMemoryRuleProvider : INotableDateRuleProvider
+    {
+        /// <summary>
+        /// The rules surfaced from <see cref="LoadRules" />.
+        /// </summary>
+        private readonly IReadOnlyList<NotableDateRule> _rules;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryRuleProvider" /> class.
+        /// </summary>
+        /// <param name="rules">The rules to expose.</param>
+        public InMemoryRuleProvider(params NotableDateRule[] rules) => _rules = rules;
+
+        /// <inheritdoc />
+        public IEnumerable<NotableDateRule> LoadRules() => _rules;
+    }
+
+    /// <summary>
+    /// A trivial <see cref="INotableDateRuleOverrideProvider" /> used to verify additions surface through DI.
+    /// </summary>
+    private sealed class StaticOverrideProvider : INotableDateRuleOverrideProvider
+    {
+        /// <summary>
+        /// The additions surfaced from <see cref="GetAdditions" />.
+        /// </summary>
+        private readonly IReadOnlyList<NotableDateRule> _additions;
+
+        /// <summary>
+        /// The removals surfaced from <see cref="GetRemovals" />.
+        /// </summary>
+        private readonly IReadOnlyList<RuleRemoval> _removals;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StaticOverrideProvider" /> class.
+        /// </summary>
+        /// <param name="additions">The additions to expose.</param>
+        /// <param name="removals">The removals to expose.</param>
+        public StaticOverrideProvider(IReadOnlyList<NotableDateRule> additions, IReadOnlyList<RuleRemoval> removals)
+        {
+            _additions = additions;
+            _removals = removals;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<NotableDateRule> GetAdditions() => _additions;
+
+        /// <inheritdoc />
+        public IEnumerable<RuleRemoval> GetRemovals() => _removals;
+    }
+
+    /// <summary>
+    /// Builds a fixed-month rule used in tests.
+    /// </summary>
+    /// <param name="name">The rule name.</param>
+    /// <param name="month">The fixed month.</param>
+    /// <param name="day">The fixed day.</param>
+    /// <returns>A configured <see cref="NotableDateRule" />.</returns>
+    private static NotableDateRule Fixed(string name, int month = 1, int day = 1) =>
+        new()
+        {
+            Name = name,
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = month,
+            Day = day,
+        };
+
+    /// <summary>
+    /// Builds a fresh <see cref="INotableDateServiceBuilder" /> over an empty service collection.
+    /// </summary>
+    /// <returns>The builder.</returns>
+    private static (IServiceCollection Services, INotableDateServiceBuilder Builder) NewBuilder()
+    {
+        ServiceCollection services = new();
+        INotableDateServiceBuilder builder = services.AddNotableDates();
+        return (services, builder);
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.AddNotableDates.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.AddNotableDates.cs
@@ -1,0 +1,266 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.AddNotableDates.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Extensions;
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.DependencyInjection;
+
+public partial class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ServiceCollectionExtensions.AddNotableDates(IServiceCollection, IConfiguration?, string)" />
+    /// throws when the service collection is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenServicesIsNull_ShouldThrowArgumentNullException()
+    {
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ServiceCollectionExtensions.AddNotableDates((IServiceCollection)null!);
+        });
+
+        Assert.AreEqual("services", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the builder-callback overload throws when the callback is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenConfigureCallbackIsNull_ShouldThrowArgumentNullException()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = services.AddNotableDates((Action<INotableDateServiceBuilder>)null!);
+        });
+
+        Assert.AreEqual("configure", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the configuration overload throws when the section name is empty.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenSectionNameIsEmpty_ShouldThrowArgumentException()
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = services.AddNotableDates(configuration: null, sectionName: string.Empty);
+        });
+
+        Assert.AreEqual("sectionName", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that registering with no rule providers resolves an <see cref="INotableDateService" /> backed by an
+    /// empty effective rule set.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenNoRuleProvidersRegistered_ShouldResolveServiceWithEmptyRuleSet()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsNotNull(service);
+        Assert.AreEqual(0, service.GetNotableDates(2026).Count);
+    }
+
+    /// <summary>
+    /// Verifies that the resolved <see cref="INotableDateService" /> is registered as a singleton — the same instance
+    /// is returned on subsequent resolutions.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenResolvedTwice_ShouldReturnSameSingletonInstance()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates();
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+
+        INotableDateService first = provider.GetRequiredService<INotableDateService>();
+        INotableDateService second = provider.GetRequiredService<INotableDateService>();
+
+        Assert.AreSame(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that repeated <see cref="ServiceCollectionExtensions.AddNotableDates(IServiceCollection, IConfiguration?, string)" />
+    /// calls do not register the service factory more than once.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenInvokedRepeatedly_ShouldRegisterServiceFactoryIdempotently()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates();
+        services.AddNotableDates();
+        services.AddNotableDates();
+
+        int factoryCount = services.Count(d => d.ServiceType == typeof(INotableDateService));
+        Assert.AreEqual(1, factoryCount);
+    }
+
+    /// <summary>
+    /// Verifies that the builder-callback overload returns the same builder instance the callback received.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenConfigureCallbackSupplied_ShouldReturnSameBuilderInstance()
+    {
+        IServiceCollection services = new ServiceCollection();
+        INotableDateServiceBuilder? captured = null;
+
+        INotableDateServiceBuilder returned = services.AddNotableDates(builder =>
+        {
+            captured = builder;
+        });
+
+        Assert.AreSame(captured, returned);
+    }
+
+    /// <summary>
+    /// Verifies that providers registered via <c>AddRuleProvider</c> are surfaced in the resolved service's queries.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenRuleProviderRegistered_ShouldSurfaceRuleProviderInService()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Custom Day", 6, 1)));
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Custom Day"));
+    }
+
+    /// <summary>
+    /// Verifies that the working week selected via <see cref="NotableDateOptions.WorkingDays" /> drives the resolved
+    /// service's classification of weekend days.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenWorkingDaysConfigured_ShouldRespectThemAsWorkingWeek()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .UseWorkingDays(WorkingDaysOfWeek.MondayToSaturday);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday.ToWeekPattern(), service.WorkingWeek);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOptions" /> populated from an <see cref="IConfiguration" /> section is
+    /// honoured by the resolved service.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenConfigurationBindsWorkingDays_ShouldHonourBoundValue()
+    {
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:WorkingDays"] = "MondayToSaturday",
+                ["NotableDates:DefaultTerritoryCode"] = "AU-NSW",
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+        NotableDateOptions opts = provider.GetRequiredService<IOptions<NotableDateOptions>>().Value;
+
+        Assert.AreEqual(WorkingDaysOfWeek.MondayToSaturday.ToWeekPattern(), service.WorkingWeek);
+        Assert.AreEqual("AU-NSW", opts.DefaultTerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOptions.RegisterAsAmbientDefault" /> wires the resolved singleton into
+    /// <see cref="NotableDateContext.Default" /> on first resolution.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenRegisterAsAmbientDefaultSet_ShouldAssignNotableDateContextDefaultOnFirstResolve()
+    {
+        NotableDateContext.Reset();
+        try
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddNotableDates()
+                .RegisterAsAmbientDefault();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+            Assert.AreSame(service, NotableDateContext.Default);
+        }
+        finally
+        {
+            NotableDateContext.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOptions.RegisterAsAmbientDefault" /> defaults to <see langword="false" />
+    /// so that downstream tests are not affected by accidental ambient assignment.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenRegisterAsAmbientDefaultUnset_ShouldNotAssignNotableDateContextDefault()
+    {
+        NotableDateContext.Reset();
+        try
+        {
+            IServiceCollection services = new ServiceCollection();
+            services.AddNotableDates();
+
+            using ServiceProvider provider = services.BuildServiceProvider();
+            INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+            // The lazy fallback is a fresh instance distinct from the DI-resolved service.
+            Assert.AreNotSame(service, NotableDateContext.Default);
+        }
+        finally
+        {
+            NotableDateContext.Reset();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider" /> registered through the builder is
+    /// auto-wired to <see cref="INotableDateService.Reload" /> on its <c>Changed</c> event.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenMutableOverrideRegistered_ShouldAutoReloadServiceOnChange()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates()
+            .AddRuleProvider(new InMemoryRuleProvider(Fixed("Base", 6, 1)))
+            .AddOverrideProvider(overrides);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        // No mutations yet — the override rule must not appear.
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Auto"));
+
+        overrides.AddRule(Fixed("Auto", 7, 1));
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Auto"));
+    }
+}

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.AddNotableDates.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.AddNotableDates.cs
@@ -240,6 +240,81 @@ public partial class ServiceCollectionExtensionsTests
     }
 
     /// <summary>
+    /// Verifies that the configuration overload throws when the section name is whitespace.
+    /// </summary>
+    /// <param name="sectionName">The section name argument under test.</param>
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("\t")]
+    [DataRow("   ")]
+    public void AddNotableDates_WhenSectionNameIsBlank_ShouldThrowArgumentException(string sectionName)
+    {
+        IServiceCollection services = new ServiceCollection();
+
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = services.AddNotableDates(configuration: null, sectionName: sectionName);
+        });
+
+        Assert.AreEqual("sectionName", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOptions.WorkingDays" /> bound from configuration drives the resolved
+    /// service's <see cref="INotableDateService.WorkingWeek" /> for every named preset.
+    /// </summary>
+    /// <param name="workingDays">The enum member to bind and verify.</param>
+    [TestMethod]
+    [DataRow(nameof(WorkingDaysOfWeek.MondayToFriday))]
+    [DataRow(nameof(WorkingDaysOfWeek.MondayToSaturday))]
+    [DataRow(nameof(WorkingDaysOfWeek.SundayToThursday))]
+    [DataRow(nameof(WorkingDaysOfWeek.SaturdayToWednesday))]
+    public void AddNotableDates_WhenConfigurationBindsKnownWorkingDaysValue_ShouldHonourIt(string workingDays)
+    {
+        WorkingDaysOfWeek expected = Enum.Parse<WorkingDaysOfWeek>(workingDays);
+
+        IConfigurationRoot configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["NotableDates:WorkingDays"] = workingDays,
+            })
+            .Build();
+
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates(configuration);
+
+        using ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.AreEqual(expected.ToWeekPattern(), service.WorkingWeek);
+    }
+
+    /// <summary>
+    /// Verifies that the resolved <see cref="NotableDateService" /> is disposed when the owning
+    /// <see cref="ServiceProvider" /> is disposed — the container honours <see cref="IDisposable" /> on registered
+    /// singletons.
+    /// </summary>
+    [TestMethod]
+    public void AddNotableDates_WhenServiceProviderDisposed_ShouldDisposeResolvedSingleton()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddNotableDates();
+
+        ServiceProvider provider = services.BuildServiceProvider();
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        provider.Dispose();
+
+        // After disposal a subsequent call into the service that touches its internal ThreadLocal must throw, proving
+        // the container called Dispose on the singleton (which disposes the ThreadLocal field).
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = service.GetNotableDates(2026);
+        });
+    }
+
+    /// <summary>
     /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider" /> registered through the builder is
     /// auto-wired to <see cref="INotableDateService.Reload" /> on its <c>Changed</c> event.
     /// </summary>

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/Globalization.Calendar.DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,59 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.DependencyInjection;
+
+/// <summary>
+/// Verifies the registration semantics, defaults, builder return values, and argument validation for the
+/// <see cref="ServiceCollectionExtensions.AddNotableDates(IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />
+/// extension family.
+/// </summary>
+[TestClass]
+public sealed partial class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// A trivial in-memory <see cref="INotableDateRuleProvider" /> used to seed test compositions.
+    /// </summary>
+    private sealed class InMemoryRuleProvider : INotableDateRuleProvider
+    {
+        /// <summary>
+        /// The rules surfaced from <see cref="LoadRules" />.
+        /// </summary>
+        private readonly IReadOnlyList<NotableDateRule> _rules;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InMemoryRuleProvider" /> class with the supplied rule set.
+        /// </summary>
+        /// <param name="rules">The rules to expose.</param>
+        public InMemoryRuleProvider(params NotableDateRule[] rules) => _rules = rules;
+
+        /// <inheritdoc />
+        public IEnumerable<NotableDateRule> LoadRules() => _rules;
+    }
+
+    /// <summary>
+    /// Builds a fixed-month rule used in test fixtures.
+    /// </summary>
+    /// <param name="name">The rule name.</param>
+    /// <param name="month">The fixed month.</param>
+    /// <param name="day">The fixed day.</param>
+    /// <param name="territory">The optional territory scope.</param>
+    /// <returns>A configured <see cref="NotableDateRule" />.</returns>
+    private static NotableDateRule Fixed(string name, int month = 1, int day = 1, string? territory = null) =>
+        new()
+        {
+            Name = name,
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = month,
+            Day = day,
+            TerritoryCode = territory,
+        };
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -230,4 +230,59 @@ public interface INotableDateService
     /// </summary>
     /// <param name="year">The year whose cache entries should be cleared.</param>
     void Invalidate(int year);
+
+    /// <summary>
+    /// Re-queries every registered <see cref="INotableDateRuleOverrideProvider" /> and rebuilds the effective rule set
+    /// so that subsequent queries observe the current additions and removals.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The default implementation is a no-op suitable for services whose rules are immutable for the lifetime of the
+    /// instance. The canonical <see cref="NotableDateService" /> overrides this method to re-snapshot every override
+    /// provider's <see cref="INotableDateRuleOverrideProvider.GetAdditions" /> and
+    /// <see cref="INotableDateRuleOverrideProvider.GetRemovals" /> contributions, rebuild the merged rule set, and clear
+    /// all cached year results. Base rule providers are <em>not</em> re-queried; they are considered load-time inputs.
+    /// </para>
+    /// <para>
+    /// Call this method after mutating a runtime-mutable override provider (for example,
+    /// <see cref="MutableNotableDateRuleOverrideProvider" />) so that additions and removals authored after construction
+    /// take effect.
+    /// </para>
+    /// </remarks>
+    void Reload()
+    {
+        Invalidate();
+    }
+
+    /// <summary>
+    /// Returns the distinct set of territory codes referenced by the service's effective rule set.
+    /// </summary>
+    /// <returns>
+    /// A read-only collection of every non-empty <see cref="NotableDateRule.TerritoryCode" /> that the loaded providers
+    /// cover, sorted case-insensitively. Rules without an explicit territory (global rules) contribute no entry.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The default implementation returns an empty collection; concrete services should override it to project over
+    /// their effective rule set. Consumers typically use the returned codes to drive territory pickers in UI or to
+    /// enumerate query scopes programmatically.
+    /// </para>
+    /// </remarks>
+    IReadOnlyCollection<string> GetSupportedTerritories() => [];
+
+    /// <summary>
+    /// Returns the distinct set of calendar types referenced by the service's effective rule set.
+    /// </summary>
+    /// <returns>
+    /// A read-only collection of every non-<see langword="null" /> <see cref="NotableDateRule.CalendarType" /> that the
+    /// loaded providers reference. Rules without an explicit calendar scope contribute no entry.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// The default implementation returns an empty collection; concrete services should override it to project over
+    /// their effective rule set. Consumers typically use the returned types to expose calendar-specific filters
+    /// (for example, separating Gregorian observances from <see cref="SysGlobal.HebrewCalendar" />-anchored ones).
+    /// </para>
+    /// </remarks>
+    IReadOnlyCollection<Type> GetSupportedCalendars() => [];
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -249,6 +249,34 @@ public interface INotableDateService
     /// take effect.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <para>
+    /// Wire a <see cref="MutableNotableDateRuleOverrideProvider" /> so the service auto-reloads when the provider
+    /// changes:
+    /// </para>
+    /// <code>
+    ///<![CDATA[
+    /// var overrides = new MutableNotableDateRuleOverrideProvider();
+    /// INotableDateService service = new NotableDateService(
+    ///     ruleProviders: AsiaPacificCalendarData.CreateProviders(),
+    ///     workingWeek: WeekPattern.MondayToFriday,
+    ///     options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+    ///
+    /// overrides.Changed += (_, _) => service.Reload();
+    ///
+    /// overrides.AddRule(new NotableDateRule
+    /// {
+    ///     Name = "Site Maintenance Day",
+    ///     Strategy = DateResolutionStrategy.Fixed,
+    ///     Category = NotableDateCategory.Observance,
+    ///     Month = 3,
+    ///     Day = 28,
+    ///     IsNonWorkingDay = true,
+    /// });
+    /// // New rule is now visible to service.GetNotableDates(...).
+    ///]]>
+    /// </code>
+    /// </example>
     void Reload()
     {
         Invalidate();
@@ -268,6 +296,16 @@ public interface INotableDateService
     /// enumerate query scopes programmatically.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// foreach (string code in service.GetSupportedTerritories())
+    /// {
+    ///     Console.WriteLine($"{code}: {service.GetNotableDates(2026, code).Count} notable dates");
+    /// }
+    ///]]>
+    /// </code>
+    /// </example>
     IReadOnlyCollection<string> GetSupportedTerritories() => [];
 
     /// <summary>
@@ -284,5 +322,13 @@ public interface INotableDateService
     /// (for example, separating Gregorian observances from <see cref="SysGlobal.HebrewCalendar" />-anchored ones).
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code>
+    ///<![CDATA[
+    /// IReadOnlyCollection<Type> calendars = service.GetSupportedCalendars();
+    /// bool hasHebrewRules = calendars.Contains(typeof(System.Globalization.HebrewCalendar));
+    ///]]>
+    /// </code>
+    /// </example>
     IReadOnlyCollection<Type> GetSupportedCalendars() => [];
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateRuleOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateRuleOverrideProvider.cs
@@ -1,0 +1,188 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProvider.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Immutable;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Provides a thread-safe, runtime-mutable <see cref="INotableDateRuleOverrideProvider" /> whose additions and removals
+/// can be modified after the consuming <see cref="NotableDateService" /> has been constructed.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The provider exposes <see cref="AddRule" />, <see cref="RemoveRule" />, and <see cref="Clear" /> mutators that
+/// each raise <see cref="Changed" /> after applying their update. Consumers that wire the provider through a service
+/// composition root should subscribe <see cref="INotableDateService.Reload" /> to <see cref="Changed" /> so that
+/// mutations take effect against the live service without rebuilding it. Without a corresponding
+/// <see cref="INotableDateService.Reload" /> the service continues to observe the snapshot taken at construction.
+/// </para>
+/// <para>
+/// Internal storage uses <see cref="ImmutableList{T}" /> so that concurrent enumerators returned by
+/// <see cref="GetAdditions" /> and <see cref="GetRemovals" /> observe a coherent snapshot even while another thread is
+/// mutating the provider. Updates are committed under a single internal gate to keep insertion ordering deterministic.
+/// </para>
+/// </remarks>
+/// <example>
+/// <para>
+/// Authoring a one-off observance at runtime and refreshing the service:
+/// </para>
+/// <code>
+///<![CDATA[
+/// var overrides = new MutableNotableDateRuleOverrideProvider();
+/// var service = new NotableDateService(
+///     ruleProviders: AsiaPacificCalendarData.CreateProviders(),
+///     workingWeek: WeekPattern.MondayToFriday,
+///     options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+///
+/// overrides.Changed += (_, _) => service.Reload();
+///
+/// overrides.AddRule(new NotableDateRule
+/// {
+///     Name = "Company Founding Day",
+///     Strategy = DateResolutionStrategy.Fixed,
+///     Category = NotableDateCategory.Observance,
+///     Month = 6,
+///     Day = 15,
+///     IsNonWorkingDay = true,
+/// });
+///]]>
+/// </code>
+/// </example>
+public sealed class MutableNotableDateRuleOverrideProvider : INotableDateRuleOverrideProvider
+{
+    /// <summary>
+    /// Gate protecting writes to <see cref="_additions" /> and <see cref="_removals" />. Reads sample the immutable
+    /// reference unsynchronised — atomic on a 64-bit runtime — so they incur no contention.
+    /// </summary>
+    private readonly object _gate = new();
+
+    /// <summary>
+    /// The current set of override additions in insertion order. Replaced on every mutation; never mutated in place.
+    /// </summary>
+    private ImmutableList<NotableDateRule> _additions = ImmutableList<NotableDateRule>.Empty;
+
+    /// <summary>
+    /// The current set of override removals in insertion order. Replaced on every mutation; never mutated in place.
+    /// </summary>
+    private ImmutableList<RuleRemoval> _removals = ImmutableList<RuleRemoval>.Empty;
+
+    /// <summary>
+    /// Raised after every mutation (<see cref="AddRule" />, <see cref="RemoveRule" />, <see cref="Clear" />) so that
+    /// hosts can refresh dependent <see cref="INotableDateService" /> instances via
+    /// <see cref="INotableDateService.Reload" />.
+    /// </summary>
+    /// <remarks>
+    /// The event is raised after the internal state has been updated and outside the mutation gate, so handlers may
+    /// safely call back into this provider. Handlers should treat the event as a coalescable hint, not a per-rule
+    /// notification — a single <see cref="Clear" /> call raises one <see cref="Changed" /> event regardless of the
+    /// number of rules dropped.
+    /// </remarks>
+    public event EventHandler? Changed;
+
+    /// <summary>
+    /// Adds a notable date rule to the override layer, replacing any same-name base rule when the service rebuilds.
+    /// </summary>
+    /// <param name="rule">The rule to add. Must not be <see langword="null" />.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="rule" /> is <see langword="null" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Insertion order is preserved across <see cref="GetAdditions" /> calls. The same instance may be added more than
+    /// once and will appear in the addition list each time, although the resolver applies same-name replacement, so
+    /// duplicate additions of the same name collapse during service rebuild.
+    /// </para>
+    /// </remarks>
+    public void AddRule(NotableDateRule rule)
+    {
+        ThrowHelper.ThrowIfNull(rule);
+
+        lock (_gate)
+        {
+            _additions = _additions.Add(rule);
+        }
+
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Adds a removal entry that suppresses a base rule by name, optionally scoped to a year range and territory.
+    /// </summary>
+    /// <param name="name">The rule name to suppress. Must not be <see langword="null" /> or empty.</param>
+    /// <param name="fromYear">Optional inclusive first year of the suppression.</param>
+    /// <param name="toYear">Optional inclusive last year of the suppression.</param>
+    /// <param name="territoryCode">Optional territory scope for the suppression.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="name" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="name" /> is empty or whitespace.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The method appends a new <see cref="RuleRemoval" /> rather than coalescing overlapping removals. The
+    /// <see cref="NotableDateService" /> evaluates the full removal list when applying overrides, so multiple removals
+    /// targeting the same name compose by union of their year and territory scopes.
+    /// </para>
+    /// </remarks>
+    public void RemoveRule(string name, int? fromYear = null, int? toYear = null, string? territoryCode = null)
+    {
+        ThrowHelper.ThrowIfNull(name);
+        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Rule name must not be blank.", nameof(name));
+
+        RuleRemoval removal = new(name, fromYear, toYear, territoryCode);
+
+        lock (_gate)
+        {
+            _removals = _removals.Add(removal);
+        }
+
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Drops every authored addition and removal so that the provider contributes nothing to the next service rebuild.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A single <see cref="Changed" /> event is raised after both lists have been cleared, regardless of how many
+    /// entries were present.
+    /// </para>
+    /// </remarks>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _additions = ImmutableList<NotableDateRule>.Empty;
+            _removals = ImmutableList<RuleRemoval>.Empty;
+        }
+
+        OnChanged();
+    }
+
+    /// <summary>
+    /// Returns a snapshot of the rules currently authored as additions, in the order they were added.
+    /// </summary>
+    /// <returns>The current addition list. The returned snapshot is stable under concurrent mutation.</returns>
+    public IEnumerable<NotableDateRule> GetAdditions() => _additions;
+
+    /// <summary>
+    /// Returns a snapshot of the removals currently authored, in the order they were added.
+    /// </summary>
+    /// <returns>The current removal list. The returned snapshot is stable under concurrent mutation.</returns>
+    public IEnumerable<RuleRemoval> GetRemovals() => _removals;
+
+    /// <summary>
+    /// Raises the <see cref="Changed" /> event with this provider as the sender and
+    /// <see cref="EventArgs.Empty" /> as the payload.
+    /// </summary>
+    /// <remarks>
+    /// The event is raised outside the mutation gate so that subscribed handlers may call back into this provider
+    /// without re-entrancy hazards.
+    /// </remarks>
+    private void OnChanged() => Changed?.Invoke(this, EventArgs.Empty);
+}

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateRuleOverrideProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateRuleOverrideProvider.cs
@@ -131,8 +131,7 @@ public sealed class MutableNotableDateRuleOverrideProvider : INotableDateRuleOve
     /// </remarks>
     public void RemoveRule(string name, int? fromYear = null, int? toYear = null, string? territoryCode = null)
     {
-        ThrowHelper.ThrowIfNull(name);
-        if (string.IsNullOrWhiteSpace(name)) throw new ArgumentException("Rule name must not be blank.", nameof(name));
+        ThrowHelper.ThrowIfNullOrWhiteSpace(name);
 
         RuleRemoval removal = new(name, fromYear, toYear, territoryCode);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -144,9 +144,10 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     private readonly INotableDateCollisionResolver _collisionResolver;
 
     /// <summary>
-    /// The merged rule set after all overrides have been applied; drives every resolution pass.
+    /// The merged rule set after all overrides have been applied; drives every resolution pass. Rebuilt by
+    /// <see cref="Reload" /> when an <see cref="INotableDateRuleOverrideProvider" /> mutates its contributions.
     /// </summary>
-    private readonly IReadOnlyList<NotableDateRule> _effectiveRules;
+    private IReadOnlyList<NotableDateRule> _effectiveRules;
 
     /// <summary>
     /// Lock protecting write access to <see cref="_yearCache" /> during first-time year generation.
@@ -167,8 +168,9 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     /// Identity-keyed set of every rule contributed by an <see cref="INotableDateRuleOverrideProvider" /> addition.
     /// Used by <see cref="IsRemovedByOverride" /> to exempt override additions from same-name
     /// <see cref="RuleRemoval" /> suppression, so an addition can replace a removed base rule of the same name.
+    /// Rebuilt by <see cref="Reload" /> alongside <see cref="_effectiveRules" />.
     /// </summary>
-    private readonly HashSet<NotableDateRule> _overrideAdditions;
+    private HashSet<NotableDateRule> _overrideAdditions;
 
     /// <summary>
     /// The ordered list of override providers applied on top of the base rule set.
@@ -176,9 +178,11 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     private readonly IReadOnlyList<INotableDateRuleOverrideProvider> _overrideProviders;
 
     /// <summary>
-    /// Snapshot of all override removals, materialized once at construction to avoid re-querying providers per year.
+    /// Snapshot of all override removals, materialized once at construction and refreshed by <see cref="Reload" /> so
+    /// that downstream lookups iterate a materialized list once per rule × year × territory rather than re-invoking
+    /// <see cref="INotableDateRuleOverrideProvider.GetRemovals" /> on every check.
     /// </summary>
-    private readonly IReadOnlyList<RuleRemoval> _overrideRemovals;
+    private IReadOnlyList<RuleRemoval> _overrideRemovals;
 
     /// <summary>
     /// The chronological windows resolved by <see cref="ResolveNotableDatesInRange" /> since the last
@@ -192,9 +196,16 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     private readonly object _resolvedWindowsGate = new();
 
     /// <summary>
-    /// The resolver that turns each rule into an anchor date for a given year.
+    /// The resolver that turns each rule into an anchor date for a given year. Rebuilt by <see cref="Reload" /> when
+    /// the effective rule set changes.
     /// </summary>
-    private readonly NotableDateRuleResolver _resolver;
+    private NotableDateRuleResolver _resolver;
+
+    /// <summary>
+    /// The composed algorithm registry that was supplied to the resolver, retained so <see cref="Reload" /> can
+    /// reconstruct an equivalent resolver against the refreshed rule set.
+    /// </summary>
+    private readonly INotableDateAlgorithmRegistry? _algorithmRegistry;
 
     /// <summary>
     /// The resolver used to locate embedded XML resource files.
@@ -340,28 +351,43 @@ public sealed class NotableDateService : INotableDateService, IDisposable
             .Where(r => r is not null)];
         _overrideProviders = opts.OverrideProviders?.ToList() ?? (IReadOnlyList<INotableDateRuleOverrideProvider>)[];
 
-        // Snapshot every override provider's contributions at construction so that downstream lookups iterate a materialized
-        // list once per rule × year × territory rather than re-invoking GetRemovals / GetAdditions on every check. This pins
-        // the cost of any non-trivial override provider (database-backed, configuration-bound, lazily-enumerated) to a single
-        // call per provider and removes a runaway vector for providers that return fresh, infinite, or expensive enumerables
-        // on each invocation. Materialise additions once into a list so the same instances are reused by ApplyOverrides and
-        // by the addition-identity set below.
-        _overrideRemovals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
-        List<NotableDateRule> overrideAdditionList = [.. _overrideProviders.SelectMany(p => p.GetAdditions())];
-
-        // Track the addition instances by reference identity. NotableDateRule is a record with value equality, so a HashSet
-        // keyed on its default equality would treat two unrelated rules with identical property values as the same entry —
-        // ReferenceEqualityComparer ensures we only exempt the specific instances contributed by override providers.
-        _overrideAdditions = new HashSet<NotableDateRule>(overrideAdditionList, ReferenceEqualityComparer.Instance);
-
         WorkingWeek = workingWeek;
         _collisionResolver = opts.CollisionResolver ?? new DefaultNotableDateCollisionResolver();
         _nameLocalizer = opts.NameLocalizer;
         _resourcePathResolver = opts.ResourcePathResolver ?? new ResourcePathResolver();
-
-        _effectiveRules = ApplyOverrides(_baseRules, overrideAdditionList);
-        _resolver = new NotableDateRuleResolver(_effectiveRules, effectiveRegistry);
+        _algorithmRegistry = effectiveRegistry;
         _adjustmentHandlers = opts.AdjustmentHandlers;
+
+        (_overrideRemovals, _overrideAdditions, _effectiveRules, _resolver) = BuildOverrideState();
+    }
+
+    /// <summary>
+    /// Re-queries every registered <see cref="INotableDateRuleOverrideProvider" /> and returns the freshly snapshotted
+    /// override removals, addition identity set, merged effective rule set, and resolver. Shared by the constructor
+    /// and <see cref="Reload" /> so that the two callers cannot drift.
+    /// </summary>
+    /// <returns>
+    /// A tuple comprising the override-derived state needed by the resolution pipeline.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Snapshotting every override provider's contributions in a single pass pins the cost of any non-trivial override
+    /// provider (database-backed, configuration-bound, lazily-enumerated) to a single call per provider and removes a
+    /// runaway vector for providers that return fresh, infinite, or expensive enumerables on each invocation. Override
+    /// additions are tracked by reference identity because <see cref="NotableDateRule" /> is a record with value
+    /// equality — <see cref="ReferenceEqualityComparer" /> ensures we only exempt the specific instances contributed
+    /// by override providers from same-name <see cref="RuleRemoval" /> suppression.
+    /// </para>
+    /// </remarks>
+    private (IReadOnlyList<RuleRemoval> Removals, HashSet<NotableDateRule> Additions, IReadOnlyList<NotableDateRule> Effective, NotableDateRuleResolver Resolver) BuildOverrideState()
+    {
+        IReadOnlyList<RuleRemoval> removals = [.. _overrideProviders.SelectMany(p => p.GetRemovals())];
+        List<NotableDateRule> additionList = [.. _overrideProviders.SelectMany(p => p.GetAdditions())];
+        HashSet<NotableDateRule> additions = new(additionList, ReferenceEqualityComparer.Instance);
+        IReadOnlyList<NotableDateRule> effective = ApplyOverrides(_baseRules, additionList);
+        NotableDateRuleResolver resolver = new(effective, _algorithmRegistry);
+
+        return (removals, additions, effective, resolver);
     }
 
     /// <summary>
@@ -572,6 +598,77 @@ public sealed class NotableDateService : INotableDateService, IDisposable
 
     /// <inheritdoc />
     public void Invalidate(int year) => _yearCache.TryRemove(year, out _);
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Re-snapshots every registered <see cref="INotableDateRuleOverrideProvider" /> by calling
+    /// <see cref="INotableDateRuleOverrideProvider.GetAdditions" /> and
+    /// <see cref="INotableDateRuleOverrideProvider.GetRemovals" />, rebuilds the merged effective rule set, recreates
+    /// the resolver, and clears all cached year results. Base <see cref="INotableDateRuleProvider" /> sources are not
+    /// re-queried; their contribution is fixed for the lifetime of the service.
+    /// </para>
+    /// <para>
+    /// The rebuild is performed under the same gate used by per-year cache writes so that a concurrent reader cannot
+    /// observe a half-applied state. Resolved-window state is cleared identically to <see cref="Invalidate()" />.
+    /// </para>
+    /// </remarks>
+    public void Reload()
+    {
+        lock (_gate)
+        {
+            (_overrideRemovals, _overrideAdditions, _effectiveRules, _resolver) = BuildOverrideState();
+        }
+
+        Invalidate();
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Projects the effective rule set's <see cref="NotableDateRule.TerritoryCode" /> values through case-insensitive
+    /// distinctness, eliding rules whose territory is <see langword="null" /> or empty. Returned codes preserve their
+    /// authored casing.
+    /// </para>
+    /// </remarks>
+    public IReadOnlyCollection<string> GetSupportedTerritories()
+    {
+        IReadOnlyList<NotableDateRule> snapshot = _effectiveRules;
+        SortedSet<string> territories = new(StringComparer.OrdinalIgnoreCase);
+
+        foreach (NotableDateRule rule in snapshot)
+        {
+            if (!string.IsNullOrEmpty(rule.TerritoryCode))
+            {
+                _ = territories.Add(rule.TerritoryCode);
+            }
+        }
+
+        return territories;
+    }
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Projects the effective rule set's <see cref="NotableDateRule.CalendarType" /> values through reference
+    /// distinctness, eliding rules whose calendar is <see langword="null" /> (global / unscoped rules).
+    /// </para>
+    /// </remarks>
+    public IReadOnlyCollection<Type> GetSupportedCalendars()
+    {
+        IReadOnlyList<NotableDateRule> snapshot = _effectiveRules;
+        HashSet<Type> calendars = [];
+
+        foreach (NotableDateRule rule in snapshot)
+        {
+            if (rule.CalendarType is not null)
+            {
+                _ = calendars.Add(rule.CalendarType);
+            }
+        }
+
+        return calendars;
+    }
 
     /// <inheritdoc />
     public bool IsHolidayNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -627,8 +627,8 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     /// <remarks>
     /// <para>
     /// Projects the effective rule set's <see cref="NotableDateRule.TerritoryCode" /> values through case-insensitive
-    /// distinctness, eliding rules whose territory is <see langword="null" /> or empty. Returned codes preserve their
-    /// authored casing.
+    /// distinctness, eliding rules whose territory is <see langword="null" />, empty, or whitespace. Returned codes
+    /// preserve their authored casing.
     /// </para>
     /// </remarks>
     public IReadOnlyCollection<string> GetSupportedTerritories()
@@ -638,7 +638,7 @@ public sealed class NotableDateService : INotableDateService, IDisposable
 
         foreach (NotableDateRule rule in snapshot)
         {
-            if (!string.IsNullOrEmpty(rule.TerritoryCode))
+            if (!string.IsNullOrWhiteSpace(rule.TerritoryCode))
             {
                 _ = territories.Add(rule.TerritoryCode);
             }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/INotableDateServiceDefaultMembersTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/INotableDateServiceDefaultMembersTests.cs
@@ -1,0 +1,167 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="INotableDateServiceDefaultMembersTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the default-implemented members of <see cref="INotableDateService" /> against a minimal stub
+/// implementation that does not override them. These tests exercise the default interface method bodies — which
+/// would otherwise be shadowed by every override on the canonical <see cref="NotableDateService" /> implementation.
+/// </summary>
+[TestClass]
+public sealed class INotableDateServiceDefaultMembersTests
+{
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.WorkingWeek" /> reports
+    /// <see cref="WeekPattern.Weekdays" />.
+    /// </summary>
+    [TestMethod]
+    public void WorkingWeek_WhenImplementorDoesNotOverride_ShouldDefaultToWeekdays()
+    {
+        INotableDateService service = new MinimalNotableDateService();
+
+        Assert.AreEqual(WeekPattern.Weekdays, service.WorkingWeek);
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.GetSupportedTerritories" /> returns
+    /// an empty collection.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenImplementorDoesNotOverride_ShouldReturnEmpty()
+    {
+        INotableDateService service = new MinimalNotableDateService();
+
+        Assert.AreEqual(0, service.GetSupportedTerritories().Count);
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.GetSupportedCalendars" /> returns
+    /// an empty collection.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenImplementorDoesNotOverride_ShouldReturnEmpty()
+    {
+        INotableDateService service = new MinimalNotableDateService();
+
+        Assert.AreEqual(0, service.GetSupportedCalendars().Count);
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.Reload" /> delegates to
+    /// <see cref="INotableDateService.Invalidate()" /> exactly once.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenImplementorDoesNotOverride_ShouldDelegateToInvalidate()
+    {
+        MinimalNotableDateService implementation = new();
+        INotableDateService service = implementation;
+
+        service.Reload();
+
+        Assert.AreEqual(1, implementation.InvalidateCallCount);
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.IsHolidayNonWorkingDay" /> walks
+    /// <see cref="INotableDateService.GetNotableDates(DateTime, string?, Type?)" /> and returns <see langword="true" />
+    /// when any covering date is flagged non-working.
+    /// </summary>
+    [TestMethod]
+    public void IsHolidayNonWorkingDay_WhenImplementorDoesNotOverrideAndCoveringDateIsNonWorking_ShouldReturnTrue()
+    {
+        DateTime date = new(2026, 6, 1);
+        INotableDateService service = new MinimalNotableDateService
+        {
+            DatesForSingleDay = new[]
+            {
+                new NotableDate { Date = date, Name = "X", Category = NotableDateCategory.Holiday, IsNonWorkingDay = false },
+                new NotableDate { Date = date, Name = "Y", Category = NotableDateCategory.Holiday, IsNonWorkingDay = true },
+            },
+        };
+
+        Assert.IsTrue(service.IsHolidayNonWorkingDay(date));
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.IsHolidayNonWorkingDay" /> returns
+    /// <see langword="false" /> when no covering date is non-working.
+    /// </summary>
+    [TestMethod]
+    public void IsHolidayNonWorkingDay_WhenImplementorDoesNotOverrideAndNoCoveringDateIsNonWorking_ShouldReturnFalse()
+    {
+        DateTime date = new(2026, 6, 1);
+        INotableDateService service = new MinimalNotableDateService
+        {
+            DatesForSingleDay = new[]
+            {
+                new NotableDate { Date = date, Name = "X", Category = NotableDateCategory.Holiday, IsNonWorkingDay = false },
+            },
+        };
+
+        Assert.IsFalse(service.IsHolidayNonWorkingDay(date));
+    }
+
+    /// <summary>
+    /// Verifies that the default implementation of <see cref="INotableDateService.IsHolidayNonWorkingDay" /> returns
+    /// <see langword="false" /> when no notable date covers the supplied day.
+    /// </summary>
+    [TestMethod]
+    public void IsHolidayNonWorkingDay_WhenImplementorDoesNotOverrideAndNoCoveringDate_ShouldReturnFalse()
+    {
+        INotableDateService service = new MinimalNotableDateService { DatesForSingleDay = [] };
+
+        Assert.IsFalse(service.IsHolidayNonWorkingDay(new DateTime(2026, 6, 1)));
+    }
+
+    /// <summary>
+    /// Stub implementation of <see cref="INotableDateService" /> that overrides only the abstract members and lets the
+    /// default interface methods run unmodified. Used by the per-test cases above to exercise the fallback bodies.
+    /// </summary>
+    private sealed class MinimalNotableDateService : INotableDateService
+    {
+        /// <summary>
+        /// Gets the number of times <see cref="Invalidate()" /> has been called on this stub.
+        /// </summary>
+        public int InvalidateCallCount { get; private set; }
+
+        /// <summary>
+        /// Gets or sets the result returned from the single-day <c>GetNotableDates</c> overload. Used by
+        /// <see cref="INotableDateService.IsHolidayNonWorkingDay" /> tests to drive the default body.
+        /// </summary>
+        public IReadOnlyList<NotableDate> DatesForSingleDay { get; set; } = [];
+
+        /// <inheritdoc />
+        public bool IsWeekend(DateTime date) => date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday;
+
+        /// <inheritdoc />
+        public bool IsNonWorkingDay(DateTime date, string? territoryCode = null, Type? calendarType = null) => IsWeekend(date);
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(int year, string? territoryCode = null, Type? calendarType = null) => [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(int year, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null) => [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(DateTime startDate, DateTime endDate, string? territoryCode = null, Type? calendarType = null) => [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(DateTime startDate, DateTime endDate, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null) => [];
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(DateTime date, string? territoryCode = null, Type? calendarType = null) => DatesForSingleDay;
+
+        /// <inheritdoc />
+        public IReadOnlyList<NotableDate> GetNotableDates(DateTime date, NotableDateFilter filter, string? territoryCode = null, Type? calendarType = null) => DatesForSingleDay;
+
+        /// <inheritdoc />
+        public void Invalidate() => InvalidateCallCount++;
+
+        /// <inheritdoc />
+        public void Invalidate(int year) => InvalidateCallCount++;
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.AddRule.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.AddRule.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.AddRule.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> exposes a freshly added rule
+    /// through <see cref="MutableNotableDateRuleOverrideProvider.GetAdditions" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenRuleSupplied_ShouldAppearInGetAdditions()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        NotableDateRule rule = Fixed("Company Day");
+
+        provider.AddRule(rule);
+
+        List<NotableDateRule> additions = provider.GetAdditions().ToList();
+        Assert.AreEqual(1, additions.Count);
+        Assert.AreSame(rule, additions[0]);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> throws when the rule is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenRuleIsNull_ShouldThrowArgumentNullException()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            provider.AddRule(null!);
+        });
+
+        Assert.AreEqual("rule", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that multiple <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> calls preserve insertion
+    /// order in <see cref="MutableNotableDateRuleOverrideProvider.GetAdditions" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenCalledMultipleTimes_ShouldPreserveInsertionOrder()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        NotableDateRule first = Fixed("First", 1, 1);
+        NotableDateRule second = Fixed("Second", 2, 1);
+        NotableDateRule third = Fixed("Third", 3, 1);
+
+        provider.AddRule(first);
+        provider.AddRule(second);
+        provider.AddRule(third);
+
+        List<NotableDateRule> additions = provider.GetAdditions().ToList();
+        CollectionAssert.AreEqual(new[] { first, second, third }, additions);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> raises
+    /// <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> exactly once per call.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenCalled_ShouldRaiseChangedExactlyOnce()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        int changedCount = 0;
+        provider.Changed += (_, _) => changedCount++;
+
+        provider.AddRule(Fixed("X"));
+
+        Assert.AreEqual(1, changedCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> receives this provider as the
+    /// sender and <see cref="EventArgs.Empty" /> as the payload.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenCalled_ShouldRaiseChangedWithProviderAsSender()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        object? capturedSender = null;
+        EventArgs? capturedArgs = null;
+        provider.Changed += (sender, args) =>
+        {
+            capturedSender = sender;
+            capturedArgs = args;
+        };
+
+        provider.AddRule(Fixed("X"));
+
+        Assert.AreSame(provider, capturedSender);
+        Assert.AreSame(EventArgs.Empty, capturedArgs);
+    }
+
+    /// <summary>
+    /// Verifies that the same <see cref="NotableDateRule" /> instance may be added multiple times and each
+    /// occurrence appears in the addition list.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenSameInstanceAddedTwice_ShouldAppearTwiceInGetAdditions()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        NotableDateRule rule = Fixed("Repeat");
+
+        provider.AddRule(rule);
+        provider.AddRule(rule);
+
+        Assert.AreEqual(2, provider.GetAdditions().Count());
+    }
+
+    /// <summary>
+    /// Verifies that a previously captured <see cref="MutableNotableDateRuleOverrideProvider.GetAdditions" />
+    /// enumerator continues to yield the same snapshot even when the provider is subsequently mutated.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenMutatedAfterGetAdditions_ShouldNotInvalidateEarlierSnapshot()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.AddRule(Fixed("First"));
+
+        IEnumerable<NotableDateRule> snapshot = provider.GetAdditions();
+
+        provider.AddRule(Fixed("Second"));
+
+        Assert.AreEqual(1, snapshot.Count(), "Snapshot must remain stable under concurrent mutation.");
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.Clear.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.Clear.cs
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.Clear.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Clear" /> drops every previously authored
+    /// addition and removal.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenAdditionsAndRemovalsArePresent_ShouldEmptyBothCollections()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.AddRule(Fixed("A"));
+        provider.AddRule(Fixed("B"));
+        provider.RemoveRule("Boxing Day");
+
+        provider.Clear();
+
+        Assert.AreEqual(0, provider.GetAdditions().Count());
+        Assert.AreEqual(0, provider.GetRemovals().Count());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Clear" /> raises
+    /// <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> exactly once regardless of how many entries
+    /// were dropped.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenMultipleEntriesPresent_ShouldRaiseChangedExactlyOnce()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.AddRule(Fixed("A"));
+        provider.AddRule(Fixed("B"));
+        provider.RemoveRule("X");
+        provider.RemoveRule("Y");
+
+        int changedCount = 0;
+        provider.Changed += (_, _) => changedCount++;
+
+        provider.Clear();
+
+        Assert.AreEqual(1, changedCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Clear" /> on an empty provider still raises
+    /// <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> exactly once.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenEmpty_ShouldStillRaiseChangedOnce()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        int changedCount = 0;
+        provider.Changed += (_, _) => changedCount++;
+
+        provider.Clear();
+
+        Assert.AreEqual(1, changedCount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Clear" /> leaves the provider in a usable state
+    /// for further mutations.
+    /// </summary>
+    [TestMethod]
+    public void Clear_WhenFollowedByAddRule_ShouldExposeNewAddition()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.AddRule(Fixed("Old"));
+        provider.Clear();
+
+        NotableDateRule newRule = Fixed("New");
+        provider.AddRule(newRule);
+
+        Assert.AreSame(newRule, provider.GetAdditions().Single());
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.Concurrency.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.Concurrency.cs
@@ -1,0 +1,97 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.Concurrency.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Verifies that concurrent <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> calls from multiple
+    /// threads do not lose entries and result in a final addition count equal to the total number of writes.
+    /// </summary>
+    [TestMethod]
+    public void AddRule_WhenInvokedConcurrentlyFromMultipleThreads_ShouldNotLoseEntries()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        const int threadCount = 8;
+        const int rulesPerThread = 250;
+
+        Parallel.For(0, threadCount, threadIndex =>
+        {
+            for (int i = 0; i < rulesPerThread; i++)
+            {
+                provider.AddRule(Fixed($"T{threadIndex}-R{i}"));
+            }
+        });
+
+        Assert.AreEqual(threadCount * rulesPerThread, provider.GetAdditions().Count());
+    }
+
+    /// <summary>
+    /// Verifies that a <see cref="MutableNotableDateRuleOverrideProvider.GetAdditions" /> snapshot enumerated while
+    /// concurrent <see cref="MutableNotableDateRuleOverrideProvider.AddRule" /> calls are in flight does not throw
+    /// and continues to yield a consistent view of the state observed at snapshot time.
+    /// </summary>
+    [TestMethod]
+    public void GetAdditions_WhenEnumeratedDuringConcurrentMutation_ShouldNotThrow()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        for (int i = 0; i < 100; i++)
+        {
+            provider.AddRule(Fixed($"Seed-{i}"));
+        }
+
+        IEnumerable<NotableDateRule> snapshot = provider.GetAdditions();
+
+        using CancellationTokenSource cts = new();
+        Task mutator = Task.Run(() =>
+        {
+            int n = 0;
+            while (!cts.IsCancellationRequested)
+            {
+                provider.AddRule(Fixed($"Live-{n++}"));
+            }
+        });
+
+        try
+        {
+            // Enumerate the snapshot multiple times while the writer thread mutates the provider.
+            for (int iteration = 0; iteration < 50; iteration++)
+            {
+                int observed = snapshot.Count();
+                Assert.IsTrue(observed >= 100, $"Snapshot must observe at least the seed entries; got {observed}.");
+            }
+        }
+        finally
+        {
+            cts.Cancel();
+            mutator.Wait(TimeSpan.FromSeconds(5));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> handlers may themselves mutate the
+    /// provider without causing re-entrancy deadlock.
+    /// </summary>
+    [TestMethod]
+    public void Changed_WhenHandlerMutatesProvider_ShouldNotDeadlock()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        int handlerInvocations = 0;
+        provider.Changed += (_, _) =>
+        {
+            if (Interlocked.Increment(ref handlerInvocations) == 1)
+            {
+                provider.RemoveRule("From handler");
+            }
+        };
+
+        provider.AddRule(Fixed("Initial"));
+
+        Assert.AreEqual(2, handlerInvocations, "Handler must be invoked once for the initial AddRule and once for the re-entrant RemoveRule.");
+        Assert.AreEqual(1, provider.GetRemovals().Count());
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.InitialState.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.InitialState.cs
@@ -1,0 +1,49 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.InitialState.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Verifies that a freshly constructed <see cref="MutableNotableDateRuleOverrideProvider" /> reports no additions.
+    /// </summary>
+    [TestMethod]
+    public void GetAdditions_WhenFreshlyConstructed_ShouldReturnEmpty()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        Assert.AreEqual(0, provider.GetAdditions().Count());
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed <see cref="MutableNotableDateRuleOverrideProvider" /> reports no removals.
+    /// </summary>
+    [TestMethod]
+    public void GetRemovals_WhenFreshlyConstructed_ShouldReturnEmpty()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        Assert.AreEqual(0, provider.GetRemovals().Count());
+    }
+
+    /// <summary>
+    /// Verifies that no <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> event is raised before any
+    /// mutation is performed.
+    /// </summary>
+    [TestMethod]
+    public void Changed_WhenNoMutationPerformed_ShouldNotBeRaised()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        int changedCount = 0;
+        provider.Changed += (_, _) => changedCount++;
+
+        _ = provider.GetAdditions().ToList();
+        _ = provider.GetRemovals().ToList();
+
+        Assert.AreEqual(0, changedCount);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.RemoveRule.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.RemoveRule.cs
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.RemoveRule.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+public partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> exposes a <see cref="RuleRemoval" />
+    /// with the supplied scope through <see cref="MutableNotableDateRuleOverrideProvider.GetRemovals" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenNameSupplied_ShouldAppearInGetRemovals()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.RemoveRule("Boxing Day");
+
+        List<RuleRemoval> removals = provider.GetRemovals().ToList();
+        Assert.AreEqual(1, removals.Count);
+        Assert.AreEqual("Boxing Day", removals[0].RuleName);
+        Assert.IsNull(removals[0].FromYear);
+        Assert.IsNull(removals[0].ToYear);
+        Assert.IsNull(removals[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> records all supplied scope
+    /// arguments on the materialised <see cref="RuleRemoval" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenScopedByYearAndTerritory_ShouldPropagateScope()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.RemoveRule("Picnic Day", fromYear: 2026, toYear: 2030, territoryCode: "AU-NT");
+
+        RuleRemoval removal = provider.GetRemovals().Single();
+        Assert.AreEqual("Picnic Day", removal.RuleName);
+        Assert.AreEqual(2026, removal.FromYear);
+        Assert.AreEqual(2030, removal.ToYear);
+        Assert.AreEqual("AU-NT", removal.TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> throws when the rule name is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenNameIsNull_ShouldThrowArgumentNullException()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        ArgumentNullException ex = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            provider.RemoveRule(null!);
+        });
+
+        Assert.AreEqual("name", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> throws when the rule name is
+    /// empty.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenNameIsEmpty_ShouldThrowArgumentException()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            provider.RemoveRule(string.Empty);
+        });
+
+        Assert.AreEqual("name", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> throws when the rule name is
+    /// whitespace.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenNameIsWhitespace_ShouldThrowArgumentException()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        ArgumentException ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            provider.RemoveRule("   ");
+        });
+
+        Assert.AreEqual("name", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that multiple <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> calls preserve
+    /// insertion order.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenCalledMultipleTimes_ShouldPreserveInsertionOrder()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.RemoveRule("A");
+        provider.RemoveRule("B");
+        provider.RemoveRule("C");
+
+        List<RuleRemoval> removals = provider.GetRemovals().ToList();
+        CollectionAssert.AreEqual(new[] { "A", "B", "C" }, removals.Select(r => r.RuleName).ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> raises
+    /// <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> exactly once per call.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenCalled_ShouldRaiseChangedExactlyOnce()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        int changedCount = 0;
+        provider.Changed += (_, _) => changedCount++;
+
+        provider.RemoveRule("X");
+
+        Assert.AreEqual(1, changedCount);
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.RemoveRule.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.RemoveRule.cs
@@ -128,4 +128,70 @@ public partial class MutableNotableDateRuleOverrideProviderTests
 
         Assert.AreEqual(1, changedCount);
     }
+
+    /// <summary>
+    /// Verifies the scope-binding contract of <see cref="MutableNotableDateRuleOverrideProvider.RemoveRule" /> across
+    /// every combination of year and territory scoping.
+    /// </summary>
+    /// <param name="fromYear">The <c>fromYear</c> argument under test.</param>
+    /// <param name="toYear">The <c>toYear</c> argument under test.</param>
+    /// <param name="territoryCode">The <c>territoryCode</c> argument under test.</param>
+    [TestMethod]
+    [DataRow(null, null, null)]
+    [DataRow(2026, null, null)]
+    [DataRow(null, 2030, null)]
+    [DataRow(2026, 2030, null)]
+    [DataRow(null, null, "AU-NSW")]
+    [DataRow(2026, 2030, "AU-NSW")]
+    [DataRow(null, null, "")]
+    public void RemoveRule_WhenScopedByVariousCombinations_ShouldRecordScopeUnchanged(int? fromYear, int? toYear, string? territoryCode)
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.RemoveRule("Target", fromYear, toYear, territoryCode);
+
+        RuleRemoval removal = provider.GetRemovals().Single();
+        Assert.AreEqual("Target", removal.RuleName);
+        Assert.AreEqual(fromYear, removal.FromYear);
+        Assert.AreEqual(toYear, removal.ToYear);
+        Assert.AreEqual(territoryCode, removal.TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that multiple removals authored against the same rule name with differing scopes are kept distinct in
+    /// the snapshot — the provider composes by union, not by replacement.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenSameNameWithDifferentScopes_ShouldKeepAllRemovals()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.RemoveRule("Boxing Day", fromYear: 2026, toYear: 2026);
+        provider.RemoveRule("Boxing Day", territoryCode: "AU-NT");
+        provider.RemoveRule("Boxing Day", fromYear: 2030, toYear: 2030, territoryCode: "AU-VIC");
+
+        List<RuleRemoval> removals = provider.GetRemovals().ToList();
+
+        Assert.AreEqual(3, removals.Count);
+        Assert.IsTrue(removals.Any(r => r.FromYear == 2026 && r.ToYear == 2026 && r.TerritoryCode is null));
+        Assert.IsTrue(removals.Any(r => r.FromYear is null && r.TerritoryCode == "AU-NT"));
+        Assert.IsTrue(removals.Any(r => r.FromYear == 2030 && r.TerritoryCode == "AU-VIC"));
+    }
+
+    /// <summary>
+    /// Verifies that a previously captured <see cref="MutableNotableDateRuleOverrideProvider.GetRemovals" /> enumerator
+    /// continues to yield the same snapshot even when the provider is subsequently mutated.
+    /// </summary>
+    [TestMethod]
+    public void RemoveRule_WhenMutatedAfterGetRemovals_ShouldNotInvalidateEarlierSnapshot()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.RemoveRule("First");
+
+        IEnumerable<RuleRemoval> snapshot = provider.GetRemovals();
+
+        provider.RemoveRule("Second");
+
+        Assert.AreEqual(1, snapshot.Count(), "Snapshot must remain stable under concurrent mutation.");
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.cs
@@ -29,4 +29,40 @@ public sealed partial class MutableNotableDateRuleOverrideProviderTests
             Month = month,
             Day = day,
         };
+
+    /// <summary>
+    /// Verifies that raising <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> with no subscribers does
+    /// not throw — i.e. the provider null-checks the event field correctly.
+    /// </summary>
+    [TestMethod]
+    public void Mutations_WhenNoChangedSubscribers_ShouldNotThrow()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+
+        provider.AddRule(Fixed("X"));
+        provider.RemoveRule("Y");
+        provider.Clear();
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.GetAdditions" /> and
+    /// <see cref="MutableNotableDateRuleOverrideProvider.GetRemovals" /> return independent snapshots — mutating one
+    /// list does not perturb a previously captured snapshot of the other.
+    /// </summary>
+    [TestMethod]
+    public void GetAdditionsAndGetRemovals_WhenMutatedAcrossEachOther_ShouldYieldIndependentSnapshots()
+    {
+        MutableNotableDateRuleOverrideProvider provider = new();
+        provider.AddRule(Fixed("Initial Add"));
+        provider.RemoveRule("Initial Remove");
+
+        IEnumerable<NotableDateRule> additionsSnapshot = provider.GetAdditions();
+        IEnumerable<RuleRemoval> removalsSnapshot = provider.GetRemovals();
+
+        provider.AddRule(Fixed("Late Add"));
+        provider.RemoveRule("Late Remove");
+
+        Assert.AreEqual(1, additionsSnapshot.Count(), "Additions snapshot must not see the late-added rule.");
+        Assert.AreEqual(1, removalsSnapshot.Count(), "Removals snapshot must not see the late-added removal.");
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/MutableNotableDateRuleOverrideProviderTests.cs
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MutableNotableDateRuleOverrideProviderTests.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the runtime-mutation contract, snapshot semantics, and event-raising behaviour of
+/// <see cref="MutableNotableDateRuleOverrideProvider" />.
+/// </summary>
+[TestClass]
+public sealed partial class MutableNotableDateRuleOverrideProviderTests
+{
+    /// <summary>
+    /// Builds a simple fixed-month rule used by tests that do not care about the rule shape itself.
+    /// </summary>
+    /// <param name="name">The rule name.</param>
+    /// <param name="month">The fixed month.</param>
+    /// <param name="day">The fixed day.</param>
+    /// <returns>A new <see cref="NotableDateRule" /> with the supplied identity.</returns>
+    private static NotableDateRule Fixed(string name, int month = 1, int day = 1) =>
+        new()
+        {
+            Name = name,
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = month,
+            Day = day,
+        };
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Dispose.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Dispose.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.Dispose.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the disposal contract of <see cref="NotableDateService" />.
+/// </summary>
+public partial class NotableDateServiceTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Dispose" /> releases the internal per-thread tracking field so that
+    /// subsequent generation calls fail fast rather than silently consuming a disposed resource.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInvoked_ShouldReleaseInternalThreadLocalState()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Base", 6, 1)) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        service.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            _ = service.GetNotableDates(2026);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Dispose" /> is safe to call before any query has been issued — the
+    /// internal lazy-initialised state still releases cleanly.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInvokedOnNewService_ShouldNotThrow()
+    {
+        NotableDateService service = new(
+            ruleProviders: Array.Empty<INotableDateRuleProvider>(),
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        service.Dispose();
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedCalendars.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedCalendars.cs
@@ -1,0 +1,161 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.GetSupportedCalendars.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the calendar-enumeration contract of <see cref="NotableDateService.GetSupportedCalendars" />.
+/// </summary>
+public partial class NotableDateServiceTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> returns no entries when every rule omits
+    /// the <see cref="NotableDateRule.CalendarType" /> property.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenAllRulesGlobal_ShouldReturnEmpty()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Global", 1, 1)) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(0, service.GetSupportedCalendars().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> projects through every authored calendar
+    /// and returns a distinct set.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenRulesAcrossMultipleCalendars_ShouldReturnDistinctSet()
+    {
+        NotableDateRule gregorian = new()
+        {
+            Name = "Gregorian",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+        NotableDateRule hebrew = new()
+        {
+            Name = "Hebrew",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(HebrewCalendar),
+        };
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(gregorian, hebrew) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<Type> calendars = service.GetSupportedCalendars();
+
+        CollectionAssert.AreEquivalent(new[] { typeof(GregorianCalendar), typeof(HebrewCalendar) }, calendars.ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> elides rules with no calendar type.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenMixedScopedAndGlobalRules_ShouldOnlyReportScopedCalendars()
+    {
+        NotableDateRule gregorian = new()
+        {
+            Name = "Gregorian",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(gregorian, Fixed("Global", 2, 1)) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<Type> calendars = service.GetSupportedCalendars();
+
+        Assert.AreEqual(1, calendars.Count);
+        Assert.IsTrue(calendars.Contains(typeof(GregorianCalendar)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> deduplicates by reference identity so that
+    /// multiple rules referencing the same calendar type collapse to a single entry.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenMultipleRulesShareCalendar_ShouldCollapseToOneEntry()
+    {
+        NotableDateRule a = new()
+        {
+            Name = "A",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+        NotableDateRule b = new()
+        {
+            Name = "B",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 2,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(a, b) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(1, service.GetSupportedCalendars().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> reflects override additions after
+    /// <see cref="NotableDateService.Reload" /> has been called.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenOverrideAddsCalendarAndReloadCalled_ShouldIncludeNewCalendar()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateRule gregorian = new()
+        {
+            Name = "Gregorian",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(gregorian) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        Assert.IsFalse(service.GetSupportedCalendars().Contains(typeof(HebrewCalendar)));
+
+        overrides.AddRule(new NotableDateRule
+        {
+            Name = "Hebrew",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(HebrewCalendar),
+        });
+        service.Reload();
+
+        Assert.IsTrue(service.GetSupportedCalendars().Contains(typeof(HebrewCalendar)));
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedCalendars.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedCalendars.cs
@@ -122,6 +122,102 @@ public partial class NotableDateServiceTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> returns an empty collection when no rule
+    /// providers are registered.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenNoRuleProviders_ShouldReturnEmpty()
+    {
+        NotableDateService service = new(
+            ruleProviders: Array.Empty<INotableDateRuleProvider>(),
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(0, service.GetSupportedCalendars().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> deduplicates across providers — when two
+    /// providers both contribute rules referencing the same calendar type the calendar appears once.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenMultipleProvidersShareCalendar_ShouldReportOnce()
+    {
+        NotableDateRule a = new()
+        {
+            Name = "A",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+        NotableDateRule b = new()
+        {
+            Name = "B",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 2,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(a),
+                (INotableDateRuleProvider)new InMemoryRuleProvider(b),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<Type> calendars = service.GetSupportedCalendars();
+
+        Assert.AreEqual(1, calendars.Count);
+        Assert.IsTrue(calendars.Contains(typeof(GregorianCalendar)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> returns a fresh snapshot on each call,
+    /// reflecting override additions made between successive reads.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_WhenCalledRepeatedlyAroundReload_ShouldReturnFreshSnapshotEachTime()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateRule gregorian = new()
+        {
+            Name = "Gregorian",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(GregorianCalendar),
+        };
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(gregorian) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        IReadOnlyCollection<Type> firstSnapshot = service.GetSupportedCalendars();
+        Assert.AreEqual(1, firstSnapshot.Count);
+
+        overrides.AddRule(new NotableDateRule
+        {
+            Name = "Hebrew",
+            Strategy = DateResolutionStrategy.Fixed,
+            Category = NotableDateCategory.Holiday,
+            Month = 1,
+            Day = 1,
+            CalendarType = typeof(HebrewCalendar),
+        });
+        service.Reload();
+
+        IReadOnlyCollection<Type> secondSnapshot = service.GetSupportedCalendars();
+        Assert.AreEqual(2, secondSnapshot.Count);
+        Assert.AreEqual(1, firstSnapshot.Count, "Earlier snapshot must remain a frozen view of its read.");
+    }
+
+    /// <summary>
     /// Verifies that <see cref="NotableDateService.GetSupportedCalendars" /> reflects override additions after
     /// <see cref="NotableDateService.Reload" /> has been called.
     /// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedTerritories.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedTerritories.cs
@@ -1,0 +1,143 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.GetSupportedTerritories.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the territory-enumeration contract of <see cref="NotableDateService.GetSupportedTerritories" />.
+/// </summary>
+public partial class NotableDateServiceTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> returns no entries when every rule is
+    /// global (territory-less).
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenAllRulesGlobal_ShouldReturnEmpty()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Global", 1, 1)) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(0, service.GetSupportedTerritories().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> projects through every authored
+    /// territory and returns a distinct set.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenRulesAcrossMultipleTerritories_ShouldReturnDistinctSet()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(
+                    Fixed("AU-NSW Holiday", 1, 1, territory: "AU-NSW"),
+                    Fixed("AU-NSW Other",   2, 1, territory: "AU-NSW"),
+                    Fixed("AU-VIC Holiday", 3, 1, territory: "AU-VIC"),
+                    Fixed("US Federal",     7, 4, territory: "US")),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<string> territories = service.GetSupportedTerritories();
+
+        CollectionAssert.AreEquivalent(new[] { "AU-NSW", "AU-VIC", "US" }, territories.ToList());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> elides rules whose territory is
+    /// <see langword="null" /> or empty.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenMixedScopedAndGlobalRules_ShouldOnlyReportScopedTerritories()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(
+                    Fixed("Global A", 1, 1),
+                    Fixed("Global B", 2, 1),
+                    Fixed("Scoped",  3, 1, territory: "AU")),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<string> territories = service.GetSupportedTerritories();
+
+        Assert.AreEqual(1, territories.Count);
+        Assert.IsTrue(territories.Contains("AU"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> treats territory codes case-insensitively
+    /// when deduplicating.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenTerritoryCodesDifferOnlyByCase_ShouldCollapseToOneEntry()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(
+                    Fixed("Upper", 1, 1, territory: "AU"),
+                    Fixed("Lower", 2, 1, territory: "au"),
+                    Fixed("Mixed", 3, 1, territory: "Au")),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(1, service.GetSupportedTerritories().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> reflects override additions after
+    /// <see cref="NotableDateService.Reload" /> has been called.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenOverrideAddsTerritoryAndReloadCalled_ShouldIncludeNewTerritory()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("AU Rule", 1, 1, territory: "AU")) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        Assert.IsFalse(service.GetSupportedTerritories().Contains("NZ"));
+
+        overrides.AddRule(Fixed("NZ Rule", 2, 6, territory: "NZ"));
+        service.Reload();
+
+        Assert.IsTrue(service.GetSupportedTerritories().Contains("NZ"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> reflects rule suppression via overrides
+    /// after <see cref="NotableDateService.Reload" /> has been called.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenOverrideRemovesLastRuleInTerritoryAndReloadCalled_ShouldRemoveTerritory()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(
+                    Fixed("AU Rule", 1, 1, territory: "AU"),
+                    Fixed("NZ Rule", 2, 6, territory: "NZ")),
+            },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        Assert.IsTrue(service.GetSupportedTerritories().Contains("NZ"));
+
+        overrides.RemoveRule("NZ Rule");
+        service.Reload();
+
+        // Note: rule remains in the effective set as a removal-suppressed entry; GetSupportedTerritories projects
+        // over _effectiveRules so the territory still appears unless the rule itself is dropped via override.
+        // The contract returns territories present in the effective rule set, not yet-resolvable territories.
+        Assert.IsTrue(service.GetSupportedTerritories().Contains("AU"));
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedTerritories.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.GetSupportedTerritories.cs
@@ -113,6 +113,108 @@ public partial class NotableDateServiceTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> returns an empty collection when no
+    /// rule providers are registered.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenNoRuleProviders_ShouldReturnEmpty()
+    {
+        NotableDateService service = new(
+            ruleProviders: Array.Empty<INotableDateRuleProvider>(),
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(0, service.GetSupportedTerritories().Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> deduplicates across providers — when
+    /// two providers both contribute rules scoped to the same territory the territory appears once.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenMultipleProvidersContributeSameTerritory_ShouldReportOnce()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("A", 1, 1, territory: "AU")),
+                (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("B", 2, 1, territory: "AU")),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyCollection<string> territories = service.GetSupportedTerritories();
+
+        Assert.AreEqual(1, territories.Count);
+        Assert.IsTrue(territories.Contains("AU"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> returns territories in stable,
+    /// case-insensitive sorted order so consumers driving UI pickers see deterministic output.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenMultipleTerritories_ShouldReturnInCaseInsensitiveSortedOrder()
+    {
+        NotableDateService service = new(
+            ruleProviders: new[]
+            {
+                (INotableDateRuleProvider)new InMemoryRuleProvider(
+                    Fixed("z", 1, 1, territory: "ZZ"),
+                    Fixed("c", 2, 1, territory: "CN"),
+                    Fixed("a", 3, 1, territory: "AU-NSW"),
+                    Fixed("b", 4, 1, territory: "AU")),
+            },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        List<string> territories = service.GetSupportedTerritories().ToList();
+
+        CollectionAssert.AreEqual(new[] { "AU", "AU-NSW", "CN", "ZZ" }, territories);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> returns a snapshot — successive calls
+    /// after <see cref="NotableDateService.Reload" /> reflect the latest effective rule set while the previously
+    /// returned collection is unaffected by subsequent mutations.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenCalledRepeatedlyAroundReload_ShouldReturnFreshSnapshotEachTime()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Base", 1, 1, territory: "AU")) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        IReadOnlyCollection<string> firstSnapshot = service.GetSupportedTerritories();
+        Assert.AreEqual(1, firstSnapshot.Count);
+
+        overrides.AddRule(Fixed("Extra", 2, 1, territory: "NZ"));
+        service.Reload();
+
+        IReadOnlyCollection<string> secondSnapshot = service.GetSupportedTerritories();
+        Assert.AreEqual(2, secondSnapshot.Count);
+        Assert.AreEqual(1, firstSnapshot.Count, "Earlier snapshot must remain a frozen view of its read.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> elides rules whose territory is empty
+    /// or whitespace-only so that authoring noise does not surface in UI pickers.
+    /// </summary>
+    /// <param name="territory">The territory code authored on the test rule.</param>
+    [TestMethod]
+    [DataRow("")]
+    [DataRow(" ")]
+    [DataRow("\t")]
+    [DataRow("   ")]
+    public void GetSupportedTerritories_WhenTerritoryIsBlank_ShouldElideRule(string territory)
+    {
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Blank", 1, 1, territory: territory)) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        Assert.AreEqual(0, service.GetSupportedTerritories().Count);
+    }
+
+    /// <summary>
     /// Verifies that <see cref="NotableDateService.GetSupportedTerritories" /> reflects rule suppression via overrides
     /// after <see cref="NotableDateService.Reload" /> has been called.
     /// </summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Reload.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Reload.cs
@@ -1,0 +1,200 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateServiceTests.Reload.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies the behaviour of <see cref="NotableDateService.Reload" /> when override providers mutate after the service
+/// has been constructed, including cache invalidation, idempotent reloads, and thread-safe concurrent use.
+/// </summary>
+public partial class NotableDateServiceTests
+{
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> on a service with no override providers leaves the
+    /// emitted notable dates unchanged.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenNoOverrideProvidersRegistered_ShouldBeIdempotent()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingDaysOfWeek: WorkingDaysOfWeek.MondayToFriday);
+
+        IReadOnlyList<NotableDate> before = service.GetNotableDates(2026);
+
+        service.Reload();
+
+        IReadOnlyList<NotableDate> after = service.GetNotableDates(2026);
+
+        Assert.AreEqual(before.Count, after.Count);
+        Assert.IsTrue(after.Any(n => n.Name == "Base"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> re-queries an override provider so that an addition made
+    /// after construction appears in the resolved output for the next query.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenOverrideProviderAddsRuleAfterConstruction_ShouldExposeAdditionAfterReload()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Late Addition"));
+
+        overrides.AddRule(Fixed("Late Addition", 9, 9));
+        service.Reload();
+
+        IReadOnlyList<NotableDate> after = service.GetNotableDates(2026);
+        Assert.IsTrue(after.Any(n => n.Name == "Late Addition" && n.Date == new DateTime(2026, 9, 9)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> re-queries an override provider so that a removal made
+    /// after construction suppresses the targeted base rule on the next query.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenOverrideProviderRemovesRuleAfterConstruction_ShouldSuppressBaseRuleAfterReload()
+    {
+        NotableDateRule baseRule = Fixed("Holiday", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Holiday"));
+
+        overrides.RemoveRule("Holiday");
+        service.Reload();
+
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Holiday"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> clears the per-year cache so that subsequent queries
+    /// rebuild rather than returning a stale snapshot.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenInvoked_ShouldClearPerYearCache()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        IReadOnlyList<NotableDate> firstQuery = service.GetNotableDates(2026);
+
+        overrides.AddRule(Fixed("New", 12, 1));
+        service.Reload();
+
+        IReadOnlyList<NotableDate> secondQuery = service.GetNotableDates(2026);
+
+        Assert.AreEqual(firstQuery.Count + 1, secondQuery.Count, "Cache must be invalidated so the new rule contributes a fresh entry.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> picks up a fresh override addition even when the
+    /// override provider's enumerable produces new instances on each enumeration.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenOverrideProviderEnumerableYieldsFreshInstances_ShouldStillReflectLatestState()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        overrides.AddRule(Fixed("First", 9, 1));
+        service.Reload();
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "First"));
+
+        overrides.Clear();
+        overrides.AddRule(Fixed("Second", 10, 1));
+        service.Reload();
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsFalse(emitted.Any(n => n.Name == "First"), "Cleared override must no longer contribute.");
+        Assert.IsTrue(emitted.Any(n => n.Name == "Second"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> may be called concurrently with
+    /// <see cref="NotableDateService.GetNotableDates(int, string?, Type?)" /> without throwing or producing torn
+    /// reads.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenInvokedConcurrentlyWithQueries_ShouldNotThrow()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        using CancellationTokenSource cts = new();
+        Task readerA = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                _ = service.GetNotableDates(2026);
+            }
+        });
+        Task readerB = Task.Run(() =>
+        {
+            while (!cts.IsCancellationRequested)
+            {
+                _ = service.GetNotableDates(2027);
+            }
+        });
+
+        for (int i = 0; i < 50; i++)
+        {
+            overrides.AddRule(Fixed($"R-{i}", (i % 12) + 1, ((i * 3) % 28) + 1));
+            service.Reload();
+        }
+
+        cts.Cancel();
+        Task.WaitAll(new[] { readerA, readerB }, TimeSpan.FromSeconds(5));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> can be wired to
+    /// <see cref="NotableDateService.Reload" /> so that mutations propagate without explicit reload calls.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenSubscribedToMutableOverrideChanged_ShouldAutoApplyMutations()
+    {
+        NotableDateRule baseRule = Fixed("Base", 6, 1);
+        MutableNotableDateRuleOverrideProvider overrides = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(baseRule) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        overrides.Changed += (_, _) => service.Reload();
+
+        overrides.AddRule(Fixed("Auto", 4, 4));
+
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Auto"));
+    }
+}

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Reload.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.Reload.cs
@@ -177,6 +177,97 @@ public partial class NotableDateServiceTests
     }
 
     /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> composes additions from multiple registered override
+    /// providers so each provider's contribution surfaces in the resolved output.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenMultipleOverrideProvidersRegistered_ShouldComposeAllContributions()
+    {
+        MutableNotableDateRuleOverrideProvider providerA = new();
+        MutableNotableDateRuleOverrideProvider providerB = new();
+
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Base", 6, 1)) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new INotableDateRuleOverrideProvider[] { providerA, providerB } });
+
+        providerA.AddRule(Fixed("From A", 7, 1));
+        providerB.AddRule(Fixed("From B", 8, 1));
+        service.Reload();
+
+        IReadOnlyList<NotableDate> emitted = service.GetNotableDates(2026);
+        Assert.IsTrue(emitted.Any(n => n.Name == "From A"));
+        Assert.IsTrue(emitted.Any(n => n.Name == "From B"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> honours year-scoped removals through the rebuilt
+    /// override snapshot.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenYearScopedRemovalAddedAndReloadCalled_ShouldSuppressOnlyMatchingYears()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Holiday", 6, 1)) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        overrides.RemoveRule("Holiday", fromYear: 2026, toYear: 2026);
+        service.Reload();
+
+        Assert.IsTrue(service.GetNotableDates(2025).Any(n => n.Name == "Holiday"));
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Holiday"));
+        Assert.IsTrue(service.GetNotableDates(2027).Any(n => n.Name == "Holiday"));
+    }
+
+    /// <summary>
+    /// Verifies that repeated <see cref="NotableDateService.Reload" /> calls are stable — successive reloads do not
+    /// accumulate duplicate additions or removals.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenInvokedRepeatedly_ShouldNotAccumulateDuplicateRules()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Base", 6, 1)) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        overrides.AddRule(Fixed("Once", 9, 9));
+
+        service.Reload();
+        service.Reload();
+        service.Reload();
+
+        int matches = service.GetNotableDates(2026).Count(n => n.Name == "Once");
+        Assert.AreEqual(1, matches);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateService.Reload" /> drops contributions that have since been cleared from
+    /// the underlying override provider.
+    /// </summary>
+    [TestMethod]
+    public void Reload_WhenOverrideContributionsCleared_ShouldDropThem()
+    {
+        MutableNotableDateRuleOverrideProvider overrides = new();
+        NotableDateService service = new(
+            ruleProviders: new[] { (INotableDateRuleProvider)new InMemoryRuleProvider(Fixed("Base", 6, 1)) },
+            workingWeek: WeekPattern.MondayToFriday,
+            options: new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+        overrides.AddRule(Fixed("Temporary", 7, 1));
+        service.Reload();
+        Assert.IsTrue(service.GetNotableDates(2026).Any(n => n.Name == "Temporary"));
+
+        overrides.Clear();
+        service.Reload();
+
+        Assert.IsFalse(service.GetNotableDates(2026).Any(n => n.Name == "Temporary"));
+    }
+
+    /// <summary>
     /// Verifies that <see cref="MutableNotableDateRuleOverrideProvider.Changed" /> can be wired to
     /// <see cref="NotableDateService.Reload" /> so that mutations propagate without explicit reload calls.
     /// </summary>

--- a/bodu.slnx
+++ b/bodu.slnx
@@ -19,6 +19,8 @@
     <Project Path="Bodu.Globalization.Calendar.Data.AsiaPacific\test\Bodu.Globalization.Calendar.Data.AsiaPacific.Test.csproj" />
     <Project Path="Bodu.Globalization.Calendar.Data.Europe\src\Bodu.Globalization.Calendar.Data.Europe.csproj" />
     <Project Path="Bodu.Globalization.Calendar.Data.Europe\test\Bodu.Globalization.Calendar.Data.Europe.Test.csproj" />
+    <Project Path="Bodu.Globalization.Calendar.DependencyInjection\src\Bodu.Globalization.Calendar.DependencyInjection.csproj" />
+    <Project Path="Bodu.Globalization.Calendar.DependencyInjection\test\Bodu.Globalization.Calendar.DependencyInjection.Test.csproj" />
     <Project Path="Bodu.Globalization.Calendar\src\Bodu.Globalization.Calendar.csproj" />
     <Project Path="Bodu.Globalization.Calendar\test-plugins\Globalization.Calendar.Plugin1.TestAssembly\Bodu.Globalization.Calendar.Plugin1.TestAssembly.csproj" />
     <Project Path="Bodu.Globalization.Calendar\test-plugins\Globalization.Calendar.Plugin2.TestAssembly\Bodu.Globalization.Calendar.Plugin2.TestAssembly.csproj" />

--- a/docs/apidoc/Bodu.Globalization.Calendar.DependencyInjection.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.DependencyInjection.md
@@ -1,0 +1,67 @@
+---
+uid: Bodu.Globalization.Calendar.DependencyInjection
+---
+
+# Bodu.Globalization.Calendar.DependencyInjection
+
+## Purpose
+
+**Bodu.Globalization.Calendar.DependencyInjection** provides the `Microsoft.Extensions.DependencyInjection` integration for [`Bodu.Globalization.Calendar`](Bodu.Globalization.Calendar.md). It registers <xref:Bodu.Globalization.Calendar.INotableDateService> as a singleton, binds [`NotableDateOptions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions) from `IConfiguration`, and exposes a fluent builder for layering rule providers, override providers, plugins, algorithm registries, collision resolvers, and name localizers from across a host's composition root.
+
+Reach for this package when you want ASP.NET Core (or any `Microsoft.Extensions.*`-style host) to construct and inject the calendar service for you rather than composing `new NotableDateService(...)` by hand. The package is optional — direct construction continues to work for consoles, libraries, and tests that prefer not to bring in `IServiceCollection`.
+
+## Static documentation
+
+- **[Calendar dependency injection guide](~/guides/calendar/dependency-injection.md)** — `AddNotableDates`, fluent builder, `IConfiguration` binding, ambient default wiring, and the `PostConfigure` consumer-options projection hook.
+- **[Building and extending the service](~/guides/calendar/building-the-service.md)** — explains every collaborator interface that the DI package wires up.
+
+## Key types
+
+**Entry points**
+
+- <xref:Bodu.Globalization.Calendar.DependencyInjection.ServiceCollectionExtensions> — the `AddNotableDates(IServiceCollection, IConfiguration?, string)` and `AddNotableDates(IServiceCollection, Action<INotableDateServiceBuilder>)` extension methods that register the service singleton and return an <xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder>.
+- <xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder> — the fluent registration surface returned by `AddNotableDates`. Exposes the host's <xref:Microsoft.Extensions.DependencyInjection.IServiceCollection> so extension methods can register additional collaborators.
+
+**Bindable options**
+
+- <xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions> — the POCO bound from an `IConfiguration` section. Composed of bindable primitives (`WorkingDays`, `DefaultTerritoryCode`, `DefaultCalendarTypeName`, `RegisterAsAmbientDefault`) and distinct from <xref:Bodu.Globalization.Calendar.NotableDateServiceOptions>, which carries non-bindable interface-typed dependencies.
+
+**Builder extension methods**
+
+- <xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateServiceBuilderExtensions> — the fluent surface exposed on <xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder>:
+  - `AddRuleProvider` / `AddRuleProviders` / `AddPlugin` — register collaborators resolved via `IEnumerable<T>` injection.
+  - `AddOverrideProvider` — register an <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>; when the supplied instance is a <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider>, the service is auto-wired to call <xref:Bodu.Globalization.Calendar.INotableDateService.Reload> on every change.
+  - `UseAlgorithmRegistry` / `UseCollisionResolver` / `UseNameLocalizer` / `UseAdjustmentHandlers` / `UseResourcePathResolver` — register single-instance collaborators.
+  - `Configure(Action<NotableDateOptions>)` — overlay programmatic settings onto any value bound from configuration.
+  - `PostConfigure(Action<IServiceProvider, NotableDateOptions>)` — the consumer-defined-options hook for projecting from custom POCOs registered through the standard `Configure<TOptions>` API. Backed by `IPostConfigureOptions<NotableDateOptions>`.
+  - `UseWorkingDays(WorkingDaysOfWeek)` / `UseWorkingWeek(WeekPattern)` — sugar over `Configure`.
+  - `RegisterAsAmbientDefault()` — wire the resolved singleton into <xref:Bodu.Globalization.Calendar.NotableDateContext.Default> on first resolution so that extension-method overloads without an explicit service argument resolve through the DI-registered instance.
+
+## Minimal sample
+
+```csharp
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Data.AsiaPacific;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services
+    .AddNotableDates(builder.Configuration)
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    .AddOverrideProvider(new MutableNotableDateRuleOverrideProvider())
+    .RegisterAsAmbientDefault();
+```
+
+With `appsettings.json`:
+
+```json
+{
+  "NotableDates": {
+    "WorkingDays": "MondayToFriday",
+    "DefaultTerritoryCode": "AU-NSW",
+    "RegisterAsAmbientDefault": true
+  }
+}
+```
+
+The full guide — including the `PostConfigure` consumer-options projection pattern, runtime-mutable overrides, and the resolved `INotableDateService` lifetime semantics — is in [Calendar dependency injection](~/guides/calendar/dependency-injection.md).

--- a/docs/apidoc/Bodu.Globalization.Calendar.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.md
@@ -14,7 +14,11 @@ Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you
 
 - **[Bodu.Globalization.Calendar introduction](~/docs/calendar/index.md)** — namespaces, headline types, scenarios.
 - **[Bodu.Globalization.Calendar getting started](~/docs/calendar/getting-started.md)** — install and minimal samples for algorithms, the service, and working-day arithmetic.
-- **[Bodu.Globalization.Calendar guides](~/guides/calendar/index.md)** — [`NotableDateService`](~/guides/calendar/notable-dates.md), [rule authoring](~/guides/calendar/rule-authoring.md), [date-calculation algorithms](~/guides/calendar/algorithms.md), [companion data packs](~/guides/calendar/data-packs.md).
+- **[Bodu.Globalization.Calendar guides](~/guides/calendar/index.md)** — [`NotableDateService`](~/guides/calendar/notable-dates.md), [rule authoring](~/guides/calendar/rule-authoring.md), [date-calculation algorithms](~/guides/calendar/algorithms.md), [companion data packs](~/guides/calendar/data-packs.md), [dependency injection](~/guides/calendar/dependency-injection.md).
+
+## Companion packages
+
+- [`Bodu.Globalization.Calendar.DependencyInjection`](Bodu.Globalization.Calendar.DependencyInjection.md) — `Microsoft.Extensions.DependencyInjection` integration: `services.AddNotableDates(...)`, the fluent <xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder>, bindable [`NotableDateOptions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions), and the `PostConfigure` consumer-options projection hook.
 
 ## Key types
 
@@ -30,7 +34,7 @@ Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you
 
 - <xref:Bodu.Globalization.Calendar.NotableDateRule> — an immutable rule record describing how a notable date is defined (fixed, day-of-week-in-month, offset, or delegated to a named algorithm).
 - <xref:Bodu.Globalization.Calendar.NotableDateRuleParser>, <xref:Bodu.Globalization.Calendar.NotableDateRuleJsonParser>, <xref:Bodu.Globalization.Calendar.ParsedNotableDateDocument>, <xref:Bodu.Globalization.Calendar.NotableDateRuleUseGroup>, <xref:Bodu.Globalization.Calendar.NotableDateRuleUseDirective>, <xref:Bodu.Globalization.Calendar.NotableDateRuleOverrideBody>, <xref:Bodu.Globalization.Calendar.RuleRemoval> — XML / JSON rule-document model.
-- <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.NotableDateRuleResourceProviderBase> — plug-points for the rule source (built-in XML / JSON, overlays, custom).
+- <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.NotableDateRuleResourceProviderBase> — plug-points for the rule source (built-in XML / JSON, overlays, the runtime-mutable override provider, and custom).
 - <xref:Bodu.Globalization.Calendar.INotableDateProvider>, <xref:Bodu.Globalization.Calendar.INotableDateNameLocalizer> — extension surfaces for custom date sources and culture-specific naming.
 - <xref:Bodu.Globalization.Calendar.INotableDateCollisionResolver>, <xref:Bodu.Globalization.Calendar.DefaultNotableDateCollisionResolver> — decide what happens when two rules resolve to the same date.
 - <xref:Bodu.Globalization.Calendar.IResourcePathResolver>, <xref:Bodu.Globalization.Calendar.ResourcePathResolver>, <xref:Bodu.Globalization.Calendar.ResourcePathResolverOptions> — resource-path resolution for embedded providers.

--- a/docs/docs/calendar/getting-started.md
+++ b/docs/docs/calendar/getting-started.md
@@ -15,6 +15,9 @@ dotnet add package Bodu.Globalization.Calendar
 dotnet add package Bodu.Globalization.Calendar.Data.Americas
 dotnet add package Bodu.Globalization.Calendar.Data.Europe
 dotnet add package Bodu.Globalization.Calendar.Data.AsiaPacific
+
+# Optional Microsoft.Extensions.DependencyInjection integration:
+dotnet add package Bodu.Globalization.Calendar.DependencyInjection
 ```
 
 Targets `net8.0`. The base package contains the resolution engine and the built-in algorithms; the data packs contain region-specific rule sets.
@@ -119,7 +122,38 @@ INotableDateService service = new NotableDateService(
     options: new NotableDateServiceOptions { OverrideProviders = [ overrides ] });
 ```
 
-Override providers can add new rules (via `INotableDateRuleProvider.LoadRules`), remove a base rule by name and territory (via `GetRemovals` returning `RuleRemoval` values), or layer adjustment overrides. Implement <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider> directly, or store overrides in your own XML / JSON file and load them through <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider> / <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>.
+Override providers can add new rules (via `INotableDateRuleProvider.LoadRules`), remove a base rule by name and territory (via `GetRemovals` returning `RuleRemoval` values), or layer adjustment overrides. Implement <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider> directly, store overrides in your own XML / JSON file and load them through <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider> / <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>, or use the runtime-mutable <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider> when rules need to be added or removed while the service is alive — paired with `service.Reload()` to take effect.
+
+### Register through dependency injection
+
+When the host is an ASP.NET Core application (or any `IServiceCollection`-based composition root), install the optional `Bodu.Globalization.Calendar.DependencyInjection` package and register the service idiomatically:
+
+```csharp
+using Bodu.Globalization.Calendar;
+using Bodu.Globalization.Calendar.Data.AsiaPacific;
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services
+    .AddNotableDates(builder.Configuration)                       // binds "NotableDates" section
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    .AddOverrideProvider(new MutableNotableDateRuleOverrideProvider())
+    .RegisterAsAmbientDefault();                                  // also assigns NotableDateContext.Default
+```
+
+`appsettings.json`:
+
+```json
+{
+  "NotableDates": {
+    "WorkingDays": "MondayToFriday",
+    "DefaultTerritoryCode": "AU-NSW",
+    "RegisterAsAmbientDefault": true
+  }
+}
+```
+
+See the [Calendar dependency injection guide](../../guides/calendar/dependency-injection.md) for the full builder reference, the `PostConfigure` projection hook for projecting from consumer-defined POCOs, and the runtime-mutable override workflow.
 
 ## Where to go next
 

--- a/docs/docs/calendar/index.md
+++ b/docs/docs/calendar/index.md
@@ -64,7 +64,10 @@ The same flow applies to every other rule — only the strategy in step 2 and th
 | Compute Easter Sunday for any year | <xref:Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateAlgorithm>`.Calculate(year)` |
 | Compute Tibetan Losar (Lunar New Year) | <xref:Bodu.Globalization.Calendar.Algorithms.LosarNotableDateAlgorithm>`.Calculate(year)` |
 | Author rules in XML / JSON and load them | <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider> / <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider> |
-| Layer runtime overrides on top of a base rule set | <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider> |
+| Layer runtime overrides on top of a base rule set | <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider> / <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider> |
+| Register the service in an `IServiceCollection`-based host | `services.AddNotableDates(...)` from `Bodu.Globalization.Calendar.DependencyInjection` — see the [dependency-injection guide](../../guides/calendar/dependency-injection.md). |
+| Enumerate the territories / calendar systems covered by the loaded rules | `service.GetSupportedTerritories()` / `service.GetSupportedCalendars()` |
+| Pick up runtime override mutations on a live service | `service.Reload()` |
 | Load rules / algorithms from external assemblies safely | <xref:Bodu.Globalization.Calendar.Plugins.ExternalPluginLoader> + a trust policy |
 | Apply observance adjustments (e.g. holiday-falls-on-weekend → next Monday) | <xref:Bodu.Globalization.Calendar.ObservanceAdjustment> + <xref:Bodu.Globalization.Calendar.AdjustmentHandlerRegistry> |
 | Filter resolved notable dates by category, tag, or date range | <xref:Bodu.Globalization.Calendar.NotableDateFilter>`.ForCategory(...)`, `.WithTag(...)`, `.InDateRange(...)` (combine with `.And` / `.Or`). |
@@ -115,11 +118,15 @@ Region-specific holiday rule providers ship separately in `Bodu.Globalization.Ca
 | Type | Purpose |
 |---|---|
 | <xref:Bodu.Globalization.Calendar.INotableDateAlgorithm>, <xref:Bodu.Globalization.Calendar.INotableDateAlgorithmRegistry>, <xref:Bodu.Globalization.Calendar.NotableDateAlgorithmRegistry> | Pluggable algorithm contract and registry. |
-| <xref:Bodu.Globalization.Calendar.INotableDateProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.NotableDateRuleResourceProviderBase> | Rule-source contracts and the base class shared by the built-in resource providers. |
+| <xref:Bodu.Globalization.Calendar.INotableDateProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider>, <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider>, <xref:Bodu.Globalization.Calendar.NotableDateRuleResourceProviderBase> | Rule-source contracts, the runtime-mutable override provider, and the base class shared by the built-in resource providers. |
 | <xref:Bodu.Globalization.Calendar.IAdjustmentHandler>, <xref:Bodu.Globalization.Calendar.AdjustmentHandlerRegistry>, <xref:Bodu.Globalization.Calendar.IAdjustmentHandlerRegistry>, <xref:Bodu.Globalization.Calendar.AdjustmentHandlerContext>, <xref:Bodu.Globalization.Calendar.AdjustmentHandlerResult> | Handler model for adjustments. |
 | <xref:Bodu.Globalization.Calendar.INotableDateCollisionResolver>, <xref:Bodu.Globalization.Calendar.DefaultNotableDateCollisionResolver> | Behavior when multiple rules resolve to the same date. |
 | <xref:Bodu.Globalization.Calendar.INotableDateNameLocalizer> | Pluggable display-name localization. |
 | <xref:Bodu.Globalization.Calendar.IResourcePathResolver>, <xref:Bodu.Globalization.Calendar.ResourcePathResolver>, <xref:Bodu.Globalization.Calendar.ResourcePathResolverOptions> | Resource-path resolution for embedded providers. |
+
+## Dependency injection
+
+The optional `Bodu.Globalization.Calendar.DependencyInjection` companion package wires `INotableDateService` into a `Microsoft.Extensions.DependencyInjection` container via `services.AddNotableDates(...)`, binds [`NotableDateOptions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions) from `IConfiguration`, exposes the fluent <xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder> for layering rule providers and collaborators, and provides a `PostConfigure` hook for projecting from consumer-defined POCOs. See the [dependency-injection guide](../../guides/calendar/dependency-injection.md) for the full walkthrough.
 
 ## Advanced extensibility
 

--- a/docs/guides/calendar/building-the-service.md
+++ b/docs/guides/calendar/building-the-service.md
@@ -353,17 +353,70 @@ var service = new NotableDateService(
     });
 ```
 
-### Cache invalidation after override state changes
+### Cache invalidation and reload
 
-The effective rule list is derived once and cached internally. If override provider state
-changes at runtime (e.g. a database-driven list of company closures is updated), call
-`Invalidate()` to force re-derivation:
+The service maintains two distinct caches:
+
+- The **per-year resolved-date cache** — cleared by `Invalidate()` (all years) or `Invalidate(int year)` (one year). Use these after a configuration change that does not alter the rule set itself (for example, switching the active culture if you also use a localizer that varies output by year).
+- The **effective rule set** — built once at construction from every registered base provider and override provider, and cached on the service. Use `Reload()` to re-query every registered <xref:Bodu.Globalization.Calendar.INotableDateRuleOverrideProvider>, rebuild the merged rule set, and clear the per-year cache in one call.
 
 ```csharp
-// After updating the override source
+// Per-year cache only:
 service.Invalidate();       // clear all years
 service.Invalidate(2026);   // clear one year only
+
+// Effective rule set + per-year cache:
+service.Reload();           // re-snapshot overrides, rebuild merged rules, drop cached years
 ```
+
+Base <xref:Bodu.Globalization.Calendar.INotableDateRuleProvider> sources are *not* re-queried by `Reload()` — they are considered load-time inputs. If you need to swap a base provider you must construct a new service.
+
+### MutableNotableDateRuleOverrideProvider — runtime add / remove
+
+If your application needs to add or remove notable-date rules after the service is alive — for example, a one-off "company closed for stocktake" entry, or rules authored through a CMS — use <xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider>. It is a thread-safe `INotableDateRuleOverrideProvider` with mutation methods and a `Changed` event:
+
+```csharp
+var overrides = new MutableNotableDateRuleOverrideProvider();
+
+var service = new NotableDateService(
+    ruleProviders:    new[] { baseProvider },
+    workingWeek:      WeekPattern.MondayToFriday,
+    options:          new NotableDateServiceOptions { OverrideProviders = new[] { overrides } });
+
+// Wire the auto-reload so mutations take effect on the next query:
+overrides.Changed += (_, _) => service.Reload();
+
+overrides.AddRule(new NotableDateRule
+{
+    Name            = "Stocktake Day",
+    Strategy        = DateResolutionStrategy.Fixed,
+    Category        = NotableDateCategory.Observance,
+    Month           = 6,
+    Day             = 30,
+    IsNonWorkingDay = true,
+});
+
+overrides.RemoveRule(name: "Boxing Day", fromYear: 2026, toYear: 2026);
+overrides.Clear();   // drop every authored addition and removal
+```
+
+`AddRule` / `RemoveRule` / `Clear` each raise `Changed` exactly once. The `Bodu.Globalization.Calendar.DependencyInjection` companion package wires `Changed` to `Reload()` automatically when the mutable provider is registered through its builder (see [Calendar dependency injection](dependency-injection.md)).
+
+### Enumerating supported territories and calendars
+
+The service exposes two discovery methods so consumers can introspect the loaded rule set without having to know the territory / calendar codes up front:
+
+```csharp
+IReadOnlyCollection<string> territories = service.GetSupportedTerritories();
+IReadOnlyCollection<Type>   calendars   = service.GetSupportedCalendars();
+
+foreach (string code in territories)
+{
+    Console.WriteLine($"{code}: {service.GetNotableDates(2026, code).Count} dates in 2026");
+}
+```
+
+Both methods project over the *effective* rule set and refresh after `Reload()`. Rules without an explicit `TerritoryCode` (global rules) contribute no entry; territory codes are deduplicated case-insensitively. The collections are typical inputs for UI pickers and for sanity-checking that a deployed data pack is actually loaded.
 
 ---
 

--- a/docs/guides/calendar/dependency-injection.md
+++ b/docs/guides/calendar/dependency-injection.md
@@ -1,0 +1,235 @@
+---
+title: Calendar dependency injection
+---
+
+# Calendar dependency injection
+
+The optional `Bodu.Globalization.Calendar.DependencyInjection` companion package wires `INotableDateService` into a `Microsoft.Extensions.DependencyInjection` container so ASP.NET Core, generic-host, or any `IServiceCollection`-based application can resolve the service like any other framework-registered dependency.
+
+If you are constructing the service by hand — for example in a console app or a test — keep using `new NotableDateService(...)`; this page is only relevant when you want the host to compose the service for you.
+
+---
+
+## Install
+
+```bash
+dotnet add package Bodu.Globalization.Calendar.DependencyInjection
+```
+
+The package depends on:
+
+- `Bodu.Globalization.Calendar`
+- `Microsoft.Extensions.DependencyInjection.Abstractions`
+- `Microsoft.Extensions.Options` (+ `Options.ConfigurationExtensions` for binding)
+
+## AddNotableDates — two entry shapes
+
+Both overloads return an [`INotableDateServiceBuilder`](xref:Bodu.Globalization.Calendar.DependencyInjection.INotableDateServiceBuilder) for further chaining.
+
+### Configuration-driven
+
+```csharp
+using Bodu.Globalization.Calendar.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services
+    .AddNotableDates(builder.Configuration)           // binds "NotableDates" section
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders());
+```
+
+`AddNotableDates(IConfiguration?, string sectionName = "NotableDates")` binds the named section into [`NotableDateOptions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions). Pass `configuration: null` if you do not want any configuration binding.
+
+### Builder-callback driven
+
+```csharp
+builder.Services.AddNotableDates(notable =>
+{
+    notable
+        .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+        .UseWorkingDays(WorkingDaysOfWeek.MondayToFriday)
+        .RegisterAsAmbientDefault();
+});
+```
+
+The callback receives the same `INotableDateServiceBuilder` instance the caller would otherwise receive as a return value, so both shapes are equivalent.
+
+---
+
+## NotableDateOptions
+
+[`NotableDateOptions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateOptions) is the bindable POCO. It is intentionally composed of bindable primitives so the entire surface can be populated from `appsettings.json`. Interface-typed collaborators (algorithm registries, collision resolvers, plugins) are configured through the builder instead.
+
+| Property | Default | Purpose |
+|---|---|---|
+| `WorkingDays` | `WorkingDaysOfWeek.MondayToFriday` | Named working-week preset converted to a `WeekPattern` before the service is constructed. |
+| `DefaultTerritoryCode` | `null` | Optional default territory code exposed to consumers via `IOptions<NotableDateOptions>`. Not pushed into the service itself — pass it explicitly to per-call queries. |
+| `DefaultCalendarTypeName` | `null` | Assembly-qualified name of the default calendar type. Stored as a string for bindability; resolve with `Type.GetType(name)`. |
+| `RegisterAsAmbientDefault` | `false` | When `true`, the resolved singleton is also assigned to <xref:Bodu.Globalization.Calendar.NotableDateContext.Default> the first time it is resolved. |
+
+```json
+{
+  "NotableDates": {
+    "WorkingDays": "MondayToSaturday",
+    "DefaultTerritoryCode": "AU-NSW",
+    "RegisterAsAmbientDefault": true
+  }
+}
+```
+
+---
+
+## Builder reference
+
+Every fluent extension method lives on [`NotableDateServiceBuilderExtensions`](xref:Bodu.Globalization.Calendar.DependencyInjection.NotableDateServiceBuilderExtensions). The method shapes mirror conventional `Microsoft.Extensions.*` builders — chains return the builder, registrations accumulate via `IEnumerable<T>` injection, and overlapping options follow the standard `IConfiguration` → `IConfigureOptions` → `IPostConfigureOptions` ordering.
+
+### Rule and override providers
+
+```csharp
+notable
+    .AddRuleProvider(new XmlResourceNotableDateRuleProvider(
+        "MyApp/Calendar/Resources/holidays.xml",
+        new ResourcePathResolver()))
+    .AddRuleProvider<MyCustomProvider>()             // typed registration, container-instantiated
+    .AddRuleProvider(sp => sp.GetRequiredService<DatabaseRuleProvider>())
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    .AddOverrideProvider(new MutableNotableDateRuleOverrideProvider());
+```
+
+Multiple calls accumulate — a host can compose contributions from several data packs without overwriting earlier registrations.
+
+### Single-instance collaborators
+
+```csharp
+notable
+    .UseAlgorithmRegistry(new NotableDateAlgorithmRegistry()
+        .Register("easter-sunday", new EasterSundayNotableDateAlgorithm()))
+    .UseCollisionResolver(new MyCollisionResolver())
+    .UseNameLocalizer(new MyResxNameLocalizer())
+    .UseAdjustmentHandlers(new AdjustmentHandlerRegistry())
+    .UseResourcePathResolver(new ResourcePathResolver());
+```
+
+Later calls replace earlier registrations, so you can override a default supplied elsewhere in your composition root.
+
+### Options shaping
+
+```csharp
+notable
+    .UseWorkingDays(WorkingDaysOfWeek.MondayToFriday)   // sugar over Configure
+    .Configure(opts => opts.DefaultTerritoryCode = "AU-NSW")
+    .RegisterAsAmbientDefault();
+```
+
+---
+
+## The PostConfigure hook — projecting from custom POCOs
+
+If your application already has its own bindable settings class — perhaps `MyAppCalendarSettings` bound from `appsettings.json:MyApp:Calendar` — you do not need to abandon it. Register it through the standard `services.Configure<TOptions>(...)` call and project values into `NotableDateOptions` via `PostConfigure`:
+
+```csharp
+public sealed class MyAppCalendarSettings
+{
+    public string?            RegionCode { get; set; }
+    public WorkingDaysOfWeek  WorkWeek   { get; set; } = WorkingDaysOfWeek.MondayToFriday;
+}
+
+services.Configure<MyAppCalendarSettings>(configuration.GetSection("MyApp:Calendar"));
+
+services.AddNotableDates()
+    .PostConfigure((sp, opts) =>
+    {
+        MyAppCalendarSettings custom = sp.GetRequiredService<IOptions<MyAppCalendarSettings>>().Value;
+        opts.DefaultTerritoryCode = custom.RegionCode;
+        opts.WorkingDays          = custom.WorkWeek;
+    });
+```
+
+`PostConfigure` is the consumer-defined-options hook. It is backed by `IPostConfigureOptions<NotableDateOptions>`, runs after `IConfiguration` binding and any `Configure(...)` callbacks, and is given the host's `IServiceProvider` so the callback can resolve arbitrary services. The same pattern is used by EF Core's `AddDbContext((sp, builder) => ...)` and ASP.NET Core's authentication post-configuration.
+
+The effective precedence is:
+
+1. Defaults on `NotableDateOptions`
+2. `IConfiguration` binding (when supplied)
+3. `Configure(...)` callbacks in registration order
+4. `PostConfigure(...)` callbacks last — these always win on overlapping properties
+
+---
+
+## Runtime-mutable overrides
+
+`Bodu.Globalization.Calendar` ships [`MutableNotableDateRuleOverrideProvider`](xref:Bodu.Globalization.Calendar.MutableNotableDateRuleOverrideProvider) for hosts that need to add or remove notable-date rules after the service has been constructed (for example, "company closed for stocktake on Friday" or a CMS-authored one-off observance). When you register it via `AddOverrideProvider`, the DI factory subscribes <xref:Bodu.Globalization.Calendar.INotableDateService.Reload> to the provider's `Changed` event so runtime mutations propagate without further intervention:
+
+```csharp
+var overrides = new MutableNotableDateRuleOverrideProvider();
+
+services.AddNotableDates()
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    .AddOverrideProvider(overrides);
+
+// Later, anywhere in the host:
+overrides.AddRule(new NotableDateRule
+{
+    Name            = "Stocktake Day",
+    Strategy        = DateResolutionStrategy.Fixed,
+    Category        = NotableDateCategory.Observance,
+    Month           = 6,
+    Day             = 30,
+    IsNonWorkingDay = true,
+    TerritoryCode   = "AU-NSW",
+});
+// Auto-reload fires; the new rule is visible on the next query.
+```
+
+`AddRule` / `RemoveRule` / `Clear` each raise `Changed` exactly once. The provider is thread-safe: concurrent mutations preserve insertion order, and snapshots returned from `GetAdditions` / `GetRemovals` remain stable for the duration of any enumeration.
+
+For details on how `Reload` integrates with the cache, see [Cache invalidation and reload](building-the-service.md#cache-invalidation-and-reload).
+
+---
+
+## Ambient default wiring
+
+When `RegisterAsAmbientDefault` is set (either through configuration binding, the `Configure` callback, or the `RegisterAsAmbientDefault()` sugar), the DI-resolved singleton is also assigned to <xref:Bodu.Globalization.Calendar.NotableDateContext.Default> on first resolution. This lets the parameterless `DateOnly` / `DateTime` extension overloads (`date.NextWorkingDay()`, `date.IsNotableDate()`) resolve through the same instance:
+
+```csharp
+services.AddNotableDates(configuration)
+    .AddRuleProviders(AsiaPacificCalendarData.CreateProviders())
+    .RegisterAsAmbientDefault();
+
+// Later, anywhere:
+DateTime nextWorking = DateTime.Today.NextWorkingDay(territoryCode: "AU-NSW");
+```
+
+Without `RegisterAsAmbientDefault`, the ambient context falls back to its lazy default (an internal service backed by the embedded minimal rule set) — the DI-registered service is still resolvable via `IServiceProvider`, but the extension methods will not see it.
+
+---
+
+## Discovering supported territories and calendars
+
+<xref:Bodu.Globalization.Calendar.INotableDateService.GetSupportedTerritories> and <xref:Bodu.Globalization.Calendar.INotableDateService.GetSupportedCalendars> enumerate what the loaded providers cover. They are useful for driving UI pickers or for sanity-checking deployment:
+
+```csharp
+INotableDateService service = host.Services.GetRequiredService<INotableDateService>();
+
+foreach (string code in service.GetSupportedTerritories())
+{
+    Console.WriteLine($"{code}: {service.GetNotableDates(2026, code).Count} dates in 2026");
+}
+```
+
+The returned set reflects the *effective* rule set — base rules plus any active override additions. Calls to <xref:Bodu.Globalization.Calendar.INotableDateService.Reload> refresh the set when override providers contribute new territories or calendars.
+
+---
+
+## Service lifetime and re-entrancy
+
+- `INotableDateService` is registered as a singleton via `TryAddSingleton`, so repeated `AddNotableDates(...)` calls do not create duplicate registrations.
+- The factory is invoked lazily on first resolution. `RegisterAsAmbientDefault` performs its assignment at that point.
+- `Reload()` rebuilds the effective rule set under the service's internal gate; concurrent `GetNotableDates(...)` calls during a reload either see the old state or the new state, never a torn read.
+
+---
+
+## Where to go next
+
+- **[Building and extending the service](building-the-service.md)** — every collaborator interface the DI builder wires up.
+- **[Using NotableDateService](notable-dates.md)** — query patterns and working-day arithmetic.
+- **[Calendar data packs](data-packs.md)** — composing the Asia-Pacific, Americas, and Europe data packs through `AddRuleProviders`.

--- a/docs/guides/calendar/index.md
+++ b/docs/guides/calendar/index.md
@@ -24,6 +24,7 @@ A **`NotableDateRule`** is an authored recipe — strategy, category, territory,
 | `Bodu.Globalization.Calendar.Plugins` | Plugin host with trust policies for loading rules / algorithms from external assemblies — `ExternalPluginLoader`, `IPluginTrustPolicy`, and the deny-by-default trust policies. | [Building and extending the service — Plugin system](building-the-service.md#plugin-system) |
 | `Bodu.Extensions` | Working-day arithmetic over `DateOnly` and `DateTime` — `IsWorkingDay`, `NextWorkingDay`, `AddWorkingDays`, … (`NotableDateOnlyExtensions`, `NotableDateTimeExtensions`). | [Working-day arithmetic](working-days.md) |
 | `Bodu.Globalization.Calendar.Data.*` | Region-specific public-holiday rule providers shipped in `Bodu.Globalization.Calendar.Data.Americas`, `.Europe`, and `.AsiaPacific` companion packages. | [Calendar data packs](data-packs.md) |
+| `Bodu.Globalization.Calendar.DependencyInjection` | `IServiceCollection.AddNotableDates(...)`, `INotableDateServiceBuilder`, `NotableDateOptions`, and the `PostConfigure` consumer-options projection hook. | [Calendar dependency injection](dependency-injection.md) |
 
 ## Guides
 
@@ -85,7 +86,12 @@ A **`NotableDateRule`** is an authored recipe — strategy, category, territory,
 
 <div class="bodu-card">
   <h3><a href="building-the-service.md">Building and extending the service</a></h3>
-  <p>How to use the registry and factory types — <code>NotableDateAlgorithmRegistry</code>, <code>AdjustmentHandlerRegistry</code>, <code>NotableDateFilter</code> composition, <code>INotableDateRuleOverrideProvider</code>, <code>INotableDateNameLocalizer</code>, <code>INotableDateCollisionResolver</code>, and the plugin system.</p>
+  <p>How to use the registry and factory types — <code>NotableDateAlgorithmRegistry</code>, <code>AdjustmentHandlerRegistry</code>, <code>NotableDateFilter</code> composition, <code>INotableDateRuleOverrideProvider</code>, <code>MutableNotableDateRuleOverrideProvider</code>, <code>INotableDateNameLocalizer</code>, <code>INotableDateCollisionResolver</code>, and the plugin system.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="dependency-injection.md">Calendar dependency injection</a></h3>
+  <p>The <code>Bodu.Globalization.Calendar.DependencyInjection</code> companion package — <code>services.AddNotableDates(...)</code>, the fluent <code>INotableDateServiceBuilder</code>, <code>IConfiguration</code>-bound <code>NotableDateOptions</code>, ambient default wiring, runtime-mutable overrides, and the <code>PostConfigure</code> hook for projecting from consumer-defined POCOs.</p>
 </div>
 
 </div>

--- a/docs/guides/calendar/toc.yml
+++ b/docs/guides/calendar/toc.yml
@@ -24,6 +24,8 @@
       href: working-days.md
     - name: Building and extending the service
       href: building-the-service.md
+    - name: Dependency injection
+      href: dependency-injection.md
 - name: Bodu.Globalization.Calendar.Algorithms
   items:
     - name: Date calculation algorithms


### PR DESCRIPTION
Layers a new `Bodu.Globalization.Calendar.DependencyInjection` package that
registers `INotableDateService` via `services.AddNotableDates(...)`, binds
`NotableDateOptions` from `IConfiguration`, and exposes a fluent builder for
rule providers, override providers, plugins, algorithm registries, and a
`PostConfigure((sp, opts) => ...)` hook for projecting from consumer-defined
POCOs.

Adds `MutableNotableDateRuleOverrideProvider` for runtime add/remove of
override rules, a public `INotableDateService.Reload()` that re-snapshots
override providers and rebuilds the effective rule set, and
`GetSupportedTerritories()` / `GetSupportedCalendars()` so consumers can
enumerate the loaded coverage. The DI factory auto-wires the mutable
provider's `Changed` event to `Reload()` so runtime mutations propagate
without further intervention.

Covered by 92 new BVT tests across the Calendar core and DI projects
(provider semantics, event raising, snapshot stability, concurrency,
service registration defaults, configuration binding, ambient-default
wiring, and an Asia-Pacific data pack integration smoke).