### PR TITLE
Add NSW Anzac Day weekend-substitute trial (2026–2027)

### DIFF
--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-au.xml
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/Resources/region-au.xml
@@ -106,6 +106,37 @@
       <Tag>NationalHoliday</Tag>
       <Adjustment key="nt-weekend-sub" when="IfWeekend" action="MoveToNextWeekday" />
     </Rule>
+    <!--
+      New South Wales — two-year Anzac Day weekend-substitute trial (2026 and 2027 only).
+
+      Announced 15 February 2026 by the Minns Labor Government (Premier Chris Minns; Industrial Relations Minister
+      Sophie Cotsis) as an additional public holiday on the Monday following Anzac Day when 25 April falls on a
+      weekend. The trial covers exactly two years because Anzac Day falls on Saturday 25 April 2026 and Sunday
+      25 April 2027 — both years produce a substitute Monday (Monday 27 April 2026 and Monday 26 April 2027).
+
+      Under the Public Holidays Act 2010 (NSW) Anzac Day is fixed to 25 April regardless of weekday; the additional
+      Monday is gazetted as a separate public holiday for the trial period. The arrangement brings NSW into line with
+      Western Australia and the ACT for those two years. A review of NSW public holidays commencing in 2027 will
+      consider whether the substitute becomes a permanent fixture; if it does, the adjustment's effective-year window
+      below should be extended (or the bounds removed) accordingly.
+
+      Implementation note: the trial is expressed by bounding the *adjustment* (fromYear/toYear), not the rule. This
+      keeps the rule present in every year so same-name territory shadowing reliably routes AU-NSW queries through
+      the NSW entry; outside the trial window the adjustment is dormant and the rule emits the canonical 25 April
+      base date unchanged. A follow-up engine change to make territory shadowing year-aware would allow rule-level
+      firstYear/lastYear bounds to express the trial more directly.
+
+      Source: https://www.nsw.gov.au/ministerial-releases/minns-labor-government-announces-extra-public-holiday-year
+    -->
+    <Rule name="fixed-apr-25-au-nsw"
+          category="Remembrance"
+          territory="AU-NSW"
+          nonWorking="true"
+          comment="NSW Anzac Day with a weekend-substitute Monday gated to the 2026–2027 trial period.">
+      <Fixed month="April" day="25" />
+      <Tag>NationalHoliday</Tag>
+      <Adjustment key="nsw-2026-2027-weekend-sub" when="IfWeekend" action="MoveToNextWeekday" fromYear="2026" toYear="2027" />
+    </Rule>
   </NotableDate>
 
   <NotableDate name="Boxing Day">

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/test/AustralianNotableDatesTests.cs
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/test/AustralianNotableDatesTests.cs
@@ -215,11 +215,11 @@ public sealed class AustralianNotableDatesTests
 
     /// <summary>
     /// Verifies that querying any Australian subdivision returns Anzac Day on 25 April 2026 (a Saturday) for the
-    /// subdivisions that do not publish their own narrower rule (NSW, VIC, QLD, SA, TAS, ACT). WA and NT have their
-    /// own subdivision-scoped rules with weekend substitutes — those are exercised separately.
+    /// subdivisions that do not publish their own narrower rule (VIC, QLD, SA, TAS, ACT). NSW, WA, and NT have their
+    /// own subdivision-scoped rules with weekend substitutes — those are exercised separately. The 2026 trial brought
+    /// NSW into this set; prior to the trial NSW was a canonical-AU subdivision.
     /// </summary>
     [TestMethod]
-    [DataRow("AU-NSW")]
     [DataRow("AU-VIC")]
     [DataRow("AU-QLD")]
     [DataRow("AU-SA")]
@@ -262,14 +262,18 @@ public sealed class AustralianNotableDatesTests
     }
 
     /// <summary>
-    /// Verifies that New South Wales does NOT observe a substitute Monday when Anzac Day falls on a Saturday (25 April
-    /// 2020): NSW has no narrower rule, so the canonical AU rule wins and emits the unadjusted Saturday observance.
+    /// Verifies that New South Wales does NOT observe a substitute Monday when Anzac Day falls on a Saturday outside
+    /// the 2026–2027 Minns-government trial. The NSW rule's adjustment is dormant outside the trial window so the
+    /// rule emits the base 25 April observance unchanged. The emission carries the AU-NSW territory code because the
+    /// NSW rule shadows the canonical AU rule whenever it is queried — its adjustment being dormant does not retire
+    /// the rule itself.
     /// </summary>
     [TestMethod]
-    public void GetNotableDates_WhenAnzacDayOnSaturday_ShouldNotEmitSubstitute_ForAuNsw()
+    public void GetNotableDates_WhenAnzacDayOnSaturdayOutsideTrial_ShouldNotEmitSubstitute_ForAuNsw()
     {
         var service = BuildAuService();
 
+        // 25 April 2020 was a Saturday — outside the NSW 2026–2027 trial window, so the adjustment does not fire.
         var occurrences = service.GetNotableDates(2020, "AU-NSW")
             .Where(d => d.Name == "Anzac Day")
             .ToList();
@@ -277,7 +281,54 @@ public sealed class AustralianNotableDatesTests
         Assert.AreEqual(1, occurrences.Count);
         Assert.AreEqual(new DateTime(2020, 4, 25), occurrences[0].Date);
         Assert.IsFalse(occurrences[0].WasAdjusted);
-        Assert.AreEqual("AU", occurrences[0].TerritoryCode);
+        Assert.AreEqual("AU-NSW", occurrences[0].TerritoryCode,
+            "NSW rule wins shadowing in every year; its adjustment-bound trial only controls whether the weekend substitute fires.");
+    }
+
+    /// <summary>
+    /// Verifies that the NSW Anzac Day weekend-substitute trial activates for Saturday 25 April 2026, emitting an
+    /// adjusted Monday 27 April 2026 occurrence scoped to AU-NSW. This is the first year of the two-year trial
+    /// announced by the Minns Labor Government on 15 February 2026.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenAnzacDayOnSaturday_ShouldEmitMondaySubstitute_ForAuNsw_TrialYear2026()
+    {
+        var service = BuildAuService();
+
+        var occurrences = service.GetNotableDates(2026, "AU-NSW")
+            .Where(d => d.Name == "Anzac Day")
+            .OrderBy(d => d.Date)
+            .ToList();
+
+        Assert.AreEqual(1, occurrences.Count);
+        Assert.AreEqual(new DateTime(2026, 4, 27), occurrences[0].Date);
+        Assert.IsTrue(occurrences[0].WasAdjusted);
+        Assert.AreEqual(DayOfWeek.Monday, occurrences[0].Date.DayOfWeek);
+        Assert.AreEqual(new DateTime(2026, 4, 25), occurrences[0].AdjustmentReason!.OriginalDate);
+        Assert.AreEqual("AU-NSW", occurrences[0].TerritoryCode);
+    }
+
+    /// <summary>
+    /// Verifies that the NSW Anzac Day weekend-substitute trial activates for Sunday 25 April 2027, emitting an
+    /// adjusted Monday 26 April 2027 occurrence scoped to AU-NSW. This is the second (and final) year of the trial
+    /// pending the 2027 review of NSW public holidays.
+    /// </summary>
+    [TestMethod]
+    public void GetNotableDates_WhenAnzacDayOnSunday_ShouldEmitMondaySubstitute_ForAuNsw_TrialYear2027()
+    {
+        var service = BuildAuService();
+
+        var occurrences = service.GetNotableDates(2027, "AU-NSW")
+            .Where(d => d.Name == "Anzac Day")
+            .OrderBy(d => d.Date)
+            .ToList();
+
+        Assert.AreEqual(1, occurrences.Count);
+        Assert.AreEqual(new DateTime(2027, 4, 26), occurrences[0].Date);
+        Assert.IsTrue(occurrences[0].WasAdjusted);
+        Assert.AreEqual(DayOfWeek.Monday, occurrences[0].Date.DayOfWeek);
+        Assert.AreEqual(new DateTime(2027, 4, 25), occurrences[0].AdjustmentReason!.OriginalDate);
+        Assert.AreEqual("AU-NSW", occurrences[0].TerritoryCode);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements support for the New South Wales Anzac Day weekend-substitute trial announced by the Minns Labor Government on 15 February 2026. The trial provides an additional public holiday on the Monday following Anzac Day when 25 April falls on a weekend, for exactly two years (2026 and 2027).

## Key Changes

- **New NSW-scoped Anzac Day rule** (`region-au.xml`): Added `fixed-apr-25-au-nsw` rule with a time-bounded adjustment (`nsw-2026-2027-weekend-sub`) that fires only during the trial window (fromYear="2026" toYear="2027"). Outside the trial, the rule emits the canonical 25 April date unchanged, maintaining territory shadowing so AU-NSW queries always route through the NSW entry.

- **Updated test data and documentation** (`AustralianNotableDatesTests.cs`):
  - Removed NSW from the canonical-AU subdivision list in the Anzac Day Saturday test (now only VIC, QLD, SA, TAS, ACT).
  - Renamed and updated `GetNotableDates_WhenAnzacDayOnSaturday_ShouldNotEmitSubstitute_ForAuNsw()` to clarify that the NSW rule is always present but its adjustment is dormant outside the trial window; the territory code is now correctly expected to be `AU-NSW` (not `AU`).
  - Added two new test methods validating the trial activation:
    - `GetNotableDates_WhenAnzacDayOnSaturday_ShouldEmitMondaySubstitute_ForAuNsw_TrialYear2026()` — verifies Monday 27 April 2026 substitute.
    - `GetNotableDates_WhenAnzacDayOnSunday_ShouldEmitMondaySubstitute_ForAuNsw_TrialYear2027()` — verifies Monday 26 April 2027 substitute.

## Implementation Details

The trial is expressed by bounding the *adjustment* (not the rule itself) to the 2026–2027 window. This design keeps the NSW rule present in every year so territory shadowing reliably routes AU-NSW queries through the NSW entry; outside the trial window the adjustment is dormant and the rule emits the base 25 April date unchanged. This approach avoids the need for year-aware territory shadowing in the engine.

The arrangement brings NSW into line with Western Australia and the ACT for those two years. A review of NSW public holidays commencing in 2027 will determine whether the substitute becomes permanent; if so, the adjustment's effective-year window can be extended accordingly.

https://claude.ai/code/session_01Dwc5y66hs2SfXMaZrF13hN