### PR TITLE
Document Interval<T> factories and set operations with examples

### DIFF
--- a/Bodu.Numerics/src/Numerics/Interval.Factories.cs
+++ b/Bodu.Numerics/src/Numerics/Interval.Factories.cs
@@ -16,6 +16,29 @@ public readonly partial struct Interval<T>
     /// <returns>
     /// An <see cref="Interval{T}" /> whose <see cref="IsEmpty" /> property is <see langword="true" />.
     /// </returns>
+    /// <remarks>
+    /// <para>
+    /// Use <see cref="Empty" /> as the neutral element of the interval set algebra: <see cref="Intersect" /> returns it
+    /// when two operands share no values, and <see cref="TryUnion" /> treats it as the identity. The
+    /// default-constructed <c>Interval&lt;T&gt;</c> compares equal to <see cref="Empty" />, so a field or local that
+    /// was never assigned reads as the empty interval rather than as a malformed value.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var none = Interval<int>.Empty;
+    /// none.IsEmpty;                    // True
+    /// none.ToString();                 // "∅"
+    ///
+    /// // Any inverted-bounds or equal-bounds-with-open-endpoint interval compares equal to Empty.
+    /// var inverted = new Interval<int>(5, 1, true, true);
+    /// var collapsed = new Interval<int>(0, 0, false, false);
+    /// none == inverted;                // True
+    /// none == collapsed;               // True
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> Empty =>
         new(T.Zero, T.Zero, lowerInclusive: false, upperInclusive: false);
 
@@ -26,10 +49,31 @@ public readonly partial struct Interval<T>
     /// <param name="upper">The upper endpoint.</param>
     /// <returns>A closed-closed interval over the supplied bounds.</returns>
     /// <remarks>
+    /// <para>
+    /// The closed-closed shape — also called <i>inclusive</i> — is the natural choice for ranges where both boundary
+    /// values are valid members of the set: a percentage in <c>[0, 100]</c>, a die roll in <c>[1, 6]</c>, a thermometer
+    /// reading in <c>[-273.15, +∞)</c>. Prefer <see cref="ClosedOpen(T, T)" /> for spans, slices, and scheduling
+    /// windows where adjacent ranges should partition cleanly.
+    /// </para>
+    /// <para>
     /// When <paramref name="lower" /> is greater than <paramref name="upper" />, the returned interval is empty. When
     /// the two endpoints are equal, the returned interval is a degenerate single-point interval (see
     /// <see cref="Singleton(T)" />).
+    /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var percentage = Interval<int>.Closed(0, 100);   // [0, 100]
+    /// percentage.Contains(0);                          // True — closed lower
+    /// percentage.Contains(100);                        // True — closed upper
+    /// percentage.ToString();                           // "[0, 100]"
+    ///
+    /// // Inverted bounds collapse to Empty.
+    /// Interval<int>.Closed(10, 5).IsEmpty;             // True
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> Closed(T lower, T upper) =>
         new(lower, upper, lowerInclusive: true, upperInclusive: true);
 
@@ -40,9 +84,27 @@ public readonly partial struct Interval<T>
     /// <param name="upper">The upper endpoint.</param>
     /// <returns>An open-open interval over the supplied bounds.</returns>
     /// <remarks>
+    /// <para>
+    /// The open-open shape — also called <i>exclusive</i> — is the natural choice for strict inequalities such as
+    /// <c>0 &lt; rate &lt; 1</c> or "between but not at" semantics where neither boundary value is itself a member.
+    /// </para>
+    /// <para>
     /// When <paramref name="lower" /> is greater than or equal to <paramref name="upper" />, the returned interval is
-    /// empty.
+    /// empty — there is no value strictly between two equal or inverted bounds.
+    /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var strictlyPositive = Interval<double>.Open(0.0, double.PositiveInfinity);  // (0, +∞)
+    /// strictlyPositive.Contains(0.0);                                              // False — open lower
+    /// strictlyPositive.Contains(1e-300);                                           // True
+    ///
+    /// // Equal bounds with both endpoints open are empty.
+    /// Interval<int>.Open(5, 5).IsEmpty;                                            // True
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> Open(T lower, T upper) =>
         new(lower, upper, lowerInclusive: false, upperInclusive: false);
 
@@ -54,10 +116,29 @@ public readonly partial struct Interval<T>
     /// <param name="upper">The upper endpoint (excluded).</param>
     /// <returns>A closed-open interval over the supplied bounds.</returns>
     /// <remarks>
+    /// <para>
     /// The closed-open shape is the most common in programming contexts: a range starting at an inclusive lower bound
     /// and ending before an exclusive upper bound matches the conventions of <c>System.Range</c>, LINQ's
-    /// <c>Enumerable.Range</c>, and most iterator protocols.
+    /// <c>Enumerable.Range</c>, and most iterator protocols. Adjacent closed-open intervals partition a span cleanly —
+    /// <c>[0, 90)</c> and <c>[90, 181)</c> together cover exactly <c>[0, 181)</c> with no overlap and no gap — so this
+    /// shape is the default choice for scheduling windows, bucket boundaries, and time slots.
+    /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var window = Interval<int>.ClosedOpen(0, 100);   // [0, 100)
+    /// window.Contains(0);                              // True  — closed lower
+    /// window.Contains(99);                             // True
+    /// window.Contains(100);                            // False — open upper
+    ///
+    /// // Adjacent half-open windows merge with no overlap and no gap.
+    /// var q1 = Interval<int>.ClosedOpen(0, 90);
+    /// var q2 = Interval<int>.ClosedOpen(90, 181);
+    /// q1.TryUnion(q2, out var firstHalf);              // firstHalf = [0, 181)
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> ClosedOpen(T lower, T upper) =>
         new(lower, upper, lowerInclusive: true, upperInclusive: false);
 
@@ -68,6 +149,24 @@ public readonly partial struct Interval<T>
     /// <param name="lower">The lower endpoint (excluded).</param>
     /// <param name="upper">The upper endpoint (included).</param>
     /// <returns>An open-closed interval over the supplied bounds.</returns>
+    /// <remarks>
+    /// <para>
+    /// The open-closed shape is the mirror image of <see cref="ClosedOpen(T, T)" /> and the natural choice for ranges
+    /// expressed as "strictly greater than X, up to and including Y" — a billing tier above a threshold, a histogram
+    /// bin that owns its upper edge, or a tax bracket that exits at one boundary and enters at the next.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// // Billing tier: anything above $1,000 up to and including $10,000.
+    /// var tier = Interval<decimal>.OpenClosed(1000m, 10_000m);   // (1000, 10000]
+    /// tier.Contains(1000m);                                       // False — open lower
+    /// tier.Contains(10_000m);                                     // True  — closed upper
+    /// tier.ToString();                                            // "(1000, 10000]"
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> OpenClosed(T lower, T upper) =>
         new(lower, upper, lowerInclusive: false, upperInclusive: true);
 
@@ -79,6 +178,25 @@ public readonly partial struct Interval<T>
     /// <returns>
     /// A closed-closed interval whose lower and upper endpoints both equal <paramref name="value" />.
     /// </returns>
+    /// <remarks>
+    /// <para>
+    /// A degenerate interval has algebraic <see cref="Length" /> of zero but is not empty: it contains exactly the one
+    /// value its endpoints share. Use it as the identity for an "any-of" intersection sweep, as a single-value filter
+    /// that composes uniformly with multi-value filters, or as the seed of a union that accumulates a span.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var single = Interval<int>.Singleton(42);
+    /// single.Contains(42);                              // True
+    /// single.IsDegenerate;                              // True
+    /// single.IsEmpty;                                   // False
+    /// single.Length;                                    // 0
+    /// single.ToString();                                // "[42, 42]"
+    ///]]>
+    /// </code>
+    /// </example>
     public static Interval<T> Singleton(T value) =>
         new(value, value, lowerInclusive: true, upperInclusive: true);
 }

--- a/Bodu.Numerics/src/Numerics/Interval.Helpers.cs
+++ b/Bodu.Numerics/src/Numerics/Interval.Helpers.cs
@@ -12,11 +12,37 @@ namespace Bodu.Numerics;
 /// Provides type-inferring factory methods for <see cref="Interval{T}" />.
 /// </summary>
 /// <remarks>
+/// <para>
 /// The methods on this class mirror the static factories declared on <see cref="Interval{T}" /> but accept the endpoint
-/// values directly, letting the compiler infer <typeparamref name="T" /> from the arguments. This avoids the need to
-/// repeat the generic parameter at the call site, so <c>Interval.Closed(1, 5)</c> compiles to a
-/// <see cref="Interval{T}" /> over <see cref="int" /> without an explicit type argument.
+/// values directly, letting the compiler infer the endpoint type from the arguments. This avoids the need to repeat the
+/// generic parameter at the call site: <c>Interval.Closed(1, 5)</c> compiles to a <see cref="Interval{T}" /> over
+/// <see cref="int" /> without an explicit type argument, and <c>Interval.ClosedOpen(0m, 100m)</c> picks
+/// <see cref="decimal" /> from the literal suffixes.
+/// </para>
+/// <para>
+/// Prefer the non-generic helpers when the endpoint type is obvious from the arguments — typical for literals, local
+/// variables, and expressions that already carry the type — and use <see cref="Interval{T}" />'s own static factories
+/// (e.g. <see cref="Interval{T}.Closed(T, T)" />) when the call site needs an explicit type to disambiguate, when the
+/// endpoint type comes from a generic context, or when the factory is being held as a method group.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// using Bodu.Numerics;
+///
+/// // Type inferred from the int literals.
+/// var ints = Interval.ClosedOpen(0, 100);           // Interval<int>
+///
+/// // Type inferred from the decimal-suffixed literals.
+/// var prices = Interval.OpenClosed(1000m, 10_000m); // Interval<decimal>
+///
+/// // Type inferred from the local variable.
+/// double low = 1.5, high = 2.5;
+/// var span = Interval.Closed(low, high);            // Interval<double>
+///]]>
+/// </code>
+/// </example>
 public static class Interval
 {
     /// <summary>

--- a/Bodu.Numerics/src/Numerics/Interval.SetOperations.cs
+++ b/Bodu.Numerics/src/Numerics/Interval.SetOperations.cs
@@ -18,6 +18,19 @@ public readonly partial struct Interval<T>
     /// under the configured inclusivity rules; otherwise <see langword="false" />. An empty interval contains no value,
     /// including itself.
     /// </returns>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var window = Interval<int>.ClosedOpen(1, 5);   // [1, 5)
+    /// window.Contains(1);                            // True  — closed lower
+    /// window.Contains(4);                            // True  — interior
+    /// window.Contains(5);                            // False — open upper
+    /// window.Contains(0);                            // False — outside
+    ///
+    /// Interval<int>.Empty.Contains(0);               // False — the empty interval contains nothing
+    ///]]>
+    /// </code>
+    /// </example>
     public bool Contains(T value)
     {
         if (IsEmpty)
@@ -38,6 +51,24 @@ public readonly partial struct Interval<T>
     /// <see langword="false" />. The empty interval is a subset of every interval, so any interval contains the empty
     /// interval; only the empty interval contains the empty interval as a non-empty member.
     /// </returns>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var outer = Interval<int>.Closed(0, 10);
+    ///
+    /// outer.Contains(Interval<int>.Closed(2, 8));        // True — strict subset
+    /// outer.Contains(Interval<int>.Closed(0, 10));       // True — equal sets
+    /// outer.Contains(Interval<int>.Closed(2, 11));       // False — exceeds upper
+    /// outer.Contains(Interval<int>.Empty);               // True — ∅ ⊆ every set
+    ///
+    /// // Endpoint inclusivity is honored: an open lower fits inside a closed lower at the same value.
+    /// var closed = Interval<int>.Closed(0, 10);          // [0, 10]
+    /// var open   = Interval<int>.Open(0, 10);            // (0, 10)
+    /// closed.Contains(open);                             // True
+    /// open.Contains(closed);                             // False — closed includes 0 and 10
+    ///]]>
+    /// </code>
+    /// </example>
     public bool Contains(Interval<T> other)
     {
         if (other.IsEmpty)
@@ -64,6 +95,21 @@ public readonly partial struct Interval<T>
     /// overlap, because no single value belongs to both. To test whether they are adjacent (touching), inspect the
     /// endpoints directly.
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// var a = Interval<int>.Closed(1, 5);
+    /// var b = Interval<int>.Closed(3, 7);
+    /// a.Overlaps(b);                                                     // True — share [3, 5]
+    ///
+    /// // Touching at a boundary but not both including it: NOT overlapping.
+    /// Interval<int>.ClosedOpen(1, 5).Overlaps(Interval<int>.Closed(5, 10));   // False — neither holds 5 jointly
+    /// Interval<int>.OpenClosed(1, 5).Overlaps(Interval<int>.Closed(5, 10));   // True  — both include 5
+    ///
+    /// Interval<int>.Closed(1, 2).Overlaps(Interval<int>.Closed(5, 6));   // False — disjoint
+    ///]]>
+    /// </code>
+    /// </example>
     public bool Overlaps(Interval<T> other)
     {
         if (IsEmpty || other.IsEmpty)
@@ -82,6 +128,25 @@ public readonly partial struct Interval<T>
     /// </summary>
     /// <param name="other">The interval to intersect with.</param>
     /// <returns>The intersection interval, or <see cref="Empty" /> when the two intervals share no values.</returns>
+    /// <remarks>
+    /// <para>
+    /// On endpoint ties, the <b>stricter</b> (open) inclusivity wins so that the result is a true subset of both
+    /// operands. For example, <c>[1, 5]</c> intersected with <c>(1, 5)</c> yields <c>(1, 5)</c>.
+    /// </para>
+    /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// Interval<int>.Closed(1, 5).Intersect(Interval<int>.Closed(3, 7));   // [3, 5]
+    /// Interval<int>.Closed(1, 3).Intersect(Interval<int>.Closed(5, 7));   // ∅ — disjoint
+    ///
+    /// // On ties, the stricter (open) inclusivity wins.
+    /// var closed = Interval<int>.Closed(1, 5);   // [1, 5]
+    /// var open   = Interval<int>.Open(1, 5);     // (1, 5)
+    /// closed.Intersect(open);                    // (1, 5)
+    ///]]>
+    /// </code>
+    /// </example>
     public Interval<T> Intersect(Interval<T> other)
     {
         if (IsEmpty || other.IsEmpty || !Overlaps(other))
@@ -151,9 +216,37 @@ public readonly partial struct Interval<T>
     /// and the result would not be contiguous.
     /// </para>
     /// <para>
-    /// Union with the empty interval is always defined: an empty operand leaves the other operand unchanged.
+    /// On endpoint ties, the <b>looser</b> (closed) inclusivity wins so that the result is a superset of either
+    /// operand. Union with the empty interval is always defined: an empty operand leaves the other operand unchanged.
+    /// </para>
+    /// <para>
+    /// When the two intervals are disjoint with a true gap between them, the union would require two pieces to
+    /// represent and this method returns <see langword="false" /> rather than synthesise a non-contiguous result.
+    /// Callers that need a multi-piece result should accumulate the operands into a higher-level collection of
+    /// intervals.
     /// </para>
     /// </remarks>
+    /// <example>
+    /// <code language="csharp">
+    ///<![CDATA[
+    /// // Adjacent — [1, 5) ∪ [5, 10] → [1, 10]
+    /// Interval<int>.ClosedOpen(1, 5).TryUnion(Interval<int>.Closed(5, 10), out var contiguous);
+    /// // contiguous == [1, 10], result == true
+    ///
+    /// // Overlapping — [1, 5] ∪ [3, 7] → [1, 7]
+    /// Interval<int>.Closed(1, 5).TryUnion(Interval<int>.Closed(3, 7), out var merged);
+    /// // merged == [1, 7], result == true
+    ///
+    /// // Disjoint — [1, 5) ∪ (5, 10] is not contiguous (no operand contains 5).
+    /// bool ok = Interval<int>.ClosedOpen(1, 5).TryUnion(Interval<int>.OpenClosed(5, 10), out _);
+    /// // ok == false
+    ///
+    /// // Empty operand acts as identity.
+    /// Interval<int>.Empty.TryUnion(Interval<int>.Closed(1, 5), out var same);
+    /// // same == [1, 5], result == true
+    ///]]>
+    /// </code>
+    /// </example>
     public bool TryUnion(Interval<T> other, out Interval<T> result)
     {
         if (IsEmpty)

--- a/Bodu.Numerics/src/Numerics/Interval.cs
+++ b/Bodu.Numerics/src/Numerics/Interval.cs
@@ -22,16 +22,36 @@ namespace Bodu.Numerics;
 /// </typeparam>
 /// <remarks>
 /// <para>
+/// <see cref="Interval{T}" /> is the value-typed building block for working with numeric ranges as first-class data.
+/// Rather than encoding a range as a <c>(min, max)</c> tuple or a pair of <c>bool</c> predicates and threading the
+/// inclusivity convention through every call site, an interval carries both endpoints and their inclusivity in a single
+/// immutable value, with set algebra — membership, containment, intersection, union, overlap, adjacency — defined on
+/// the type. Reach for it whenever the range itself is a value the code passes around, validates against, intersects,
+/// merges, or persists. <see cref="Interval{T}" /> is more general than <c>System.Range</c> (which is integer-only and
+/// always <c>[start, end)</c>) and safer than untyped tuples or <c>(bool, bool)</c> flags, where the inclusivity
+/// convention lives in comments rather than in the value.
+/// </para>
+/// <para>
+/// The generic-math constraint on <typeparamref name="T" /> means the same code can carry an integer scheduling window,
+/// a <see cref="double" /> percentage range, a <see cref="decimal" /> price band, or a <see cref="BigInteger" />
+/// arbitrary-magnitude bound; any type implementing <see cref="INumber{TSelf}" /> is a valid endpoint type, including
+/// consumer-defined numeric types.
+/// </para>
+/// <para>
 /// An interval is the set of values <c>x</c> such that <c>Lower &#x2264; x &#x2264; Upper</c> (closed-closed),
 /// <c>Lower &lt; x &lt; Upper</c> (open-open), <c>Lower &#x2264; x &lt; Upper</c> (closed-open), or
 /// <c>Lower &lt; x &#x2264; Upper</c> (open-closed). Endpoint inclusion is independent for the two sides and is
-/// preserved through every operation defined on the type.
+/// preserved through every operation defined on the type. The closed-open shape — <c>[a, b)</c> — is the most common in
+/// programming contexts because adjacent half-open intervals partition a span with no overlap and no gap, matching the
+/// conventions of <c>System.Range</c>, LINQ's <c>Enumerable.Range</c>, and slice iterators.
 /// </para>
 /// <para>
 /// An interval is <b>empty</b> when its bounds do not admit any value — either <c>Lower &gt; Upper</c>, or
 /// <c>Lower &#x2261; Upper</c> with at least one endpoint open. All empty intervals are equal to <see cref="Empty" />
 /// by <see cref="IEquatable{T}.Equals(T)" />, and a structural pattern-match against an empty instance always returns
-/// the same canonical projection regardless of how the empty value was constructed.
+/// the same canonical projection regardless of how the empty value was constructed. The default-constructed
+/// <c>Interval&lt;T&gt;</c> is empty, so a <c>default(Interval&lt;T&gt;)</c> field reads as the empty interval rather
+/// than as a malformed value.
 /// </para>
 /// <para>
 /// Unbounded intervals (intervals with no lower or no upper limit, conventionally written <c>(-&#x221E;, b]</c> or
@@ -42,11 +62,34 @@ namespace Bodu.Numerics;
 /// </para>
 /// <para>
 /// Instances are immutable, structurally equatable, and safe to share. They format using ISO 31-11 interval notation
-/// (square brackets for closed endpoints and round brackets for open endpoints) via <see cref="ToString()" />, and
-/// parse the same notation through <see cref="Parse(string, IFormatProvider?)" /> and the
+/// (square brackets for closed endpoints, round brackets for open endpoints, and the U+2205 EMPTY SET glyph for the
+/// empty interval) via <see cref="ToString()" />, and parse the same notation through
+/// <see cref="Parse(string, IFormatProvider?)" /> and the
 /// <see cref="TryParse(string?, IFormatProvider?, out Interval{T})" /> family.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// using Bodu.Numerics;
+///
+/// // Scheduling windows — closed-open at the end keeps adjacent slots disjoint.
+/// var morning = Interval<int>.ClosedOpen(9, 12);
+/// var meeting = Interval<int>.ClosedOpen(11, 13);
+/// bool clash   = morning.Overlaps(meeting);            // True
+/// var conflict = morning.Intersect(meeting);           // [11, 12)
+///
+/// // Validation predicate — a percentage in [0, 100].
+/// var percentage = Interval<double>.Closed(0.0, 100.0);
+/// bool ok = percentage.Contains(99.5);                 // True
+///
+/// // Adjacent half-open ranges merge into a single contiguous interval.
+/// var q1 = Interval<int>.ClosedOpen(0, 90);
+/// var q2 = Interval<int>.ClosedOpen(90, 181);
+/// q1.TryUnion(q2, out var firstHalf);                  // firstHalf = [0, 181)
+///]]>
+/// </code>
+/// </example>
 [Serializable]
 [DebuggerDisplay("{ToString(),nq}")]
 [JsonConverter(typeof(IntervalJsonConverterFactory))]

--- a/docs/docs/numerics/concepts.md
+++ b/docs/docs/numerics/concepts.md
@@ -66,22 +66,62 @@ The **convergents** of a continued fraction — the rationals produced by trunca
 
 The search walks the convergents of the continued-fraction expansion and selects between the last convergent and a final semiconvergent. Overloads accept `double`, `decimal`, and string input. `Fraction<T>.LimitDenominator(maxDenominator)` is the streaming variant that re-approximates an existing fraction within a tighter denominator bound.
 
+## Range as a first-class value
+
+An <xref:Bodu.Numerics.Interval`1> is a **range encoded as a single value**: lower endpoint, upper endpoint, and the inclusivity of each side, packed into one immutable `readonly struct`. The point of having a dedicated type is that the range can be passed, stored, compared, and operated on without splitting it into separate `min` / `max` / `(bool, bool)` parameters whose meaning depends on convention.
+
+Reach for it whenever the range itself is the data:
+
+- A scheduling window or time slot persisted in a database column.
+- A validation predicate exposed by an API (`var valid = Interval<int>.Closed(0, 100);`).
+- A reservation that needs to detect overlap with other reservations.
+- A bucket whose membership semantics carry through a pipeline.
+
+When the range is *only* an immediate `for (int i = 0; i < count; i++)` loop bound, a plain `int` pair or `System.Range` is enough and `Interval<T>` is overkill. The line is "is the range a value other code receives" — `Interval<T>` when yes, primitive pair when no.
+
+## Comparison with `System.Range`, tuples, and `(bool, bool)` flags
+
+| Alternative | Limitation | When `Interval<T>` wins |
+|---|---|---|
+| `System.Range` | Integer-only; always `[start, end)`; intended for slicing, not membership. | Non-integer endpoints, mixed inclusivity, or set algebra. |
+| `(T min, T max)` tuple | Inclusivity is implicit — readers have to infer or check a comment. | The contract is in the value; the four shapes are distinguishable. |
+| `(T, T, bool, bool)` tuple | Possible but loses the named API (`Contains`, `Intersect`, `TryUnion`) and structural equality on the *set*. | All operations are methods on the type; equality compares sets, not field shapes. |
+| `Predicate<T>` | Composable for membership but throws away the endpoints — no intersection, union, or persistence. | The data form is preserved; predicates are easy to derive when needed. |
+
+`System.Range` and `Interval<T>` are not competitors — `Range` is the right tool for slicing `Span<T>` / arrays, while `Interval<T>` is the right tool when "the range itself" is a value.
+
+## Numeric backing types
+
+The type parameter is constrained as `where T : INumber<T>`, so any .NET generic-math number is a valid endpoint type: `int`, `long`, `Int128`, `double`, `float`, `decimal`, `BigInteger`, and consumer-defined numeric types built on the generic-math interfaces. The same set-algebra code runs over integer scheduling slots, decimal price bands, and arbitrary-magnitude `BigInteger` bounds without a per-type overload.
+
+Endpoints are stored at full `T` precision — no widening, no narrowing — and `Contains`, `Intersect`, `Overlaps`, and `TryUnion` use `T`'s native comparison operators.
+
 ## Endpoint inclusivity
 
 An <xref:Bodu.Numerics.Interval`1> endpoint is either **closed** (included in the set — written with a square bracket: `[`, `]`) or **open** (excluded — written with a round bracket: `(`, `)`). Inclusivity is tracked independently on each side, so a single interval value expresses any of the four conventional shapes; the constructor takes a separate `lowerInclusive` / `upperInclusive` flag for each end.
 
 `Contains(value)` honours inclusivity: a closed endpoint accepts the boundary value, an open endpoint rejects it.
 
+```csharp
+var closed = Interval<int>.Closed(0, 10);       // [0, 10]
+var open   = Interval<int>.Open(0, 10);         // (0, 10)
+
+closed.Contains(0);    // True  — closed lower
+open.Contains(0);      // False — open lower
+closed.Contains(10);   // True  — closed upper
+open.Contains(10);     // False — open upper
+```
+
 ## Interval kinds
 
 The four canonical shapes follow from independent inclusivity flags on each end:
 
-| Shape | Notation | Factory |
-|---|---|---|
-| Closed-closed | `[a, b]` | `Interval<T>.Closed(a, b)` |
-| Open-open | `(a, b)` | `Interval<T>.Open(a, b)` |
-| Closed-open | `[a, b)` | `Interval<T>.ClosedOpen(a, b)` |
-| Open-closed | `(a, b]` | `Interval<T>.OpenClosed(a, b)` |
+| Shape | Notation | Factory | Typical use |
+|---|---|---|---|
+| Closed-closed | `[a, b]` | `Interval<T>.Closed(a, b)` | A percentage `[0, 100]`, a die roll `[1, 6]`, any range whose boundary values are valid members. |
+| Open-open | `(a, b)` | `Interval<T>.Open(a, b)` | Strict-inequality conditions: `0 < rate < 1`, "strictly between". |
+| Closed-open | `[a, b)` | `Interval<T>.ClosedOpen(a, b)` | Spans, slices, scheduling windows, bucket boundaries — see [Half-open by convention](#half-open-by-convention). |
+| Open-closed | `(a, b]` | `Interval<T>.OpenClosed(a, b)` | Billing tiers, histogram bins owning their upper edge, "strictly above X, up to Y". |
 
 A **degenerate** interval is a closed-closed interval whose endpoints are equal — `[5, 5]` — and contains exactly one value. `Interval<T>.Singleton(value)` is the dedicated factory.
 
@@ -91,11 +131,32 @@ An interval is **empty** when its bounds admit no value — either `Lower > Uppe
 
 The default-constructed `Interval<T>` is empty — the all-zero representation `(0, 0, false, false)` satisfies the equal-bounds-both-open case. `IsEmpty` reports the predicate; equality with `Empty` is the same test.
 
+```csharp
+var none      = Interval<int>.Empty;
+var inverted  = new Interval<int>(5, 1, true, true);     // Lower > Upper
+var collapsed = new Interval<int>(0, 0, false, false);   // equal + open
+Interval<int> defaulted = default;
+
+none == inverted && none == collapsed && none == defaulted;  // True
+none.ToString();                                             // "∅"
+```
+
+`Empty` acts as the identity in the set algebra: `Intersect` returns it whenever two operands share no values, and `TryUnion` returns the other operand unchanged when one side is empty.
+
 ## Membership
 
 `Interval<T>.Contains(T value)` reports whether `value` belongs to the interval. The lower test uses `>=` when `LowerInclusive` and `>` otherwise; the upper test mirrors it. An empty interval contains no value, including itself.
 
 `Interval<T>.Contains(Interval<T> other)` tests subset containment — every value of `other` is also a value of this interval. The empty interval is a subset of every interval, so any interval contains the empty interval.
+
+```csharp
+var outer = Interval<int>.Closed(0, 10);
+
+outer.Contains(5);                                    // True — value
+outer.Contains(Interval<int>.Closed(2, 8));           // True — strict subset
+outer.Contains(Interval<int>.Closed(2, 11));          // False — exceeds upper
+outer.Contains(Interval<int>.Empty);                  // True — ∅ ⊆ every set
+```
 
 ## Overlap, intersection, union, adjacency
 
@@ -105,9 +166,34 @@ The default-constructed `Interval<T>` is empty — the all-zero representation `
 
 `TryUnion(other, out result)` succeeds when the union is itself a single contiguous interval — that is, when the operands either overlap or are *adjacent*. Two intervals are **adjacent** when one's upper endpoint equals the other's lower endpoint and at least one of those endpoints is inclusive. On endpoint ties in the union, the **looser** (closed) inclusivity wins. When the operands are disjoint with a true gap, `TryUnion` returns `false` rather than synthesising a two-piece union.
 
+```csharp
+var a = Interval<int>.Closed(1, 5);
+var b = Interval<int>.Closed(3, 7);
+
+a.Overlaps(b);                          // True
+a.Intersect(b);                         // [3, 5] — shared values
+a.TryUnion(b, out var merged);          // merged = [1, 7], result = true
+
+// Adjacent half-open shapes union cleanly.
+Interval<int>.ClosedOpen(1, 5)
+    .TryUnion(Interval<int>.Closed(5, 10), out var span);   // span = [1, 10]
+
+// Disjoint operands cannot form a contiguous union.
+Interval<int>.Closed(1, 2)
+    .TryUnion(Interval<int>.Closed(5, 6), out _);           // returns false
+```
+
 ## Half-open by convention
 
 The **closed-open** shape `[a, b)` is the most common in programming contexts: it matches `System.Range`, `Enumerable.Range`, slice iterators, and the inclusive-start / exclusive-end convention used in scheduling, time windows, and bucket ranges. `Interval<T>.ClosedOpen` and the non-generic `Interval.ClosedOpen` are the factories. Adjacent half-open intervals partition a span cleanly with no overlap and no gap, which is why the convention dominates.
+
+```csharp
+// Quarter buckets that together cover [0, 365) with no overlap and no gap.
+var q1 = Interval<int>.ClosedOpen(0,   90);
+var q2 = Interval<int>.ClosedOpen(90,  181);
+var q3 = Interval<int>.ClosedOpen(181, 273);
+var q4 = Interval<int>.ClosedOpen(273, 365);
+```
 
 ## Where to go next
 

--- a/docs/docs/numerics/getting-started.md
+++ b/docs/docs/numerics/getting-started.md
@@ -87,6 +87,8 @@ Fraction<int> roundTrip = JsonSerializer.Deserialize<Fraction<int>>(json);
 
 ### Bounded intervals (`Interval<T>`)
 
+`Interval<T>` packs a range — lower endpoint, upper endpoint, and the inclusivity of each side — into a single immutable value over any `INumber<T>` endpoint type. The set algebra (membership, containment, intersection, union, overlap, adjacency) is defined on the type.
+
 ```csharp
 using Bodu.Numerics;
 
@@ -101,10 +103,125 @@ period.Contains(50);                                       // True
 period.Contains(100);                                      // False — upper exclusive
 ```
 
-Use the non-generic `Interval` helper class when you want the compiler to infer the endpoint type:
+#### Inferring the endpoint type
+
+The non-generic `Interval` helper class mirrors every factory on `Interval<T>` but lets the compiler infer `T` from the arguments — useful when the endpoint type is obvious from literals or locals:
 
 ```csharp
-var span = Interval.Closed(1.5, 2.5);   // Interval<double>
+var span    = Interval.Closed(1.5, 2.5);            // Interval<double>
+var prices  = Interval.OpenClosed(1000m, 10_000m);  // Interval<decimal>
+var ints    = Interval.ClosedOpen(0, 100);          // Interval<int>
+```
+
+#### Scheduling: detect a clash and trim it
+
+The closed-open shape `[a, b)` is the natural choice for time slots — adjacent slots share a single boundary without double-counting it.
+
+```csharp
+var morning = Interval<int>.ClosedOpen(9,  12);   // [9, 12) — 9am–noon
+var meeting = Interval<int>.ClosedOpen(11, 13);   // [11, 13) — overlapping meeting
+
+if (morning.Overlaps(meeting))
+{
+    var clash = morning.Intersect(meeting);       // [11, 12)
+    Console.WriteLine($"Clash: {clash}");          // "Clash: [11, 12)"
+}
+```
+
+#### Validation predicate
+
+A `Closed` interval doubles as a "valid input" predicate that documents its own bounds:
+
+```csharp
+var percentage = Interval<double>.Closed(0.0, 100.0);
+
+double Sanitize(double value) =>
+    percentage.Contains(value) ? value : throw new ArgumentOutOfRangeException(nameof(value));
+
+Sanitize(99.5);   // 99.5
+Sanitize(100.0);  // 100.0 — closed upper
+Sanitize(101.0);  // throws
+```
+
+#### Partitioning a span into adjacent buckets
+
+Adjacent half-open intervals partition a range cleanly with no overlap and no gap. Together they cover the whole span and exactly one of them contains any given value.
+
+```csharp
+var q1 = Interval<int>.ClosedOpen(0,   90);
+var q2 = Interval<int>.ClosedOpen(90,  181);
+var q3 = Interval<int>.ClosedOpen(181, 273);
+var q4 = Interval<int>.ClosedOpen(273, 365);
+
+int BucketOf(int dayOfYear) =>
+    q1.Contains(dayOfYear) ? 1 :
+    q2.Contains(dayOfYear) ? 2 :
+    q3.Contains(dayOfYear) ? 3 :
+    q4.Contains(dayOfYear) ? 4 :
+    throw new ArgumentOutOfRangeException(nameof(dayOfYear));
+
+BucketOf(0);    // 1 — closed lower of q1
+BucketOf(90);   // 2 — q1 ends before 90; q2 includes it
+BucketOf(364);  // 4 — q4 contains [273, 365)
+```
+
+#### Formatting and parsing
+
+`Interval<T>` formats using ISO 31-11 bracket notation and parses the same syntax. The empty interval renders as the U+2205 EMPTY SET glyph (`∅`).
+
+```csharp
+using System.Globalization;
+
+Interval<int>.Closed(1, 5).ToString();       // "[1, 5]"
+Interval<int>.ClosedOpen(0, 100).ToString(); // "[0, 100)"
+Interval<int>.Empty.ToString();              // "∅"
+
+Interval<double>
+    .Closed(1.5, 2.75)
+    .ToString("F2", CultureInfo.InvariantCulture);   // "[1.50, 2.75]"
+
+Interval<int> parsed = Interval<int>.Parse("(0, 100]", CultureInfo.InvariantCulture);
+Interval<int>.TryParse("∅", CultureInfo.InvariantCulture, out var none);  // none = Empty
+```
+
+`Interval<T>` implements `ISpanFormattable` and `IUtf8SpanFormattable`, so the same text round-trips through character and UTF-8 byte buffers without allocation.
+
+#### JSON
+
+`Interval<T>` is wired to `System.Text.Json` via `[JsonConverter(typeof(IntervalJsonConverterFactory))]`, so values round-trip without explicit converter registration. The default policy is `Strict` and produces an explicit object shape; pass a different `NumericsJsonPolicy` to the factory when you want the bracket-notation string form on the wire.
+
+```csharp
+using System.Text.Json;
+using Bodu.Numerics;
+using Bodu.Numerics.Serialization;
+
+// Default (Strict) — explicit object shape, all four fields required on read.
+string json = JsonSerializer.Serialize(Interval<int>.ClosedOpen(0, 100));
+// {"lower":0,"upper":100,"lowerInclusive":true,"upperInclusive":false}
+
+Interval<int> roundTrip = JsonSerializer.Deserialize<Interval<int>>(json);
+
+// Compact policy — string form using ISO 31-11 bracket notation.
+JsonSerializerOptions options = new JsonSerializerOptions()
+    .AddNumericsJsonConverters(NumericsJsonPolicy.Compact);
+
+string compact = JsonSerializer.Serialize(Interval<int>.ClosedOpen(0, 100), options);
+// "[0, 100)"
+```
+
+The empty interval serializes to `{"empty":true}` under `Strict` and `Lenient`, and to `"∅"` under `Compact`.
+
+#### The empty interval is unique
+
+Any inverted-bounds or equal-bounds-with-open-endpoint interval compares equal to `Interval<T>.Empty` regardless of the bounds used to construct it. A default-constructed value is empty too, so `Interval<T>` fields never carry a malformed default.
+
+```csharp
+var none      = Interval<int>.Empty;
+var inverted  = new Interval<int>(5, 1, true, true);
+var collapsed = new Interval<int>(0, 0, false, false);
+Interval<int> defaulted = default;
+
+none == inverted && none == collapsed && none == defaulted;  // True
 ```
 
 ### Cross-package: Fraction-backed monetary arithmetic


### PR DESCRIPTION
## Summary

Adds comprehensive XML documentation to the `Interval<T>` type and its factory methods, including remarks sections explaining use cases and code examples demonstrating each shape and operation.

## Changes

- **Interval.Factories.cs**: Added detailed remarks and code examples to all factory methods:
  - `Empty`: Explains its role as the neutral element in set algebra; shows that inverted-bounds and equal-bounds-with-open-endpoint intervals all compare equal to `Empty`
  - `Closed(T, T)`: Documents the closed-closed shape for ranges where boundary values are valid members; includes example showing containment and inverted-bounds behavior
  - `Open(T, T)`: Explains strict-inequality semantics; demonstrates that equal bounds with both endpoints open collapse to empty
  - `ClosedOpen(T, T)`: Emphasizes the half-open convention for spans, slices, and scheduling windows; shows how adjacent half-open intervals partition cleanly
  - `OpenClosed(T, T)`: Documents the mirror-image use case (billing tiers, histogram bins); includes a billing-tier example
  - `Singleton(T)`: Explains degenerate intervals as identity for intersection sweeps and union seeds; shows that `Length` is zero but `IsEmpty` is false

- **Interval.SetOperations.cs**: Added examples to membership and set-algebra methods:
  - `Contains(T value)`: Shows closed vs. open endpoint behavior and that empty intervals contain nothing
  - `Contains(Interval<T> other)`: Demonstrates subset testing, equality, and that empty is a subset of every interval
  - `Overlaps(Interval<T> other)`: Shows overlapping and touching-but-not-overlapping cases
  - `Intersect(Interval<T> other)`: Explains that stricter (open) inclusivity wins on ties; includes disjoint and tie examples
  - `TryUnion(Interval<T> other, out result)`: Documents adjacency, overlapping, disjoint, and empty-operand cases with examples

- **Interval.cs**: Expanded the type-level remarks to emphasize:
  - `Interval<T>` as a value-typed building block for ranges as first-class data
  - Comparison with `System.Range` (integer-only, always `[start, end)`) and untyped tuples
  - Generic-math constraint allowing any `INumber<T>` endpoint type
  - Closed-open as the most common shape in programming contexts
  - Default-constructed value is empty (safe default)
  - Added a comprehensive example showing scheduling windows, validation predicates, and union of adjacent ranges

- **Interval.Helpers.cs**: Enhanced remarks on the non-generic `Interval` helper class:
  - Clarifies when to prefer type inference vs. explicit generic parameters
  - Added examples showing inference from int literals, decimal suffixes, and local variables

- **docs/docs/numerics/getting-started.md**: Expanded the "Bounded intervals" section with:
  - Brief introduction to what `Interval<T>` is
  - New subsections: "Inferring the endpoint type", "Scheduling: detect a clash and trim it", "Validation predicate", "Partitioning a span into adjacent buckets", "Formatting and parsing", "JSON", "The empty interval is unique"
  - Multiple runnable examples demonstrating each use case

- **docs/docs/numerics/concepts.md**: Added new sections:
  - "Range as a first-class value": Explains when to reach for `Interval<T>` vs. plain pairs
  - "Comparison with `System.Range`, tuples, and `(bool, bool)` flags": Comparison table showing limitations and when `Interval<T>` wins
  - "Numeric backing types": Documents the `INumber<T>` constraint and endpoint precision
  - Expanded "Endpoint inclusivity" with code examples
  - Enhanced "Interval kinds" table with typical-use column
  - Added code examples to "Membership", "Overlap, intersection, union, adjacency", and "Half-open by convention" sections

## Notable Details

- All examples use `<![CDATA[...]]>` to preserve angle brackets and special characters in XML

https://claude.ai/code/session_017bJ9vQBTUxfaMM53YgHAHt