### PR TITLE
Extract variant display name helpers to dedicated classes

### DIFF
--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.NmaxBoundary.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.NmaxBoundary.cs
@@ -20,7 +20,7 @@ public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenSingleCallEqualsNmaxBoundary_ShouldMatchPerByteRecurrence(SingleTestVariant variant)
     {
         var data = new byte[Nmax];
@@ -54,7 +54,7 @@ public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
     /// </para>
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenSingleCallExceedsNmaxBoundary_ShouldMatchPerByteRecurrence(SingleTestVariant variant)
     {
         // Two NMAX windows plus one trailing byte: forces the scalar NMAX boundary to be crossed twice (at

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/AdlerTests.SimdParity.cs
@@ -26,7 +26,7 @@ public abstract partial class AdlerTests<TTest, TAlgorithm, TModulo>
     /// scalar tail.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenInputEngagesSimdBranch_ShouldMatchPerByteScalarPath(SingleTestVariant variant)
     {
         var data = AdlerSimdRegressionInputs.ModuloByte8K;

--- a/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing.Checksums/CrcTests.ComputeHash.cs
@@ -36,7 +36,7 @@ public partial class CrcTests
     /// </summary>
     /// <param name="variant">The CRC variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenComparedToStreamingHash_ShouldAgree(CrcTestVariant variant)
     {
         Crc oneShot = CreateAlgorithm(variant);
@@ -55,7 +55,7 @@ public partial class CrcTests
     /// </summary>
     /// <param name="variant">The CRC variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenInputIsEmpty_ShouldMatchSpecificationEmptyDigest(CrcTestVariant variant)
     {
         NonCryptographicHashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/FnvTests.AlgorithmName.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/FnvTests.AlgorithmName.cs
@@ -15,7 +15,7 @@ public abstract partial class FnvTests<TTest, TAlgorithm>
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(SingleTestVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Append.cs
@@ -18,7 +18,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenCalledInChunks_ShouldMatchSingleAppend(TVariant variant)
     {
         var data = NonCryptographicHashSharedInputs.Sequential0To255;
@@ -41,7 +41,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenCalledOneByteAtATime_ShouldMatchSingleAppend(TVariant variant)
     {
         var data = NonCryptographicHashSharedInputs.QuickBrownFox;
@@ -61,7 +61,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Append_WhenInputIsEmpty_ShouldLeaveHashUnchanged(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.AppendAsync.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.AppendAsync.cs
@@ -39,7 +39,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="variant">The algorithm variant under test.</param>
     /// <returns>A task that represents the asynchronous test operation.</returns>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public async Task AppendAsync_WhenHashingStream_ShouldMatchSynchronousAppend(TVariant variant)
     {
         var data = NonCryptographicHashSharedInputs.Sequential0To255;
@@ -80,7 +80,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="variant">The variant identifier supplied by the dynamic data source.</param>
     /// <returns>A task that completes when all incremental lengths have been verified.</returns>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public Task AppendAsync_WhenUsingIncrementalInput_ShouldMatchExpected(TVariant variant) =>
         AssertIncrementalInputAsync(variant, async (algorithm, input, byteCount) =>
         {

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Ctors.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Ctors.cs
@@ -18,7 +18,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Ctor_WhenDefaultConstructed_ShouldReportExpectedHashLength(TVariant variant)
     {
         NonCryptographicHashAlgorithmSpecification specification = GetSpecification(variant);
@@ -32,7 +32,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Ctor_WhenDefaultConstructed_ShouldReturnNonNullInstance(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetCurrentHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetCurrentHash.cs
@@ -17,7 +17,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// Verifies that two inputs that span multiple input chunks produce different hashes.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetCurrentHash_ForMultiChunkInputs_ShouldProduceDistinctHashes(TVariant variant)
     {
         NonCryptographicHashAlgorithmSpecification specification = GetSpecification(variant);
@@ -44,7 +44,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetCurrentHash_WhenCalledRepeatedly_ShouldReturnSameDigest(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -65,7 +65,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="variant">The algorithm variant under test.</param>
     /// <returns>A task that completes when all incremental stages have been verified.</returns>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public Task GetCurrentHash_WhenUsingIncrementalInput_ShouldMatchExpected(TVariant variant) =>
         AssertIncrementalCurrentHashAsync(variant,
             (algorithm, source) =>
@@ -80,7 +80,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetCurrentHash_WhenWritingToSpan_ShouldMatchArrayOverload(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashAndReset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashAndReset.cs
@@ -17,7 +17,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetHashAndReset_AfterAppend_ShouldResetInstance(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -34,7 +34,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetHashAndReset_AfterAppend_ShouldReturnFinalDigest(TVariant variant)
     {
         NonCryptographicHashAlgorithm snapshot = CreateAlgorithm(variant);
@@ -56,7 +56,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// <param name="variant">The variant identifier supplied by the dynamic data source.</param>
     /// <returns>A task that completes when all incremental lengths have been verified.</returns>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public Task GetHashAndReset_WhenUsingIncrementalInput_ShouldMatchExpected(TVariant variant) =>
         AssertIncrementalInputAsync(variant,
             (algorithm, input, byteCount) =>
@@ -72,7 +72,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetHashAndReset_WhenWritingToSpan_ShouldReturnHashAndResetInstance(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashCode.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.GetHashCode.cs
@@ -18,7 +18,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetHashCode_WhenCalled_ShouldThrowExactly(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.HashLengthInBytes.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.HashLengthInBytes.cs
@@ -17,7 +17,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void GetCurrentHash_WhenReturningDigest_ShouldHaveLengthMatchingHashLengthInBytes(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -33,7 +33,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void HashLengthInBytes_WhenQueried_ShouldMatchSpecification(TVariant variant)
     {
         NonCryptographicHashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Reset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.Reset.cs
@@ -17,7 +17,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Reset_AfterAppend_ShouldRestoreInitialState(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -35,7 +35,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Reset_BetweenAppends_ShouldDiscardAccumulatedInput(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -55,7 +55,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Reset_OnFreshInstance_ShouldBeNoOp(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetCurrentHash.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetCurrentHash.cs
@@ -18,7 +18,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetCurrentHash_WhenDestinationIsExactSize_ShouldReturnTrueAndWriteHash(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -40,7 +40,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetCurrentHash_WhenDestinationIsTooSmall_ShouldReturnFalse(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -65,7 +65,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetCurrentHash_WhenSuccessful_ShouldNotMutateAccumulatorState(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetHashAndReset.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.TryGetHashAndReset.cs
@@ -17,7 +17,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetHashAndReset_WhenDestinationIsExactSize_ShouldReturnTrueAndWriteHash(TVariant variant)
     {
         NonCryptographicHashAlgorithm snapshot = CreateAlgorithm(variant);
@@ -41,7 +41,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetHashAndReset_WhenDestinationIsTooSmall_ShouldReturnFalseAndPreserveState(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -69,7 +69,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void TryGetHashAndReset_WhenSuccessful_ShouldResetInstance(TVariant variant)
     {
         TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmTests.cs
@@ -204,7 +204,7 @@ public abstract partial class NonCryptographicHashAlgorithmTests<TTest, TAlgorit
     /// inconclusive rather than failing.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void HashAlgorithm_TestData_Check(TVariant variant)
     {
         IReadOnlyList<string> incrementalHashes = GetExpectedHashesForIncrementalInput(variant);

--- a/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmVariantDisplayName.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/NonCryptographicHashAlgorithmVariantDisplayName.cs
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonCryptographicHashAlgorithmVariantDisplayName.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.IO.Hashing;
+
+/// <summary>
+/// Produces variant-named display strings for MSTest <c>[DynamicData]</c> rows whose first element is a
+/// non-cryptographic hash algorithm variant value, so that failures in CI and Test Explorer name the variant
+/// rather than showing an opaque row index.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire this helper to a test method via the <c>DynamicDataDisplayName</c> and
+/// <c>DynamicDataDisplayNameDeclaringType</c> arguments of the <c>DynamicData</c> attribute. The signature
+/// matches the MSTest contract <c>static string (MethodInfo methodInfo, object?[] data)</c>.
+/// </para>
+/// <para>
+/// Resolution must be wired through <c>DynamicDataDisplayNameDeclaringType</c> because MSTest 4.x resolves the
+/// display name method via <see cref="TypeInfo.GetDeclaredMethod(string)" />, which does not walk inheritance.
+/// Hosting the helper on a non-generic static class lets every test class — base, intermediate, or concrete —
+/// share a single implementation.
+/// </para>
+/// </remarks>
+public static class NonCryptographicHashAlgorithmVariantDisplayName
+{
+    /// <summary>
+    /// Returns a display name for a single MSTest <c>[DynamicData]</c> row driven by
+    /// <see cref="NonCryptographicHashAlgorithmTests{TTest, TAlgorithm, TVariant}.NonCryptographicHashAlgorithmVariants" />.
+    /// </summary>
+    /// <param name="methodInfo">The test method whose row is being named.</param>
+    /// <param name="data">The row payload supplied by the dynamic data source.</param>
+    /// <returns>
+    /// A readable variant description prefixed with <c>"Variant: "</c>. Falls back to <c>"Variant: Default"</c>
+    /// when the row is empty.
+    /// </returns>
+    public static string GetDisplayName(MethodInfo methodInfo, object[] data) =>
+        FormatVariantForDisplay(data.Length > 0 ? data[0] : null);
+
+    /// <summary>
+    /// Formats a non-cryptographic hash algorithm variant for use in data-driven test display names.
+    /// </summary>
+    /// <param name="variant">The variant value.</param>
+    /// <returns>A readable variant description.</returns>
+    private static string FormatVariantForDisplay(object? variant)
+    {
+        if (variant is null)
+            return "Variant: Default";
+
+        var variantText = variant.ToString();
+        if (!string.IsNullOrWhiteSpace(variantText) &&
+            !string.Equals(variantText, variant.GetType().FullName, StringComparison.Ordinal))
+        {
+            return $"Variant: {variantText}";
+        }
+
+        var properties = variant.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .Select(p => $"{p.Name}={p.GetValue(variant)}")
+            .ToArray();
+
+        return properties.Length == 0
+            ? $"Variant: {variant.GetType().Name}"
+            : $"Variant: {variant.GetType().Name}({string.Join(", ", properties)})";
+    }
+}

--- a/Bodu.IO.Hashing/test/IO.Hashing/PearsonTests.Table.cs
+++ b/Bodu.IO.Hashing/test/IO.Hashing/PearsonTests.Table.cs
@@ -28,7 +28,7 @@ public partial class PearsonTests
     /// </summary>
     /// <param name="variant">The predefined table type under test.</param>
     [TestMethod]
-    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants))]
+    [DynamicData(nameof(NonCryptographicHashAlgorithmVariants), DynamicDataDisplayName = nameof(NonCryptographicHashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(NonCryptographicHashAlgorithmVariantDisplayName))]
     public void Table_WhenBuiltIn_ShouldBeA256ByteUniquePermutation(Pearson.PearsonTableType variant)
     {
         Pearson algorithm = new(8, variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2bTests.AlgorithmName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2bTests.AlgorithmName.cs
@@ -13,7 +13,7 @@ public partial class Blake2bTests
     /// <c>"BLAKE2b-<i>n</i>"</c>, where <i>n</i> is the configured digest size in bits.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(Blake2bVariant variant)
     {
         using Blake2b algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2sTests.AlgorithmName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/Blake2sTests.AlgorithmName.cs
@@ -13,7 +13,7 @@ public partial class Blake2sTests
     /// <c>"BLAKE2s-<i>n</i>"</c>, where <i>n</i> is the configured digest size in bits.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(Blake2sVariant variant)
     {
         using Blake2s algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockHashAlgorithmTests.ComputeHash.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockHashAlgorithmTests.ComputeHash.cs
@@ -21,7 +21,7 @@ public abstract partial class BlockHashAlgorithmTests<TTest, TAlgorithm, TVarian
     /// to guarantee coverage of sub-block, exact-block, and multi-block boundaries.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public virtual void ComputeHash_WhenInputStreamedInChunks_ShouldMatchSinglePassResult(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -67,7 +67,7 @@ public abstract partial class BlockHashAlgorithmTests<TTest, TAlgorithm, TVarian
     /// produces a digest of the size advertised by <see cref="HashAlgorithm.HashSize" />.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public virtual void ComputeHash_WhenInputIsUnaligned_ShouldProduceValidHash(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -103,7 +103,7 @@ public abstract partial class BlockHashAlgorithmTests<TTest, TAlgorithm, TVarian
     /// entropy tests in the suite.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public virtual void ComputeHash_WhenInputIsBlockAligned_ShouldMatchAcrossTransformSplits(TVariant variant)
     {
         const int blockCount = 4;

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/BlockHashAlgorithmTests.PadBlock.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/BlockHashAlgorithmTests.PadBlock.cs
@@ -45,7 +45,7 @@ public abstract partial class BlockHashAlgorithmTests<TTest, TAlgorithm, TVarian
     /// <c>PadBlock</c> error message.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void HashPipeline_ExceptionMessages_ShouldContainOnlyPrintableAscii(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/CubeHashTests.AlgorithmName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/CubeHashTests.AlgorithmName.cs
@@ -12,7 +12,7 @@ public partial class CubeHashTests
     /// Verifies that <see cref="CubeHash.AlgorithmName" />, when UsingVariant, returns the expected value.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(CubeHashVariants variant)
     {
         using CubeHash algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.ComputeHash.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.ComputeHash.cs
@@ -84,7 +84,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// Verifies that repeated calls to <see cref="HashAlgorithm.ComputeHash(byte[])" /> with the same input produce the same result.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_ShouldBeDeterministic(TVariant variant)
     {
         var input = Enumerable.Range(0, 128).Select(i => (byte)(i % 256)).ToArray();
@@ -238,7 +238,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// <param name="variant">The variant identifier supplied by the dynamic data source.</param>
     /// <returns>A task that completes when all incremental lengths have been verified.</returns>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public Task ComputeHash_WhenUsingIncrementalInput_ShouldMatchExpected(TVariant variant) =>
         AssertIncrementalInputAsync(variant,
             (algorithm, input, byteCount) => Task.FromResult(algorithm.ComputeHash(input, 0, byteCount)));
@@ -357,7 +357,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// for a representative range of input lengths.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenCalled_ShouldAlwaysReturnCorrectHashSize(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -384,7 +384,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// internal algorithm path is exercised correctly and produces well-distributed output.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_AtBoundaryLengths_ShouldProduceDistinctNonZeroHashes(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -421,7 +421,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// spread across the output bytes. The minimum non-zero byte threshold is declared in the algorithm specification.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenInputIsLong_ShouldDistributeEntropyAcrossAllBytes(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -451,7 +451,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// Verifies that two inputs that span multiple input chunks produce different hashes.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_ForMultiChunkInputs_ShouldProduceDistinctHashes(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.ComputeHashAsync.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.ComputeHashAsync.cs
@@ -163,7 +163,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// <param name="variant">The variant identifier supplied by the dynamic data source.</param>
     /// <returns>A task that completes when all incremental lengths have been verified.</returns>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public Task ComputeHashAsync_WhenUsingIncrementalInput_ShouldMatchExpected(TVariant variant) =>
         AssertIncrementalInputAsync(variant, async (algorithm, input, byteCount) =>
         {

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.Ctors.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.Ctors.cs
@@ -15,7 +15,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// when default-constructed.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void HashSize_WhenDefaultConstructed_ShouldBeExpectedBitLength(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -28,7 +28,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// one byte when default-constructed.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void InputBlockSize_WhenDefaultConstructed_ShouldBePositive(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -41,7 +41,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// one byte when default-constructed.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void OutputBlockSize_WhenDefaultConstructed_ShouldBePositive(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -54,7 +54,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// <see cref="HashAlgorithm" /> contract.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void CanReuseTransform_WhenDefaultConstructed_ShouldBeTrue(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -67,7 +67,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// required by the <see cref="HashAlgorithm" /> contract.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void CanTransformMultipleBlocks_WhenDefaultConstructed_ShouldBeTrue(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -80,7 +80,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// <typeparamref name="TAlgorithm" /> before any data has been hashed.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Hash_WhenDefaultConstructed_ShouldBeNull(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.Initialize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.Initialize.cs
@@ -121,7 +121,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// supports reuse.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public virtual void Initialize_AfterHashing_ShouldResetInternalState(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -155,7 +155,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// is <see langword="false" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public virtual void Initialize_AfterHashing_ShouldClearResidualBlockState(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);
@@ -189,7 +189,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// than touching the cleared internal state.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Initialize_WhenCalledAfterDispose_ShouldThrowExactly(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.InputBlockSize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.InputBlockSize.cs
@@ -14,7 +14,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// Verifies that <see cref="HashAlgorithm.InputBlockSize" /> returns the expected default block size.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void InputBlockSize_ShouldBeExpectedInputBlockSize(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.OutputBlockSize.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.OutputBlockSize.cs
@@ -14,7 +14,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// Verifies that <see cref="HashAlgorithm.OutputBlockSize" /> returns the expected default block size.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void OutputBlockSize_ShouldBeExpectedOutputBlockSize(TVariant variant)
     {
         HashAlgorithmSpecification specification = GetSpecification(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmTests.cs
@@ -157,7 +157,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(GetHashAlgorithmVariantDisplayName))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void HashAlgorithm_TestData_IncrementalHashes_ShouldBeDefined(TVariant variant)
     {
         IReadOnlyList<string> incrementalHashes = GetExpectedHashesForIncrementalInput(variant);
@@ -172,7 +172,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// </summary>
     /// <param name="variant">The algorithm variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(GetHashAlgorithmVariantDisplayName))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void HashAlgorithm_TestData_EmptyKnownAnswer_ShouldBeDefined(TVariant variant)
     {
         var emptyHash = GetSpecification(variant).KnownAnswers.Empty;
@@ -191,7 +191,7 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
     /// fixed <see cref="HashAlgorithmKnownAnswers.Empty" /> slot and the incremental output series.
     /// </remarks>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(GetHashAlgorithmVariantDisplayName))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void HashAlgorithm_TestData_EmptyKnownAnswer_ShouldMatchFirstIncrementalHash(TVariant variant)
     {
         IReadOnlyList<string> incrementalHashes = GetExpectedHashesForIncrementalInput(variant);
@@ -213,46 +213,6 @@ public abstract partial class HashAlgorithmTests<TTest, TAlgorithm, TVariant>
             emptyHash,
             incrementalHashes[0],
             "Expected hash value for 'Empty' named input should equal the first item of incremental input.");
-    }
-
-    /// <summary>
-    /// Gets the display name for hash algorithm variant data-driven tests.
-    /// </summary>
-    /// <param name="methodInfo">The test method being displayed.</param>
-    /// <param name="data">The data row supplied by <see cref="DynamicDataAttribute" />.</param>
-    /// <returns>A display name containing the test method and variant details.</returns>
-    public static string GetHashAlgorithmVariantDisplayName(MethodInfo methodInfo, object[] data)
-    {
-        var variant = data.Length > 0 ? data[0] : null;
-        return $"{FormatVariantForDisplay(variant)}";
-    }
-
-    /// <summary>
-    /// Formats a hash algorithm variant for use in data-driven test display names.
-    /// </summary>
-    /// <param name="variant">The variant value.</param>
-    /// <returns>A readable variant description.</returns>
-    private static string FormatVariantForDisplay(object? variant)
-    {
-        if (variant is null)
-            return "Variant: Default";
-
-        var variantText = variant.ToString();
-        if (!string.IsNullOrWhiteSpace(variantText) &&
-            !string.Equals(variantText, variant.GetType().FullName, StringComparison.Ordinal))
-        {
-            return $"Variant: {variantText}";
-        }
-
-        var properties = variant.GetType()
-            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
-            .Select(p => $"{p.Name}={p.GetValue(variant)}")
-            .ToArray();
-
-        return properties.Length == 0
-            ? $"Variant: {variant.GetType().Name}"
-            : $"Variant: {variant.GetType().Name}({string.Join(", ", properties)})";
     }
 
     /// <summary>

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmVariantDisplayName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/HashAlgorithmVariantDisplayName.cs
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="HashAlgorithmVariantDisplayName.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+
+namespace Bodu.Security.Cryptography;
+
+/// <summary>
+/// Produces variant-named display strings for MSTest <c>[DynamicData]</c> rows whose first element is a hash
+/// algorithm variant value, so that failures in CI and Test Explorer name the variant rather than showing an
+/// opaque row index.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Wire this helper to a test method via the <c>DynamicDataDisplayName</c> and
+/// <c>DynamicDataDisplayNameDeclaringType</c> arguments of the <c>DynamicData</c> attribute. The signature
+/// matches the MSTest contract <c>static string (MethodInfo methodInfo, object?[] data)</c>.
+/// </para>
+/// <para>
+/// Resolution must be wired through <c>DynamicDataDisplayNameDeclaringType</c> because MSTest 4.x resolves the
+/// display name method via <see cref="TypeInfo.GetDeclaredMethod(string)" />, which does not walk inheritance.
+/// Hosting the helper on a non-generic static class lets every test class — base, intermediate, or concrete —
+/// share a single implementation.
+/// </para>
+/// </remarks>
+public static class HashAlgorithmVariantDisplayName
+{
+    /// <summary>
+    /// Returns a display name for a single MSTest <c>[DynamicData]</c> row driven by
+    /// <see cref="HashAlgorithmTests{TTest, TAlgorithm, TVariant}.HashAlgorithmVariants" />.
+    /// </summary>
+    /// <param name="methodInfo">The test method whose row is being named.</param>
+    /// <param name="data">The row payload supplied by the dynamic data source.</param>
+    /// <returns>
+    /// A readable variant description prefixed with <c>"Variant: "</c>. Falls back to <c>"Variant: Default"</c>
+    /// when the row is empty.
+    /// </returns>
+    public static string GetDisplayName(MethodInfo methodInfo, object[] data) =>
+        FormatVariantForDisplay(data.Length > 0 ? data[0] : null);
+
+    /// <summary>
+    /// Formats a hash algorithm variant for use in data-driven test display names.
+    /// </summary>
+    /// <param name="variant">The variant value.</param>
+    /// <returns>A readable variant description.</returns>
+    private static string FormatVariantForDisplay(object? variant)
+    {
+        if (variant is null)
+            return "Variant: Default";
+
+        var variantText = variant.ToString();
+        if (!string.IsNullOrWhiteSpace(variantText) &&
+            !string.Equals(variantText, variant.GetType().FullName, StringComparison.Ordinal))
+        {
+            return $"Variant: {variantText}";
+        }
+
+        var properties = variant.GetType()
+            .GetProperties(BindingFlags.Instance | BindingFlags.Public)
+            .Where(p => p.CanRead && p.GetIndexParameters().Length == 0)
+            .Select(p => $"{p.Name}={p.GetValue(variant)}")
+            .ToArray();
+
+        return properties.Length == 0
+            ? $"Variant: {variant.GetType().Name}"
+            : $"Variant: {variant.GetType().Name}({string.Join(", ", properties)})";
+    }
+}

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedBlockHashAlgorithmTests.ComputeHash.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedBlockHashAlgorithmTests.ComputeHash.cs
@@ -14,7 +14,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that the algorithm's key remains unchanged after hashing.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenHashing_ShouldRespectKeyRetentionPolicy(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -48,7 +48,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// chaining value.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenKeyIsSet_ShouldDifferFromUnkeyedHashOfSameInput(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -75,7 +75,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that <see cref="KeyedBlockHashAlgorithm.ComputeHash" /> returns the same result when called multiple times with the same key and input.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenSameKeyAndInputUsed_ShouldReturnIdenticalResults(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -101,7 +101,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that <see cref="KeyedBlockHashAlgorithm.ComputeHash" /> returns different results when different keys are used with the same input.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenDifferentKeysUsed_ShouldReturnDifferentResults(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -131,7 +131,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that two valid keys with different lengths produce different digests for the same input.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenValidKeysHaveDifferentLengths_ShouldProduceDifferentDigests(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -182,7 +182,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// </summary>
     [TestMethod]
 
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void ComputeHash_WhenRepresentativeVariableKeyLengthsUsed_ShouldProduceDistinctDigests(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedBlockHashAlgorithmTests.Key.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/KeyedBlockHashAlgorithmTests.Key.cs
@@ -61,7 +61,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// <see cref="CryptographicException" /> with the correct message.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenSetToInvalidLength_ShouldThrowExactly(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -91,7 +91,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// without throwing.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenSetToValidLength_ShouldNotThrow(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -122,7 +122,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// valid range declared in the specification.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenDefaultConstructed_ShouldNotBeNull(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -135,7 +135,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies the correct get/set behaviour of the <see cref="KeyedHashAlgorithm.Key" /> property.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenSetAndRetrieved_ShouldBehaveAsExpected(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -166,7 +166,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that accessing the <see cref="KeyedHashAlgorithm.Key" /> property multiple times returns distinct array instances.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenAccessedMultipleTimes_ShouldReturnDistinctInstances(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -189,7 +189,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that updating the key after a hash operation does not retroactively affect the result of the previous hash.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenChangedAfterHash_ShouldNotAffectPreviousResult(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -219,7 +219,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that reassigning the same key hashValue multiple times does not throw or alter behaviour.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenSetToSameValueMultipleTimes_ShouldNotThrow(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -241,7 +241,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that calling <see cref="HashAlgorithm.Initialise" /> does not reset the key unless explicitly cleared.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenInitializeCalled_ShouldNotResetKey(TVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);
@@ -255,7 +255,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that using the same key with different inputs produces different hashes.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenCallingComputeHashUsingSameKeyAndDifferentInputs_ShouldReturnDifferentHashes(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -289,7 +289,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// algorithm supports reuse.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenModifiedAfterAssignment_ShouldNotAffectInternalState(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -336,7 +336,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that modifying the input array after setting it as a key does not mutate the internal copy.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenInputArrayModified_ShouldNotMutateInternalKey(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -361,7 +361,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that assigning a key larger than the maximum legal length throws a CryptographicException.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenAboveMaximumLength_ShouldThrowExactly(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -391,7 +391,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that <see cref="KeyedBlockHashAlgorithm.Key" />, when BelowMinimumLength, throws <see cref="CryptographicException" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenBelowMinimumLength_ShouldThrowExactly(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -420,7 +420,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// Verifies that modifying the key after hashing has begun throws an exception.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenSetAfterHashingBegins_ShouldThrowExactly(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -450,7 +450,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// would produce identical digests for reversed keys.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenKeyBytesReversed_ShouldProduceDistinctDigest_fix(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -487,7 +487,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// mutate the internal key material through the accessor.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenGetterCalledTwice_ShouldReturnIndependentCopies(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)
@@ -510,7 +510,7 @@ public abstract partial class KeyedBlockHashAlgorithmTests<TTest, TAlgorithm, TV
     /// <see cref="CryptographicException" />.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Key_WhenAssignedLongerThanMaximum_ShouldThrowExactly(TVariant variant)
     {
         if (GetSpecification(variant) is not KeyedAlgorithmSpecification specification)

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SipHashTests.AlgorithmName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SipHashTests.AlgorithmName.cs
@@ -12,7 +12,7 @@ public abstract partial class SipHashTests<TTest, TAlgorithm>
     /// Verifies that <see cref="SipHash.AlgorithmName" />, when UsingVariant, returns the expected value.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(SipHashVariant variant)
     {
         using TAlgorithm algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.InitialChainingValues.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/SkeinTests.InitialChainingValues.cs
@@ -28,7 +28,7 @@ public abstract partial class SkeinTests<TTest, TAlgorithm, TVariant>
     /// </summary>
     /// <param name="variant">The variant under test.</param>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void InitialChainingValue_WhenComputed_ShouldMatchAppendixB(TVariant variant)
     {
         IReadOnlyList<ulong>? expected = GetExpectedAppendixBChainingValue(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.AlgorithmName.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.AlgorithmName.cs
@@ -13,7 +13,7 @@ public partial class TigerTests
     /// Verifies that <see cref="Tiger.AlgorithmName" />, when UsingVariant, returns the expected value.
     /// </summary>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void AlgorithmName_WhenUsingVariant_ShouldReturnCorrectlyFormattedString(TigerVariant variant)
     {
         using Tiger algorithm = CreateAlgorithm(variant);

--- a/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.Variant.cs
+++ b/Bodu.Security.Cryptography/test/Security.Cryptography/TigerTests.Variant.cs
@@ -17,7 +17,7 @@ public partial class TigerTests
     /// </summary>
     /// <param name="variant">The table type to test.</param>
     [TestMethod]
-    [DynamicData(nameof(HashAlgorithmVariants))]
+    [DynamicData(nameof(HashAlgorithmVariants), DynamicDataDisplayName = nameof(HashAlgorithmVariantDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(HashAlgorithmVariantDisplayName))]
     public void Variant_Set_WhenValid_ShouldProduceExpectedHash(TigerVariant variant)
     {
         using Tiger algorithm = CreateAlgorithm(variant);


### PR DESCRIPTION
## Summary

Refactors the variant display name logic for data-driven tests by extracting it from test base classes into dedicated, reusable helper classes. This improves code organization, eliminates duplication, and makes the display name contract explicit and shareable across test hierarchies.

## Changes

- **New file: `NonCryptographicHashAlgorithmVariantDisplayName`** (`Bodu.IO.Hashing/test/`)
  - Static helper class implementing the MSTest `DynamicDataDisplayName` contract
  - Formats non-cryptographic hash algorithm variants for test display names
  - Handles null variants, custom `ToString()` implementations, and reflection-based property enumeration

- **New file: `HashAlgorithmVariantDisplayName`** (`Bodu.Security.Cryptography/test/`)
  - Static helper class implementing the MSTest `DynamicDataDisplayName` contract
  - Formats cryptographic hash algorithm variants for test display names
  - Identical implementation to non-cryptographic variant (shared pattern across domains)

- **Updated test files** (both projects)
  - Removed `GetHashAlgorithmVariantDisplayName()` and `FormatVariantForDisplay()` methods from `HashAlgorithmTests.cs`
  - Updated all `[DynamicData]` attributes to wire through the new dedicated helpers via `DynamicDataDisplayName` and `DynamicDataDisplayNameDeclaringType` parameters
  - Applied consistently across all test partial files (Ctors, ComputeHash, ComputeHashAsync, Initialize, InputBlockSize, OutputBlockSize, ComputeHash variants for keyed/block algorithms, etc.)
  - Updated non-cryptographic hash algorithm test files similarly

## Implementation Details

- Both helper classes are non-generic static classes to allow inheritance-independent resolution (MSTest 4.x uses `TypeInfo.GetDeclaredMethod()` which does not walk inheritance)
- Display name format: `"Variant: <name>"` with fallback to `"Variant: Default"` for null
- Intelligent formatting: prefers custom `ToString()` output, falls back to type name with public property enumeration
- Signature matches MSTest contract: `static string GetDisplayName(MethodInfo methodInfo, object[] data)`

https://claude.ai/code/session_015JF9NzjoiWTiR3NHfQP8mc