### PR TITLE
test+docs(financial): internal-type tests and static-docs coverage for ExchangeRateSeriesBuilder

### DIFF
--- a/Bodu.Financial/test/Financial/ExchangeRateDateSearchTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateDateSearchTests.cs
@@ -1,0 +1,215 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateDateSearchTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+[TestClass]
+public class ExchangeRateDateSearchTests
+{
+    private static readonly int[] s_dayNumbers = { 1000, 1010, 1020 };
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.PreviousOnOrBefore" /> selects the previous index when
+    /// one exists.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenPreviousOnOrBeforeAndPreviousAvailable_ShouldSelectPrevious()
+    {
+        var requested = 1005;
+        var previous = 0;
+        var next = 1;
+
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, requested, ExchangeRateDateResolution.PreviousOnOrBefore, previous, next, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(0, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.PreviousOnOrBefore" /> reports failure when the
+    /// requested day precedes every observation.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenPreviousOnOrBeforeAndNoPrevious_ShouldFail()
+    {
+        var requested = 999;
+        var previous = -1;
+        var next = 0;
+
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, requested, ExchangeRateDateResolution.PreviousOnOrBefore, previous, next, out var candidate);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual(-1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.NextOnOrAfter" /> selects the next index when one
+    /// exists.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNextOnOrAfterAndNextAvailable_ShouldSelectNext()
+    {
+        var requested = 1005;
+        var previous = 0;
+        var next = 1;
+
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, requested, ExchangeRateDateResolution.NextOnOrAfter, previous, next, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.NextOnOrAfter" /> reports failure when the requested day
+    /// follows every observation.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNextOnOrAfterAndNoNext_ShouldFail()
+    {
+        var requested = 1100;
+        var previous = 2;
+        var next = 3; // == dayNumbers.Length
+
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, requested, ExchangeRateDateResolution.NextOnOrAfter, previous, next, out var candidate);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual(-1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Nearest" /> selects the closer of the previous and next
+    /// candidates when they are unequally distant.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestAndPreviousCloser_ShouldSelectPrevious()
+    {
+        // requested 1003 — previous 1000 distance 3, next 1010 distance 7
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1003, ExchangeRateDateResolution.Nearest, 0, 1, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(0, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Nearest" /> selects the next candidate when it is
+    /// closer to the requested date.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestAndNextCloser_ShouldSelectNext()
+    {
+        // requested 1008 — previous 1000 distance 8, next 1010 distance 2
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1008, ExchangeRateDateResolution.Nearest, 0, 1, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Nearest" /> with a tie returns <see langword="false" />
+    /// because the policy cannot deterministically pick a side.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestAndTie_ShouldFail()
+    {
+        // requested 1005 — previous 1000 distance 5, next 1010 distance 5
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1005, ExchangeRateDateResolution.Nearest, 0, 1, out var candidate);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual(-1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.NearestPreferPrevious" /> selects the previous
+    /// candidate on a tie.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestPreferPreviousAndTie_ShouldSelectPrevious()
+    {
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1005, ExchangeRateDateResolution.NearestPreferPrevious, 0, 1, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(0, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.NearestPreferNext" /> selects the next candidate on a
+    /// tie.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestPreferNextAndTie_ShouldSelectNext()
+    {
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1005, ExchangeRateDateResolution.NearestPreferNext, 0, 1, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Nearest" /> falls back to the only available candidate
+    /// when the requested day precedes every observation.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestAndOnlyNextAvailable_ShouldSelectNext()
+    {
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 999, ExchangeRateDateResolution.Nearest, -1, 0, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(0, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Nearest" /> falls back to the only available candidate
+    /// when the requested day follows every observation.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNearestAndOnlyPreviousAvailable_ShouldSelectPrevious()
+    {
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1100, ExchangeRateDateResolution.Nearest, 2, 3, out var candidate);
+
+        Assert.IsTrue(found);
+        Assert.AreEqual(2, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateDateResolution.Exact" /> always returns <see langword="false" />
+    /// because the caller is responsible for the exact-hit fast path.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenExact_ShouldAlwaysFail()
+    {
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            s_dayNumbers, 1005, ExchangeRateDateResolution.Exact, 0, 1, out var candidate);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual(-1, candidate);
+    }
+
+    /// <summary>
+    /// Verifies that when neither a previous nor a next candidate exists (only possible against an empty
+    /// day-number span) the helper reports failure.
+    /// </summary>
+    [TestMethod]
+    public void TrySelectCandidate_WhenNoCandidatesAvailable_ShouldFail()
+    {
+        int[] empty = Array.Empty<int>();
+        var found = ExchangeRateDateSearch.TrySelectCandidate(
+            empty, 1000, ExchangeRateDateResolution.Nearest, -1, 0, out var candidate);
+
+        Assert.IsFalse(found);
+        Assert.AreEqual(-1, candidate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Add.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Add.cs
@@ -1,0 +1,185 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.Add.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> appends a single observation to an empty buffer.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenBufferEmpty_ShouldInsertFirstObservation()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        buffer.Add(1000, 1.5m, RateParam, DateParam);
+
+        Assert.AreEqual(1, buffer.Count);
+        Assert.IsTrue(buffer.TryGetRate(1000, out var rate));
+        Assert.AreEqual(1.5m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> inserts before all existing entries when the new
+    /// day number is smaller than every present day number.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDayNumberLessThanAllExisting_ShouldInsertAtFront()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1010, 1.5m), (1020, 1.6m));
+
+        buffer.Add(1000, 1.4m, RateParam, DateParam);
+
+        AssertContents(buffer, (1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> inserts between existing entries to preserve
+    /// strictly ascending order.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDayNumberFallsBetweenExisting_ShouldInsertInMiddle()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1020, 1.6m));
+
+        buffer.Add(1010, 1.5m, RateParam, DateParam);
+
+        AssertContents(buffer, (1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> appends to the end when the new day number exceeds
+    /// every existing day number.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDayNumberGreaterThanAllExisting_ShouldInsertAtEnd()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+
+        buffer.Add(1020, 1.6m, RateParam, DateParam);
+
+        AssertContents(buffer, (1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> rejects a duplicate day with
+    /// <see cref="ArgumentException" /> and the supplied <paramref name="dateParamName" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenDayAlreadyExists_ShouldThrowWithSuppliedDateParamName()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                buffer.Add(1000, 1.5m, RateParam, "customDate");
+            },
+            "customDate");
+    }
+
+    /// <summary>
+    /// Verifies that a non-positive rate raises <see cref="ArgumentOutOfRangeException" /> using the supplied
+    /// <paramref name="rateParamName" />.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenRateIsZeroOrNegative_ShouldThrowWithSuppliedRateParamName()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.Add(1000, 0m, "customRate", DateParam);
+            },
+            "customRate");
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.Add(1000, -1m, "customRate", DateParam);
+            },
+            "customRate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Add" /> rejects an invalid rate without mutating the
+    /// buffer.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenRateInvalid_ShouldNotMutateBuffer()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+            buffer.Add(1010, 0m, RateParam, DateParam));
+
+        Assert.AreEqual(1, buffer.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryAdd" /> inserts and returns <see langword="true" />
+    /// when the day number is new.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenDayNumberIsNew_ShouldInsertAndReturnTrue()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        var inserted = buffer.TryAdd(1000, 1.5m, RateParam);
+
+        Assert.IsTrue(inserted);
+        Assert.AreEqual(1, buffer.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryAdd" /> returns <see langword="false" /> and preserves
+    /// the existing rate when the day number is already present.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenDayNumberExists_ShouldReturnFalseAndNotMutate()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        var inserted = buffer.TryAdd(1000, 1.9m, RateParam);
+
+        Assert.IsFalse(inserted);
+        Assert.IsTrue(buffer.TryGetRate(1000, out var rate));
+        Assert.AreEqual(1.5m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryAdd" /> validates the rate before checking for an
+    /// existing day number.
+    /// </summary>
+    [TestMethod]
+    public void TryAdd_WhenRateInvalid_ShouldThrowEvenIfDayAlreadyExists()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.TryAdd(1000, 0m, "customRate");
+            },
+            "customRate");
+    }
+
+    private static void AssertContents(ExchangeRateSeriesBuffer buffer, params (int Day, decimal Rate)[] expected)
+    {
+        Assert.AreEqual(expected.Length, buffer.Count);
+
+        var observations = buffer.Enumerate().ToArray();
+        for (var i = 0; i < expected.Length; i++)
+        {
+            Assert.AreEqual(DateOnly.FromDayNumber(expected[i].Day), observations[i].Date);
+            Assert.AreEqual(expected[i].Rate, observations[i].Rate);
+        }
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.AddRange.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.AddRange.cs
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.AddRange.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that an empty incoming sequence is a no-op against an empty buffer.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingEmptyOnEmptyBuffer_ShouldRemainEmpty()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        buffer.AddRange(Array.Empty<ExchangeRateObservation>(), ObservationsParam);
+
+        Assert.IsTrue(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that an empty incoming sequence is a no-op against a populated buffer.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingEmptyOnPopulatedBuffer_ShouldLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+        var before = buffer.Enumerate().ToArray();
+
+        buffer.AddRange(Array.Empty<ExchangeRateObservation>(), ObservationsParam);
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that an unsorted incoming batch is reordered into strictly ascending day order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingUnsorted_ShouldSortBeforeMerging()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1020), 1.6m),
+            new(DateOnly.FromDayNumber(1000), 1.4m),
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+        ];
+
+        buffer.AddRange(batch, ObservationsParam);
+
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+    }
+
+    /// <summary>
+    /// Verifies that an incoming batch interleaved with existing entries produces a single sorted result.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingInterleavedWithExisting_ShouldMergeIntoSortedOrder()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1020, 1.6m), (1040, 1.8m));
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1030), 1.7m),
+        ];
+
+        buffer.AddRange(batch, ObservationsParam);
+
+        Assert.AreEqual(5, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1030), observations[3].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1040), observations[4].Date);
+    }
+
+    /// <summary>
+    /// Verifies that an incoming batch whose dates all precede the buffer's contents merges in front while
+    /// preserving the buffer's existing order.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingPrecedesExisting_ShouldMergeAtFront()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1020, 1.6m), (1030, 1.7m));
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1000), 1.4m),
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+        ];
+
+        buffer.AddRange(batch, ObservationsParam);
+
+        Assert.AreEqual(4, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1030), observations[3].Date);
+    }
+
+    /// <summary>
+    /// Verifies that an incoming batch whose dates all follow the buffer's contents merges at the end.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingFollowsExisting_ShouldAppendAfter()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1020), 1.6m),
+            new(DateOnly.FromDayNumber(1030), 1.7m),
+        ];
+
+        buffer.AddRange(batch, ObservationsParam);
+
+        Assert.AreEqual(4, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1030), observations[3].Date);
+    }
+
+    /// <summary>
+    /// Verifies that the batch is rejected as a whole when one of its entries collides with an existing date.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenAnyIncomingDateCollidesWithExisting_ShouldThrowAndLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1020, 1.6m));
+        var before = buffer.Enumerate().ToArray();
+
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1020), 1.65m), // collides
+            new(DateOnly.FromDayNumber(1030), 1.7m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                buffer.AddRange(batch, ObservationsParam);
+            },
+            ObservationsParam);
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that an in-batch duplicate triggers an <see cref="ArgumentException" /> using the supplied
+    /// parameter name and leaves the buffer unchanged.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenIncomingBatchContainsDuplicate_ShouldThrowAndLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+        var before = buffer.Enumerate().ToArray();
+
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1010), 1.55m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                buffer.AddRange(batch, "customParam");
+            },
+            "customParam");
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that any non-positive rate in the batch raises <see cref="ArgumentOutOfRangeException" /> and the
+    /// buffer remains untouched.
+    /// </summary>
+    [TestMethod]
+    public void AddRange_WhenAnyRateInvalid_ShouldThrowAndLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+        var before = buffer.Enumerate().ToArray();
+
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1020), 0m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.AddRange(batch, ObservationsParam);
+            },
+            ObservationsParam);
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Capacity.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Capacity.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.Capacity.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that growing from zero capacity through many inserts produces a strictly ascending, complete buffer
+    /// — exercising the doubling growth path inside <see cref="ExchangeRateSeriesBuffer" />.
+    /// </summary>
+    [TestMethod]
+    public void Capacity_WhenManyInsertsForceGrowth_ShouldPreserveAllObservations()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+        const int Total = 100;
+
+        for (var i = 0; i < Total; i++)
+        {
+            buffer.Add(1000 + i, 1m + (decimal)i / 1000m, RateParam, DateParam);
+        }
+
+        Assert.AreEqual(Total, buffer.Count);
+
+        var observations = buffer.Enumerate().ToArray();
+        for (var i = 0; i < Total; i++)
+        {
+            Assert.AreEqual(DateOnly.FromDayNumber(1000 + i), observations[i].Date);
+            Assert.AreEqual(1m + (decimal)i / 1000m, observations[i].Rate);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that repeatedly inserting at the front (lowest day number first each time) shifts existing entries
+    /// without corrupting the buffer.
+    /// </summary>
+    [TestMethod]
+    public void Capacity_WhenInsertingDescending_ShouldPreserveAllObservations()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+        const int Total = 64;
+
+        for (var i = Total - 1; i >= 0; i--)
+        {
+            buffer.Add(1000 + i, 1m + (decimal)i / 1000m, RateParam, DateParam);
+        }
+
+        Assert.AreEqual(Total, buffer.Count);
+
+        var observations = buffer.Enumerate().ToArray();
+        for (var i = 0; i < Total; i++)
+        {
+            Assert.AreEqual(DateOnly.FromDayNumber(1000 + i), observations[i].Date);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that an <see cref="ExchangeRateSeriesBuffer.AddRange" /> whose batch size exceeds the buffer's
+    /// existing capacity completes successfully and preserves all observations.
+    /// </summary>
+    [TestMethod]
+    public void Capacity_WhenAddRangeBatchExceedsCapacity_ShouldGrowAndPreserveAllObservations()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+        const int Total = 200;
+
+        var batch = new ExchangeRateObservation[Total];
+        for (var i = 0; i < Total; i++)
+        {
+            batch[i] = new ExchangeRateObservation(DateOnly.FromDayNumber(1000 + i), 1m + (decimal)i / 1000m);
+        }
+
+        buffer.AddRange(batch, ObservationsParam);
+
+        Assert.AreEqual(Total, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1000 + Total - 1), observations[Total - 1].Date);
+    }
+
+    /// <summary>
+    /// Verifies that alternating insert and remove operations preserve buffer integrity over many iterations.
+    /// </summary>
+    [TestMethod]
+    public void Capacity_WhenAlternatingInsertAndRemove_ShouldPreserveIntegrity()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        for (var i = 0; i < 50; i++)
+        {
+            buffer.Add(2000 + i, 1m, RateParam, DateParam);
+        }
+
+        for (var i = 0; i < 50; i += 2)
+        {
+            buffer.Remove(2000 + i);
+        }
+
+        Assert.AreEqual(25, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        for (var i = 0; i < 25; i++)
+        {
+            Assert.AreEqual(DateOnly.FromDayNumber(2001 + 2 * i), observations[i].Date);
+        }
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Remove.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Remove.cs
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.Remove.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that removing the first observation shifts subsequent entries left and reports success.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenRemovingFront_ShouldShiftRemainingLeft()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+
+        var removed = buffer.Remove(1000);
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(2, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[1].Date);
+    }
+
+    /// <summary>
+    /// Verifies that removing the middle observation preserves the order of the remaining entries.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenRemovingMiddle_ShouldPreserveSurroundingOrder()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+
+        var removed = buffer.Remove(1010);
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(2, buffer.Count);
+        Assert.IsFalse(buffer.Contains(1010));
+        Assert.IsTrue(buffer.Contains(1000));
+        Assert.IsTrue(buffer.Contains(1020));
+    }
+
+    /// <summary>
+    /// Verifies that removing the last observation reduces the count by one and clears the trailing slot so a
+    /// subsequent insert reuses the capacity correctly.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenRemovingBack_ShouldReduceCountAndAllowReinsert()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+
+        var removed = buffer.Remove(1020);
+
+        Assert.IsTrue(removed);
+        Assert.AreEqual(2, buffer.Count);
+        Assert.IsFalse(buffer.Contains(1020));
+
+        buffer.Add(1030, 1.7m, RateParam, DateParam);
+        Assert.IsTrue(buffer.Contains(1030));
+        Assert.IsTrue(buffer.TryGetRate(1030, out var rate));
+        Assert.AreEqual(1.7m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that removing every observation leaves the buffer empty and ready for fresh inserts.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenRemovingEvery_ShouldEmptyBuffer()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+
+        buffer.Remove(1000);
+        buffer.Remove(1010);
+
+        Assert.IsTrue(buffer.IsEmpty);
+        Assert.AreEqual(0, buffer.Count);
+
+        buffer.Add(1020, 1.6m, RateParam, DateParam);
+        Assert.AreEqual(1, buffer.Count);
+    }
+
+    /// <summary>
+    /// Verifies that removing an unknown day number returns <see langword="false" /> and does not mutate the
+    /// buffer.
+    /// </summary>
+    [TestMethod]
+    public void Remove_WhenDayMissing_ShouldReturnFalseAndNotMutate()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+
+        var removed = buffer.Remove(1010);
+
+        Assert.IsFalse(removed);
+        Assert.AreEqual(1, buffer.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Contains" /> reports <see langword="true" /> for a present
+    /// day number and <see langword="false" /> for a missing one.
+    /// </summary>
+    [TestMethod]
+    public void Contains_WhenDayPresentOrMissing_ShouldReflectState()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+
+        Assert.IsTrue(buffer.Contains(1000));
+        Assert.IsTrue(buffer.Contains(1010));
+        Assert.IsFalse(buffer.Contains(1005));
+        Assert.IsFalse(buffer.Contains(2000));
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Set.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Set.cs
@@ -1,0 +1,109 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.Set.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Set" /> overwrites the rate for a present day number.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenDayExists_ShouldReplaceRate()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m), (1010, 1.6m));
+
+        buffer.Set(1010, 1.75m, RateParam);
+
+        Assert.AreEqual(2, buffer.Count);
+        Assert.IsTrue(buffer.TryGetRate(1010, out var rate));
+        Assert.AreEqual(1.75m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Set" /> on a missing day number throws
+    /// <see cref="KeyNotFoundException" />.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenDayMissing_ShouldThrowKeyNotFoundException()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        var ex = Assert.ThrowsExactly<KeyNotFoundException>(() =>
+            buffer.Set(1010, 1.6m, RateParam));
+
+        Assert.IsTrue(ex.Message.Contains(
+            DateOnly.FromDayNumber(1010).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
+            StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// Verifies that an invalid rate is rejected before the buffer is consulted for the day number.
+    /// </summary>
+    [TestMethod]
+    public void Set_WhenRateInvalid_ShouldThrowEvenIfDayMissing()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.Set(1000, 0m, "customRate");
+            },
+            "customRate");
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TrySet" /> updates and returns <see langword="true" /> for
+    /// a present day number.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenDayExists_ShouldUpdateAndReturnTrue()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        var updated = buffer.TrySet(1000, 1.9m, RateParam);
+
+        Assert.IsTrue(updated);
+        Assert.IsTrue(buffer.TryGetRate(1000, out var rate));
+        Assert.AreEqual(1.9m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TrySet" /> returns <see langword="false" /> for a missing
+    /// day number and does not mutate the buffer.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenDayMissing_ShouldReturnFalseAndNotMutate()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        var updated = buffer.TrySet(1010, 1.6m, RateParam);
+
+        Assert.IsFalse(updated);
+        Assert.AreEqual(1, buffer.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TrySet" /> validates the rate before checking the day
+    /// number.
+    /// </summary>
+    [TestMethod]
+    public void TrySet_WhenRateInvalid_ShouldThrowEvenIfDayMissing()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.TrySet(1000, -1m, "customRate");
+            },
+            "customRate");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.ToStorage.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.ToStorage.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.ToStorage.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.ToStorage" /> on an empty buffer throws
+    /// <see cref="InvalidOperationException" /> with the empty-builder message.
+    /// </summary>
+    [TestMethod]
+    public void ToStorage_WhenBufferEmpty_ShouldThrowInvalidOperationException()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        var ex = Assert.ThrowsExactly<InvalidOperationException>(() => buffer.ToStorage());
+        Assert.AreEqual(FinancialResourceStrings.Op_Invalid_RateSeriesBuilderEmpty, ex.Message);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.ToStorage" /> trims to the live segment so that excess
+    /// buffer capacity does not leak into the snapshot.
+    /// </summary>
+    [TestMethod]
+    public void ToStorage_WhenBufferOverCapacity_ShouldTrimToLiveCount()
+    {
+        ExchangeRateSeriesBuffer buffer = new(64);
+        buffer.Add(1000, 1.4m, RateParam, DateParam);
+        buffer.Add(1010, 1.5m, RateParam, DateParam);
+
+        ExchangeRateSeriesStorage storage = buffer.ToStorage();
+
+        Assert.AreEqual(2, storage.Count);
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), storage.FirstDate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), storage.LastDate);
+    }
+
+    /// <summary>
+    /// Verifies that further mutations on the buffer do not bleed into a previously produced storage snapshot.
+    /// </summary>
+    [TestMethod]
+    public void ToStorage_WhenBufferMutatedAfterCall_ShouldNotAffectSnapshot()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+        ExchangeRateSeriesStorage snapshot = buffer.ToStorage();
+
+        buffer.Upsert(1000, 99m, RateParam);
+        buffer.Add(1010, 1.5m, RateParam, DateParam);
+
+        var observations = snapshot.Enumerate().ToArray();
+        Assert.AreEqual(1, observations.Length);
+        Assert.AreEqual(1.4m, observations[0].Rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.FromStorage" /> copies every observation from the source
+    /// storage into a new buffer.
+    /// </summary>
+    [TestMethod]
+    public void FromStorage_WhenSeeded_ShouldCopyAllObservations()
+    {
+        ExchangeRateSeriesStorage source = ExchangeRateSeriesStorage.Create(
+            new[]
+            {
+                new ExchangeRateObservation(DateOnly.FromDayNumber(1000), 1.4m),
+                new ExchangeRateObservation(DateOnly.FromDayNumber(1010), 1.5m),
+                new ExchangeRateObservation(DateOnly.FromDayNumber(1020), 1.6m),
+            },
+            ObservationsParam);
+
+        ExchangeRateSeriesBuffer buffer = ExchangeRateSeriesBuffer.FromStorage(source);
+
+        Assert.AreEqual(3, buffer.Count);
+        Assert.IsTrue(buffer.Contains(1000));
+        Assert.IsTrue(buffer.Contains(1010));
+        Assert.IsTrue(buffer.Contains(1020));
+    }
+
+    /// <summary>
+    /// Verifies that a buffer seeded by <see cref="ExchangeRateSeriesBuffer.FromStorage" /> can be mutated without
+    /// affecting the source storage.
+    /// </summary>
+    [TestMethod]
+    public void FromStorage_WhenBufferMutated_ShouldNotAffectSourceStorage()
+    {
+        ExchangeRateSeriesStorage source = ExchangeRateSeriesStorage.Create(
+            new[] { new ExchangeRateObservation(DateOnly.FromDayNumber(1000), 1.4m) },
+            ObservationsParam);
+
+        ExchangeRateSeriesBuffer buffer = ExchangeRateSeriesBuffer.FromStorage(source);
+        buffer.Upsert(1000, 99m, RateParam);
+        buffer.Add(1010, 1.5m, RateParam, DateParam);
+
+        Assert.AreEqual(1, source.Count);
+        var sourceObservations = source.Enumerate().ToArray();
+        Assert.AreEqual(1.4m, sourceObservations[0].Rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Enumerate" /> emits observations in strictly ascending
+    /// date order.
+    /// </summary>
+    [TestMethod]
+    public void Enumerate_WhenInvoked_ShouldYieldInAscendingOrder()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+        buffer.Add(1020, 1.6m, RateParam, DateParam);
+        buffer.Add(1000, 1.4m, RateParam, DateParam);
+        buffer.Add(1010, 1.5m, RateParam, DateParam);
+
+        var observations = buffer.Enumerate().ToArray();
+
+        Assert.AreEqual(3, observations.Length);
+        Assert.IsTrue(observations[0].Date < observations[1].Date);
+        Assert.IsTrue(observations[1].Date < observations[2].Date);
+    }
+
+    /// <summary>
+    /// Verifies that two enumeration passes over the same buffer yield equivalent observation sequences.
+    /// </summary>
+    [TestMethod]
+    public void Enumerate_WhenInvokedTwice_ShouldYieldEquivalentSequences()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+
+        var first = buffer.Enumerate().ToArray();
+        var second = buffer.Enumerate().ToArray();
+
+        CollectionAssert.AreEqual(first, second);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.TryGetRate.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.TryGetRate.cs
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.TryGetRate.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryGetRate" /> returns the recorded rate on exact match.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenDayExists_ShouldReturnTrueAndRate()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+
+        Assert.IsTrue(buffer.TryGetRate(1000, out var rate0));
+        Assert.AreEqual(1.4m, rate0);
+        Assert.IsTrue(buffer.TryGetRate(1010, out var rate1));
+        Assert.AreEqual(1.5m, rate1);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryGetRate" /> returns <see langword="false" /> and a
+    /// default rate for a missing day number — the buffer's lookup is intentionally exact-only.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenDayMissing_ShouldReturnFalseAndDefault()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m));
+
+        Assert.IsFalse(buffer.TryGetRate(1005, out var rate));
+        Assert.AreEqual(0m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.TryGetRate" /> on an empty buffer returns
+    /// <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenBufferEmpty_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        Assert.IsFalse(buffer.TryGetRate(1000, out _));
+    }
+
+    /// <summary>
+    /// Verifies that lookups around the boundary day numbers (one less and one more than every entry) all return
+    /// <see langword="false" />.
+    /// </summary>
+    [TestMethod]
+    public void TryGetRate_WhenBoundaryNeighboursQueried_ShouldReturnFalse()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+
+        Assert.IsFalse(buffer.TryGetRate(999, out _));
+        Assert.IsFalse(buffer.TryGetRate(1001, out _));
+        Assert.IsFalse(buffer.TryGetRate(1009, out _));
+        Assert.IsFalse(buffer.TryGetRate(1011, out _));
+        Assert.IsFalse(buffer.TryGetRate(1019, out _));
+        Assert.IsFalse(buffer.TryGetRate(1021, out _));
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Upsert.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.Upsert.cs
@@ -1,0 +1,63 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.Upsert.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Upsert" /> inserts a new observation when the day number
+    /// is unknown, preserving sorted order.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenDayMissing_ShouldInsertInSortedPosition()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1020, 1.6m));
+
+        buffer.Upsert(1010, 1.5m, RateParam);
+
+        Assert.AreEqual(3, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Upsert" /> replaces an existing rate in place without
+    /// changing the count.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenDayExists_ShouldReplaceRateInPlace()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.5m));
+
+        buffer.Upsert(1000, 1.9m, RateParam);
+
+        Assert.AreEqual(1, buffer.Count);
+        Assert.IsTrue(buffer.TryGetRate(1000, out var rate));
+        Assert.AreEqual(1.9m, rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.Upsert" /> validates the rate using the supplied parameter
+    /// name.
+    /// </summary>
+    [TestMethod]
+    public void Upsert_WhenRateInvalid_ShouldThrowWithSuppliedRateParamName()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.Upsert(1000, 0m, "customRate");
+            },
+            "customRate");
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.UpsertRange.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.UpsertRange.cs
@@ -1,0 +1,127 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.UpsertRange.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesBufferTests
+{
+    /// <summary>
+    /// Verifies that an empty incoming sequence is a no-op against an empty buffer.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenIncomingEmptyOnEmptyBuffer_ShouldRemainEmpty()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        buffer.UpsertRange(Array.Empty<ExchangeRateObservation>(), ObservationsParam);
+
+        Assert.IsTrue(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that batch entries that collide with existing dates are replaced and untouched entries remain.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenIncomingCollidesWithExisting_ShouldReplaceMatchingAndPreserveOthers()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1010, 1.5m), (1020, 1.6m));
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 2.5m),
+            new(DateOnly.FromDayNumber(1020), 2.6m),
+        ];
+
+        buffer.UpsertRange(batch, ObservationsParam);
+
+        Assert.AreEqual(3, buffer.Count);
+        Assert.IsTrue(buffer.TryGetRate(1000, out var r1));
+        Assert.IsTrue(buffer.TryGetRate(1010, out var r2));
+        Assert.IsTrue(buffer.TryGetRate(1020, out var r3));
+        Assert.AreEqual(1.4m, r1);
+        Assert.AreEqual(2.5m, r2);
+        Assert.AreEqual(2.6m, r3);
+    }
+
+    /// <summary>
+    /// Verifies that a batch containing both new and existing dates simultaneously inserts the new entries and
+    /// replaces the existing ones.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenIncomingMixesNewAndExisting_ShouldInsertAndReplaceCorrectly()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m), (1020, 1.6m));
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m), // new
+            new(DateOnly.FromDayNumber(1020), 2.6m), // replace
+            new(DateOnly.FromDayNumber(1030), 1.7m), // new
+        ];
+
+        buffer.UpsertRange(batch, ObservationsParam);
+
+        Assert.AreEqual(4, buffer.Count);
+        var observations = buffer.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(1.4m, observations[0].Rate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+        Assert.AreEqual(2.6m, observations[2].Rate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1030), observations[3].Date);
+    }
+
+    /// <summary>
+    /// Verifies that an in-batch duplicate raises <see cref="ArgumentException" /> and leaves the buffer unchanged.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenIncomingBatchContainsDuplicate_ShouldThrowAndLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+        var before = buffer.Enumerate().ToArray();
+
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1010), 1.55m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                buffer.UpsertRange(batch, ObservationsParam);
+            },
+            ObservationsParam);
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that a non-positive rate in the batch raises <see cref="ArgumentOutOfRangeException" /> and the
+    /// buffer remains untouched.
+    /// </summary>
+    [TestMethod]
+    public void UpsertRange_WhenAnyRateInvalid_ShouldThrowAndLeaveBufferUnchanged()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBufferWith((1000, 1.4m));
+        var before = buffer.Enumerate().ToArray();
+
+        ExchangeRateObservation[] batch =
+        [
+            new(DateOnly.FromDayNumber(1010), 1.5m),
+            new(DateOnly.FromDayNumber(1020), -1m),
+        ];
+
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                buffer.UpsertRange(batch, ObservationsParam);
+            },
+            ObservationsParam);
+
+        CollectionAssert.AreEqual(before, buffer.Enumerate().ToArray());
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesBufferTests.cs
@@ -1,0 +1,90 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesBufferTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+[TestClass]
+public partial class ExchangeRateSeriesBufferTests
+{
+    private const string RateParam = "rate";
+    private const string DateParam = "date";
+    private const string ObservationsParam = "observations";
+
+    private static ExchangeRateSeriesBuffer NewBuffer() => new();
+
+    private static ExchangeRateSeriesBuffer NewBufferWith(params (int Day, decimal Rate)[] entries)
+    {
+        var buffer = new ExchangeRateSeriesBuffer();
+        foreach (var (day, rate) in entries)
+        {
+            buffer.Add(day, rate, RateParam, DateParam);
+        }
+
+        return buffer;
+    }
+
+    /// <summary>
+    /// Verifies that a default-constructed buffer reports zero count and empty state.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenDefaultConstructed_ShouldStartEmpty()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        Assert.AreEqual(0, buffer.Count);
+        Assert.IsTrue(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that a non-positive capacity argument is clamped to zero and produces an empty buffer that still
+    /// accepts subsequent inserts.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenCapacityIsZeroOrNegative_ShouldStartEmptyAndAcceptInserts()
+    {
+        ExchangeRateSeriesBuffer zero = new(0);
+        ExchangeRateSeriesBuffer negative = new(-5);
+
+        Assert.AreEqual(0, zero.Count);
+        Assert.AreEqual(0, negative.Count);
+
+        zero.Add(1000, 1.5m, RateParam, DateParam);
+        negative.Add(1000, 1.5m, RateParam, DateParam);
+
+        Assert.AreEqual(1, zero.Count);
+        Assert.AreEqual(1, negative.Count);
+    }
+
+    /// <summary>
+    /// Verifies that a positive initial capacity is allocated up front while live count starts at zero.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenPositiveCapacitySupplied_ShouldStartEmpty()
+    {
+        ExchangeRateSeriesBuffer buffer = new(32);
+
+        Assert.AreEqual(0, buffer.Count);
+        Assert.IsTrue(buffer.IsEmpty);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesBuffer.IsEmpty" /> flips from <see langword="true" /> to
+    /// <see langword="false" /> as observations are added and back to <see langword="true" /> as they are removed.
+    /// </summary>
+    [TestMethod]
+    public void IsEmpty_WhenObservationsAddedAndRemoved_ShouldReflectLiveCount()
+    {
+        ExchangeRateSeriesBuffer buffer = NewBuffer();
+
+        Assert.IsTrue(buffer.IsEmpty);
+
+        buffer.Add(1000, 1.5m, RateParam, DateParam);
+        Assert.IsFalse(buffer.IsEmpty);
+
+        buffer.Remove(1000);
+        Assert.IsTrue(buffer.IsEmpty);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.CreateFromSortedUnique.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.CreateFromSortedUnique.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesStorageTests.CreateFromSortedUnique.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesStorageTests
+{
+    /// <summary>
+    /// Verifies that the trusted entry point <see cref="ExchangeRateSeriesStorage.CreateFromSortedUnique" />
+    /// adopts the supplied arrays without revalidation.
+    /// </summary>
+    [TestMethod]
+    public void CreateFromSortedUnique_WhenArraysSupplied_ShouldAdoptArrays()
+    {
+        int[] days = [1000, 1010, 1020];
+        decimal[] rates = [1.4m, 1.5m, 1.6m];
+
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.CreateFromSortedUnique(days, rates);
+
+        Assert.AreEqual(3, storage.Count);
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), storage.FirstDate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), storage.LastDate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.CreateFromSortedUnique" /> exposes the adopted
+    /// observations via <see cref="ExchangeRateSeriesStorage.Enumerate" />.
+    /// </summary>
+    [TestMethod]
+    public void CreateFromSortedUnique_WhenEnumerated_ShouldYieldSuppliedEntries()
+    {
+        int[] days = [1000, 1010, 1020];
+        decimal[] rates = [1.4m, 1.5m, 1.6m];
+
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.CreateFromSortedUnique(days, rates);
+
+        var observations = storage.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(1.4m, observations[0].Rate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+        Assert.AreEqual(1.6m, observations[2].Rate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.CreateFromSortedUnique" /> supports a single-entry
+    /// storage instance.
+    /// </summary>
+    [TestMethod]
+    public void CreateFromSortedUnique_WhenSingleEntry_ShouldExposeBothFirstAndLastDate()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.CreateFromSortedUnique(
+            new[] { 1234 },
+            new[] { 2.5m });
+
+        Assert.AreEqual(1, storage.Count);
+        Assert.AreEqual(DateOnly.FromDayNumber(1234), storage.FirstDate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1234), storage.LastDate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.Dates.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.Dates.cs
@@ -1,0 +1,51 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesStorageTests.Dates.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesStorageTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.FirstDate" /> reflects the earliest observation date.
+    /// </summary>
+    [TestMethod]
+    public void FirstDate_WhenStoragePopulated_ShouldReturnEarliestObservation()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1020, 1.6m), Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), storage.FirstDate);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.LastDate" /> reflects the latest observation date.
+    /// </summary>
+    [TestMethod]
+    public void LastDate_WhenStoragePopulated_ShouldReturnLatestObservation()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1020, 1.6m), Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), storage.LastDate);
+    }
+
+    /// <summary>
+    /// Verifies that a single-entry storage reports the same date for both <see cref="ExchangeRateSeriesStorage.FirstDate" />
+    /// and <see cref="ExchangeRateSeriesStorage.LastDate" />.
+    /// </summary>
+    [TestMethod]
+    public void FirstAndLastDate_WhenSingleEntry_ShouldMatch()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1234, 2.5m) },
+            ObservationsParam);
+
+        Assert.AreEqual(storage.FirstDate, storage.LastDate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1234), storage.FirstDate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.Enumerate.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.Enumerate.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesStorageTests.Enumerate.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class ExchangeRateSeriesStorageTests
+{
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.Enumerate" /> emits observations in strictly ascending
+    /// date order regardless of input order.
+    /// </summary>
+    [TestMethod]
+    public void Enumerate_WhenInvoked_ShouldYieldInAscendingOrder()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1020, 1.6m), Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        var observations = storage.Enumerate().ToArray();
+
+        Assert.AreEqual(3, observations.Length);
+        Assert.IsTrue(observations[0].Date < observations[1].Date);
+        Assert.IsTrue(observations[1].Date < observations[2].Date);
+    }
+
+    /// <summary>
+    /// Verifies that calling <see cref="ExchangeRateSeriesStorage.Enumerate" /> twice on the same storage produces
+    /// equivalent sequences.
+    /// </summary>
+    [TestMethod]
+    public void Enumerate_WhenInvokedTwice_ShouldYieldEquivalentSequences()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1000, 1.4m), Obs(1010, 1.5m), Obs(1020, 1.6m) },
+            ObservationsParam);
+
+        var first = storage.Enumerate().ToArray();
+        var second = storage.Enumerate().ToArray();
+
+        CollectionAssert.AreEqual(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that each emitted <see cref="ExchangeRateObservation" /> carries both the recorded date and the
+    /// recorded rate.
+    /// </summary>
+    [TestMethod]
+    public void Enumerate_WhenInvoked_ShouldEmitDateAndRateTogether()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        var observations = storage.Enumerate().ToArray();
+
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(1.4m, observations[0].Rate);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(1.5m, observations[1].Rate);
+    }
+}

--- a/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.cs
+++ b/Bodu.Financial/test/Financial/ExchangeRateSeriesStorageTests.cs
@@ -1,0 +1,150 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ExchangeRateSeriesStorageTests.cs" company="Bodu Pty. Ltd.">
+//     Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Test.Assertions;
+
+namespace Bodu.Financial;
+
+[TestClass]
+public partial class ExchangeRateSeriesStorageTests
+{
+    private const string ObservationsParam = "observations";
+    private const string RatesParam = "rates";
+
+    private static ExchangeRateObservation Obs(int dayNumber, decimal rate) =>
+        new(DateOnly.FromDayNumber(dayNumber), rate);
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.Create(IEnumerable{ExchangeRateObservation}, string)" />
+    /// stores the supplied observations.
+    /// </summary>
+    [TestMethod]
+    public void Create_Observations_WhenInputsValid_ShouldStoreObservations()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        Assert.AreEqual(2, storage.Count);
+    }
+
+    /// <summary>
+    /// Verifies that an empty observation sequence raises <see cref="ArgumentException" /> with the supplied
+    /// parameter name.
+    /// </summary>
+    [TestMethod]
+    public void Create_Observations_WhenEmpty_ShouldThrowArgumentException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                _ = ExchangeRateSeriesStorage.Create(Array.Empty<ExchangeRateObservation>(), ObservationsParam);
+            },
+            ObservationsParam);
+    }
+
+    /// <summary>
+    /// Verifies that a non-positive rate raises <see cref="ArgumentOutOfRangeException" /> with the supplied
+    /// parameter name.
+    /// </summary>
+    [TestMethod]
+    public void Create_Observations_WhenAnyRateInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentOutOfRangeException>(
+            () =>
+            {
+                _ = ExchangeRateSeriesStorage.Create(
+                    new[] { Obs(1000, 1.4m), Obs(1010, 0m) },
+                    ObservationsParam);
+            },
+            ObservationsParam);
+    }
+
+    /// <summary>
+    /// Verifies that a duplicate observation date raises <see cref="ArgumentException" /> with the supplied
+    /// parameter name.
+    /// </summary>
+    [TestMethod]
+    public void Create_Observations_WhenDuplicateDate_ShouldThrowArgumentException()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                _ = ExchangeRateSeriesStorage.Create(
+                    new[] { Obs(1000, 1.4m), Obs(1000, 1.5m) },
+                    ObservationsParam);
+            },
+            ObservationsParam);
+    }
+
+    /// <summary>
+    /// Verifies that unsorted observations are reordered into strictly ascending date order during creation.
+    /// </summary>
+    [TestMethod]
+    public void Create_Observations_WhenUnsorted_ShouldStoreInAscendingOrder()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new[] { Obs(1020, 1.6m), Obs(1000, 1.4m), Obs(1010, 1.5m) },
+            ObservationsParam);
+
+        var observations = storage.Enumerate().ToArray();
+        Assert.AreEqual(DateOnly.FromDayNumber(1000), observations[0].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1010), observations[1].Date);
+        Assert.AreEqual(DateOnly.FromDayNumber(1020), observations[2].Date);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ExchangeRateSeriesStorage.Create(IEnumerable{ValueTuple{DateOnly, decimal}}, string)" />
+    /// stores the supplied tuples.
+    /// </summary>
+    [TestMethod]
+    public void Create_Tuples_WhenInputsValid_ShouldStoreObservations()
+    {
+        ExchangeRateSeriesStorage storage = ExchangeRateSeriesStorage.Create(
+            new (DateOnly, decimal)[]
+            {
+                (DateOnly.FromDayNumber(1000), 1.4m),
+                (DateOnly.FromDayNumber(1010), 1.5m),
+            },
+            RatesParam);
+
+        Assert.AreEqual(2, storage.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the tuple overload rejects an empty sequence with <see cref="ArgumentException" /> using its
+    /// caller-supplied parameter name.
+    /// </summary>
+    [TestMethod]
+    public void Create_Tuples_WhenEmpty_ShouldThrowWithRatesParamName()
+    {
+        ExceptionAssert.ThrowsExactlyWithParamName<ArgumentException>(
+            () =>
+            {
+                _ = ExchangeRateSeriesStorage.Create(
+                    Array.Empty<(DateOnly, decimal)>(),
+                    RatesParam);
+            },
+            RatesParam);
+    }
+
+    /// <summary>
+    /// Verifies that the tuple overload preserves the legacy <c>Rate must be greater than zero.</c> message text
+    /// so existing callers' message assertions continue to hold.
+    /// </summary>
+    [TestMethod]
+    public void Create_Tuples_WhenRateInvalid_ShouldUseLegacyMessage()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+            ExchangeRateSeriesStorage.Create(
+                new (DateOnly, decimal)[] { (DateOnly.FromDayNumber(1000), 0m) },
+                RatesParam));
+
+        Assert.IsTrue(ex.Message.Contains(
+            FinancialResourceStrings.Arg_OutOfRange_RateNotPositive,
+            StringComparison.Ordinal));
+    }
+}

--- a/docs/apidoc/Bodu.Financial.md
+++ b/docs/apidoc/Bodu.Financial.md
@@ -34,7 +34,8 @@ Reach for this library when you need monetary arithmetic that the compiler valid
 **Exchange rate stack**
 
 - <xref:Bodu.Financial.IExchangeRateProvider>, <xref:Bodu.Financial.IDatedExchangeRateProvider> — timeless and dated contracts.
-- <xref:Bodu.Financial.ExchangeRate>, <xref:Bodu.Financial.ExchangeRatePair>, <xref:Bodu.Financial.ExchangeRateSeries> — observation record, strongly-typed (from, to) key, and an O(log n) time series.
+- <xref:Bodu.Financial.ExchangeRate>, <xref:Bodu.Financial.ExchangeRatePair>, <xref:Bodu.Financial.ExchangeRateObservation>, <xref:Bodu.Financial.ExchangeRateSeries> — observation record, strongly-typed (from, to) key, single dated observation value, and an O(log n) read-optimised time series.
+- <xref:Bodu.Financial.ExchangeRateSeriesBuilder>, <xref:Bodu.Financial.ExchangeRateSeriesKey>, <xref:Bodu.Financial.ExchangeRateTable> — mutable companion for building or editing a series, the (pair, provider) key, and a higher-level multi-series editor for import workflows.
 - <xref:Bodu.Financial.ExchangeRateLookupOptions>, <xref:Bodu.Financial.ExchangeRateLookupResult>, <xref:Bodu.Financial.ExchangeRateDateResolution> — resolution policy options and the audit-grade lookup result.
 - <xref:Bodu.Financial.FixedExchangeRateTable>, <xref:Bodu.Financial.FixedDatedExchangeRateTable>, <xref:Bodu.Financial.CompositeDatedExchangeRateProvider>, <xref:Bodu.Financial.DatedExchangeRateProviderAdapter> — in-memory provider implementations, a composite stack for prioritised fallback, and an adapter that pins a date to a dated provider for codebases that don't need the dated surface.
 - <xref:Bodu.Financial.MoneyConversionResult`2> — audit record bundling source and target money with the full lookup result.

--- a/docs/docs/financial/concepts.md
+++ b/docs/docs/financial/concepts.md
@@ -106,7 +106,23 @@ Custom or future currencies (e.g. cryptocurrencies, in-game tokens, regional vou
 
 ## `ExchangeRateSeries`
 
-<xref:Bodu.Financial.ExchangeRateSeries> stores every observation for one `(pair, provider)` combination in two parallel sorted arrays — dates and rates — so resolution is allocation-free and runs in `O(log n)` over the date array via <xref:System.Array.BinarySearch``1(``0[],``0)>. The two-array layout improves cache locality compared to a <xref:System.Collections.Generic.SortedDictionary`2>, and instances are safe to share across threads after construction.
+<xref:Bodu.Financial.ExchangeRateSeries> stores every observation for one `(pair, provider)` combination in two parallel sorted arrays — day numbers (<xref:System.DateOnly.DayNumber>) and rates — so resolution is allocation-free and runs in `O(log n)` over the day-number array via <xref:System.Array.BinarySearch``1(``0[],``0)>. The two-array layout improves cache locality compared to a <xref:System.Collections.Generic.SortedDictionary`2>, and instances are safe to share across threads after construction. Public APIs continue to accept and return <xref:System.DateOnly>; conversion to and from the internal day-number representation happens at the boundary.
+
+The series is **immutable**. Use the companion <xref:Bodu.Financial.ExchangeRateSeriesBuilder> to construct or edit observations imperatively, or the copy-on-write helpers `ExchangeRateSeries.WithRate(date, rate)` and `ExchangeRateSeries.WithoutRate(date)` for single-edit return-new patterns. `ExchangeRateSeries.GetObservations()` yields the observations as an <xref:Bodu.Financial.ExchangeRateObservation> sequence in strictly ascending date order, and `ExchangeRateSeries.ToBuilder()` returns a fresh builder pre-populated from the snapshot.
+
+## `ExchangeRateObservation`
+
+<xref:Bodu.Financial.ExchangeRateObservation> is the lightweight `(Date, Rate)` `readonly record struct` used as the transport shape for series enumeration, builder mutation, and bulk-import APIs. Unlike <xref:Bodu.Financial.ExchangeRate> it does not carry provider or inversion metadata — those are owned by the enclosing series. The type itself does not validate `Rate`; the surrounding series and builder reject zero or negative values at the boundary.
+
+## `ExchangeRateSeriesBuilder`
+
+<xref:Bodu.Financial.ExchangeRateSeriesBuilder> is the mutable companion to <xref:Bodu.Financial.ExchangeRateSeries>. It maintains strictly ascending unique observation dates and strictly positive rates while supporting single-observation edits and bulk import. The public surface distinguishes intent through three explicit shapes — `Add` (throws on duplicate), `Set` (throws on missing), and `Upsert` (insert-or-replace) — plus their `Try`-prefixed boolean siblings. Bulk import uses `AddRange` (rejects duplicates) and `UpsertRange` (replaces existing dates, rejects in-batch duplicates) with atomic-rollback semantics: a mid-batch validation failure leaves the builder unchanged. `ToSeries()` produces an immutable <xref:Bodu.Financial.ExchangeRateSeries> snapshot; further builder mutations do not affect previously produced snapshots, and vice versa. Instances are not thread-safe.
+
+## `ExchangeRateSeriesKey` and `ExchangeRateTable`
+
+<xref:Bodu.Financial.ExchangeRateSeriesKey> is a `readonly record struct` carrying a <xref:Bodu.Financial.ExchangeRatePair> and the publishing provider's identifier — the natural dictionary key when the same pair has rates from multiple sources.
+
+<xref:Bodu.Financial.ExchangeRateTable> is the higher-level mutable collection that owns one <xref:Bodu.Financial.ExchangeRateSeriesBuilder> per `(pair, provider)` key. It exposes `GetOrAddSeries`, `Upsert(pair, provider, date, rate)`, `TryGetBuilder` (returns the mutable builder), `TryGetSeries` (returns an immutable snapshot), and `ToSeries()` (snapshots every non-empty series). Use it for import workflows that ingest rate observations across many currency pairs and providers before producing immutable snapshots for production lookup. Like the builder it is not thread-safe.
 
 ## Timeless vs. dated provider
 

--- a/docs/docs/financial/index.md
+++ b/docs/docs/financial/index.md
@@ -21,7 +21,8 @@ The package depends on `Bodu.Numerics` so `Money<TCurrency>` can round-trip thro
 | <xref:Bodu.Financial.MoneyBag> | Immutable mixed-currency portfolio. Aggregates per-ISO balances, prunes zero balances, enumerates in lexicographic ISO order. |
 | <xref:Bodu.Financial.ICurrency> | Static-abstract interface carrying ISO code, minor-unit count, cash rounding increment, and demonetisation metadata. Implemented by every shipped currency tag. |
 | <xref:Bodu.Financial.CurrencyInfo>, <xref:Bodu.Financial.CurrencyRegistry> | Runtime currency metadata record and a thread-safe registry over shipped + caller-registered custom currencies. |
-| <xref:Bodu.Financial.ExchangeRate>, <xref:Bodu.Financial.ExchangeRatePair>, <xref:Bodu.Financial.ExchangeRateSeries> | Immutable FX observation value object, strongly-typed (from, to) key, and an O(log n) time series over observations. |
+| <xref:Bodu.Financial.ExchangeRate>, <xref:Bodu.Financial.ExchangeRatePair>, <xref:Bodu.Financial.ExchangeRateObservation>, <xref:Bodu.Financial.ExchangeRateSeries> | Immutable FX observation value object, strongly-typed (from, to) key, single dated observation, and an O(log n) time series over observations. |
+| <xref:Bodu.Financial.ExchangeRateSeriesBuilder>, <xref:Bodu.Financial.ExchangeRateSeriesKey>, <xref:Bodu.Financial.ExchangeRateTable> | Mutable companion to `ExchangeRateSeries` for building or editing observations, the `(pair, provider)` key, and a higher-level multi-series editor for import workflows. |
 | <xref:Bodu.Financial.IExchangeRateProvider>, <xref:Bodu.Financial.IDatedExchangeRateProvider> | Timeless and dated provider contracts. The dated form returns an <xref:Bodu.Financial.ExchangeRateLookupResult> with provenance metadata (offset days, resolution policy, provider name). |
 | <xref:Bodu.Financial.FixedExchangeRateTable>, <xref:Bodu.Financial.FixedDatedExchangeRateTable>, <xref:Bodu.Financial.CompositeDatedExchangeRateProvider> | In-memory provider implementations and a composite stack for prioritised fallback across multiple FX sources. |
 | <xref:Bodu.Financial.MoneyConversionResult`2> | Audit record returned by extension methods that convert through a dated provider — pairs source and target amount with the full lookup result. |
@@ -53,6 +54,8 @@ The tag types only ever exist statically — every one has a `private` construct
 | Custom or future currencies not in the shipped catalogue | `CurrencyRegistry.Register(CurrencyInfo)` + your own `ICurrency` tag |
 | Dated FX lookup with audit-grade provenance metadata | <xref:Bodu.Financial.IDatedExchangeRateProvider> + <xref:Bodu.Financial.ExchangeRateLookupResult> |
 | Prioritised fallback across multiple FX sources | <xref:Bodu.Financial.CompositeDatedExchangeRateProvider> |
+| Build a rate series imperatively, or edit an existing one and snapshot the result | <xref:Bodu.Financial.ExchangeRateSeriesBuilder>, `ExchangeRateSeries.ToBuilder()` / `WithRate(...)` / `WithoutRate(...)` |
+| Import rates for many `(pair, provider)` combinations before producing immutable snapshots | <xref:Bodu.Financial.ExchangeRateTable> |
 | Three JSON wire shapes (strict-canonical, lenient-import, compact-string) for the same monetary type | <xref:Bodu.Financial.Serialization.FinancialJsonPolicy> |
 
 ## Design choices

--- a/docs/guides/financial/exchange-rates.md
+++ b/docs/guides/financial/exchange-rates.md
@@ -16,7 +16,10 @@ reports, and multi-source feeds that carry their provenance.
 
 - **Rate** — `ExchangeRate` is an immutable record-struct (`FromIsoCode`, `ToIsoCode`, `Date`, `Rate`, `Provider`, `IsInverted`). Rounding is deferred to the money boundary.
 - **Pair** — `ExchangeRatePair` is the `(From, To)` key. Validates both ISO codes at construction; exposes `Inverse()`.
-- **Series** — `ExchangeRateSeries` stores every observation for one `(pair, provider)` in two parallel sorted arrays. Resolution is `O(log n)` via `Array.BinarySearch`, allocation-free.
+- **Observation** — `ExchangeRateObservation` is the lightweight `(Date, Rate)` carrier used by series enumeration, builder mutation, and bulk-import APIs.
+- **Series** — `ExchangeRateSeries` stores every observation for one `(pair, provider)` in two parallel sorted arrays. Resolution is `O(log n)` via `Array.BinarySearch`, allocation-free. Immutable; use `ExchangeRateSeriesBuilder` to construct or edit observations.
+- **Builder** — `ExchangeRateSeriesBuilder` is the mutable companion that maintains strictly ascending unique dates and produces immutable `ExchangeRateSeries` snapshots via `ToSeries()`.
+- **Table** — `ExchangeRateTable` keys one builder per `(pair, provider)` for multi-series import workflows.
 - **Provider** — `IExchangeRateProvider` is timeless; `IDatedExchangeRateProvider` is dated and returns an `ExchangeRateLookupResult` with provenance.
 - **Lookup result** — `ExchangeRateLookupResult` carries the rate, requested date, resolution policy, and offset-day distance.
 
@@ -117,6 +120,91 @@ For finer control, construct the record directly with
 `AllowSameCurrencyIdentityRate` (both default `true`) disable the
 reverse-pair fallback and identity short-circuit.
 
+## Building a series imperatively
+
+`ExchangeRateSeries` is immutable, so the construction path for series
+that aren't shipped as a one-shot literal is `ExchangeRateSeriesBuilder`.
+Use it for manual data entry, streaming imports, and merge-with-history
+flows. Three explicit shapes distinguish caller intent:
+
+- `Add(date, rate)` — throws if the date is already present (the data
+  is wrong if you see this).
+- `Set(date, rate)` — throws if the date is missing (you expected an
+  observation to be there).
+- `Upsert(date, rate)` — insert-or-replace; the right shape for merge
+  semantics.
+
+Each has a `Try`-prefixed `bool` sibling. Bulk import uses `AddRange`
+(rejects duplicates outright) and `UpsertRange` (replaces existing
+dates; rejects in-batch duplicates). Both apply atomic rollback: a
+mid-batch validation failure leaves the builder unchanged.
+
+```csharp
+ExchangeRatePair pair = new("USD", "AUD");
+ExchangeRateSeriesBuilder builder = new(pair, "RBA");
+
+builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+builder.AddRange(new[]
+{
+    new ExchangeRateObservation(new DateOnly(2026, 6, 2), 1.51m),
+    new ExchangeRateObservation(new DateOnly(2026, 6, 3), 1.52m),
+});
+builder.Upsert(new DateOnly(2026, 6, 3), 1.53m);  // replaces 1.52m
+
+ExchangeRateSeries snapshot = builder.ToSeries();
+```
+
+`ToSeries()` produces a fresh immutable `ExchangeRateSeries` that is
+isolated from further builder mutations. Calling `ToSeries()` on an
+empty builder throws `InvalidOperationException` because the immutable
+series contract requires at least one observation.
+
+### Copy-on-write edits on an existing series
+
+When the source of truth is already an `ExchangeRateSeries` snapshot,
+the copy-on-write helpers wrap the builder roundtrip for the common
+single-edit case:
+
+```csharp
+ExchangeRateSeries withUpdate = original.WithRate(new DateOnly(2026, 6, 3), 1.55m);
+ExchangeRateSeries withRemoval = original.WithoutRate(new DateOnly(2026, 6, 3));
+
+foreach (var observation in original.GetObservations())
+{
+    // observation.Date / observation.Rate
+}
+```
+
+`original` is unchanged in both cases. `ToBuilder()` returns a fresh
+builder seeded from the snapshot for multi-edit workflows.
+
+## Editing across many pairs and providers
+
+When import data arrives flat — many pairs from many providers — keep
+the builder bookkeeping in `ExchangeRateTable`. It owns one
+`ExchangeRateSeriesBuilder` per `(pair, provider)` key and exposes
+both lazy creation and a multi-series snapshot operation:
+
+```csharp
+ExchangeRateTable table = new();
+
+table.Upsert(new ExchangeRatePair("USD", "AUD"), "RBA", new DateOnly(2026, 6, 1), 1.50m);
+table.Upsert(new ExchangeRatePair("USD", "JPY"), "BoJ", new DateOnly(2026, 6, 1), 110m);
+
+// Reach for the underlying builder if you need bulk operations on one series.
+ExchangeRateSeriesBuilder rba = table.GetOrAddSeries(new ExchangeRatePair("USD", "AUD"), "RBA");
+rba.AddRange(/* observations */);
+
+// Snapshot every non-empty series in one pass.
+IReadOnlyList<ExchangeRateSeries> snapshots = table.ToSeries();
+```
+
+`TryGetSeries` returns a fresh immutable snapshot when the series
+exists and is non-empty; `TryGetBuilder` returns the mutable builder
+directly. Empty builders are skipped by `ToSeries()` because an
+immutable series cannot be empty. The table is not thread-safe; use
+external synchronisation for concurrent edits.
+
 ## Composite fallback stack
 
 `CompositeDatedExchangeRateProvider` wraps an ordered set of dated
@@ -204,11 +292,15 @@ extension methods for runtime-tagged amounts. For bags, see
 | Ledger entry that records the rate provenance | `Money<T>.ConvertToWithRate<,>(provider, date, options)` returning `MoneyConversionResult<,>` |
 | Runtime-tagged amount via a dated provider | `MoneyExchangeRateExtensions.ConvertToWithRate(...)` |
 | Aggregate-then-convert a bag with per-line provenance | `MoneyBag.ConvertToWithAudit<TTarget>(provider, date, options)` |
+| Build a new series imperatively, or merge incoming observations into an existing one | `ExchangeRateSeriesBuilder` + `Add` / `Upsert` / `AddRange` / `UpsertRange` |
+| Single insert/replace/remove that returns a fresh immutable series | `ExchangeRateSeries.WithRate(date, rate)` / `WithoutRate(date)` |
+| Import flat rate data across many `(pair, provider)` combinations before producing immutable snapshots | `ExchangeRateTable` |
 
 ## See also
 
 - [Bodu.Financial introduction](../../docs/financial/index.md), [Core concepts](../../docs/financial/concepts.md), [Working with `Money<TCurrency>`](money.md)
 - Contracts — [`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider), [`IDatedExchangeRateProvider`](xref:Bodu.Financial.IDatedExchangeRateProvider)
-- Values — [`ExchangeRate`](xref:Bodu.Financial.ExchangeRate), [`ExchangeRatePair`](xref:Bodu.Financial.ExchangeRatePair), [`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries)
+- Values — [`ExchangeRate`](xref:Bodu.Financial.ExchangeRate), [`ExchangeRatePair`](xref:Bodu.Financial.ExchangeRatePair), [`ExchangeRateObservation`](xref:Bodu.Financial.ExchangeRateObservation), [`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries)
+- Editing — [`ExchangeRateSeriesBuilder`](xref:Bodu.Financial.ExchangeRateSeriesBuilder), [`ExchangeRateSeriesKey`](xref:Bodu.Financial.ExchangeRateSeriesKey), [`ExchangeRateTable`](xref:Bodu.Financial.ExchangeRateTable)
 - Providers — [`FixedExchangeRateTable`](xref:Bodu.Financial.FixedExchangeRateTable), [`FixedDatedExchangeRateTable`](xref:Bodu.Financial.FixedDatedExchangeRateTable), [`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider), [`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter)
 - Lookup metadata — [`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions), [`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult), [`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution), [`MoneyConversionResult<TSource, TTarget>`](xref:Bodu.Financial.MoneyConversionResult`2)

--- a/docs/guides/financial/index.md
+++ b/docs/guides/financial/index.md
@@ -39,6 +39,12 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
   [`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries),
   [`FixedDatedExchangeRateTable`](xref:Bodu.Financial.FixedDatedExchangeRateTable),
   [`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider)).
+- **FX editing surface:**
+  [`ExchangeRateSeriesBuilder`](xref:Bodu.Financial.ExchangeRateSeriesBuilder)
+  as the mutable companion to `ExchangeRateSeries`, plus
+  [`ExchangeRateTable`](xref:Bodu.Financial.ExchangeRateTable) for
+  multi-pair / multi-provider import workflows that produce
+  immutable snapshots.
 
 ## Articles
 
@@ -47,8 +53,9 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
   formatting and parsing.
 - [Working with exchange rates](exchange-rates.md) — the FX provider
   stack: timeless vs. dated contracts, the audit-grade
-  `ExchangeRateLookupResult`, the composite fallback stack, and the
-  `MoneyConversionResult<,>` audit record.
+  `ExchangeRateLookupResult`, the composite fallback stack, the
+  `MoneyConversionResult<,>` audit record, and the
+  `ExchangeRateSeriesBuilder` + `ExchangeRateTable` editing surface.
 
 ## See also
 


### PR DESCRIPTION
## Summary

Follow-on to #379 (which merged the feat itself). Two pieces of work that weren't part of that PR:

1. **Direct internal-type test coverage** — `ExchangeRateSeriesBuffer`, `ExchangeRateSeriesStorage`, `ExchangeRateDateSearch`. Previously exercised only indirectly via the public builder/series/table surfaces; this commit pins down each algorithm in isolation.
2. **Static documentation** — the five hand-written financial doc pages now cover the new mutable surface introduced by #379. Auto-generated API pages already pick up the new types from their XML docs.

The branch was rebased onto current `master`; the duplicate feat commit was dropped during rebase since #379 already landed it.

## What's in this PR

### Internal-type tests (15 new files, 88 tests)

- **`ExchangeRateSeriesBufferTests`** — 10 partials covering ctor / `Count` / `IsEmpty`, `Add` / `TryAdd`, `Set` / `TrySet`, `Upsert`, `Remove` / `Contains`, `TryGetRate`, `AddRange`, `UpsertRange` (including atomic-rollback on duplicate-in-batch / existing-collision / invalid-rate), `ToStorage` / `FromStorage` / `Enumerate`, and `Capacity` (100-insert growth, descending-insert shifts, 200-entry `AddRange`, alternating insert/remove).
- **`ExchangeRateSeriesStorageTests`** — 4 partials covering both `Create` overloads (`(DateOnly, decimal)` tuples and `ExchangeRateObservation` observations), the `CreateFromSortedUnique` trust-boundary entry point, `FirstDate` / `LastDate`, and `Enumerate`.
- **`ExchangeRateDateSearchTests`** — every `ExchangeRateDateResolution` policy plus tie behaviour, one-sided candidate fallback, `Exact` always-false, and empty-span case.

### Static documentation

Five hand-written financial doc pages updated:
- `apidoc/Bodu.Financial.md` — new types under "Exchange rate stack".
- `docs/financial/index.md` — namespace table + two new scenarios.
- `docs/financial/concepts.md` — clarified immutability + day-number storage; added concept entries for `ExchangeRateObservation`, `ExchangeRateSeriesBuilder`, `ExchangeRateSeriesKey`, `ExchangeRateTable`.
- `guides/financial/exchange-rates.md` — extended "Concepts in one minute"; new sections "Building a series imperatively" (with copy-on-write subsection) and "Editing across many pairs and providers"; extended patterns table.
- `guides/financial/index.md` — new editing-surface bullet.

## Test plan

- [x] `dotnet build Bodu.Financial/src/Bodu.Financial.csproj` — green.
- [x] `dotnet test Bodu.Financial/test/Bodu.Financial.Test.csproj --settings bvt.runsettings` — **1277/1277 passing** post-rebase.
- [x] `docfx docs/docfx.json` — every new `xref:` resolves; no new warnings caused by this PR.
- [ ] CI on this PR turns green (DocFX `--warningsAsErrors`, full solution build + test).

https://claude.ai/code/session_012BpfWBjYxSieNEeM2YDGAj