### PR TITLE
Centralize Calendar exception messages in resx and expand CalendarThrowHelper

### DIFF
--- a/Bodu.Globalization.Calendar/src/CalendarResourceStrings.Designer.cs
+++ b/Bodu.Globalization.Calendar/src/CalendarResourceStrings.Designer.cs
@@ -241,7 +241,7 @@ namespace Bodu {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Year must be greater than or equal to 1..
+        ///   Looks up a localized string similar to Year must be between 1 and 9999..
         /// </summary>
         internal static string Arg_OutOfRange_Year {
             get {
@@ -358,6 +358,15 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to The calculation anchor rule '{0}' could not be found..
+        /// </summary>
+        internal static string Op_Invalid_CalculationAnchorRuleNotFound {
+            get {
+                return ResourceManager.GetString("Op_Invalid_CalculationAnchorRuleNotFound", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Circular dependency detected while resolving notable date rule '{0}': {1}..
         /// </summary>
         internal static string Op_Invalid_CircularDependencyInRule {
@@ -403,6 +412,33 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Failed to activate plugin type '{0}' from assembly '{1}': {2}.
+        /// </summary>
+        internal static string Op_Invalid_PluginActivationFailedFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginActivationFailedFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin assembly name is missing..
+        /// </summary>
+        internal static string Op_Invalid_PluginAssemblyNameMissing {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginAssemblyNameMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly '{0}' is not in the hash allowlist..
+        /// </summary>
+        internal static string Op_Invalid_PluginAssemblyNotInAllowlistFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginAssemblyNotInAllowlistFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to attribute not present on the assembly.
         /// </summary>
         internal static string Op_Invalid_PluginAttributeMissing {
@@ -412,11 +448,83 @@ namespace Bodu {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Assembly '{0}' hash length mismatch..
+        /// </summary>
+        internal static string Op_Invalid_PluginHashLengthMismatchFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginHashLengthMismatchFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Assembly '{0}' hash does not match the pinned value..
+        /// </summary>
+        internal static string Op_Invalid_PluginHashMismatchFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginHashMismatchFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin assembly '{0}' is missing a valid NotableDatePluginAttribute: {1}..
+        /// </summary>
+        internal static string Op_Invalid_PluginMissingAttributeFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginMissingAttributeFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin assembly is not strong-named..
+        /// </summary>
+        internal static string Op_Invalid_PluginNotStrongNamed {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginNotStrongNamed", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Plugin assembly '{0}' was rejected by the trust policy: {1}..
+        /// </summary>
+        internal static string Op_Invalid_PluginNotTrustedFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginNotTrustedFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to no reason supplied.
+        /// </summary>
+        internal static string Op_Invalid_PluginReasonMissing {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginReasonMissing", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Public-key token '{0}' is not in the allowlist..
+        /// </summary>
+        internal static string Op_Invalid_PluginTokenNotInAllowlistFormat {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginTokenNotInAllowlistFormat", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to declared plugin type '{0}' does not implement INotableDatePlugin.
         /// </summary>
         internal static string Op_Invalid_PluginTypeMissingInterface {
             get {
                 return ResourceManager.GetString("Op_Invalid_PluginTypeMissingInterface", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;unknown&gt;.
+        /// </summary>
+        internal static string Op_Invalid_PluginUnknownTypeName {
+            get {
+                return ResourceManager.GetString("Op_Invalid_PluginUnknownTypeName", resourceCulture);
             }
         }
 

--- a/Bodu.Globalization.Calendar/src/CalendarResourceStrings.resx
+++ b/Bodu.Globalization.Calendar/src/CalendarResourceStrings.resx
@@ -124,7 +124,7 @@
     <value>The working-week pattern is not defined.</value>
   </data>
   <data name="Arg_OutOfRange_Year" xml:space="preserve">
-    <value>Year must be greater than or equal to 1.</value>
+    <value>Year must be between 1 and 9999.</value>
   </data>
   <data name="Format_Invalid_JsonSchema" xml:space="preserve">
     <value>JSON failed schema validation: {0}</value>
@@ -162,6 +162,9 @@
   <data name="Op_Invalid_AnchorRuleNotFound" xml:space="preserve">
     <value>Anchor rule '{0}' referenced by '{1}' was not found.</value>
   </data>
+  <data name="Op_Invalid_CalculationAnchorRuleNotFound" xml:space="preserve">
+    <value>The calculation anchor rule '{0}' could not be found.</value>
+  </data>
   <data name="Op_Invalid_CircularDependencyInRule" xml:space="preserve">
     <value>Circular dependency detected while resolving notable date rule '{0}': {1}.</value>
   </data>
@@ -177,11 +180,44 @@
   <data name="Op_Invalid_MissingRequiredAttribute" xml:space="preserve">
     <value>Missing required attribute '{0}' on element '{1}'.</value>
   </data>
+  <data name="Op_Invalid_PluginActivationFailedFormat" xml:space="preserve">
+    <value>Failed to activate plugin type '{0}' from assembly '{1}': {2}</value>
+  </data>
+  <data name="Op_Invalid_PluginAssemblyNameMissing" xml:space="preserve">
+    <value>Plugin assembly name is missing.</value>
+  </data>
+  <data name="Op_Invalid_PluginAssemblyNotInAllowlistFormat" xml:space="preserve">
+    <value>Assembly '{0}' is not in the hash allowlist.</value>
+  </data>
   <data name="Op_Invalid_PluginAttributeMissing" xml:space="preserve">
     <value>attribute not present on the assembly</value>
   </data>
+  <data name="Op_Invalid_PluginHashLengthMismatchFormat" xml:space="preserve">
+    <value>Assembly '{0}' hash length mismatch.</value>
+  </data>
+  <data name="Op_Invalid_PluginHashMismatchFormat" xml:space="preserve">
+    <value>Assembly '{0}' hash does not match the pinned value.</value>
+  </data>
+  <data name="Op_Invalid_PluginMissingAttributeFormat" xml:space="preserve">
+    <value>Plugin assembly '{0}' is missing a valid NotableDatePluginAttribute: {1}.</value>
+  </data>
+  <data name="Op_Invalid_PluginNotStrongNamed" xml:space="preserve">
+    <value>Plugin assembly is not strong-named.</value>
+  </data>
+  <data name="Op_Invalid_PluginNotTrustedFormat" xml:space="preserve">
+    <value>Plugin assembly '{0}' was rejected by the trust policy: {1}.</value>
+  </data>
+  <data name="Op_Invalid_PluginReasonMissing" xml:space="preserve">
+    <value>no reason supplied</value>
+  </data>
+  <data name="Op_Invalid_PluginTokenNotInAllowlistFormat" xml:space="preserve">
+    <value>Public-key token '{0}' is not in the allowlist.</value>
+  </data>
   <data name="Op_Invalid_PluginTypeMissingInterface" xml:space="preserve">
     <value>declared plugin type '{0}' does not implement INotableDatePlugin</value>
+  </data>
+  <data name="Op_Invalid_PluginUnknownTypeName" xml:space="preserve">
+    <value>&lt;unknown&gt;</value>
   </data>
   <data name="Op_Invalid_ResourcePathEscapesRoot" xml:space="preserve">
     <value>The resource path '{0}' escapes the resource root.</value>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/AsalhaPujaNotableDateAlgorithm.cs
@@ -48,9 +48,7 @@ public sealed class AsalhaPujaNotableDateAlgorithm
     /// </exception>
     public DateTime? GetDate(int year, SysGlobal.Calendar? calendar = null)
     {
-        if (year < 1)
-            throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         DateTime? fullMoon = LunarPhaseAlgorithm.GetFullMoonOnOrAfter(new DateTime(year, 6, 15));
         if (fullMoon is null)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateAlgorithm.cs
@@ -53,8 +53,7 @@ public sealed class EasterSundayNotableDateAlgorithm
     /// <inheritdoc />
     public DateTime? GetDate(int year, System.Globalization.Calendar? calendar)
     {
-        ThrowHelper.ThrowIfLessThan(year, 1);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         return GetOrAddEasterSunday(year, calendar);
     }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/EasterSundayNotableDateProviderBase.cs
@@ -82,8 +82,7 @@ public abstract class EasterSundayNotableDateProviderBase
     /// <inheritdoc />
     public IReadOnlyList<NotableDate> GetDates(int year, SysGlobal.Calendar? calendar = null)
     {
-        ThrowHelper.ThrowIfLessThan(year, 1);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         ValidateCalendar(calendar);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/GregorianEasterSundayNotableDateProvider.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System.Globalization;
+using Bodu.Globalization.Calendar;
 using Bodu.Globalization.Calendar.Algorithms;
 using SysGlobal = System.Globalization;
 
@@ -36,17 +36,8 @@ public sealed class GregorianEasterSundayNotableDateProvider
     protected override string? Comment => "Calculated using the Gregorian computus.";
 
     /// <inheritdoc />
-    protected override void ValidateCalendar(SysGlobal.Calendar? calendar)
-    {
-        if (calendar is null or SysGlobal.GregorianCalendar)
-        {
-            return;
-        }
-
-        throw new NotSupportedException(
-            string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_NotSupported_CalendarType,
-                calendar.GetType().FullName, GetType().Name, typeof(SysGlobal.GregorianCalendar).FullName));
-    }
+    protected override void ValidateCalendar(SysGlobal.Calendar? calendar) =>
+        CalendarThrowHelper.ThrowIfUnsupportedCalendarType(calendar, GetType(), typeof(SysGlobal.GregorianCalendar));
 
     /// <inheritdoc />
     protected override DateTime CalculateDate(int year)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/HinduLunarNotableDateAlgorithm.cs
@@ -125,9 +125,7 @@ public sealed class HinduLunarNotableDateAlgorithm
     /// </exception>
     public DateTime? GetDate(int year, SysGlobal.Calendar? calendar = null)
     {
-        if (year < 1)
-            throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         // Find the new moon that begins the target lunar month.
         var searchMonth = GetSearchMonth(_month);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/LosarNotableDateAlgorithm.cs
@@ -53,9 +53,7 @@ public sealed class LosarNotableDateAlgorithm
     /// </exception>
     public DateTime? GetDate(int year, SysGlobal.Calendar? calendar = null)
     {
-        if (year < 1)
-            throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         // The Tibetan New Year falls on or shortly after the second new moon after the winter
         // solstice. The winter solstice is approximately 21 December; the second new moon after

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/OrthodoxEasterSundayNotableDateProvider.cs
@@ -4,7 +4,7 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
-using System.Globalization;
+using Bodu.Globalization.Calendar;
 using Bodu.Globalization.Calendar.Algorithms;
 using SysGlobal = System.Globalization;
 
@@ -43,17 +43,8 @@ public sealed class OrthodoxEasterSundayNotableDateProvider
     protected override string? Comment => "Calculated using the Julian computus and projected to a Gregorian DateTime.";
 
     /// <inheritdoc />
-    protected override void ValidateCalendar(SysGlobal.Calendar? calendar)
-    {
-        if (calendar is null or SysGlobal.JulianCalendar)
-        {
-            return;
-        }
-
-        throw new NotSupportedException(
-            string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_NotSupported_CalendarType,
-                calendar.GetType().FullName, GetType().Name, typeof(SysGlobal.JulianCalendar).FullName));
-    }
+    protected override void ValidateCalendar(SysGlobal.Calendar? calendar) =>
+        CalendarThrowHelper.ThrowIfUnsupportedCalendarType(calendar, GetType(), typeof(SysGlobal.JulianCalendar));
 
     /// <inheritdoc />
     protected override DateTime CalculateDate(int year)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/QingmingNotableDateAlgorithm.cs
@@ -75,9 +75,7 @@ public sealed class QingmingNotableDateAlgorithm
     /// </exception>
     public DateTime? GetDate(int year, SysGlobal.Calendar? calendar = null)
     {
-        if (year < 1)
-            throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         var equinoxJde = ComputeVernalEquinoxJde(year);
         var qingmingJde = equinoxJde + DegreesToDays15;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Algorithms/VesakNotableDateAlgorithm.cs
@@ -49,9 +49,7 @@ public sealed class VesakNotableDateAlgorithm
     /// </exception>
     public DateTime? GetDate(int year, SysGlobal.Calendar? calendar = null)
     {
-        if (year < 1)
-            throw new ArgumentOutOfRangeException(nameof(year), CalendarResourceStrings.Arg_OutOfRange_Year);
-        ThrowHelper.ThrowIfGreaterThan(year, 9999);
+        CalendarThrowHelper.ThrowIfYearOutOfRange(year);
 
         DateTime? fullMoon = LunarPhaseAlgorithm.GetFullMoonOnOrAfter(new DateTime(year, 5, 1));
         return fullMoon is null ? null : ProjectToCalendar(fullMoon.Value, calendar);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.NextWorkingDay.cs
@@ -105,7 +105,7 @@ public static partial class NotableDateOnlyExtensions
     {
         ThrowHelper.ThrowIfNull(service);
         ThrowHelper.ThrowIfNegative(count);
-        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+        CalendarThrowHelper.ThrowIfWorkingWeekEmpty(workingWeek);
 
         if (count == 0) return DateOnly.FromDayNumber(date.DayNumber);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateOnlyExtensions.PreviousWorkingDay.cs
@@ -105,7 +105,7 @@ public static partial class NotableDateOnlyExtensions
     {
         ThrowHelper.ThrowIfNull(service);
         ThrowHelper.ThrowIfNegative(count);
-        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+        CalendarThrowHelper.ThrowIfWorkingWeekEmpty(workingWeek);
 
         if (count == 0) return DateOnly.FromDayNumber(date.DayNumber);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.NextWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.NextWorkingDay.cs
@@ -121,7 +121,7 @@ public static partial class NotableDateTimeExtensions
     {
         ThrowHelper.ThrowIfNull(service);
         ThrowHelper.ThrowIfNegative(count);
-        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+        CalendarThrowHelper.ThrowIfWorkingWeekEmpty(workingWeek);
 
         if (count == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.PreviousWorkingDay.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Extensions/NotableDateTimeExtensions.PreviousWorkingDay.cs
@@ -113,7 +113,7 @@ public static partial class NotableDateTimeExtensions
     {
         ThrowHelper.ThrowIfNull(service);
         ThrowHelper.ThrowIfNegative(count);
-        if (workingWeek.Count == 0) throw new ArgumentOutOfRangeException(nameof(workingWeek), CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+        CalendarThrowHelper.ThrowIfWorkingWeekEmpty(workingWeek);
 
         if (count == 0) return new DateTime(dateTime.Ticks, dateTime.Kind);
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/CompositePluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/CompositePluginTrustPolicy.cs
@@ -40,7 +40,7 @@ public sealed class CompositePluginTrustPolicy
     /// </exception>
     public CompositePluginTrustPolicy(params IPluginTrustPolicy[] policies)
     {
-        if (policies is null) throw new ArgumentNullException(nameof(policies));
+        ThrowHelper.ThrowIfNull(policies);
         if (policies.Length == 0)
             throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_PoliciesEmpty, nameof(policies));
         foreach (IPluginTrustPolicy? policy in policies)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/FileHashPluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/FileHashPluginTrustPolicy.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
@@ -42,7 +44,7 @@ public sealed class FileHashPluginTrustPolicy
     /// </exception>
     public FileHashPluginTrustPolicy(IReadOnlyDictionary<string, byte[]> allowedHashesByAssemblyName)
     {
-        if (allowedHashesByAssemblyName is null) throw new ArgumentNullException(nameof(allowedHashesByAssemblyName));
+        ThrowHelper.ThrowIfNull(allowedHashesByAssemblyName);
 
         var normalized = new Dictionary<string, byte[]>(StringComparer.OrdinalIgnoreCase);
         foreach (KeyValuePair<string, byte[]> entry in allowedHashesByAssemblyName)
@@ -63,13 +65,17 @@ public sealed class FileHashPluginTrustPolicy
     {
         var name = context.AssemblyName.Name;
         if (string.IsNullOrEmpty(name))
-            return new PluginTrustResult(Trusted: false, Reason: "Plugin assembly name is missing.");
+            return new PluginTrustResult(Trusted: false, Reason: CalendarResourceStrings.Op_Invalid_PluginAssemblyNameMissing);
 
         if (!_allowedHashesByAssemblyName.TryGetValue(name, out var expected))
-            return new PluginTrustResult(Trusted: false, Reason: $"Assembly '{name}' is not in the hash allowlist.");
+            return new PluginTrustResult(
+                Trusted: false,
+                Reason: string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_Invalid_PluginAssemblyNotInAllowlistFormat, name));
 
         if (expected.Length != context.FileHash.Length)
-            return new PluginTrustResult(Trusted: false, Reason: $"Assembly '{name}' hash length mismatch.");
+            return new PluginTrustResult(
+                Trusted: false,
+                Reason: string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_Invalid_PluginHashLengthMismatchFormat, name));
 
         // Constant-time comparison is overkill for a plain integrity check, but cheap — use it anyway.
         var diff = 0;
@@ -78,6 +84,8 @@ public sealed class FileHashPluginTrustPolicy
 
         return diff == 0
             ? new PluginTrustResult(Trusted: true, Reason: null)
-            : new PluginTrustResult(Trusted: false, Reason: $"Assembly '{name}' hash does not match the pinned value.");
+            : new PluginTrustResult(
+                Trusted: false,
+                Reason: string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_Invalid_PluginHashMismatchFormat, name));
     }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginActivationException.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginActivationException.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
@@ -59,7 +61,14 @@ public sealed class PluginActivationException
     /// activation target in addition to the formatted exception message.
     /// </remarks>
     public PluginActivationException(string assemblyPath, Type? pluginType, Exception innerException)
-        : base($"Failed to activate plugin type '{pluginType?.FullName ?? "<unknown>"}' from assembly '{assemblyPath}': {innerException.Message}", innerException)
+        : base(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                CalendarResourceStrings.Op_Invalid_PluginActivationFailedFormat,
+                pluginType?.FullName ?? CalendarResourceStrings.Op_Invalid_PluginUnknownTypeName,
+                assemblyPath,
+                innerException.Message),
+            innerException)
     {
         AssemblyPath = assemblyPath;
         PluginType = pluginType;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginMissingAttributeException.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginMissingAttributeException.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
@@ -62,7 +64,11 @@ public sealed class PluginMissingAttributeException
     /// candidate in addition to the formatted exception message.
     /// </remarks>
     public PluginMissingAttributeException(string assemblyPath, string reason)
-        : base($"Plugin assembly '{assemblyPath}' is missing a valid NotableDatePluginAttribute: {reason}.")
+        : base(string.Format(
+            CultureInfo.InvariantCulture,
+            CalendarResourceStrings.Op_Invalid_PluginMissingAttributeFormat,
+            assemblyPath,
+            reason))
     {
         AssemblyPath = assemblyPath;
         Reason = reason;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginNotTrustedException.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/PluginNotTrustedException.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
@@ -62,7 +64,11 @@ public sealed class PluginNotTrustedException
     /// the failed trust evaluation in addition to the formatted exception message.
     /// </remarks>
     public PluginNotTrustedException(string assemblyPath, string? reason)
-        : base($"Plugin assembly '{assemblyPath}' was rejected by the trust policy: {reason ?? "no reason supplied"}.")
+        : base(string.Format(
+            CultureInfo.InvariantCulture,
+            CalendarResourceStrings.Op_Invalid_PluginNotTrustedFormat,
+            assemblyPath,
+            reason ?? CalendarResourceStrings.Op_Invalid_PluginReasonMissing))
     {
         AssemblyPath = assemblyPath;
         Reason = reason;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/StrongNamePluginTrustPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.Plugins/StrongNamePluginTrustPolicy.cs
@@ -4,6 +4,8 @@
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
+
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
@@ -42,7 +44,7 @@ public sealed class StrongNamePluginTrustPolicy
     /// </exception>
     public StrongNamePluginTrustPolicy(IEnumerable<string> allowedPublicKeyTokens)
     {
-        if (allowedPublicKeyTokens is null) throw new ArgumentNullException(nameof(allowedPublicKeyTokens));
+        ThrowHelper.ThrowIfNull(allowedPublicKeyTokens);
         _allowedTokens = new HashSet<string>(allowedPublicKeyTokens.Select(NormalizeToken), StringComparer.OrdinalIgnoreCase);
     }
 
@@ -51,12 +53,14 @@ public sealed class StrongNamePluginTrustPolicy
     {
         var tokenBytes = context.AssemblyName.GetPublicKeyToken();
         if (tokenBytes is null || tokenBytes.Length == 0)
-            return new PluginTrustResult(Trusted: false, Reason: "Plugin assembly is not strong-named.");
+            return new PluginTrustResult(Trusted: false, Reason: CalendarResourceStrings.Op_Invalid_PluginNotStrongNamed);
 
         var token = ToHexString(tokenBytes);
         return _allowedTokens.Contains(token)
             ? new PluginTrustResult(Trusted: true, Reason: null)
-            : new PluginTrustResult(Trusted: false, Reason: $"Public-key token '{token}' is not in the allowlist.");
+            : new PluginTrustResult(
+                Trusted: false,
+                Reason: string.Format(CultureInfo.InvariantCulture, CalendarResourceStrings.Op_Invalid_PluginTokenNotInAllowlistFormat, token));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePipeline.cs
@@ -150,7 +150,7 @@ internal sealed class NotableDateRangePipeline
     /// </remarks>
     public IReadOnlyList<NotableDate> Resolve(NotableDateRangeRequest request)
     {
-        if (request is null) throw new ArgumentNullException(nameof(request));
+        ThrowHelper.ThrowIfNull(request);
 
         NotableDateRangePlan plan = _planner.Plan(request);
         NotableDateRangeResolutionCache cache = new();

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangePlanner.cs
@@ -71,7 +71,7 @@ internal sealed class NotableDateRangePlanner
     /// <exception cref="ArgumentNullException"><paramref name="request" /> is <see langword="null" />.</exception>
     public NotableDateRangePlan Plan(NotableDateRangeRequest request)
     {
-        if (request is null) throw new ArgumentNullException(nameof(request));
+        ThrowHelper.ThrowIfNull(request);
 
         // Eligible rules: filtered by static territory, calendar, and filter checks. Year applicability is deferred to per-(rule,
         // year) materialization since FirstYear / LastYear / OccurrenceYears bounds depend on the year being resolved.

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeRequest.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeRequest.cs
@@ -38,8 +38,7 @@ internal sealed record NotableDateRangeRequest
         DateTime start = startDate.Date;
         DateTime end = endDate.Date;
 
-        if (end < start)
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_EndDateBeforeStartDate, nameof(endDate));
+        CalendarThrowHelper.ThrowIfEndDateBeforeStartDate(start, end, nameof(endDate));
 
         StartDate = start;
         EndDate = end;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeResolutionCache.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/NotableDateRangeResolutionCache.cs
@@ -64,7 +64,7 @@ internal sealed class NotableDateRangeResolutionCache
     /// <exception cref="ArgumentNullException"><paramref name="entry" /> is <see langword="null" />.</exception>
     public void Add(NotableDateCacheEntry entry)
     {
-        if (entry is null) throw new ArgumentNullException(nameof(entry));
+        ThrowHelper.ThrowIfNull(entry);
 
         NotableDateCacheKey key = new(
             entry.Rule.Name,

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar.RangeResolution/RuleStaticAnalysis.cs
@@ -119,7 +119,7 @@ internal sealed class RuleStaticAnalysis
     /// <exception cref="ArgumentNullException"><paramref name="rules" /> is <see langword="null" />.</exception>
     public static RuleStaticAnalysis Build(IReadOnlyList<NotableDateRule> rules)
     {
-        if (rules is null) throw new ArgumentNullException(nameof(rules));
+        ThrowHelper.ThrowIfNull(rules);
 
         Dictionary<string, NotableDateRule> rulesByName = new(StringComparer.OrdinalIgnoreCase);
         foreach (NotableDateRule rule in rules)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentHandlerRegistry.cs
@@ -71,7 +71,7 @@ public sealed class AdjustmentHandlerRegistry
     /// </exception>
     public AdjustmentHandlerRegistry(IEnumerable<KeyValuePair<string, IAdjustmentHandler>> handlers)
     {
-        if (handlers is null) throw new ArgumentNullException(nameof(handlers));
+        ThrowHelper.ThrowIfNull(handlers);
 
         foreach (KeyValuePair<string, IAdjustmentHandler> pair in handlers)
             Register(pair.Key, pair.Value);
@@ -91,10 +91,8 @@ public sealed class AdjustmentHandlerRegistry
     /// </exception>
     public AdjustmentHandlerRegistry Register(string key, IAdjustmentHandler handler)
     {
-        if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_KeyNullOrWhiteSpace, nameof(key));
-        if (handler is null)
-            throw new ArgumentNullException(nameof(handler));
+        CalendarThrowHelper.ThrowIfKeyNullOrWhiteSpace(key);
+        ThrowHelper.ThrowIfNull(handler);
 
         lock (_gate)
         {

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AnchorRelativeRuleIndex.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AnchorRelativeRuleIndex.cs
@@ -78,8 +78,7 @@ internal sealed class AnchorRelativeRuleIndex
         int minOffsetDays,
         int maxOffsetDays)
     {
-        if (string.IsNullOrWhiteSpace(anchorRuleName))
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_AnchorRuleNameNullOrWhiteSpace, nameof(anchorRuleName));
+        CalendarThrowHelper.ThrowIfAnchorRuleNameNullOrWhiteSpace(anchorRuleName);
 
         if (minOffsetDays > maxOffsetDays)
             return [];

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/CachingCalculationAnchorResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/CachingCalculationAnchorResolver.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Collections.Concurrent;
+using System.Globalization;
 
 namespace Bodu.Globalization.Calendar;
 
@@ -63,8 +64,7 @@ internal sealed class CachingCalculationAnchorResolver
     /// <inheritdoc />
     public DateTime? Resolve(string anchorRuleName, int year)
     {
-        if (string.IsNullOrWhiteSpace(anchorRuleName))
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_AnchorRuleNameNullOrWhiteSpace, nameof(anchorRuleName));
+        CalendarThrowHelper.ThrowIfAnchorRuleNameNullOrWhiteSpace(anchorRuleName);
 
         CalculationAnchorCacheKey key = new(anchorRuleName, year);
 
@@ -100,7 +100,10 @@ internal sealed class CachingCalculationAnchorResolver
     {
         return !_rulesByName.TryGetValue(key.AnchorRuleName, out NotableDateRule? rule)
             ? throw new InvalidOperationException(
-                $"The calculation anchor rule '{key.AnchorRuleName}' could not be found.")
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    CalendarResourceStrings.Op_Invalid_CalculationAnchorRuleNotFound,
+                    key.AnchorRuleName))
             : _ruleResolver.ResolveAnchorDate(rule, key.Year);
     }
 }

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarThrowHelper.CallerExpression.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarThrowHelper.CallerExpression.cs
@@ -1,11 +1,14 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="CalendarThrowHelper.CallerExpression.cs" company="Bodu Pty. Ltd.". />
 //     Copyright (c) Bodu Pty. Ltd.. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
 #if !NETSTANDARD2_0_OR_GREATER
+using System.Globalization;
 using System.Runtime.CompilerServices;
+
+using SysGlobal = System.Globalization;
 
 namespace Bodu.Globalization.Calendar;
 
@@ -21,6 +24,7 @@ internal static partial class CalendarThrowHelper
     /// <exception cref="ArgumentException">
     /// Thrown when <paramref name="endDate" /> is earlier than <paramref name="startDate" />.
     /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static void ThrowIfEndDateBeforeStartDate(
         DateTime startDate,
         DateTime endDate,
@@ -33,22 +37,133 @@ internal static partial class CalendarThrowHelper
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> when <paramref name="value" /> is <see langword="null" />, empty, or
-    /// contains only white-space characters.
+    /// Throws an <see cref="ArgumentException" /> when <paramref name="key" /> is <see langword="null" />, empty, or
+    /// contains only white-space characters, using the standard registry-key message.
     /// </summary>
-    /// <param name="value">The string value to test.</param>
-    /// <param name="message">The exception message describing the violated contract.</param>
+    /// <param name="key">The registry key value to validate.</param>
     /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="value" /> is null, empty, or white-space.
+    /// Thrown when <paramref name="key" /> is <see langword="null" />, empty, or white-space.
     /// </exception>
-    internal static void ThrowIfNullOrWhiteSpace(
-        string? value,
-        string message,
-        [CallerArgumentExpression(nameof(value))] string? paramName = null)
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfKeyNullOrWhiteSpace(
+        string? key,
+        [CallerArgumentExpression(nameof(key))] string? paramName = null)
     {
-        if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException(message, paramName);
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException(
+                CalendarResourceStrings.Arg_Invalid_KeyNullOrWhiteSpace,
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> when <paramref name="anchorRuleName" /> is <see langword="null" />,
+    /// empty, or contains only white-space characters.
+    /// </summary>
+    /// <param name="anchorRuleName">The anchor-rule name to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="anchorRuleName" /> is <see langword="null" />, empty, or white-space.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfAnchorRuleNameNullOrWhiteSpace(
+        string? anchorRuleName,
+        [CallerArgumentExpression(nameof(anchorRuleName))] string? paramName = null)
+    {
+        if (string.IsNullOrWhiteSpace(anchorRuleName))
+            throw new ArgumentException(
+                CalendarResourceStrings.Arg_Invalid_AnchorRuleNameNullOrWhiteSpace,
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="year" /> is outside the supported
+    /// range <c>[1, 9999]</c>.
+    /// </summary>
+    /// <param name="year">The year value to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="year" /> is less than 1 or greater than 9999.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfYearOutOfRange(
+        int year,
+        [CallerArgumentExpression(nameof(year))] string? paramName = null)
+    {
+        if (year is < 1 or > 9999)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                year,
+                CalendarResourceStrings.Arg_OutOfRange_Year);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="workingWeek" /> is not a defined
+    /// member of <see cref="WorkingDaysOfWeek" />.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined <see cref="WorkingDaysOfWeek" /> value.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfWorkingWeekUndefined(
+        WorkingDaysOfWeek workingWeek,
+        [CallerArgumentExpression(nameof(workingWeek))] string? paramName = null)
+    {
+        if (!Enum.IsDefined(typeof(WorkingDaysOfWeek), workingWeek))
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                workingWeek,
+                CalendarResourceStrings.Arg_OutOfRange_WorkingWeekUndefined);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="workingWeek" /> selects no days.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> selects no days.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfWorkingWeekEmpty(
+        WeekPattern workingWeek,
+        [CallerArgumentExpression(nameof(workingWeek))] string? paramName = null)
+    {
+        if (workingWeek.Count == 0)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+    }
+
+    /// <summary>
+    /// Throws a <see cref="NotSupportedException" /> when <paramref name="calendar" /> is not <see langword="null" />
+    /// and is not an instance of <paramref name="supportedCalendarType" />.
+    /// </summary>
+    /// <param name="calendar">The calendar to validate; <see langword="null" /> is accepted as the provider default.</param>
+    /// <param name="providerType">The Easter provider type that issued the validation, used in the exception message.</param>
+    /// <param name="supportedCalendarType">The single calendar type accepted by <paramref name="providerType" />.</param>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="calendar" /> is not <see langword="null" /> and is not assignable to
+    /// <paramref name="supportedCalendarType" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfUnsupportedCalendarType(
+        SysGlobal.Calendar? calendar,
+        Type providerType,
+        Type supportedCalendarType)
+    {
+        if (calendar is null || supportedCalendarType.IsInstanceOfType(calendar))
+            return;
+
+        throw new NotSupportedException(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                CalendarResourceStrings.Op_NotSupported_CalendarType,
+                calendar.GetType().FullName,
+                providerType.Name,
+                supportedCalendarType.FullName));
     }
 }
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarThrowHelper.NetStandard.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarThrowHelper.NetStandard.cs
@@ -6,7 +6,10 @@
 
 #if NETSTANDARD2_0_OR_GREATER
 using System;
+using System.Globalization;
 using System.Runtime.CompilerServices;
+
+using SysGlobal = System.Globalization;
 
 namespace Bodu.Globalization.Calendar;
 
@@ -32,20 +35,123 @@ internal static partial class CalendarThrowHelper
     }
 
     /// <summary>
-    /// Throws an <see cref="ArgumentException" /> when <paramref name="value" /> is <see langword="null" />,
-    /// empty, or contains only white-space characters.
+    /// Throws an <see cref="ArgumentException" /> when <paramref name="key" /> is <see langword="null" />, empty, or
+    /// contains only white-space characters, using the standard registry-key message.
     /// </summary>
-    /// <param name="value">The string value to test.</param>
-    /// <param name="message">The exception message describing the violated contract.</param>
+    /// <param name="key">The registry key value to validate.</param>
     /// <param name="paramName">The parameter name reported in the exception.</param>
     /// <exception cref="ArgumentException">
-    /// Thrown when <paramref name="value" /> is null, empty, or white-space.
+    /// Thrown when <paramref name="key" /> is <see langword="null" />, empty, or white-space.
     /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    internal static void ThrowIfNullOrWhiteSpace(string? value, string message, string? paramName = null)
+    internal static void ThrowIfKeyNullOrWhiteSpace(string? key, string? paramName = null)
     {
-        if (string.IsNullOrWhiteSpace(value))
-            throw new ArgumentException(message, paramName);
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentException(
+                CalendarResourceStrings.Arg_Invalid_KeyNullOrWhiteSpace,
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentException" /> when <paramref name="anchorRuleName" /> is <see langword="null" />,
+    /// empty, or contains only white-space characters.
+    /// </summary>
+    /// <param name="anchorRuleName">The anchor-rule name to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception.</param>
+    /// <exception cref="ArgumentException">
+    /// Thrown when <paramref name="anchorRuleName" /> is <see langword="null" />, empty, or white-space.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfAnchorRuleNameNullOrWhiteSpace(string? anchorRuleName, string? paramName = null)
+    {
+        if (string.IsNullOrWhiteSpace(anchorRuleName))
+            throw new ArgumentException(
+                CalendarResourceStrings.Arg_Invalid_AnchorRuleNameNullOrWhiteSpace,
+                paramName);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="year" /> is outside the supported
+    /// range <c>[1, 9999]</c>.
+    /// </summary>
+    /// <param name="year">The year value to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="year" /> is less than 1 or greater than 9999.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfYearOutOfRange(int year, string? paramName = null)
+    {
+        if (year < 1 || year > 9999)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                year,
+                CalendarResourceStrings.Arg_OutOfRange_Year);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="workingWeek" /> is not a defined
+    /// member of <see cref="WorkingDaysOfWeek" />.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> is not a defined <see cref="WorkingDaysOfWeek" /> value.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfWorkingWeekUndefined(WorkingDaysOfWeek workingWeek, string? paramName = null)
+    {
+        if (!Enum.IsDefined(typeof(WorkingDaysOfWeek), workingWeek))
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                workingWeek,
+                CalendarResourceStrings.Arg_OutOfRange_WorkingWeekUndefined);
+    }
+
+    /// <summary>
+    /// Throws an <see cref="ArgumentOutOfRangeException" /> when <paramref name="workingWeek" /> selects no days.
+    /// </summary>
+    /// <param name="workingWeek">The working-week pattern to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="workingWeek" /> selects no days.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfWorkingWeekEmpty(WeekPattern workingWeek, string? paramName = null)
+    {
+        if (workingWeek.Count == 0)
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                CalendarResourceStrings.Arg_OutOfRange_WorkingWeekEmpty);
+    }
+
+    /// <summary>
+    /// Throws a <see cref="NotSupportedException" /> when <paramref name="calendar" /> is not <see langword="null" />
+    /// and is not an instance of <paramref name="supportedCalendarType" />.
+    /// </summary>
+    /// <param name="calendar">The calendar to validate; <see langword="null" /> is accepted as the provider default.</param>
+    /// <param name="providerType">The Easter provider type that issued the validation, used in the exception message.</param>
+    /// <param name="supportedCalendarType">The single calendar type accepted by <paramref name="providerType" />.</param>
+    /// <exception cref="NotSupportedException">
+    /// Thrown when <paramref name="calendar" /> is not <see langword="null" /> and is not assignable to
+    /// <paramref name="supportedCalendarType" />.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfUnsupportedCalendarType(
+        SysGlobal.Calendar? calendar,
+        Type providerType,
+        Type supportedCalendarType)
+    {
+        if (calendar is null || supportedCalendarType.IsInstanceOfType(calendar))
+            return;
+
+        throw new NotSupportedException(
+            string.Format(
+                CultureInfo.InvariantCulture,
+                CalendarResourceStrings.Op_NotSupported_CalendarType,
+                calendar.GetType().FullName,
+                providerType.Name,
+                supportedCalendarType.FullName));
     }
 }
 

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAdjuster.cs
@@ -97,7 +97,7 @@ internal sealed class NotableDateAdjuster
     /// <exception cref="ArgumentNullException"><paramref name="adjustment" /> is <see langword="null" />.</exception>
     public static bool IsInScope(ObservanceAdjustment adjustment, int year, string? territoryCode, Type? calendarType)
     {
-        if (adjustment is null) throw new ArgumentNullException(nameof(adjustment));
+        ThrowHelper.ThrowIfNull(adjustment);
 
         if (adjustment.EffectiveFromYear is { } from && year < from) return false;
         if (adjustment.EffectiveToYear is { } to && year > to) return false;
@@ -156,8 +156,8 @@ internal sealed class NotableDateAdjuster
         string? territoryCode = null,
         Type? calendarType = null)
     {
-        if (adjustment is null) throw new ArgumentNullException(nameof(adjustment));
-        if (rule is null) throw new ArgumentNullException(nameof(rule));
+        ThrowHelper.ThrowIfNull(adjustment);
+        ThrowHelper.ThrowIfNull(rule);
 
         if (!IsInScope(adjustment, originalDate.Year, territoryCode, calendarType))
             return AdjustmentApplyResult.NotActivated(originalDate);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateAlgorithmRegistry.cs
@@ -86,7 +86,7 @@ public sealed class NotableDateAlgorithmRegistry
     /// </exception>
     public NotableDateAlgorithmRegistry(IEnumerable<KeyValuePair<string, INotableDateAlgorithm>> algorithms)
     {
-        if (algorithms is null) throw new ArgumentNullException(nameof(algorithms));
+        ThrowHelper.ThrowIfNull(algorithms);
 
         foreach (KeyValuePair<string, INotableDateAlgorithm> pair in algorithms)
             Register(pair.Key, pair.Value);
@@ -109,10 +109,8 @@ public sealed class NotableDateAlgorithmRegistry
     /// </exception>
     public NotableDateAlgorithmRegistry Register(string key, INotableDateAlgorithm algorithm)
     {
-        if (string.IsNullOrWhiteSpace(key))
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_KeyNullOrWhiteSpace, nameof(key));
-        if (algorithm is null)
-            throw new ArgumentNullException(nameof(algorithm));
+        CalendarThrowHelper.ThrowIfKeyNullOrWhiteSpace(key);
+        ThrowHelper.ThrowIfNull(algorithm);
 
         lock (_gate)
         {

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionAdjustmentProcessor.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionAdjustmentProcessor.cs
@@ -50,11 +50,10 @@ internal sealed class NotableDateResolutionAdjustmentProcessor
         IAdjustmentHandlerRegistry? handlerRegistry = null,
         INotableDateRuleOccurrenceResolver? occurrenceResolver = null)
     {
-        if (!Enum.IsDefined(workingWeek))
-            throw new ArgumentOutOfRangeException(nameof(workingWeek), workingWeek, CalendarResourceStrings.Arg_OutOfRange_WorkingWeekUndefined);
+        CalendarThrowHelper.ThrowIfWorkingWeekUndefined(workingWeek);
 
-        if (workingWeek == WorkingDaysOfWeek.Custom && weekendProvider is null)
-            throw new ArgumentNullException(nameof(weekendProvider));
+        if (workingWeek == WorkingDaysOfWeek.Custom)
+            ThrowHelper.ThrowIfNull(weekendProvider);
 
         this._workingWeek = workingWeek;
         this._weekendProvider = weekendProvider;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionRequest.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionRequest.cs
@@ -34,8 +34,7 @@ internal sealed record NotableDateResolutionRequest
         DateTime start = startDate.Date;
         DateTime end = endDate.Date;
 
-        if (end < start)
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_EndDateBeforeStartDate, nameof(endDate));
+        CalendarThrowHelper.ThrowIfEndDateBeforeStartDate(start, end, nameof(endDate));
 
         StartDate = start;
         EndDate = end;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionService.cs
@@ -48,12 +48,10 @@ internal sealed class NotableDateResolutionService
         IAdjustmentHandlerRegistry? adjustmentHandlers = null)
     {
         ArgumentNullException.ThrowIfNull(ruleProviders);
+        CalendarThrowHelper.ThrowIfWorkingWeekUndefined(workingWeek);
 
-        if (!Enum.IsDefined(workingWeek))
-            throw new ArgumentOutOfRangeException(nameof(workingWeek), workingWeek, CalendarResourceStrings.Arg_OutOfRange_WorkingWeekUndefined);
-
-        if (workingWeek == WorkingDaysOfWeek.Custom && weekendProvider is null)
-            throw new ArgumentNullException(nameof(weekendProvider));
+        if (workingWeek == WorkingDaysOfWeek.Custom)
+            ThrowHelper.ThrowIfNull(weekendProvider);
 
         this.EffectiveRules = LoadRules(ruleProviders);
         this._collisionResolver = collisionResolver;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionWindow.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResolutionWindow.cs
@@ -51,8 +51,7 @@ internal sealed class NotableDateResolutionWindow
         DateTime start = startDate.Date;
         DateTime end = endDate.Date;
 
-        if (end < start)
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_EndDateBeforeStartDate, nameof(endDate));
+        CalendarThrowHelper.ThrowIfEndDateBeforeStartDate(start, end, nameof(endDate));
 
         StartDate = start;
         EndDate = end;

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleParser.cs
@@ -137,8 +137,7 @@ public static class NotableDateRuleParser
     /// </exception>
     public static ParsedNotableDateDocument ParseDocument(XDocument document)
     {
-        if (document is null)
-            throw new ArgumentNullException(nameof(document));
+        ThrowHelper.ThrowIfNull(document);
 
         ValidateDocument(document);
         return ParseDocumentInternal(document);

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResolver.cs
@@ -47,7 +47,7 @@ internal sealed class NotableDateRuleResolver
     /// </exception>
     public NotableDateRuleResolver(IReadOnlyList<NotableDateRule> rules, INotableDateAlgorithmRegistry? algorithms = null)
     {
-        if (rules is null) throw new ArgumentNullException(nameof(rules));
+        ThrowHelper.ThrowIfNull(rules);
 
         // Build a name-keyed lookup once; rule names are unique within a service. Duplicates collapse silently with the last wins.
         var lookup = new Dictionary<string, NotableDateRule>(StringComparer.OrdinalIgnoreCase);
@@ -100,9 +100,9 @@ internal sealed class NotableDateRuleResolver
     /// </exception>
     public DateTime? ResolveAnchorDate(NotableDateRule rule, int year)
     {
-        return rule is null
-            ? throw new ArgumentNullException(nameof(rule))
-            : ResolveInternal(rule, year, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        ThrowHelper.ThrowIfNull(rule);
+
+        return ResolveInternal(rule, year, new HashSet<string>(StringComparer.OrdinalIgnoreCase));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResourceProviderBase.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRuleResourceProviderBase.cs
@@ -116,7 +116,7 @@ public abstract class NotableDateRuleResourceProviderBase
     {
         _rootResourceName = rootResourceName ?? throw new ArgumentNullException(nameof(rootResourceName));
         _resourcePathResolver = resourcePathResolver ?? throw new ArgumentNullException(nameof(resourcePathResolver));
-        if (assemblies is null) throw new ArgumentNullException(nameof(assemblies));
+        ThrowHelper.ThrowIfNull(assemblies);
 
         Assembly[] snapshot = [.. assemblies];
         if (snapshot.Length == 0) throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_AssemblyChainEmpty, nameof(assemblies));

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -736,8 +736,7 @@ public sealed class NotableDateService : INotableDateService, IDisposable
     /// </exception>
     public bool IsRangeResolved(DateTime startDate, DateTime endDate)
     {
-        if (endDate < startDate)
-            throw new ArgumentException(CalendarResourceStrings.Arg_Invalid_EndDateBeforeStartDate, nameof(endDate));
+        CalendarThrowHelper.ThrowIfEndDateBeforeStartDate(startDate, endDate);
 
         DateRange probe = new(startDate.Date, endDate.Date);
 


### PR DESCRIPTION
Brings Bodu.Globalization.Calendar in line with the exception-handling pattern
used by Bodu.IO.Hashing and Bodu.Security.Cryptography: every exception message
is now sourced from CalendarResourceStrings.resx, and validation patterns shared
across two or more files are consolidated in the internal CalendarThrowHelper.

* resx: add 12 keys for plugin trust/activation/missing-attribute formats, the
  calculation-anchor-rule-not-found message, and the trust-policy reason
  fragments; reword Arg_OutOfRange_Year to cover both bounds [1, 9999].
* CalendarThrowHelper: add ThrowIfYearOutOfRange, ThrowIfWorkingWeekUndefined,
  ThrowIfWorkingWeekEmpty, ThrowIfKeyNullOrWhiteSpace,
  ThrowIfAnchorRuleNameNullOrWhiteSpace, ThrowIfUnsupportedCalendarType across
  both CallerExpression and NetStandard partials; remove the unused generic
  ThrowIfNullOrWhiteSpace helper.
* Plugin exceptions + trust policies: refactor PluginNotTrustedException,
  PluginMissingAttributeException, PluginActivationException, and the trust
  policy Reason strings to format from resx via string.Format(InvariantCulture).
* CachingCalculationAnchorResolver: replace $"..." interpolation with the new
  Op_Invalid_CalculationAnchorRuleNotFound resx key.
* Call sites: adopt the new CalendarThrowHelper methods for year bounds,
  working-week validation, registry key/anchor-rule-name guards, and Easter
  calendar-type validation across all algorithm and extension files.
* Null-check sweep: convert statement-form
  `throw new ArgumentNullException(nameof(x))` to `ThrowHelper.ThrowIfNull(x)`;
  preserve `?? throw new ArgumentNullException(...)` C# idioms and the
  combined IsNullOrWhiteSpace+ArgumentNullException sites whose exception
  contract differs.

All 2745 BVT tests pass; one pre-existing regression failure
(ParseJson_WhenFixedMonthIsStringNumeric "13",13) reproduces on master and is
unrelated to this change.

https://claude.ai/code/session_01XVGtzsviu3CcUx4pBN69rm