### PR TITLE
Prevent orphaning of trailing punctuation in XML doc wrapping

### DIFF
--- a/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation.Core/src/Layout/DocWrapper.cs
+++ b/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation.Core/src/Layout/DocWrapper.cs
@@ -26,6 +26,12 @@ namespace Bodu.CodeStyle.XmlDocumentation.Layout;
 /// <c>'.'</c>, or <c>':'</c>) is deliberately not applied — it caused multi-sentence paragraphs to fragment
 /// at every clause even when the line could comfortably absorb more text.
 /// </para>
+/// <para>
+/// Adjacent atoms with no whitespace between them (for example a trailing <c>'.'</c> immediately after an
+/// inline <c>&lt;see /&gt;</c> reference) are treated as a single typographic unit and are never split across
+/// a line boundary, even when the join exceeds the budget. There is no whitespace to absorb such a break and
+/// the resulting orphan-punctuation line is wrong.
+/// </para>
 /// </remarks>
 internal static class DocWrapper
 {
@@ -59,7 +65,11 @@ internal static class DocWrapper
             var hasLeadingSpace = pendingWhitespace && lineAtoms.Count > 0;
             var addedLength = (hasLeadingSpace ? 1 : 0) + atom.Length;
 
-            if (lineAtoms.Count == 0 || lineLength + addedLength <= contentBudget)
+            // Atoms with no preceding whitespace are typographically joined to the previous atom (e.g. a
+            // trailing '.' after </see> or <see ... />) and must not be split across a line boundary even
+            // when the join exceeds the budget — there is no whitespace to absorb the break and an orphan
+            // punctuation line is wrong.
+            if (lineAtoms.Count == 0 || lineLength + addedLength <= contentBudget || !hasLeadingSpace)
             {
                 lineAtoms.Add(new LineAtom(atom, hasLeadingSpace));
                 lineLength += addedLength;

--- a/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation.Core/test/Formatting/XmlDocFormatterTests.Wrapping.cs
+++ b/Bodu.CodeStyle/Bodu.CodeStyle.XmlDocumentation.Core/test/Formatting/XmlDocFormatterTests.Wrapping.cs
@@ -46,4 +46,28 @@ public partial class XmlDocFormatterTests
             Assert.IsTrue(line.Length <= 80, $"Line '{line}' exceeds 80 characters.");
         }
     }
+
+    /// <summary>
+    /// Verifies that a trailing punctuation atom adjacent to an oversize inline atom (no whitespace between
+    /// them) is kept on the same line as the atom, rather than being orphaned onto its own line by the wrapper.
+    /// </summary>
+    [TestMethod]
+    public void Format_WhenTrailingPunctuationAdjacentToOversizeInlineAtom_ShouldStayOnSameLine()
+    {
+        var input =
+            "/// <returns>\r\n" +
+            "    /// The service collection passed to\r\n" +
+            "    /// <see cref=\"ServiceCollectionExtensions.AddNotableDates(Microsoft.Extensions.DependencyInjection.IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)\" />.\r\n" +
+            "    /// </returns>\r\n";
+
+        XmlDocFormatResult result = CreateFormatter().FormatTrivia(input, CreateContext(), CreateOptions());
+
+        Assert.IsFalse(result.Changed, "Already-canonical input should be reported as unchanged.");
+        Assert.AreEqual(input, result.FormattedText);
+        StringAssert.Contains(result.FormattedText, "string)\" />.");
+        foreach (var line in result.FormattedText.Split(["\r\n"], System.StringSplitOptions.None))
+        {
+            Assert.AreNotEqual("    /// .", line, "Trailing '.' must not be orphaned onto its own line.");
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fix XML documentation formatter to keep trailing punctuation (e.g. a period after `</see>`) on the same line as the preceding inline element, rather than orphaning it onto its own line when wrapping exceeds the line-length budget.

## Changes

- **DocWrapper.cs**: Modified the line-wrapping logic to treat adjacent atoms with no whitespace between them as a typographic unit that must never be split across line boundaries. This prevents scenarios where a trailing punctuation mark gets orphaned onto its own line (e.g. `    /// .`), which is incorrect formatting.

- **XmlDocFormatterTests.Wrapping.cs**: Added test case `Format_WhenTrailingPunctuationAdjacentToOversizeInlineAtom_ShouldStayOnSameLine()` to verify that trailing punctuation adjacent to an oversize inline atom (such as a long `<see cref="..." />` reference) remains on the same line rather than being orphaned.

## Implementation Details

The fix adds a condition `|| !hasLeadingSpace` to the line-wrapping decision logic. When an atom has no preceding whitespace (indicated by `hasLeadingSpace == false`), it is forced onto the current line regardless of whether the join exceeds the content budget. This is correct because:

1. There is no whitespace to absorb a line break between the atoms
2. Splitting them would create an orphan-punctuation line, which is typographically wrong
3. The atoms form a single semantic unit (e.g. `</see>.`)

The test confirms that already-canonical input is reported as unchanged and that no line contains only `    /// .` (the orphaned punctuation pattern).

https://claude.ai/code/session_01HWXRPSK4oT5T6tLFjfZsF5