### PR TITLE
docs: clear all DocFX warningsAsErrors failures

### DIFF
--- a/Bodu.Core/src/Bodu.Core.csproj
+++ b/Bodu.Core/src/Bodu.Core.csproj
@@ -55,8 +55,13 @@
     <!--
       Wire the in-repo XML-doc analyzer and code-fix as a Roslyn analyzer reference scoped to this project.
       Used to exercise BODU1405 (<code> must begin with CDATA flush against ///) against Bodu.Core in isolation.
+
+      Skipped when DocFX is generating the documentation site (BuildingForDocfx=true): docfx's Roslyn
+      workspace cannot resolve analyzer-only ProjectReferences that fall outside its scanned project set,
+      and emits "Found project reference without a matching metadata reference" warnings that are escalated
+      to errors by the warningsAsErrors flag the docfx workflow sets.
     -->
-    <ItemGroup>
+    <ItemGroup Condition="'$(BuildingForDocfx)' != 'true'">
         <ProjectReference Include="..\..\Bodu.CodeStyle\Bodu.CodeStyle.XmlDocumentation.Analyzers\src\Bodu.CodeStyle.XmlDocumentation.Analyzers.csproj"
                           ReferenceOutputAssembly="false"
                           OutputItemType="Analyzer" />

--- a/Bodu.Financial/src/Financial.Currencies/AED.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AED.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AFN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AFN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ALL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ALL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AMD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AMD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ANG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ANG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AOA.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AOA.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ARS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ARS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ATS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ATS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AUD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AUD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AWG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AWG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AZM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AZM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/AZN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/AZN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BAM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BAM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BBD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BBD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BDT.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BDT.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BEF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BEF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BGN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BGN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BHD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BHD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BIF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BIF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BMD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BMD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BND.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BND.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BOB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BOB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BRL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BRL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BSD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BSD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BTN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BTN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BWP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BWP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BYN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BYN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/BZD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/BZD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CAD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CAD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CDF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CDF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CHF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CHF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CLP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CLP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CNY.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CNY.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/COP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/COP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CRC.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CRC.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CUP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CUP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CVE.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CVE.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CYP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CYP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/CZK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/CZK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/DEM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/DEM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/DJF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/DJF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/DKK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/DKK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/DOP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/DOP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/DZD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/DZD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/EEK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/EEK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/EGP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/EGP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ERN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ERN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ESP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ESP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ETB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ETB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/EUR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/EUR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/FIM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/FIM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/FJD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/FJD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/FKP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/FKP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/FRF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/FRF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GBP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GBP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GEL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GEL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GHC.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GHC.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GHS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GHS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GIP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GIP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GMD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GMD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GNF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GNF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GRD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GRD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GTQ.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GTQ.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GYD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GYD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/GeneratedCurrencyRegistration.cs
+++ b/Bodu.Financial/src/Financial.Currencies/GeneratedCurrencyRegistration.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 using global::System.Collections.Generic;

--- a/Bodu.Financial/src/Financial.Currencies/HKD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/HKD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/HNL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/HNL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/HRK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/HRK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/HTG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/HTG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/HUF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/HUF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/IDR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/IDR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/IEP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/IEP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ILS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ILS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/INR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/INR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/IQD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/IQD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/IRR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/IRR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ISK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ISK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ITL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ITL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/JMD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/JMD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/JOD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/JOD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/JPY.cs
+++ b/Bodu.Financial/src/Financial.Currencies/JPY.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KES.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KES.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KGS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KGS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KHR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KHR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KMF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KMF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KPW.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KPW.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KRW.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KRW.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KWD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KWD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KYD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KYD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/KZT.cs
+++ b/Bodu.Financial/src/Financial.Currencies/KZT.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LAK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LAK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LBP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LBP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LKR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LKR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LRD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LRD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LSL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LSL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LTL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LTL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LUF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LUF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LVL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LVL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/LYD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/LYD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MAD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MAD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MDL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MDL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MGA.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MGA.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MKD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MKD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MMK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MMK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MNT.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MNT.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MOP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MOP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MRU.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MRU.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MTL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MTL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MUR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MUR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MVR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MVR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MWK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MWK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MXN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MXN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MYR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MYR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MZM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MZM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/MZN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/MZN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NAD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NAD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NGN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NGN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NIO.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NIO.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NLG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NLG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NOK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NOK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NPR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NPR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/NZD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/NZD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/OMR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/OMR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PAB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PAB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PEN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PEN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PGK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PGK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PHP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PHP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PKR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PKR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PLN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PLN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PTE.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PTE.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/PYG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/PYG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/QAR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/QAR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ROL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ROL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/RON.cs
+++ b/Bodu.Financial/src/Financial.Currencies/RON.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/RSD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/RSD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/RUB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/RUB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/RWF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/RWF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SAR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SAR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SBD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SBD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SCR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SCR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SDG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SDG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SEK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SEK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SGD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SGD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SHP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SHP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SIT.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SIT.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SKK.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SKK.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SLE.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SLE.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SOS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SOS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SRD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SRD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SRG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SRG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SSP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SSP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/STN.cs
+++ b/Bodu.Financial/src/Financial.Currencies/STN.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SVC.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SVC.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SYP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SYP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/SZL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/SZL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/THB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/THB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TJS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TJS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TMM.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TMM.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TMT.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TMT.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TND.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TND.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TOP.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TOP.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TRY.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TRY.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TTD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TTD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TWD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TWD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/TZS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/TZS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/UAH.cs
+++ b/Bodu.Financial/src/Financial.Currencies/UAH.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/UGX.cs
+++ b/Bodu.Financial/src/Financial.Currencies/UGX.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/USD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/USD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/UYU.cs
+++ b/Bodu.Financial/src/Financial.Currencies/UYU.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/UZS.cs
+++ b/Bodu.Financial/src/Financial.Currencies/UZS.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/VEB.cs
+++ b/Bodu.Financial/src/Financial.Currencies/VEB.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/VEF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/VEF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/VES.cs
+++ b/Bodu.Financial/src/Financial.Currencies/VES.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/VND.cs
+++ b/Bodu.Financial/src/Financial.Currencies/VND.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/VUV.cs
+++ b/Bodu.Financial/src/Financial.Currencies/VUV.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/WST.cs
+++ b/Bodu.Financial/src/Financial.Currencies/WST.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/XAF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/XAF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/XCD.cs
+++ b/Bodu.Financial/src/Financial.Currencies/XCD.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/XOF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/XOF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/XPF.cs
+++ b/Bodu.Financial/src/Financial.Currencies/XPF.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/YER.cs
+++ b/Bodu.Financial/src/Financial.Currencies/YER.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ZAR.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ZAR.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ZMW.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ZMW.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ZWG.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ZWG.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/Bodu.Financial/src/Financial.Currencies/ZWL.cs
+++ b/Bodu.Financial/src/Financial.Currencies/ZWL.cs
@@ -4,6 +4,7 @@
 //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
 // </auto-generated>
 // ---------------------------------------------------------------------------------------------------------------
+#nullable enable
 namespace Bodu.Financial.Currencies;
 
 /// <summary>

--- a/docs/apidoc/Bodu.Collections.Generic.Extensions.md
+++ b/docs/apidoc/Bodu.Collections.Generic.Extensions.md
@@ -13,8 +13,8 @@ uid: Bodu.Collections.Generic.Extensions
 - <xref:Bodu.Collections.Generic.Extensions.IEnumerableExtensions> — generic enumerable utilities: `Aggregate`, `Batch`, `Cache`, `ContainsAll`, `ContainsAny`, `ForEach`, `Index`, `IsNullOrEmpty`, `Randomize`, `RecursiveSelect`, `WhereNotNull`, and more.
 - <xref:Bodu.Collections.Generic.Extensions.IListExtensions> — list-specific utilities: `IndexOf`, `LastIndexOf`, `ReplaceAll`, `TryMove`, `TrySwap`.
 - <xref:Bodu.Collections.Generic.Extensions.IDictionaryExtensions> — dictionary utilities: `AddOrUpdate`, `GetOrAdd`.
-- <xref:Bodu.Collections.Generic.Extensions.SequenceGenerator> — common sequence factories: `Fibonacci`, `Farey`, `Leibniz`, `LookAndSay`, `ThueMorse`, `Range`, `Repeat`, …
-- <xref:Bodu.Collections.Generic.ShuffleHelpers>, <xref:Bodu.Collections.Generic.SystemRandomAdapter>, <xref:Bodu.RandomizationMode> — pluggable randomness-driven shuffles backed by <xref:Bodu.IRandomGenerator>.
+- <xref:Bodu.Collections.Generic.SequenceGenerator> — common sequence factories: `Range`, `Repeat`, `NextWhile`. The richer mathematical series (`Fibonacci`, `Farey`, `Leibniz`, `LookAndSay`, `ThueMorse`) live on the companion <xref:Bodu.Collections.Extensions.SequenceGenerator> in <xref:Bodu.Collections.Extensions>.
+- <xref:Bodu.Collections.Generic.ShuffleHelpers>, <xref:Bodu.Collections.Generic.Extensions.SystemRandomAdapter>, <xref:Bodu.Collections.Generic.Extensions.RandomizationMode> — pluggable randomness-driven shuffles backed by <xref:Bodu.IRandomGenerator>.
 
 ## Example
 

--- a/docs/apidoc/Bodu.Extensions.md
+++ b/docs/apidoc/Bodu.Extensions.md
@@ -21,15 +21,15 @@ This is the single highest-leverage namespace in `Bodu.Core` by surface area. Re
 
 - <xref:Bodu.Extensions.DateTimeExtensions> — first / last / next / previous day-of-week within month / quarter / year, ISO week-of-year, day name, weekday tests, midday, end-of-day, truncation. 50+ methods.
 - <xref:Bodu.Extensions.DateOnlyExtensions> — `DateOnly`-specific equivalents plus `Age` calculation.
-- <xref:Bodu.Extensions.DateTimeFormatInfoExtensions> — culture-aware day-of-week and month-name helpers.
+- <xref:Bodu.Globalization.Extensions.DateTimeFormatInfoExtensions> — culture-aware day-of-week and month-name helpers.
 - <xref:Bodu.Extensions.IQuarterDefinitionProvider>, <xref:Bodu.Extensions.IWeekendDefinitionProvider>, <xref:Bodu.Extensions.IWeekendDefinitionProviderExtensions> — pluggable calendar-shape providers for non-Gregorian or fiscal quarters and non-Saturday/Sunday weekend conventions.
 - <xref:Bodu.Extensions.WorkingDaysOfWeekExtensions>, <xref:Bodu.WorkingDaysOfWeek> — working-day bitmask helpers.
 
 **Calendar-shape enums**
 
-- <xref:Bodu.CalendarQuarterDefinition> — `Fiscal`, `Calendar`.
-- <xref:Bodu.DateTimeResolution> — truncation resolution.
-- <xref:Bodu.FiscalWeekPattern> — fiscal-week enumeration.
+- <xref:Bodu.Extensions.CalendarQuarterDefinition> — `Fiscal`, `Calendar`.
+- <xref:Bodu.Extensions.DateTimeResolution> — truncation resolution.
+- <xref:Bodu.Extensions.FiscalWeekPattern> — fiscal-week enumeration.
 - <xref:Bodu.Extensions.WeekOfMonthOrdinal> — `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`.
 
 **Numeric**
@@ -46,7 +46,7 @@ This is the single highest-leverage namespace in `Bodu.Core` by surface area. Re
 **Strings**
 
 - <xref:Bodu.Extensions.StringExtensions> — `After`, `Before`, `Between`, `Brace`, `Bracket`, `CollapseWhitespace`, `Contains` / `EndsWith` / `StartsWith` variants, `EnsureEndsWith` / `EnsureStartsWith`, `Indent`, `IsValidIdentifier`, `Keep` / `Remove` variants, `Normalize`, `Outdent`, `Parenthesize`, `Parse`, `PrefixLines`, `Quote`, `RemoveControlCharacters`, `RemoveDiacritics`, `Slice`, case conversions (`ToCamelCase`, `ToPascalCase`, `ToSnakeCase`, `ToKebabCase`, …), `Truncate`, `Unwrap`, `Wrap`, slug generation.
-- <xref:Bodu.IdentifierCase> — case convention enum used by `IsValidIdentifier` / case conversions.
+- <xref:Bodu.Extensions.IdentifierCase> — case convention enum used by `IsValidIdentifier` / case conversions.
 - <xref:Bodu.Extensions.SentenceCaseOptions>, <xref:Bodu.Extensions.TitleCaseOptions>, <xref:Bodu.Extensions.WordCasingOptions>, <xref:Bodu.Extensions.SlugOptions> — option flags consumed by the casing helpers.
 
 **Comparable**

--- a/docs/apidoc/Bodu.Globalization.Calendar.Algorithms.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.Algorithms.md
@@ -19,23 +19,23 @@ Reach for this namespace when an authored rule needs Easter, Vesak, Asalha Puja,
 
 **Easter algorithms**
 
-- <xref:Bodu.Globalization.Calendar.EasterSundayNotableDateAlgorithm> — Computus-based Gregorian Easter Sunday for years ≥ 1583 and Meeus's Julian adaptation for earlier years. Results cached per `(year, calendar)`. Algorithm key: `"easter"`.
-- <xref:Bodu.Globalization.Calendar.GregorianEasterSundayNotableDateProvider> — Gregorian-only provider variant; accepts `null` or `GregorianCalendar`.
-- <xref:Bodu.Globalization.Calendar.OrthodoxEasterSundayNotableDateProvider> — Orthodox (Julian computus) Easter, returned as the Gregorian-equivalent `DateTime`. Accepts `null` or `JulianCalendar`.
+- <xref:Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateAlgorithm> — Computus-based Gregorian Easter Sunday for years ≥ 1583 and Meeus's Julian adaptation for earlier years. Results cached per `(year, calendar)`. Algorithm key: `"easter"`.
+- <xref:Bodu.Globalization.Calendar.Algorithms.GregorianEasterSundayNotableDateProvider> — Gregorian-only provider variant; accepts `null` or `GregorianCalendar`.
+- <xref:Bodu.Globalization.Calendar.Algorithms.OrthodoxEasterSundayNotableDateProvider> — Orthodox (Julian computus) Easter, returned as the Gregorian-equivalent `DateTime`. Accepts `null` or `JulianCalendar`.
 - <xref:Bodu.Globalization.Calendar.Algorithms.EasterSundayNotableDateProviderBase> — abstract base for Easter providers with per-year caching via a `ConcurrentDictionary`. Derive when you need a custom Easter variant.
 
 **Lunar / solar-term algorithms**
 
-- <xref:Bodu.Globalization.Calendar.VesakNotableDateAlgorithm> — the first full moon on or after 1 May. Accurate within one day for 1900–2100. Uses Meeus Chapter 49 lunar-phase computation.
-- <xref:Bodu.Globalization.Calendar.AsalhaPujaNotableDateAlgorithm> — the first full moon on or after 15 June (Theravada Dharma Day; start of Vassa).
-- <xref:Bodu.Globalization.Calendar.LosarNotableDateAlgorithm> — Tibetan New Year, approximated as the first new moon on or after 20 January using the Chinese lunisolar approximation. Diverges from the official Tibetan calendar approximately every 3–5 years by ~1 month; register a custom algorithm using TMAI tables when exact dates are required.
-- <xref:Bodu.Globalization.Calendar.QingmingNotableDateAlgorithm> — the Qingming solar term (清明節), when the sun's ecliptic longitude reaches 15° (typically 4–5 April). Accurate within one day for 1901–2100.
+- <xref:Bodu.Globalization.Calendar.Algorithms.VesakNotableDateAlgorithm> — the first full moon on or after 1 May. Accurate within one day for 1900–2100. Uses Meeus Chapter 49 lunar-phase computation.
+- <xref:Bodu.Globalization.Calendar.Algorithms.AsalhaPujaNotableDateAlgorithm> — the first full moon on or after 15 June (Theravada Dharma Day; start of Vassa).
+- <xref:Bodu.Globalization.Calendar.Algorithms.LosarNotableDateAlgorithm> — Tibetan New Year, approximated as the first new moon on or after 20 January using the Chinese lunisolar approximation. Diverges from the official Tibetan calendar approximately every 3–5 years by ~1 month; register a custom algorithm using TMAI tables when exact dates are required.
+- <xref:Bodu.Globalization.Calendar.Algorithms.QingmingNotableDateAlgorithm> — the Qingming solar term (清明節), when the sun's ecliptic longitude reaches 15° (typically 4–5 April). Accurate within one day for 1901–2100.
 
 **Hindu lunisolar**
 
-- <xref:Bodu.Globalization.Calendar.HinduLunarNotableDateAlgorithm> — Hindu festival dates from (month, paksha, tithi) lunisolar coordinates. Constructor: `(HinduLunarMonth month, HinduPaksha paksha, int tithi)`. Uses fixed month-offset approximation with ~19-year Metonic-cycle correction; accurate within 1–2 days for 1900–2100.
-- <xref:Bodu.Globalization.Calendar.HinduLunarMonth> — `Chaitra`, `Vaisakha`, `Jyaistha`, `Asadha`, `Sravana`, `Bhadrapada`, `Asvina`, `Kartika`, `Margasirsa`, `Pausa`, `Magha`, `Phalguna`.
-- <xref:Bodu.Globalization.Calendar.HinduPaksha> — `Shukla` (bright fortnight) or `Krishna` (dark fortnight).
+- <xref:Bodu.Globalization.Calendar.Algorithms.HinduLunarNotableDateAlgorithm> — Hindu festival dates from (month, paksha, tithi) lunisolar coordinates. Constructor: `(HinduLunarMonth month, HinduPaksha paksha, int tithi)`. Uses fixed month-offset approximation with ~19-year Metonic-cycle correction; accurate within 1–2 days for 1900–2100.
+- <xref:Bodu.Globalization.Calendar.Algorithms.HinduLunarMonth> — `Chaitra`, `Vaisakha`, `Jyaistha`, `Asadha`, `Sravana`, `Bhadrapada`, `Asvina`, `Kartika`, `Margasirsa`, `Pausa`, `Magha`, `Phalguna`.
+- <xref:Bodu.Globalization.Calendar.Algorithms.HinduPaksha> — `Shukla` (bright fortnight) or `Krishna` (dark fortnight).
 
 ## Example
 

--- a/docs/apidoc/Bodu.Globalization.Calendar.Builder.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.Builder.md
@@ -21,7 +21,7 @@ Reach for this namespace when you need to author calendar rules in C# rather tha
 - <xref:Bodu.Globalization.Calendar.Builder.NotableDateBuilder> — accumulates one or more resolution rules under a single notable-date name. Obtained via `NotableDateDocumentBuilder.AddDate(name, configure)`.
 - <xref:Bodu.Globalization.Calendar.Builder.NotableDateRuleBuilder> — the fluent rule configurator. Supports every field of <xref:Bodu.Globalization.Calendar.NotableDateRule> — strategy, category, territory, year bounds, tags, observance adjustments, calendar type, comments. Exactly one resolution strategy must be set; a second strategy call throws `InvalidOperationException`.
 - <xref:Bodu.Globalization.Calendar.Builder.ObservanceAdjustmentBuilder> — the fluent adjustment configurator. Supports trigger, action, day-of-week / fixed-date / ordinal conditional parameters, target rule for `ReplaceWithNamedDate`, custom-handler key + parameters, territory / calendar / year scope, priority, and `MaxAdjustmentReachDays` envelope.
-- <xref:Bodu.Globalization.Calendar.Builder.InlineNotableDateRuleProvider> — in-memory `INotableDateRuleProvider` over a pre-built `IReadOnlyList<NotableDateRule>`. Produced by `NotableDateDocumentBuilder.ToProvider()` and suitable for passing directly to `NotableDateService`.
+- <xref:Bodu.Globalization.Calendar.InlineNotableDateRuleProvider> — in-memory `INotableDateRuleProvider` over a pre-built `IReadOnlyList<NotableDateRule>`. Produced by `NotableDateDocumentBuilder.ToProvider()` and suitable for passing directly to `NotableDateService`.
 
 ## Example
 

--- a/docs/apidoc/Bodu.Globalization.Calendar.Plugins.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.Plugins.md
@@ -14,35 +14,35 @@ Reach for this namespace when you need to load notable-date rules and algorithms
 
 **Plugin contracts**
 
-- <xref:Bodu.Globalization.Calendar.INotableDatePlugin> — the minimum surface every external plugin must expose: `string Name`, `System.Version Version`. Plugins additionally implement one or both of the contributor interfaces below.
-- <xref:Bodu.Globalization.Calendar.INotableDateRulePlugin> — contributes rule providers via `IEnumerable<INotableDateRuleProvider> GetRuleProviders()`.
-- <xref:Bodu.Globalization.Calendar.INotableDateAlgorithmPlugin> — contributes algorithm registrations via `IEnumerable<(string key, INotableDateAlgorithm algorithm)> GetAlgorithms()`.
+- <xref:Bodu.Globalization.Calendar.Plugins.INotableDatePlugin> — the minimum surface every external plugin must expose: `string Name`, `System.Version Version`. Plugins additionally implement one or both of the contributor interfaces below.
+- <xref:Bodu.Globalization.Calendar.Plugins.INotableDateRulePlugin> — contributes rule providers via `IEnumerable<INotableDateRuleProvider> GetRuleProviders()`.
+- <xref:Bodu.Globalization.Calendar.Plugins.INotableDateAlgorithmPlugin> — contributes algorithm registrations via `IEnumerable<(string key, INotableDateAlgorithm algorithm)> GetAlgorithms()`.
 
 **Plugin declaration**
 
-- <xref:Bodu.Globalization.Calendar.NotableDatePluginAttribute> — assembly-level attribute declaring the plugin entry-point type. Exactly one attribute is required per plugin assembly. Constructor: `NotableDatePluginAttribute(Type pluginType)` where `pluginType` implements `INotableDatePlugin`.
+- <xref:Bodu.Globalization.Calendar.Plugins.NotableDatePluginAttribute> — assembly-level attribute declaring the plugin entry-point type. Exactly one attribute is required per plugin assembly. Constructor: `NotableDatePluginAttribute(Type pluginType)` where `pluginType` implements `INotableDatePlugin`.
 
 **Plugin loader**
 
-- <xref:Bodu.Globalization.Calendar.ExternalPluginLoader> — static loader: `Load(string filePath, IPluginTrustPolicy trustPolicy)` → `INotableDatePlugin`. Reflects only the `NotableDatePluginAttribute`, evaluates the supplied trust policy, and instantiates the declared entry-point type in its own non-collectible `AssemblyLoadContext`.
+- <xref:Bodu.Globalization.Calendar.Plugins.ExternalPluginLoader> — static loader: `Load(string filePath, IPluginTrustPolicy trustPolicy)` → `INotableDatePlugin`. Reflects only the `NotableDatePluginAttribute`, evaluates the supplied trust policy, and instantiates the declared entry-point type in its own non-collectible `AssemblyLoadContext`.
 
 **Trust policies**
 
-- <xref:Bodu.Globalization.Calendar.IPluginTrustPolicy> — admission gate: `Evaluate(PluginTrustContext) → PluginTrustResult`.
-- <xref:Bodu.Globalization.Calendar.PluginTrustContext> — record struct carrying `AssemblyPath`, `AssemblyName`, and `FileHash` (SHA-256).
-- <xref:Bodu.Globalization.Calendar.PluginTrustResult> — record struct: `Trusted` plus an optional `Reason`.
-- <xref:Bodu.Globalization.Calendar.FileHashPluginTrustPolicy> — admits assemblies whose SHA-256 file hash matches a pinned value keyed by assembly name. Tamper-resistant when combined with a strong-name policy.
-- <xref:Bodu.Globalization.Calendar.StrongNamePluginTrustPolicy> — admits assemblies whose strong-name public-key token is in a consumer-supplied allow-list. Tokens are compared case-insensitively as hex. Does **not** cryptographically verify the signature on its own; compose with `FileHashPluginTrustPolicy` for full tamper resistance.
-- <xref:Bodu.Globalization.Calendar.CompositePluginTrustPolicy> — AND-composes two or more policies; every child must return trusted.
-- <xref:Bodu.Globalization.Calendar.DelegatingPluginTrustPolicy> — adapts an arbitrary callback `Func<PluginTrustContext, PluginTrustResult>` into a policy. Use for runtime-driven decisions (configuration, remote attestation, logged-in user).
-- <xref:Bodu.Globalization.Calendar.AllowAllPluginTrustPolicy> — dev/test only; marks every plugin as trusted. Intentionally easy to spot in code review.
+- <xref:Bodu.Globalization.Calendar.Plugins.IPluginTrustPolicy> — admission gate: `Evaluate(PluginTrustContext) → PluginTrustResult`.
+- <xref:Bodu.Globalization.Calendar.Plugins.PluginTrustContext> — record struct carrying `AssemblyPath`, `AssemblyName`, and `FileHash` (SHA-256).
+- <xref:Bodu.Globalization.Calendar.Plugins.PluginTrustResult> — record struct: `Trusted` plus an optional `Reason`.
+- <xref:Bodu.Globalization.Calendar.Plugins.FileHashPluginTrustPolicy> — admits assemblies whose SHA-256 file hash matches a pinned value keyed by assembly name. Tamper-resistant when combined with a strong-name policy.
+- <xref:Bodu.Globalization.Calendar.Plugins.StrongNamePluginTrustPolicy> — admits assemblies whose strong-name public-key token is in a consumer-supplied allow-list. Tokens are compared case-insensitively as hex. Does **not** cryptographically verify the signature on its own; compose with `FileHashPluginTrustPolicy` for full tamper resistance.
+- <xref:Bodu.Globalization.Calendar.Plugins.CompositePluginTrustPolicy> — AND-composes two or more policies; every child must return trusted.
+- <xref:Bodu.Globalization.Calendar.Plugins.DelegatingPluginTrustPolicy> — adapts an arbitrary callback `Func<PluginTrustContext, PluginTrustResult>` into a policy. Use for runtime-driven decisions (configuration, remote attestation, logged-in user).
+- <xref:Bodu.Globalization.Calendar.Plugins.AllowAllPluginTrustPolicy> — dev/test only; marks every plugin as trusted. Intentionally easy to spot in code review.
 
 **Exception hierarchy**
 
-- <xref:Bodu.Globalization.Calendar.NotableDatePluginException> — abstract base.
-- <xref:Bodu.Globalization.Calendar.PluginNotTrustedException> — thrown when the trust policy rejects the candidate.
-- <xref:Bodu.Globalization.Calendar.PluginMissingAttributeException> — thrown when the assembly lacks a valid `NotableDatePluginAttribute` or the declared type does not implement `INotableDatePlugin`.
-- <xref:Bodu.Globalization.Calendar.PluginActivationException> — thrown when the plugin type lacks a public parameterless constructor or the constructor throws.
+- <xref:Bodu.Globalization.Calendar.Plugins.NotableDatePluginException> — abstract base.
+- <xref:Bodu.Globalization.Calendar.Plugins.PluginNotTrustedException> — thrown when the trust policy rejects the candidate.
+- <xref:Bodu.Globalization.Calendar.Plugins.PluginMissingAttributeException> — thrown when the assembly lacks a valid `NotableDatePluginAttribute` or the declared type does not implement `INotableDatePlugin`.
+- <xref:Bodu.Globalization.Calendar.Plugins.PluginActivationException> — thrown when the plugin type lacks a public parameterless constructor or the constructor throws.
 
 ## Example
 

--- a/docs/apidoc/Bodu.Globalization.Calendar.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.md
@@ -51,7 +51,7 @@ Reach for this library when a `DateTime.DayOfWeek` check is not enough: when you
 
 **Bundled Easter providers — `Bodu.Globalization.Calendar.Providers`**
 
-- <xref:Bodu.Globalization.Calendar.Providers.GregorianEasterSundayNotableDateProvider>, <xref:Bodu.Globalization.Calendar.Providers.OrthodoxEasterSundayNotableDateProvider> — Western (Gregorian) and Eastern (Julian-anchored) Easter providers.
+- <xref:Bodu.Globalization.Calendar.Algorithms.GregorianEasterSundayNotableDateProvider>, <xref:Bodu.Globalization.Calendar.Algorithms.OrthodoxEasterSundayNotableDateProvider> — Western (Gregorian) and Eastern (Julian-anchored) Easter providers.
 
 **Adjustment pipeline**
 

--- a/docs/apidoc/Bodu.Globalization.Extensions.md
+++ b/docs/apidoc/Bodu.Globalization.Extensions.md
@@ -12,7 +12,7 @@ uid: Bodu.Globalization.Extensions
 
 The namespace provides helpers for working with `CultureInfo`, `RegionInfo`, `CalendarWeekendDefinition`, and `WorkingDaysOfWeek` in scenarios where the BCL surface is too narrow for calendar-style queries.
 
-For the broader date / time / culture surface, see <xref:Bodu.Extensions.DateTimeExtensions>, <xref:Bodu.Extensions.DateOnlyExtensions>, and <xref:Bodu.Extensions.DateTimeFormatInfoExtensions>.
+For the broader date / time / culture surface, see <xref:Bodu.Extensions.DateTimeExtensions>, <xref:Bodu.Extensions.DateOnlyExtensions>, and <xref:Bodu.Globalization.Extensions.DateTimeFormatInfoExtensions>.
 
 ## Notes
 

--- a/docs/apidoc/Bodu.IO.Hashing.CheckDigits.md
+++ b/docs/apidoc/Bodu.IO.Hashing.CheckDigits.md
@@ -6,19 +6,19 @@ uid: Bodu.IO.Hashing.CheckDigits
 
 ## Purpose
 
-**Bodu.IO.Hashing.CheckDigits** ships the catalogue of single-character and multi-character check-digit algorithms — Luhn, Damm, Verhoeff, Pearson, plus the standard catalogues used by financial, retail, securities, and publishing identifiers (IBAN, LEI, EAN, GTIN, UPC, ISBN, ISIN, SEDOL, CUSIP, ABA routing, …). Every algorithm derives from <xref:Bodu.IO.Hashing.CheckDigitAlgorithm>, <xref:Bodu.IO.Hashing.MultiCharCheckDigitAlgorithm>, or <xref:Bodu.IO.Hashing.AlphanumericCheckDigitAlgorithm>.
+**Bodu.IO.Hashing.CheckDigits** ships the catalogue of single-character and multi-character check-digit algorithms — Luhn, Damm, Verhoeff, Pearson, plus the standard catalogues used by financial, retail, securities, and publishing identifiers (IBAN, LEI, EAN, GTIN, UPC, ISBN, ISIN, SEDOL, CUSIP, ABA routing, …). Every algorithm derives from <xref:Bodu.IO.Hashing.CheckDigits.CheckDigitAlgorithm>, <xref:Bodu.IO.Hashing.CheckDigits.MultiCharCheckDigitAlgorithm>, or <xref:Bodu.IO.Hashing.CheckDigits.AlphanumericCheckDigitAlgorithm>.
 
 ## Key types
 
 **Generic algorithms** — applicable to any identifier shape:
 
-- <xref:Bodu.IO.Hashing.CheckDigits.Luhn>, <xref:Bodu.IO.Hashing.CheckDigits.Damm>, <xref:Bodu.IO.Hashing.CheckDigits.Verhoeff>, <xref:Bodu.IO.Hashing.CheckDigits.Pearson>, <xref:Bodu.IO.Hashing.CheckDigits.Gumm>
+- <xref:Bodu.IO.Hashing.CheckDigits.Luhn>, <xref:Bodu.IO.Hashing.CheckDigits.Damm>, <xref:Bodu.IO.Hashing.CheckDigits.Verhoeff>, <xref:Bodu.IO.Hashing.Pearson>, <xref:Bodu.IO.Hashing.CheckDigits.Gumm>
 
 **Financial / banking identifiers:**
 
 - <xref:Bodu.IO.Hashing.CheckDigits.AbaRoutingNumber> — ABA routing number (US).
-- <xref:Bodu.IO.Hashing.CheckDigits.Iban> — IBAN MOD-97.
-- <xref:Bodu.IO.Hashing.CheckDigits.Lei> — Legal Entity Identifier (ISO 17442).
+- <xref:Bodu.IO.Hashing.Checksums.Iban> — IBAN MOD-97.
+- <xref:Bodu.IO.Hashing.Checksums.Lei> — Legal Entity Identifier (ISO 17442).
 
 **Retail / GS1:**
 
@@ -26,11 +26,11 @@ uid: Bodu.IO.Hashing.CheckDigits
 
 **Securities:**
 
-- <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Isin>, <xref:Bodu.IO.Hashing.CheckDigits.Sedol>
+- <xref:Bodu.IO.Hashing.Checksums.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Isin>, <xref:Bodu.IO.Hashing.Checksums.Sedol>
 
 **Publishing:**
 
-- <xref:Bodu.IO.Hashing.CheckDigits.Isbn10>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn13>
+- <xref:Bodu.IO.Hashing.Checksums.Isbn10>, <xref:Bodu.IO.Hashing.Checksums.Isbn13>
 
 **Encoded identifiers:**
 
@@ -38,7 +38,7 @@ uid: Bodu.IO.Hashing.CheckDigits
 
 **ISO 7064:**
 
-- <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod97_10>
+- <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod97_10>
 
 ## Example
 

--- a/docs/apidoc/Bodu.IO.Hashing.Checksums.md
+++ b/docs/apidoc/Bodu.IO.Hashing.Checksums.md
@@ -6,7 +6,7 @@ uid: Bodu.IO.Hashing.Checksums
 
 ## Purpose
 
-**Bodu.IO.Hashing.Checksums** ships the cyclic redundancy check (CRC) catalogue from the [RevEng project](https://reveng.sourceforge.io/crc-catalogue/) — every variant from CRC-1 through CRC-64, addressable by name. The catalogue is auto-generated and partial; the consumer-facing surface is the static <xref:Bodu.IO.Hashing.Checksums.CrcStandard> class, used as a parameter to <xref:Bodu.IO.Hashing.Crc>.
+**Bodu.IO.Hashing.Checksums** ships the cyclic redundancy check (CRC) catalogue from the [RevEng project](https://reveng.sourceforge.io/crc-catalogue/) — every variant from CRC-1 through CRC-64, addressable by name. The catalogue is auto-generated and partial; the consumer-facing surface is the static <xref:Bodu.IO.Hashing.Checksums.CrcStandard> class, used as a parameter to <xref:Bodu.IO.Hashing.Checksums.Crc>.
 
 ## Key types
 

--- a/docs/apidoc/Bodu.IO.Hashing.Extensions.md
+++ b/docs/apidoc/Bodu.IO.Hashing.Extensions.md
@@ -10,7 +10,7 @@ uid: Bodu.IO.Hashing.Extensions
 
 ## Key types
 
-- <xref:Bodu.IO.Hashing.Extensions.CrcLookupTableBuilder> — builds the precomputed lookup table for a given CRC standard. The same table is cached process-wide by <xref:Bodu.IO.Hashing.CrcLookupTableCache>; reach for the builder directly only when you need to compute a table for a non-standard CRC variant.
+- <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableBuilder> — builds the precomputed lookup table for a given CRC standard. The same table is cached process-wide by <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableCache>; reach for the builder directly only when you need to compute a table for a non-standard CRC variant.
 - <xref:Bodu.IO.Hashing.Extensions.NonCryptographicHashAlgorithmExtensions> — convenience methods on `System.IO.Hashing.NonCryptographicHashAlgorithm` — `GetCurrentHashAsUInt32`, `GetCurrentHashAsUInt64`, stream / span overloads, and helpers that fit between the BCL surface and the Bodu hash algorithms.
 
 ## Example
@@ -28,5 +28,5 @@ uint value = crc.GetCurrentHashAsUInt32();
 
 ## Notes
 
-- **Cache, don't rebuild.** Lookup-table construction is non-trivial; prefer <xref:Bodu.IO.Hashing.CrcLookupTableCache> for standard CRC variants. The builder is exposed for non-standard cases (custom polynomial, custom refIn / refOut configuration).
+- **Cache, don't rebuild.** Lookup-table construction is non-trivial; prefer <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableCache> for standard CRC variants. The builder is exposed for non-standard cases (custom polynomial, custom refIn / refOut configuration).
 - **See also:** the [CRC guide](~/guides/io-hashing/crc.md), the [Bodu.IO.Hashing landing page](xref:Bodu.IO.Hashing).

--- a/docs/apidoc/Bodu.IO.Hashing.md
+++ b/docs/apidoc/Bodu.IO.Hashing.md
@@ -26,7 +26,7 @@ Reach for this library when you need a fast, deterministic checksum for error de
 - <xref:Bodu.IO.Hashing.Fnv1a32> / <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Fnv132> / <xref:Bodu.IO.Hashing.Fnv164> — constant-memory streaming FNV; prefer `Fnv1a*` for better avalanche.
 - <xref:Bodu.IO.Hashing.CityHash32> / <xref:Bodu.IO.Hashing.CityHash64> / <xref:Bodu.IO.Hashing.CityHash128> — SIMD-friendly hashes optimized for long inputs.
 - <xref:Bodu.IO.Hashing.MurmurHash3_32> / <xref:Bodu.IO.Hashing.MurmurHash3_128> — seeded high-avalanche fingerprints.
-- <xref:Bodu.IO.Hashing.Pearson> — table-driven hash with output widths from 8 to 2048 bits in 8-bit steps; five built-in permutation tables via <xref:Bodu.IO.Hashing.PearsonTableType>.
+- <xref:Bodu.IO.Hashing.Pearson> — table-driven hash with output widths from 8 to 2048 bits in 8-bit steps; five built-in permutation tables via <xref:Bodu.IO.Hashing.Pearson.PearsonTableType>.
 - <xref:Bodu.IO.Hashing.Bernstein>, <xref:Bodu.IO.Hashing.BKDR>, <xref:Bodu.IO.Hashing.SDBM>, <xref:Bodu.IO.Hashing.JSHash>, <xref:Bodu.IO.Hashing.Elf64>, <xref:Bodu.IO.Hashing.ApHash>, <xref:Bodu.IO.Hashing.Pjw32>, <xref:Bodu.IO.Hashing.SuperFastHash> — classic string hashes from compilers and early web tooling.
 - <xref:Bodu.IO.Hashing.BlockNonCryptographicHashAlgorithm`1> — abstract CRTP base for buffered block-oriented algorithms.
 - <xref:Bodu.IO.Hashing.IResumableHashAlgorithm> — optional contract that reverse-finalizes a stored digest and continues appending; implemented by <xref:Bodu.IO.Hashing.Checksums.Crc>.

--- a/docs/apidoc/Bodu.Numerics.md
+++ b/docs/apidoc/Bodu.Numerics.md
@@ -21,7 +21,7 @@ Reach for this library when you need rational arithmetic that does not lose prec
 **Rational arithmetic**
 
 - <xref:Bodu.Numerics.Fraction`1> — immutable rational with auto-reduction to canonical form, `BigInteger`-promoted intermediates for safe arithmetic, and the full `INumber<T>` / `ISignedNumber<T>` surface. Backed by any `IBinaryInteger<T>` — `int`, `long`, `BigInteger`, or a custom type.
-- <xref:Bodu.Numerics.FractionJsonConverter`1>, <xref:Bodu.Numerics.FractionJsonConverterFactory> — `System.Text.Json` converters auto-registered via `[JsonConverter]`; wire shape is the string form `"numerator/denominator"`.
+- <xref:Bodu.Numerics.Serialization.FractionJsonConverter`1>, <xref:Bodu.Numerics.Serialization.FractionJsonConverterFactory> — `System.Text.Json` converters auto-registered via `[JsonConverter]`; wire shape is the string form `"numerator/denominator"`.
 
 **Bounded intervals**
 

--- a/docs/apidoc/Bodu.Security.Cryptography.md
+++ b/docs/apidoc/Bodu.Security.Cryptography.md
@@ -34,7 +34,7 @@ For non-cryptographic checksums and hash-table hashes (CRC, Fletcher, Adler, FNV
 - <xref:Bodu.Security.Cryptography.Threefish256>, <xref:Bodu.Security.Cryptography.Threefish512>, <xref:Bodu.Security.Cryptography.Threefish1024> — 256 / 512 / 1024-bit blocks and keys, all with a 128-bit tweak. Threefish-512 is the recommended general-purpose variant; Threefish-256 underpins Skein-256.
 - <xref:Bodu.Security.Cryptography.Serpent256>, <xref:Bodu.Security.Cryptography.Serpent512>, <xref:Bodu.Security.Cryptography.Serpent1024> — wide-block tweakable Serpent constructions (non-standard).
 
-**Stream ciphers** (<xref:Bodu.Security.Cryptography.StreamCipherAlgorithm> lifecycle — a `SymmetricAlgorithm` with no block mode or padding; the nonce is the `IV`. Self-inverse and **confidentiality-only — no authentication**)
+**Stream ciphers** (<xref:Bodu.Security.Cryptography.SymmetricStreamAlgorithm> lifecycle — a `SymmetricAlgorithm` with no block mode or padding; the nonce is the `IV`. Self-inverse and **confidentiality-only — no authentication**)
 
 - <xref:Bodu.Security.Cryptography.ChaCha20> — 256-bit key, 96-bit nonce, 32-bit counter (Bernstein; RFC 8439). The modern default.
 - <xref:Bodu.Security.Cryptography.XChaCha20> — 256-bit key, 192-bit nonce; extended-nonce ChaCha20 via an HChaCha20 subkey, so the nonce can be chosen at random.
@@ -80,7 +80,7 @@ For non-cryptographic checksums and hash-table hashes (CRC, Fletcher, Adler, FNV
 **Extensions and helpers**
 
 - <xref:Bodu.Security.Cryptography.Extensions.SymmetricAlgorithmExtensions>, <xref:Bodu.Security.Cryptography.Extensions.TweakableSymmetricAlgorithmExtensions>, <xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions>, <xref:Bodu.Security.Cryptography.Extensions.HashAlgorithmExtensions>, <xref:Bodu.Security.Cryptography.Extensions.ICryptoTransformExtensions> — ergonomic one-shot, async, and verify helpers.
-- <xref:Bodu.Security.Cryptography.CryptoHelpers> — secure zeroization, padding helpers, cryptographically secure random key/IV/tweak generation, bit reflection.
+- Secure-zeroization, padding, and cryptographically secure random key/IV/tweak generation helpers ship as internal infrastructure; consumers reach them indirectly through the extension surfaces above (for example `SymmetricAlgorithmExtensions.GenerateNonce`, `HashAlgorithmExtensions.VerifyHash`).
 - <xref:Bodu.Security.Cryptography.HashAlgorithmHelper>, <xref:Bodu.Security.Cryptography.HashAlgorithmFactory>, <xref:Bodu.Security.Cryptography.IHashAlgorithmFactory`1>, <xref:Bodu.Security.Cryptography.DelegateHashAlgorithmFactory`1> — helper utilities for `HashAlgorithm` consumers and factory abstractions used by the keyed / Merkle constructions.
 
 ## Example

--- a/docs/apidoc/Bodu.Text.Configuration.md
+++ b/docs/apidoc/Bodu.Text.Configuration.md
@@ -8,7 +8,7 @@ uid: Bodu.Text.Configuration
 
 **Bodu.Text.Configuration** is the configuration-layering package of the Bodu suite. It parses INI / EditorConfig-style text, optionally collects diagnostics, layers a preamble plus glob-anchored sections in source order for a target path, and projects the result into a flat, colon-delimited <xref:Bodu.Text.Configuration.ConfigurationView>. The view exposes typed accessors (`GetString`, `GetInt32`, `GetBoolean`, `GetEnum<T>`, `GetValue<T>` for any <xref:System.ISpanParsable`1>) and integrates directly with `Microsoft.Extensions.Configuration` through the sibling <xref:Bodu.Extensions.Configuration.Text> package.
 
-Reach for this library when you need EditorConfig-style file-targeted configuration layering, programmatic INI parsing with diagnostic collection, or a `Microsoft.Extensions.Configuration`-compatible flat key/value view without taking a dependency on `Microsoft.Extensions.*` from the parser itself. The underlying data model is <xref:Bodu.Text.Ini.IniDocument> from the <xref:Bodu.Text.Formats> package, so anything the INI codec can read is something `Bodu.Text.Configuration` can resolve.
+Reach for this library when you need EditorConfig-style file-targeted configuration layering, programmatic INI parsing with diagnostic collection, or a `Microsoft.Extensions.Configuration`-compatible flat key/value view without taking a dependency on `Microsoft.Extensions.*` from the parser itself. The underlying data model is <xref:Bodu.Text.Ini.IniDocument> from the `Bodu.Text.Formats` package, so anything the INI codec can read is something `Bodu.Text.Configuration` can resolve.
 
 ## Static documentation
 

--- a/docs/apidoc/Bodu.Text.Encoding.md
+++ b/docs/apidoc/Bodu.Text.Encoding.md
@@ -10,7 +10,7 @@ uid: Bodu.Text.Encoding
 
 The package fills two gaps that <xref:System.Convert> and `System.Buffers.Text.Base64` leave open: **variants** the BCL does not cover (base32hex, Crockford Base32, z-base-32, Base58 Bitcoin / Flickr / Ripple, Ascii85, Z85), and **lenient parsing** / **formatting decoration** — `0x` prefix tolerance, whitespace stripping, byte spacing, line breaks every 64 / 76 characters — for the encodings that benefit from them.
 
-For structured binary serialization formats with their own framing grammar (Bencode, INI), see the companion <xref:Bodu.Text.Formats> package.
+For structured binary serialization formats with their own framing grammar (Bencode, INI), see the companion `Bodu.Text.Formats` package — namespaces <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Ini>.
 
 ## Static documentation
 

--- a/docs/docfx.json
+++ b/docs/docfx.json
@@ -15,7 +15,8 @@
       "globalNamespaceId": "global",
       "disableDefaultFilter": false,
       "properties": {
-        "TargetFramework": "net8.0"
+        "TargetFramework": "net8.0",
+        "BuildingForDocfx": "true"
       }
     }
   ],

--- a/docs/docs/calendar/index.md
+++ b/docs/docs/calendar/index.md
@@ -126,7 +126,7 @@ The `Bodu.Globalization.Calendar.Algorithms` namespace ships concrete algorithm 
 | <xref:Bodu.Globalization.Calendar.Algorithms.VesakNotableDateAlgorithm> | Buddhist Vesak / Buddha Day. |
 | <xref:Bodu.Globalization.Calendar.Algorithms.AsalhaPujaNotableDateAlgorithm> | Asalha Puja. |
 | <xref:Bodu.Globalization.Calendar.Algorithms.QingmingNotableDateAlgorithm> | Qingming festival (sun-longitude based). |
-| <xref:Bodu.Globalization.Calendar.Providers.GregorianEasterSundayNotableDateProvider>, <xref:Bodu.Globalization.Calendar.Providers.OrthodoxEasterSundayNotableDateProvider> | Bundled Easter providers — Western (Gregorian) and Eastern (Julian-anchored). |
+| <xref:Bodu.Globalization.Calendar.Algorithms.GregorianEasterSundayNotableDateProvider>, <xref:Bodu.Globalization.Calendar.Algorithms.OrthodoxEasterSundayNotableDateProvider> | Bundled Easter providers — Western (Gregorian) and Eastern (Julian-anchored). |
 
 Region-specific holiday rule providers ship separately in `Bodu.Globalization.Calendar.Data.*` companion packages on independent release schedules — see [Calendar data packs](../../guides/calendar/data-packs.md).
 

--- a/docs/docs/core/index.md
+++ b/docs/docs/core/index.md
@@ -85,8 +85,8 @@ Text and XML helpers used internally by the other Bodu packages; available publi
 
 | Type | Purpose |
 |---|---|
-| <xref:Bodu.Text.BaseEncoding> | Entry points for Base16, Base24, Base32, and Base64 over text or binary input. |
-| <xref:Bodu.Text.BaseFormatStyles>, <xref:Bodu.Text.BaseFormattingOptions> | Formatting-style and option flags consumed by `BaseEncoding`. |
+| <xref:Bodu.Text.Encoding.Base16>, <xref:Bodu.Text.Encoding.Base32>, <xref:Bodu.Text.Encoding.Base58>, <xref:Bodu.Text.Encoding.Base64>, <xref:Bodu.Text.Encoding.Base85> | Per-radix codec entry points over text or binary input. Ship in the companion `Bodu.Text.Encoding` package. |
+| <xref:Bodu.Text.Encoding.BaseFormatStyles>, <xref:Bodu.Text.Encoding.BaseFormattingOptions> | Formatting-style and option flags consumed by every per-radix codec. |
 | <xref:Bodu.Xml.Linq.XmlNamespaceResolver> | `IXmlNamespaceResolver` helper used by the calendar rule parsers. |
 
 ## Scenarios this library covers
@@ -104,7 +104,7 @@ Text and XML helpers used internally by the other Bodu packages; available publi
 | Pooled byte / char buffer for zero-allocation building | <xref:Bodu.Buffers.PooledBufferBuilder`1> |
 | Date arithmetic — first Monday, ISO week-of-year, age | <xref:Bodu.Extensions.DateTimeExtensions>, <xref:Bodu.Extensions.DateOnlyExtensions> |
 | Bit / byte rotation and reversal | <xref:Bodu.Extensions.NumericExtensions> |
-| Base16 / Base24 / Base32 / Base64 encoding | <xref:Bodu.Text.BaseEncoding> |
+| Base16 / Base32 / Base58 / Base64 / Base85 encoding | <xref:Bodu.Text.Encoding.Base16>, <xref:Bodu.Text.Encoding.Base32>, <xref:Bodu.Text.Encoding.Base58>, <xref:Bodu.Text.Encoding.Base64>, <xref:Bodu.Text.Encoding.Base85> (in `Bodu.Text.Encoding`) |
 | Centralized argument validation in your own code | <xref:Bodu.ThrowHelper> |
 
 ## Where to go next

--- a/docs/docs/cryptography/index.md
+++ b/docs/docs/cryptography/index.md
@@ -81,7 +81,7 @@ Cryptographic digests in this table provide **integrity only when the digest its
 | <xref:Bodu.Security.Cryptography.Serpent1024> | 1024 bits | 1024 bits | 128 bits | Wide-block tweakable Serpent — non-standard construction. |
 
 ### Stream ciphers
-*<xref:Bodu.Security.Cryptography.StreamCipherAlgorithm> lifecycle (a `SymmetricAlgorithm` with no block mode or padding): configure `Key` and `IV` (the nonce), then `CreateEncryptor()` / `Encrypt`. Self-inverse and raw — **confidentiality only, no authentication**. Never reuse a `(key, nonce)` pair; pair with a MAC or prefer AEAD.*
+*<xref:Bodu.Security.Cryptography.SymmetricStreamAlgorithm> lifecycle (a `SymmetricAlgorithm` with no block mode or padding): configure `Key` and `IV` (the nonce), then `CreateEncryptor()` / `Encrypt`. Self-inverse and raw — **confidentiality only, no authentication**. Never reuse a `(key, nonce)` pair; pair with a MAC or prefer AEAD.*
 
 | Type | Key | Nonce / IV | Notes |
 |---|---|---|---|
@@ -161,8 +161,9 @@ Cryptographic digests in this table provide **integrity only when the digest its
 
 | Type | Purpose |
 |---|---|
-| <xref:Bodu.Security.Cryptography.CryptoHelpers> | Random key/IV/tweak generation, padding helpers, secure-clear helpers. |
 | <xref:Bodu.Security.Cryptography.HashAlgorithmHelper> | Helper utilities for `HashAlgorithm` consumers. |
+
+Random key/IV/tweak generation, padding helpers, and secure-clear helpers ship as internal infrastructure; consumers reach them indirectly through the extension surfaces above.
 
 ## Scenarios this library covers
 

--- a/docs/docs/formats/concepts.md
+++ b/docs/docs/formats/concepts.md
@@ -48,7 +48,7 @@ BEP 3 invariants enforced by the parser:
 - The declared payload must fit in the remaining input.
 - The length itself must fit in `Int32`.
 
-A bencoded string is **not** required to be text. Consumers that know a field is UTF-8 can call <xref:Bodu.Text.Bencode.BencodedString.GetUtf8String> to project it, or build one from a `string` via <xref:Bodu.Text.Bencode.BencodedString.FromUtf8>. For arbitrary binary, hold onto the raw `Bytes` directly.
+A bencoded string is **not** required to be text. Consumers that know a field is UTF-8 can call <xref:Bodu.Text.Bencode.BencodedString.GetUtf8String> to project it, or build one from a `string` via <xref:Bodu.Text.Bencode.BencodedString.FromUtf8(System.String)>. For arbitrary binary, hold onto the raw `Bytes` directly.
 
 ### List (`BencodedList`)
 

--- a/docs/docs/formats/index.md
+++ b/docs/docs/formats/index.md
@@ -92,8 +92,8 @@ Every format follows the same shape — a static codec, a typed value tree, a fo
 | Type | Purpose |
 |---|---|
 | <xref:Bodu.Text.Delimited.Delimited> | Static codec — read and write delimited records over span / byte / `Stream` / `TextReader` / `TextWriter`. |
-| <xref:Bodu.Text.Delimited.DelimitedDocument>, <xref:Bodu.Text.Delimited.DelimitedRow>, <xref:Bodu.Text.Delimited.DelimitedField> | Immutable document model. |
-| <xref:Bodu.Text.Delimited.DelimitedParseOptions>, <xref:Bodu.Text.Delimited.DelimitedWriteOptions> | Quoting policy, delimiter selection (comma / tab / custom), header handling. |
+| <xref:Bodu.Text.Delimited.DelimitedDocument>, <xref:Bodu.Text.Delimited.DelimitedRow> | Immutable document model. Each row exposes its `Fields` as `IReadOnlyList<string>`. |
+| <xref:Bodu.Text.Delimited.DelimitedParseOptions> | Quoting policy, delimiter selection (comma / tab / custom), header handling. Shared between read and write paths. |
 | <xref:Bodu.Text.Delimited.DelimitedFormatException> | Thrown for unterminated quotes, ragged rows under strict mode, and other structural violations. |
 
 ### DotEnv — <xref:Bodu.Text.DotEnv>
@@ -102,7 +102,7 @@ Every format follows the same shape — a static codec, a typed value tree, a fo
 |---|---|
 | <xref:Bodu.Text.DotEnv.DotEnv> | Static codec — read and write `.env` documents. |
 | <xref:Bodu.Text.DotEnv.DotEnvDocument>, <xref:Bodu.Text.DotEnv.DotEnvEntry> | Ordered key/value model that preserves entry order. |
-| <xref:Bodu.Text.DotEnv.DotEnvParseOptions>, <xref:Bodu.Text.DotEnv.DotEnvWriteOptions> | Quote handling, comment preservation, escape policy. |
+| <xref:Bodu.Text.DotEnv.DotEnvParseOptions> | Quote handling, comment preservation, escape policy. Shared between read and write paths. |
 | <xref:Bodu.Text.DotEnv.DotEnvFormatException> | Thrown for malformed key/value lines. |
 
 ### INI — <xref:Bodu.Text.Ini>
@@ -111,7 +111,7 @@ Every format follows the same shape — a static codec, a typed value tree, a fo
 |---|---|
 | <xref:Bodu.Text.Ini.Ini> | Static codec — read and write INI documents. |
 | <xref:Bodu.Text.Ini.IniDocument>, <xref:Bodu.Text.Ini.IniSection>, <xref:Bodu.Text.Ini.IniEntry> | Section/entry model that preserves comments, whitespace, and order. |
-| <xref:Bodu.Text.Ini.IniParseOptions>, <xref:Bodu.Text.Ini.IniWriteOptions> | Profile presets, escape rules, duplicate-section policy. |
+| <xref:Bodu.Text.Ini.IniParseOptions> | Profile presets, escape rules, duplicate-section policy. Shared between read and write paths. |
 | <xref:Bodu.Text.Ini.IniFormatException> | Thrown for malformed headers, entries, or escape sequences. |
 
 ## Where to go next

--- a/docs/docs/numerics/index.md
+++ b/docs/docs/numerics/index.md
@@ -19,7 +19,7 @@ title: Bodu.Numerics — Introduction
 | <xref:Bodu.Numerics.Fraction`1> | Immutable canonical rational over any `IBinaryInteger<T>` backing type. Auto-reduces to GCD-normalised form on construction, raises overflow to `BigInteger` precision internally, and implements the full `INumber<T>` / `ISignedNumber<T>` surface. |
 | <xref:Bodu.Numerics.Interval`1> | Immutable bounded interval over any `INumber<T>` endpoint type. Endpoint inclusivity is independent on each side so a single type expresses closed-closed, open-open, closed-open, and open-closed forms. |
 | <xref:Bodu.Numerics.Interval> | Non-generic helper class with factory methods (`Closed`, `Open`, `ClosedOpen`, `OpenClosed`) that infer the endpoint type from the arguments. |
-| <xref:Bodu.Numerics.FractionJsonConverter`1>, <xref:Bodu.Numerics.FractionJsonConverterFactory> | `System.Text.Json` converters auto-registered via `[JsonConverter]` on `Fraction<T>` — wire shape is the string `"numerator/denominator"`. |
+| <xref:Bodu.Numerics.Serialization.FractionJsonConverter`1>, <xref:Bodu.Numerics.Serialization.FractionJsonConverterFactory> | `System.Text.Json` converters auto-registered via `[JsonConverter]` on `Fraction<T>` — wire shape is the string `"numerator/denominator"`. |
 
 ## Scenarios this library covers
 

--- a/docs/docs/text-configuration/concepts.md
+++ b/docs/docs/text-configuration/concepts.md
@@ -12,7 +12,7 @@ For the high-level shape of the library and the pipeline diagram, start with the
 ## Document and view
 
 A **document** is the parsed-but-not-yet-resolved representation of the source text. It is an
-<xref:Bodu.Text.Ini.IniDocument> from <xref:Bodu.Text.Formats> — the same structure the INI codec produces — with a
+<xref:Bodu.Text.Ini.IniDocument> from the `Bodu.Text.Formats` package — the same structure the INI codec produces — with a
 preamble (the global section) and zero or more named sections in source order. The document preserves comments,
 ordering, and duplicate-policy decisions, so it can be re-emitted byte-for-byte.
 

--- a/docs/guides/calendar/notable-date-builder.md
+++ b/docs/guides/calendar/notable-date-builder.md
@@ -56,7 +56,7 @@ INotableDateRuleProvider      provider  = builder.ToProvider();
 - `Build()` — returns the in-memory rule set. Use this when wiring the builder directly into a test, the range-resolution pipeline, or a one-off `NotableDateService` instance.
 - `ToXDocument()` / `ToXml()` — emits the document in the schema-valid XML form recognised by <xref:Bodu.Globalization.Calendar.XmlResourceNotableDateRuleProvider>. The XML conforms to the `urn:bodu:globalization:calendar` namespace and is suitable for embedding in a resource assembly.
 - `ToJsonNode()` / `ToJson()` — emits the JSON peer, conforming to `NotableDates.schema.json` and consumable by <xref:Bodu.Globalization.Calendar.JsonResourceNotableDateRuleProvider>.
-- `ToProvider()` — wraps `Build()` in an <xref:Bodu.Globalization.Calendar.Builder.InlineNotableDateRuleProvider> for passing directly to `NotableDateService`.
+- `ToProvider()` — wraps `Build()` in an <xref:Bodu.Globalization.Calendar.InlineNotableDateRuleProvider> for passing directly to `NotableDateService`.
 
 The XML / JSON forms strip programmatic-only fields that have no schema representation: `AddHandlerParameter` entries on adjustments and `MaxAdjustmentReachDays` are preserved in `Build()` / `ToProvider()` but dropped from `ToXDocument()` / `ToJsonNode()`.
 

--- a/docs/guides/calendar/working-days.md
+++ b/docs/guides/calendar/working-days.md
@@ -123,18 +123,18 @@ If `NotableDateContext.Default` is left unassigned, the property lazily construc
 
 ## Weekend behaviour
 
-The service's <xref:Bodu.Globalization.Calendar.CalendarWeekendDefinition> controls which days the working-day extensions treat as weekends:
+The service's `WorkingWeek` property (a <xref:Bodu.WeekPattern>) defines which days are working; any day outside the pattern is treated as a weekend. Use the named presets on <xref:Bodu.WeekPattern> for common shapes, or construct a custom pattern for non-standard schedules:
 
-| Value | Weekend days |
-|---|---|
-| `None` | No weekend — every weekday counts as working unless a non-working notable date applies. |
-| `SaturdaySunday` | Saturday + Sunday (most western territories). |
-| `FridaySaturday` | Friday + Saturday (parts of the Middle East). |
-| `SundayOnly` | Sunday only. |
-| `FridayOnly` | Friday only. |
-| `Custom` | Any explicit subset via `WeekPattern`. |
+| Preset | Working days | Weekend days |
+|---|---|---|
+| `WeekPattern.AllDays` | Every day | No weekend — every day counts as working unless a non-working notable date applies. |
+| `WeekPattern.MondayToFriday` | Mon–Fri | Saturday + Sunday (most western territories). |
+| `WeekPattern.SundayToThursday` | Sun–Thu | Friday + Saturday (parts of the Middle East). |
+| `WeekPattern.MondayToSaturday` | Mon–Sat | Sunday only. |
+| `WeekPattern.SaturdayToThursday` | Sat–Thu | Friday only. |
+| Custom | Any caller-supplied bitmask | Any complementary subset via <xref:Bodu.WeekPattern>. |
 
-Set this at service construction time. Mixed-weekend services are best modelled by composing multiple services or by combining weekend definitions in custom rules.
+Set this at service construction time via the `workingWeek` constructor argument. Mixed-weekend services are best modelled by composing multiple services or by combining weekend definitions in custom rules.
 
 ## Public holidays vs. observances
 

--- a/docs/guides/core/choosing-a-collection.md
+++ b/docs/guides/core/choosing-a-collection.md
@@ -9,21 +9,21 @@ Bodu.Core ships more than a dozen collection types. This page is the decision gu
 ## Quick decision tree
 
 1. **Do you need a key-value store?**
-   - Bounded with eviction (cache) → <xref:Bodu.Collections.Generic.EvictingDictionary\`2>.
-   - Keys are ranges (`[start, end)`) → <xref:Bodu.Collections.Generic.RangeDictionary\`2>.
-   - One key maps to many values → <xref:Bodu.Collections.Generic.MultiValueDictionary\`2>.
+   - Bounded with eviction (cache) → <xref:Bodu.Collections.Generic.EvictingDictionary`2>.
+   - Keys are ranges (`[start, end)`) → <xref:Bodu.Collections.Generic.RangeDictionary`2>.
+   - One key maps to many values → <xref:Bodu.Collections.Generic.MultiValueDictionary`2>.
 2. **Do you need a sequence (FIFO / LIFO / two-ended)?**
-   - Fixed capacity, single-threaded, overwrite-or-throw on full → <xref:Bodu.Collections.Generic.CircularBuffer\`1>.
-   - Fixed capacity, multi-threaded → <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer\`1>.
-   - Both ends, O(1) push / pop on either end → <xref:Bodu.Collections.Generic.Deque\`1>.
-   - Append-only, unknown final length → <xref:Bodu.Collections.Generic.SegmentedBuffer\`1>.
+   - Fixed capacity, single-threaded, overwrite-or-throw on full → <xref:Bodu.Collections.Generic.CircularBuffer`1>.
+   - Fixed capacity, multi-threaded → <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer`1>.
+   - Both ends, O(1) push / pop on either end → <xref:Bodu.Collections.Generic.Deque`1>.
+   - Append-only, unknown final length → <xref:Bodu.Collections.Generic.SegmentedBuffer`1>.
 3. **Do you need set semantics?**
-   - Insertion-ordered, unique, indexable like a list → <xref:Bodu.Collections.Generic.IndexedSet\`1>.
-   - Insertion-ordered, unique, read-only index view → <xref:Bodu.Collections.Generic.OrderedSet\`1>.
-   - Unordered, unique, multi-threaded → <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet\`1>.
-   - Duplicates retained as multiplicity → <xref:Bodu.Collections.Generic.Multiset\`1>.
-   - Set of disjoint half-open intervals → <xref:Bodu.Collections.Generic.RangeSet\`1>.
-4. **Do you need a priority queue with key-based updates?** → <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2>.
+   - Insertion-ordered, unique, indexable like a list → <xref:Bodu.Collections.Generic.IndexedSet`1>.
+   - Insertion-ordered, unique, read-only index view → <xref:Bodu.Collections.Generic.OrderedSet`1>.
+   - Unordered, unique, multi-threaded → <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet`1>.
+   - Duplicates retained as multiplicity → <xref:Bodu.Collections.Generic.Multiset`1>.
+   - Set of disjoint half-open intervals → <xref:Bodu.Collections.Generic.RangeSet`1>.
+4. **Do you need a priority queue with key-based updates?** → <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2>.
 
 If none of the above fit, the BCL types (`List<T>`, `Dictionary<TKey,TValue>`, `HashSet<T>`, `Queue<T>`, `Stack<T>`) are the right choice. Bodu.Core does not duplicate BCL primitives — every type below adds a contract the BCL does not provide.
 
@@ -35,57 +35,57 @@ The remainder of this page deepens that tree into per-axis tables, real-world sc
 
 | Requirement | Reach for | Notes |
 |---|---|---|
-| Single-ended FIFO ring | <xref:Bodu.Collections.Generic.CircularBuffer\`1> | `AllowOverwrite` toggles between sliding-window and bounded-throw modes. |
-| Double-ended ring | <xref:Bodu.Collections.Generic.Deque\`1> | O(1) `AddFirst` / `AddLast` / `RemoveFirst` / `RemoveLast`. |
-| Append-only stream of unknown length | <xref:Bodu.Collections.Generic.SegmentedBuffer\`1> | Grows by fixed-size chunks; avoids the array-doubling copy. |
-| Min-heap priority queue with O(1) lookup-by-element | <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2> | Required by Dijkstra, Prim, A* — the `Update` / `EnqueueOrUpdate` calls the BCL `PriorityQueue<TElement,TPriority>` cannot perform. |
-| Range-keyed lookup (interval → value) | <xref:Bodu.Collections.Generic.RangeDictionary\`2> | O(log n) lookup; rejects overlapping inserts. |
-| Range membership (in any interval?) | <xref:Bodu.Collections.Generic.RangeSet\`1> | Merges adjacent and overlapping intervals on insertion. |
-| Cache with policy-driven eviction | <xref:Bodu.Collections.Generic.EvictingDictionary\`2> | FIFO, LRU, LFU, MRU, Random, or Second-Chance. |
-| One key → many values | <xref:Bodu.Collections.Generic.MultiValueDictionary\`2> | Indexer returns an empty live view, never `null`. |
+| Single-ended FIFO ring | <xref:Bodu.Collections.Generic.CircularBuffer`1> | `AllowOverwrite` toggles between sliding-window and bounded-throw modes. |
+| Double-ended ring | <xref:Bodu.Collections.Generic.Deque`1> | O(1) `AddFirst` / `AddLast` / `RemoveFirst` / `RemoveLast`. |
+| Append-only stream of unknown length | <xref:Bodu.Collections.Generic.SegmentedBuffer`1> | Grows by fixed-size chunks; avoids the array-doubling copy. |
+| Min-heap priority queue with O(1) lookup-by-element | <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2> | Required by Dijkstra, Prim, A* — the `Update` / `EnqueueOrUpdate` calls the BCL `PriorityQueue<TElement,TPriority>` cannot perform. |
+| Range-keyed lookup (interval → value) | <xref:Bodu.Collections.Generic.RangeDictionary`2> | O(log n) lookup; rejects overlapping inserts. |
+| Range membership (in any interval?) | <xref:Bodu.Collections.Generic.RangeSet`1> | Merges adjacent and overlapping intervals on insertion. |
+| Cache with policy-driven eviction | <xref:Bodu.Collections.Generic.EvictingDictionary`2> | FIFO, LRU, LFU, MRU, Random, or Second-Chance. |
+| One key → many values | <xref:Bodu.Collections.Generic.MultiValueDictionary`2> | Indexer returns an empty live view, never `null`. |
 
 ### By capacity and lifecycle
 
 | Requirement | Reach for | Notes |
 |---|---|---|
-| Fixed capacity, never grows, reject on full | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = false` | Or <xref:Bodu.Collections.Generic.Deque\`1> with `AllowGrow = false` for two-ended access. |
-| Fixed capacity, overwrite on full | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = true` | Sliding-window semantics — the default. |
-| Fixed capacity, evict by policy on full | <xref:Bodu.Collections.Generic.EvictingDictionary\`2> | The only collection in the namespace that evicts a non-end element. |
-| Growable with O(1) ends | <xref:Bodu.Collections.Generic.Deque\`1> with `AllowGrow = true` | Backing array doubles on overflow; capped at <xref:System.Array.MaxLength>. |
-| Growable append-only without per-doubling copy | <xref:Bodu.Collections.Generic.SegmentedBuffer\`1> | New segments allocate without rehoming existing elements. |
-| Runtime toggle between growable and fixed | <xref:Bodu.Collections.Generic.Deque\`1> | `AllowGrow` is a settable property; switching to `false` does not shrink the array. |
-| Pre-grow before a known burst | <xref:Bodu.Collections.Generic.Deque\`1>.EnsureCapacity | Honoured even when `AllowGrow = false`. |
+| Fixed capacity, never grows, reject on full | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = false` | Or <xref:Bodu.Collections.Generic.Deque`1> with `AllowGrow = false` for two-ended access. |
+| Fixed capacity, overwrite on full | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = true` | Sliding-window semantics — the default. |
+| Fixed capacity, evict by policy on full | <xref:Bodu.Collections.Generic.EvictingDictionary`2> | The only collection in the namespace that evicts a non-end element. |
+| Growable with O(1) ends | <xref:Bodu.Collections.Generic.Deque`1> with `AllowGrow = true` | Backing array doubles on overflow; capped at <xref:System.Array.MaxLength>. |
+| Growable append-only without per-doubling copy | <xref:Bodu.Collections.Generic.SegmentedBuffer`1> | New segments allocate without rehoming existing elements. |
+| Runtime toggle between growable and fixed | <xref:Bodu.Collections.Generic.Deque`1> | `AllowGrow` is a settable property; switching to `false` does not shrink the array. |
+| Pre-grow before a known burst | <xref:Bodu.Collections.Generic.Deque`1>.EnsureCapacity | Honoured even when `AllowGrow = false`. |
 
 ### By concurrency
 
 | Requirement | Reach for | Notes |
 |---|---|---|
-| Multi-threaded FIFO ring | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer\`1> | Implements <xref:System.Collections.Concurrent.IProducerConsumerCollection\`1> over a Vyukov MPMC algorithm. |
-| Multi-threaded unique set | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet\`1> | Lock-striped hash table; disjoint writers proceed in parallel. |
+| Multi-threaded FIFO ring | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer`1> | Implements <xref:System.Collections.Concurrent.IProducerConsumerCollection`1> over a Vyukov MPMC algorithm. |
+| Multi-threaded unique set | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet`1> | Lock-striped hash table; disjoint writers proceed in parallel. |
 | Single-threaded, every other scenario | All non-concurrent types in <xref:Bodu.Collections.Generic> | Wrap with external synchronisation if shared across threads. |
 
-The non-concurrent types are **not** thread-safe even for concurrent reads — <xref:Bodu.Collections.Generic.EvictingDictionary\`2> mutates LRU and LFU metadata on read, and <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2> mutates the element-to-slot map on every heap operation. Wrap with a lock or `ReaderWriterLockSlim` when sharing a single instance.
+The non-concurrent types are **not** thread-safe even for concurrent reads — <xref:Bodu.Collections.Generic.EvictingDictionary`2> mutates LRU and LFU metadata on read, and <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2> mutates the element-to-slot map on every heap operation. Wrap with a lock or `ReaderWriterLockSlim` when sharing a single instance.
 
 ### By ordering and uniqueness
 
 | Requirement | Reach for | Notes |
 |---|---|---|
-| Unique elements, no order | <xref:System.Collections.Generic.HashSet\`1> (BCL) | Bodu does not duplicate this. |
-| Unique elements, insertion-ordered, indexable | <xref:Bodu.Collections.Generic.IndexedSet\`1> | Implements `IList<T>` over an open-addressing hash table; O(1) `Contains`, `IndexOf`, indexed read. |
-| Unique elements, insertion-ordered, set surface | <xref:Bodu.Collections.Generic.OrderedSet\`1> | Same engine as `IndexedSet<T>`; exposes indices only as a read-only view. |
-| Duplicates retained with count | <xref:Bodu.Collections.Generic.Multiset\`1> | `Count` includes multiplicity; `DistinctCount` does not. |
-| Sorted by priority, unique elements, mutable priorities | <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2> | `Enqueue` of an existing element throws — use `EnqueueOrUpdate`. |
-| Sorted by interval | <xref:Bodu.Collections.Generic.RangeSet\`1> | Half-open intervals over any `IComparable<T>`. |
+| Unique elements, no order | <xref:System.Collections.Generic.HashSet`1> (BCL) | Bodu does not duplicate this. |
+| Unique elements, insertion-ordered, indexable | <xref:Bodu.Collections.Generic.IndexedSet`1> | Implements `IList<T>` over an open-addressing hash table; O(1) `Contains`, `IndexOf`, indexed read. |
+| Unique elements, insertion-ordered, set surface | <xref:Bodu.Collections.Generic.OrderedSet`1> | Same engine as `IndexedSet<T>`; exposes indices only as a read-only view. |
+| Duplicates retained with count | <xref:Bodu.Collections.Generic.Multiset`1> | `Count` includes multiplicity; `DistinctCount` does not. |
+| Sorted by priority, unique elements, mutable priorities | <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2> | `Enqueue` of an existing element throws — use `EnqueueOrUpdate`. |
+| Sorted by interval | <xref:Bodu.Collections.Generic.RangeSet`1> | Half-open intervals over any `IComparable<T>`. |
 
 ### By failure mode on overflow
 
 | Add when full does… | Reach for |
 |---|---|
-| Throws <xref:System.InvalidOperationException>. | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = false`; <xref:Bodu.Collections.Generic.Deque\`1> with `AllowGrow = false`. |
-| Overwrites the oldest element. | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = true`. |
-| Doubles the backing array. | <xref:Bodu.Collections.Generic.Deque\`1> with `AllowGrow = true`. |
-| Evicts a policy-selected entry. | <xref:Bodu.Collections.Generic.EvictingDictionary\`2>. |
-| Cannot happen (collection always grows). | <xref:Bodu.Collections.Generic.SegmentedBuffer\`1>, <xref:Bodu.Collections.Generic.IndexedSet\`1>, <xref:Bodu.Collections.Generic.OrderedSet\`1>, <xref:Bodu.Collections.Generic.MultiValueDictionary\`2>, <xref:Bodu.Collections.Generic.Multiset\`1>, <xref:Bodu.Collections.Generic.RangeDictionary\`2>, <xref:Bodu.Collections.Generic.RangeSet\`1>, <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2>, <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet\`1>. |
+| Throws <xref:System.InvalidOperationException>. | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = false`; <xref:Bodu.Collections.Generic.Deque`1> with `AllowGrow = false`. |
+| Overwrites the oldest element. | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = true`. |
+| Doubles the backing array. | <xref:Bodu.Collections.Generic.Deque`1> with `AllowGrow = true`. |
+| Evicts a policy-selected entry. | <xref:Bodu.Collections.Generic.EvictingDictionary`2>. |
+| Cannot happen (collection always grows). | <xref:Bodu.Collections.Generic.SegmentedBuffer`1>, <xref:Bodu.Collections.Generic.IndexedSet`1>, <xref:Bodu.Collections.Generic.OrderedSet`1>, <xref:Bodu.Collections.Generic.MultiValueDictionary`2>, <xref:Bodu.Collections.Generic.Multiset`1>, <xref:Bodu.Collections.Generic.RangeDictionary`2>, <xref:Bodu.Collections.Generic.RangeSet`1>, <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2>, <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet`1>. |
 
 The `Try…` overloads on the bounded ring-backed types substitute a `false` return for the throw, so callers can stay non-throwing without changing the toggle.
 
@@ -93,29 +93,29 @@ The `Try…` overloads on the bounded ring-backed types substitute a `false` ret
 
 | I want to… | Reach for |
 |---|---|
-| Track the last *N* sensor readings, dropping the oldest. | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = true`. |
-| Implement a rate limiter that rejects bursts. | <xref:Bodu.Collections.Generic.CircularBuffer\`1> with `AllowOverwrite = false`. |
-| Build a producer-consumer queue between threads. | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer\`1>. |
-| Build an undo / redo history with capped size. | <xref:Bodu.Collections.Generic.Deque\`1> with `AllowGrow = false`. |
-| Cache compiled artifacts by name with LRU eviction. | <xref:Bodu.Collections.Generic.EvictingDictionary\`2> + `EvictingDictionaryPolicy.LeastRecentlyUsed`. |
-| Track session liveness without reading the value. | <xref:Bodu.Collections.Generic.EvictingDictionary\`2>.Touch. |
-| Build a lookup from IP ranges to country codes. | <xref:Bodu.Collections.Generic.RangeDictionary\`2>. |
-| Maintain a set of free disk extents that merges on insert. | <xref:Bodu.Collections.Generic.RangeSet\`1>. |
-| Run Dijkstra's algorithm on a weighted graph. | <xref:Bodu.Collections.Generic.IndexedPriorityQueue\`2>. |
-| Group log entries by correlation id. | <xref:Bodu.Collections.Generic.MultiValueDictionary\`2>. |
-| Count occurrences of tokens in a corpus. | <xref:Bodu.Collections.Generic.Multiset\`1>. |
-| Maintain a list of items in entry order while ensuring uniqueness. | <xref:Bodu.Collections.Generic.IndexedSet\`1>. |
-| Track a thread-safe set of active correlation ids. | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet\`1>. |
-| Stream-build a payload whose total length is unknown. | <xref:Bodu.Collections.Generic.SegmentedBuffer\`1>, or <xref:Bodu.Buffers.PooledBufferBuilder\`1> for an `ArrayPool<T>`-backed builder. |
+| Track the last *N* sensor readings, dropping the oldest. | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = true`. |
+| Implement a rate limiter that rejects bursts. | <xref:Bodu.Collections.Generic.CircularBuffer`1> with `AllowOverwrite = false`. |
+| Build a producer-consumer queue between threads. | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentCircularBuffer`1>. |
+| Build an undo / redo history with capped size. | <xref:Bodu.Collections.Generic.Deque`1> with `AllowGrow = false`. |
+| Cache compiled artifacts by name with LRU eviction. | <xref:Bodu.Collections.Generic.EvictingDictionary`2> + `EvictingDictionaryPolicy.LeastRecentlyUsed`. |
+| Track session liveness without reading the value. | <xref:Bodu.Collections.Generic.EvictingDictionary`2>.Touch. |
+| Build a lookup from IP ranges to country codes. | <xref:Bodu.Collections.Generic.RangeDictionary`2>. |
+| Maintain a set of free disk extents that merges on insert. | <xref:Bodu.Collections.Generic.RangeSet`1>. |
+| Run Dijkstra's algorithm on a weighted graph. | <xref:Bodu.Collections.Generic.IndexedPriorityQueue`2>. |
+| Group log entries by correlation id. | <xref:Bodu.Collections.Generic.MultiValueDictionary`2>. |
+| Count occurrences of tokens in a corpus. | <xref:Bodu.Collections.Generic.Multiset`1>. |
+| Maintain a list of items in entry order while ensuring uniqueness. | <xref:Bodu.Collections.Generic.IndexedSet`1>. |
+| Track a thread-safe set of active correlation ids. | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet`1>. |
+| Stream-build a payload whose total length is unknown. | <xref:Bodu.Collections.Generic.SegmentedBuffer`1>, or <xref:Bodu.Buffers.PooledBufferBuilder`1> for an `ArrayPool<T>`-backed builder. |
 
 ## Anti-patterns
 
-- **Do not use <xref:Bodu.Collections.Generic.Deque\`1> when you only need single-ended FIFO.** A `CircularBuffer<T>` with `AllowOverwrite = false` expresses the constraint more clearly and is the same shape under the hood — both inherit from <xref:Bodu.Collections.Generic.RingBackedCollection\`1>.
-- **Do not use <xref:Bodu.Collections.Generic.EvictingDictionary\`2> as a general dictionary.** It evicts on overflow even when you would prefer growth — choose the BCL `Dictionary<TKey,TValue>` when the working set is unbounded.
-- **Do not assume the non-concurrent types are safe under concurrent reads.** Reads on <xref:Bodu.Collections.Generic.EvictingDictionary\`2> mutate eviction metadata; reads on every collection rely on a structural-version counter that is not interlocked. Wrap with external synchronisation or pick the explicit concurrent variant.
-- **Do not pair <xref:Bodu.Collections.Generic.IndexedSet\`1> with <xref:System.Collections.Generic.List\`1> "to also enforce uniqueness".** `IndexedSet<T>` already implements `IList<T>` with O(1) `Contains` and `IndexOf` — keeping two structures in sync introduces drift bugs.
-- **Do not implement an LRU cache by hand around <xref:System.Collections.Generic.Dictionary\`2> + <xref:Bodu.Collections.Generic.Deque\`1>.** <xref:Bodu.Collections.Generic.EvictingDictionary\`2> already provides LRU, LFU, FIFO, MRU, Random, and Second-Chance through a single `EvictingDictionaryPolicy` selector.
-- **Do not allocate a fresh <xref:Bodu.Buffers.PooledBufferBuilder\`1> per call to "reuse the pool".** The pool is global; the builder is the rental handle. For repeated rebuilds, call `Reset` to keep the current rented buffer.
+- **Do not use <xref:Bodu.Collections.Generic.Deque`1> when you only need single-ended FIFO.** A `CircularBuffer<T>` with `AllowOverwrite = false` expresses the constraint more clearly and is the same shape under the hood — both inherit from <xref:Bodu.Collections.Generic.RingBackedCollection`1>.
+- **Do not use <xref:Bodu.Collections.Generic.EvictingDictionary`2> as a general dictionary.** It evicts on overflow even when you would prefer growth — choose the BCL `Dictionary<TKey,TValue>` when the working set is unbounded.
+- **Do not assume the non-concurrent types are safe under concurrent reads.** Reads on <xref:Bodu.Collections.Generic.EvictingDictionary`2> mutate eviction metadata; reads on every collection rely on a structural-version counter that is not interlocked. Wrap with external synchronisation or pick the explicit concurrent variant.
+- **Do not pair <xref:Bodu.Collections.Generic.IndexedSet`1> with <xref:System.Collections.Generic.List`1> "to also enforce uniqueness".** `IndexedSet<T>` already implements `IList<T>` with O(1) `Contains` and `IndexOf` — keeping two structures in sync introduces drift bugs.
+- **Do not implement an LRU cache by hand around <xref:System.Collections.Generic.Dictionary`2> + <xref:Bodu.Collections.Generic.Deque`1>.** <xref:Bodu.Collections.Generic.EvictingDictionary`2> already provides LRU, LFU, FIFO, MRU, Random, and Second-Chance through a single `EvictingDictionaryPolicy` selector.
+- **Do not allocate a fresh <xref:Bodu.Buffers.PooledBufferBuilder`1> per call to "reuse the pool".** The pool is global; the builder is the rental handle. For repeated rebuilds, call `Reset` to keep the current rented buffer.
 
 ## See also
 

--- a/docs/guides/core/index.md
+++ b/docs/guides/core/index.md
@@ -13,7 +13,7 @@ If you have not yet installed the package or want the high-level shape of the li
 | Namespace | What lives here | Guides |
 |---|---|---|
 | `Bodu.Collections.Generic` | Bounded ring-backed collections — `CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`, `RingBackedCollection<T>` base. | [Circular buffer](circular-buffer.md) · [Deque](deque.md) · [Evicting dictionary](evicting-dictionary.md) |
-| `Bodu.Collections.Generic.Concurrent` | Thread-safe collection variants — `ConcurrentCircularBuffer<T>`. | (covered in [Circular buffer](circular-buffer.md#thread-safety)) |
+| `Bodu.Collections.Generic.Concurrent` | Thread-safe collection variants — `ConcurrentCircularBuffer<T>`. | (covered in [Circular buffer](circular-buffer.md#pattern-5--concurrent-access-with-concurrentcircularbuffer)) |
 | `Bodu` | Root namespace primitives — `WeekPattern`, `IRandomGenerator`, `XorShiftRandom`, `ThrowHelper`. | [WeekPattern](week-pattern.md) |
 | `Bodu.Buffers` | Pooled buffer infrastructure — `PooledBufferBuilder<T>`. | (no dedicated guide yet — see API reference) |
 | `Bodu.Extensions` | Date, numeric, span, array, and comparable extension methods — `DateTimeExtensions`, `DateOnlyExtensions`, `NumericExtensions`, `ArrayExtensions`, `BufferConverter`, `SpanExtensions`, `IComparableExtensions`. | (no dedicated guide yet — see API reference) |

--- a/docs/guides/cryptography/index.md
+++ b/docs/guides/cryptography/index.md
@@ -8,7 +8,7 @@ Recipe-style walk-throughs for **Bodu.Security.Cryptography**, organized by the 
 
 If you have not yet installed the package or want the high-level shape of the library, start with the [Bodu.Security.Cryptography introduction](../../docs/cryptography/index.md) and the [getting-started page](../../docs/cryptography/getting-started.md). Not sure which primitive to use? The introduction's *shape of the library* section maps the six subfamilies and explains how they differ.
 
-For the auto-generated API reference, see the [Bodu.Security.Cryptography namespace page](xref:Bodu.Security.Cryptography). For non-cryptographic checksums and fingerprints, see the [Bodu.IO.Hashing guides](../io-hashing/).
+For the auto-generated API reference, see the [Bodu.Security.Cryptography namespace page](xref:Bodu.Security.Cryptography). For non-cryptographic checksums and fingerprints, see the [Bodu.IO.Hashing guides](../io-hashing/index.md).
 
 ## Namespace map
 
@@ -165,5 +165,5 @@ The library also exposes `Whirlpool`, `Blake2b`, `Blake2s`, `Blake3`, `Skein256`
 
 - [Bodu.Security.Cryptography introduction](../../docs/cryptography/index.md) — namespaces, headline types, scenarios.
 - [Bodu.Security.Cryptography getting started](../../docs/cryptography/getting-started.md) — install and minimal samples per subfamily.
-- [Bodu.IO.Hashing guides](../io-hashing/) — non-cryptographic checksums and fingerprints.
+- [Bodu.IO.Hashing guides](../io-hashing/index.md) — non-cryptographic checksums and fingerprints.
 - [Bodu.Security.Cryptography API reference](xref:Bodu.Security.Cryptography) — full type-by-type docs.

--- a/docs/guides/cryptography/stream-ciphers.md
+++ b/docs/guides/cryptography/stream-ciphers.md
@@ -4,7 +4,7 @@ title: Using stream ciphers
 
 # Using stream ciphers
 
-A **stream cipher** generates a key- and nonce-dependent keystream and XORs it with the plaintext. Unlike the block ciphers elsewhere in this library, there is no cipher block, no block mode, and no padding: any byte length is encrypted directly. All of Bodu's stream ciphers derive from <xref:Bodu.Security.Cryptography.StreamCipherAlgorithm> (itself a <xref:System.Security.Cryptography.SymmetricAlgorithm>), so they flow through `CreateEncryptor()` / `CreateDecryptor()`, a `CryptoStream`, and the `Encrypt` / `Decrypt` extension methods exactly like the block ciphers.
+A **stream cipher** generates a key- and nonce-dependent keystream and XORs it with the plaintext. Unlike the block ciphers elsewhere in this library, there is no cipher block, no block mode, and no padding: any byte length is encrypted directly. All of Bodu's stream ciphers derive from <xref:Bodu.Security.Cryptography.SymmetricStreamAlgorithm> (itself a <xref:System.Security.Cryptography.SymmetricAlgorithm>), so they flow through `CreateEncryptor()` / `CreateDecryptor()`, a `CryptoStream`, and the `Encrypt` / `Decrypt` extension methods exactly like the block ciphers.
 
 Because the keystream is XORed in, every stream cipher here is **self-inverse**: encryption and decryption are the same operation, and `CreateEncryptor()` and `CreateDecryptor()` are interchangeable. The nonce / IV is supplied as the <xref:System.Security.Cryptography.SymmetricAlgorithm.IV> property.
 

--- a/docs/guides/io-hashing/murmurhash3.md
+++ b/docs/guides/io-hashing/murmurhash3.md
@@ -86,7 +86,7 @@ byte[] full = murmur.GetCurrentHash();
 murmur.Reset();                             // discards the buffer and resets to seed
 ```
 
-> **Memory note.** The internal buffer grows with each `Append`. For very large inputs (hundreds of MB) where you do not want to hold the entire payload in memory, prefer a streaming algorithm such as <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Crc>, or <xref:Bodu.IO.Hashing.Fletcher32>.
+> **Memory note.** The internal buffer grows with each `Append`. For very large inputs (hundreds of MB) where you do not want to hold the entire payload in memory, prefer a streaming algorithm such as <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Checksums.Crc>, or <xref:Bodu.IO.Hashing.Checksums.Fletcher32>.
 > **Memory note.** The internal buffer grows with each `Append`. For very large inputs (hundreds of MB) where you do not want to hold the entire payload in memory, prefer a streaming algorithm such as <xref:Bodu.IO.Hashing.Fnv1a64>, <xref:Bodu.IO.Hashing.Checksums.Crc>, or <xref:Bodu.IO.Hashing.Checksums.Fletcher32>.
 
 ## Pattern 5 — Bloom filter with two hash functions

--- a/docs/guides/numerics/formatting-and-parsing.md
+++ b/docs/guides/numerics/formatting-and-parsing.md
@@ -30,7 +30,7 @@ Fraction<int>.Create(6, 2).ToString();    // "3"     — canonical denominator i
 Fraction<int>.Zero.ToString();            // "0"
 ```
 
-The general form is the round-trip wire shape: `JsonSerializer.Serialize` (see below) and `<xref:Bodu.Numerics.Fraction\`1>.Parse` both treat `"n/d"` as the lossless text form.
+The general form is the round-trip wire shape: `JsonSerializer.Serialize` (see below) and `<xref:Bodu.Numerics.Fraction`1>.Parse` both treat `"n/d"` as the lossless text form.
 
 ## Mixed-number form
 
@@ -45,7 +45,7 @@ Fraction<int>.Create(4, 1).ToString("M");    // "4"       — whole number: no f
 Fraction<int>.Zero.ToString("M");            // "0"
 ```
 
-The convenience methods <xref:Bodu.Numerics.Fraction\`1>.`ToMixedString(provider)` and `ToMixedNumberString(provider)` are aliases for `ToString("M", provider)`.
+The convenience methods <xref:Bodu.Numerics.Fraction`1>.`ToMixedString(provider)` and `ToMixedNumberString(provider)` are aliases for `ToString("M", provider)`.
 
 ## Unicode vulgar-fraction form
 
@@ -72,7 +72,7 @@ Fraction<int>.Create(3, 1).ToString("U");    // "3"      — whole number
 Fraction<int>.Create(5, 9).ToString("U");    // "5/9"    — no 5/9 glyph: falls back to mixed
 ```
 
-The convenience method <xref:Bodu.Numerics.Fraction\`1>.`ToUnicodeString(provider)` is an alias for `ToString("U", provider)`.
+The convenience method <xref:Bodu.Numerics.Fraction`1>.`ToUnicodeString(provider)` is an alias for `ToString("U", provider)`.
 
 ## Parsing
 
@@ -99,9 +99,9 @@ Fraction<int>.Parse("75%");          // 3/4
 Fraction<int>.TryParse("nope", out var _);   // false
 ```
 
-The numeric components are read with <xref:System.Globalization.NumberStyles>.`None`, so scientific notation and group separators are rejected; the parser is intentionally strict about the shape so the wire format remains unambiguous. A `0` denominator is rejected (`TryParse` returns `false`; `Parse` throws <xref:System.FormatException>), as is any input whose canonical form does not fit in the backing type `T` — overflow is reported through `false` from `TryParse` and through <xref:System.FormatException> from `Parse`.
+The numeric components are read with `NumberStyles.None`, so scientific notation and group separators are rejected; the parser is intentionally strict about the shape so the wire format remains unambiguous. A `0` denominator is rejected (`TryParse` returns `false`; `Parse` throws <xref:System.FormatException>), as is any input whose canonical form does not fit in the backing type `T` — overflow is reported through `false` from `TryParse` and through <xref:System.FormatException> from `Parse`.
 
-`Fraction<T>` implements <xref:System.IParsable\`1> and <xref:System.ISpanParsable\`1>, so the same call sites work for `string` and `ReadOnlySpan<char>` inputs.
+`Fraction<T>` implements <xref:System.IParsable`1> and <xref:System.ISpanParsable`1>, so the same call sites work for `string` and `ReadOnlySpan<char>` inputs.
 
 ## Culture handling
 
@@ -122,8 +122,8 @@ var back = Fraction<int>.Parse(text, CultureInfo.InvariantCulture);
 
 - <xref:System.ISpanFormattable>.`TryFormat(Span<char>, out int, ReadOnlySpan<char>, IFormatProvider?)` — writes the formatted text into a char buffer; returns `false` when the destination is too small.
 - <xref:System.IUtf8SpanFormattable>.`TryFormat(Span<byte>, out int, ReadOnlySpan<char>, IFormatProvider?)` — writes the same text UTF-8 encoded into a byte buffer.
-- <xref:System.ISpanParsable\`1>.`TryParse(ReadOnlySpan<char>, IFormatProvider?, out Fraction<T>)` — parses without allocating a `string`.
-- <xref:System.IUtf8SpanParsable\`1>.`Parse(ReadOnlySpan<byte>, IFormatProvider?)` and `TryParse(...)` — accept UTF-8 input.
+- <xref:System.ISpanParsable`1>.`TryParse(ReadOnlySpan<char>, IFormatProvider?, out Fraction<T>)` — parses without allocating a `string`.
+- <xref:System.IUtf8SpanParsable`1>.`Parse(ReadOnlySpan<byte>, IFormatProvider?)` and `TryParse(...)` — accept UTF-8 input.
 
 ```csharp
 Span<char> buffer = stackalloc char[16];
@@ -138,7 +138,7 @@ Fraction<int> parsed = Fraction<int>.Parse("3/4"u8, null);
 
 ## Round-tripping JSON
 
-`Fraction<T>` carries `[JsonConverter(typeof(FractionJsonConverterFactory))]`, so <xref:System.Text.Json.JsonSerializer> picks up the converter automatically. The wire shape is the general form rendered with <xref:System.Globalization.CultureInfo>.`InvariantCulture` — a single JSON string token, `"numerator/denominator"`, or a bare integer string for whole values:
+`Fraction<T>` carries `[JsonConverter(typeof(FractionJsonConverterFactory))]`, so `System.Text.Json.JsonSerializer` picks up the converter automatically. The wire shape is the general form rendered with <xref:System.Globalization.CultureInfo>.`InvariantCulture` — a single JSON string token, `"numerator/denominator"`, or a bare integer string for whole values:
 
 ```csharp
 using System.Text.Json;
@@ -155,5 +155,5 @@ The converter reads via `Fraction<T>.Parse(text, CultureInfo.InvariantCulture)`;
 
 - [Working with `Fraction<T>`](fraction.md) — construction, arithmetic, continued fractions, approximation.
 - [Bodu.Numerics core concepts](../../docs/numerics/concepts.md) — canonical form, mixed-number, Unicode vulgar fraction.
-- <xref:Bodu.Numerics.Fraction\`1> — API reference.
-- <xref:Bodu.Numerics.FractionJsonConverter\`1> — JSON converter reference.
+- <xref:Bodu.Numerics.Fraction`1> — API reference.
+- <xref:Bodu.Numerics.Serialization.FractionJsonConverter`1> — JSON converter reference.

--- a/docs/guides/numerics/fraction.md
+++ b/docs/guides/numerics/fraction.md
@@ -409,7 +409,7 @@ same rational value compare equal. Equal fractions share a hash code.
 ## See also
 
 - [`Fraction<T>` API reference](xref:Bodu.Numerics.Fraction`1)
-- [`FractionJsonConverter<T>` API reference](xref:Bodu.Numerics.FractionJsonConverter`1)
-- [`FractionJsonConverterFactory`](xref:Bodu.Numerics.FractionJsonConverterFactory)
+- [`FractionJsonConverter<T>` API reference](xref:Bodu.Numerics.Serialization.FractionJsonConverter`1)
+- [`FractionJsonConverterFactory`](xref:Bodu.Numerics.Serialization.FractionJsonConverterFactory)
 - [`Interval<T>` guide](interval.md) — the other `Bodu.Numerics` value type.
 - [`Money<TCurrency>` guide](../financial/money.md) — uses `Fraction<BigInteger>` as the precision escape hatch via `ToFraction()` / `FromFraction()` / `MultiplyExact()`.

--- a/docs/guides/text-configuration/parsing-and-profiles.md
+++ b/docs/guides/text-configuration/parsing-and-profiles.md
@@ -158,7 +158,7 @@ Construct a custom option set when none of the four profiles fits. Every field i
 
 ### Key shape and encoding
 
-- `KeyOptions` (`ConfigurationKeyOptions`, default `Default`) — segment-separator characters, dotted-to-colon mapping, case sensitivity. See [Views and resolution](views-and-resolution.md#configurationkeyoptions).
+- `KeyOptions` (`ConfigurationKeyOptions`, default `Default`) — segment-separator characters, dotted-to-colon mapping, case sensitivity. See [Views and resolution](views-and-resolution.md#configurationkey-and-configurationkeyoptions).
 - `DefaultEncoding` (`Encoding`, default `Encoding.UTF8`) — encoding used by `Load(string)` and `Load(Stream)` when the source has no BOM.
 
 ## Static presets

--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ Ten focused NuGet packages — plus three companion calendar data packs, a calen
   <div class="bodu-card-links">
     <a href="docs/extensions-configuration-text/index.md">Introduction</a>
     <a href="guides/extensions-configuration-text/index.md">Guides</a>
-    <a href="apidoc/Bodu.Extensions.Configuration.Text.md">API reference</a>
+    <a href="xref:Bodu.Extensions.Configuration.Text">API reference</a>
   </div>
 </div>
 
@@ -178,5 +178,5 @@ dotnet add package Bodu.Financial
   <a href="docs/package-matrix.md">Package matrix</a>
   <a href="docs/getting-started.md">Getting started</a>
   <a href="articles/index.md">Articles</a>
-  <a href="api/index.html">API reference</a>
+  <a href="xref:Bodu">API reference</a>
 </div>

--- a/tools/CurrencyCatalogueGenerator/Program.cs
+++ b/tools/CurrencyCatalogueGenerator/Program.cs
@@ -22,6 +22,7 @@ internal static class Program
         //     To regenerate: dotnet run --project tools/CurrencyCatalogueGenerator
         // </auto-generated>
         // ---------------------------------------------------------------------------------------------------------------
+        #nullable enable
 
         """;
 


### PR DESCRIPTION
PR #377 added `--warningsAsErrors` to the DocFX workflow and introduced a
batch of new concepts / apidoc / guides pages whose `<xref:...>` references
pointed at types that either don't exist or live under a different
namespace. With the strict gate in place the 69 latent warnings now break
the build (exit 255).

Fixes, by warning class:

- 29 x CS8669 (nullable annotation in auto-generated code without an
  explicit `#nullable` directive). Adds `#nullable enable` to every
  currency tag-class in `Bodu.Financial/src/Financial.Currencies/` and
  teaches `tools/CurrencyCatalogueGenerator` to emit the directive so
  the next regeneration stays clean.

- 3 x InvalidFileLink. `docs/index.md` linked to a non-existent
  `api/index.html`; the cryptography guide index linked to
  `~/guides/io-hashing/` (directory rather than file). Switched the
  first to `xref:Bodu` and the second to `../io-hashing/index.md`.

- 2 x InvalidBookmark. `circular-buffer.md#thread-safety` updated to the
  actual Pattern 5 anchor; `views-and-resolution.md#configurationkeyoptions`
  updated to the actual combined heading slug.

- 29 x UidNotFound across nine doc/apidoc files. Remapped plugin types
  into `Bodu.Globalization.Calendar.Plugins`, Easter / Vesak / Asalha /
  Losar / Qingming / Hindu lunar algorithms + providers into
  `.Algorithms.`, IBAN / LEI / CUSIP / SEDOL / ISBN / ISO 7064 into
  `.Checksums.`, CRC / Fletcher32 / CrcLookupTable* into `.Checksums.`,
  the inline rule-provider out of `.Builder.`, the date / fiscal /
  identifier enums under `Bodu.Extensions.`, the `FractionJsonConverter`
  pair under `Bodu.Numerics.Serialization`, and `StreamCipherAlgorithm`
  to `SymmetricStreamAlgorithm`. Removed escaped backticks from xref
  arity suffixes (`Foo\`1` -> `Foo`1`) in `choosing-a-collection.md` and
  `formatting-and-parsing.md`. Replaced references to types that genuinely
  don't ship (`CalendarWeekendDefinition`, `CryptoHelpers`, `BaseEncoding`,
  `DelimitedField`, `*WriteOptions`) with the real surface and rewrote the
  weekend-behaviour section of `working-days.md` to use the actual
  `WorkingWeek : WeekPattern` API. Demoted the two BCL xrefs the Microsoft
  xrefService didn't resolve (`System.Globalization.NumberStyles`,
  `System.Text.Json.JsonSerializer`) to plain code spans.

- 3 x "Found project reference without a matching metadata reference"
  about the Bodu.CodeStyle analyzer / code-fix ProjectReferences in
  Bodu.Core.csproj. Adds a `BuildingForDocfx` MSBuild property in
  `docs/docfx.json` and wraps the analyzer ItemGroup in
  `Bodu.Core/src/Bodu.Core.csproj` with
  `Condition="'$(BuildingForDocfx)' != 'true'"` so DocFX's Roslyn
  workspace never traverses into them. Normal CI / dev builds (where the
  property is unset) still wire the analyzers in.

Also dropped the one direct `apidoc/Bodu.Extensions.Configuration.Text.md`
link from the landing page (caught by the workflow's link audit) in favour
of `xref:Bodu.Extensions.Configuration.Text`.

DocFX build now exits 0 with zero warnings; all ten primary-library
namespace pages still generate.