### PR TITLE
feat(financial): add ExchangeRateSeriesBuilder + ExchangeRateTable for mutable rate editing

### DIFF
--- a/Bodu.Financial/src/Financial/ExchangeRateDateSearch.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateDateSearch.cs
@@ -1,0 +1,162 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateDateSearch.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Provides the shared candidate-selection algorithm used to resolve a requested date to an observation index
+/// under an <see cref="ExchangeRateDateResolution" /> policy.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Both the immutable storage backing <see cref="ExchangeRateSeries" /> and any mutable buffer can route through
+/// this helper so that the previous/next/nearest selection rules — including the tie-break semantics encoded in
+/// <see cref="ExchangeRateDateResolution.NearestPreferPrevious" /> and
+/// <see cref="ExchangeRateDateResolution.NearestPreferNext" /> — have a single source of truth. The helper
+/// operates on a <see cref="ReadOnlySpan{T}" /> of day numbers so callers can pass either a full backing array
+/// or the active prefix of a growing buffer without allocation.
+/// </para>
+/// </remarks>
+internal static class ExchangeRateDateSearch
+{
+    /// <summary>
+    /// Selects the observation index for the supplied <paramref name="resolution" /> given the previous and next
+    /// bracket indices produced by a binary search.
+    /// </summary>
+    /// <param name="dayNumbers">The sorted, unique day numbers of the underlying observations.</param>
+    /// <param name="requestedDayNumber">The day number the caller originally requested.</param>
+    /// <param name="resolution">The date-resolution policy in effect.</param>
+    /// <param name="previous">The index immediately before the insertion point, or <c>-1</c> if none.</param>
+    /// <param name="next">The insertion point, or <c><paramref name="dayNumbers" />.Length</c> if past the end.</param>
+    /// <param name="candidate">
+    /// When this method returns <see langword="true" />, the index of the selected observation; otherwise
+    /// <c>-1</c>.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if a candidate was selected; otherwise <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// <para>
+    /// For <see cref="ExchangeRateDateResolution.Exact" /> the caller should perform the exact-hit check itself
+    /// before calling; this helper returns <see langword="false" /> for that value because no fallback
+    /// candidate is permitted.
+    /// </para>
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool TrySelectCandidate(
+        ReadOnlySpan<int> dayNumbers,
+        int requestedDayNumber,
+        ExchangeRateDateResolution resolution,
+        int previous,
+        int next,
+        out int candidate)
+    {
+        var hasPrevious = previous >= 0;
+        var hasNext = next < dayNumbers.Length;
+
+        switch (resolution)
+        {
+            case ExchangeRateDateResolution.PreviousOnOrBefore:
+                if (hasPrevious)
+                {
+                    candidate = previous;
+                    return true;
+                }
+                break;
+
+            case ExchangeRateDateResolution.NextOnOrAfter:
+                if (hasNext)
+                {
+                    candidate = next;
+                    return true;
+                }
+                break;
+
+            case ExchangeRateDateResolution.Nearest:
+            case ExchangeRateDateResolution.NearestPreferPrevious:
+            case ExchangeRateDateResolution.NearestPreferNext:
+                return TrySelectNearest(dayNumbers, requestedDayNumber, resolution, hasPrevious, hasNext, previous, next, out candidate);
+        }
+
+        candidate = -1;
+        return false;
+    }
+
+    /// <summary>
+    /// Selects the nearest candidate index, honouring the tie-break preference encoded in
+    /// <paramref name="resolution" />.
+    /// </summary>
+    /// <param name="dayNumbers">The sorted day numbers of the underlying observations.</param>
+    /// <param name="requestedDayNumber">The day number the caller originally requested.</param>
+    /// <param name="resolution">A <c>Nearest*</c> resolution value.</param>
+    /// <param name="hasPrevious">Whether a previous candidate is available.</param>
+    /// <param name="hasNext">Whether a next candidate is available.</param>
+    /// <param name="previous">The previous candidate index.</param>
+    /// <param name="next">The next candidate index.</param>
+    /// <param name="candidate">When this method returns <see langword="true" />, the chosen index.</param>
+    /// <returns><see langword="true" /> if a candidate was selected; otherwise <see langword="false" />.</returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TrySelectNearest(
+        ReadOnlySpan<int> dayNumbers,
+        int requestedDayNumber,
+        ExchangeRateDateResolution resolution,
+        bool hasPrevious,
+        bool hasNext,
+        int previous,
+        int next,
+        out int candidate)
+    {
+        if (!hasPrevious && !hasNext)
+        {
+            candidate = -1;
+            return false;
+        }
+
+        if (!hasPrevious)
+        {
+            candidate = next;
+            return true;
+        }
+
+        if (!hasNext)
+        {
+            candidate = previous;
+            return true;
+        }
+
+        var previousDistance = requestedDayNumber - dayNumbers[previous];
+        var nextDistance = dayNumbers[next] - requestedDayNumber;
+
+        if (previousDistance < nextDistance)
+        {
+            candidate = previous;
+            return true;
+        }
+
+        if (nextDistance < previousDistance)
+        {
+            candidate = next;
+            return true;
+        }
+
+        switch (resolution)
+        {
+            case ExchangeRateDateResolution.NearestPreferPrevious:
+                candidate = previous;
+                return true;
+
+            case ExchangeRateDateResolution.NearestPreferNext:
+                candidate = next;
+                return true;
+
+            default:
+                candidate = -1;
+                return false;
+        }
+    }
+}

--- a/Bodu.Financial/src/Financial/ExchangeRateObservation.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateObservation.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateObservation.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Represents a single observed exchange rate on a specific calendar date for a series.
+/// </summary>
+/// <param name="Date">The calendar date on which the rate was observed.</param>
+/// <param name="Rate">
+/// The observed rate. Must be strictly positive when consumed by an <see cref="ExchangeRateSeries" /> or
+/// <see cref="ExchangeRateSeriesBuilder" />; the type itself does not validate the value because it is also used
+/// as a transport record in scenarios that produce default instances.
+/// </param>
+/// <remarks>
+/// <para>
+/// This type is a lightweight value carrier used by the series API in preference to repeated
+/// <c>(DateOnly, decimal)</c> tuples. The surrounding series enforces the &quot;strictly positive rate&quot; and
+/// &quot;unique date&quot; invariants; values constructed in isolation (including
+/// <see langword="default" /><c>(ExchangeRateObservation)</c>) carry no validation guarantees.
+/// </para>
+/// </remarks>
+public readonly record struct ExchangeRateObservation(DateOnly Date, decimal Rate);

--- a/Bodu.Financial/src/Financial/ExchangeRateSeries.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeries.cs
@@ -1,11 +1,10 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="ExchangeRateSeries.cs" company="Bodu Pty. Ltd.">
 //     Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Diagnostics;
-using System.Globalization;
 using System.Runtime.CompilerServices;
 
 namespace Bodu.Financial;
@@ -17,33 +16,30 @@ namespace Bodu.Financial;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The collection is immutable after construction. Internally it stores observations as two parallel sorted arrays — a
-/// <see cref="DateOnly" /> array of observation dates and a <see cref="decimal" /> array of rates — so that the binary
-/// search at lookup time touches only the compact (4 bytes per element) date array. Compared with
+/// The collection is immutable after construction. Internally it stores observations in a shared
+/// <see cref="ExchangeRateSeriesStorage" /> backed by two parallel sorted arrays — an <see cref="int" /> array
+/// of day numbers (<see cref="DateOnly.DayNumber" />) and a <see cref="decimal" /> array of rates — so that the
+/// binary search at lookup time touches only the compact date array. Compared with
 /// <see cref="System.Collections.Generic.SortedDictionary{TKey, TValue}" /> this gives substantially better cache
 /// locality, no per-node allocation, and predictable hot-path performance for the multi-year daily series typical of FX
 /// data.
 /// </para>
 /// <para>
 /// Instances are safe to share across threads after construction because all read paths only touch read-only arrays.
+/// Use <see cref="ExchangeRateSeriesBuilder" /> to construct or edit observations imperatively before producing a
+/// snapshot via <see cref="ExchangeRateSeriesBuilder.ToSeries" />.
 /// </para>
 /// </remarks>
 [DebuggerDisplay("{Pair.FromIsoCode,nq}/{Pair.ToIsoCode,nq} ({Provider,nq}) Count={Count}")]
 public sealed class ExchangeRateSeries
 {
     /// <summary>
-    /// The observation dates in strictly ascending order. Index <c>i</c> corresponds to <see cref="_rates" /> at the
-    /// same index.
+    /// The shared immutable storage holding the validated, sorted, unique day-number / rate arrays.
     /// </summary>
-    private readonly DateOnly[] _dates;
+    private readonly ExchangeRateSeriesStorage _storage;
 
     /// <summary>
-    /// The observed rates aligned positionally with <see cref="_dates" />. Every entry is strictly positive.
-    /// </summary>
-    private readonly decimal[] _rates;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ExchangeRateSeries" /> class.
+    /// Initializes a new instance of the <see cref="ExchangeRateSeries" /> class from a sequence of date/rate tuples.
     /// </summary>
     /// <param name="pair">The currency pair this series describes.</param>
     /// <param name="provider">The non-empty identifier of the publishing source.</param>
@@ -70,46 +66,53 @@ public sealed class ExchangeRateSeries
 
         Pair = pair;
         Provider = provider;
+        _storage = ExchangeRateSeriesStorage.Create(rates, nameof(rates));
+    }
 
-        List<(DateOnly Date, decimal Rate)> buffer = new(rates);
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeries" /> class from a sequence of
+    /// <see cref="ExchangeRateObservation" /> records.
+    /// </summary>
+    /// <param name="pair">The currency pair this series describes.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <param name="observations">
+    /// The observations to include. Must contain at least one entry and must not contain duplicate dates.
+    /// </param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> or <paramref name="observations" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space, if <paramref name="observations" /> is empty,
+    /// or if it contains duplicate dates.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate in <paramref name="observations" /> is zero or negative.
+    /// </exception>
+    public ExchangeRateSeries(
+        ExchangeRatePair pair,
+        string provider,
+        IEnumerable<ExchangeRateObservation> observations)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+        ThrowHelper.ThrowIfNull(observations);
 
-        if (buffer.Count == 0)
-            throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_RateSeriesEmpty, nameof(rates));
+        Pair = pair;
+        Provider = provider;
+        _storage = ExchangeRateSeriesStorage.Create(observations, nameof(observations));
+    }
 
-        for (var i = 0; i < buffer.Count; i++)
-        {
-            if (buffer[i].Rate <= 0m)
-            {
-                throw new ArgumentOutOfRangeException(
-                    nameof(rates),
-                    buffer[i].Rate,
-                    FinancialResourceStrings.Arg_OutOfRange_RateNotPositive);
-            }
-        }
-
-        buffer.Sort(static (a, b) => a.Date.CompareTo(b.Date));
-
-        for (var i = 1; i < buffer.Count; i++)
-        {
-            if (buffer[i].Date == buffer[i - 1].Date)
-            {
-                throw new ArgumentException(
-                    string.Format(
-                        CultureInfo.InvariantCulture,
-                        FinancialResourceStrings.Arg_Invalid_RateSeriesDuplicateDate,
-                        buffer[i].Date),
-                    nameof(rates));
-            }
-        }
-
-        _dates = new DateOnly[buffer.Count];
-        _rates = new decimal[buffer.Count];
-
-        for (var i = 0; i < buffer.Count; i++)
-        {
-            _dates[i] = buffer[i].Date;
-            _rates[i] = buffer[i].Rate;
-        }
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeries" /> class from pre-validated storage. Used by
+    /// the builder snapshot path to avoid revalidation.
+    /// </summary>
+    /// <param name="pair">The currency pair this series describes.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <param name="storage">The storage instance the new series should adopt.</param>
+    internal ExchangeRateSeries(ExchangeRatePair pair, string provider, ExchangeRateSeriesStorage storage)
+    {
+        Pair = pair;
+        Provider = provider;
+        _storage = storage;
     }
 
     /// <summary>
@@ -128,7 +131,7 @@ public sealed class ExchangeRateSeries
     /// Gets the number of observations stored in this series.
     /// </summary>
     /// <returns>A non-negative count equal to the number of rate entries supplied at construction.</returns>
-    public int Count => _dates.Length;
+    public int Count => _storage.Count;
 
     /// <summary>
     /// Attempts to resolve a rate for <paramref name="requestedDate" /> under <paramref name="options" />.
@@ -148,12 +151,12 @@ public sealed class ExchangeRateSeries
     /// </returns>
     /// <remarks>
     /// <para>
-    /// The resolution algorithm performs a single <see cref="Array.BinarySearch{T}(T[], T)" /> over the date array. On
-    /// an exact hit the corresponding rate is returned immediately. On a miss the previous and next candidate indices
-    /// are derived from the bitwise complement of the returned index, then selected per <paramref name="options" />.
-    /// For <see cref="ExchangeRateDateResolution.Nearest" /> with a tie (the requested date lies exactly midway between
-    /// two observations), this method returns <see langword="false" /> so callers receive a deterministic failure
-    /// rather than an arbitrary pick.
+    /// The resolution algorithm performs a single <see cref="Array.BinarySearch{T}(T[], T)" /> over the day-number
+    /// array. On an exact hit the corresponding rate is returned immediately. On a miss the previous and next
+    /// candidate indices are derived from the bitwise complement of the returned index, then selected per
+    /// <paramref name="options" />. For <see cref="ExchangeRateDateResolution.Nearest" /> with a tie (the requested
+    /// date lies exactly midway between two observations), this method returns <see langword="false" /> so callers
+    /// receive a deterministic failure rather than an arbitrary pick.
     /// </para>
     /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -165,171 +168,58 @@ public sealed class ExchangeRateSeries
     {
         options.Validate();
 
-        DateOnly[] dates = _dates;
-        var rates = _rates;
-
-        var index = Array.BinarySearch(dates, requestedDate);
-
-        if (index >= 0)
-        {
-            resolvedDate = dates[index];
-            rate = rates[index];
-            return true;
-        }
-
-        if (options.DateResolution == ExchangeRateDateResolution.Exact)
-        {
-            resolvedDate = default;
-            rate = default;
-            return false;
-        }
-
-        var next = ~index;
-        var previous = next - 1;
-
-        if (!TrySelectCandidate(dates, requestedDate, options.DateResolution, previous, next, out var candidate))
-        {
-            resolvedDate = default;
-            rate = default;
-            return false;
-        }
-
-        var offsetDays = Math.Abs(dates[candidate].DayNumber - requestedDate.DayNumber);
-
-        if (offsetDays > options.ToleranceDays)
-        {
-            resolvedDate = default;
-            rate = default;
-            return false;
-        }
-
-        resolvedDate = dates[candidate];
-        rate = rates[candidate];
-        return true;
+        return _storage.TryGetRate(requestedDate, options, out resolvedDate, out rate);
     }
 
     /// <summary>
-    /// Selects the candidate index for the supplied <paramref name="resolution" /> given the previous and next bracket
-    /// indices produced by the binary search.
+    /// Enumerates the observations in strictly ascending date order.
     /// </summary>
-    /// <param name="dates">The series date array.</param>
-    /// <param name="requestedDate">The date the caller originally requested.</param>
-    /// <param name="resolution">The date-resolution policy in effect.</param>
-    /// <param name="previous">The index immediately before the insertion point, or <c>-1</c> if none.</param>
-    /// <param name="next">The insertion point, or <c><see cref="Count" /></c> if past the end.</param>
-    /// <param name="candidate">When this method returns <see langword="true" />, the chosen index.</param>
-    /// <returns><see langword="true" /> if a candidate was selected; otherwise <see langword="false" />.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool TrySelectCandidate(
-        DateOnly[] dates,
-        DateOnly requestedDate,
-        ExchangeRateDateResolution resolution,
-        int previous,
-        int next,
-        out int candidate)
+    /// <returns>A lazy sequence of <see cref="ExchangeRateObservation" /> values.</returns>
+    public IEnumerable<ExchangeRateObservation> GetObservations() => _storage.Enumerate();
+
+    /// <summary>
+    /// Returns a new series with the observation for <paramref name="date" /> upserted to <paramref name="rate" />.
+    /// </summary>
+    /// <param name="date">The observation date to insert or update.</param>
+    /// <param name="rate">The rate to record on <paramref name="date" />.</param>
+    /// <returns>A new <see cref="ExchangeRateSeries" /> reflecting the updated observation.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public ExchangeRateSeries WithRate(DateOnly date, decimal rate)
     {
-        var hasPrevious = previous >= 0;
-        var hasNext = next < dates.Length;
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate);
 
-        switch (resolution)
-        {
-            case ExchangeRateDateResolution.PreviousOnOrBefore:
-                if (hasPrevious)
-                {
-                    candidate = previous;
-                    return true;
-                }
-                break;
-
-            case ExchangeRateDateResolution.NextOnOrAfter:
-                if (hasNext)
-                {
-                    candidate = next;
-                    return true;
-                }
-                break;
-
-            case ExchangeRateDateResolution.Nearest:
-            case ExchangeRateDateResolution.NearestPreferPrevious:
-            case ExchangeRateDateResolution.NearestPreferNext:
-                return TrySelectNearest(dates, requestedDate, resolution, hasPrevious, hasNext, previous, next, out candidate);
-        }
-
-        candidate = -1;
-        return false;
+        var builder = ToBuilder();
+        builder.Upsert(date, rate);
+        return builder.ToSeries();
     }
 
     /// <summary>
-    /// Selects the nearest candidate index, honouring the tie-break preference encoded in
-    /// <paramref name="resolution" />.
+    /// Returns a new series with the observation for <paramref name="date" /> removed if present.
     /// </summary>
-    /// <param name="dates">The series date array.</param>
-    /// <param name="requestedDate">The date the caller originally requested.</param>
-    /// <param name="resolution">A <c>Nearest*</c> resolution.</param>
-    /// <param name="hasPrevious">Whether a previous candidate is available.</param>
-    /// <param name="hasNext">Whether a next candidate is available.</param>
-    /// <param name="previous">The previous candidate index.</param>
-    /// <param name="next">The next candidate index.</param>
-    /// <param name="candidate">When this method returns <see langword="true" />, the chosen index.</param>
-    /// <returns><see langword="true" /> if a candidate was selected; otherwise <see langword="false" />.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool TrySelectNearest(
-        DateOnly[] dates,
-        DateOnly requestedDate,
-        ExchangeRateDateResolution resolution,
-        bool hasPrevious,
-        bool hasNext,
-        int previous,
-        int next,
-        out int candidate)
+    /// <param name="date">The observation date to remove.</param>
+    /// <returns>A new <see cref="ExchangeRateSeries" /> reflecting the removal.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if removing the observation would leave the series empty.
+    /// </exception>
+    public ExchangeRateSeries WithoutRate(DateOnly date)
     {
-        if (!hasPrevious && !hasNext)
-        {
-            candidate = -1;
-            return false;
-        }
-
-        if (!hasPrevious)
-        {
-            candidate = next;
-            return true;
-        }
-
-        if (!hasNext)
-        {
-            candidate = previous;
-            return true;
-        }
-
-        var requestedDay = requestedDate.DayNumber;
-        var previousDistance = requestedDay - dates[previous].DayNumber;
-        var nextDistance = dates[next].DayNumber - requestedDay;
-
-        if (previousDistance < nextDistance)
-        {
-            candidate = previous;
-            return true;
-        }
-
-        if (nextDistance < previousDistance)
-        {
-            candidate = next;
-            return true;
-        }
-
-        switch (resolution)
-        {
-            case ExchangeRateDateResolution.NearestPreferPrevious:
-                candidate = previous;
-                return true;
-
-            case ExchangeRateDateResolution.NearestPreferNext:
-                candidate = next;
-                return true;
-
-            default:
-                candidate = -1;
-                return false;
-        }
+        var builder = ToBuilder();
+        builder.Remove(date);
+        return builder.ToSeries();
     }
+
+    /// <summary>
+    /// Creates a mutable builder pre-populated from this series.
+    /// </summary>
+    /// <returns>A new <see cref="ExchangeRateSeriesBuilder" /> seeded with the current observations.</returns>
+    public ExchangeRateSeriesBuilder ToBuilder() => new(this);
+
+    /// <summary>
+    /// Provides internal access to the underlying storage so the builder can seed its buffer without copying
+    /// through a public enumeration.
+    /// </summary>
+    /// <returns>The series' immutable storage.</returns>
+    internal ExchangeRateSeriesStorage GetStorage() => _storage;
 }

--- a/Bodu.Financial/src/Financial/ExchangeRateSeriesBuffer.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeriesBuffer.cs
@@ -1,0 +1,588 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuffer.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Holds the mutable sorted day-number / rate arrays backing an <see cref="ExchangeRateSeriesBuilder" /> and
+/// implements the validation, search, insert, remove, and bulk-merge primitives shared with the immutable storage.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The buffer maintains the same invariants as <see cref="ExchangeRateSeriesStorage" /> — strictly ascending unique
+/// day numbers and strictly positive rates — but grows its arrays with spare capacity using the
+/// <see cref="List{T}" /> doubling rule. Single-element mutations perform a <see cref="Array.BinarySearch{T}(T[], int,
+/// int, T)" /> followed by an <see cref="Array.Copy(Array, int, Array, int, int)" /> shift. Range mutations sort and
+/// deduplicate the incoming batch, then run a two-pointer merge against the existing buffer into fresh arrays so a
+/// validation failure leaves the buffer unchanged.
+/// </para>
+/// <para>
+/// Instances are not thread-safe.
+/// </para>
+/// </remarks>
+internal sealed class ExchangeRateSeriesBuffer
+{
+    /// <summary>
+    /// The default growable capacity used when the buffer first needs to grow.
+    /// </summary>
+    private const int DefaultCapacity = 16;
+
+    /// <summary>
+    /// The backing day-number array. Slots <c>[0, _count)</c> are live and strictly ascending; trailing slots are
+    /// uninitialised capacity.
+    /// </summary>
+    private int[] _dayNumbers;
+
+    /// <summary>
+    /// The backing rate array. Slots <c>[0, _count)</c> are live and aligned with <see cref="_dayNumbers" />.
+    /// </summary>
+    private decimal[] _rates;
+
+    /// <summary>
+    /// The number of live observations in the buffer.
+    /// </summary>
+    private int _count;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeriesBuffer" /> class with zero capacity.
+    /// </summary>
+    public ExchangeRateSeriesBuffer()
+    {
+        _dayNumbers = Array.Empty<int>();
+        _rates = Array.Empty<decimal>();
+        _count = 0;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeriesBuffer" /> class with at least
+    /// <paramref name="capacity" /> slots pre-allocated.
+    /// </summary>
+    /// <param name="capacity">The initial capacity. Negative values are clamped to zero.</param>
+    public ExchangeRateSeriesBuffer(int capacity)
+    {
+        if (capacity <= 0)
+        {
+            _dayNumbers = Array.Empty<int>();
+            _rates = Array.Empty<decimal>();
+        }
+        else
+        {
+            _dayNumbers = new int[capacity];
+            _rates = new decimal[capacity];
+        }
+
+        _count = 0;
+    }
+
+    /// <summary>
+    /// Gets the number of live observations.
+    /// </summary>
+    /// <returns>A non-negative count.</returns>
+    public int Count => _count;
+
+    /// <summary>
+    /// Gets a value indicating whether the buffer holds no observations.
+    /// </summary>
+    /// <returns><see langword="true" /> if the buffer is empty; otherwise <see langword="false" />.</returns>
+    public bool IsEmpty => _count == 0;
+
+    /// <summary>
+    /// Inserts a new observation, throwing if an observation already exists for <paramref name="dayNumber" />.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <param name="rate">The observed rate.</param>
+    /// <param name="rateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentOutOfRangeException" />.
+    /// </param>
+    /// <param name="dateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentException" /> for a duplicate date.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if an observation already exists for <paramref name="dayNumber" />.
+    /// </exception>
+    public void Add(int dayNumber, decimal rate, string rateParamName, string dateParamName)
+    {
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate, rateParamName);
+
+        var index = IndexOf(dayNumber);
+        if (index >= 0)
+        {
+            throw new ArgumentException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.Arg_Invalid_RateSeriesDuplicateDate,
+                    DateOnly.FromDayNumber(dayNumber)),
+                dateParamName);
+        }
+
+        Insert(~index, dayNumber, rate);
+    }
+
+    /// <summary>
+    /// Attempts to insert a new observation, returning <see langword="false" /> if one already exists for
+    /// <paramref name="dayNumber" />.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <param name="rate">The observed rate.</param>
+    /// <param name="rateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentOutOfRangeException" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the observation was inserted; <see langword="false" /> if one already existed for
+    /// <paramref name="dayNumber" />.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public bool TryAdd(int dayNumber, decimal rate, string rateParamName)
+    {
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate, rateParamName);
+
+        var index = IndexOf(dayNumber);
+        if (index >= 0)
+            return false;
+
+        Insert(~index, dayNumber, rate);
+        return true;
+    }
+
+    /// <summary>
+    /// Updates the rate for an existing observation, throwing if none exists for <paramref name="dayNumber" />.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <param name="rate">The new rate.</param>
+    /// <param name="rateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentOutOfRangeException" />.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown if no observation exists for <paramref name="dayNumber" />.
+    /// </exception>
+    public void Set(int dayNumber, decimal rate, string rateParamName)
+    {
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate, rateParamName);
+
+        var index = IndexOf(dayNumber);
+        if (index < 0)
+        {
+            throw new KeyNotFoundException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.IO_KeyNotFound_RateObservationDate,
+                    DateOnly.FromDayNumber(dayNumber)));
+        }
+
+        _rates[index] = rate;
+    }
+
+    /// <summary>
+    /// Attempts to update the rate for an existing observation; returns <see langword="false" /> if none exists.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <param name="rate">The new rate.</param>
+    /// <param name="rateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentOutOfRangeException" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the rate was updated; <see langword="false" /> if no observation existed.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public bool TrySet(int dayNumber, decimal rate, string rateParamName)
+    {
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate, rateParamName);
+
+        var index = IndexOf(dayNumber);
+        if (index < 0)
+            return false;
+
+        _rates[index] = rate;
+        return true;
+    }
+
+    /// <summary>
+    /// Inserts a new observation or replaces the rate of an existing one.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <param name="rate">The rate to record.</param>
+    /// <param name="rateParamName">
+    /// The caller's parameter name to report in any raised <see cref="ArgumentOutOfRangeException" />.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public void Upsert(int dayNumber, decimal rate, string rateParamName)
+    {
+        FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate, rateParamName);
+
+        var index = IndexOf(dayNumber);
+        if (index >= 0)
+            _rates[index] = rate;
+        else
+            Insert(~index, dayNumber, rate);
+    }
+
+    /// <summary>
+    /// Removes the observation for <paramref name="dayNumber" /> if present.
+    /// </summary>
+    /// <param name="dayNumber">The observation day number.</param>
+    /// <returns>
+    /// <see langword="true" /> if an observation was removed; <see langword="false" /> if none existed.
+    /// </returns>
+    public bool Remove(int dayNumber)
+    {
+        var index = IndexOf(dayNumber);
+        if (index < 0)
+            return false;
+
+        RemoveAt(index);
+        return true;
+    }
+
+    /// <summary>
+    /// Reports whether an observation exists for <paramref name="dayNumber" />.
+    /// </summary>
+    /// <param name="dayNumber">The day number to query.</param>
+    /// <returns>
+    /// <see langword="true" /> if an observation exists; otherwise <see langword="false" />.
+    /// </returns>
+    public bool Contains(int dayNumber) => IndexOf(dayNumber) >= 0;
+
+    /// <summary>
+    /// Attempts to retrieve the rate observed exactly on <paramref name="dayNumber" />.
+    /// </summary>
+    /// <param name="dayNumber">The day number to query.</param>
+    /// <param name="rate">
+    /// When this method returns <see langword="true" />, the observed rate; otherwise <see langword="default" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if an observation exists for <paramref name="dayNumber" />; otherwise
+    /// <see langword="false" />.
+    /// </returns>
+    public bool TryGetRate(int dayNumber, out decimal rate)
+    {
+        var index = IndexOf(dayNumber);
+        if (index < 0)
+        {
+            rate = default;
+            return false;
+        }
+
+        rate = _rates[index];
+        return true;
+    }
+
+    /// <summary>
+    /// Inserts a batch of observations, rejecting duplicate dates inside the batch and dates that already exist in
+    /// the buffer.
+    /// </summary>
+    /// <param name="observations">The observations to insert.</param>
+    /// <param name="observationsParamName">
+    /// The caller's parameter name to report in raised argument exceptions.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the batch contains a duplicate date or a date already present in the buffer.
+    /// </exception>
+    public void AddRange(IEnumerable<ExchangeRateObservation> observations, string observationsParamName)
+    {
+        var incoming = PrepareIncoming(observations, observationsParamName);
+        if (incoming.Count == 0)
+            return;
+
+        Merge(incoming, observationsParamName, throwOnConflict: true);
+    }
+
+    /// <summary>
+    /// Merges a batch of observations: inserts new dates and replaces rates for dates already present. Rejects
+    /// duplicate dates within the incoming batch.
+    /// </summary>
+    /// <param name="observations">The observations to merge.</param>
+    /// <param name="observationsParamName">
+    /// The caller's parameter name to report in raised argument exceptions.
+    /// </param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the batch contains a duplicate date.
+    /// </exception>
+    public void UpsertRange(IEnumerable<ExchangeRateObservation> observations, string observationsParamName)
+    {
+        var incoming = PrepareIncoming(observations, observationsParamName);
+        if (incoming.Count == 0)
+            return;
+
+        Merge(incoming, observationsParamName, throwOnConflict: false);
+    }
+
+    /// <summary>
+    /// Enumerates the live observations in strictly ascending date order.
+    /// </summary>
+    /// <returns>A lazy sequence of <see cref="ExchangeRateObservation" /> values.</returns>
+    public IEnumerable<ExchangeRateObservation> Enumerate()
+    {
+        for (var i = 0; i < _count; i++)
+        {
+            yield return new ExchangeRateObservation(DateOnly.FromDayNumber(_dayNumbers[i]), _rates[i]);
+        }
+    }
+
+    /// <summary>
+    /// Produces a fresh immutable storage snapshot of the live observations.
+    /// </summary>
+    /// <returns>A new <see cref="ExchangeRateSeriesStorage" /> instance.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the buffer holds no observations.
+    /// </exception>
+    public ExchangeRateSeriesStorage ToStorage()
+    {
+        if (_count == 0)
+            throw new InvalidOperationException(FinancialResourceStrings.Op_Invalid_RateSeriesBuilderEmpty);
+
+        var dayNumbers = new int[_count];
+        var rates = new decimal[_count];
+
+        Array.Copy(_dayNumbers, dayNumbers, _count);
+        Array.Copy(_rates, rates, _count);
+
+        return ExchangeRateSeriesStorage.CreateFromSortedUnique(dayNumbers, rates);
+    }
+
+    /// <summary>
+    /// Creates a buffer seeded from the supplied immutable storage. Mutations on the resulting buffer do not affect
+    /// the source storage.
+    /// </summary>
+    /// <param name="storage">The storage to copy.</param>
+    /// <returns>A new <see cref="ExchangeRateSeriesBuffer" /> with the same observations.</returns>
+    public static ExchangeRateSeriesBuffer FromStorage(ExchangeRateSeriesStorage storage)
+    {
+        var count = storage.Count;
+        var buffer = new ExchangeRateSeriesBuffer(count);
+
+        var i = 0;
+        foreach (var observation in storage.Enumerate())
+        {
+            buffer._dayNumbers[i] = observation.Date.DayNumber;
+            buffer._rates[i] = observation.Rate;
+            i++;
+        }
+
+        buffer._count = count;
+        return buffer;
+    }
+
+    /// <summary>
+    /// Validates and pre-sorts an incoming batch into a duplicate-free list of (day, rate) pairs.
+    /// </summary>
+    /// <param name="observations">The candidate observations.</param>
+    /// <param name="observationsParamName">The caller's parameter name to report in raised exceptions.</param>
+    /// <returns>A sorted list of validated incoming observations.</returns>
+    private static List<(int DayNumber, decimal Rate)> PrepareIncoming(
+        IEnumerable<ExchangeRateObservation> observations,
+        string observationsParamName)
+    {
+        var incoming = new List<(int DayNumber, decimal Rate)>();
+        foreach (var observation in observations)
+        {
+            if (observation.Rate <= 0m)
+            {
+                throw new ArgumentOutOfRangeException(
+                    observationsParamName,
+                    observation.Rate,
+                    FinancialResourceStrings.Arg_OutOfRange_ExchangeRateNotPositive);
+            }
+
+            incoming.Add((observation.Date.DayNumber, observation.Rate));
+        }
+
+        if (incoming.Count == 0)
+            return incoming;
+
+        incoming.Sort(static (a, b) => a.DayNumber.CompareTo(b.DayNumber));
+
+        for (var i = 1; i < incoming.Count; i++)
+        {
+            if (incoming[i].DayNumber == incoming[i - 1].DayNumber)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        FinancialResourceStrings.Arg_Invalid_RateSeriesDuplicateDate,
+                        DateOnly.FromDayNumber(incoming[i].DayNumber)),
+                    observationsParamName);
+            }
+        }
+
+        return incoming;
+    }
+
+    /// <summary>
+    /// Merges a pre-validated sorted incoming batch with the existing buffer. The merge writes into fresh arrays and
+    /// only commits to the buffer after the entire pass succeeds, so a thrown exception leaves the buffer unchanged.
+    /// </summary>
+    /// <param name="incoming">The sorted unique incoming batch.</param>
+    /// <param name="observationsParamName">The caller's parameter name to report in raised exceptions.</param>
+    /// <param name="throwOnConflict">
+    /// When <see langword="true" /> (AddRange semantics) a collision with an existing date throws; when
+    /// <see langword="false" /> (UpsertRange semantics) the incoming value replaces the existing one.
+    /// </param>
+    private void Merge(
+        List<(int DayNumber, decimal Rate)> incoming,
+        string observationsParamName,
+        bool throwOnConflict)
+    {
+        var maxLength = _count + incoming.Count;
+        var mergedDays = new int[maxLength];
+        var mergedRates = new decimal[maxLength];
+
+        var i = 0;
+        var j = 0;
+        var k = 0;
+
+        while (i < _count && j < incoming.Count)
+        {
+            var existingDay = _dayNumbers[i];
+            var incomingDay = incoming[j].DayNumber;
+
+            if (existingDay < incomingDay)
+            {
+                mergedDays[k] = existingDay;
+                mergedRates[k] = _rates[i];
+                i++;
+                k++;
+            }
+            else if (existingDay > incomingDay)
+            {
+                mergedDays[k] = incomingDay;
+                mergedRates[k] = incoming[j].Rate;
+                j++;
+                k++;
+            }
+            else
+            {
+                if (throwOnConflict)
+                {
+                    throw new ArgumentException(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            FinancialResourceStrings.Arg_Invalid_RateSeriesAddRangeConflict,
+                            DateOnly.FromDayNumber(incomingDay)),
+                        observationsParamName);
+                }
+
+                mergedDays[k] = incomingDay;
+                mergedRates[k] = incoming[j].Rate;
+                i++;
+                j++;
+                k++;
+            }
+        }
+
+        while (i < _count)
+        {
+            mergedDays[k] = _dayNumbers[i];
+            mergedRates[k] = _rates[i];
+            i++;
+            k++;
+        }
+
+        while (j < incoming.Count)
+        {
+            mergedDays[k] = incoming[j].DayNumber;
+            mergedRates[k] = incoming[j].Rate;
+            j++;
+            k++;
+        }
+
+        if (k != mergedDays.Length)
+        {
+            Array.Resize(ref mergedDays, k);
+            Array.Resize(ref mergedRates, k);
+        }
+
+        _dayNumbers = mergedDays;
+        _rates = mergedRates;
+        _count = k;
+    }
+
+    /// <summary>
+    /// Performs a binary search across the live segment of the day-number array.
+    /// </summary>
+    /// <param name="dayNumber">The day number to locate.</param>
+    /// <returns>
+    /// A non-negative index if the value is present; otherwise the bitwise complement of the insertion index.
+    /// </returns>
+    private int IndexOf(int dayNumber) => Array.BinarySearch(_dayNumbers, 0, _count, dayNumber);
+
+    /// <summary>
+    /// Inserts a new entry at <paramref name="index" />, shifting subsequent entries to the right.
+    /// </summary>
+    /// <param name="index">The insertion index in <c>[0, _count]</c>.</param>
+    /// <param name="dayNumber">The day number to insert.</param>
+    /// <param name="rate">The rate to insert.</param>
+    private void Insert(int index, int dayNumber, decimal rate)
+    {
+        EnsureCapacity(_count + 1);
+
+        var moveCount = _count - index;
+        if (moveCount > 0)
+        {
+            Array.Copy(_dayNumbers, index, _dayNumbers, index + 1, moveCount);
+            Array.Copy(_rates, index, _rates, index + 1, moveCount);
+        }
+
+        _dayNumbers[index] = dayNumber;
+        _rates[index] = rate;
+        _count++;
+    }
+
+    /// <summary>
+    /// Removes the entry at <paramref name="index" />, shifting subsequent entries to the left.
+    /// </summary>
+    /// <param name="index">The index to remove from the live segment.</param>
+    private void RemoveAt(int index)
+    {
+        var moveCount = _count - index - 1;
+        if (moveCount > 0)
+        {
+            Array.Copy(_dayNumbers, index + 1, _dayNumbers, index, moveCount);
+            Array.Copy(_rates, index + 1, _rates, index, moveCount);
+        }
+
+        _count--;
+        _dayNumbers[_count] = 0;
+        _rates[_count] = 0m;
+    }
+
+    /// <summary>
+    /// Ensures both backing arrays can accommodate at least <paramref name="minimumCapacity" /> slots, growing using
+    /// the standard doubling rule.
+    /// </summary>
+    /// <param name="minimumCapacity">The minimum capacity required.</param>
+    private void EnsureCapacity(int minimumCapacity)
+    {
+        if (_dayNumbers.Length >= minimumCapacity)
+            return;
+
+        var newCapacity = _dayNumbers.Length == 0 ? DefaultCapacity : _dayNumbers.Length * 2;
+        if (newCapacity < minimumCapacity)
+            newCapacity = minimumCapacity;
+
+        Array.Resize(ref _dayNumbers, newCapacity);
+        Array.Resize(ref _rates, newCapacity);
+    }
+}

--- a/Bodu.Financial/src/Financial/ExchangeRateSeriesBuilder.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeriesBuilder.cs
@@ -1,0 +1,249 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilder.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Provides a mutable construction and editing surface for an <see cref="ExchangeRateSeries" />, maintaining strictly
+/// ascending unique observation dates and strictly positive rates while supporting single-observation edits and bulk
+/// import.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The builder is the natural entry point for assembling rate observations imperatively (manual data entry,
+/// streaming import, merge with prior history). After mutations complete, call <see cref="ToSeries" /> to produce
+/// an immutable <see cref="ExchangeRateSeries" /> snapshot for use in production lookup. Further mutations on the
+/// builder do not affect previously produced snapshots, and vice versa.
+/// </para>
+/// <para>
+/// Instances are not thread-safe; concurrent mutation requires external synchronisation.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{Pair.FromIsoCode,nq}/{Pair.ToIsoCode,nq} ({Provider,nq}) Count={Count}")]
+public sealed class ExchangeRateSeriesBuilder
+{
+    /// <summary>
+    /// The mutable buffer holding the live observations.
+    /// </summary>
+    private readonly ExchangeRateSeriesBuffer _buffer;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeriesBuilder" /> class with no observations.
+    /// </summary>
+    /// <param name="pair">The currency pair this builder is editing.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public ExchangeRateSeriesBuilder(ExchangeRatePair pair, string provider)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        Pair = pair;
+        Provider = provider;
+        _buffer = new ExchangeRateSeriesBuffer();
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeriesBuilder" /> class seeded from the supplied
+    /// immutable series.
+    /// </summary>
+    /// <param name="series">The series to copy observations from.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="series" /> is <see langword="null" />.
+    /// </exception>
+    public ExchangeRateSeriesBuilder(ExchangeRateSeries series)
+    {
+        ThrowHelper.ThrowIfNull(series);
+
+        Pair = series.Pair;
+        Provider = series.Provider;
+        _buffer = ExchangeRateSeriesBuffer.FromStorage(series.GetStorage());
+    }
+
+    /// <summary>
+    /// Gets the currency pair this builder is editing.
+    /// </summary>
+    /// <returns>The series pair.</returns>
+    public ExchangeRatePair Pair { get; }
+
+    /// <summary>
+    /// Gets the identifier of the source the builder represents.
+    /// </summary>
+    /// <returns>A non-empty provider identifier.</returns>
+    public string Provider { get; }
+
+    /// <summary>
+    /// Gets the number of observations currently held.
+    /// </summary>
+    /// <returns>A non-negative count.</returns>
+    public int Count => _buffer.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the builder holds no observations.
+    /// </summary>
+    /// <returns><see langword="true" /> if the builder is empty; otherwise <see langword="false" />.</returns>
+    public bool IsEmpty => _buffer.IsEmpty;
+
+    /// <summary>
+    /// Inserts a new observation; throws if an observation already exists for <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if an observation already exists for <paramref name="date" />.
+    /// </exception>
+    public void Add(DateOnly date, decimal rate) =>
+        _buffer.Add(date.DayNumber, rate, nameof(rate), nameof(date));
+
+    /// <summary>
+    /// Attempts to insert a new observation; returns <see langword="false" /> if one already exists for
+    /// <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The observed rate.</param>
+    /// <returns>
+    /// <see langword="true" /> if the observation was inserted; <see langword="false" /> if one already existed.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public bool TryAdd(DateOnly date, decimal rate) =>
+        _buffer.TryAdd(date.DayNumber, rate, nameof(rate));
+
+    /// <summary>
+    /// Updates the rate for an existing observation; throws if no observation exists for <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date to update.</param>
+    /// <param name="rate">The new rate.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="KeyNotFoundException">
+    /// Thrown if no observation exists for <paramref name="date" />.
+    /// </exception>
+    public void Set(DateOnly date, decimal rate) =>
+        _buffer.Set(date.DayNumber, rate, nameof(rate));
+
+    /// <summary>
+    /// Attempts to update the rate for an existing observation; returns <see langword="false" /> if none exists.
+    /// </summary>
+    /// <param name="date">The observation date to update.</param>
+    /// <param name="rate">The new rate.</param>
+    /// <returns>
+    /// <see langword="true" /> if the rate was updated; <see langword="false" /> if no observation existed.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public bool TrySet(DateOnly date, decimal rate) =>
+        _buffer.TrySet(date.DayNumber, rate, nameof(rate));
+
+    /// <summary>
+    /// Inserts a new observation or replaces the rate of an existing one for <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The rate to record.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public void Upsert(DateOnly date, decimal rate) =>
+        _buffer.Upsert(date.DayNumber, rate, nameof(rate));
+
+    /// <summary>
+    /// Removes the observation for <paramref name="date" /> if present.
+    /// </summary>
+    /// <param name="date">The observation date to remove.</param>
+    /// <returns>
+    /// <see langword="true" /> if an observation was removed; <see langword="false" /> if none existed.
+    /// </returns>
+    public bool Remove(DateOnly date) => _buffer.Remove(date.DayNumber);
+
+    /// <summary>
+    /// Reports whether an observation exists for <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date to query.</param>
+    /// <returns>
+    /// <see langword="true" /> if an observation exists; otherwise <see langword="false" />.
+    /// </returns>
+    public bool ContainsDate(DateOnly date) => _buffer.Contains(date.DayNumber);
+
+    /// <summary>
+    /// Attempts to retrieve the rate observed exactly on <paramref name="date" />.
+    /// </summary>
+    /// <param name="date">The observation date to query.</param>
+    /// <param name="rate">
+    /// When this method returns <see langword="true" />, the rate observed on <paramref name="date" />; otherwise
+    /// <see langword="default" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if an observation exists; otherwise <see langword="false" />.
+    /// </returns>
+    public bool TryGetRate(DateOnly date, out decimal rate) => _buffer.TryGetRate(date.DayNumber, out rate);
+
+    /// <summary>
+    /// Inserts a batch of observations, rejecting duplicate dates inside the batch and dates already present in the
+    /// builder. On any validation failure the builder remains unchanged.
+    /// </summary>
+    /// <param name="observations">The observations to insert.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="observations" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate in <paramref name="observations" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the batch contains a duplicate date or a date already present in the builder.
+    /// </exception>
+    public void AddRange(IEnumerable<ExchangeRateObservation> observations)
+    {
+        ThrowHelper.ThrowIfNull(observations);
+        _buffer.AddRange(observations, nameof(observations));
+    }
+
+    /// <summary>
+    /// Merges a batch of observations into the builder: inserts new dates and replaces rates for dates already
+    /// present. Rejects duplicate dates within the batch. On any validation failure the builder remains unchanged.
+    /// </summary>
+    /// <param name="observations">The observations to merge.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="observations" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate in <paramref name="observations" /> is zero or negative.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if the batch contains a duplicate date.
+    /// </exception>
+    public void UpsertRange(IEnumerable<ExchangeRateObservation> observations)
+    {
+        ThrowHelper.ThrowIfNull(observations);
+        _buffer.UpsertRange(observations, nameof(observations));
+    }
+
+    /// <summary>
+    /// Enumerates the observations in strictly ascending date order.
+    /// </summary>
+    /// <returns>A lazy sequence of <see cref="ExchangeRateObservation" /> values.</returns>
+    public IEnumerable<ExchangeRateObservation> GetObservations() => _buffer.Enumerate();
+
+    /// <summary>
+    /// Produces an immutable <see cref="ExchangeRateSeries" /> snapshot of the current observations.
+    /// </summary>
+    /// <returns>A new <see cref="ExchangeRateSeries" /> reflecting the builder's current state.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if the builder is empty; an immutable series must contain at least one observation.
+    /// </exception>
+    public ExchangeRateSeries ToSeries() => new(Pair, Provider, _buffer.ToStorage());
+}

--- a/Bodu.Financial/src/Financial/ExchangeRateSeriesKey.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeriesKey.cs
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesKey.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Identifies a single rate series within an <see cref="ExchangeRateTable" /> by its currency pair and provider.
+/// </summary>
+/// <param name="Pair">The currency pair the series describes.</param>
+/// <param name="Provider">The non-empty identifier of the publishing source.</param>
+public readonly record struct ExchangeRateSeriesKey(ExchangeRatePair Pair, string Provider);

--- a/Bodu.Financial/src/Financial/ExchangeRateSeriesStorage.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeriesStorage.cs
@@ -1,0 +1,290 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesStorage.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Runtime.CompilerServices;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Stores the validated, sorted, deduplicated day-number / rate arrays that back an immutable
+/// <see cref="ExchangeRateSeries" /> snapshot and provides the lookup, enumeration, and construction logic
+/// shared with the mutable buffer.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The storage owns its arrays and treats them as immutable. Day numbers are stored as <see cref="int" />
+/// (<see cref="DateOnly.DayNumber" />) to keep comparisons branch-light and to allow direct
+/// <see cref="Array.BinarySearch{T}(T[], int, int, T)" /> dispatch without an <see cref="IComparable{T}" />
+/// virtual call. Public boundaries continue to use <see cref="DateOnly" />.
+/// </para>
+/// <para>
+/// Instances are safe to share across threads after construction because all read paths only touch read-only
+/// arrays.
+/// </para>
+/// </remarks>
+internal sealed class ExchangeRateSeriesStorage
+{
+    /// <summary>
+    /// The observation day numbers in strictly ascending order. Index <c>i</c> corresponds to <see cref="_rates" />
+    /// at the same index.
+    /// </summary>
+    private readonly int[] _dayNumbers;
+
+    /// <summary>
+    /// The observed rates aligned positionally with <see cref="_dayNumbers" />. Every entry is strictly positive.
+    /// </summary>
+    private readonly decimal[] _rates;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateSeriesStorage" /> class with the supplied
+    /// pre-validated arrays. The instance assumes ownership; callers must not mutate the arrays after the call.
+    /// </summary>
+    /// <param name="dayNumbers">The strictly ascending day-number array.</param>
+    /// <param name="rates">The aligned strictly-positive rate array.</param>
+    private ExchangeRateSeriesStorage(int[] dayNumbers, decimal[] rates)
+    {
+        _dayNumbers = dayNumbers;
+        _rates = rates;
+    }
+
+    /// <summary>
+    /// Gets the number of observations stored.
+    /// </summary>
+    /// <returns>A positive count.</returns>
+    public int Count => _dayNumbers.Length;
+
+    /// <summary>
+    /// Gets the calendar date of the first (earliest) observation.
+    /// </summary>
+    /// <returns>The earliest observation date.</returns>
+    public DateOnly FirstDate => DateOnly.FromDayNumber(_dayNumbers[0]);
+
+    /// <summary>
+    /// Gets the calendar date of the last (latest) observation.
+    /// </summary>
+    /// <returns>The latest observation date.</returns>
+    public DateOnly LastDate => DateOnly.FromDayNumber(_dayNumbers[_dayNumbers.Length - 1]);
+
+    /// <summary>
+    /// Attempts to resolve a rate for <paramref name="requestedDate" /> under <paramref name="options" />.
+    /// </summary>
+    /// <param name="requestedDate">The calendar date the caller is asking about.</param>
+    /// <param name="options">The lookup rules to apply.</param>
+    /// <param name="resolvedDate">
+    /// When this method returns <see langword="true" />, the observation date selected as the answer; otherwise
+    /// <see langword="default" />.
+    /// </param>
+    /// <param name="rate">
+    /// When this method returns <see langword="true" />, the rate observed on <paramref name="resolvedDate" />;
+    /// otherwise <see langword="default" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if a rate was resolved within tolerance; otherwise <see langword="false" />.
+    /// </returns>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryGetRate(
+        DateOnly requestedDate,
+        ExchangeRateLookupOptions options,
+        out DateOnly resolvedDate,
+        out decimal rate)
+    {
+        var dayNumbers = _dayNumbers;
+        var rates = _rates;
+        var requestedDayNumber = requestedDate.DayNumber;
+
+        var index = Array.BinarySearch(dayNumbers, requestedDayNumber);
+
+        if (index >= 0)
+        {
+            resolvedDate = DateOnly.FromDayNumber(dayNumbers[index]);
+            rate = rates[index];
+            return true;
+        }
+
+        if (options.DateResolution == ExchangeRateDateResolution.Exact)
+        {
+            resolvedDate = default;
+            rate = default;
+            return false;
+        }
+
+        var next = ~index;
+        var previous = next - 1;
+
+        if (!ExchangeRateDateSearch.TrySelectCandidate(dayNumbers, requestedDayNumber, options.DateResolution, previous, next, out var candidate))
+        {
+            resolvedDate = default;
+            rate = default;
+            return false;
+        }
+
+        var offsetDays = Math.Abs(dayNumbers[candidate] - requestedDayNumber);
+
+        if (offsetDays > options.ToleranceDays)
+        {
+            resolvedDate = default;
+            rate = default;
+            return false;
+        }
+
+        resolvedDate = DateOnly.FromDayNumber(dayNumbers[candidate]);
+        rate = rates[candidate];
+        return true;
+    }
+
+    /// <summary>
+    /// Enumerates the observations in strictly ascending date order.
+    /// </summary>
+    /// <returns>A lazy sequence of <see cref="ExchangeRateObservation" /> values.</returns>
+    public IEnumerable<ExchangeRateObservation> Enumerate()
+    {
+        for (var i = 0; i < _dayNumbers.Length; i++)
+        {
+            yield return new ExchangeRateObservation(DateOnly.FromDayNumber(_dayNumbers[i]), _rates[i]);
+        }
+    }
+
+    /// <summary>
+    /// Validates, sorts, and deduplicates the supplied tuple sequence and returns a new storage instance.
+    /// </summary>
+    /// <param name="rates">The candidate observations.</param>
+    /// <param name="ratesParamName">
+    /// The parameter name used in raised exceptions so the caller's signature is reflected in
+    /// <see cref="ArgumentException.ParamName" />.
+    /// </param>
+    /// <returns>A new <see cref="ExchangeRateSeriesStorage" /> wrapping the validated arrays.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="rates" /> is empty or contains duplicate dates.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate is zero or negative.
+    /// </exception>
+    public static ExchangeRateSeriesStorage Create(
+        IEnumerable<(DateOnly Date, decimal Rate)> rates,
+        string ratesParamName)
+    {
+        List<(DateOnly Date, decimal Rate)> buffer = new(rates);
+
+        if (buffer.Count == 0)
+            throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_RateSeriesEmpty, ratesParamName);
+
+        for (var i = 0; i < buffer.Count; i++)
+        {
+            if (buffer[i].Rate <= 0m)
+            {
+                throw new ArgumentOutOfRangeException(
+                    ratesParamName,
+                    buffer[i].Rate,
+                    FinancialResourceStrings.Arg_OutOfRange_RateNotPositive);
+            }
+        }
+
+        buffer.Sort(static (a, b) => a.Date.CompareTo(b.Date));
+
+        for (var i = 1; i < buffer.Count; i++)
+        {
+            if (buffer[i].Date == buffer[i - 1].Date)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        FinancialResourceStrings.Arg_Invalid_RateSeriesDuplicateDate,
+                        buffer[i].Date),
+                    ratesParamName);
+            }
+        }
+
+        var dayNumbers = new int[buffer.Count];
+        var rateArray = new decimal[buffer.Count];
+
+        for (var i = 0; i < buffer.Count; i++)
+        {
+            dayNumbers[i] = buffer[i].Date.DayNumber;
+            rateArray[i] = buffer[i].Rate;
+        }
+
+        return new ExchangeRateSeriesStorage(dayNumbers, rateArray);
+    }
+
+    /// <summary>
+    /// Validates, sorts, and deduplicates the supplied observation sequence and returns a new storage instance.
+    /// </summary>
+    /// <param name="observations">The candidate observations.</param>
+    /// <param name="observationsParamName">
+    /// The parameter name used in raised exceptions so the caller's signature is reflected in
+    /// <see cref="ArgumentException.ParamName" />.
+    /// </param>
+    /// <returns>A new <see cref="ExchangeRateSeriesStorage" /> wrapping the validated arrays.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="observations" /> is empty or contains duplicate dates.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if any rate is zero or negative.
+    /// </exception>
+    public static ExchangeRateSeriesStorage Create(
+        IEnumerable<ExchangeRateObservation> observations,
+        string observationsParamName)
+    {
+        List<ExchangeRateObservation> buffer = new(observations);
+
+        if (buffer.Count == 0)
+            throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_RateSeriesEmpty, observationsParamName);
+
+        for (var i = 0; i < buffer.Count; i++)
+        {
+            if (buffer[i].Rate <= 0m)
+            {
+                throw new ArgumentOutOfRangeException(
+                    observationsParamName,
+                    buffer[i].Rate,
+                    FinancialResourceStrings.Arg_OutOfRange_RateNotPositive);
+            }
+        }
+
+        buffer.Sort(static (a, b) => a.Date.CompareTo(b.Date));
+
+        for (var i = 1; i < buffer.Count; i++)
+        {
+            if (buffer[i].Date == buffer[i - 1].Date)
+            {
+                throw new ArgumentException(
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        FinancialResourceStrings.Arg_Invalid_RateSeriesDuplicateDate,
+                        buffer[i].Date),
+                    observationsParamName);
+            }
+        }
+
+        var dayNumbers = new int[buffer.Count];
+        var rateArray = new decimal[buffer.Count];
+
+        for (var i = 0; i < buffer.Count; i++)
+        {
+            dayNumbers[i] = buffer[i].Date.DayNumber;
+            rateArray[i] = buffer[i].Rate;
+        }
+
+        return new ExchangeRateSeriesStorage(dayNumbers, rateArray);
+    }
+
+    /// <summary>
+    /// Creates a storage instance directly from arrays that the caller guarantees are strictly ascending, unique,
+    /// and strictly positive. Used by the mutable buffer's snapshot path to avoid revalidation.
+    /// </summary>
+    /// <param name="dayNumbers">
+    /// The strictly ascending unique day numbers. The instance takes ownership; the caller must not mutate the
+    /// array after the call.
+    /// </param>
+    /// <param name="rates">
+    /// The aligned strictly-positive rates. The instance takes ownership; the caller must not mutate the array
+    /// after the call.
+    /// </param>
+    /// <returns>A new <see cref="ExchangeRateSeriesStorage" /> wrapping the supplied arrays.</returns>
+    internal static ExchangeRateSeriesStorage CreateFromSortedUnique(int[] dayNumbers, decimal[] rates) =>
+        new(dayNumbers, rates);
+}

--- a/Bodu.Financial/src/Financial/ExchangeRateTable.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateTable.cs
@@ -1,0 +1,212 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTable.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Provides a mutable collection of <see cref="ExchangeRateSeriesBuilder" /> instances keyed by currency pair and
+/// provider, intended for assembling rate observations across many series before producing immutable snapshots.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The table delegates per-series mutation to the underlying <see cref="ExchangeRateSeriesBuilder" /> instances,
+/// so single-observation edits, bulk import, and snapshot semantics behave identically to working with a builder
+/// directly. The table itself adds only the multi-series indexing, lazy creation, and bulk snapshot operations.
+/// </para>
+/// <para>
+/// Instances are not thread-safe; concurrent mutation requires external synchronisation.
+/// </para>
+/// </remarks>
+public sealed class ExchangeRateTable
+{
+    /// <summary>
+    /// The series builders, keyed by (pair, provider).
+    /// </summary>
+    private readonly Dictionary<ExchangeRateSeriesKey, ExchangeRateSeriesBuilder> _series;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExchangeRateTable" /> class with no series.
+    /// </summary>
+    public ExchangeRateTable()
+    {
+        _series = new Dictionary<ExchangeRateSeriesKey, ExchangeRateSeriesBuilder>();
+    }
+
+    /// <summary>
+    /// Gets the number of series currently tracked.
+    /// </summary>
+    /// <returns>A non-negative series count.</returns>
+    public int Count => _series.Count;
+
+    /// <summary>
+    /// Gets the set of keys currently tracked.
+    /// </summary>
+    /// <returns>An enumeration of <see cref="ExchangeRateSeriesKey" /> values in dictionary order.</returns>
+    public IEnumerable<ExchangeRateSeriesKey> Keys => _series.Keys;
+
+    /// <summary>
+    /// Returns the builder for the supplied pair and provider, creating an empty one if it does not yet exist.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <returns>The existing or freshly created builder.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public ExchangeRateSeriesBuilder GetOrAddSeries(ExchangeRatePair pair, string provider)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        var key = new ExchangeRateSeriesKey(pair, provider);
+        if (!_series.TryGetValue(key, out var builder))
+        {
+            builder = new ExchangeRateSeriesBuilder(pair, provider);
+            _series[key] = builder;
+        }
+
+        return builder;
+    }
+
+    /// <summary>
+    /// Upserts an observation into the series identified by <paramref name="pair" /> and <paramref name="provider" />,
+    /// creating the series if it does not yet exist.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <param name="date">The observation date.</param>
+    /// <param name="rate">The rate to record.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown if <paramref name="rate" /> is zero or negative.
+    /// </exception>
+    public void Upsert(ExchangeRatePair pair, string provider, DateOnly date, decimal rate) =>
+        GetOrAddSeries(pair, provider).Upsert(date, rate);
+
+    /// <summary>
+    /// Removes the entire series for the supplied pair and provider.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <returns>
+    /// <see langword="true" /> if a series was removed; <see langword="false" /> if none existed.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public bool Remove(ExchangeRatePair pair, string provider)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        return _series.Remove(new ExchangeRateSeriesKey(pair, provider));
+    }
+
+    /// <summary>
+    /// Reports whether the table tracks a series for the supplied pair and provider.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <returns>
+    /// <see langword="true" /> if a series exists; otherwise <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public bool ContainsSeries(ExchangeRatePair pair, string provider)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        return _series.ContainsKey(new ExchangeRateSeriesKey(pair, provider));
+    }
+
+    /// <summary>
+    /// Attempts to retrieve the builder for the supplied pair and provider without creating one.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <param name="builder">
+    /// When this method returns <see langword="true" />, the existing builder; otherwise <see langword="null" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if the builder was found; otherwise <see langword="false" />.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public bool TryGetBuilder(ExchangeRatePair pair, string provider, out ExchangeRateSeriesBuilder? builder)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        return _series.TryGetValue(new ExchangeRateSeriesKey(pair, provider), out builder);
+    }
+
+    /// <summary>
+    /// Attempts to retrieve an immutable snapshot of the series for the supplied pair and provider.
+    /// </summary>
+    /// <param name="pair">The currency pair.</param>
+    /// <param name="provider">The non-empty identifier of the publishing source.</param>
+    /// <param name="series">
+    /// When this method returns <see langword="true" />, the snapshot; otherwise <see langword="null" />.
+    /// </param>
+    /// <returns>
+    /// <see langword="true" /> if a non-empty series snapshot was produced; <see langword="false" /> if no series
+    /// existed or it held no observations.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown if <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown if <paramref name="provider" /> is empty or white-space.
+    /// </exception>
+    public bool TryGetSeries(ExchangeRatePair pair, string provider, out ExchangeRateSeries? series)
+    {
+        FinancialThrowHelper.ThrowIfNullOrWhiteSpaceProvider(provider);
+
+        if (_series.TryGetValue(new ExchangeRateSeriesKey(pair, provider), out var builder) && !builder.IsEmpty)
+        {
+            series = builder.ToSeries();
+            return true;
+        }
+
+        series = null;
+        return false;
+    }
+
+    /// <summary>
+    /// Produces immutable snapshots for every non-empty series in the table.
+    /// </summary>
+    /// <returns>
+    /// A list of <see cref="ExchangeRateSeries" /> instances, one per non-empty builder. Empty builders are
+    /// skipped because an immutable series must contain at least one observation.
+    /// </returns>
+    public IReadOnlyList<ExchangeRateSeries> ToSeries()
+    {
+        var snapshots = new List<ExchangeRateSeries>(_series.Count);
+        foreach (var builder in _series.Values)
+        {
+            if (!builder.IsEmpty)
+                snapshots.Add(builder.ToSeries());
+        }
+
+        return snapshots;
+    }
+}

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -187,6 +187,15 @@ namespace Bodu.Financial {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot add observation for {0:yyyy-MM-dd}: a rate already exists for that date..
+        /// </summary>
+        internal static string Arg_Invalid_RateSeriesAddRangeConflict {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_RateSeriesAddRangeConflict", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Series contains duplicate date {0:yyyy-MM-dd}..
         /// </summary>
         internal static string Arg_Invalid_RateSeriesDuplicateDate {
@@ -318,6 +327,15 @@ namespace Bodu.Financial {
         internal static string IO_KeyNotFound_ExchangeRate {
             get {
                 return ResourceManager.GetString("IO_KeyNotFound_ExchangeRate", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to No exchange-rate observation exists on {0:yyyy-MM-dd}..
+        /// </summary>
+        internal static string IO_KeyNotFound_RateObservationDate {
+            get {
+                return ResourceManager.GetString("IO_KeyNotFound_RateObservationDate", resourceCulture);
             }
         }
         
@@ -707,7 +725,16 @@ namespace Bodu.Financial {
                 return ResourceManager.GetString("Op_Invalid_RateNotStrictlyPositive", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot create an immutable series snapshot from an empty builder..
+        /// </summary>
+        internal static string Op_Invalid_RateSeriesBuilderEmpty {
+            get {
+                return ResourceManager.GetString("Op_Invalid_RateSeriesBuilderEmpty", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Unable to create a JSON converter for &apos;{0}&apos;..
         /// </summary>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -105,6 +105,9 @@
   <data name="Arg_Invalid_ProviderNullOrWhiteSpace" xml:space="preserve">
     <value>Provider identifier must not be empty or white-space.</value>
   </data>
+  <data name="Arg_Invalid_RateSeriesAddRangeConflict" xml:space="preserve">
+    <value>Cannot add observation for {0:yyyy-MM-dd}: a rate already exists for that date.</value>
+  </data>
   <data name="Arg_Invalid_RateSeriesDuplicateDate" xml:space="preserve">
     <value>Series contains duplicate date {0:yyyy-MM-dd}.</value>
   </data>
@@ -149,6 +152,9 @@
   </data>
   <data name="IO_KeyNotFound_ExchangeRate" xml:space="preserve">
     <value>No exchange rate available for {0} → {1}.</value>
+  </data>
+  <data name="IO_KeyNotFound_RateObservationDate" xml:space="preserve">
+    <value>No exchange-rate observation exists on {0:yyyy-MM-dd}.</value>
   </data>
   <data name="Json_Invalid_AmountMustBeNumber" xml:space="preserve">
     <value>The 'amount' property must be a number.</value>
@@ -278,6 +284,9 @@
   </data>
   <data name="Op_Invalid_RateNotStrictlyPositive" xml:space="preserve">
     <value>Exchange rate for {0} → {1} must be strictly positive; rate provider returned {2}.</value>
+  </data>
+  <data name="Op_Invalid_RateSeriesBuilderEmpty" xml:space="preserve">
+    <value>Cannot create an immutable series snapshot from an empty builder.</value>
   </data>
   <data name="Op_Invalid_UnableToCreateConverter" xml:space="preserve">
     <value>Unable to create a JSON converter for '{0}'.</value>

--- a/Bodu.Financial/test/Financial/ExchangeRateObservationTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateObservationTests.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateObservationTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+[TestClass]
+public class ExchangeRateObservationTests
+{
+    /// <summary>
+    /// Verifies that a default-constructed instance carries <see cref="DateOnly.MinValue" /> and a zero rate.
+    /// </summary>
+    [TestMethod]
+    public void Default_WhenUninitialized_ShouldHaveZeroRateAndMinDate()
+    {
+        ExchangeRateObservation observation = default;
+
+        Assert.AreEqual(DateOnly.MinValue, observation.Date);
+        Assert.AreEqual(0m, observation.Rate);
+    }
+
+    /// <summary>
+    /// Verifies that two observations with identical date and rate compare equal.
+    /// </summary>
+    [TestMethod]
+    public void Equality_WhenSameDateAndRate_ShouldBeEqual()
+    {
+        ExchangeRateObservation left = new(new DateOnly(2026, 6, 1), 1.5m);
+        ExchangeRateObservation right = new(new DateOnly(2026, 6, 1), 1.5m);
+
+        Assert.AreEqual(left, right);
+        Assert.AreEqual(left.GetHashCode(), right.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that two observations differing only by rate do not compare equal.
+    /// </summary>
+    [TestMethod]
+    public void Equality_WhenDifferentRate_ShouldNotBeEqual()
+    {
+        ExchangeRateObservation left = new(new DateOnly(2026, 6, 1), 1.5m);
+        ExchangeRateObservation right = new(new DateOnly(2026, 6, 1), 1.6m);
+
+        Assert.AreNotEqual(left, right);
+    }
+
+    /// <summary>
+    /// Verifies that deconstruction surfaces the recorded date and rate.
+    /// </summary>
+    [TestMethod]
+    public void Deconstruct_WhenCalled_ShouldReturnDateAndRate()
+    {
+        ExchangeRateObservation observation = new(new DateOnly(2026, 6, 1), 1.5m);
+
+        var (date, rate) = observation;
+
+        Assert.AreEqual(new DateOnly(2026, 6, 1), date);
+        Assert.AreEqual(1.5m, rate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Add.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Add.cs
@@ -1,0 +1,131 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.Add.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that adding observations in arbitrary order results in strictly ascending enumeration order.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenInsertedOutOfOrder_ShouldMaintainSortedEnumeration()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 5), 1.54m);
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+        builder.Add(new DateOnly(2026, 6, 3), 1.52m);
+
+        ExchangeRateObservation[] expected =
+        [
+            new(new DateOnly(2026, 6, 1), 1.50m),
+            new(new DateOnly(2026, 6, 3), 1.52m),
+            new(new DateOnly(2026, 6, 5), 1.54m),
+        ];
+
+        CollectionAssert.AreEqual(expected, builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that adding an observation for an already-present date throws
+    /// <see cref="ArgumentException" /> with parameter name <c>date</c>.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDateExists_ShouldThrowArgumentException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                builder.Add(new DateOnly(2026, 6, 1), 1.60m);
+            },
+            "date");
+    }
+
+    /// <summary>
+    /// Verifies that a zero rate throws <see cref="ArgumentOutOfRangeException" /> with parameter name <c>rate</c>.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenRateIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.Add(new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+
+    /// <summary>
+    /// Verifies that a negative rate throws <see cref="ArgumentOutOfRangeException" /> with parameter name
+    /// <c>rate</c>.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenRateIsNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.Add(new DateOnly(2026, 6, 1), -1m);
+            },
+            "rate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryAdd" /> reports success and inserts when the date is new.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenDateIsNew_ShouldReturnTrueAndInsert()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        var inserted = builder.TryAdd(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsTrue(inserted);
+        Assert.AreEqual(1, builder.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryAdd" /> reports failure and leaves the existing rate
+    /// untouched when the date already exists.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenDateExists_ShouldReturnFalseAndNotMutate()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var inserted = builder.TryAdd(new DateOnly(2026, 6, 1), 1.60m);
+
+        Assert.IsFalse(inserted);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryAdd" /> validates the rate before checking the date.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.TryAdd(new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.AddRange.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.AddRange.cs
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.AddRange.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.AddRange" /> throws on a null sequence.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenObservationsNull_ShouldThrowArgumentNullException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                builder.AddRange(null!);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that pre-sorted observations are inserted in order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenAllNew_ShouldInsertSortedAndPreserveOrder()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.AddRange(SampleObservations());
+
+        CollectionAssert.AreEqual(SampleObservations(), builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that an unsorted incoming batch is reordered into strictly ascending enumeration order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenInputUnsorted_ShouldInsertSorted()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        ExchangeRateObservation[] unsorted =
+        [
+            new(new DateOnly(2026, 6, 5), 1.54m),
+            new(new DateOnly(2026, 6, 1), 1.50m),
+            new(new DateOnly(2026, 6, 3), 1.52m),
+        ];
+
+        builder.AddRange(unsorted);
+
+        CollectionAssert.AreEqual(SampleObservations(), builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that duplicate dates inside the incoming batch throw <see cref="ArgumentException" /> with
+    /// parameter name <c>observations</c>.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingBatchContainsDuplicateDate_ShouldThrowArgumentException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 1.50m),
+            new(new DateOnly(2026, 6, 1), 1.55m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                builder.AddRange(batch);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that incoming dates that collide with existing observations throw
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingDateAlreadyPresent_ShouldThrowArgumentException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 1.55m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                builder.AddRange(batch);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that an invalid (non-positive) rate inside the batch throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenRateIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 0m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.AddRange(batch);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that a validation failure during <see cref="ExchangeRateSeriesBuilder.AddRange" /> leaves the
+    /// builder in its prior state (the merge is atomic).
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenThrows_ShouldLeaveBuilderUnchanged()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+        builder.Add(new DateOnly(2026, 6, 3), 1.52m);
+
+        var snapshotBefore = builder.GetObservations().ToArray();
+        ExchangeRateObservation[] conflicting =
+        [
+            new(new DateOnly(2026, 6, 1), 1.55m), // collides with existing
+            new(new DateOnly(2026, 6, 7), 1.60m), // would otherwise be inserted
+        ];
+
+        Assert.ThrowsExactly<ArgumentException>(() => builder.AddRange(conflicting));
+
+        CollectionAssert.AreEqual(snapshotBefore, builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that a batch of new dates merged with existing observations produces a single sorted result.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenAllNewBatchMergesWithExisting_ShouldPreserveSortedOrder()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+        builder.Add(new DateOnly(2026, 6, 5), 1.54m);
+
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 2), 1.51m),
+            new(new DateOnly(2026, 6, 4), 1.53m),
+        ];
+
+        builder.AddRange(batch);
+
+        ExchangeRateObservation[] expected =
+        [
+            new(new DateOnly(2026, 6, 1), 1.50m),
+            new(new DateOnly(2026, 6, 2), 1.51m),
+            new(new DateOnly(2026, 6, 4), 1.53m),
+            new(new DateOnly(2026, 6, 5), 1.54m),
+        ];
+
+        CollectionAssert.AreEqual(expected, builder.GetObservations().ToArray());
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Remove.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Remove.cs
@@ -1,0 +1,87 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.Remove.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Remove" /> removes an existing observation and reports
+    /// success.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenDateExists_ShouldRemoveAndReturnTrue()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+        builder.Add(new DateOnly(2026, 6, 3), 1.52m);
+
+        var removed = builder.Remove(new DateOnly(2026, 6, 1));
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(1, builder.Count);
+        Assert.IsFalse(builder.ContainsDate(new DateOnly(2026, 6, 1)));
+        Assert.IsTrue(builder.ContainsDate(new DateOnly(2026, 6, 3)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Remove" /> reports failure when the date is unknown.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenDateMissing_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var removed = builder.Remove(new DateOnly(2026, 6, 2));
+
+        Assert.IsFalse(removed);
+        Assert.AreEqual(1, builder.Count);
+    }
+
+    /// <summary>
+    /// Verifies that repeatedly removing the first observation maintains strictly ascending order in the remaining
+    /// buffer.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenRepeatedlyRemovingFromBeginning_ShouldMaintainOrder()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.AddRange(SampleObservations());
+
+        builder.Remove(new DateOnly(2026, 6, 1));
+        builder.Remove(new DateOnly(2026, 6, 3));
+
+        ExchangeRateObservation[] expected = [new(new DateOnly(2026, 6, 5), 1.54m)];
+
+        CollectionAssert.AreEqual(expected, builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.ContainsDate" /> reports <see langword="true" /> for a
+    /// present observation.
+    /// </summary>
+    [TestMethod]
+    public void ContainsDate_WhenDateExists_ShouldReturnTrue()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsTrue(builder.ContainsDate(new DateOnly(2026, 6, 1)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.ContainsDate" /> reports <see langword="false" /> for a
+    /// missing observation.
+    /// </summary>
+    [TestMethod]
+    public void ContainsDate_WhenDateMissing_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        Assert.IsFalse(builder.ContainsDate(new DateOnly(2026, 6, 1)));
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Set.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Set.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.Set.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Set" /> overwrites the rate for an existing date.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenDateExists_ShouldOverwriteRate()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        builder.Set(new DateOnly(2026, 6, 1), 1.75m);
+
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.75m, rate);
+        Assert.AreEqual(1, builder.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Set" /> on an unknown date throws
+    /// <see cref="KeyNotFoundException" />.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenDateMissing_ShouldThrowKeyNotFoundException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        Assert.ThrowsExactly<KeyNotFoundException>(() =>
+        {
+            builder.Set(new DateOnly(2026, 6, 1), 1.50m);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Set" /> validates the rate.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenRateIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.Set(new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TrySet" /> overwrites and returns <see langword="true" />
+    /// when the date exists.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenDateExists_ShouldOverwriteAndReturnTrue()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var updated = builder.TrySet(new DateOnly(2026, 6, 1), 1.75m);
+
+        Assert.IsTrue(updated);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.75m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TrySet" /> returns <see langword="false" /> when the date
+    /// is unknown and does not mutate the builder.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenDateMissing_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        var updated = builder.TrySet(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsFalse(updated);
+        Assert.IsTrue(builder.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TrySet" /> validates the rate.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.TrySet(new DateOnly(2026, 6, 1), -0.01m);
+            },
+            "rate");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.ToSeries.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.ToSeries.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.ToSeries.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.ToSeries" /> produces a snapshot whose observations match
+    /// the builder's current state.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenBuilderHasObservations_ShouldReturnSnapshot()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.AddRange(SampleObservations());
+
+        ExchangeRateSeries snapshot = builder.ToSeries();
+
+        Assert.AreEqual(s_usdAud, snapshot.Pair);
+        Assert.AreEqual("RBA", snapshot.Provider);
+        Assert.AreEqual(3, snapshot.Count);
+        CollectionAssert.AreEqual(SampleObservations(), snapshot.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="ExchangeRateSeriesBuilder.ToSeries" /> on an empty builder throws
+    /// <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenBuilderIsEmpty_ShouldThrowInvalidOperationException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => builder.ToSeries());
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="ExchangeRateSeriesBuilder.ToSeries" /> twice produces two separate series
+    /// instances.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenCalledTwice_ShouldReturnSeparateInstances()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.AddRange(SampleObservations());
+
+        ExchangeRateSeries first = builder.ToSeries();
+        ExchangeRateSeries second = builder.ToSeries();
+
+        Assert.AreNotSame(first, second);
+        CollectionAssert.AreEqual(first.GetObservations().ToArray(), second.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that mutating the builder after producing a snapshot does not affect the snapshot.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenBuilderMutatedAfterCall_ShouldNotAffectSnapshot()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExchangeRateSeries snapshot = builder.ToSeries();
+        builder.Upsert(new DateOnly(2026, 6, 1), 99.99m);
+        builder.Add(new DateOnly(2026, 6, 2), 1.51m);
+
+        Assert.AreEqual(1, snapshot.Count);
+        Assert.IsTrue(snapshot.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that producing a fresh series from <see cref="ExchangeRateSeries.WithRate" /> does not affect the
+    /// underlying builder seeded by <see cref="ExchangeRateSeries.ToBuilder" />.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenSnapshotMutated_ShouldNotAffectBuilder()
+    {
+        ExchangeRateSeries original = new(s_usdAud, "RBA", SampleObservations());
+        ExchangeRateSeriesBuilder builder = original.ToBuilder();
+
+        ExchangeRateSeries updated = original.WithRate(new DateOnly(2026, 6, 1), 99m);
+
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.50m, rate);
+        Assert.IsTrue(updated.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var updatedRate));
+        Assert.AreEqual(99m, updatedRate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.TryGetRate.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.TryGetRate.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.TryGetRate.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryGetRate" /> returns the recorded rate on an exact-date
+    /// match.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenDateExists_ShouldReturnTrueAndRate()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryGetRate" /> returns <see langword="false" /> and a
+    /// default rate when no observation exists on the supplied date.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenDateMissing_ShouldReturnFalseAndDefault()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsFalse(builder.TryGetRate(new DateOnly(2026, 6, 2), out var rate));
+        Assert.AreEqual(0m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.TryGetRate" /> on an empty builder returns
+    /// <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenEmpty_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        Assert.IsFalse(builder.TryGetRate(new DateOnly(2026, 6, 1), out _));
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Upsert.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.Upsert.cs
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.Upsert.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Upsert" /> inserts a new observation when the date is
+    /// unknown.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenDateMissing_ShouldInsert()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        builder.Upsert(new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.AreEqual(1, builder.Count);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Upsert" /> overwrites an existing observation without
+    /// changing the count.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenDateExists_ShouldReplace()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        builder.Upsert(new DateOnly(2026, 6, 1), 1.75m);
+
+        Assert.AreEqual(1, builder.Count);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.75m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.Upsert" /> validates the rate.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.Upsert(new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.UpsertRange.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.UpsertRange.cs
@@ -1,0 +1,157 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.UpsertRange.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBuilderTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.UpsertRange" /> throws on a null sequence.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenObservationsNull_ShouldThrowArgumentNullException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                builder.UpsertRange(null!);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that a batch of entirely new observations is inserted in sorted order.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenAllNew_ShouldInsertSorted()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        builder.UpsertRange(SampleObservations());
+
+        CollectionAssert.AreEqual(SampleObservations(), builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuilder.UpsertRange" /> replaces existing observations in place.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenAllExisting_ShouldReplaceRates()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.AddRange(SampleObservations());
+
+        ExchangeRateObservation[] replacements =
+        [
+            new(new DateOnly(2026, 6, 1), 2.00m),
+            new(new DateOnly(2026, 6, 3), 2.10m),
+        ];
+
+        builder.UpsertRange(replacements);
+
+        Assert.AreEqual(3, builder.Count);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate1));
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 3), out var rate3));
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 5), out var rate5));
+        Assert.AreEqual(2.00m, rate1);
+        Assert.AreEqual(2.10m, rate3);
+        Assert.AreEqual(1.54m, rate5);
+    }
+
+    /// <summary>
+    /// Verifies that a batch combining new and existing dates inserts and replaces respectively.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenMixed_ShouldInsertAndReplace()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 1.55m), // replace
+            new(new DateOnly(2026, 6, 2), 1.51m), // insert
+        ];
+
+        builder.UpsertRange(batch);
+
+        ExchangeRateObservation[] expected =
+        [
+            new(new DateOnly(2026, 6, 1), 1.55m),
+            new(new DateOnly(2026, 6, 2), 1.51m),
+        ];
+
+        CollectionAssert.AreEqual(expected, builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that duplicate dates inside the incoming batch throw <see cref="ArgumentException" /> with
+    /// parameter name <c>observations</c>.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenIncomingBatchContainsDuplicateDate_ShouldThrowArgumentException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 1.50m),
+            new(new DateOnly(2026, 6, 1), 1.55m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                builder.UpsertRange(batch);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that an invalid rate inside the batch throws <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenRateIsZero_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        ExchangeRateObservation[] batch =
+        [
+            new(new DateOnly(2026, 6, 1), 0m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                builder.UpsertRange(batch);
+            },
+            "observations");
+    }
+
+    /// <summary>
+    /// Verifies that a validation failure during <see cref="ExchangeRateSeriesBuilder.UpsertRange" /> leaves the
+    /// builder in its prior state.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenThrows_ShouldLeaveBuilderUnchanged()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var snapshotBefore = builder.GetObservations().ToArray();
+        ExchangeRateObservation[] invalidBatch =
+        [
+            new(new DateOnly(2026, 6, 2), 1.55m),
+            new(new DateOnly(2026, 6, 2), 1.60m), // duplicate within batch
+        ];
+
+        Assert.ThrowsExactly<ArgumentException>(() => builder.UpsertRange(invalidBatch));
+
+        CollectionAssert.AreEqual(snapshotBefore, builder.GetObservations().ToArray());
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBuilderTests.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBuilderTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test;
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+[TestClass]
+public partial class ExchangeRateSeriesBuilderTests
+{
+    private static readonly ExchangeRatePair s_usdAud = new("USD", "AUD");
+
+    private static ExchangeRateObservation[] SampleObservations() =>
+    [
+        new(new DateOnly(2026, 6, 1), 1.50m),
+        new(new DateOnly(2026, 6, 3), 1.52m),
+        new(new DateOnly(2026, 6, 5), 1.54m),
+    ];
+
+    /// <summary>
+    /// Verifies that the smoke-tier happy path builds an empty builder, accepts a single observation, and
+    /// produces an immutable snapshot exposing the inserted observation.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategories.Smoke)]
+    public void Builder_WhenAddingSingleObservationAndSnapshotting_ShouldExposeObservationInSeries()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+        builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        ExchangeRateSeries snapshot = builder.ToSeries();
+
+        Assert.AreEqual(s_usdAud, snapshot.Pair);
+        Assert.AreEqual("RBA", snapshot.Provider);
+        Assert.AreEqual(1, snapshot.Count);
+        Assert.IsTrue(snapshot.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that a freshly constructed builder stores the supplied pair and provider and reports empty state.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenInputsValid_ShouldStorePairProviderAndEmpty()
+    {
+        ExchangeRateSeriesBuilder builder = new(s_usdAud, "RBA");
+
+        Assert.AreEqual(s_usdAud, builder.Pair);
+        Assert.AreEqual("RBA", builder.Provider);
+        Assert.AreEqual(0, builder.Count);
+        Assert.IsTrue(builder.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that a null provider on the empty constructor throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                _ = new ExchangeRateSeriesBuilder(s_usdAud, null!);
+            },
+            "provider");
+    }
+
+    /// <summary>
+    /// Verifies that a white-space provider on the empty constructor throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenProviderIsEmpty_ShouldThrowArgumentException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                _ = new ExchangeRateSeriesBuilder(s_usdAud, "   ");
+            },
+            "provider");
+    }
+
+    /// <summary>
+    /// Verifies that a null series on the copy constructor throws <see cref="ArgumentNullException" />.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenSeriesIsNull_ShouldThrowArgumentNullException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                _ = new ExchangeRateSeriesBuilder((ExchangeRateSeries)null!);
+            },
+            "series");
+    }
+
+    /// <summary>
+    /// Verifies that the copy constructor seeds the builder with the same observations as the source series.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenSeriesSupplied_ShouldCopyObservations()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", SampleObservations());
+        ExchangeRateSeriesBuilder builder = new(series);
+
+        Assert.AreEqual(s_usdAud, builder.Pair);
+        Assert.AreEqual("RBA", builder.Provider);
+        Assert.AreEqual(3, builder.Count);
+        CollectionAssert.AreEqual(series.GetObservations().ToArray(), builder.GetObservations().ToArray());
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesTests.CopyOnWrite.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesTests.CopyOnWrite.cs
@@ -1,0 +1,183 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesTests.CopyOnWrite.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesTests
+{
+    private static ExchangeRateObservation[] CopyOnWriteSampleObservations() =>
+    [
+        new(new DateOnly(2026, 6, 1), 1.50m),
+        new(new DateOnly(2026, 6, 3), 1.52m),
+        new(new DateOnly(2026, 6, 5), 1.54m),
+    ];
+
+    /// <summary>
+    /// Verifies that the observation-based constructor stores the supplied observations.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenObservationsSupplied_ShouldStoreObservations()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        Assert.AreEqual(3, series.Count);
+        CollectionAssert.AreEqual(CopyOnWriteSampleObservations(), series.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.ToBuilder" /> returns a builder seeded with the same
+    /// observations as the source series.
+    /// </summary>
+    [TestMethod]
+    public void ToBuilder_WhenCalled_ShouldReturnBuilderWithSameObservations()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExchangeRateSeriesBuilder builder = series.ToBuilder();
+
+        Assert.AreEqual(s_usdAud, builder.Pair);
+        Assert.AreEqual("RBA", builder.Provider);
+        CollectionAssert.AreEqual(CopyOnWriteSampleObservations(), builder.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that mutating a builder seeded from a series does not affect the source series.
+    /// </summary>
+    [TestMethod]
+    public void ToBuilder_WhenBuilderMutated_ShouldNotAffectOriginalSeries()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+        ExchangeRateSeriesBuilder builder = series.ToBuilder();
+
+        builder.Upsert(new DateOnly(2026, 6, 1), 99m);
+        builder.Add(new DateOnly(2026, 6, 7), 1.60m);
+
+        Assert.AreEqual(3, series.Count);
+        Assert.IsTrue(series.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var originalRate));
+        Assert.AreEqual(1.50m, originalRate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithRate" /> on a missing date inserts a new observation.
+    /// </summary>
+    [TestMethod]
+    public void WithRate_WhenDateMissing_ShouldReturnSeriesWithNewObservation()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExchangeRateSeries updated = series.WithRate(new DateOnly(2026, 6, 4), 1.53m);
+
+        Assert.AreEqual(4, updated.Count);
+        Assert.IsTrue(updated.TryGetRate(new DateOnly(2026, 6, 4), ExchangeRateLookupOptions.Exact, out _, out var rate));
+        Assert.AreEqual(1.53m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithRate" /> on an existing date replaces the rate.
+    /// </summary>
+    [TestMethod]
+    public void WithRate_WhenDateExists_ShouldReturnSeriesWithReplacedRate()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExchangeRateSeries updated = series.WithRate(new DateOnly(2026, 6, 1), 2.00m);
+
+        Assert.AreEqual(3, updated.Count);
+        Assert.IsTrue(updated.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var rate));
+        Assert.AreEqual(2.00m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithRate" /> validates the rate.
+    /// </summary>
+    [TestMethod]
+    public void WithRate_WhenRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                _ = series.WithRate(new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithoutRate" /> on an existing date removes it.
+    /// </summary>
+    [TestMethod]
+    public void WithoutRate_WhenDateExists_ShouldReturnSmallerSeries()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExchangeRateSeries updated = series.WithoutRate(new DateOnly(2026, 6, 3));
+
+        Assert.AreEqual(2, updated.Count);
+        Assert.IsFalse(updated.TryGetRate(new DateOnly(2026, 6, 3), ExchangeRateLookupOptions.Exact, out _, out _));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithoutRate" /> on a missing date returns a series with the same
+    /// observations.
+    /// </summary>
+    [TestMethod]
+    public void WithoutRate_WhenDateMissing_ShouldReturnEquivalentSeries()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        ExchangeRateSeries updated = series.WithoutRate(new DateOnly(2026, 6, 15));
+
+        Assert.AreEqual(3, updated.Count);
+        CollectionAssert.AreEqual(CopyOnWriteSampleObservations(), updated.GetObservations().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.WithoutRate" /> removing the last observation throws
+    /// <see cref="InvalidOperationException" /> because immutable series must be non-empty.
+    /// </summary>
+    [TestMethod]
+    public void WithoutRate_WhenRemovingLastObservation_ShouldThrowInvalidOperationException()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", new[] { new ExchangeRateObservation(new DateOnly(2026, 6, 1), 1.50m) });
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => series.WithoutRate(new DateOnly(2026, 6, 1)));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeries.GetObservations" /> yields the observations in ascending date
+    /// order.
+    /// </summary>
+    [TestMethod]
+    public void GetObservations_WhenCalled_ShouldYieldInAscendingOrder()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        var observations = series.GetObservations().ToArray();
+
+        Assert.AreEqual(3, observations.Length);
+        for (var i = 1; i < observations.Length; i++)
+        {
+            Assert.IsTrue(observations[i - 1].Date < observations[i].Date);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="ExchangeRateSeries.GetObservations" /> twice produces equivalent sequences.
+    /// </summary>
+    [TestMethod]
+    public void GetObservations_WhenCalledTwice_ShouldYieldEquivalentSequences()
+    {
+        ExchangeRateSeries series = new(s_usdAud, "RBA", CopyOnWriteSampleObservations());
+
+        var first = series.GetObservations().ToArray();
+        var second = series.GetObservations().ToArray();
+
+        CollectionAssert.AreEqual(first, second);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesTests.cs
@@ -70,7 +70,7 @@ public partial class ExchangeRateSeriesTests
         ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
             () =>
             {
-                _ = new ExchangeRateSeries(s_usdAud, "RBA", null!);
+                _ = new ExchangeRateSeries(s_usdAud, "RBA", (IEnumerable<(DateOnly, decimal)>)null!);
             },
             "rates");
     }
@@ -99,7 +99,7 @@ public partial class ExchangeRateSeriesTests
         ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
             () =>
             {
-                _ = new ExchangeRateSeries(s_usdAud, "RBA", []);
+                _ = new ExchangeRateSeries(s_usdAud, "RBA", (IEnumerable<(DateOnly, decimal)>)[]);
             },
             "rates");
     }

--- a/Bodu.Financial/test/Financial/ExchangeRateTableTests.GetOrAddSeries.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateTableTests.GetOrAddSeries.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTableTests.GetOrAddSeries.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateTableTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.GetOrAddSeries" /> returns a new empty builder for an unknown key.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAddSeries_WhenSeriesMissing_ShouldCreateAndReturnEmptyBuilder()
+    {
+        ExchangeRateTable table = new();
+
+        ExchangeRateSeriesBuilder builder = table.GetOrAddSeries(s_usdAud, "RBA");
+
+        Assert.IsNotNull(builder);
+        Assert.IsTrue(builder.IsEmpty);
+        Assert.AreEqual(s_usdAud, builder.Pair);
+        Assert.AreEqual("RBA", builder.Provider);
+        Assert.IsTrue(table.ContainsSeries(s_usdAud, "RBA"));
+    }
+
+    /// <summary>
+    /// Verifies that repeated calls for the same key return the same builder instance.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAddSeries_WhenCalledTwice_ShouldReturnSameBuilder()
+    {
+        ExchangeRateTable table = new();
+        ExchangeRateSeriesBuilder first = table.GetOrAddSeries(s_usdAud, "RBA");
+        ExchangeRateSeriesBuilder second = table.GetOrAddSeries(s_usdAud, "RBA");
+
+        Assert.AreSame(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.GetOrAddSeries" /> validates the provider argument.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAddSeries_WhenProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        ExchangeRateTable table = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                _ = table.GetOrAddSeries(s_usdAud, null!);
+            },
+            "provider");
+    }
+
+    /// <summary>
+    /// Verifies that distinct providers for the same pair produce distinct series.
+    /// </summary>
+    [TestMethod]
+    public void GetOrAddSeries_WhenDifferentProvidersForSamePair_ShouldCreateSeparateSeries()
+    {
+        ExchangeRateTable table = new();
+        ExchangeRateSeriesBuilder rba = table.GetOrAddSeries(s_usdAud, "RBA");
+        ExchangeRateSeriesBuilder ecb = table.GetOrAddSeries(s_usdAud, "ECB");
+
+        Assert.AreNotSame(rba, ecb);
+        Assert.AreEqual(2, table.Count);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateTableTests.ToSeries.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateTableTests.ToSeries.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTableTests.ToSeries.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateTableTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.ToSeries" /> on an empty table returns an empty list.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenEmpty_ShouldReturnEmptyList()
+    {
+        ExchangeRateTable table = new();
+
+        IReadOnlyList<ExchangeRateSeries> snapshots = table.ToSeries();
+
+        Assert.AreEqual(0, snapshots.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.ToSeries" /> produces one snapshot per non-empty series.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenSeriesPopulated_ShouldReturnSnapshotPerSeries()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+        table.Upsert(s_usdJpy, "BoJ", new DateOnly(2026, 6, 1), 110m);
+
+        IReadOnlyList<ExchangeRateSeries> snapshots = table.ToSeries();
+
+        Assert.AreEqual(2, snapshots.Count);
+    }
+
+    /// <summary>
+    /// Verifies that empty builders are skipped because immutable series cannot be empty.
+    /// </summary>
+    [TestMethod]
+    public void ToSeries_WhenSomeBuildersEmpty_ShouldSkipThem()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+        table.GetOrAddSeries(s_usdJpy, "BoJ"); // intentionally empty
+
+        IReadOnlyList<ExchangeRateSeries> snapshots = table.ToSeries();
+
+        Assert.AreEqual(1, snapshots.Count);
+        Assert.AreEqual(s_usdAud, snapshots[0].Pair);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateTableTests.TryGetSeries.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateTableTests.TryGetSeries.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTableTests.TryGetSeries.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateTableTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetSeries" /> returns <see langword="false" /> when the series
+    /// is unknown.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSeries_WhenSeriesMissing_ShouldReturnFalse()
+    {
+        ExchangeRateTable table = new();
+
+        var found = table.TryGetSeries(s_usdAud, "RBA", out var series);
+
+        Assert.IsFalse(found);
+        Assert.IsNull(series);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetSeries" /> returns <see langword="false" /> when the
+    /// builder for the key is empty, because immutable series must be non-empty.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSeries_WhenBuilderEmpty_ShouldReturnFalse()
+    {
+        ExchangeRateTable table = new();
+        table.GetOrAddSeries(s_usdAud, "RBA");
+
+        var found = table.TryGetSeries(s_usdAud, "RBA", out var series);
+
+        Assert.IsFalse(found);
+        Assert.IsNull(series);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetSeries" /> returns a fresh immutable snapshot when the
+    /// series exists and is non-empty.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSeries_WhenBuilderHasObservations_ShouldReturnSnapshot()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+
+        var found = table.TryGetSeries(s_usdAud, "RBA", out var series);
+
+        Assert.IsTrue(found);
+        Assert.IsNotNull(series);
+        Assert.AreEqual(s_usdAud, series!.Pair);
+        Assert.AreEqual("RBA", series.Provider);
+        Assert.AreEqual(1, series.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetSeries" /> snapshots a fresh series each call so further
+    /// builder mutation does not affect previously returned snapshots.
+    /// </summary>
+    [TestMethod]
+    public void TryGetSeries_WhenBuilderMutatedAfterSnapshot_ShouldNotAffectSnapshot()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsTrue(table.TryGetSeries(s_usdAud, "RBA", out var snapshot));
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 99m);
+
+        Assert.IsTrue(snapshot!.TryGetRate(new DateOnly(2026, 6, 1), ExchangeRateLookupOptions.Exact, out _, out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateTableTests.Upsert.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateTableTests.Upsert.cs
@@ -1,0 +1,76 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTableTests.Upsert.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateTableTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Upsert" /> creates a series on first call and inserts the rate.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenSeriesMissing_ShouldCreateAndInsert()
+    {
+        ExchangeRateTable table = new();
+
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+
+        Assert.IsTrue(table.TryGetBuilder(s_usdAud, "RBA", out var builder));
+        Assert.IsTrue(builder!.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.50m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Upsert" /> replaces an existing observation in place.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenSeriesExists_ShouldReplaceRate()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.75m);
+
+        Assert.IsTrue(table.TryGetBuilder(s_usdAud, "RBA", out var builder));
+        Assert.AreEqual(1, builder!.Count);
+        Assert.IsTrue(builder.TryGetRate(new DateOnly(2026, 6, 1), out var rate));
+        Assert.AreEqual(1.75m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Upsert" /> validates the rate.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExchangeRateTable table = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 0m);
+            },
+            "rate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Upsert" /> validates the provider argument.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenProviderIsEmpty_ShouldThrowArgumentException()
+    {
+        ExchangeRateTable table = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                table.Upsert(s_usdAud, "  ", new DateOnly(2026, 6, 1), 1.50m);
+            },
+            "provider");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateTableTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateTableTests.cs
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateTableTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test;
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+[TestClass]
+public partial class ExchangeRateTableTests
+{
+    private static readonly ExchangeRatePair s_usdAud = new("USD", "AUD");
+    private static readonly ExchangeRatePair s_usdJpy = new("USD", "JPY");
+
+    /// <summary>
+    /// Verifies that the smoke-tier happy path constructs a table, upserts one rate across two series, snapshots,
+    /// and reports the expected pair-count.
+    /// </summary>
+    [TestMethod]
+    [TestCategory(TestCategories.Smoke)]
+    public void Table_WhenUpsertingTwoSeriesAndSnapshotting_ShouldProduceImmutableSnapshots()
+    {
+        ExchangeRateTable table = new();
+        table.Upsert(s_usdAud, "RBA", new DateOnly(2026, 6, 1), 1.50m);
+        table.Upsert(s_usdJpy, "BoJ", new DateOnly(2026, 6, 1), 110m);
+
+        IReadOnlyList<ExchangeRateSeries> snapshots = table.ToSeries();
+
+        Assert.AreEqual(2, table.Count);
+        Assert.AreEqual(2, snapshots.Count);
+    }
+
+    /// <summary>
+    /// Verifies that a fresh table reports zero series.
+    /// </summary>
+    [TestMethod]
+    public void Count_WhenNewTable_ShouldBeZero()
+    {
+        ExchangeRateTable table = new();
+
+        Assert.AreEqual(0, table.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Remove" /> reports success when removing an existing series.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenSeriesExists_ShouldReturnTrue()
+    {
+        ExchangeRateTable table = new();
+        table.GetOrAddSeries(s_usdAud, "RBA").Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var removed = table.Remove(s_usdAud, "RBA");
+
+        Assert.IsTrue(removed);
+        Assert.IsFalse(table.ContainsSeries(s_usdAud, "RBA"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Remove" /> reports failure when the series does not exist.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenSeriesMissing_ShouldReturnFalse()
+    {
+        ExchangeRateTable table = new();
+
+        var removed = table.Remove(s_usdAud, "RBA");
+
+        Assert.IsFalse(removed);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.ContainsSeries" /> validates the provider argument.
+    /// </summary>
+    [TestMethod]
+    public void ContainsSeries_WhenProviderIsNull_ShouldThrowArgumentNullException()
+    {
+        ExchangeRateTable table = new();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentNullException>(
+            () =>
+            {
+                _ = table.ContainsSeries(s_usdAud, null!);
+            },
+            "provider");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetBuilder" /> returns <see langword="false" /> when the
+    /// series does not exist.
+    /// </summary>
+    [TestMethod]
+    public void TryGetBuilder_WhenSeriesMissing_ShouldReturnFalse()
+    {
+        ExchangeRateTable table = new();
+
+        var found = table.TryGetBuilder(s_usdAud, "RBA", out var builder);
+
+        Assert.IsFalse(found);
+        Assert.IsNull(builder);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.TryGetBuilder" /> returns the existing builder when present.
+    /// </summary>
+    [TestMethod]
+    public void TryGetBuilder_WhenSeriesExists_ShouldReturnTrueAndBuilder()
+    {
+        ExchangeRateTable table = new();
+        ExchangeRateSeriesBuilder seeded = table.GetOrAddSeries(s_usdAud, "RBA");
+        seeded.Add(new DateOnly(2026, 6, 1), 1.50m);
+
+        var found = table.TryGetBuilder(s_usdAud, "RBA", out var builder);
+
+        Assert.IsTrue(found);
+        Assert.AreSame(seeded, builder);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateTable.Keys" /> exposes the currently tracked series keys.
+    /// </summary>
+    [TestMethod]
+    public void Keys_WhenSeriesAdded_ShouldEnumerateKeys()
+    {
+        ExchangeRateTable table = new();
+        table.GetOrAddSeries(s_usdAud, "RBA");
+        table.GetOrAddSeries(s_usdJpy, "BoJ");
+
+        var keys = table.Keys.ToArray();
+
+        Assert.AreEqual(2, keys.Length);
+        CollectionAssert.Contains(keys, new ExchangeRateSeriesKey(s_usdAud, "RBA"));
+        CollectionAssert.Contains(keys, new ExchangeRateSeriesKey(s_usdJpy, "BoJ"));
+    }
+}


### PR DESCRIPTION
Adds a mutable companion to the immutable ExchangeRateSeries plus a higher-level
table that keys series by (pair, provider). Internal arrays now use int day numbers
for sharper binary-search comparisons. Existing ExchangeRateSeries public surface,
exception types, parameter names, and message text are preserved.

New public types:
- ExchangeRateObservation (readonly record struct)
- ExchangeRateSeriesBuilder (Add/TryAdd/Set/TrySet/Upsert/Remove/ContainsDate/
  TryGetRate/AddRange/UpsertRange/ToSeries)
- ExchangeRateSeriesKey + ExchangeRateTable (multi-pair / multi-provider editor)

ExchangeRateSeries additions: IEnumerable<ExchangeRateObservation> constructor
overload, GetObservations(), WithRate, WithoutRate, ToBuilder.

Internal:
- ExchangeRateSeriesStorage owns the immutable arrays + lookup logic shared with
  ExchangeRateSeries; ExchangeRateSeriesBuffer owns the mutable arrays + merge.
- ExchangeRateDateSearch centralises previous/next/nearest candidate selection.
- AddRange/UpsertRange use an atomic two-pointer merge into fresh arrays so a
  mid-batch validation failure leaves the buffer unchanged.

Three new resx keys: Arg_Invalid_RateSeriesAddRangeConflict,
IO_KeyNotFound_RateObservationDate, Op_Invalid_RateSeriesBuilderEmpty.

Two existing ExchangeRateSeriesTests calls disambiguate (IEnumerable<(DateOnly,
decimal)>) for null and empty literals against the new observation overload.

All 1119 Bodu.Financial.Test BVT cases pass.

https://claude.ai/code/session_012BpfWBjYxSieNEeM2YDGAj