### PR TITLE
Add hero SVG illustrations for Numerics and Financial packages

### DIFF
--- a/docs/apidoc/Bodu.Financial.Currencies.md
+++ b/docs/apidoc/Bodu.Financial.Currencies.md
@@ -2,7 +2,7 @@
 uid: Bodu.Financial.Currencies
 ---
 
-![Bodu.Financial](~/images/hero-core.svg)
+![Bodu.Financial](~/images/hero-financial.svg)
 
 ## Purpose
 

--- a/docs/apidoc/Bodu.Financial.Serialization.md
+++ b/docs/apidoc/Bodu.Financial.Serialization.md
@@ -2,7 +2,7 @@
 uid: Bodu.Financial.Serialization
 ---
 
-![Bodu.Financial](~/images/hero-core.svg)
+![Bodu.Financial](~/images/hero-financial.svg)
 
 ## Purpose
 

--- a/docs/apidoc/Bodu.Financial.md
+++ b/docs/apidoc/Bodu.Financial.md
@@ -2,7 +2,7 @@
 uid: Bodu.Financial
 ---
 
-![Bodu.Financial](~/images/hero-core.svg)
+![Bodu.Financial](~/images/hero-financial.svg)
 
 ## Purpose
 

--- a/docs/apidoc/Bodu.Numerics.md
+++ b/docs/apidoc/Bodu.Numerics.md
@@ -2,7 +2,7 @@
 uid: Bodu.Numerics
 ---
 
-![Bodu.Numerics](~/images/hero-core.svg)
+![Bodu.Numerics](~/images/hero-numerics.svg)
 
 ## Purpose
 

--- a/docs/images/hero-financial.svg
+++ b/docs/images/hero-financial.svg
@@ -1,0 +1,77 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.Financial — type-safe monetary primitives with audit-grade FX">
+  <title>Bodu.Financial</title>
+  <defs>
+    <linearGradient id="fin-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="fin-usd" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+    <linearGradient id="fin-eur" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#A78BFA"/>
+      <stop offset="1" stop-color="#7C3AED"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#fin-bg)"/>
+
+  <!-- Left: typed Money<USD> chip -->
+  <g transform="translate(28 36)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+    <rect width="160" height="92" rx="10" fill="url(#fin-usd)" stroke="#3B82F6" stroke-width="1.4"/>
+    <text x="80" y="22" fill="#DBEAFE" font-family="'Consolas','Menlo',monospace" font-size="11" text-anchor="middle">Money&lt;USD&gt;</text>
+    <line x1="14" y1="30" x2="146" y2="30" stroke="#BFDBFE" stroke-width="1" opacity="0.4"/>
+    <text x="80" y="62" fill="#F8FAFC" text-anchor="middle" font-size="24" font-weight="700">$1,234.56</text>
+    <text x="80" y="82" fill="#BFDBFE" font-family="'Consolas','Menlo',monospace" font-size="10" text-anchor="middle">ISO 4217 · minor=2</text>
+  </g>
+
+  <!-- middle: exchange-rate arrow -->
+  <g transform="translate(196 76)">
+    <g fill="none" stroke="#60A5FA" stroke-width="2" stroke-linecap="round">
+      <line x1="0" y1="6" x2="96" y2="6"/>
+      <polygon points="96,6 88,2 88,10" fill="#60A5FA" stroke="none"/>
+    </g>
+    <text x="48" y="-4" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="12" font-weight="700" text-anchor="middle">× 0.93</text>
+    <text x="48" y="24" fill="#94A3B8" font-family="'Consolas','Menlo',monospace" font-size="9" text-anchor="middle">2026-06-01</text>
+    <text x="48" y="38" fill="#94A3B8" font-family="'Consolas','Menlo',monospace" font-size="9" text-anchor="middle">audit-grade FX</text>
+  </g>
+
+  <!-- Right: typed Money<EUR> chip -->
+  <g transform="translate(292 36)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif">
+    <rect width="160" height="92" rx="10" fill="url(#fin-eur)" stroke="#A78BFA" stroke-width="1.4"/>
+    <text x="80" y="22" fill="#EDE9FE" font-family="'Consolas','Menlo',monospace" font-size="11" text-anchor="middle">Money&lt;EUR&gt;</text>
+    <line x1="14" y1="30" x2="146" y2="30" stroke="#DDD6FE" stroke-width="1" opacity="0.4"/>
+    <text x="80" y="62" fill="#F8FAFC" text-anchor="middle" font-size="24" font-weight="700">€1,148.14</text>
+    <text x="80" y="82" fill="#DDD6FE" font-family="'Consolas','Menlo',monospace" font-size="10" text-anchor="middle">ISO 4217 · minor=2</text>
+  </g>
+
+  <!-- Bottom: MoneyBag chips -->
+  <g transform="translate(28 154)" font-family="'Consolas','Menlo',monospace" font-size="11">
+    <text x="0" y="14" fill="#94A3B8" font-size="10">MoneyBag »</text>
+    <g transform="translate(72 0)">
+      <rect width="68" height="22" rx="5" fill="#1E3A8A" stroke="#60A5FA" stroke-width="1"/>
+      <text x="34" y="16" fill="#DBEAFE" text-anchor="middle">$120.00</text>
+    </g>
+    <g transform="translate(150 0)">
+      <rect width="68" height="22" rx="5" fill="#2E1065" stroke="#A78BFA" stroke-width="1"/>
+      <text x="34" y="16" fill="#EDE9FE" text-anchor="middle">€80.00</text>
+    </g>
+    <g transform="translate(228 0)">
+      <rect width="68" height="22" rx="5" fill="#064E3B" stroke="#2DD4BF" stroke-width="1"/>
+      <text x="34" y="16" fill="#CCFBF1" text-anchor="middle">¥9 500</text>
+    </g>
+    <g transform="translate(306 0)">
+      <rect width="68" height="22" rx="5" fill="#7C2D12" stroke="#FB923C" stroke-width="1"/>
+      <text x="34" y="16" fill="#FFE4D6" text-anchor="middle">£75.00</text>
+    </g>
+    <g transform="translate(384 0)">
+      <rect width="68" height="22" rx="5" fill="#3F1D38" stroke="#F472B6" stroke-width="1"/>
+      <text x="34" y="16" fill="#FCE7F3" text-anchor="middle">A$210</text>
+    </g>
+  </g>
+
+  <!-- caption -->
+  <g font-family="'Consolas','Menlo',monospace" font-size="10" fill="#94A3B8">
+    <text x="240" y="208" text-anchor="middle">type-safe · ISO 4217 · audit-grade FX · fair allocation</text>
+  </g>
+</svg>

--- a/docs/images/hero-numerics.svg
+++ b/docs/images/hero-numerics.svg
@@ -1,0 +1,90 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.Numerics — exact rational arithmetic and bounded intervals">
+  <title>Bodu.Numerics</title>
+  <defs>
+    <linearGradient id="num-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+    <linearGradient id="num-cell" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#3B82F6"/>
+      <stop offset="1" stop-color="#1D4ED8"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#num-bg)"/>
+
+  <!-- Fraction<T> visual: numerator over denominator -->
+  <g transform="translate(40 36)" font-family="'Consolas','Menlo',monospace">
+    <text x="0" y="0" fill="#94A3B8" font-size="11">Fraction&lt;T&gt;</text>
+
+    <!-- numerator -->
+    <rect x="0" y="10" width="54" height="34" rx="6" fill="url(#num-cell)" stroke="#3B82F6" stroke-width="1.4"/>
+    <text x="27" y="34" fill="#F8FAFC" text-anchor="middle" font-size="18" font-weight="700">3</text>
+    <!-- division bar -->
+    <line x1="-2" y1="52" x2="56" y2="52" stroke="#60A5FA" stroke-width="2.4" stroke-linecap="round"/>
+    <!-- denominator -->
+    <rect x="0" y="58" width="54" height="34" rx="6" fill="url(#num-cell)" stroke="#3B82F6" stroke-width="1.4"/>
+    <text x="27" y="82" fill="#F8FAFC" text-anchor="middle" font-size="18" font-weight="700">4</text>
+
+    <!-- equals to decimal / continued fraction -->
+    <text x="74" y="56" fill="#94A3B8" font-size="20">=</text>
+    <text x="98" y="40" fill="#A78BFA" font-size="14" font-weight="700">0.75</text>
+    <text x="98" y="58" fill="#94A3B8" font-size="10">decimal</text>
+    <text x="98" y="80" fill="#FBBF24" font-size="14" font-weight="700">[0; 1, 3]</text>
+    <text x="98" y="98" fill="#94A3B8" font-size="10">continued fraction</text>
+
+    <!-- BigInteger-promoted arrow -->
+    <g transform="translate(220 50)">
+      <line x1="0" y1="0" x2="44" y2="0" stroke="#60A5FA" stroke-width="1.8" stroke-linecap="round"/>
+      <polygon points="44,0 36,-4 36,4" fill="#60A5FA"/>
+      <text x="22" y="-8" fill="#60A5FA" font-size="10" text-anchor="middle">promote</text>
+    </g>
+
+    <!-- BigInteger numerator/denominator -->
+    <g transform="translate(266 10)">
+      <rect width="138" height="34" rx="6" fill="#1E293B" stroke="#475569" stroke-width="1.2"/>
+      <text x="69" y="22" fill="#E2E8F0" text-anchor="middle" font-size="12" font-weight="700">1 234 567 891</text>
+    </g>
+    <line x1="266" y1="52" x2="404" y2="52" stroke="#A78BFA" stroke-width="2.4" stroke-linecap="round"/>
+    <g transform="translate(266 58)">
+      <rect width="138" height="34" rx="6" fill="#1E293B" stroke="#475569" stroke-width="1.2"/>
+      <text x="69" y="22" fill="#E2E8F0" text-anchor="middle" font-size="12" font-weight="700">9 876 543 210</text>
+    </g>
+    <text x="335" y="108" fill="#94A3B8" text-anchor="middle" font-size="10">BigInteger · canonical</text>
+  </g>
+
+  <!-- Interval<T> visual: number line with closed / open intervals -->
+  <g transform="translate(40 152)" font-family="'Consolas','Menlo',monospace">
+    <text x="0" y="0" fill="#94A3B8" font-size="11">Interval&lt;T&gt;</text>
+    <!-- base line -->
+    <line x1="0" y1="22" x2="360" y2="22" stroke="#475569" stroke-width="1.6"/>
+    <g stroke="#475569" stroke-width="1">
+      <line x1="0"   y1="18" x2="0"   y2="26"/>
+      <line x1="90"  y1="18" x2="90"  y2="26"/>
+      <line x1="180" y1="18" x2="180" y2="26"/>
+      <line x1="270" y1="18" x2="270" y2="26"/>
+      <line x1="360" y1="18" x2="360" y2="26"/>
+    </g>
+    <g fill="#94A3B8" font-size="10" text-anchor="middle">
+      <text x="0"   y="42">0</text>
+      <text x="90"  y="42">1</text>
+      <text x="180" y="42">2</text>
+      <text x="270" y="42">3</text>
+      <text x="360" y="42">4</text>
+    </g>
+    <!-- closed [0, 1] -->
+    <line x1="0" y1="22" x2="90" y2="22" stroke="#60A5FA" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="0"  cy="22" r="5.5" fill="#60A5FA"/>
+    <circle cx="90" cy="22" r="5.5" fill="#60A5FA"/>
+    <text x="45" y="10" fill="#60A5FA" font-size="10" text-anchor="middle">[0, 1]</text>
+    <!-- open (2, 3) -->
+    <line x1="180" y1="22" x2="270" y2="22" stroke="#A78BFA" stroke-width="5" stroke-linecap="round"/>
+    <circle cx="180" cy="22" r="5.5" fill="#1E293B" stroke="#A78BFA" stroke-width="2"/>
+    <circle cx="270" cy="22" r="5.5" fill="#1E293B" stroke="#A78BFA" stroke-width="2"/>
+    <text x="225" y="10" fill="#A78BFA" font-size="10" text-anchor="middle">(2, 3)</text>
+  </g>
+
+  <!-- caption -->
+  <g font-family="'Consolas','Menlo',monospace" font-size="10" fill="#94A3B8">
+    <text x="240" y="212" text-anchor="middle">canonical · BigInteger-promoted · INumber&lt;T&gt;</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -94,7 +94,7 @@ Six independent NuGet packages that share a single solution, a single set of con
 </div>
 
 <div class="bodu-card">
-  <img src="images/hero-core.svg" alt="Bodu.Numerics" />
+  <img src="images/hero-numerics.svg" alt="Bodu.Numerics" />
   <h3>Bodu.Numerics</h3>
   <p>Exact rational arithmetic (<code>Fraction&lt;T&gt;</code>) over any <code>IBinaryInteger&lt;T&gt;</code> backing type with canonical-form auto-reduction, <code>BigInteger</code>-promoted intermediates, the full <code>INumber&lt;T&gt;</code> / <code>ISignedNumber&lt;T&gt;</code> surface, mixed-number and Unicode-vulgar-fraction formatting, continued-fraction expansion, and best rational approximation — plus <code>Interval&lt;T&gt;</code> for closed / open / half-open bounded numeric intervals with intersection, union, and adjacency operations.</p>
   <div class="bodu-card-links">
@@ -105,7 +105,7 @@ Six independent NuGet packages that share a single solution, a single set of con
 </div>
 
 <div class="bodu-card">
-  <img src="images/hero-core.svg" alt="Bodu.Financial" />
+  <img src="images/hero-financial.svg" alt="Bodu.Financial" />
   <h3>Bodu.Financial</h3>
   <p>Type-safe monetary primitives: <code>Money&lt;TCurrency&gt;</code> where the currency is encoded as the type parameter so cross-currency arithmetic fails the build, <code>MoneyValue</code> for runtime-tagged scenarios, <code>MoneyBag</code> for multi-currency portfolios, a shipped catalogue of ~185 ISO 4217 currencies (active and historic), an audit-grade exchange-rate provider stack with both timeless and dated lookup, fair allocation, cash rounding, sub-minor-unit-precise <code>Fraction&lt;BigInteger&gt;</code> interop, and three JSON wire shapes (strict / lenient / compact).</p>
   <div class="bodu-card-links">
@@ -116,7 +116,7 @@ Six independent NuGet packages that share a single solution, a single set of con
 </div>
 
 <div class="bodu-card">
-  <img src="images/hero-text.svg" alt="Bodu.Text.Configuration" />
+  <img src="images/hero-configuration.svg" alt="Bodu.Text.Configuration" />
   <h3>Bodu.Text.Configuration</h3>
   <p>INI / EditorConfig-style configuration parser with three profiles (Standard, PureIni, Relaxed), structured diagnostics, key pattern matching, and a typed view layer for projecting flattened paths into a <code>ConfigurationView</code> consumers can read without parsing twice.</p>
   <div class="bodu-card-links">
@@ -127,33 +127,13 @@ Six independent NuGet packages that share a single solution, a single set of con
 </div>
 
 <div class="bodu-card">
-  <img src="images/hero-text.svg" alt="Bodu.Extensions.Configuration.Text" />
+  <img src="images/hero-extensions-config.svg" alt="Bodu.Extensions.Configuration.Text" />
   <h3>Bodu.Extensions.Configuration.Text</h3>
   <p>Bridge between <code>Bodu.Text.Configuration</code> and <code>Microsoft.Extensions.Configuration</code> — file-based and stream-based configuration sources and providers that surface Bodu-parsed INI documents through the standard ASP.NET / Generic Host configuration pipeline.</p>
   <div class="bodu-card-links">
     <a href="docs/extensions-configuration-text/index.md">Introduction</a>
     <a href="guides/extensions-configuration-text/index.md">Guides</a>
     <a href="apidoc/Bodu.Extensions.Configuration.Text.md">API reference</a>
-  </div>
-</div>
-
-<div class="bodu-card">
-  <img src="images/hero-calendar.svg" alt="Bodu.Globalization.Calendar.Builder" />
-  <h3>Bodu.Globalization.Calendar.Builder</h3>
-  <p>Fluent, chainable API for programmatically authoring <code>NotableDateRule</code> instances in C# — supports every rule field (strategy, scope, tags, observance adjustments), deep cloning for template-mutate workflows, and round-tripping to / from the schema-valid XML and JSON forms consumed by the embedded-resource rule providers.</p>
-  <div class="bodu-card-links">
-    <a href="guides/calendar/notable-date-builder.md">Guide</a>
-    <a href="apidoc/Bodu.Globalization.Calendar.Builder.md">API reference</a>
-  </div>
-</div>
-
-<div class="bodu-card">
-  <img src="images/hero-calendar.svg" alt="Bodu.Globalization.Calendar.Data" />
-  <h3>Bodu.Globalization.Calendar.Data.*</h3>
-  <p>Region-specific notable-date rule bundles ship as independent NuGet packages so national public-holiday data can be re-released without a main-library rebuild. <code>Data.Americas</code> covers United States and Canada; <code>Data.Europe</code> covers eight countries including DE / ES / FR / GB / IT; <code>Data.AsiaPacific</code> covers eight countries including AU / CN / IN / JP / KR / NZ.</p>
-  <div class="bodu-card-links">
-    <a href="guides/calendar/data-packs.md">Guide</a>
-    <a href="apidoc/Bodu.Globalization.Calendar.Data.md">API reference</a>
   </div>
 </div>
 
@@ -174,11 +154,6 @@ dotnet add package Bodu.Text.Configuration
 dotnet add package Bodu.Extensions.Configuration.Text
 dotnet add package Bodu.Numerics
 dotnet add package Bodu.Financial
-
-# Optional region-specific calendar data packs:
-dotnet add package Bodu.Globalization.Calendar.Data.Americas
-dotnet add package Bodu.Globalization.Calendar.Data.Europe
-dotnet add package Bodu.Globalization.Calendar.Data.AsiaPacific
 ```
 
 </div>


### PR DESCRIPTION
## Summary

Adds two new hero SVG illustrations for the documentation and updates image references across the docs to use package-specific visuals instead of generic placeholders.

## Changes

- **New SVG assets:**
  - `docs/images/hero-numerics.svg` — Visual representation of `Fraction<T>` (numerator/denominator with decimal and continued-fraction equivalents) and `Interval<T>` (number line with closed/open interval notation)
  - `docs/images/hero-financial.svg` — Visual representation of type-safe `Money<TCurrency>` with currency-specific styling, exchange-rate conversion, and `MoneyBag` multi-currency portfolio

- **Documentation updates:**
  - Updated `docs/index.md` to reference the new package-specific hero images:
    - `Bodu.Numerics` now uses `hero-numerics.svg` (was `hero-core.svg`)
    - `Bodu.Financial` now uses `hero-financial.svg` (was `hero-core.svg`)
    - `Bodu.Text.Configuration` now uses `hero-configuration.svg` (was `hero-text.svg`)
    - `Bodu.Extensions.Configuration.Text` now uses `hero-extensions-config.svg` (was `hero-text.svg`)
  - Removed two calendar-related package cards from the main index (Calendar.Builder and Calendar.Data.*)
  - Removed calendar data pack installation instructions from the install section

- **API documentation updates:**
  - Updated image references in `docs/apidoc/Bodu.Financial.md`, `Bodu.Financial.Currencies.md`, `Bodu.Financial.Serialization.md`, and `Bodu.Numerics.md` to use the new package-specific hero images

## Implementation Details

Both SVG illustrations use:
- Dark slate gradient backgrounds matching the Bodu design system
- Monospace fonts (Consolas/Menlo) for code elements
- Color-coded visual elements (blue for Numerics, purple for Financial)
- Accessibility attributes (`role="img"`, `aria-label`, `<title>`)
- Responsive viewBox scaling for documentation embedding

https://claude.ai/code/session_01YAovc61HEnSCkzfaFVAK6F