### PR TITLE
Restrict month validation to 1–12 for Gregorian calendar rules

### DIFF
--- a/Bodu.Globalization.Calendar/src/CalendarResourceStrings.resx
+++ b/Bodu.Globalization.Calendar/src/CalendarResourceStrings.resx
@@ -130,7 +130,7 @@
     <value>JSON failed schema validation: {0}</value>
   </data>
   <data name="Format_Invalid_MonthValueGregorian" xml:space="preserve">
-    <value>Invalid month value '{0}'. Expected a full English month name (e.g. 'January') or an integer 1&#x2013;13.</value>
+    <value>Invalid month value '{0}'. Expected a full English month name (e.g. 'January') or an integer 1&#x2013;12.</value>
   </data>
   <data name="Format_Invalid_MonthValueHebrew" xml:space="preserve">
     <value>Invalid month value '{0}'. Expected a full English month name, an integer 1&#x2013;13, or a Hebrew month name.</value>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleJsonParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleJsonParser.cs
@@ -617,10 +617,15 @@ public static class NotableDateRuleJsonParser
     }
 
     /// <summary>
-    /// Parses an English Gregorian month name or numeric month token (1–13).
+    /// Parses an English Gregorian month name or numeric month token (1–12). Used for schema-constrained Gregorian
+    /// month attributes (<c>dayOfWeekInMonth.month</c>, <c>adjustment.comparisonMonth</c>) that admit only the
+    /// twelve Gregorian months by enum.
     /// </summary>
     /// <param name="monthName">The month token to parse.</param>
-    /// <returns>The parsed month number.</returns>
+    /// <returns>The parsed month number in the range 1–12.</returns>
+    /// <exception cref="FormatException">
+    /// <paramref name="monthName" /> is neither a recognized English month name nor an integer in 1–12.
+    /// </exception>
     private static int ParseMonth(string monthName)
     {
         if (string.IsNullOrWhiteSpace(monthName))
@@ -630,7 +635,7 @@ public static class NotableDateRuleJsonParser
             return result.Month;
 
         return int.TryParse(monthName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numeric)
-            && numeric is >= 1 and <= 13
+            && numeric is >= 1 and <= 12
             ? numeric
             : throw new FormatException(
             string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Format_Invalid_MonthValueGregorian, monthName));

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -594,17 +594,18 @@ public static class NotableDateRuleParser
 
     /// <summary>
     /// Parses <paramref name="monthName" /> as a culture-invariant English month name (e.g. <c>January</c>) or an
-    /// integer month number in the range <c>1</c>–<c>13</c>.
+    /// integer month number in the range <c>1</c>–<c>12</c>.
     /// </summary>
     /// <remarks>
-    /// Integer months are accepted to support non-Gregorian BCL calendar rules (e.g. <c>month="1"</c> on a <c>Fixed</c>
-    /// rule with <c>calendarType="System.Globalization.ChineseLunisolarCalendar"</c>). Lunisolar calendars can carry up
-    /// to 13 months in intercalary years.
+    /// Used for schema-constrained Gregorian month attributes (<c>DayOfWeekInMonth/@month</c>,
+    /// <c>Adjustment/@comparisonMonth</c>) whose XSD type <c>monthName</c> admits only the twelve Gregorian months by
+    /// enumeration. Numeric month 13 belongs to the lunisolar/Hebrew strategy surface and is handled by
+    /// <see cref="ParseMonthToken(string, Type?)" />.
     /// </remarks>
-    /// <param name="monthName">The month token — either an English month name or an integer 1–13.</param>
-    /// <returns>The month number.</returns>
+    /// <param name="monthName">The month token — either an English month name or an integer 1–12.</param>
+    /// <returns>The month number in the range 1–12.</returns>
     /// <exception cref="FormatException">
-    /// <paramref name="monthName" /> is neither a recognized English month name nor an integer in 1–13.
+    /// <paramref name="monthName" /> is neither a recognized English month name nor an integer in 1–12.
     /// </exception>
     private static int ParseMonth(string monthName)
     {
@@ -612,7 +613,7 @@ public static class NotableDateRuleParser
 
         return DateTime.TryParseExact(monthName, "MMMM", CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime result)
             ? result.Month
-            : int.TryParse(monthName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numeric) && numeric is >= 1 and <= 13
+            : int.TryParse(monthName, NumberStyles.Integer, CultureInfo.InvariantCulture, out var numeric) && numeric is >= 1 and <= 12
                 ? numeric
                 : throw new FormatException(string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Format_Invalid_MonthValueGregorian, monthName));
     }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleJsonParserTests.MonthToken.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleJsonParserTests.MonthToken.cs
@@ -399,9 +399,11 @@ public partial class NotableDateRuleJsonParserTests
     }
 
     /// <summary>
-    /// Verifies that every supported string-form numeric month token <c>"1"</c> through <c>"13"</c> resolves to the
-    /// matching integer, exercising the schema's string-numeric pattern branch and <c>ParseMonthToken</c>'s numeric
-    /// alternative.
+    /// Verifies that every supported string-form numeric month token <c>"1"</c> through <c>"12"</c> resolves to the
+    /// matching integer in the default Gregorian context, exercising the schema's string-numeric pattern branch and
+    /// <c>ParseMonthToken</c>'s numeric alternative. The lunisolar-only <c>"13"</c> case is covered separately by
+    /// <see cref="ParseJson_WhenFixedMonthIsMaximumNumericMonth_ShouldReturnNumericMonth" /> with an explicit
+    /// non-Gregorian <c>calendarType</c>.
     /// </summary>
     [TestCategory("Regression")]
     [DataRow("1", 1)]
@@ -416,7 +418,6 @@ public partial class NotableDateRuleJsonParserTests
     [DataRow("10", 10)]
     [DataRow("11", 11)]
     [DataRow("12", 12)]
-    [DataRow("13", 13)]
     [TestMethod]
     public void ParseJson_WhenFixedMonthIsStringNumeric_ShouldReturnExpectedMonth(string monthToken, int expectedMonth)
     {

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleJsonParserTests.MonthValidation.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleJsonParserTests.MonthValidation.cs
@@ -14,10 +14,11 @@ public partial class NotableDateRuleJsonParserTests
 {
     /// <summary>
     /// Verifies that a Fixed rule authored without a <c>calendarType</c> (Gregorian by default) and a numeric
-    /// month token of <c>"13"</c> is rejected at parse time.
+    /// month token of <c>"13"</c> is rejected at parse time with a <see cref="FormatException" /> whose message
+    /// names the offending token and the Gregorian 1–12 bound.
     /// </summary>
     [TestMethod]
-    public void ParseJson_WhenFixedMonthIsThirteenWithoutCalendarType_ShouldThrow()
+    public void ParseJson_WhenFixedMonthIsThirteenWithoutCalendarType_ShouldThrowExactly()
     {
         const string json = @"{
 			""notableDates"": [
@@ -29,10 +30,13 @@ public partial class NotableDateRuleJsonParserTests
 			]
 		}";
 
-        Assert.ThrowsExactly<FormatException>(() =>
+        FormatException ex = Assert.ThrowsExactly<FormatException>(() =>
         {
             _ = NotableDateRuleJsonParser.ParseJson(json);
         });
+
+        Assert.IsTrue(ex.Message.Contains("'13'", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("1–12", StringComparison.Ordinal));
     }
 
     /// <summary>
@@ -40,7 +44,7 @@ public partial class NotableDateRuleJsonParserTests
     /// <c>"13"</c> is rejected at parse time. Gregorian has only 12 months; the value cannot be honoured.
     /// </summary>
     [TestMethod]
-    public void ParseJson_WhenFixedMonthIsThirteenWithGregorianCalendarType_ShouldThrow()
+    public void ParseJson_WhenFixedMonthIsThirteenWithGregorianCalendarType_ShouldThrowExactly()
     {
         const string json = @"{
 			""notableDates"": [
@@ -53,9 +57,37 @@ public partial class NotableDateRuleJsonParserTests
 			]
 		}";
 
-        Assert.ThrowsExactly<FormatException>(() =>
+        FormatException ex = Assert.ThrowsExactly<FormatException>(() =>
         {
             _ = NotableDateRuleJsonParser.ParseJson(json);
         });
+
+        Assert.IsTrue(ex.Message.Contains("'13'", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("1–12", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed rule with the Hebrew calendar accepts numeric month token <c>"13"</c>, which represents
+    /// the intercalary Adar I in a Hebrew leap year. The lunisolar branch in <c>ParseMonthToken</c> is exercised
+    /// for a calendar other than <see cref="System.Globalization.ChineseLunisolarCalendar" />.
+    /// </summary>
+    [TestMethod]
+    public void ParseJson_WhenFixedMonthIsThirteenWithHebrewCalendarType_ShouldReturnNumericMonth()
+    {
+        const string json = @"{
+			""notableDates"": [
+				{ ""name"": ""Intercalary Hebrew"", ""rules"": [ {
+					""name"": ""Intercalary Hebrew Rule"",
+					""category"": ""Religious"",
+					""calendarType"": ""System.Globalization.HebrewCalendar"",
+					""fixed"": { ""month"": ""13"", ""day"": 1 }
+				} ] }
+			]
+		}";
+
+        NotableDateRule rule = NotableDateRuleJsonParser.ParseJson(json).Single();
+
+        Assert.AreEqual(13, rule.Month);
+        Assert.IsNull(rule.CalendarMonthAlias);
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.MonthValidation.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateRuleParserTests.MonthValidation.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NotableDateRuleParserTests.MonthValidation.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd.. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar;
+
+/// <summary>
+/// Verifies calendar-aware month validation on the XML parser: numeric month 13 is rejected for Gregorian rules
+/// (where 13 has no meaning) but accepted for lunisolar / Hebrew calendars that carry intercalary months. Mirrors
+/// the JSON parser's MonthValidation coverage so the two surfaces stay in lockstep.
+/// </summary>
+public partial class NotableDateRuleParserTests
+{
+    /// <summary>
+    /// Verifies that a Fixed rule authored without a <c>calendarType</c> (Gregorian by default) and a numeric
+    /// month token of <c>"13"</c> is rejected at parse time with a <see cref="FormatException" /> whose message
+    /// names the offending token and the Gregorian 1–12 bound.
+    /// </summary>
+    [TestMethod]
+    public void ParseXml_WhenFixedMonthIsThirteenWithoutCalendarType_ShouldThrowExactly()
+    {
+        const string xml = @"
+			<NotableDates xmlns=""urn:bodu:globalization:calendar"">
+				<NotableDate name=""Bad Month"">
+					<Rule name=""Bad Month Rule"" category=""Holiday"">
+						<Fixed month=""13"" day=""1"" />
+					</Rule>
+				</NotableDate>
+			</NotableDates>";
+
+        FormatException ex = Assert.ThrowsExactly<FormatException>(() =>
+        {
+            _ = NotableDateRuleParser.ParseXml(xml);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("'13'", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("1–12", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed rule with an explicit Gregorian <c>calendarType</c> and a numeric month token of
+    /// <c>"13"</c> is rejected at parse time. Gregorian has only 12 months; the value cannot be honoured.
+    /// </summary>
+    [TestMethod]
+    public void ParseXml_WhenFixedMonthIsThirteenWithGregorianCalendarType_ShouldThrowExactly()
+    {
+        const string xml = @"
+			<NotableDates xmlns=""urn:bodu:globalization:calendar"">
+				<NotableDate name=""Bad Month"">
+					<Rule name=""Bad Month Rule""
+					      category=""Holiday""
+					      calendarType=""System.Globalization.GregorianCalendar"">
+						<Fixed month=""13"" day=""1"" />
+					</Rule>
+				</NotableDate>
+			</NotableDates>";
+
+        FormatException ex = Assert.ThrowsExactly<FormatException>(() =>
+        {
+            _ = NotableDateRuleParser.ParseXml(xml);
+        });
+
+        Assert.IsTrue(ex.Message.Contains("'13'", StringComparison.Ordinal));
+        Assert.IsTrue(ex.Message.Contains("1–12", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that a Fixed rule with the Hebrew calendar accepts numeric month token <c>"13"</c>, which represents
+    /// the intercalary Adar I in a Hebrew leap year. Confirms the lunisolar branch in <c>ParseMonthToken</c> is
+    /// reached for a calendar other than <see cref="System.Globalization.ChineseLunisolarCalendar" />.
+    /// </summary>
+    [TestMethod]
+    public void ParseXml_WhenFixedMonthIsThirteenWithHebrewCalendarType_ShouldReturnNumericMonth()
+    {
+        const string xml = @"
+			<NotableDates xmlns=""urn:bodu:globalization:calendar"">
+				<NotableDate name=""Intercalary Hebrew"">
+					<Rule name=""Intercalary Hebrew Rule""
+					      category=""Religious""
+					      calendarType=""System.Globalization.HebrewCalendar"">
+						<Fixed month=""13"" day=""1"" />
+					</Rule>
+				</NotableDate>
+			</NotableDates>";
+
+        NotableDateRule rule = NotableDateRuleParser.ParseXml(xml).Single();
+
+        Assert.AreEqual(13, rule.Month);
+        Assert.IsNull(rule.CalendarMonthAlias);
+    }
+}


### PR DESCRIPTION
## Summary

Tightens month validation in the XML and JSON parsers to reject numeric month 13 for Gregorian calendar rules, while preserving support for month 13 in lunisolar and Hebrew calendars via the dedicated `ParseMonthToken` strategy surface.

## Changes

- **NotableDateRuleParser.cs**: Updated `ParseMonth()` to accept only months 1–12 (was 1–13). This method is used exclusively for schema-constrained Gregorian month attributes (`DayOfWeekInMonth/@month`, `Adjustment/@comparisonMonth`). Lunisolar month 13 is now handled only by `ParseMonthToken()`, which applies calendar-aware validation.

- **NotableDateRuleJsonParser.cs**: Updated `ParseMonth()` to accept only months 1–12 (was 1–13), with improved documentation clarifying the method's role in schema-constrained Gregorian contexts.

- **CalendarResourceStrings.resx**: Updated error message to reflect the 1–12 bound for Gregorian months.

- **Test coverage**: 
  - Enhanced existing JSON tests (`NotableDateRuleJsonParserTests.MonthValidation.cs`) to verify error messages contain the offending token and the 1–12 bound.
  - Added new XML test file (`NotableDateRuleParserTests.MonthValidation.cs`) with three tests mirroring JSON coverage: rejection of month 13 without calendar type, rejection with explicit Gregorian calendar, and acceptance with Hebrew calendar.
  - Removed month 13 from the parametrized regression test in `NotableDateRuleJsonParserTests.MonthToken.cs` (now covered separately by the Hebrew calendar test).

## Implementation Details

The change enforces a clear separation of concerns: `ParseMonth()` handles only Gregorian-constrained attributes (1–12), while `ParseMonthToken()` applies calendar-aware logic to support intercalary months (13) in lunisolar and Hebrew calendars. This prevents accidental acceptance of invalid month values in schema-constrained contexts while maintaining full support for non-Gregorian calendars where month 13 is semantically valid.

https://claude.ai/code/session_01FkyBVF36LgVnst1ePskiLG