### PR TITLE
fix(crypto): use full-range RNG for keys, IVs, nonces, and tweaks

### DIFF
--- a/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
+++ b/Bodu.Security.Cryptography/src/Bodu.Security.Cryptography.csproj
@@ -1,53 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Bodu</RootNamespace>
     <AssemblyName>$(MSBuildProjectName)</AssemblyName>
     <OutputType>Library</OutputType>
-    <OutputType>Library</OutputType>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD2_0</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <DefineConstants>$(DefineConstants);NET6_0_OR_GREATER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net7.0'">
-    <DefineConstants>$(DefineConstants);NET7_0_OR_GREATER</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <DefineConstants>$(DefineConstants);NET8_0_OR_GREATER</DefineConstants>
-  </PropertyGroup>
-
   <PropertyGroup Condition="'$(AllowUnsafeBlocks)' == 'true'">
     <DefineConstants>$(DefineConstants);ALLOW_UNSAFE</DefineConstants>
   </PropertyGroup>
-
-  <!--
-    The CryptoHelpers ThrowHelper partial is split into a CallerArgumentExpression variant and a
-    NetStandard variant:
-      - CryptoHelpers.ThrowHelper.*NetStandard.cs       : compiled for netstandard2.0 / netstandard2.1,
-                                                          where CallerArgumentExpressionAttribute is unavailable.
-      - CryptoHelpers.ThrowHelper.*CallerExpression.cs  : compiled for all other targets (net5.0+),
-                                                          where CallerArgumentExpressionAttribute is supported.
-  -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'netstandard2.1'">
-    <Compile Remove="Security.Cryptography\CryptoHelpers.ThrowHelper.*CallerExpression.cs" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'netstandard2.1'">
-    <Compile Remove="Security.Cryptography\CryptoHelpers.ThrowHelper.*NetStandard.cs" />
-  </ItemGroup>
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
@@ -64,11 +32,6 @@
       <LastGenOutput>CryptoResourceStrings.Designer.cs</LastGenOutput>
       <Generator>ResXFileCodeGenerator</Generator>
     </EmbeddedResource>
-    <Compile Update="CryptoCryptoResourceStrings.Designer.cs">
-      <DependentUpon>CryptoCryptoResourceStrings.resx</DependentUpon>
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-    </Compile>
     <Compile Update="CryptoResourceStrings.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/Bodu.Security.Cryptography/src/CryptoResourceStrings.Designer.cs
+++ b/Bodu.Security.Cryptography/src/CryptoResourceStrings.Designer.cs
@@ -448,7 +448,7 @@ namespace Bodu {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The input and output buffers refer to the same array but partially overlap. A stream-cipher transform supports only exact in-place transformation (identical offsets) or fully disjoint buffers..
+        ///   Looks up a localized string similar to The input and output buffers partially overlap. Cryptographic transforms support only exact in-place transformation (identical start and length) or fully disjoint buffers..
         /// </summary>
         internal static string Crypt_Invalid_PartialBufferOverlap {
             get {

--- a/Bodu.Security.Cryptography/src/CryptoResourceStrings.resx
+++ b/Bodu.Security.Cryptography/src/CryptoResourceStrings.resx
@@ -191,7 +191,7 @@
     <value>The input data is not a complete block.</value>
   </data>
   <data name="Crypt_Invalid_PartialBufferOverlap" xml:space="preserve">
-    <value>The input and output buffers refer to the same array but partially overlap. A stream-cipher transform supports only exact in-place transformation (identical offsets) or fully disjoint buffers.</value>
+    <value>The input and output buffers partially overlap. Cryptographic transforms support only exact in-place transformation (identical start and length) or fully disjoint buffers.</value>
   </data>
   <data name="Crypt_Invalid_PropertyValue" xml:space="preserve">
     <value>The specified value for '{0}' is not supported by this algorithm.</value>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
@@ -378,6 +378,14 @@ public sealed class AsconAead128
     /// <paramref name="output" /> is too small.
     /// </exception>
     /// <exception cref="CryptographicException">The authentication tag did not match.</exception>
+    /// <remarks>
+    /// <strong>Authentication pattern: write-then-clear.</strong> Ascon-AEAD-128 streams plaintext into
+    /// <paramref name="output" /> as it processes the ciphertext because the duplex sponge derives the tag from the
+    /// final state; the tag is then compared in constant time, and on mismatch
+    /// <see cref="CryptographicOperations.ZeroMemory" /> clears the plaintext-length region of
+    /// <paramref name="output" /> before <see cref="CryptographicException" /> is thrown — no plaintext is observable
+    /// to the caller.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -261,6 +261,7 @@ public abstract class BlockCipherTransform
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf<byte>(input, _cipher.BlockSize / 8, throwIfZero: false);
         Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf<byte>(output, _cipher.BlockSize / 8, throwIfZero: false);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         if (_encrypt)
             return _mode.Transform(input, output, true);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
@@ -305,7 +305,7 @@ public sealed class Blowfish
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeValue / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeValue / 8);
     }
 
     /// <summary>
@@ -324,7 +324,7 @@ public sealed class Blowfish
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeValue / 8);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeValue / 8);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Camellia.cs
@@ -273,7 +273,7 @@ public sealed class Camellia
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeValue / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeValue / 8);
     }
 
     /// <summary>
@@ -290,7 +290,7 @@ public sealed class Camellia
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeBytes);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeBytes);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
@@ -89,6 +89,7 @@ public sealed class CbcModeTransform
 
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         Span<byte> tempBlock = stackalloc byte[blockSize];
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CcmModeTransform.cs
@@ -169,6 +169,12 @@ public sealed class CcmModeTransform
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <strong>Authentication pattern: verify-before-release.</strong> The CBC-MAC tag is recomputed and compared in
+    /// constant time before the CTR decryption stream is applied to <paramref name="output" />; no plaintext byte is
+    /// ever written when authentication fails. See <see cref="IAeadBlockCipherModeTransform.Decrypt" /> for the
+    /// library-wide failure contract.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -89,6 +89,7 @@ public sealed class CfbModeTransform
         // Empty input is a no-op, consistent with CbcModeTransform.
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         Span<byte> feedback = stackalloc byte[blockSize];
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.Overlap.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptoHelpers.Overlap.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpers.Overlap.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+internal static partial class CryptoHelpers
+{
+    /// <summary>
+    /// Throws a <see cref="CryptographicException" /> if <paramref name="input" /> and <paramref name="output" />
+    /// partially overlap in memory.
+    /// </summary>
+    /// <param name="input">The input span being read by the transform.</param>
+    /// <param name="output">The output span being written by the transform.</param>
+    /// <param name="allowExactInPlace">
+    /// When <see langword="true" /> (the default) the spans may alias exactly — same start address and same length —
+    /// so that the caller can perform an in-place transform with a single buffer. When <see langword="false" />, any
+    /// overlap (including exact aliasing) is rejected.
+    /// </param>
+    /// <exception cref="CryptographicException">
+    /// The spans overlap in a way that is not safe for forward byte-by-byte processing: either a partial overlap, or
+    /// exact aliasing when <paramref name="allowExactInPlace" /> is <see langword="false" />.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Cryptographic transforms read input sequentially and write output sequentially. Exact in-place aliasing is
+    /// safe for stream and block ciphers because each output byte is computed and written before the next input byte
+    /// is read. Partial overlap, however, lets a write into not-yet-read input clobber the keystream / chaining input,
+    /// producing a silently corrupted result.
+    /// </para>
+    /// <para>
+    /// The check is short-circuited when either span is empty: zero-length operations cannot overlap meaningfully.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfInvalidOverlap(ReadOnlySpan<byte> input, Span<byte> output, bool allowExactInPlace = true)
+    {
+        if (input.IsEmpty || output.IsEmpty)
+            return;
+
+        if (!input.Overlaps(output, out int elementOffset))
+            return;
+
+        if (allowExactInPlace && elementOffset == 0 && input.Length == output.Length)
+            return;
+
+        throw new CryptographicException(CryptoResourceStrings.Crypt_Invalid_PartialBufferOverlap);
+    }
+}

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
@@ -99,6 +99,7 @@ public sealed class CtrModeTransform
     public int Transform(ReadOnlySpan<byte> input, Span<byte> output, bool encrypt)
     {
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         var blockSize = _cipher.BlockSize / 8;
         Span<byte> keystream = stackalloc byte[blockSize];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
@@ -113,6 +113,7 @@ public sealed class CtsModeTransform
         }
 
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         // If perfectly block-aligned (or exactly one block), use plain CBC — no stealing needed.
         if (input.Length % blockSize == 0)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -182,6 +182,12 @@ public sealed class EaxModeTransform
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <strong>Authentication pattern: verify-before-release.</strong> The OMAC-derived tag is recomputed and compared
+    /// in constant time before the CTR decryption stream is applied to <paramref name="output" />; no plaintext byte
+    /// is ever written when authentication fails. See <see cref="IAeadBlockCipherModeTransform.Decrypt" /> for the
+    /// library-wide failure contract.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -80,6 +80,7 @@ public sealed class EcbModeTransform
         // Empty input is a no-op, consistent with CbcModeTransform.
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         for (var offset = 0; offset < input.Length; offset += blockSize)
         {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
@@ -308,6 +308,12 @@ public sealed class GcmModeTransform
     /// The implicit plaintext length (<c><paramref name="ciphertextWithTag" />.Length − 16</c>) exceeds the SP 800-38D
     /// §5.2.1.1 ceiling. Unreachable through the public int-typed span surface today.
     /// </exception>
+    /// <remarks>
+    /// <strong>Authentication pattern: verify-before-release.</strong> The GHASH-derived tag is compared in constant
+    /// time before the CTR decryption stream is applied to <paramref name="output" />; no plaintext byte is ever
+    /// written when authentication fails. See <see cref="IAeadBlockCipherModeTransform.Decrypt" /> for the
+    /// library-wide failure contract.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -156,6 +156,14 @@ public sealed class GcmSivModeTransform
     public int TagSize => TagSizeBits;
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <strong>Authentication pattern: write-then-clear.</strong> The candidate plaintext is decrypted into
+    /// <paramref name="output" /> first because the synthetic IV used by AES-GCM-SIV is derived over the plaintext.
+    /// The tag is then compared in constant time; on mismatch <paramref name="output" /> is zeroed via
+    /// <see cref="CryptoHelpers.Clear" /> and <see cref="CryptographicException" /> is thrown — no plaintext is
+    /// observable to the caller. See <see cref="IAeadBlockCipherModeTransform.Decrypt" /> for the library-wide
+    /// failure contract.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/IAeadBlockCipherModeTransform.cs
@@ -186,5 +186,33 @@ public interface IAeadBlockCipherModeTransform
     /// The instance has already encrypted or decrypted a message, including after a previous tag-mismatch failure. AEAD
     /// transforms are single-use per message — construct a fresh instance.
     /// </exception>
+    /// <remarks>
+    /// <para>
+    /// <strong>Authentication failure contract.</strong> All implementations honour the same observable guarantee
+    /// on tag mismatch: <see cref="CryptographicException" /> is thrown and no plaintext is released to the caller.
+    /// Implementations achieve this in one of two ways:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>
+    /// <description>
+    /// <em>Verify-before-release.</em> The tag is compared in constant time before any plaintext byte is written to
+    /// <paramref name="output" />. Used by GCM, CCM, EAX, and OCB.
+    /// </description>
+    /// </item>
+    /// <item>
+    /// <description>
+    /// <em>Write-then-clear.</em> The candidate plaintext is streamed into <paramref name="output" /> first because the
+    /// algorithm's structure requires the transform to complete before the tag can be computed. The tag is then
+    /// compared in constant time; on mismatch <paramref name="output" /> is zeroed via
+    /// <see cref="CryptographicOperations.ZeroMemory" /> before the exception is thrown. Used by Ascon-AEAD-128 and
+    /// GCM-SIV.
+    /// </description>
+    /// </item>
+    /// </list>
+    /// <para>
+    /// In both cases the API is strictly one-shot: a failed decryption invalidates the instance, and subsequent calls
+    /// throw <see cref="InvalidOperationException" />. Construct a fresh instance per message.
+    /// </para>
+    /// </remarks>
     int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output);
 }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OcbModeTransform.cs
@@ -298,6 +298,12 @@ public sealed class OcbModeTransform
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <strong>Authentication pattern: verify-before-release.</strong> The OCB3 tag is recomputed from the offsets,
+    /// checksum, and AAD hash, then compared in constant time before the per-block decryption is applied to
+    /// <paramref name="output" />; no plaintext byte is ever written when authentication fails. See
+    /// <see cref="IAeadBlockCipherModeTransform.Decrypt" /> for the library-wide failure contract.
+    /// </remarks>
     public int Decrypt(ReadOnlySpan<byte> ciphertextWithTag, Span<byte> output)
     {
         ThrowIfDisposed();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -90,6 +90,7 @@ public sealed class OfbModeTransform
         // Empty input is a no-op, consistent with CbcModeTransform.
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         Span<byte> keystream = stackalloc byte[blockSize];
 

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.cs
@@ -130,21 +130,21 @@ public abstract class Serpent
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeBytes);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeBytes);
     }
 
     /// <inheritdoc />
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeBytes);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeBytes);
     }
 
     /// <inheritdoc />
     public override void GenerateTweak()
     {
         ThrowIfDisposed();
-        TweakValue = CryptoHelpers.GetRandomNonZeroBytes(_defaultTweakSizeBytes);
+        TweakValue = CryptoHelpers.GetRandomBytes(_defaultTweakSizeBytes);
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128.cs
@@ -220,14 +220,14 @@ public sealed class Serpent128
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeBits / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeBits / 8);
     }
 
     /// <inheritdoc />
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeValue / 8);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeValue / 8);
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.cs
@@ -114,7 +114,7 @@ public abstract class SipHash<T>
         CryptoHelpers.ThrowIfInvalidHashSize(hashSize, s_permittedHashSizes);
 
         KeyValue = new byte[KeySize / 8];
-        CryptoHelpers.FillWithRandomNonZeroBytes(KeyValue);
+        CryptoHelpers.FillWithRandomBytes(KeyValue);
         _compressionRounds = MinCompressionRounds;
         _finalizationRounds = MinFinalizationRounds;
         HashSizeValue = hashSize;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -269,7 +269,7 @@ public sealed class Skipjack
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeValue / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeValue / 8);
     }
 
     /// <summary>
@@ -288,7 +288,7 @@ public sealed class Skipjack
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeValue / 8);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeValue / 8);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/StreamCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/StreamCipherTransform.cs
@@ -151,17 +151,15 @@ internal sealed class StreamCipherTransform
         CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(inputBuffer, inputOffset, inputCount);
         CryptoHelpers.ThrowIfArrayOffsetOrCountInvalid(outputBuffer, outputOffset, inputCount);
 
-        // Forward byte-by-byte XOR is safe for exact in-place (equal offsets) and disjoint ranges, but a partial
-        // same-array overlap would let an earlier write clobber input that has not been read yet.
-        if (ReferenceEquals(inputBuffer, outputBuffer)
-            && inputCount > 0
-            && inputOffset != outputOffset
-            && RangesOverlap(inputOffset, outputOffset, inputCount))
-        {
-            throw new CryptographicException(CryptoResourceStrings.Crypt_Invalid_PartialBufferOverlap);
-        }
+        ReadOnlySpan<byte> input = inputBuffer.AsSpan(inputOffset, inputCount);
+        Span<byte> output = outputBuffer.AsSpan(outputOffset, inputCount);
 
-        Apply(inputBuffer.AsSpan(inputOffset, inputCount), outputBuffer.AsSpan(outputOffset, inputCount));
+        // Forward byte-by-byte XOR is safe for exact in-place (input and output cover the same memory) and for
+        // fully disjoint ranges, but a partial overlap would let an earlier write clobber input that has not yet
+        // been read.
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
+
+        Apply(input, output);
         return inputCount;
     }
 
@@ -232,19 +230,6 @@ internal sealed class StreamCipherTransform
             output[i] = (byte)(input[i] ^ _keystream[_keystreamOffset++]);
         }
     }
-
-    /// <summary>
-    /// Determines whether two equal-length ranges within the same array overlap.
-    /// </summary>
-    /// <param name="offsetA">The start offset of the first range.</param>
-    /// <param name="offsetB">The start offset of the second range.</param>
-    /// <param name="count">The length, in elements, shared by both ranges.</param>
-    /// <returns>
-    /// <see langword="true" /> if the ranges <c>[offsetA, offsetA + count)</c> and <c>[offsetB, offsetB + count)</c>
-    /// share any element; otherwise, <see langword="false" />.
-    /// </returns>
-    private static bool RangesOverlap(int offsetA, int offsetB, int count) =>
-        offsetA < offsetB + count && offsetB < offsetA + count;
 
     /// <summary>
     /// Throws an <see cref="ObjectDisposedException" /> if this transform has been disposed.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SymmetricStreamAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SymmetricStreamAlgorithm.cs
@@ -246,7 +246,7 @@ public abstract class SymmetricStreamAlgorithm
         ThrowIfDisposed();
 
         CryptoHelpers.ClearAndNullify(ref _key);
-        _key = CryptoHelpers.GetRandomNonZeroBytes(_keySizeBits / 8);
+        _key = CryptoHelpers.GetRandomBytes(_keySizeBits / 8);
     }
 
     /// <summary>
@@ -258,7 +258,7 @@ public abstract class SymmetricStreamAlgorithm
         ThrowIfDisposed();
 
         CryptoHelpers.ClearAndNullify(ref _nonce);
-        _nonce = CryptoHelpers.GetRandomNonZeroBytes(_nonceSizeBits / 8);
+        _nonce = CryptoHelpers.GetRandomBytes(_nonceSizeBits / 8);
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
@@ -148,21 +148,21 @@ public abstract class Threefish
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeValue / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeValue / 8);
     }
 
     /// <inheritdoc />
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeValue / 8);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeValue / 8);
     }
 
     /// <inheritdoc />
     public override void GenerateTweak()
     {
         ThrowIfDisposed();
-        TweakValue = CryptoHelpers.GetRandomNonZeroBytes(TweakSizeValue / 8);
+        TweakValue = CryptoHelpers.GetRandomBytes(TweakSizeValue / 8);
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
@@ -224,14 +224,14 @@ public sealed class Twofish
     public override void GenerateIV()
     {
         ThrowIfDisposed();
-        IVValue = CryptoHelpers.GetRandomNonZeroBytes(BlockSizeValue / 8);
+        IVValue = CryptoHelpers.GetRandomBytes(BlockSizeValue / 8);
     }
 
     /// <inheritdoc />
     public override void GenerateKey()
     {
         ThrowIfDisposed();
-        KeyValue = CryptoHelpers.GetRandomNonZeroBytes(KeySizeValue / 8);
+        KeyValue = CryptoHelpers.GetRandomBytes(KeySizeValue / 8);
     }
 
     /// <inheritdoc />

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
@@ -125,6 +125,7 @@ public sealed class XtsModeTransform
         // Empty input is a no-op, consistent with CbcModeTransform.
         CryptoHelpers.ThrowIfSpanLengthNotPositiveMultipleOf(input, blockSize, throwIfZero: false);
         ThrowHelper.ThrowIfSpanLengthIsInsufficient(output, 0, input.Length);
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
 
         // T_0 = tweakCipher.Encrypt(sector_number)
         Span<byte> T = stackalloc byte[blockSize];

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTransformOverlapTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockCipherModeTransformOverlapTests.cs
@@ -1,0 +1,126 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockCipherModeTransformOverlapTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// End-to-end wire-up tests confirming that every <see cref="IBlockCipherModeTransform" /> implementation invokes
+/// <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> and rejects partial input/output overlap. The detailed
+/// helper semantics are covered separately in <c>CryptoHelpersTests.ThrowIfInvalidOverlap</c>.
+/// </summary>
+[TestClass]
+public sealed class BlockCipherModeTransformOverlapTests
+{
+    private const int BlockSizeBytes = 8;
+
+    private static IBlockCipher CreateCipher() => new SkipjackBlockCipher(new byte[10]);
+
+    private static byte[] CreateIv() => new byte[BlockSizeBytes];
+
+    /// <summary>
+    /// Verifies that <see cref="CbcModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void CbcModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new CbcModeTransform(CreateCipher(), CreateIv());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="EcbModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void EcbModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new EcbModeTransform(CreateCipher());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CtrModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void CtrModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new CtrModeTransform(CreateCipher(), CreateIv());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CfbModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void CfbModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new CfbModeTransform(CreateCipher(), CreateIv());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="OfbModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void OfbModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new OfbModeTransform(CreateCipher(), CreateIv());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CtsModeTransform.Transform" /> rejects a partial input/output overlap with
+    /// <see cref="CryptographicException" />.
+    /// </summary>
+    [TestMethod]
+    public void CtsModeTransform_Transform_WhenPartialOverlap_ShouldThrowCryptographicException()
+    {
+        using var mode = new CtsModeTransform(CreateCipher(), CreateIv());
+
+        var buffer = new byte[BlockSizeBytes * 4];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = mode.Transform(buffer.AsSpan(0, BlockSizeBytes * 2), buffer.AsSpan(BlockSizeBytes, BlockSizeBytes * 2), encrypt: true);
+        });
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockSizeUnitContractTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockSizeUnitContractTests.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="BlockSizeUnitContractTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Library-wide contract tests for block-size units across the low-level <see cref="IBlockCipher" /> layer,
+/// the BCL <see cref="SymmetricAlgorithm" /> adapter layer, and the bridging <see cref="BlockCipherTransform" />.
+/// </summary>
+/// <remarks>
+/// The contract is intentional and load-bearing:
+/// <list type="bullet">
+/// <item>
+/// <description>
+/// <see cref="IBlockCipher.BlockSize" /> reports the cipher's block size in <em>bits</em> (matches the BCL
+/// <see cref="SymmetricAlgorithm.BlockSize" /> convention so the same number flows through both layers).
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="ICryptoTransform.InputBlockSize" /> and <see cref="ICryptoTransform.OutputBlockSize" /> report
+/// the value in <em>bytes</em> (per the BCL contract), computed as <c>IBlockCipher.BlockSize / 8</c>.
+/// </description>
+/// </item>
+/// </list>
+/// These tests catch any future change that quietly flips a unit at one boundary while leaving the other in place.
+/// </remarks>
+[TestClass]
+public sealed class BlockSizeUnitContractTests
+{
+    /// <summary>
+    /// Verifies that every low-level <see cref="IBlockCipher" /> implementation reports its block size in bits,
+    /// matches the expected value, and is a multiple of eight.
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(BlockCipherFactories), DynamicDataSourceType.Method)]
+    public void IBlockCipher_BlockSize_ShouldReportBitsAndBeMultipleOfEight(
+        string name,
+        Func<IBlockCipher> factory,
+        int expectedBlockSizeBits)
+    {
+        using IBlockCipher cipher = factory();
+
+        Assert.AreEqual(expectedBlockSizeBits, cipher.BlockSize, $"{name}: IBlockCipher.BlockSize must report bits.");
+        Assert.AreEqual(0, cipher.BlockSize % 8, $"{name}: IBlockCipher.BlockSize must be a multiple of 8.");
+        Assert.IsTrue(cipher.BlockSize >= 64, $"{name}: BlockSize implausibly small for a block cipher.");
+    }
+
+    /// <summary>
+    /// Verifies that every <see cref="SymmetricAlgorithm" />-derived cipher reports its block size in bits and
+    /// that the bridging <see cref="ICryptoTransform.InputBlockSize" /> / <see cref="ICryptoTransform.OutputBlockSize" />
+    /// equal <c>BlockSize / 8</c> (bytes).
+    /// </summary>
+    [TestMethod]
+    [DynamicData(nameof(SymmetricAlgorithmFactories), DynamicDataSourceType.Method)]
+    public void SymmetricAlgorithm_BlockSizeAndTransform_ShouldAgreeOnBitsAndBytes(
+        string name,
+        Func<SymmetricAlgorithm> factory,
+        int expectedBlockSizeBits)
+    {
+        using SymmetricAlgorithm alg = factory();
+
+        Assert.AreEqual(expectedBlockSizeBits, alg.BlockSize, $"{name}: SymmetricAlgorithm.BlockSize must report bits.");
+
+        using ICryptoTransform xfm = alg.CreateEncryptor();
+        int expectedBytes = expectedBlockSizeBits / 8;
+
+        Assert.AreEqual(expectedBytes, xfm.InputBlockSize, $"{name}: ICryptoTransform.InputBlockSize must equal BlockSize / 8.");
+        Assert.AreEqual(expectedBytes, xfm.OutputBlockSize, $"{name}: ICryptoTransform.OutputBlockSize must equal BlockSize / 8.");
+    }
+
+    /// <summary>
+    /// Returns factory delegates for every low-level <see cref="IBlockCipher" /> primitive together with the
+    /// expected block size in bits.
+    /// </summary>
+    public static IEnumerable<object[]> BlockCipherFactories()
+    {
+        yield return new object[] { "AesBlockCipher", (Func<IBlockCipher>)(() => new AesBlockCipher(new byte[16])), 128 };
+        yield return new object[] { "BlowfishBlockCipher", (Func<IBlockCipher>)(() => new BlowfishBlockCipher(new byte[16])), 64 };
+        yield return new object[] { "SkipjackBlockCipher", (Func<IBlockCipher>)(() => new SkipjackBlockCipher(new byte[10])), 64 };
+        yield return new object[] { "TwofishBlockCipher", (Func<IBlockCipher>)(() => new TwofishBlockCipher(new byte[16])), 128 };
+        yield return new object[] { "CamelliaBlockCipher", (Func<IBlockCipher>)(() => new CamelliaBlockCipher(new byte[16])), 128 };
+        yield return new object[] { "Serpent128Cipher", (Func<IBlockCipher>)(() => new Serpent128Cipher(new byte[16])), 128 };
+        yield return new object[] { "Serpent256Cipher", (Func<IBlockCipher>)(() => new Serpent256Cipher(new byte[32], new byte[16])), 256 };
+        yield return new object[] { "Serpent512Cipher", (Func<IBlockCipher>)(() => new Serpent512Cipher(new byte[64], new byte[16])), 512 };
+        yield return new object[] { "Serpent1024Cipher", (Func<IBlockCipher>)(() => new Serpent1024Cipher(new byte[128], new byte[16])), 1024 };
+        yield return new object[] { "Threefish256Cipher", (Func<IBlockCipher>)(() => new Threefish256Cipher(new byte[32], new byte[16])), 256 };
+        yield return new object[] { "Threefish512Cipher", (Func<IBlockCipher>)(() => new Threefish512Cipher(new byte[64], new byte[16])), 512 };
+        yield return new object[] { "Threefish1024Cipher", (Func<IBlockCipher>)(() => new Threefish1024Cipher(new byte[128], new byte[16])), 1024 };
+    }
+
+    /// <summary>
+    /// Returns factory delegates for every <see cref="SymmetricAlgorithm" />-derived cipher together with the
+    /// expected block size in bits.
+    /// </summary>
+    public static IEnumerable<object[]> SymmetricAlgorithmFactories()
+    {
+        yield return new object[] { "Skipjack", (Func<SymmetricAlgorithm>)(() => new Skipjack()), 64 };
+        yield return new object[] { "Blowfish", (Func<SymmetricAlgorithm>)(() => new Blowfish()), 64 };
+        yield return new object[] { "Camellia", (Func<SymmetricAlgorithm>)(() => new Camellia()), 128 };
+        yield return new object[] { "Twofish", (Func<SymmetricAlgorithm>)(() => new Twofish()), 128 };
+        yield return new object[] { "Serpent128", (Func<SymmetricAlgorithm>)(() => new Serpent128()), 128 };
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Contracts/SymmetricStreamAlgorithmContractTests.Dispose.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Contracts/SymmetricStreamAlgorithmContractTests.Dispose.cs
@@ -1,0 +1,245 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SymmetricStreamAlgorithmContractTests.Dispose.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography.Contracts;
+
+public abstract partial class SymmetricStreamAlgorithmContractTests<TCipher>
+{
+    /// <summary>
+    /// Verifies that calling <see cref="SymmetricStreamAlgorithm.Dispose()" /> twice on the same instance is
+    /// idempotent and does not throw.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalledTwice_ShouldNotThrow()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.Dispose();
+
+        cipher.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that disposing a freshly-constructed cipher — one that has never had any property accessed or
+    /// transform created — completes without throwing.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenInstanceUntouched_ShouldNotThrow()
+    {
+        TCipher cipher = CreateAlgorithm();
+
+        cipher.Dispose();
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SymmetricStreamAlgorithm.Dispose()" /> zeroes the internal key buffer in place
+    /// before nullifying the field, so the secret bytes do not linger on the managed heap after disposal.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalled_ShouldZeroInternalKeyBuffer()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+
+        FieldInfo keyField = typeof(SymmetricStreamAlgorithm)
+            .GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var capturedKey = (byte[]?)keyField.GetValue(cipher);
+
+        Assert.IsNotNull(capturedKey, "Internal key buffer must exist after GenerateKey.");
+        Assert.IsTrue(Array.Exists(capturedKey, b => b != 0), "Generated key must not be all-zero before disposal.");
+
+        cipher.Dispose();
+
+        CollectionAssert.AreEqual(
+            new byte[capturedKey.Length],
+            capturedKey,
+            "Dispose must zero the captured key buffer in place before nullifying the _key field.");
+        Assert.IsNull(keyField.GetValue(cipher), "Dispose must nullify the _key field.");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="SymmetricStreamAlgorithm.Dispose()" /> zeroes the internal nonce buffer in place
+    /// before nullifying the field.
+    /// </summary>
+    [TestMethod]
+    public void Dispose_WhenCalled_ShouldZeroInternalNonceBuffer()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateNonce();
+
+        FieldInfo nonceField = typeof(SymmetricStreamAlgorithm)
+            .GetField("_nonce", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var capturedNonce = (byte[]?)nonceField.GetValue(cipher);
+
+        Assert.IsNotNull(capturedNonce, "Internal nonce buffer must exist after GenerateNonce.");
+        Assert.IsTrue(Array.Exists(capturedNonce, b => b != 0), "Generated nonce must not be all-zero before disposal.");
+
+        cipher.Dispose();
+
+        CollectionAssert.AreEqual(
+            new byte[capturedNonce.Length],
+            capturedNonce,
+            "Dispose must zero the captured nonce buffer in place before nullifying the _nonce field.");
+        Assert.IsNull(nonceField.GetValue(cipher), "Dispose must nullify the _nonce field.");
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SymmetricStreamAlgorithm.Key" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Key_WhenAccessedAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = cipher.Key);
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SymmetricStreamAlgorithm.Nonce" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void Nonce_WhenAccessedAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateNonce();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = cipher.Nonce);
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SymmetricStreamAlgorithm.KeySize" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void KeySize_WhenAccessedAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = cipher.KeySize);
+    }
+
+    /// <summary>
+    /// Verifies that reading <see cref="SymmetricStreamAlgorithm.NonceSize" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void NonceSize_WhenAccessedAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = cipher.NonceSize);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="SymmetricStreamAlgorithm.CreateEncryptor()" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateEncryptor_WhenCalledAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+        cipher.GenerateNonce();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            using ICryptoTransform _ = cipher.CreateEncryptor();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="SymmetricStreamAlgorithm.CreateDecryptor()" /> after disposal throws
+    /// <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateDecryptor_WhenCalledAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+        cipher.GenerateNonce();
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            using ICryptoTransform _ = cipher.CreateDecryptor();
+        });
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="SymmetricStreamAlgorithm.CreateTransform(byte[], byte[])" /> after
+    /// disposal throws <see cref="ObjectDisposedException" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateTransform_WhenCalledAfterDispose_ShouldThrowObjectDisposedException()
+    {
+        TCipher cipher = CreateAlgorithm();
+        var key = new byte[KeyLengthBytes];
+        var nonce = new byte[NonceLengthBytes];
+        cipher.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() =>
+        {
+            using ICryptoTransform _ = cipher.CreateTransform(key, nonce);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="ICryptoTransform" /> obtained from the cipher rejects further
+    /// <see cref="ICryptoTransform.TransformBlock" /> calls after it has been disposed.
+    /// </summary>
+    [TestMethod]
+    public void Transform_WhenDisposedAndReused_ShouldThrow()
+    {
+        using TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+        cipher.GenerateNonce();
+
+        ICryptoTransform transform = cipher.CreateEncryptor();
+        transform.Dispose();
+
+        var input = new byte[16];
+        var output = new byte[16];
+
+        var threw = false;
+        try
+        {
+            transform.TransformBlock(input, 0, input.Length, output, 0);
+        }
+        catch
+        {
+            threw = true;
+        }
+
+        Assert.IsTrue(threw, $"{typeof(TCipher).Name} transform must not be reusable after Dispose.");
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="IDisposable.Dispose" /> twice on an <see cref="ICryptoTransform" />
+    /// obtained from the cipher is safe and idempotent.
+    /// </summary>
+    [TestMethod]
+    public void Transform_WhenDisposedTwice_ShouldNotThrow()
+    {
+        using TCipher cipher = CreateAlgorithm();
+        cipher.GenerateKey();
+        cipher.GenerateNonce();
+
+        ICryptoTransform transform = cipher.CreateEncryptor();
+        transform.Dispose();
+
+        transform.Dispose();
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidOverlap.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CryptoHelpersTests.ThrowIfInvalidOverlap.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CryptoHelpersTests.ThrowIfInvalidOverlap.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public partial class CryptoHelpersTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> permits non-overlapping spans in different
+    /// arrays.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenSpansInDifferentArrays_ShouldNotThrow()
+    {
+        var input = new byte[16];
+        var output = new byte[16];
+
+        CryptoHelpers.ThrowIfInvalidOverlap(input, output);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> permits non-overlapping spans within the same
+    /// array.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenSpansAreDisjointInSameArray_ShouldNotThrow()
+    {
+        var buffer = new byte[32];
+
+        CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(0, 16), buffer.AsSpan(16, 16));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> permits exact in-place aliasing when
+    /// <c>allowExactInPlace</c> is <see langword="true" /> (the default).
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenExactInPlace_ShouldNotThrow()
+    {
+        var buffer = new byte[16];
+
+        CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(), buffer.AsSpan());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> rejects exact aliasing when
+    /// <c>allowExactInPlace</c> is <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenExactInPlaceAndNotAllowed_ShouldThrowCryptographicException()
+    {
+        var buffer = new byte[16];
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(), buffer.AsSpan(), allowExactInPlace: false);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> rejects an output range that starts inside
+    /// the input range.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenOutputStartsInsideInput_ShouldThrowCryptographicException()
+    {
+        var buffer = new byte[32];
+
+        // input [0, 16); output [8, 24) → shares [8, 16).
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(0, 16), buffer.AsSpan(8, 16));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> rejects an input range that starts inside
+    /// the output range.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenInputStartsInsideOutput_ShouldThrowCryptographicException()
+    {
+        var buffer = new byte[32];
+
+        // output [0, 16); input [8, 24) → shares [8, 16).
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(8, 16), buffer.AsSpan(0, 16));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> rejects a one-byte overlap between the
+    /// trailing edge of the input and the leading edge of the output.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenOneByteOverlap_ShouldThrowCryptographicException()
+    {
+        var buffer = new byte[32];
+
+        // input [0, 16); output [15, 31) → shares [15, 16).
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(0, 16), buffer.AsSpan(15, 16));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> rejects spans that share the same start
+    /// position but differ in length.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenSameStartDifferentLength_ShouldThrowCryptographicException()
+    {
+        var buffer = new byte[32];
+
+        // input [0, 16); output [0, 24): same start, different length → not "exact in-place".
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(0, 16), buffer.AsSpan(0, 24));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> short-circuits and accepts an empty input.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenInputIsEmpty_ShouldNotThrow()
+    {
+        var buffer = new byte[16];
+
+        CryptoHelpers.ThrowIfInvalidOverlap(ReadOnlySpan<byte>.Empty, buffer.AsSpan());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CryptoHelpers.ThrowIfInvalidOverlap" /> short-circuits and accepts an empty output.
+    /// </summary>
+    [TestMethod]
+    public void ThrowIfInvalidOverlap_WhenOutputIsEmpty_ShouldNotThrow()
+    {
+        var buffer = new byte[16];
+
+        CryptoHelpers.ThrowIfInvalidOverlap(buffer.AsSpan(), Span<byte>.Empty);
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CtrModeTransformTests.CounterWrap.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CtrModeTransformTests.CounterWrap.cs
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CtrModeTransformTests.CounterWrap.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+public sealed partial class CtrModeTransformTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CtrModeTransform.Transform" /> latches and throws
+    /// <see cref="CryptographicException" /> when the counter would wrap back to its initial value, preventing
+    /// keystream reuse under a single (key, IV) pair.
+    /// </summary>
+    /// <remarks>
+    /// The CTR engine uses big-endian increment of the cipher-block-sized counter and latches a
+    /// <c>_counterWrapped</c> flag when the counter matches its initial value after increment. Driving a full
+    /// 2^64 / 2^128 cycle is infeasible, so this test uses reflection to position the counter one increment short
+    /// of wrap (all-<c>0xFF</c> with an initial counter of all zeros) and asserts both the wrap-and-latch
+    /// transition and the rejection on the next call.
+    /// </remarks>
+    [TestMethod]
+    public void Transform_WhenCounterWouldWrapToInitial_ShouldThrowCryptographicException()
+    {
+        using var cipher = new SkipjackBlockCipher(new byte[10]);
+        int blockSize = cipher.BlockSize / 8;
+
+        var initialCounter = new byte[blockSize];
+        using var transform = new CtrModeTransform(cipher, initialCounter);
+
+        // Drive the internal counter to all-0xFF. The next increment carries through every byte and lands back
+        // on the initial all-zero state, latching _counterWrapped.
+        FieldInfo counterField = typeof(CtrModeTransform)
+            .GetField("_counter", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        var atMax = new byte[blockSize];
+        Array.Fill(atMax, (byte)0xFF);
+        counterField.SetValue(transform, atMax);
+
+        var input = new byte[blockSize];
+        var output = new byte[blockSize];
+
+        // First call succeeds: it emits one keystream block under the 0xFF... counter, then increment wraps to
+        // all-zero (== initialCounter) and latches.
+        _ = transform.Transform(input, output, encrypt: true);
+
+        // Second call must throw before producing any duplicate keystream.
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            _ = transform.Transform(input, output, encrypt: true);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that once the counter-wrap latch is set, every subsequent <see cref="CtrModeTransform.Transform" />
+    /// call continues to throw rather than silently producing keystream.
+    /// </summary>
+    [TestMethod]
+    public void Transform_WhenCounterWrapLatched_ShouldThrowOnEverySubsequentCall()
+    {
+        using var cipher = new SkipjackBlockCipher(new byte[10]);
+        int blockSize = cipher.BlockSize / 8;
+
+        using var transform = new CtrModeTransform(cipher, new byte[blockSize]);
+
+        FieldInfo latchField = typeof(CtrModeTransform)
+            .GetField("_counterWrapped", BindingFlags.NonPublic | BindingFlags.Instance)!;
+        latchField.SetValue(transform, true);
+
+        var input = new byte[blockSize];
+        var output = new byte[blockSize];
+
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.ThrowsExactly<CryptographicException>(() =>
+            {
+                _ = transform.Transform(input, output, encrypt: true);
+            });
+        }
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/RngBiasContractTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/RngBiasContractTests.cs
@@ -1,0 +1,184 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RngBiasContractTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Buffers.Binary;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Library-wide contract tests for cryptographically secure key, IV, nonce, and tweak generation.
+/// </summary>
+[TestClass]
+public sealed class RngBiasContractTests
+{
+    private static readonly string[] s_generateMethodNames =
+    {
+        "GenerateKey",
+        "GenerateIV",
+        "GenerateNonce",
+        "GenerateTweak",
+    };
+
+    private static readonly string[] s_forbiddenHelperNames =
+    {
+        "GetRandomNonZeroBytes",
+        "FillWithRandomNonZeroBytes",
+        "TryFillWithRandomNonZeroBytes",
+    };
+
+    private static readonly int[] s_singleByteOperandSize = BuildOperandSizeTable(twoByte: false);
+    private static readonly int[] s_twoByteOperandSize = BuildOperandSizeTable(twoByte: true);
+
+    /// <summary>
+    /// Verifies that no <c>GenerateKey</c>, <c>GenerateIV</c>, <c>GenerateNonce</c>, or <c>GenerateTweak</c>
+    /// method in <see cref="SymmetricStreamAlgorithm" />'s assembly directly calls a non-zero RNG helper.
+    /// Keys, IVs, nonces, and tweaks must be sampled uniformly across all byte values; excluding <c>0x00</c>
+    /// introduces statistical bias.
+    /// </summary>
+    /// <remarks>
+    /// This is an IL-level static contract test. It walks the compiled IL of every <c>Generate*</c> method
+    /// in the production assembly, resolves every <c>call</c>, <c>callvirt</c>, or <c>newobj</c> token, and
+    /// asserts that none resolve to a <c>CryptoHelpers</c> non-zero RNG helper. The forbidden helpers remain
+    /// public-to-internal because they have legitimate non-key uses (for example, ISO 10126 random padding);
+    /// the contract is specifically about key, IV, nonce, and tweak generation.
+    /// </remarks>
+    [TestMethod]
+    public void GenerateKeyIvNonceTweak_AcrossAllAlgorithms_ShouldNotCallNonZeroRng()
+    {
+        Assembly assembly = typeof(SymmetricStreamAlgorithm).Assembly;
+        Type helpersType = assembly.GetType("Bodu.Security.Cryptography.CryptoHelpers", throwOnError: true, ignoreCase: false)!;
+
+        var forbiddenTokens = new HashSet<int>();
+        foreach (MethodInfo m in helpersType.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic))
+        {
+            if (Array.IndexOf(s_forbiddenHelperNames, m.Name) >= 0)
+                forbiddenTokens.Add(m.MetadataToken);
+        }
+
+        Assert.IsTrue(forbiddenTokens.Count > 0, "Expected CryptoHelpers to expose at least one non-zero RNG helper.");
+
+        var violations = new List<string>();
+
+        foreach (Type type in assembly.GetTypes())
+        {
+            const BindingFlags binding =
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Instance | BindingFlags.Static |
+                BindingFlags.DeclaredOnly;
+
+            foreach (MethodInfo method in type.GetMethods(binding))
+            {
+                if (Array.IndexOf(s_generateMethodNames, method.Name) < 0) continue;
+                if (method.IsAbstract) continue;
+
+                MethodBody? body = method.GetMethodBody();
+                byte[]? il = body?.GetILAsByteArray();
+                if (il is null || il.Length == 0) continue;
+
+                foreach (int token in EnumerateCallTokens(il))
+                {
+                    if (forbiddenTokens.Contains(token))
+                    {
+                        string helper = ResolveMethodName(type.Module, token);
+                        violations.Add($"{type.FullName}.{method.Name} → {helper}");
+                    }
+                }
+            }
+        }
+
+        if (violations.Count > 0)
+        {
+            var sb = new StringBuilder("Generate* methods must use full-range RNG. Found ");
+            sb.Append(violations.Count).Append(" violation(s):\n");
+            foreach (string v in violations)
+                sb.Append("  ").Append(v).Append('\n');
+            Assert.Fail(sb.ToString());
+        }
+    }
+
+    private static string ResolveMethodName(Module module, int token)
+    {
+        try
+        {
+            return module.ResolveMethod(token)?.Name ?? "<unresolved>";
+        }
+        catch
+        {
+            return "<unresolved>";
+        }
+    }
+
+    private static IEnumerable<int> EnumerateCallTokens(byte[] il)
+    {
+        int pos = 0;
+        while (pos < il.Length)
+        {
+            byte first = il[pos];
+
+            // Two-byte opcode prefix (0xFE). None of the call-family opcodes use this prefix.
+            if (first == 0xFE)
+            {
+                if (pos + 1 >= il.Length) yield break;
+                pos += 2 + s_twoByteOperandSize[il[pos + 1]];
+                continue;
+            }
+
+            int operandSize = s_singleByteOperandSize[first];
+
+            // call (0x28), callvirt (0x6F), newobj (0x73): operand is a 4-byte metadata token.
+            if (first == 0x28 || first == 0x6F || first == 0x73)
+            {
+                if (pos + 5 > il.Length) yield break;
+                yield return BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(pos + 1, 4));
+            }
+            else if (first == 0x45) // switch: 4-byte count followed by count*4 jump offsets.
+            {
+                if (pos + 5 > il.Length) yield break;
+                int n = BinaryPrimitives.ReadInt32LittleEndian(il.AsSpan(pos + 1, 4));
+                operandSize = 4 + (n * 4);
+            }
+
+            pos += 1 + operandSize;
+        }
+    }
+
+    private static int[] BuildOperandSizeTable(bool twoByte)
+    {
+        var table = new int[256];
+        foreach (FieldInfo field in typeof(OpCodes).GetFields(BindingFlags.Public | BindingFlags.Static))
+        {
+            var op = (OpCode)field.GetValue(null)!;
+            ushort value = unchecked((ushort)op.Value);
+            bool fieldIsTwoByte = (value >> 8) == 0xFE;
+            if (twoByte != fieldIsTwoByte) continue;
+            table[value & 0xFF] = OperandTypeSize(op.OperandType);
+        }
+
+        return table;
+    }
+
+    private static int OperandTypeSize(OperandType type) => type switch
+    {
+        OperandType.InlineNone => 0,
+        OperandType.ShortInlineI or OperandType.ShortInlineVar or OperandType.ShortInlineBrTarget => 1,
+        OperandType.InlineVar => 2,
+        OperandType.InlineBrTarget
+            or OperandType.InlineField
+            or OperandType.InlineI
+            or OperandType.InlineMethod
+            or OperandType.InlineSig
+            or OperandType.InlineString
+            or OperandType.InlineTok
+            or OperandType.InlineType
+            or OperandType.ShortInlineR => 4,
+        OperandType.InlineI8 or OperandType.InlineR => 8,
+        OperandType.InlineSwitch => 0, // Variable; handled in EnumerateCallTokens.
+        _ => 0,
+    };
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/StreamCipherCounterExhaustionTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/StreamCipherCounterExhaustionTests.cs
@@ -1,0 +1,130 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="StreamCipherCounterExhaustionTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Security.Cryptography;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Regression tests that exercise the block-counter exhaustion latch on the ChaCha20 and Salsa20 keystream
+/// engines. The latch is the safety guard that prevents keystream reuse once the block counter would wrap back
+/// to its initial value; if it ever stops firing, the cipher would silently emit duplicate keystream blocks under
+/// a single (key, nonce) pair — a catastrophic AEAD failure.
+/// </summary>
+/// <remarks>
+/// Both engines latch via a private <c>_counterExhausted</c> field set when <c>_counter</c> advances back to
+/// <c>_initialCounter</c>. Real wraparound across the full counter space (2^32 / 2^64 blocks) is infeasible to
+/// drive in a unit test, so these tests use reflection to position the counter one step short of the wrap and
+/// then exercise the wrap-and-throw transition. Reflection is acceptable here because the engines are friend
+/// types (<c>InternalsVisibleTo Bodu.Security.Cryptography.Test</c>) and the test asserts a security contract
+/// the engine intentionally exposes through its disposable surface.
+/// </remarks>
+[TestClass]
+public sealed class StreamCipherCounterExhaustionTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ChaCha20StreamCipher.NextKeystreamBlock" /> latches and throws
+    /// <see cref="CryptographicException" /> when the next increment would wrap the 32-bit counter back to its
+    /// initial value.
+    /// </summary>
+    [TestMethod]
+    public void ChaCha20StreamCipher_NextKeystreamBlock_WhenCounterWouldWrap_ShouldThrowCryptographicException()
+    {
+        var key = new byte[32];
+        var nonce = new byte[12];
+        var cipher = new ChaCha20StreamCipher(key, nonce, initialCounter: 1u);
+
+        // Position _counter one step short of wrap. The next NextKeystreamBlock emits block #0 and advances
+        // _counter to 1, which equals _initialCounter and latches exhaustion.
+        SetField(cipher, "_counter", 0u);
+
+        var block = new byte[64];
+        cipher.NextKeystreamBlock(block);
+
+        // Latch must reject the subsequent call before any keystream byte is emitted again.
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            cipher.NextKeystreamBlock(block);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Salsa20StreamCipher.NextKeystreamBlock" /> latches and throws
+    /// <see cref="CryptographicException" /> when the next increment would wrap the 64-bit counter back to its
+    /// initial value.
+    /// </summary>
+    [TestMethod]
+    public void Salsa20StreamCipher_NextKeystreamBlock_WhenCounterWouldWrap_ShouldThrowCryptographicException()
+    {
+        var key = new byte[32];
+        var nonce = new byte[8];
+        var cipher = new Salsa20StreamCipher(key, nonce, initialCounter: 1uL);
+
+        SetField(cipher, "_counter", 0uL);
+
+        var block = new byte[64];
+        cipher.NextKeystreamBlock(block);
+
+        Assert.ThrowsExactly<CryptographicException>(() =>
+        {
+            cipher.NextKeystreamBlock(block);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that once the latch is set, every subsequent <see cref="ChaCha20StreamCipher.NextKeystreamBlock" />
+    /// call continues to throw rather than silently producing keystream.
+    /// </summary>
+    [TestMethod]
+    public void ChaCha20StreamCipher_NextKeystreamBlock_WhenExhaustionLatched_ShouldThrowOnEverySubsequentCall()
+    {
+        var key = new byte[32];
+        var nonce = new byte[12];
+        var cipher = new ChaCha20StreamCipher(key, nonce, initialCounter: 0u);
+
+        SetField(cipher, "_counterExhausted", true);
+
+        var block = new byte[64];
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.ThrowsExactly<CryptographicException>(() =>
+            {
+                cipher.NextKeystreamBlock(block);
+            });
+        }
+    }
+
+    /// <summary>
+    /// Verifies that once the latch is set, every subsequent <see cref="Salsa20StreamCipher.NextKeystreamBlock" />
+    /// call continues to throw rather than silently producing keystream.
+    /// </summary>
+    [TestMethod]
+    public void Salsa20StreamCipher_NextKeystreamBlock_WhenExhaustionLatched_ShouldThrowOnEverySubsequentCall()
+    {
+        var key = new byte[32];
+        var nonce = new byte[8];
+        var cipher = new Salsa20StreamCipher(key, nonce, initialCounter: 0uL);
+
+        SetField(cipher, "_counterExhausted", true);
+
+        var block = new byte[64];
+        for (int i = 0; i < 3; i++)
+        {
+            Assert.ThrowsExactly<CryptographicException>(() =>
+            {
+                cipher.NextKeystreamBlock(block);
+            });
+        }
+    }
+
+    private static void SetField(object instance, string fieldName, object value)
+    {
+        FieldInfo? field = instance.GetType().GetField(fieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.IsNotNull(field, $"Expected internal field '{fieldName}' on {instance.GetType().Name}.");
+        field.SetValue(instance, value);
+    }
+}


### PR DESCRIPTION
Replaces CryptoHelpers.GetRandomNonZeroBytes (and the matching
FillWithRandomNonZeroBytes / TryFillWithRandomNonZeroBytes paths) with
the unbiased full-range CryptoHelpers.GetRandomBytes / FillWithRandomBytes
helpers across every GenerateKey, GenerateIV, GenerateNonce, and
GenerateTweak override:

- SymmetricStreamAlgorithm (key + nonce)
- Skipjack, Blowfish, Camellia, Twofish, Threefish, Serpent, Serpent128
  (key + IV; Threefish/Serpent also tweak)
- SipHash (key)

Excluding 0x00 from key/nonce/tweak material is a statistical bias and a
cryptographic design error: every byte value is a legal input, KATs
routinely include zero bytes, and the bias is not a property of any
specification we implement. The non-zero helpers remain available
internally for narrow callers that genuinely need them (e.g. ISO 10126
random padding).

Adds RngBiasContractTests, a library-wide IL-level contract test that
walks every Generate(Key|IV|Nonce|Tweak) method in the production
assembly, resolves every call/callvirt/newobj token, and fails if any
resolve to a non-zero RNG helper. The contract is asserted statically
without statistical assertions or RNG injection seams.

Also cleans up Bodu.Security.Cryptography.csproj:
- TargetFrameworks (plural with single value) -> TargetFramework
- removes duplicate <OutputType>Library</OutputType>
- removes dead conditional PropertyGroups for netstandard2.0/net6.0/net7.0/net8.0
  (project only targets net8.0; SDK auto-defines the version macros)
- removes dead conditional ItemGroups for the NetStandard ThrowHelper
  variant (the variants self-guard via NETSTANDARD2_0_OR_GREATER)
- fixes CryptoCryptoResourceStrings -> CryptoResourceStrings typo