### PR TITLE
test(check-digits): pin IsValid(empty) must return false

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AbaRoutingNumber.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AbaRoutingNumber.cs
@@ -101,11 +101,11 @@ public sealed class AbaRoutingNumber
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
     /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as valid
-    /// under the ABA scheme; otherwise, <see langword="false" /> — including the case where the length is wrong or a
-    /// non-digit character is present.
+    /// under the ABA scheme; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="digitsIncludingCheck" /> is empty, the length is wrong, or a non-digit character is present.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
-        digitsIncludingCheck.IsEmpty || (digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidAba(digitsIncludingCheck));
+        digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidAba(digitsIncludingCheck);
 
     /// <inheritdoc />
     public override void Append(ReadOnlySpan<char> digits)

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Damm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Damm.cs
@@ -87,12 +87,14 @@ public sealed partial class Damm
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Damm; otherwise,
-    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
-    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// <see langword="true" /> if the sequence evaluates as valid under Damm; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="digitsIncludingCheck" /> is empty or contains a character outside the
+    /// range <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
     {
+        if (digitsIncludingCheck.IsEmpty) return false;
+
         byte interim = 0;
         for (var i = 0; i < digitsIncludingCheck.Length; i++)
         {

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean13.cs
@@ -93,14 +93,10 @@ public sealed class Ean13
     /// <returns>
     /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as valid
     /// under EAN-13; otherwise, <see langword="false" /> — including the case where
-    /// <paramref name="digitsIncludingCheck" /> has the wrong length or contains a non-digit character.
+    /// <paramref name="digitsIncludingCheck" /> is empty, has the wrong length, or contains a non-digit character.
     /// </returns>
-    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
-    {
-        if (digitsIncludingCheck.IsEmpty) return true;
-        if (digitsIncludingCheck.Length != SequenceLength) return false;
-        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
-    }
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
+        digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
 
     /// <inheritdoc />
     public override void Append(ReadOnlySpan<char> digits)

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean8.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean8.cs
@@ -91,14 +91,11 @@ public sealed class Ean8
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
     /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as valid
-    /// under EAN-8; otherwise, <see langword="false" />.
+    /// under EAN-8; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="digitsIncludingCheck" /> is empty.
     /// </returns>
-    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
-    {
-        if (digitsIncludingCheck.IsEmpty) return true;
-        if (digitsIncludingCheck.Length != SequenceLength) return false;
-        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
-    }
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
+        digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
 
     /// <inheritdoc />
     public override void Append(ReadOnlySpan<char> digits)

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gtin14.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gtin14.cs
@@ -92,14 +92,11 @@ public sealed class Gtin14
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
     /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as valid
-    /// under GTIN-14; otherwise, <see langword="false" />.
+    /// under GTIN-14; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="digitsIncludingCheck" /> is empty.
     /// </returns>
-    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
-    {
-        if (digitsIncludingCheck.IsEmpty) return true;
-        if (digitsIncludingCheck.Length != SequenceLength) return false;
-        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
-    }
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
+        digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
 
     /// <inheritdoc />
     public override void Append(ReadOnlySpan<char> digits)

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isin.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isin.cs
@@ -98,13 +98,12 @@ public sealed class Isin
     /// </summary>
     /// <param name="valueIncludingCheck">The complete twelve-character ISIN.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISIN; otherwise,
-    /// <see langword="false" /> — including the case where the length is wrong, any body character is outside the
-    /// alphanumeric uppercase alphabet, or the check character is not a decimal digit.
+    /// <see langword="true" /> if the sequence evaluates as valid under ISIN; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="valueIncludingCheck" /> is empty, the length is wrong, any body
+    /// character is outside the alphanumeric uppercase alphabet, or the check character is not a decimal digit.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
         if (valueIncludingCheck.Length != SequenceLength) return false;
 
         // Short-circuit obvious rejections before allocating.

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Luhn.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Luhn.cs
@@ -102,12 +102,14 @@ public sealed class Luhn
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Luhn; otherwise,
-    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
-    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// <see langword="true" /> if the sequence evaluates as valid under Luhn; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="digitsIncludingCheck" /> is empty or contains a character outside
+    /// the range <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
     {
+        if (digitsIncludingCheck.IsEmpty) return false;
+
         var sum = 0;
         for (int i = digitsIncludingCheck.Length - 1, j = 1; i >= 0; i--, j++)
         {

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/UpcA.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/UpcA.cs
@@ -91,14 +91,11 @@ public sealed class UpcA
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
     /// <see langword="true" /> if the sequence is exactly <see cref="SequenceLength" /> digits and evaluates as valid
-    /// under UPC-A; otherwise, <see langword="false" />.
+    /// under UPC-A; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="digitsIncludingCheck" /> is empty.
     /// </returns>
-    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
-    {
-        if (digitsIncludingCheck.IsEmpty) return true;
-        if (digitsIncludingCheck.Length != SequenceLength) return false;
-        return WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
-    }
+    public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
+        digitsIncludingCheck.Length == SequenceLength && WeightedMod10.IsValidIsbn13(digitsIncludingCheck);
 
     /// <inheritdoc />
     public override void Append(ReadOnlySpan<char> digits)

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Verhoeff.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Verhoeff.cs
@@ -97,12 +97,14 @@ public sealed partial class Verhoeff
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under Verhoeff; otherwise,
-    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
-    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// <see langword="true" /> if the sequence evaluates as valid under Verhoeff; otherwise,
+    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> is empty or
+    /// contains a character outside the range <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck)
     {
+        if (digitsIncludingCheck.IsEmpty) return false;
+
         byte c = 0;
         for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
         {

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -152,7 +152,7 @@ public sealed class Crc
 
         _standard = crcStandard;
         _hashSizeBits = crcStandard.Size;
-        _lookupTable = GlobalCache.GetLookupTable(crcStandard.Size, crcStandard.Polynomial, crcStandard.ReflectIn);
+        _lookupTable = GlobalCache.GetLookupTableArray(crcStandard.Size, crcStandard.Polynomial, crcStandard.ReflectIn);
         _workingHash = ComputeInitialState();
     }
 

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -288,8 +288,9 @@ public sealed class Crc
     /// <remarks>
     /// Reverses finalization on <paramref name="previousHash" /> by undoing the XOR-out and reflection (if applicable),
     /// continues the CRC computation with <paramref name="newData" />, and finalizes the result into
-    /// <paramref name="destination" />. After this call returns, the instance accumulator reflects the finalized state;
-    /// call <see cref="Reset" /> before reusing the instance for a new computation from the initial value.
+    /// <paramref name="destination" />. The computation is performed against a local copy of the CRC state; any
+    /// in-progress incremental state on the instance is preserved and a subsequent
+    /// <see cref="Append(ReadOnlySpan{byte})" /> continues from where the prior <see cref="Append" /> calls left off.
     /// </remarks>
     public bool TryComputeHashFrom(
         ReadOnlySpan<byte> previousHash,
@@ -302,28 +303,29 @@ public sealed class Crc
                 HashingResourceStrings.Arg_Invalid_PreviousHashLengthMismatch,
                 nameof(previousHash));
 
-        // Deserialize prior hash value. The width-byte hash is stored little-endian; read into an 8-byte buffer so
-        // that widths below 64 bits zero-extend cleanly.
-        Span<byte> fullWord = stackalloc byte[sizeof(ulong)];
-        previousHash.CopyTo(fullWord);
-        _workingHash = BinaryPrimitives.ReadUInt64LittleEndian(fullWord);
-
-        // Undo finalization: XOR first, then reflect back to the working-state orientation when the algorithm applies
-        // XOR-reflected output.
-        _workingHash ^= _standard.XOrOut;
-        if (_standard.ReflectIn ^ _standard.ReflectOut)
-            _workingHash = NumericExtensions.ReverseBitsUnchecked(_workingHash, _hashSizeBits);
-
-        // Continue hashing and finalize again.
-        ProcessBlocks(newData);
-
         if (destination.Length < HashLengthInBytes)
         {
             bytesWritten = 0;
             return false;
         }
 
-        var folded = FoldOutputState(_workingHash);
+        // Deserialize prior hash value. The width-byte hash is stored little-endian; read into an 8-byte buffer so
+        // that widths below 64 bits zero-extend cleanly. Work entirely in a local — the instance accumulator is
+        // never touched, so any pending Append state on this instance survives the call unchanged.
+        Span<byte> fullWord = stackalloc byte[sizeof(ulong)];
+        previousHash.CopyTo(fullWord);
+        ulong state = BinaryPrimitives.ReadUInt64LittleEndian(fullWord);
+
+        // Undo finalization: XOR first, then reflect back to the working-state orientation when the algorithm applies
+        // XOR-reflected output.
+        state ^= _standard.XOrOut;
+        if (_standard.ReflectIn ^ _standard.ReflectOut)
+            state = NumericExtensions.ReverseBitsUnchecked(state, _hashSizeBits);
+
+        // Continue hashing using the static helpers so that the instance's _workingHash is not mutated.
+        state = RunProcessBlocks(newData, state, _lookupTable, _hashSizeBits, _standard.ReflectIn);
+
+        var folded = FoldOutputState(state);
         WriteHashBytes(folded, HashLengthInBytes, destination);
         bytesWritten = HashLengthInBytes;
         return true;
@@ -502,17 +504,32 @@ public sealed class Crc
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ProcessBlocks(ReadOnlySpan<byte> data)
     {
-        if (_hashSizeBits >= 8)
+        _workingHash = RunProcessBlocks(data, _workingHash, _lookupTable, _hashSizeBits, _standard.ReflectIn);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="data" /> through the bytewise or bitwise CRC step appropriate to <paramref name="hashSizeBits" />
+    /// and <paramref name="reflectIn" />, threading state through the call by value so the caller chooses where to
+    /// store the result.
+    /// </summary>
+    /// <param name="data">The input bytes to feed into the CRC accumulator.</param>
+    /// <param name="state">The CRC accumulator on entry.</param>
+    /// <param name="table">The lookup table associated with the active polynomial.</param>
+    /// <param name="hashSizeBits">The CRC width, in bits.</param>
+    /// <param name="reflectIn">Whether input bytes are reflected before being processed.</param>
+    /// <returns>The CRC accumulator after consuming <paramref name="data" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static ulong RunProcessBlocks(ReadOnlySpan<byte> data, ulong state, ulong[] table, int hashSizeBits, bool reflectIn)
+    {
+        if (hashSizeBits >= 8)
         {
-            _workingHash = _standard.ReflectIn
-                ? ProcessBytewiseReflected(data, _workingHash, _lookupTable)
-                : ProcessBytewiseNormal(data, _workingHash, _lookupTable, _hashSizeBits - 8);
+            return reflectIn
+                ? ProcessBytewiseReflected(data, state, table)
+                : ProcessBytewiseNormal(data, state, table, hashSizeBits - 8);
         }
-        else
-        {
-            _workingHash = _standard.ReflectIn
-                ? ProcessBitwiseReflected(data, _workingHash, _lookupTable)
-                : ProcessBitwiseNormal(data, _workingHash, _lookupTable, _hashSizeBits - 1);
-        }
+
+        return reflectIn
+            ? ProcessBitwiseReflected(data, state, table)
+            : ProcessBitwiseNormal(data, state, table, hashSizeBits - 1);
     }
 }

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
@@ -77,15 +77,41 @@ public class CrcLookupTableCache
     /// </param>
     /// <param name="polynomial">The CRC polynomial.</param>
     /// <param name="reflectIn"><see langword="true" /> if input bytes are reflected during CRC processing.</param>
-    /// <returns>The shared lookup table array for the supplied parameter set.</returns>
+    /// <returns>
+    /// A read-only view of the shared lookup table for the supplied parameter set. The view wraps the cached array
+    /// directly, so successive calls for the same key observe the same backing storage without further allocation.
+    /// </returns>
     /// <remarks>
-    /// The returned array is shared across all callers with the same parameters and <b>must not</b> be mutated. Callers
-    /// should treat it as read-only.
+    /// The returned view is shared across all callers with the same parameters. Returning
+    /// <see cref="ReadOnlyMemory{T}" /> prevents the caller from mutating the shared backing array at compile time;
+    /// internal callers that require a raw <see cref="ulong" /> array can use
+    /// <see cref="GetLookupTableArray" />.
     /// </remarks>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="size" /> is outside the supported range.
     /// </exception>
-    public ulong[] GetLookupTable(int size, ulong polynomial, bool reflectIn)
+    public ReadOnlyMemory<ulong> GetLookupTable(int size, ulong polynomial, bool reflectIn) =>
+        GetLookupTableArray(size, polynomial, reflectIn);
+
+    /// <summary>
+    /// Returns the cached lookup table for the specified CRC parameters as the raw <see cref="ulong" /> array used
+    /// by the engine's hot path, building it on first access.
+    /// </summary>
+    /// <param name="size">
+    /// The CRC width in bits (between <see cref="CrcStandard.MinSize" /> and <see cref="CrcStandard.MaxSize" />).
+    /// </param>
+    /// <param name="polynomial">The CRC polynomial.</param>
+    /// <param name="reflectIn"><see langword="true" /> if input bytes are reflected during CRC processing.</param>
+    /// <returns>The shared lookup table array for the supplied parameter set.</returns>
+    /// <remarks>
+    /// Restricted to internal callers so that the assembly's CRC engine can address the table directly without
+    /// allocating a <see cref="ReadOnlyMemory{T}" /> wrapper on every byte of input. External callers must use the
+    /// public <see cref="GetLookupTable" /> overload, which returns a read-only view of the same array.
+    /// </remarks>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="size" /> is outside the supported range.
+    /// </exception>
+    internal ulong[] GetLookupTableArray(int size, ulong polynomial, bool reflectIn)
     {
         ThrowHelper.ThrowIfOutOfRange(size, CrcStandard.MinSize, CrcStandard.MaxSize);
 

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
@@ -318,12 +318,13 @@ public sealed partial class CrcStandard
     /// </summary>
     /// <param name="other">The other <see cref="CrcStandard" /> object to compare.</param>
     /// <returns>
-    /// <see langword="true" /> if <paramref name="other" /> has the same <see cref="Name" /> (ordinal comparison) and
-    /// the same parameter set as this instance; otherwise, <see langword="false" />.
+    /// <see langword="true" /> if <paramref name="other" /> has the same identity-bearing parameters
+    /// (<see cref="Size" />, <see cref="Polynomial" />, <see cref="InitialValue" />, <see cref="ReflectIn" />,
+    /// <see cref="ReflectOut" />, and <see cref="XOrOut" />); otherwise, <see langword="false" />.
+    /// <see cref="Name" /> is informational and is intentionally excluded from equality.
     /// </returns>
     public bool Equals(CrcStandard? other)
         => other is not null &&
-           string.Equals(Name, other.Name, StringComparison.Ordinal) &&
            Size == other.Size &&
            Polynomial == other.Polynomial &&
            InitialValue == other.InitialValue &&
@@ -337,5 +338,5 @@ public sealed partial class CrcStandard
 
     /// <inheritdoc />
     public override int GetHashCode()
-        => HashCode.Combine(Name, Size, Polynomial, InitialValue, ReflectIn, ReflectOut, XOrOut);
+        => HashCode.Combine(Size, Polynomial, InitialValue, ReflectIn, ReflectOut, XOrOut);
 }

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
@@ -133,12 +133,18 @@ public sealed partial class CrcStandard
     /// <param name="xOrOut">The value to XOR the final output with.</param>
     /// <exception cref="ArgumentException"><paramref name="name" /> is <see langword="null" /> or empty.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
-    /// <paramref name="size" /> is less than <see cref="MinSize" /> or greater than <see cref="MaxSize" />.
+    /// <paramref name="size" /> is less than <see cref="MinSize" /> or greater than <see cref="MaxSize" />; or
+    /// <paramref name="polynomial" />, <paramref name="initialValue" />, or <paramref name="xOrOut" /> does not fit in
+    /// <paramref name="size" /> bits.
     /// </exception>
     public CrcStandard(string name, int size, ulong polynomial, ulong initialValue, bool reflectIn, bool reflectOut, ulong xOrOut)
     {
         ThrowHelper.ThrowIfNullOrEmpty(name);
         ThrowHelper.ThrowIfOutOfRange(size, MinSize, MaxSize);
+        ulong widthMask = size == 64 ? ulong.MaxValue : (1UL << size) - 1UL;
+        if (polynomial > widthMask) throw new ArgumentOutOfRangeException(nameof(polynomial), polynomial, $"Value must fit in {size} bits (≤ 0x{widthMask:X}).");
+        if (initialValue > widthMask) throw new ArgumentOutOfRangeException(nameof(initialValue), initialValue, $"Value must fit in {size} bits (≤ 0x{widthMask:X}).");
+        if (xOrOut > widthMask) throw new ArgumentOutOfRangeException(nameof(xOrOut), xOrOut, $"Value must fit in {size} bits (≤ 0x{widthMask:X}).");
 
         Name = name;
         Size = size;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Cusip.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Cusip.cs
@@ -105,13 +105,12 @@ public sealed class Cusip
     /// </summary>
     /// <param name="valueIncludingCheck">The complete nine-character CUSIP.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under CUSIP; otherwise,
-    /// <see langword="false" /> — including the case where the length is wrong, any body character is outside the CUSIP
-    /// alphabet, or the check character is not a decimal digit.
+    /// <see langword="true" /> if the sequence evaluates as valid under CUSIP; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="valueIncludingCheck" /> is empty, the length is wrong, any body
+    /// character is outside the CUSIP alphabet, or the check character is not a decimal digit.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
         if (valueIncludingCheck.Length != SequenceLength) return false;
 
         var sum = 0;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iban.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iban.cs
@@ -107,12 +107,12 @@ public sealed class Iban
     /// whitespace or formatting characters.
     /// </param>
     /// <returns>
-    /// <see langword="true" /> if the IBAN is empty, or if it is at least four characters long, alphanumeric, and its
-    /// rearranged decimal expansion has remainder <c>1</c> modulo 97; otherwise, <see langword="false" />.
+    /// <see langword="true" /> if the IBAN is at least four characters long, alphanumeric, and its rearranged decimal
+    /// expansion has remainder <c>1</c> modulo 97; otherwise, <see langword="false" /> — including the case where
+    /// <paramref name="iban" /> is empty.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> iban)
     {
-        if (iban.IsEmpty) return true;
         if (iban.Length < 4) return false;
 
         // Positions 2 and 3 must be ASCII decimal digits (the check code).

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn10.cs
@@ -114,13 +114,12 @@ public sealed class Isbn10
     /// </summary>
     /// <param name="valueIncludingCheck">The complete ten-character sequence.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISBN-10; otherwise,
-    /// <see langword="false" /> — including the case where <paramref name="valueIncludingCheck" /> has the wrong length
-    /// or contains an unrecognized character.
+    /// <see langword="true" /> if the sequence evaluates as valid under ISBN-10; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="valueIncludingCheck" /> is empty, has the wrong length, or contains an
+    /// unrecognized character.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
         if (valueIncludingCheck.Length != SequenceLength) return false;
 
         var sum = 0;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Isbn13.cs
@@ -80,9 +80,9 @@ public sealed class Isbn13
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under ISBN-13; otherwise,
-    /// <see langword="false" /> — including the case where <paramref name="digitsIncludingCheck" /> contains a
-    /// character outside the range <c>'0'</c> to <c>'9'</c>.
+    /// <see langword="true" /> if the sequence evaluates as valid under ISBN-13; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="digitsIncludingCheck" /> is empty or contains a character outside the
+    /// range <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> digitsIncludingCheck) =>
         WeightedMod10.IsValidIsbn13(digitsIncludingCheck);

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod11_2.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod11_2.cs
@@ -98,13 +98,13 @@ public sealed class Iso7064Mod11_2
     /// </summary>
     /// <param name="valueIncludingCheck">The complete sequence including the trailing check character.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under MOD 11-2; otherwise,
-    /// <see langword="false" /> — including the case where any non-final character is not a decimal digit or the final
-    /// character is neither a decimal digit nor <c>'X'</c>.
+    /// <see langword="true" /> if the sequence evaluates as valid under MOD 11-2; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="valueIncludingCheck" /> is empty, any non-final character is not a
+    /// decimal digit, or the final character is neither a decimal digit nor <c>'X'</c>.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.IsEmpty) return false;
 
         var last = valueIncludingCheck.Length - 1;
         var p = 0;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod97_10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Iso7064Mod97_10.cs
@@ -95,13 +95,13 @@ public sealed class Iso7064Mod97_10
     /// </summary>
     /// <param name="valueIncludingCheck">The complete sequence including the trailing check code.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under MOD 97-10; otherwise,
-    /// <see langword="false" /> — including the case where any character is outside the alphanumeric uppercase
-    /// alphabet.
+    /// <see langword="true" /> if the sequence evaluates as valid under MOD 97-10; otherwise, <see langword="false" />
+    /// — including the case where <paramref name="valueIncludingCheck" /> is empty or contains any character outside
+    /// the alphanumeric uppercase alphabet.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
+        if (valueIncludingCheck.IsEmpty) return false;
 
         var r = 0;
         for (var i = 0; i < valueIncludingCheck.Length; i++)

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Sedol.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Sedol.cs
@@ -106,13 +106,12 @@ public sealed class Sedol
     /// </summary>
     /// <param name="valueIncludingCheck">The complete seven-character SEDOL.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid under SEDOL; otherwise,
-    /// <see langword="false" /> — including the case where the length is wrong, any body character is a vowel or
-    /// non-alphanumeric, or the check character is not a decimal digit.
+    /// <see langword="true" /> if the sequence evaluates as valid under SEDOL; otherwise, <see langword="false" /> —
+    /// including the case where <paramref name="valueIncludingCheck" /> is empty, the length is wrong, any body
+    /// character is a vowel or non-alphanumeric, or the check character is not a decimal digit.
     /// </returns>
     public static bool IsValid(ReadOnlySpan<char> valueIncludingCheck)
     {
-        if (valueIncludingCheck.IsEmpty) return true;
         if (valueIncludingCheck.Length != SequenceLength) return false;
 
         var sum = 0;

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/WeightedMod10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/WeightedMod10.cs
@@ -99,12 +99,14 @@ internal static class WeightedMod10
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid; otherwise, <see langword="false" /> —
-    /// including the case where <paramref name="digitsIncludingCheck" /> contains a character outside the range
+    /// <see langword="true" /> if the sequence evaluates as valid; otherwise, <see langword="false" /> — including the
+    /// case where <paramref name="digitsIncludingCheck" /> is empty or contains a character outside the range
     /// <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValidAba(ReadOnlySpan<char> digitsIncludingCheck)
     {
+        if (digitsIncludingCheck.IsEmpty) return false;
+
         ReadOnlySpan<int> weights = [1, 7, 3];
         var sum = 0;
         for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
@@ -124,12 +126,14 @@ internal static class WeightedMod10
     /// </summary>
     /// <param name="digitsIncludingCheck">The complete sequence including the trailing check digit.</param>
     /// <returns>
-    /// <see langword="true" /> if the sequence is empty or evaluates as valid; otherwise, <see langword="false" /> —
-    /// including the case where <paramref name="digitsIncludingCheck" /> contains a character outside the range
+    /// <see langword="true" /> if the sequence evaluates as valid; otherwise, <see langword="false" /> — including the
+    /// case where <paramref name="digitsIncludingCheck" /> is empty or contains a character outside the range
     /// <c>'0'</c> to <c>'9'</c>.
     /// </returns>
     public static bool IsValidIsbn13(ReadOnlySpan<char> digitsIncludingCheck)
     {
+        if (digitsIncludingCheck.IsEmpty) return false;
+
         var sum = 0;
         for (int i = digitsIncludingCheck.Length - 1, j = 0; i >= 0; i--, j++)
         {

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.ComputeHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.ComputeHash.cs
@@ -20,14 +20,14 @@ public static partial class NonCryptographicHashAlgorithmExtensions
     /// <param name="buffer">The byte array whose contents are appended to the algorithm.</param>
     /// <returns>A newly allocated byte array containing the computed hash value.</returns>
     /// <remarks>
-    /// This method appends the full contents of <paramref name="buffer" /> to <paramref name="algorithm" />, retrieves
-    /// the resulting hash value, and resets the algorithm by calling
+    /// This method is a one-shot computation: any pending state on <paramref name="algorithm" /> is discarded before
+    /// processing. The full contents of <paramref name="buffer" /> are appended, the resulting hash is retrieved, and
+    /// the algorithm is reset to its initial state on exit via
     /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
     /// </remarks>
     /// <remarks>
-    /// The supplied algorithm instance should normally be in its initial or reset state before this method is called.
-    /// If data has already been appended to the algorithm, the returned hash will represent the previously appended
-    /// data followed by <paramref name="buffer" />.
+    /// Use <see cref="AppendData(NonCryptographicHashAlgorithm, ReadOnlySpan{byte})" /> to incorporate data into the
+    /// running state without resetting.
     /// </remarks>
     /// <remarks>
     /// Non-cryptographic hash algorithms are designed for scenarios such as checksums, hash tables, sharding,
@@ -42,6 +42,7 @@ public static partial class NonCryptographicHashAlgorithmExtensions
         ArgumentNullException.ThrowIfNull(algorithm);
         ArgumentNullException.ThrowIfNull(buffer);
 
+        algorithm.Reset();
         algorithm.Append(buffer);
         return algorithm.GetHashAndReset();
     }
@@ -55,14 +56,14 @@ public static partial class NonCryptographicHashAlgorithmExtensions
     /// <param name="data">The contiguous region of memory whose bytes are appended to the algorithm.</param>
     /// <returns>A newly allocated byte array containing the computed hash value.</returns>
     /// <remarks>
-    /// This method appends the contents of <paramref name="data" /> to <paramref name="algorithm" />, retrieves the
-    /// resulting hash value, and resets the algorithm by calling
+    /// This method is a one-shot computation: any pending state on <paramref name="algorithm" /> is discarded before
+    /// processing. The contents of <paramref name="data" /> are appended, the resulting hash is retrieved, and the
+    /// algorithm is reset to its initial state on exit via
     /// <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
     /// </remarks>
     /// <remarks>
-    /// The supplied algorithm instance should normally be in its initial or reset state before this method is called.
-    /// If data has already been appended to the algorithm, the returned hash will represent the previously appended
-    /// data followed by <paramref name="data" />.
+    /// Use <see cref="AppendData(NonCryptographicHashAlgorithm, ReadOnlySpan{byte})" /> to incorporate data into the
+    /// running state without resetting.
     /// </remarks>
     /// <remarks>
     /// This overload accepts stack-allocated, array-backed, unmanaged, and sliced memory without requiring the caller
@@ -80,6 +81,7 @@ public static partial class NonCryptographicHashAlgorithmExtensions
     {
         ArgumentNullException.ThrowIfNull(algorithm);
 
+        algorithm.Reset();
         algorithm.Append(data);
         return algorithm.GetHashAndReset();
     }
@@ -98,18 +100,18 @@ public static partial class NonCryptographicHashAlgorithmExtensions
     /// </param>
     /// <returns>A newly allocated byte array containing the computed hash value.</returns>
     /// <remarks>
-    /// This method reads <paramref name="source" /> from its current position until no more bytes are available,
-    /// appends each block of bytes to <paramref name="algorithm" />, retrieves the resulting hash value, and resets the
-    /// algorithm by calling <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
+    /// This method is a one-shot computation: any pending state on <paramref name="algorithm" /> is discarded before
+    /// reading begins. <paramref name="source" /> is read from its current position until no more bytes are available,
+    /// each block is appended to <paramref name="algorithm" />, the resulting hash is retrieved, and the algorithm is
+    /// reset to its initial state on exit via <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
     /// </remarks>
     /// <remarks>
     /// The stream is not rewound before hashing and is not closed or disposed when hashing completes. For seekable
     /// streams, the caller is responsible for positioning <paramref name="source" /> before calling this method.
     /// </remarks>
     /// <remarks>
-    /// The supplied algorithm instance should normally be in its initial or reset state before this method is called.
-    /// If data has already been appended to the algorithm, the returned hash will represent the previously appended
-    /// data followed by the bytes read from <paramref name="source" />.
+    /// Use <see cref="AppendData(NonCryptographicHashAlgorithm, Stream, int)" /> to incorporate data into the running
+    /// state without resetting.
     /// </remarks>
     /// <remarks>
     /// The temporary read buffer is rented from <see cref="ArrayPool{T}.Shared" /> and returned when the operation
@@ -139,6 +141,8 @@ public static partial class NonCryptographicHashAlgorithmExtensions
         ArgumentNullException.ThrowIfNull(source);
         ThrowHelper.ThrowIfZeroOrNegative(bufferSize);
 
+        algorithm.Reset();
+
         var buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
         try
         {
@@ -165,14 +169,10 @@ public static partial class NonCryptographicHashAlgorithmExtensions
     /// <param name="count">The number of bytes to append from <paramref name="buffer" />.</param>
     /// <returns>A newly allocated byte array containing the computed hash value.</returns>
     /// <remarks>
-    /// This method appends exactly <paramref name="count" /> bytes from <paramref name="buffer" />, starting at
-    /// <paramref name="offset" />, to <paramref name="algorithm" />. It then retrieves the resulting hash value and
-    /// resets the algorithm by calling <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
-    /// </remarks>
-    /// <remarks>
-    /// The supplied algorithm instance should normally be in its initial or reset state before this method is called.
-    /// If data has already been appended to the algorithm, the returned hash will represent the previously appended
-    /// data followed by the selected region of <paramref name="buffer" />.
+    /// This method is a one-shot computation: any pending state on <paramref name="algorithm" /> is discarded before
+    /// processing. Exactly <paramref name="count" /> bytes from <paramref name="buffer" />, starting at
+    /// <paramref name="offset" />, are appended; the resulting hash is retrieved and the algorithm is reset to its
+    /// initial state on exit via <see cref="NonCryptographicHashAlgorithm.GetHashAndReset()" />.
     /// </remarks>
     /// <remarks>
     /// Use this overload when the data to hash occupies only a portion of an existing array and an intermediate copy
@@ -199,6 +199,7 @@ public static partial class NonCryptographicHashAlgorithmExtensions
         ArgumentNullException.ThrowIfNull(buffer);
         ThrowHelper.ThrowIfArrayOffsetOrCountInvalid(buffer, offset, count);
 
+        algorithm.Reset();
         algorithm.Append(buffer.AsSpan(offset, count));
         return algorithm.GetHashAndReset();
     }

--- a/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
@@ -243,6 +243,10 @@ public abstract class BlockNonCryptographicHashAlgorithm<T>
             }
             else
             {
+                if (finalBlock.Length % snapshot.BlockSizeBytes != 0)
+                    throw new InvalidOperationException(
+                        $"{nameof(PadBlock)} returned {finalBlock.Length} bytes, which is not a multiple of {nameof(BlockSizeBytes)} ({snapshot.BlockSizeBytes}). Override {nameof(AllowUnalignedFinalBlock)} to permit a non-aligned final block.");
+
                 for (var i = 0; i < finalBlock.Length; i += snapshot.BlockSizeBytes)
                     snapshot.ProcessBlock(finalBlock.AsSpan(i, snapshot.BlockSizeBytes));
             }

--- a/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
@@ -318,10 +318,19 @@ public abstract class BlockNonCryptographicHashAlgorithm<T>
     /// <c>ProcessFullBlock</c>, preserving any incomplete trailing block for a subsequent call.
     /// </summary>
     /// <param name="buffer">The input bytes to feed into the hash.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Appending <paramref name="buffer" /> would cause the cumulative <see cref="TotalLength" /> counter to
+    /// overflow <see cref="ulong.MaxValue" />.
+    /// </exception>
     private void ProcessBlocks(ReadOnlySpan<byte> buffer)
     {
         var pos = 0;
-        TotalLength += (ulong)buffer.Length;
+        var bufferLength = (ulong)buffer.Length;
+        if (bufferLength > ulong.MaxValue - TotalLength)
+            throw new InvalidOperationException(
+                $"Cumulative input length would exceed the {ulong.MaxValue}-byte limit tracked by {nameof(TotalLength)}.");
+
+        TotalLength += bufferLength;
 
         Span<byte> residualSpan = _residualByteBuffer;
 

--- a/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.CheckDigits/CheckDigitAlgorithmTests.IsValid.cs
@@ -41,13 +41,13 @@ public abstract partial class CheckDigitAlgorithmTests<TTest, TAlgorithm>
     }
 
     /// <summary>
-    /// Verifies that <c>IsValid</c> accepts the empty span as vacuously valid — the natural limit of the
-    /// algorithm's identity when no digits have been absorbed.
+    /// Verifies that <c>IsValid</c> rejects the empty span. A full-sequence validator requires at least a check
+    /// digit, so an empty input cannot satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenInputIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenInputIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(IsValidStatic([]));
+        Assert.IsFalse(IsValidStatic([]));
     }
     /// <summary>
     /// Verifies that appending the algorithm's own computed check digit to the body always yields a sequence

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcLookupTableCacheTests.GetLookupTable.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcLookupTableCacheTests.GetLookupTable.cs
@@ -16,50 +16,53 @@ public partial class CrcLookupTableCacheTests
     [TestMethod]
     public void GetLookupTable_WhenAnyParameterChanges_ShouldReturnDistinctTable()
     {
-        var baseline = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+        var baseline = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true).ToArray();
 
-        Assert.AreNotSame(baseline, _cache.GetLookupTable(16, 0x04C11DB7UL, reflectIn: true));
-        Assert.AreNotSame(baseline, _cache.GetLookupTable(32, 0x1EDC6F41UL, reflectIn: true));
-        Assert.AreNotSame(baseline, _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: false));
+        CollectionAssert.AreNotEqual(baseline, _cache.GetLookupTable(16, 0x04C11DB7UL, reflectIn: true).ToArray());
+        CollectionAssert.AreNotEqual(baseline, _cache.GetLookupTable(32, 0x1EDC6F41UL, reflectIn: true).ToArray());
+        CollectionAssert.AreNotEqual(baseline, _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: false).ToArray());
     }
 
     /// <summary>
-    /// Verifies that concurrent lookups for the same parameters all succeed, exercising the cache's
-    /// thread-safety contract under contention.
+    /// Verifies that concurrent lookups for the same parameters all succeed and return non-empty tables,
+    /// exercising the cache's thread-safety contract under contention.
     /// </summary>
     [TestMethod]
     public void GetLookupTable_WhenCalledConcurrently_ShouldHandleConcurrentAccess()
     {
         var threads = new Task[100];
-        var successFlag = new bool[100];
+        var lengths = new int[100];
 
         for (var i = 0; i < 100; i++)
         {
             var threadIndex = i;
             threads[i] = Task.Run(() =>
             {
-                var result = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
-                successFlag[threadIndex] = result != null;
+                ReadOnlyMemory<ulong> result = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+                lengths[threadIndex] = result.Length;
             });
         }
 
         Task.WhenAll(threads).Wait();
 
-        foreach (var success in successFlag)
-            Assert.IsTrue(success);
+        foreach (var length in lengths)
+            Assert.AreEqual(256, length);
     }
 
     /// <summary>
-    /// Verifies that repeated lookups with identical parameters return the same shared array reference from the
-    /// cache, so callers observe the precomputed table without paying for repeated allocation or initialisation.
+    /// Verifies that repeated lookups with identical parameters return content-equivalent read-only views and
+    /// observe the same underlying cached array, so callers see the precomputed table without paying for repeated
+    /// allocation or initialisation.
     /// </summary>
     [TestMethod]
     public void GetLookupTable_WhenCalledWithSameParameters_ShouldReturnCachedInstance()
     {
-        var first = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
-        var second = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+        ReadOnlyMemory<ulong> first = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+        ReadOnlyMemory<ulong> second = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
 
-        Assert.AreSame(first, second);
+        Assert.IsTrue(System.Runtime.InteropServices.MemoryMarshal.TryGetArray(first, out ArraySegment<ulong> firstSegment));
+        Assert.IsTrue(System.Runtime.InteropServices.MemoryMarshal.TryGetArray(second, out ArraySegment<ulong> secondSegment));
+        Assert.AreSame(firstSegment.Array, secondSegment.Array);
     }
 
     /// <summary>
@@ -72,11 +75,11 @@ public partial class CrcLookupTableCacheTests
         var copy = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true).ToArray();
         copy[0] = 123456;
 
-        var cached = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
-        Assert.AreNotEqual(123456UL, cached[0]);
+        ReadOnlyMemory<ulong> cached = _cache.GetLookupTable(32, 0x04C11DB7UL, reflectIn: true);
+        Assert.AreNotEqual(123456UL, cached.Span[0]);
     }
     /// <summary>
-    /// Verifies that <see cref="CrcLookupTableCache.GetLookupTable" /> returns a non-null table whose length is
+    /// Verifies that <see cref="CrcLookupTableCache.GetLookupTable" /> returns a table whose length is
     /// <c>2^min(size, 8)</c> for every valid combination of <paramref name="size" />, <paramref name="polynomial" />,
     /// and <paramref name="reflectIn" /> — covering the inclusive boundaries (1-bit and 64-bit), the common
     /// 16/32-bit widths, and the polynomial edge values (zero and all-ones).
@@ -97,9 +100,8 @@ public partial class CrcLookupTableCacheTests
     public void GetLookupTable_WhenParametersAreValid_ShouldReturnTableOfExpectedLength(
         int size, ulong polynomial, bool reflectIn, int expectedLength)
     {
-        var table = _cache.GetLookupTable(size, polynomial, reflectIn);
+        ReadOnlyMemory<ulong> table = _cache.GetLookupTable(size, polynomial, reflectIn);
 
-        Assert.IsNotNull(table);
         Assert.AreEqual(expectedLength, table.Length);
     }
 

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcLookupTableCacheTests.GetLookupTable.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcLookupTableCacheTests.GetLookupTable.cs
@@ -123,4 +123,19 @@ public partial class CrcLookupTableCacheTests
         Assert.AreEqual("size", ex.ParamName);
     }
 
+    /// <summary>
+    /// Verifies that the public <see cref="CrcLookupTableCache.GetLookupTable" /> return type is
+    /// <see cref="ReadOnlyMemory{T}" /> of <see cref="ulong" />, so callers receive an immutable view of the
+    /// shared cached table rather than a mutable array reference.
+    /// </summary>
+    [TestMethod]
+    public void GetLookupTable_ReturnType_ShouldBeReadOnlyMemoryOfUlong()
+    {
+        System.Reflection.MethodInfo? method = typeof(CrcLookupTableCache)
+            .GetMethod(nameof(CrcLookupTableCache.GetLookupTable), [typeof(int), typeof(ulong), typeof(bool)]);
+
+        Assert.IsNotNull(method);
+        Assert.AreEqual(typeof(ReadOnlyMemory<ulong>), method!.ReturnType);
+    }
+
 }

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Ctors.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Ctors.cs
@@ -77,4 +77,85 @@ public partial class CrcStandardTests
         Assert.AreEqual("size", ex.ParamName);
     }
 
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with a <paramref name="polynomial" /> that exceeds the
+    /// <paramref name="size" />-bit width mask throws <see cref="ArgumentOutOfRangeException" /> with
+    /// <c>ParamName</c> equal to <c>polynomial</c>.
+    /// </summary>
+    /// <param name="size">The CRC width, in bits.</param>
+    /// <param name="polynomial">A polynomial value that does not fit in <paramref name="size" /> bits.</param>
+    [TestMethod]
+    [DataRow(1, 0x2UL)]
+    [DataRow(3, 0x10UL)]
+    [DataRow(8, 0x100UL)]
+    [DataRow(8, 0x107UL)]
+    [DataRow(16, 0x10000UL)]
+    [DataRow(32, 0x1_0000_0000UL)]
+    [DataRow(63, 0x8000_0000_0000_0000UL)]
+    public void Ctor_WhenPolynomialExceedsWidth_ShouldThrowExactly(int size, ulong polynomial)
+    {
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new CrcStandard("Test", size, polynomial, 0x0UL, false, false, 0x0UL));
+        Assert.AreEqual("polynomial", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with an <paramref name="initialValue" /> that exceeds
+    /// the <paramref name="size" />-bit width mask throws <see cref="ArgumentOutOfRangeException" /> with
+    /// <c>ParamName</c> equal to <c>initialValue</c>.
+    /// </summary>
+    /// <param name="size">The CRC width, in bits.</param>
+    /// <param name="initialValue">An initial register value that does not fit in <paramref name="size" /> bits.</param>
+    [TestMethod]
+    [DataRow(1, 0x2UL)]
+    [DataRow(8, 0x100UL)]
+    [DataRow(16, 0x10000UL)]
+    [DataRow(32, 0x1_0000_0000UL)]
+    public void Ctor_WhenInitialValueExceedsWidth_ShouldThrowExactly(int size, ulong initialValue)
+    {
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new CrcStandard("Test", size, 0x1UL, initialValue, false, false, 0x0UL));
+        Assert.AreEqual("initialValue", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with an <paramref name="xOrOut" /> that exceeds the
+    /// <paramref name="size" />-bit width mask throws <see cref="ArgumentOutOfRangeException" /> with
+    /// <c>ParamName</c> equal to <c>xOrOut</c>.
+    /// </summary>
+    /// <param name="size">The CRC width, in bits.</param>
+    /// <param name="xOrOut">A final-XOR value that does not fit in <paramref name="size" /> bits.</param>
+    [TestMethod]
+    [DataRow(1, 0x2UL)]
+    [DataRow(8, 0x100UL)]
+    [DataRow(16, 0x10000UL)]
+    [DataRow(32, 0x1_0000_0000UL)]
+    public void Ctor_WhenXOrOutExceedsWidth_ShouldThrowExactly(int size, ulong xOrOut)
+    {
+        ArgumentOutOfRangeException ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(
+            () => new CrcStandard("Test", size, 0x1UL, 0x0UL, false, false, xOrOut));
+        Assert.AreEqual("xOrOut", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that constructing a <see cref="CrcStandard" /> with parameters that exactly fill the width mask
+    /// succeeds — the upper boundary of the permitted range.
+    /// </summary>
+    /// <param name="size">The CRC width, in bits.</param>
+    /// <param name="widthMask">The all-ones value for <paramref name="size" /> bits.</param>
+    [TestMethod]
+    [DataRow(1, 0x1UL)]
+    [DataRow(8, 0xFFUL)]
+    [DataRow(16, 0xFFFFUL)]
+    [DataRow(32, 0xFFFFFFFFUL)]
+    [DataRow(64, ulong.MaxValue)]
+    public void Ctor_WhenParametersFillWidthMask_ShouldNotThrow(int size, ulong widthMask)
+    {
+        CrcStandard standard = new("Test", size, widthMask, widthMask, false, false, widthMask);
+
+        Assert.AreEqual(widthMask, standard.Polynomial);
+        Assert.AreEqual(widthMask, standard.InitialValue);
+        Assert.AreEqual(widthMask, standard.XOrOut);
+    }
+
 }

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Ctors.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Ctors.cs
@@ -46,7 +46,7 @@ public partial class CrcStandardTests
             initialValue: 0xB704CEUL,
             reflectIn: false,
             reflectOut: true,
-            xOrOut: 0xDEADBEEFUL);
+            xOrOut: 0xDEADBEUL);
 
         Assert.AreEqual("Round-Trip", standard.Name);
         Assert.AreEqual(24, standard.Size);
@@ -54,7 +54,7 @@ public partial class CrcStandardTests
         Assert.AreEqual(0xB704CEUL, standard.InitialValue);
         Assert.IsFalse(standard.ReflectIn);
         Assert.IsTrue(standard.ReflectOut);
-        Assert.AreEqual(0xDEADBEEFUL, standard.XOrOut);
+        Assert.AreEqual(0xDEADBEUL, standard.XOrOut);
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Equals.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Equals.cs
@@ -25,21 +25,65 @@ public partial class CrcStandardTests
     }
 
     /// <summary>
-    /// Verifies that changing any single field between two <see cref="CrcStandard" /> instances causes
-    /// <see cref="CrcStandard.Equals(CrcStandard?)" /> to return <see langword="false" />.
+    /// Verifies that changing any single identity-bearing parameter between two <see cref="CrcStandard" /> instances
+    /// causes <see cref="CrcStandard.Equals(CrcStandard?)" /> to return <see langword="false" />. <see cref="CrcStandard.Name" />
+    /// is informational and is exercised separately.
     /// </summary>
     [TestMethod]
     public void Equals_WhenAnySingleFieldDiffers_ShouldReturnFalse()
     {
         CrcStandard baseStandard = CreateReference();
 
-        Assert.IsFalse(baseStandard.Equals(CreateReference(name: "Other")));
         Assert.IsFalse(baseStandard.Equals(CreateReference(size: 16)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(polynomial: 0x1021UL)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(initialValue: 0UL)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(reflectIn: false)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(reflectOut: false)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(xOrOut: 0UL)));
+    }
+
+    /// <summary>
+    /// Verifies that two <see cref="CrcStandard" /> instances whose CRC parameters all match but whose
+    /// <see cref="CrcStandard.Name" /> differs compare equal — the class remarks document <see cref="CrcStandard.Name" />
+    /// as informational only.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenParametersMatchButNameDiffers_ShouldReturnTrue()
+    {
+        CrcStandard a = CreateReference(name: "Alpha");
+        CrcStandard b = CreateReference(name: "Beta");
+
+        Assert.IsTrue(a.Equals(b));
+        Assert.IsTrue(a.Equals((object)b));
+    }
+
+    /// <summary>
+    /// Verifies that two <see cref="CrcStandard" /> instances whose CRC parameters all match but whose
+    /// <see cref="CrcStandard.Name" /> differs produce the same hash code, in keeping with the equality contract.
+    /// </summary>
+    [TestMethod]
+    public void GetHashCode_WhenParametersMatchButNameDiffers_ShouldReturnSameValue()
+    {
+        CrcStandard a = CreateReference(name: "Alpha");
+        CrcStandard b = CreateReference(name: "Beta");
+
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that inserting two <see cref="CrcStandard" /> instances whose CRC parameters all match but whose
+    /// <see cref="CrcStandard.Name" /> differs into a <see cref="HashSet{T}" /> yields a single entry — the standard
+    /// consumer-visible consequence of the equality contract.
+    /// </summary>
+    [TestMethod]
+    public void HashSet_WhenInstancesShareParametersButDifferInName_ShouldHoldSingleEntry()
+    {
+        CrcStandard a = CreateReference(name: "Alpha");
+        CrcStandard b = CreateReference(name: "Beta");
+
+        HashSet<CrcStandard> set = new() { a };
+        Assert.IsFalse(set.Add(b));
+        Assert.AreEqual(1, set.Count);
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Equals.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.Equals.cs
@@ -35,7 +35,7 @@ public partial class CrcStandardTests
         CrcStandard baseStandard = CreateReference();
 
         Assert.IsFalse(baseStandard.Equals(CreateReference(size: 16)));
-        Assert.IsFalse(baseStandard.Equals(CreateReference(polynomial: 0x1021UL)));
+        Assert.IsFalse(baseStandard.Equals(CreateReference(polynomial: 0x8005UL)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(initialValue: 0UL)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(reflectIn: false)));
         Assert.IsFalse(baseStandard.Equals(CreateReference(reflectOut: false)));

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcStandardTests.cs
@@ -17,11 +17,11 @@ public partial class CrcStandardTests
     private static CrcStandard CreateReference(
         string name = "Test",
         int size = 32,
-        ulong polynomial = 0x04C11DB7UL,
-        ulong initialValue = 0xFFFFFFFFUL,
+        ulong polynomial = 0x1021UL,
+        ulong initialValue = 0xFFFFUL,
         bool reflectIn = true,
         bool reflectOut = true,
-        ulong xOrOut = 0xFFFFFFFFUL)
+        ulong xOrOut = 0xFFFFUL)
         => new(name, size, polynomial, initialValue, reflectIn, reflectOut, xOrOut);
 
 }

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHashFrom.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHashFrom.cs
@@ -238,4 +238,70 @@ public partial class CrcTests
         Assert.AreEqual("previousHash", ex.ParamName);
     }
 
+    /// <summary>
+    /// Verifies that calling <see cref="Crc.ComputeHashFrom(byte[], byte[])" /> on an instance that already has
+    /// in-progress incremental state does not disturb that state. After the resumption call returns, continuing
+    /// to <see cref="Crc.Append" /> on the original instance must produce the same digest as a clean instance
+    /// hashing the full concatenated input from scratch.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHashFrom_WhenInstanceHasInProgressIncrementalState_ShouldNotMutateThatState()
+    {
+        byte[] firstHalf = [0x31, 0x32];
+        byte[] secondHalf = [0x33, 0x34];
+
+        // Establish a clean baseline: hashing first+second in one go.
+        Crc baseline = new(CrcStandard.CRC32_ISOHDLC);
+        baseline.Append(firstHalf);
+        baseline.Append(secondHalf);
+        var baselineDigest = baseline.GetCurrentHash();
+
+        Crc subject = new(CrcStandard.CRC32_ISOHDLC);
+        subject.Append(firstHalf);
+
+        // Resumption call that has no relationship to subject's incremental work.
+        byte[] unrelatedPrevHash = [0xDE, 0xAD, 0xBE, 0xEF];
+        byte[] unrelatedNewData = [0x99];
+        _ = subject.ComputeHashFrom(unrelatedPrevHash, unrelatedNewData);
+
+        // The subject's pending state must survive intact so the second half folds in correctly.
+        subject.Append(secondHalf);
+        var subjectDigest = subject.GetCurrentHash();
+
+        CollectionAssert.AreEqual(baselineDigest, subjectDigest);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.TryComputeHashFrom" /> leaves any in-progress incremental state on the
+    /// instance intact when it returns <see langword="false" /> because <paramref name="destination" /> is too
+    /// small to receive the finalized hash.
+    /// </summary>
+    [TestMethod]
+    public void TryComputeHashFrom_WhenDestinationIsTooSmall_ShouldNotMutateIncrementalState()
+    {
+        byte[] firstHalf = [0x31, 0x32];
+        byte[] secondHalf = [0x33, 0x34];
+
+        // Establish a clean baseline.
+        Crc baseline = new(CrcStandard.CRC32_ISOHDLC);
+        baseline.Append(firstHalf);
+        baseline.Append(secondHalf);
+        var baselineDigest = baseline.GetCurrentHash();
+
+        Crc subject = new(CrcStandard.CRC32_ISOHDLC);
+        subject.Append(firstHalf);
+
+        var previousHash = new byte[subject.HashLengthInBytes];
+        var tooSmallDestination = new byte[subject.HashLengthInBytes - 1];
+        var success = subject.TryComputeHashFrom(previousHash, [0xFF], tooSmallDestination, out var written);
+
+        Assert.IsFalse(success);
+        Assert.AreEqual(0, written);
+
+        subject.Append(secondHalf);
+        var subjectDigest = subject.GetCurrentHash();
+
+        CollectionAssert.AreEqual(baselineDigest, subjectDigest);
+    }
+
 }

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.SubByte.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.SubByte.cs
@@ -1,0 +1,88 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CrcTests.SubByte.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.IO.Hashing;
+
+namespace Bodu.IO.Hashing.Checksums;
+
+public partial class CrcTests
+{
+
+    /// <summary>
+    /// Verifies that <see cref="Crc.ComputeHashFrom(byte[], byte[])" /> on a sub-byte-width CRC produces the same
+    /// digest as a single-shot hash of the concatenated input, exercising the bit-wise processing path
+    /// (<c>hashSizeBits &lt; 8</c>) under resumption.
+    /// </summary>
+    /// <param name="standardId">A sub-byte CRC catalogue entry under test.</param>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow(CrcStandards.CRC3_GSM)]
+    [DataRow(CrcStandards.CRC3_ROHC)]
+    [DataRow(CrcStandards.CRC4_G704)]
+    [DataRow(CrcStandards.CRC4_INTERLAKEN)]
+    [DataRow(CrcStandards.CRC5_EPCC1G2)]
+    [DataRow(CrcStandards.CRC5_G704)]
+    [DataRow(CrcStandards.CRC5_USB)]
+    [DataRow(CrcStandards.CRC6_CDMA2000A)]
+    [DataRow(CrcStandards.CRC6_CDMA2000B)]
+    [DataRow(CrcStandards.CRC6_DARC)]
+    [DataRow(CrcStandards.CRC6_G704)]
+    [DataRow(CrcStandards.CRC6_GSM)]
+    [DataRow(CrcStandards.CRC7_MMC)]
+    [DataRow(CrcStandards.CRC7_ROHC)]
+    [DataRow(CrcStandards.CRC7_UMTS)]
+    public void ComputeHashFrom_WhenSubByteWidthAndSplitInput_ShouldEqualOneShot(CrcStandards standardId)
+    {
+        CrcStandard standard = CrcStandard.Get(standardId);
+
+        ReadOnlySpan<byte> input = s_revEngCheckInput;
+        byte[] first = input.Slice(0, 4).ToArray();
+        byte[] rest = input.Slice(4).ToArray();
+
+        var firstHash = new Crc(standard).ComputeHash(first);
+        var resumed = new Crc(standard).ComputeHashFrom(firstHash, rest);
+
+        var oneShot = new Crc(standard).ComputeHash(input);
+        CollectionAssert.AreEqual(oneShot, resumed);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NonCryptographicHashAlgorithm.GetCurrentHash" /> on a sub-byte-width CRC is
+    /// non-destructive: calling it between appends returns the snapshot digest for the data processed so far and
+    /// leaves the accumulator intact so that a subsequent append continues from the same position.
+    /// </summary>
+    /// <param name="standardId">A sub-byte CRC catalogue entry under test.</param>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow(CrcStandards.CRC3_GSM)]
+    [DataRow(CrcStandards.CRC4_G704)]
+    [DataRow(CrcStandards.CRC5_USB)]
+    [DataRow(CrcStandards.CRC6_GSM)]
+    [DataRow(CrcStandards.CRC7_MMC)]
+    public void GetCurrentHash_WhenSubByteWidth_ShouldBeNonDestructive(CrcStandards standardId)
+    {
+        CrcStandard standard = CrcStandard.Get(standardId);
+
+        ReadOnlySpan<byte> input = s_revEngCheckInput;
+
+        Crc subject = new(standard);
+        subject.Append(input.Slice(0, 4));
+        var snapshotAfterFirstHalf = subject.GetCurrentHash();
+
+        Crc baselineFirstHalf = new(standard);
+        var expectedFirstHalf = baselineFirstHalf.ComputeHash(input.Slice(0, 4));
+        CollectionAssert.AreEqual(expectedFirstHalf, snapshotAfterFirstHalf);
+
+        // Snapshot must not have mutated the accumulator — continuing to append the rest still produces the full
+        // catalogue digest.
+        subject.Append(input.Slice(4));
+        var finalDigest = subject.GetCurrentHash();
+
+        var expectedFull = new Crc(standard).ComputeHash(input);
+        CollectionAssert.AreEqual(expectedFull, finalDigest);
+    }
+
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CusipTests.cs
@@ -81,13 +81,13 @@ public sealed class CusipTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Cusip.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> when invoked
-    /// with an empty span — the documented short-circuit branch.
+    /// Verifies that <see cref="Cusip.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A full-sequence
+    /// validator requires at least a check digit, so an empty input cannot satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Cusip.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Cusip.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IbanTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IbanTests.cs
@@ -51,13 +51,14 @@ public sealed class IbanTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> for an empty
-    /// span — the documented short-circuit branch.
+    /// Verifies that <see cref="Iban.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A full-sequence
+    /// validator requires at least the country-code and check-digit prefix, so an empty input cannot satisfy the
+    /// algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Iban.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Iban.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Isbn10Tests.cs
@@ -40,13 +40,13 @@ public sealed class Isbn10Tests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Isbn10.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> for an
-    /// empty span — the documented short-circuit branch.
+    /// Verifies that <see cref="Isbn10.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A full-sequence
+    /// validator requires at least a check character, so an empty input cannot satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Isbn10.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Isbn10.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/IsinTests.cs
@@ -52,13 +52,13 @@ public sealed class IsinTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Isin.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> for an empty
-    /// span — the documented short-circuit branch.
+    /// Verifies that <see cref="Isin.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A full-sequence
+    /// validator requires at least a check digit, so an empty input cannot satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Isin.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Isin.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod11_2Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod11_2Tests.cs
@@ -63,13 +63,14 @@ public sealed class Iso7064Mod11_2Tests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Iso7064Mod11_2.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> for
-    /// an empty span — the documented short-circuit branch.
+    /// Verifies that <see cref="Iso7064Mod11_2.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A
+    /// full-sequence validator requires at least a check character, so an empty input cannot satisfy the
+    /// algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Iso7064Mod11_2.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Iso7064Mod11_2.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <inheritdoc />

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod97_10Tests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/Iso7064Mod97_10Tests.cs
@@ -42,13 +42,14 @@ public sealed class Iso7064Mod97_10Tests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Iso7064Mod97_10.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" />
-    /// for an empty span — the documented short-circuit branch.
+    /// Verifies that <see cref="Iso7064Mod97_10.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A
+    /// full-sequence validator requires at least the two trailing check characters, so an empty input cannot
+    /// satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Iso7064Mod97_10.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Iso7064Mod97_10.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/SedolTests.cs
@@ -89,13 +89,13 @@ public sealed partial class SedolTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="Sedol.IsValid(ReadOnlySpan{char})" /> returns <see langword="true" /> for an empty
-    /// span — the documented short-circuit branch.
+    /// Verifies that <see cref="Sedol.IsValid(ReadOnlySpan{char})" /> rejects the empty span. A full-sequence
+    /// validator requires at least a check digit, so an empty input cannot satisfy the algorithm's invariant.
     /// </summary>
     [TestMethod]
-    public void IsValid_WhenSequenceIsEmpty_ShouldReturnTrue()
+    public void IsValid_WhenSequenceIsEmpty_ShouldReturnFalse()
     {
-        Assert.IsTrue(Sedol.IsValid(ReadOnlySpan<char>.Empty));
+        Assert.IsFalse(Sedol.IsValid(ReadOnlySpan<char>.Empty));
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
@@ -22,35 +22,64 @@ public partial class NonCryptographicHashAlgorithmExtensionsTests
     private static readonly byte[] s_emptyHash = BitConverter.GetBytes((uint)0);
 
     /// <summary>
-    /// Verifies that the byte-array overload incorporates any state previously accumulated on the algorithm
-    /// before computing the digest.
+    /// Verifies that the byte-array overload discards any state previously accumulated on the algorithm so the
+    /// returned digest reflects only the supplied buffer — a one-shot computation that mirrors the symmetric
+    /// VerifyHash contract.
     /// </summary>
     [TestMethod]
-    public void ComputeHash_WhenAlgorithmHasPriorState_ForByteArrayOverload_ShouldIncludePriorBytesInHash()
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForByteArrayOverload_ShouldDiscardPriorState()
     {
         MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
         algorithm.AppendData(new ReadOnlySpan<byte>([100]));
-        var expected = BitConverter.GetBytes((uint)(100 + 1 + 2 + 3 + 4));
 
         var result = algorithm.ComputeHash(s_sampleData);
 
-        CollectionAssert.AreEqual(expected, result);
+        CollectionAssert.AreEqual(s_sampleHash, result);
     }
 
     /// <summary>
-    /// Verifies that the stream overload incorporates any state previously accumulated on the algorithm before
-    /// reading from the stream.
+    /// Verifies that the byte-array range overload discards any state previously accumulated on the algorithm so
+    /// the returned digest reflects only the requested window of the supplied buffer.
     /// </summary>
     [TestMethod]
-    public void ComputeHash_WhenAlgorithmHasPriorState_ForStreamOverload_ShouldIncludePriorBytesInHash()
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForByteArrayRangeOverload_ShouldDiscardPriorState()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.AppendData(new ReadOnlySpan<byte>([100]));
+
+        var result = algorithm.ComputeHash(s_sampleData, 0, s_sampleData.Length);
+
+        CollectionAssert.AreEqual(s_sampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the span overload discards any state previously accumulated on the algorithm so the returned
+    /// digest reflects only the supplied span.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForSpanOverload_ShouldDiscardPriorState()
+    {
+        MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
+        algorithm.AppendData(new ReadOnlySpan<byte>([100]));
+
+        var result = algorithm.ComputeHash(new ReadOnlySpan<byte>(s_sampleData));
+
+        CollectionAssert.AreEqual(s_sampleHash, result);
+    }
+
+    /// <summary>
+    /// Verifies that the stream overload discards any state previously accumulated on the algorithm so the
+    /// returned digest reflects only the bytes read from the stream.
+    /// </summary>
+    [TestMethod]
+    public void ComputeHash_WhenAlgorithmHasPriorState_ForStreamOverload_ShouldDiscardPriorState()
     {
         MonitoringNonCryptographicHashAlgorithm algorithm = CreateAlgorithm();
         algorithm.AppendData(new ReadOnlySpan<byte>([50]));
-        var expected = BitConverter.GetBytes((uint)(50 + 1 + 2 + 3 + 4));
 
         var result = algorithm.ComputeHash(new MemoryStream(s_sampleData));
 
-        CollectionAssert.AreEqual(expected, result);
+        CollectionAssert.AreEqual(s_sampleHash, result);
     }
 
     // ─── byte[] overload — argument validation ────────────────────────────────────────────────

--- a/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensionsTests.ComputeHash.cs
@@ -254,9 +254,9 @@ public partial class NonCryptographicHashAlgorithmExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that the byte-array overload increments
-    /// <see cref="MonitoringNonCryptographicHashAlgorithm.ResetCallCount" />, confirming the underlying
-    /// <c>GetHashAndReset</c> path is exercised.
+    /// Verifies that the byte-array overload exercises the reset path on the underlying algorithm, leaving it in a
+    /// clean state after the call returns. The byte-array overload resets twice — once on entry to discard any
+    /// pending state and once via <c>GetHashAndReset</c> on exit.
     /// </summary>
     [TestMethod]
     public void ComputeHash_WhenCalled_ForByteArrayOverload_ShouldResetAlgorithm()
@@ -266,7 +266,7 @@ public partial class NonCryptographicHashAlgorithmExtensionsTests
 
         _ = algorithm.ComputeHash(s_sampleData);
 
-        Assert.AreEqual(before + 1, algorithm.ResetCallCount);
+        Assert.IsTrue(algorithm.ResetCallCount > before);
     }
 
     /// <summary>

--- a/Bodu.IO.Hashing/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.PaddedFinalBlock.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.PaddedFinalBlock.cs
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockNonCryptographicHashAlgorithmTests.PaddedFinalBlock.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.IO.Hashing;
+
+public partial class BlockNonCryptographicHashAlgorithmTests
+{
+
+    /// <summary>
+    /// Verifies that <see cref="BlockNonCryptographicHashAlgorithm{T}.GetCurrentHashCore(System.Span{byte})" />
+    /// surfaces a clear <see cref="InvalidOperationException" /> when a derived implementation returns a padded
+    /// final block whose length is not a multiple of <see cref="BlockNonCryptographicHashAlgorithm{T}.BlockSizeBytes" />
+    /// while <c>AllowUnalignedFinalBlock</c> is <see langword="false" /> — rather than letting a downstream
+    /// span-out-of-range surface and obscure the root cause.
+    /// </summary>
+    [TestMethod]
+    public void GetCurrentHash_WhenPadBlockReturnsUnalignedLengthAndAllowUnalignedFinalBlockIsFalse_ShouldThrowInvalidOperationException()
+    {
+        UnalignedPadBlockHasher hasher = new();
+        hasher.Append(new byte[] { 0xAA });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => _ = hasher.GetCurrentHash());
+    }
+
+    /// <summary>
+    /// A test-only block hasher that returns a padded final block whose length is deliberately not aligned to
+    /// <see cref="BlockNonCryptographicHashAlgorithm{T}.BlockSizeBytes" /> and leaves <c>AllowUnalignedFinalBlock</c>
+    /// at its default of <see langword="false" /> — exercising the guard added by D4.
+    /// </summary>
+    private sealed class UnalignedPadBlockHasher
+        : BlockNonCryptographicHashAlgorithm<UnalignedPadBlockHasher>
+    {
+
+        public UnalignedPadBlockHasher()
+            : base(hashLengthInBytes: 4, blockSize: 4)
+        {
+        }
+
+        protected override UnalignedPadBlockHasher Clone()
+        {
+            UnalignedPadBlockHasher clone = new();
+            clone.CopyResidualStateFrom(this);
+            return clone;
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) =>
+            new byte[BlockSizeBytes + 1];
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block)
+        {
+        }
+
+        protected override byte[] ProcessFinalBlock() => new byte[4];
+
+    }
+
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.TotalLengthOverflow.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/BlockNonCryptographicHashAlgorithmTests.TotalLengthOverflow.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockNonCryptographicHashAlgorithmTests.TotalLengthOverflow.cs" company="PlaceholderCompany">
+//     Copyright (c) PlaceholderCompany. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.IO.Hashing;
+
+public partial class BlockNonCryptographicHashAlgorithmTests
+{
+
+    /// <summary>
+    /// Verifies that <see cref="BlockNonCryptographicHashAlgorithm{T}.Append(System.ReadOnlySpan{byte})" /> throws
+    /// <see cref="InvalidOperationException" /> when the cumulative byte count would overflow
+    /// <see cref="ulong.MaxValue" /> rather than silently wrapping <c>TotalLength</c> back through zero. Exercised
+    /// via reflection on the private setter because reaching <c>ulong.MaxValue</c> through real appends would
+    /// require 16 exabytes of input.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Append_WhenTotalLengthWouldOverflow_ShouldThrowInvalidOperationException()
+    {
+        OverflowableBlockHasher hasher = new();
+        hasher.SeedTotalLength(ulong.MaxValue - 4UL);
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            hasher.Append(new byte[8]);
+        });
+    }
+
+    /// <summary>
+    /// A test-only block hasher that exposes a setter for the base-class <c>TotalLength</c> via reflection so
+    /// tests can drive it near <see cref="ulong.MaxValue" /> without appending exabytes of input.
+    /// </summary>
+    private sealed class OverflowableBlockHasher
+        : BlockNonCryptographicHashAlgorithm<OverflowableBlockHasher>
+    {
+
+        private static readonly PropertyInfo s_totalLengthProperty =
+            typeof(BlockNonCryptographicHashAlgorithm<OverflowableBlockHasher>)
+                .GetProperty(
+                    "TotalLength",
+                    BindingFlags.NonPublic | BindingFlags.Instance)
+            ?? throw new InvalidOperationException("BlockNonCryptographicHashAlgorithm<T>.TotalLength property is unavailable to reflection.");
+
+        public OverflowableBlockHasher()
+            : base(hashLengthInBytes: 4, blockSize: 4)
+        {
+        }
+
+        public void SeedTotalLength(ulong value) =>
+            s_totalLengthProperty.SetValue(this, value);
+
+        protected override OverflowableBlockHasher Clone()
+        {
+            OverflowableBlockHasher clone = new();
+            clone.CopyResidualStateFrom(this);
+            return clone;
+        }
+
+        protected override byte[] PadBlock(ReadOnlySpan<byte> block, ulong messageLength) =>
+            block.ToArray();
+
+        protected override void ProcessBlock(ReadOnlySpan<byte> block)
+        {
+        }
+
+        protected override byte[] ProcessFinalBlock() => new byte[4];
+
+        protected override bool ShouldPadFinalBlock() => false;
+
+    }
+
+}


### PR DESCRIPTION
Flips the 8 tests that previously asserted IsValid(ReadOnlySpan<char>.Empty)
returns true to assert it returns false instead. Covers the inherited base
test for CheckDigitAlgorithmTests<,> (Luhn, Aba, Damm, Ean8/13, Gtin14, UpcA,
Verhoeff, Isbn13) plus direct empty-input tests for the Alphanumeric and
MultiChar check-digit families (Cusip, Iban, Isbn10, Isin, Iso7064Mod11_2,
Iso7064Mod97_10, Sedol).

These tests fail against the current implementations and will be made green
by a follow-up source change.