### PR TITLE
docs: fix DocFX xref failures after MoneyValue→Money refactor

### DIFF
--- a/docs/apidoc/Bodu.Financial.Currencies.md
+++ b/docs/apidoc/Bodu.Financial.Currencies.md
@@ -69,7 +69,7 @@ The shipped catalogue covers every active ISO 4217 currency plus a curated set o
 
 ## Adding a custom currency
 
-Implement <xref:Bodu.Financial.ICurrency> directly and register the metadata with <xref:Bodu.Financial.CurrencyRegistry> so `MoneyValue` and `MoneyBag` round at the correct precision when they see the ISO code at runtime:
+Implement <xref:Bodu.Financial.ICurrency> directly and register the metadata with <xref:Bodu.Financial.CurrencyRegistry> so `Money` and `MoneyBag` round at the correct precision when they see the ISO code at runtime:
 
 ```csharp
 public sealed class DOGE : ICurrency

--- a/docs/apidoc/Bodu.Financial.Serialization.md
+++ b/docs/apidoc/Bodu.Financial.Serialization.md
@@ -16,15 +16,15 @@ uid: Bodu.Financial.Serialization
 ## Key types
 
 - <xref:Bodu.Financial.Serialization.FinancialJsonPolicy> — selects the wire shape (`Strict`, `Lenient`, `Compact`).
-- <xref:Bodu.Financial.Serialization.MoneyJsonConverter`1>, <xref:Bodu.Financial.Serialization.MoneyJsonConverterFactory> — converter and factory for <xref:Bodu.Financial.Money`1>.
-- <xref:Bodu.Financial.Serialization.MoneyValueJsonConverter> — converter for <xref:Bodu.Financial.MoneyValue>.
+- <xref:Bodu.Financial.Serialization.MoneyOfTCurrencyJsonConverter`1>, <xref:Bodu.Financial.Serialization.MoneyOfTCurrencyJsonConverterFactory> — converter and factory for <xref:Bodu.Financial.Money`1>.
+- <xref:Bodu.Financial.Serialization.MoneyJsonConverter> — converter for <xref:Bodu.Financial.Money>.
 - <xref:Bodu.Financial.Serialization.MoneyBagJsonConverter> — converter for <xref:Bodu.Financial.MoneyBag>.
 - <xref:Bodu.Financial.Serialization.ExchangeRateJsonConverter>, <xref:Bodu.Financial.Serialization.ExchangeRatePairJsonConverter> — converters for the FX value objects.
 - <xref:Bodu.Financial.Serialization.FinancialJsonSerializerOptionsExtensions> — the registration extension method `AddFinancialJsonConverters(options, policy)`.
 
 ## Wire shapes
 
-| Policy | `Money<TCurrency>` / `MoneyValue` | `MoneyBag` | Use when |
+| Policy | `Money<TCurrency>` / `Money` | `MoneyBag` | Use when |
 |---|---|---|---|
 | `Strict` *(default)* | `{ "amount": 19.99, "currency": "USD" }` | `{ "balances": { "USD": 100.00, "EUR": 50.00 } }` | Storing canonical ledger payloads. Validates currency match, rejects duplicate keys. |
 | `Lenient` | Same as Strict | Same as Strict | Importing third-party data. Normalises lowercase ISO codes, trims whitespace before validation. |
@@ -59,7 +59,7 @@ Money<USD> imported = JsonSerializer.Deserialize<Money<USD>>(
 
 ## Notes
 
-- **Currency-mismatch on `Money<TCurrency>`.** Strict and Lenient policies both reject payloads whose `"currency"` field does not match `TCurrency.IsoCode` — drift surfaces as `JsonException` rather than a silently re-interpreted amount. `MoneyValue` accepts any ISO code and rounds to the registry's `MinorUnits` for that code.
+- **Currency-mismatch on `Money<TCurrency>`.** Strict and Lenient policies both reject payloads whose `"currency"` field does not match `TCurrency.IsoCode` — drift surfaces as `JsonException` rather than a silently re-interpreted amount. `Money` accepts any ISO code and rounds to the registry's `MinorUnits` for that code.
 - **MoneyBag pruning.** Zero balances are pruned on round-trip — the deserialised bag matches the canonical form, not the verbatim wire shape.
 - **Strict vs. Lenient on Compact.** The compact policy accepts both `"19.99 USD"` and `"USD 19.99"` regardless of `Strict` / `Lenient` because there is no ambiguity to be strict about; lenient and strict behave identically under `Compact`.
 - **AddFinancialJsonConverters.** Registers every converter on the same `JsonSerializerOptions` instance under a single policy. Call this once per options instance; mixing policies across types is not supported.

--- a/docs/apidoc/Bodu.Financial.md
+++ b/docs/apidoc/Bodu.Financial.md
@@ -6,7 +6,7 @@ uid: Bodu.Financial
 
 ## Purpose
 
-**Bodu.Financial** is the monetary-primitives package: type-safe money (`Money<TCurrency>`), runtime-tagged money (`MoneyValue`), multi-currency portfolios (`MoneyBag`), a shipped catalogue of ~185 ISO 4217 currencies, an exchange-rate provider stack with both timeless and dated lookup, and JSON converters with strict / lenient / compact policy shapes.
+**Bodu.Financial** is the monetary-primitives package: type-safe money (`Money<TCurrency>`), runtime-tagged money (`Money`), multi-currency portfolios (`MoneyBag`), a shipped catalogue of ~185 ISO 4217 currencies, an exchange-rate provider stack with both timeless and dated lookup, and JSON converters with strict / lenient / compact policy shapes.
 
 Reach for this library when you need monetary arithmetic that the compiler validates — adding USD to JPY should fail the build, not run with the wrong unit — and when you need audit-grade FX conversion that records which date, which provider, and which fallback policy produced a given rate.
 
@@ -21,7 +21,7 @@ Reach for this library when you need monetary arithmetic that the compiler valid
 **Monetary value types**
 
 - <xref:Bodu.Financial.Money`1> — immutable, value-equatable monetary amount whose currency is encoded as the type parameter. Cross-currency arithmetic is a compile error. Provides arithmetic, allocation, conversion, formatting/parsing, cash rounding, minor-unit interop, and `Fraction<BigInteger>` interop.
-- <xref:Bodu.Financial.MoneyValue> — runtime-tagged sister type with the same surface, where the currency is an ISO 4217 string. Cross-currency arithmetic throws `InvalidOperationException` at runtime. Use for deserialisation and generic invoicing.
+- <xref:Bodu.Financial.Money> — runtime-tagged sister type with the same surface, where the currency is an ISO 4217 string. Cross-currency arithmetic throws `InvalidOperationException` at runtime. Use for deserialisation and generic invoicing.
 - <xref:Bodu.Financial.MoneyBag> — immutable mixed-currency portfolio. Aggregates per-ISO balances, prunes zero balances, enumerates in lexicographic ISO order.
 
 **Currency catalogue and registry**

--- a/docs/articles/index.md
+++ b/docs/articles/index.md
@@ -27,7 +27,7 @@ Each top-level namespace has a landing page that introduces its purpose, lists i
   `Fraction<T>` for canonical rational arithmetic over any `IBinaryInteger<T>` backing type, with `BigInteger`-promoted intermediates, the full `INumber<T>` / `ISignedNumber<T>` surface, mixed-number and Unicode-vulgar-fraction formatting, continued-fraction expansion, and best rational approximation. `Interval<T>` for closed / open / half-open intervals with intersection, union, and adjacency.
 
 - **[Bodu.Financial — type-safe monetary primitives](xref:Bodu.Financial)**
-  `Money<TCurrency>` where the currency is encoded as the type parameter so cross-currency arithmetic fails the build; `MoneyValue` for runtime-tagged scenarios; `MoneyBag` for multi-currency portfolios; a shipped catalogue of ~185 ISO 4217 currencies (active + historic with demonetisation metadata); an audit-grade `IDatedExchangeRateProvider` stack; fair allocation; cash rounding; `Fraction<BigInteger>` interop for sub-minor-unit-precise chains; and three JSON wire shapes (strict / lenient / compact).
+  `Money<TCurrency>` where the currency is encoded as the type parameter so cross-currency arithmetic fails the build; `Money` for runtime-tagged scenarios; `MoneyBag` for multi-currency portfolios; a shipped catalogue of ~185 ISO 4217 currencies (active + historic with demonetisation metadata); an audit-grade `IDatedExchangeRateProvider` stack; fair allocation; cash rounding; `Fraction<BigInteger>` interop for sub-minor-unit-precise chains; and three JSON wire shapes (strict / lenient / compact).
 
 ## Guides
 

--- a/docs/docs/financial/concepts.md
+++ b/docs/docs/financial/concepts.md
@@ -14,11 +14,11 @@ A **currency tag** is a sealed class in `Bodu.Financial.Currencies` (one per ISO
 
 Tags use C# 11 static-abstract members, so metadata is accessed through the type itself (`USD.IsoCode`, `USD.MinorUnits`) and through `TCurrency.IsoCode` from generic code constrained by `where TCurrency : ICurrency`. `IsoCode` and `MinorUnits` are required; `CashRoundingIncrement`, `IsHistoric`, `DemonetizedOn`, and `SuccessorIsoCode` are `static virtual` with sensible defaults so existing custom tags compile unchanged.
 
-## `Money<TCurrency>` vs. `MoneyValue`
+## `Money<TCurrency>` vs. `Money`
 
 <xref:Bodu.Financial.Money`1> is **compile-time-typed**: the currency is the type parameter. `Money<USD>` and `Money<JPY>` are distinct types, and adding them is a compile error. Use it whenever the currency is known at the call site.
 
-<xref:Bodu.Financial.MoneyValue> is **runtime-tagged**: it carries the currency as an ISO 4217 string. Cross-currency arithmetic surfaces as <xref:System.InvalidOperationException> at runtime rather than at build time. Use it when the currency is data — deserialised payloads, generic invoicing engines, configuration-driven accounting — and convert to typed money with `MoneyValue.ToTyped<T>()` or `TryToTyped` at the boundary where the currency becomes known.
+<xref:Bodu.Financial.Money> is **runtime-tagged**: it carries the currency as an ISO 4217 string. Cross-currency arithmetic surfaces as <xref:System.InvalidOperationException> at runtime rather than at build time. Use it when the currency is data — deserialised payloads, generic invoicing engines, configuration-driven accounting — and convert to typed money with `Money.As<T>()` or `TryAs` at the boundary where the currency becomes known.
 
 Both types are immutable, value-equatable readonly structs and both round on construction.
 
@@ -92,7 +92,7 @@ Tag types are source-generated from `currencies.json` and registered with <xref:
 
 ## `CurrencyRegistry`
 
-<xref:Bodu.Financial.CurrencyRegistry> is the thread-safe runtime table over <xref:Bodu.Financial.CurrencyInfo> records — the runtime-shape counterpart of an `ICurrency` tag. It backs <xref:Bodu.Financial.MoneyValue> rounding and <xref:Bodu.Financial.MoneyBag> conversions, both of which only know the ISO code at runtime.
+<xref:Bodu.Financial.CurrencyRegistry> is the thread-safe runtime table over <xref:Bodu.Financial.CurrencyInfo> records — the runtime-shape counterpart of an `ICurrency` tag. It backs <xref:Bodu.Financial.Money> rounding and <xref:Bodu.Financial.MoneyBag> conversions, both of which only know the ISO code at runtime.
 
 Custom or future currencies (e.g. cryptocurrencies, in-game tokens, regional vouchers) are registered via `CurrencyRegistry.Register(CurrencyInfo)` or `TryRegister`. Custom entries layer on top of the shipped catalogue and take precedence on conflict, so consumers can override shipped metadata in pinch.
 
@@ -144,11 +144,11 @@ More elaborate cross-provider policies (such as preferring an exact-date hit fro
 
 ## `MoneyConversionResult<TSource, TTarget>`
 
-<xref:Bodu.Financial.MoneyConversionResult`2> is the audit record returned by the `ConvertTo<TTarget>(IDatedExchangeRateProvider, …)` extension methods on `Money<T>`, `MoneyValue`, and `MoneyBag`. It bundles the original source amount, the rounded target amount, and the full <xref:Bodu.Financial.ExchangeRateLookupResult> that produced it — so the consumer sees both the answer and the provenance of the rate in a single value, without a second lookup.
+<xref:Bodu.Financial.MoneyConversionResult`2> is the audit record returned by the `ConvertTo<TTarget>(IDatedExchangeRateProvider, …)` extension methods on `Money<T>`, `Money`, and `MoneyBag`. It bundles the original source amount, the rounded target amount, and the full <xref:Bodu.Financial.ExchangeRateLookupResult> that produced it — so the consumer sees both the answer and the provenance of the rate in a single value, without a second lookup.
 
 ## `MoneyBag`
 
-<xref:Bodu.Financial.MoneyBag> is an immutable mixed-currency portfolio — a snapshot of balances across multiple ISO codes. Mutators return new instances; zero balances are pruned automatically on every operation; enumeration yields one <xref:Bodu.Financial.MoneyValue> per non-zero currency in lexicographic ISO order, so iteration is stable and reproducible across runs.
+<xref:Bodu.Financial.MoneyBag> is an immutable mixed-currency portfolio — a snapshot of balances across multiple ISO codes. Mutators return new instances; zero balances are pruned automatically on every operation; enumeration yields one <xref:Bodu.Financial.Money> per non-zero currency in lexicographic ISO order, so iteration is stable and reproducible across runs.
 
 The bag is the type that models the **aggregate-then-convert** pattern: accumulate per-currency balances during a batch, then convert the entire bag to a single target currency once at the boundary via `MoneyBag.ConvertTo<TTarget>(IExchangeRateProvider)` or its dated counterpart. Compared to converting each amount on the way in, aggregate-then-convert needs one FX lookup per source currency instead of one per posting.
 

--- a/docs/docs/financial/getting-started.md
+++ b/docs/docs/financial/getting-started.md
@@ -77,16 +77,16 @@ Money<USD> balance = Money<USD>.FromFraction(exact);   // one rounding event
 
 Single-step variant: `principal.MultiplyExact(growth)`.
 
-### Runtime-tagged amounts (`MoneyValue`)
+### Runtime-tagged amounts (`Money`)
 
 ```csharp
-MoneyValue invoice = JsonSerializer.Deserialize<MoneyValue>(payload)!;
+Money invoice = JsonSerializer.Deserialize<Money>(payload)!;
 // invoice could be "USD 19.99", "EUR 19.99", or "JPY 200" — same code path.
 
-MoneyValue total = invoice + new MoneyValue(5m, invoice.IsoCode);
+Money total = invoice + new Money(5m, invoice.IsoCode);
 
-Money<USD> typed = invoice.ToTyped<USD>();        // throws if mismatch
-bool ok = invoice.TryToTyped(out Money<USD> r);   // safe variant
+Money<USD> typed = invoice.As<USD>();        // throws if mismatch
+bool ok = invoice.TryAs(out Money<USD> r);   // safe variant
 ```
 
 ### Mixed-currency portfolios (`MoneyBag`)
@@ -98,7 +98,7 @@ MoneyBag wallet = MoneyBag.Empty
     .Add(new Money<JPY>(10_000m));
 
 wallet.GetBalance<USD>();      // Money<USD>? 100.00
-wallet.GetBalance("EUR");      // MoneyValue? { 50, "EUR" }
+wallet.GetBalance("EUR");      // Money? { 50, "EUR" }
 wallet.Count;                  // 3
 ```
 
@@ -141,7 +141,7 @@ The currency's `CashRoundingIncrement` (e.g. `0.05m` for CHF) drives the snap. E
 
 ### JSON
 
-`Money<T>`, `MoneyValue`, and `MoneyBag` all carry `[JsonConverter]` attributes, so the default `Strict` policy works without extra wiring:
+`Money<T>`, `Money`, and `MoneyBag` all carry `[JsonConverter]` attributes, so the default `Strict` policy works without extra wiring:
 
 ```json
 { "amount": 19.99, "currency": "USD" }
@@ -176,6 +176,6 @@ Money<DOGE> tip = new Money<DOGE>(0.12345678m);
 ## Where to go next
 
 - **[Bodu.Financial introduction](index.md)** — namespaces, headline types, scenarios.
-- **[Working with `Money<TCurrency>`](../../guides/financial/money.md)** — the full reference for typed money, including formatting/parsing, locale-aware output, cash rounding, historic-currency metadata, `MoneyValue` interop, and `MoneyBag` portfolios.
+- **[Working with `Money<TCurrency>`](../../guides/financial/money.md)** — the full reference for typed money, including formatting/parsing, locale-aware output, cash rounding, historic-currency metadata, `Money` interop, and `MoneyBag` portfolios.
 - **[Bodu.Numerics getting started](../numerics/getting-started.md)** — for the `Fraction<BigInteger>` precision escape hatch used by `Money<T>.ToFraction()`.
 - **[Bodu.Financial API reference](xref:Bodu.Financial)** — full type-by-type docs.

--- a/docs/docs/financial/index.md
+++ b/docs/docs/financial/index.md
@@ -17,7 +17,7 @@ The package depends on `Bodu.Numerics` so `Money<TCurrency>` can round-trip thro
 | Type | Purpose |
 |---|---|
 | <xref:Bodu.Financial.Money`1> | Immutable, value-equatable monetary amount whose currency is encoded as the type parameter. Cross-currency arithmetic fails the build, not at runtime. |
-| <xref:Bodu.Financial.MoneyValue> | Runtime-tagged sister type — currency carried as an ISO code string. The fallback when the currency is data rather than type, e.g. deserialisation or generic invoicing. |
+| <xref:Bodu.Financial.Money> | Runtime-tagged sister type — currency carried as an ISO code string. The fallback when the currency is data rather than type, e.g. deserialisation or generic invoicing. |
 | <xref:Bodu.Financial.MoneyBag> | Immutable mixed-currency portfolio. Aggregates per-ISO balances, prunes zero balances, enumerates in lexicographic ISO order. |
 | <xref:Bodu.Financial.ICurrency> | Static-abstract interface carrying ISO code, minor-unit count, cash rounding increment, and demonetisation metadata. Implemented by every shipped currency tag. |
 | <xref:Bodu.Financial.CurrencyInfo>, <xref:Bodu.Financial.CurrencyRegistry> | Runtime currency metadata record and a thread-safe registry over shipped + caller-registered custom currencies. |
@@ -44,7 +44,7 @@ The tag types only ever exist statically — every one has a `private` construct
 | Scenario | Reach for |
 |---|---|
 | Type-safe monetary arithmetic that catches USD-vs-JPY mistakes at compile time | <xref:Bodu.Financial.Money`1> |
-| Runtime-tagged amount for deserialisation or generic invoicing | <xref:Bodu.Financial.MoneyValue> |
+| Runtime-tagged amount for deserialisation or generic invoicing | <xref:Bodu.Financial.Money> |
 | Multi-currency portfolio with aggregate-then-convert workflows | <xref:Bodu.Financial.MoneyBag> |
 | Sub-minor-unit-precise interest / percentage chains | `Money<T>.ToFraction()` / `FromFraction()` / `MultiplyExact()` |
 | Splitting an amount fairly across N shares without remainder loss | `Money<T>.Allocate(parts)` / `Allocate(ratios)` |
@@ -57,7 +57,7 @@ The tag types only ever exist statically — every one has a `private` construct
 
 ## Design choices
 
-- **Currency in the type system, not as a field.** `Money<USD>` and `Money<JPY>` are different types. Adding them fails the build rather than running with the wrong unit. The escape hatch is `MoneyValue` when the currency is genuinely unknown until runtime.
+- **Currency in the type system, not as a field.** `Money<USD>` and `Money<JPY>` are different types. Adding them fails the build rather than running with the wrong unit. The escape hatch is `Money` when the currency is genuinely unknown until runtime.
 - **Banker's rounding default.** Construction rounds to the currency's minor-unit precision using `MidpointRounding.ToEven`, matching .NET's `decimal` convention and IEEE 754. Pass an explicit `MidpointRounding` argument to opt out.
 - **Audit-friendly FX.** Dated provider lookups return `ExchangeRateLookupResult`, which carries the provider name, the actual date used, the offset-day distance from the requested date, the resolution policy that fired, and an inversion flag — enough to reconstruct any conversion after the fact.
 - **Zero-balance pruning.** `MoneyBag` removes zero balances on every operation, so equality and enumeration are stable across insertion order and across serialisation round trips.
@@ -65,8 +65,8 @@ The tag types only ever exist statically — every one has a `private` construct
 ## Where to go next
 
 - **[Core concepts](concepts.md)** — glossary the rest of the documentation assumes.
-- **[Getting started](getting-started.md)** — install the package and run minimal samples for `Money<TCurrency>`, `MoneyValue`, `MoneyBag`, the FX provider stack, and the JSON policies.
-- **[Working with `Money<TCurrency>`](../../guides/financial/money.md)** — type-parameter currency, allocation, conversion, exact-arithmetic chains, formatting and parsing, cash rounding, historic currencies, `MoneyValue` interop, `MoneyBag` portfolios.
+- **[Getting started](getting-started.md)** — install the package and run minimal samples for `Money<TCurrency>`, `Money`, `MoneyBag`, the FX provider stack, and the JSON policies.
+- **[Working with `Money<TCurrency>`](../../guides/financial/money.md)** — type-parameter currency, allocation, conversion, exact-arithmetic chains, formatting and parsing, cash rounding, historic currencies, `Money` interop, `MoneyBag` portfolios.
 - **[Bodu.Numerics introduction](../numerics/index.md)** — the rational-arithmetic library that backs `Money<T>.ToFraction()`.
 - **[Bodu.Financial API reference](xref:Bodu.Financial)** — full type-by-type docs.
 - **[Bodu.Financial.Currencies API reference](xref:Bodu.Financial.Currencies)** — the shipped ISO 4217 catalogue.

--- a/docs/guides/financial/exchange-rates.md
+++ b/docs/guides/financial/exchange-rates.md
@@ -171,7 +171,7 @@ rate. To preserve provenance, call the dated provider directly.
 `Money<T>.Convert<TTarget>(decimal)` is the lowest-level conversion
 (supply the rate, it rounds to the destination minor-unit precision).
 When the rate comes from a dated provider and provenance matters,
-prefer the extension methods on `Money<T>` and `MoneyValue`. They
+prefer the extension methods on `Money<T>` and `Money`. They
 resolve the rate, apply it, and return either the converted amount
 (`ConvertTo`) or the full audit record (`ConvertToWithRate`):
 
@@ -188,7 +188,7 @@ audited.ExchangeRate.Rate.Provider;  // "ECB"
 audited.ExchangeRate.OffsetDays;     // 1
 ```
 
-`MoneyValue` has analogous `ConvertTo` and `ConvertToWithRate`
+`Money` has analogous `ConvertTo` and `ConvertToWithRate`
 extension methods for runtime-tagged amounts. For bags, see
 `MoneyBag.ConvertToWithAudit<TTarget>(...)`, which returns one
 `MoneyBagConversionLine` per source currency alongside the total.
@@ -202,7 +202,7 @@ extension methods for runtime-tagged amounts. For bags, see
 | Primary feed plus fallbacks | `CompositeDatedExchangeRateProvider` over multiple dated providers |
 | Reporting period that pins one date everywhere | `DatedExchangeRateProviderAdapter` over the period-end date |
 | Ledger entry that records the rate provenance | `Money<T>.ConvertToWithRate<,>(provider, date, options)` returning `MoneyConversionResult<,>` |
-| Runtime-tagged amount via a dated provider | `MoneyValueExchangeRateExtensions.ConvertToWithRate(...)` |
+| Runtime-tagged amount via a dated provider | `MoneyExchangeRateExtensions.ConvertToWithRate(...)` |
 | Aggregate-then-convert a bag with per-line provenance | `MoneyBag.ConvertToWithAudit<TTarget>(provider, date, options)` |
 
 ## See also

--- a/docs/guides/financial/index.md
+++ b/docs/guides/financial/index.md
@@ -21,7 +21,7 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
   immutable monetary amount whose currency is encoded at the type
   level via an `ICurrency` tag, so cross-currency arithmetic fails
   the build rather than running with the wrong unit at runtime.
-- **[`MoneyValue`](xref:Bodu.Financial.MoneyValue)** — the
+- **[`Money`](xref:Bodu.Financial.Money)** — the
   runtime-tagged sister type for "currency unknown until
   deserialisation" scenarios.
 - **[`MoneyBag`](xref:Bodu.Financial.MoneyBag)** — immutable
@@ -53,7 +53,7 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
 ## See also
 
 - [`Money<TCurrency>` API reference](xref:Bodu.Financial.Money`1)
-- [`MoneyValue` API reference](xref:Bodu.Financial.MoneyValue)
+- [`Money` API reference](xref:Bodu.Financial.Money)
 - [`MoneyBag` API reference](xref:Bodu.Financial.MoneyBag)
 - [`CurrencyRegistry`](xref:Bodu.Financial.CurrencyRegistry)
 - [`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider)

--- a/docs/guides/financial/money.md
+++ b/docs/guides/financial/money.md
@@ -374,16 +374,16 @@ if (info.IsHistoric && entry.PostedOn > info.DemonetizedOn)
         $"{entry.IsoCode} was demonetized {info.DemonetizedOn:d} (replaced by {info.SuccessorIsoCode}).");
 ```
 
-## Runtime-tagged amounts: `MoneyValue`
+## Runtime-tagged amounts: `Money`
 
-`MoneyValue` is the runtime-tagged sister of `Money<TCurrency>`. The
+`Money` is the runtime-tagged sister of `Money<TCurrency>`. The
 currency is carried as a string field rather than a type parameter,
 so the same code path handles any ISO code at runtime — useful for
 deserialisation, generic invoicing engines, and FX systems where the
 currency comes from data, not type.
 
 ```csharp
-MoneyValue invoice = JsonSerializer.Deserialize<MoneyValue>(payload)!;
+Money invoice = JsonSerializer.Deserialize<Money>(payload)!;
 // invoice could be "USD 19.99", "EUR 19.99", or "JPY 200" — same code.
 ```
 
@@ -392,22 +392,22 @@ throw `InvalidOperationException` at runtime instead of failing the
 build:
 
 ```csharp
-MoneyValue usd = new MoneyValue(10m, "USD");
-MoneyValue eur = new MoneyValue(10m, "EUR");
+Money usd = new Money(10m, "USD");
+Money eur = new Money(10m, "EUR");
 
-MoneyValue total = usd + new MoneyValue(5m, "USD");   // OK
+Money total = usd + new Money(5m, "USD");   // OK
 total = usd + eur;                                     // throws InvalidOperationException
 ```
 
 Bridge to and from a typed `Money<T>` when the boundary is known:
 
 ```csharp
-Money<USD> typed = runtime.ToTyped<USD>();                 // throws on mismatch
-bool ok = runtime.TryToTyped(out Money<USD> result);       // safe, returns false on mismatch
-MoneyValue runtime = MoneyValue.FromTyped(new Money<USD>(19.99m));
+Money<USD> typed = runtime.As<USD>();                  // throws on mismatch
+bool ok = runtime.TryAs(out Money<USD> result);        // safe, returns false on mismatch
+Money runtime = new Money<USD>(19.99m).ToMoney();      // typed → runtime-tagged
 ```
 
-`MoneyValue` rounds to the registry's `MinorUnits` for the supplied
+`Money` rounds to the registry's `MinorUnits` for the supplied
 ISO code on construction. Custom currencies not in the catalogue can
 be pre-registered (see [Custom currencies](#custom-currencies)) so
 the rounding follows your declared precision.
@@ -424,7 +424,7 @@ MoneyBag wallet = MoneyBag.Empty
     .Add(new Money<JPY>(10_000m));
 
 wallet.GetBalance<USD>();           // Money<USD> 100.00
-wallet.GetBalance("EUR");           // MoneyValue { 50, "EUR" }
+wallet.GetBalance("EUR");           // Money { 50, "EUR" }
 wallet.Count;                       // 3
 ```
 
@@ -432,8 +432,8 @@ Operators chain naturally:
 
 ```csharp
 MoneyBag updated = wallet
-    + new MoneyValue(25m, "USD")
-    - new MoneyValue(10m, "EUR");
+    + new Money(25m, "USD")
+    - new Money(10m, "EUR");
 ```
 
 Bags are immutable; every operation returns a new bag. Zero balances
@@ -473,7 +473,7 @@ public sealed class DOGE : ICurrency
 }
 ```
 
-Register it with `CurrencyRegistry` so `MoneyValue` and `MoneyBag`
+Register it with `CurrencyRegistry` so `Money` and `MoneyBag`
 round to the right precision when they see the ISO code at runtime:
 
 ```csharp
@@ -483,13 +483,13 @@ CurrencyRegistry.Register(
         DemonetizedOn: null, SuccessorIsoCode: null));
 
 Money<DOGE> tip = new Money<DOGE>(0.12345678m);
-MoneyValue runtime = JsonSerializer.Deserialize<MoneyValue>(
+Money runtime = JsonSerializer.Deserialize<Money>(
     """{ "amount": 0.12345678, "currency": "DOGE" }""");
 ```
 
 ## JSON wire shape
 
-`Money<TCurrency>` and `MoneyValue` both serialise as:
+`Money<TCurrency>` and `Money` both serialise as:
 
 ```json
 { "amount": 19.99, "currency": "USD" }
@@ -498,7 +498,7 @@ MoneyValue runtime = JsonSerializer.Deserialize<MoneyValue>(
 Deserialisation on `Money<TCurrency>` rejects payloads whose
 `"currency"` field does not match `TCurrency.IsoCode` —
 currency drift surfaces as `JsonException`, not as a silently
-re-interpreted amount. `MoneyValue` accepts any ISO code (and rounds
+re-interpreted amount. `Money` accepts any ISO code (and rounds
 to the registry's `MinorUnits` for that code).
 
 `MoneyBag` uses a `{ "balances": { ... } }` wrapper:
@@ -516,7 +516,7 @@ arbitrary-precision number support.
 - **Calculations that genuinely span unknown currencies.** When you
   cannot fix the currency at the type-system level (for example, a
   generic invoicing engine that handles arbitrary user-supplied
-  currencies), use `MoneyValue` instead — the trade-off is runtime
+  currencies), use `Money` instead — the trade-off is runtime
   cross-currency checks rather than compile-time ones.
 - **Mixed-currency totals.** Use `MoneyBag` and a single
   `ConvertTo<TTarget>` call at the boundary where the total is
@@ -533,7 +533,7 @@ arbitrary-precision number support.
 ## See also
 
 - [`Money<TCurrency>` API reference](xref:Bodu.Financial.Money`1)
-- [`MoneyValue` API reference](xref:Bodu.Financial.MoneyValue)
+- [`Money` API reference](xref:Bodu.Financial.Money)
 - [`MoneyBag` API reference](xref:Bodu.Financial.MoneyBag)
 - [`CurrencyRegistry`](xref:Bodu.Financial.CurrencyRegistry)
 - [`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider)

--- a/docs/images/diagrams/financial-namespace-map.svg
+++ b/docs/images/diagrams/financial-namespace-map.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 412" role="img" aria-labelledby="fin-t fin-d">
   <title id="fin-t">Bodu.Financial — namespace map</title>
-  <desc id="fin-d">Bodu.Financial is organised into three namespaces. Bodu.Financial hosts the monetary primitives Money&lt;TCurrency&gt;, MoneyValue, MoneyBag, and the exchange-rate provider stack. Bodu.Financial.Currencies ships sealed tag types — one per ISO 4217 code — that implement the static-abstract ICurrency interface. Bodu.Financial.Serialization ships System.Text.Json converters plus the FinancialJsonPolicy enum that switches between Strict, Lenient, and Compact wire shapes. Currency tags are erased at runtime but their static metadata flows through Money&lt;TCurrency&gt;, the registry, and the serialization layer.</desc>
+  <desc id="fin-d">Bodu.Financial is organised into three namespaces. Bodu.Financial hosts the monetary primitives Money&lt;TCurrency&gt;, Money, MoneyBag, and the exchange-rate provider stack. Bodu.Financial.Currencies ships sealed tag types — one per ISO 4217 code — that implement the static-abstract ICurrency interface. Bodu.Financial.Serialization ships System.Text.Json converters plus the FinancialJsonPolicy enum that switches between Strict, Lenient, and Compact wire shapes. Currency tags are erased at runtime but their static metadata flows through Money&lt;TCurrency&gt;, the registry, and the serialization layer.</desc>
 
   <defs>
     <style>
@@ -36,7 +36,7 @@
       <text class="fin-name" x="14" y="22">Bodu.Financial</text>
       <text class="fin-ns" x="14" y="37">monetary primitives</text>
       <text class="fin-role" x="14" y="58">Money types</text>
-      <text class="fin-type" x="14" y="76">Money&lt;TCurrency&gt; · MoneyValue</text>
+      <text class="fin-type" x="14" y="76">Money&lt;TCurrency&gt; · Money</text>
       <text class="fin-type" x="14" y="94">MoneyBag · MoneyConversionResult</text>
       <text class="fin-role" x="14" y="116">Currency contract</text>
       <text class="fin-type" x="14" y="134">ICurrency · CurrencyInfo</text>

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,7 +111,7 @@ Ten focused NuGet packages — plus three companion calendar data packs, a calen
 <div class="bodu-card">
   <img src="images/hero-financial.svg" alt="Bodu.Financial" />
   <h3>Bodu.Financial</h3>
-  <p>Type-safe monetary primitives: <code>Money&lt;TCurrency&gt;</code> where the currency is encoded as the type parameter so cross-currency arithmetic fails the build, <code>MoneyValue</code> for runtime-tagged scenarios, <code>MoneyBag</code> for multi-currency portfolios, a shipped catalogue of ~185 ISO 4217 currencies (active and historic), an audit-grade exchange-rate provider stack with both timeless and dated lookup, fair allocation, cash rounding, sub-minor-unit-precise <code>Fraction&lt;BigInteger&gt;</code> interop, and three JSON wire shapes (strict / lenient / compact).</p>
+  <p>Type-safe monetary primitives: <code>Money&lt;TCurrency&gt;</code> where the currency is encoded as the type parameter so cross-currency arithmetic fails the build, <code>Money</code> for runtime-tagged scenarios, <code>MoneyBag</code> for multi-currency portfolios, a shipped catalogue of ~185 ISO 4217 currencies (active and historic), an audit-grade exchange-rate provider stack with both timeless and dated lookup, fair allocation, cash rounding, sub-minor-unit-precise <code>Fraction&lt;BigInteger&gt;</code> interop, and three JSON wire shapes (strict / lenient / compact).</p>
   <div class="bodu-card-links">
     <a href="docs/financial/index.md">Introduction</a>
     <a href="guides/financial/index.md">Guides</a>


### PR DESCRIPTION
Update the financial documentation to match the type names introduced
by the runtime-tagged/strongly-typed Money refactor:

- Bodu.Financial.MoneyValue -> Bodu.Financial.Money (runtime-tagged struct)
- Serialization.MoneyValueJsonConverter -> Serialization.MoneyJsonConverter
- typed converter/factory -> MoneyOfTCurrencyJsonConverter{,Factory}
- MoneyValueExchangeRateExtensions -> MoneyExchangeRateExtensions
- replace removed bridge methods (ToTyped/TryToTyped/FromTyped) with the
  real As<T>()/TryAs()/ToMoney() surface

Clears the 6 warningsAsErrors UidNotFound failures in the DocFX build.