### PR TITLE
feat(financial): reject unknown currencies by default with explicit-scale escape hatch

### DIFF
--- a/Bodu.Financial.DependencyInjection/src/Bodu.Financial.DependencyInjection.csproj
+++ b/Bodu.Financial.DependencyInjection/src/Bodu.Financial.DependencyInjection.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <OutputType>Library</OutputType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Bodu.Financial.DependencyInjection.Test</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Core\src\Bodu.Core.csproj" />
+    <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/DependencyInjectionResourceStrings.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/DependencyInjectionResourceStrings.cs
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="DependencyInjectionResourceStrings.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Centralizes the exception message templates used by the financial dependency-injection extension surface.
+/// </summary>
+/// <remarks>
+/// Messages are exposed as <see langword="const" /> strings, matching the <c>DependencyInjectionResourceStrings</c>
+/// convention used by <c>Bodu.Globalization.Calendar.DependencyInjection</c>.
+/// </remarks>
+[SuppressMessage("StyleCop.CSharp.NamingRules", "SA1310:Field names should not contain underscore", Justification = "Resource string identifiers follow the diagnostic-class_subject convention used by RESX-generated equivalents elsewhere in the solution.")]
+internal static class DependencyInjectionResourceStrings
+{
+    /// <summary>
+    /// A monetary-context name supplied to a builder method was empty or white space.
+    /// </summary>
+    internal const string Arg_Invalid_MonetaryContextNameBlank = "The monetary-context name must not be empty or white space.";
+}

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialOptions.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialOptions.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FinancialOptions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Bodu.Financial.Serialization;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Configuration-bindable options for the Bodu.Financial dependency-injection surface.
+/// </summary>
+public sealed class FinancialOptions
+{
+    /// <summary>
+    /// Gets or sets the JSON serialization policy registered for financial types.
+    /// </summary>
+    /// <value>The configured policy; defaults to <see cref="FinancialJsonPolicy.Strict" />.</value>
+    public FinancialJsonPolicy JsonPolicy { get; set; } = FinancialJsonPolicy.Strict;
+
+    /// <summary>
+    /// Gets or sets the default unknown-currency policy advertised to consumers.
+    /// </summary>
+    /// <value>The configured policy; defaults to <see cref="UnknownCurrencyPolicy.Reject" />.</value>
+    public UnknownCurrencyPolicy UnknownCurrency { get; set; } = UnknownCurrencyPolicy.Reject;
+}

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialServiceBuilder.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialServiceBuilder.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FinancialServiceBuilder.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Default <see cref="IFinancialServiceBuilder" /> implementation, a thin wrapper around an
+/// <see cref="IServiceCollection" /> that the fluent extension methods in
+/// <see cref="FinancialServiceBuilderExtensions" /> operate against.
+/// </summary>
+internal sealed class FinancialServiceBuilder
+    : IFinancialServiceBuilder
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FinancialServiceBuilder" /> class.
+    /// </summary>
+    /// <param name="services">The service collection that subsequent registrations contribute into.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> is <see langword="null" />.</exception>
+    public FinancialServiceBuilder(IServiceCollection services)
+    {
+        ThrowHelper.ThrowIfNull(services);
+
+        Services = services;
+    }
+
+    /// <inheritdoc />
+    public IServiceCollection Services { get; }
+}

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialServiceBuilderExtensions.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/FinancialServiceBuilderExtensions.cs
@@ -1,0 +1,147 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FinancialServiceBuilderExtensions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using Bodu.Financial;
+using Bodu.Financial.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Provides the fluent registration surface for <see cref="IFinancialServiceBuilder" />: currency lookup, named
+/// monetary contexts, exchange-rate providers, and JSON policy.
+/// </summary>
+public static class FinancialServiceBuilderExtensions
+{
+    /// <summary>
+    /// The service key under which the configured financial <see cref="JsonSerializerOptions" /> is registered.
+    /// </summary>
+    public const string JsonOptionsKey = "Financial";
+
+    /// <summary>
+    /// Replaces the registered <see cref="ICurrencyLookup" /> with <typeparamref name="TLookup" />.
+    /// </summary>
+    /// <typeparam name="TLookup">The lookup implementation.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    public static IFinancialServiceBuilder AddCurrencyLookup<TLookup>(this IFinancialServiceBuilder builder)
+        where TLookup : class, ICurrencyLookup
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.Replace(ServiceDescriptor.Singleton<ICurrencyLookup, TLookup>());
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers a named <see cref="MonetaryContext" /> resolvable as a keyed singleton.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="name">The key under which the context is registered.</param>
+    /// <param name="context">The monetary context.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder" /> or <paramref name="context" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException"><paramref name="name" /> is empty or white space.</exception>
+    public static IFinancialServiceBuilder AddMonetaryContext(this IFinancialServiceBuilder builder, string name, MonetaryContext context)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(context);
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException(DependencyInjectionResourceStrings.Arg_Invalid_MonetaryContextNameBlank, nameof(name));
+
+        builder.Services.AddKeyedSingleton(name, context);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IExchangeRateProvider" /> implementation as a singleton.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider implementation.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    public static IFinancialServiceBuilder AddExchangeRateProvider<TProvider>(this IFinancialServiceBuilder builder)
+        where TProvider : class, IExchangeRateProvider
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<IExchangeRateProvider, TProvider>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IExchangeRateProvider" /> instance as a singleton.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="provider">The provider instance.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder" /> or <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    public static IFinancialServiceBuilder AddExchangeRateProvider(this IFinancialServiceBuilder builder, IExchangeRateProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(provider);
+
+        builder.Services.TryAddSingleton(provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IDatedExchangeRateProvider" /> implementation as a singleton.
+    /// </summary>
+    /// <typeparam name="TProvider">The provider implementation.</typeparam>
+    /// <param name="builder">The builder.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    public static IFinancialServiceBuilder AddDatedExchangeRateProvider<TProvider>(this IFinancialServiceBuilder builder)
+        where TProvider : class, IDatedExchangeRateProvider
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.TryAddSingleton<IDatedExchangeRateProvider, TProvider>();
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers an <see cref="IDatedExchangeRateProvider" /> instance as a singleton.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="provider">The provider instance.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="builder" /> or <paramref name="provider" /> is <see langword="null" />.
+    /// </exception>
+    public static IFinancialServiceBuilder AddDatedExchangeRateProvider(this IFinancialServiceBuilder builder, IDatedExchangeRateProvider provider)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+        ThrowHelper.ThrowIfNull(provider);
+
+        builder.Services.TryAddSingleton(provider);
+        return builder;
+    }
+
+    /// <summary>
+    /// Registers a <see cref="JsonSerializerOptions" /> configured with the financial converters under the
+    /// <paramref name="policy" />, keyed by <see cref="JsonOptionsKey" />.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <param name="policy">The serialization policy.</param>
+    /// <returns>The builder, for chaining.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="builder" /> is <see langword="null" />.</exception>
+    public static IFinancialServiceBuilder AddFinancialJson(this IFinancialServiceBuilder builder, FinancialJsonPolicy policy = FinancialJsonPolicy.Strict)
+    {
+        ThrowHelper.ThrowIfNull(builder);
+
+        builder.Services.AddKeyedSingleton(JsonOptionsKey, (_, _) => new JsonSerializerOptions().AddFinancialJsonConverters(policy));
+        return builder;
+    }
+}

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/IFinancialServiceBuilder.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/IFinancialServiceBuilder.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IFinancialServiceBuilder.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Defines the fluent registration surface returned by
+/// <see cref="ServiceCollectionExtensions.AddBoduFinancial(IServiceCollection, Microsoft.Extensions.Configuration.IConfiguration?, string)" />,
+/// mirroring the <c>IHttpClientBuilder</c> / <c>IMvcBuilder</c> pattern.
+/// </summary>
+public interface IFinancialServiceBuilder
+{
+    /// <summary>
+    /// Gets the <see cref="IServiceCollection" /> that the builder is composing into.
+    /// </summary>
+    /// <returns>The underlying service collection.</returns>
+    IServiceCollection Services { get; }
+}

--- a/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/ServiceCollectionExtensions.cs
+++ b/Bodu.Financial.DependencyInjection/src/Financial.DependencyInjection/ServiceCollectionExtensions.cs
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Provides the <c>AddBoduFinancial</c> entry points that register the Bodu.Financial services into an
+/// <see cref="IServiceCollection" /> and return a fluent <see cref="IFinancialServiceBuilder" />.
+/// </summary>
+public static class ServiceCollectionExtensions
+{
+    /// <summary>
+    /// The default <see cref="IConfiguration" /> section name bound into <see cref="FinancialOptions" />.
+    /// </summary>
+    public const string DefaultConfigurationSection = "Financial";
+
+    /// <summary>
+    /// Registers the core financial services — an <see cref="ICurrencyLookup" /> singleton and bound
+    /// <see cref="FinancialOptions" /> — and returns a builder for further composition.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configuration">
+    /// Optional configuration root or section. When supplied, the section named <paramref name="sectionName" /> is
+    /// bound into <see cref="FinancialOptions" />.
+    /// </param>
+    /// <param name="sectionName">The configuration section name. Defaults to <see cref="DefaultConfigurationSection" />.</param>
+    /// <returns>An <see cref="IFinancialServiceBuilder" /> for further registration.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="services" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="sectionName" /> is empty or white space.</exception>
+    /// <remarks>
+    /// No foreign-exchange provider is registered by default; supply one via
+    /// <see cref="FinancialServiceBuilderExtensions.AddExchangeRateProvider{TProvider}(IFinancialServiceBuilder)" /> or
+    /// its dated counterpart.
+    /// </remarks>
+    public static IFinancialServiceBuilder AddBoduFinancial(
+        this IServiceCollection services,
+        IConfiguration? configuration = null,
+        string sectionName = DefaultConfigurationSection)
+    {
+        ThrowHelper.ThrowIfNull(services);
+        ThrowHelper.ThrowIfNullOrWhiteSpace(sectionName);
+
+        services.AddOptions();
+
+        if (configuration is not null)
+        {
+            services
+                .AddOptions<FinancialOptions>()
+                .Bind(configuration.GetSection(sectionName));
+        }
+
+        services.TryAddSingleton<ICurrencyLookup, CurrencyLookupService>();
+
+        return new FinancialServiceBuilder(services);
+    }
+
+    /// <summary>
+    /// Registers the core financial services and invokes <paramref name="configure" /> for programmatic composition.
+    /// </summary>
+    /// <param name="services">The service collection to register into.</param>
+    /// <param name="configure">A callback invoked with the <see cref="IFinancialServiceBuilder" />.</param>
+    /// <returns>The same builder the callback received.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="services" /> or <paramref name="configure" /> is <see langword="null" />.
+    /// </exception>
+    public static IFinancialServiceBuilder AddBoduFinancial(
+        this IServiceCollection services,
+        Action<IFinancialServiceBuilder> configure)
+    {
+        ThrowHelper.ThrowIfNull(services);
+        ThrowHelper.ThrowIfNull(configure);
+
+        IFinancialServiceBuilder builder = services.AddBoduFinancial();
+        configure(builder);
+        return builder;
+    }
+}

--- a/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
+++ b/Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Bodu</RootNamespace>
+    <AssemblyName>$(MSBuildProjectName)</AssemblyName>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="4.2.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="4.2.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Bodu.Financial\src\Bodu.Financial.csproj" />
+    <ProjectReference Include="..\..\Bodu.Test\test\Bodu.Test.csproj" />
+    <ProjectReference Include="..\src\Bodu.Financial.DependencyInjection.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/FinancialOptionsTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/FinancialOptionsTests.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FinancialOptionsTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Bodu.Financial.Serialization;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Verifies the defaults of <see cref="FinancialOptions" />.
+/// </summary>
+[TestClass]
+public sealed class FinancialOptionsTests
+{
+    /// <summary>
+    /// Verifies that a freshly constructed options instance exposes the documented defaults.
+    /// </summary>
+    [TestMethod]
+    public void Defaults_WhenConstructed_ShouldBeStrictAndReject()
+    {
+        FinancialOptions options = new();
+
+        Assert.AreEqual(FinancialJsonPolicy.Strict, options.JsonPolicy);
+        Assert.AreEqual(UnknownCurrencyPolicy.Reject, options.UnknownCurrency);
+    }
+}

--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/FinancialServiceBuilderExtensionsTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/FinancialServiceBuilderExtensionsTests.cs
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="FinancialServiceBuilderExtensionsTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using Bodu.Financial;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Verifies the fluent registration surface exposed by <see cref="FinancialServiceBuilderExtensions" />.
+/// </summary>
+[TestClass]
+public sealed class FinancialServiceBuilderExtensionsTests
+{
+    /// <summary>
+    /// A stub <see cref="IExchangeRateProvider" /> for registration tests.
+    /// </summary>
+    private sealed class StubRateProvider : IExchangeRateProvider
+    {
+        /// <inheritdoc />
+        public decimal GetRate(string fromIsoCode, string toIsoCode) => 1m;
+    }
+
+    /// <summary>
+    /// An alternative <see cref="ICurrencyLookup" /> used to verify replacement. All members are unsupported; the type
+    /// exists only to confirm the registered implementation type.
+    /// </summary>
+    private sealed class CustomLookup : ICurrencyLookup
+    {
+        /// <inheritdoc />
+        public bool TryByIsoCode(string isoCode, out CurrencyInfo currency) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryByCurrencyCode(Bodu.Financial.Currencies.CurrencyCode code, out CurrencyInfo currency) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryByNumericCode(int numericCode, out CurrencyInfo currency) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryBySymbol(string symbol, out IReadOnlyList<CurrencyInfo> matches) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public bool TryByRegion(string regionCode, out IReadOnlyList<CurrencyInfo> matches) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public IReadOnlyList<CurrencyInfo> ByCulture(System.Globalization.CultureInfo culture) => throw new NotSupportedException();
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddCurrencyLookup</c> replaces the default lookup registration.
+    /// </summary>
+    [TestMethod]
+    public void AddCurrencyLookup_WhenCustomType_ShouldReplaceDefault()
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddBoduFinancial()
+            .AddCurrencyLookup<CustomLookup>()
+            .Services.BuildServiceProvider();
+
+        Assert.IsInstanceOfType<CustomLookup>(provider.GetRequiredService<ICurrencyLookup>());
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddMonetaryContext</c> registers a keyed, resolvable context.
+    /// </summary>
+    [TestMethod]
+    public void AddMonetaryContext_WhenNamed_ShouldResolveByKey()
+    {
+        MonetaryContext tax = MonetaryContext.Default with { Rounding = MidpointRoundingStrategy.AwayFromZero };
+
+        ServiceProvider provider = new ServiceCollection()
+            .AddBoduFinancial()
+            .AddMonetaryContext("Tax", tax)
+            .Services.BuildServiceProvider();
+
+        Assert.AreSame(tax, provider.GetRequiredKeyedService<MonetaryContext>("Tax"));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddMonetaryContext</c> rejects a blank name.
+    /// </summary>
+    [TestMethod]
+    public void AddMonetaryContext_WhenNameBlank_ShouldThrowArgumentException()
+    {
+        IFinancialServiceBuilder builder = new ServiceCollection().AddBoduFinancial();
+
+        Assert.ThrowsExactly<ArgumentException>(() => builder.AddMonetaryContext("  ", MonetaryContext.Default));
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddExchangeRateProvider</c> registers a resolvable provider.
+    /// </summary>
+    [TestMethod]
+    public void AddExchangeRateProvider_WhenType_ShouldRegisterProvider()
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddBoduFinancial()
+            .AddExchangeRateProvider<StubRateProvider>()
+            .Services.BuildServiceProvider();
+
+        Assert.IsInstanceOfType<StubRateProvider>(provider.GetRequiredService<IExchangeRateProvider>());
+    }
+
+    /// <summary>
+    /// Verifies that no exchange-rate provider is registered by default.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenNoProviderSupplied_ShouldNotRegisterExchangeRateProvider()
+    {
+        ServiceProvider provider = new ServiceCollection().AddBoduFinancial().Services.BuildServiceProvider();
+
+        Assert.IsNull(provider.GetService<IExchangeRateProvider>());
+    }
+
+    /// <summary>
+    /// Verifies that <c>AddFinancialJson</c> registers configured serializer options resolvable by key.
+    /// </summary>
+    [TestMethod]
+    public void AddFinancialJson_WhenRegistered_ShouldProvideConfiguredOptions()
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddBoduFinancial()
+            .AddFinancialJson(Serialization.FinancialJsonPolicy.Compact)
+            .Services.BuildServiceProvider();
+
+        var options = provider.GetRequiredKeyedService<JsonSerializerOptions>(FinancialServiceBuilderExtensions.JsonOptionsKey);
+        var json = JsonSerializer.Serialize(new Money(19.99m, "USD"), options);
+
+        Assert.AreEqual("\"19.99 USD\"", json);
+    }
+}

--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/IntegrationTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/IntegrationTests.cs
@@ -1,0 +1,43 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IntegrationTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Verifies end-to-end composition through the builder-callback registration shape.
+/// </summary>
+[TestClass]
+public sealed class IntegrationTests
+{
+    /// <summary>
+    /// Verifies that a full composition resolves the currency lookup, named context, exchange-rate provider, and JSON
+    /// options together.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenComposedViaCallback_ShouldResolveAllServices()
+    {
+        MonetaryContext tax = MonetaryContext.Default with { Rounding = MidpointRoundingStrategy.AwayFromZero };
+
+        ServiceProvider provider = new ServiceCollection()
+            .AddBoduFinancial(builder => builder
+                .AddMonetaryContext("Tax", tax)
+                .AddExchangeRateProvider(new FixedExchangeRateTable(new Dictionary<(string, string), decimal>
+                {
+                    { ("USD", "AUD"), 1.5m },
+                }))
+                .AddFinancialJson())
+            .Services.BuildServiceProvider();
+
+        Assert.IsNotNull(provider.GetRequiredService<ICurrencyLookup>());
+        Assert.AreSame(tax, provider.GetRequiredKeyedService<MonetaryContext>("Tax"));
+
+        IExchangeRateProvider rates = provider.GetRequiredService<IExchangeRateProvider>();
+        Assert.AreEqual(1.5m, rates.GetRate("USD", "AUD"));
+    }
+}

--- a/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/ServiceCollectionExtensionsTests.cs
+++ b/Bodu.Financial.DependencyInjection/test/Financial.DependencyInjection/ServiceCollectionExtensionsTests.cs
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ServiceCollectionExtensionsTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial;
+using Bodu.Financial.Serialization;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+namespace Bodu.Financial.DependencyInjection;
+
+/// <summary>
+/// Verifies the registration semantics of the <see cref="ServiceCollectionExtensions.AddBoduFinancial(IServiceCollection, IConfiguration?, string)" />
+/// family.
+/// </summary>
+[TestClass]
+public sealed class ServiceCollectionExtensionsTests
+{
+    /// <summary>
+    /// Verifies that <c>AddBoduFinancial</c> registers an <see cref="ICurrencyLookup" /> resolvable as a singleton.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void AddBoduFinancial_WhenCalled_ShouldRegisterCurrencyLookupSingleton()
+    {
+        ServiceProvider provider = new ServiceCollection().AddBoduFinancial().Services.BuildServiceProvider();
+
+        ICurrencyLookup first = provider.GetRequiredService<ICurrencyLookup>();
+        ICurrencyLookup second = provider.GetRequiredService<ICurrencyLookup>();
+
+        Assert.IsInstanceOfType<CurrencyLookupService>(first);
+        Assert.AreSame(first, second);
+    }
+
+    /// <summary>
+    /// Verifies that the configuration-driven overload binds <see cref="FinancialOptions" /> from the named section.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenConfigurationSupplied_ShouldBindOptions()
+    {
+        IConfiguration configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Financial:JsonPolicy"] = nameof(FinancialJsonPolicy.Compact),
+                ["Financial:UnknownCurrency"] = nameof(UnknownCurrencyPolicy.AllowUnscaled),
+            })
+            .Build();
+
+        ServiceProvider provider = new ServiceCollection().AddBoduFinancial(configuration).Services.BuildServiceProvider();
+
+        FinancialOptions options = provider.GetRequiredService<IOptions<FinancialOptions>>().Value;
+
+        Assert.AreEqual(FinancialJsonPolicy.Compact, options.JsonPolicy);
+        Assert.AreEqual(UnknownCurrencyPolicy.AllowUnscaled, options.UnknownCurrency);
+    }
+
+    /// <summary>
+    /// Verifies that repeated registration resolves the same <see cref="ICurrencyLookup" /> instance.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenCalledTwice_ShouldRegisterLookupIdempotently()
+    {
+        IServiceCollection services = new ServiceCollection();
+        services.AddBoduFinancial();
+        services.AddBoduFinancial();
+
+        Assert.AreEqual(1, services.Count(d => d.ServiceType == typeof(ICurrencyLookup)));
+    }
+
+    /// <summary>
+    /// Verifies that the builder-callback overload throws when the callback is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenConfigureNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = new ServiceCollection().AddBoduFinancial((Action<IFinancialServiceBuilder>)null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that a null service collection is rejected.
+    /// </summary>
+    [TestMethod]
+    public void AddBoduFinancial_WhenServicesNull_ShouldThrowArgumentNullException()
+    {
+        Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = ServiceCollectionExtensions.AddBoduFinancial(null!);
+        });
+    }
+}

--- a/Bodu.Financial/src/Financial.Serialization/MoneyDto.cs
+++ b/Bodu.Financial/src/Financial.Serialization/MoneyDto.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyDto.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.Serialization;
+
+/// <summary>
+/// A transport-shaped money representation compatible with Google's <c>google.type.Money</c>: a currency code, a whole
+/// number of major units, and a nano-unit fraction.
+/// </summary>
+/// <param name="CurrencyCode">The ISO 4217 alphabetic currency code.</param>
+/// <param name="Units">The whole units of the amount.</param>
+/// <param name="Nanos">
+/// The fractional units in billionths (10^-9). Must be in the range -999,999,999 to 999,999,999 and share the sign of
+/// <paramref name="Units" /> when both are non-zero.
+/// </param>
+/// <remarks>
+/// This is an interchange shape only; it is not the internal money representation. Use <see cref="MoneyDtoAdapter" /> to
+/// convert to and from <see cref="Money" />.
+/// </remarks>
+public sealed record MoneyDto(string CurrencyCode, long Units, int Nanos);

--- a/Bodu.Financial/src/Financial.Serialization/MoneyDtoAdapter.cs
+++ b/Bodu.Financial/src/Financial.Serialization/MoneyDtoAdapter.cs
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyDtoAdapter.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial.Serialization;
+
+/// <summary>
+/// Converts between <see cref="Money" /> and the Google-compatible <see cref="MoneyDto" /> transport shape.
+/// </summary>
+public static class MoneyDtoAdapter
+{
+    /// <summary>
+    /// The number of nano-units in one major unit.
+    /// </summary>
+    private const decimal NanosPerUnit = 1_000_000_000m;
+
+    /// <summary>
+    /// The inclusive bound for the magnitude of the nano-unit fraction.
+    /// </summary>
+    private const int MaxNanos = 999_999_999;
+
+    /// <summary>
+    /// Converts a <see cref="Money" /> to its <see cref="MoneyDto" /> transport representation.
+    /// </summary>
+    /// <param name="money">The amount to convert.</param>
+    /// <returns>The transport-shaped representation.</returns>
+    public static MoneyDto ToDto(Money money)
+    {
+        var amount = money.Amount;
+        var units = decimal.ToInt64(decimal.Truncate(amount));
+        var nanos = (int)decimal.Round((amount - units) * NanosPerUnit, 0, MidpointRounding.ToEven);
+
+        return new MoneyDto(money.IsoCode, units, nanos);
+    }
+
+    /// <summary>
+    /// Converts a <see cref="MoneyDto" /> to a <see cref="Money" />, applying <paramref name="unknownCurrency" /> when
+    /// the currency is unregistered.
+    /// </summary>
+    /// <param name="dto">The transport-shaped representation.</param>
+    /// <param name="unknownCurrency">The policy applied when the currency is unregistered.</param>
+    /// <returns>The reconstructed <see cref="Money" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="dto" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    /// The nanos value is out of range, the units and nanos signs disagree, or the currency code is invalid or
+    /// unregistered under the policy.
+    /// </exception>
+    public static Money ToMoney(MoneyDto dto, UnknownCurrencyPolicy unknownCurrency = UnknownCurrencyPolicy.Reject)
+    {
+        ThrowHelper.ThrowIfNull(dto);
+
+        if (dto.Nanos < -MaxNanos || dto.Nanos > MaxNanos)
+        {
+            throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_MoneyDtoNanosRange, dto.Nanos),
+                nameof(dto));
+        }
+
+        if (dto.Units != 0 && dto.Nanos != 0 && Math.Sign(dto.Units) != Math.Sign(dto.Nanos))
+        {
+            throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_MoneyDtoSignMismatch, dto.Units, dto.Nanos),
+                nameof(dto));
+        }
+
+        var amount = dto.Units + (dto.Nanos / NanosPerUnit);
+        return Money.From(amount, dto.CurrencyCode, unknownCurrency);
+    }
+}

--- a/Bodu.Financial/src/Financial/AllocationPolicy.cs
+++ b/Bodu.Financial/src/Financial/AllocationPolicy.cs
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AllocationPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies the algorithm a <see cref="MonetaryContext" /> uses to distribute residual minor units when allocating a
+/// monetary amount across shares.
+/// </summary>
+public enum AllocationPolicy
+{
+    /// <summary>
+    /// Distribute residual minor units by the largest-remainder (Hamilton) method, breaking ties by ascending index.
+    /// </summary>
+    LargestRemainder = 0,
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.Conversion.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.Conversion.cs
@@ -1,0 +1,58 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.Conversion.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public readonly partial struct CalculatedMoney
+{
+    /// <summary>
+    /// Materialises this high-precision amount as a settlement <see cref="Money" />, rounding according to
+    /// <paramref name="context" />.
+    /// </summary>
+    /// <param name="context">The monetary context governing rounding and scale; <see langword="null" /> selects
+    /// <see cref="MonetaryContext.Default" />.</param>
+    /// <returns>The settled <see cref="Money" /> in this value's currency.</returns>
+    /// <exception cref="InvalidOperationException">This value carries no ISO code (default-initialised).</exception>
+    /// <exception cref="ArgumentException"><paramref name="context" /> is invalid.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="context" /> carries an out-of-range policy.</exception>
+    /// <remarks>
+    /// The scale is resolved from <paramref name="context" />: <see cref="ScalePolicy.CurrencyMinorUnits" /> rounds to
+    /// the registered currency's minor units and <see cref="ScalePolicy.Unrounded" /> falls back to that same natural
+    /// scale because a settlement value must carry a concrete precision. When the resolved scale differs from the
+    /// registered minor units (or the currency is unregistered) the result carries the resolved scale explicitly.
+    /// </remarks>
+    public Money RoundToMoney(MonetaryContext? context = null)
+    {
+        if (string.IsNullOrEmpty(IsoCode))
+            throw new InvalidOperationException(FinancialResourceStrings.Op_Invalid_MoneyRequiresCurrency);
+
+        MonetaryContext effective = context ?? MonetaryContext.Default;
+        effective.Validate();
+
+        var registered = CurrencyRegistry.TryGet(IsoCode, out CurrencyInfo? info) && info is not null;
+        var currencyMinorUnits = registered ? info!.MinorUnits : 0;
+
+        var scale = effective.ResolveScale(currencyMinorUnits);
+        if (scale < 0)
+            scale = currencyMinorUnits;
+
+        var rounded = effective.Rounding.Round(_amount, scale);
+
+        return registered && scale == currencyMinorUnits
+            ? new Money(rounded, IsoCode)
+            : Money.FromUnchecked(rounded, IsoCode, scale);
+    }
+
+    /// <summary>
+    /// Materialises this high-precision amount as a settlement <see cref="Money" />, rounding to the currency's minor
+    /// units using the supplied midpoint rule.
+    /// </summary>
+    /// <param name="rounding">The midpoint-rounding rule applied at the currency's minor-unit precision.</param>
+    /// <returns>The settled <see cref="Money" /> in this value's currency.</returns>
+    /// <exception cref="InvalidOperationException">This value carries no ISO code (default-initialised).</exception>
+    public Money RoundToMoney(MidpointRounding rounding) =>
+        RoundToMoney(MonetaryContext.Default with { Rounding = new MidpointRoundingStrategy(rounding) });
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.IEquatable.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.IEquatable.cs
@@ -1,0 +1,45 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.IEquatable.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public readonly partial struct CalculatedMoney
+    : IEquatable<CalculatedMoney>
+{
+    /// <summary>
+    /// Determines whether this value equals <paramref name="other" /> in both amount and currency.
+    /// </summary>
+    /// <param name="other">The value to compare against.</param>
+    /// <returns><see langword="true" /> when both the amount and ISO code match; otherwise <see langword="false" />.</returns>
+    public bool Equals(CalculatedMoney other) =>
+        _amount == other._amount && string.Equals(IsoCode, other.IsoCode, StringComparison.Ordinal);
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is CalculatedMoney other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        HashCode.Combine(_amount, IsoCode);
+
+    /// <summary>
+    /// Determines whether two values are equal.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> when equal.</returns>
+    public static bool operator ==(CalculatedMoney left, CalculatedMoney right) =>
+        left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two values differ.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> when they differ.</returns>
+    public static bool operator !=(CalculatedMoney left, CalculatedMoney right) =>
+        !left.Equals(right);
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.OfTCurrency.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.OfTCurrency.cs
@@ -1,0 +1,163 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.OfTCurrency.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Represents a high-precision monetary amount denominated in <typeparamref name="TCurrency" /> whose rounding is
+/// deferred until it is converted back to a settlement <see cref="Money{TCurrency}" />.
+/// </summary>
+/// <typeparam name="TCurrency">A type implementing <see cref="ICurrency" /> that identifies the currency.</typeparam>
+/// <remarks>
+/// This is the strongly-typed counterpart of <see cref="CalculatedMoney" />. Arithmetic preserves full
+/// <see cref="decimal" /> precision; rounding to <c>TCurrency.MinorUnits</c> happens once, through
+/// <see cref="RoundToMoney(MonetaryContext?)" />.
+/// </remarks>
+[DebuggerDisplay("{Amount} {IsoCode,nq} (unrounded)")]
+public readonly struct CalculatedMoney<TCurrency>
+    : IEquatable<CalculatedMoney<TCurrency>>
+    where TCurrency : ICurrency
+{
+    /// <summary>
+    /// The unrounded amount in the major unit of <typeparamref name="TCurrency" />.
+    /// </summary>
+    private readonly decimal _amount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CalculatedMoney{TCurrency}" /> struct, preserving the amount's full
+    /// precision.
+    /// </summary>
+    /// <param name="amount">The unrounded monetary amount in the major unit of <typeparamref name="TCurrency" />.</param>
+    public CalculatedMoney(decimal amount)
+    {
+        _amount = amount;
+    }
+
+    /// <summary>
+    /// Gets the ISO 4217 alphabetic code of <typeparamref name="TCurrency" />.
+    /// </summary>
+    /// <returns>The currency's ISO code.</returns>
+    public static string IsoCode =>
+        CurrencyMetadata<TCurrency>.Value.IsoCode;
+
+    /// <summary>
+    /// Gets the unrounded monetary amount in the major unit of <typeparamref name="TCurrency" />.
+    /// </summary>
+    /// <returns>The full-precision amount stored by this instance.</returns>
+    public decimal Amount =>
+        _amount;
+
+    /// <summary>
+    /// Gets a value indicating whether this amount is zero.
+    /// </summary>
+    /// <returns><see langword="true" /> when the amount is zero; otherwise <see langword="false" />.</returns>
+    public bool IsZero =>
+        _amount == 0m;
+
+    /// <summary>
+    /// Adds two high-precision amounts, preserving full precision.
+    /// </summary>
+    /// <param name="left">The first amount.</param>
+    /// <param name="right">The second amount.</param>
+    /// <returns>The sum.</returns>
+    public static CalculatedMoney<TCurrency> operator +(CalculatedMoney<TCurrency> left, CalculatedMoney<TCurrency> right) =>
+        new(left._amount + right._amount);
+
+    /// <summary>
+    /// Subtracts one high-precision amount from another, preserving full precision.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns>The difference.</returns>
+    public static CalculatedMoney<TCurrency> operator -(CalculatedMoney<TCurrency> left, CalculatedMoney<TCurrency> right) =>
+        new(left._amount - right._amount);
+
+    /// <summary>
+    /// Negates a high-precision amount.
+    /// </summary>
+    /// <param name="value">The amount to negate.</param>
+    /// <returns>The negated amount.</returns>
+    public static CalculatedMoney<TCurrency> operator -(CalculatedMoney<TCurrency> value) =>
+        new(-value._amount);
+
+    /// <summary>
+    /// Multiplies a high-precision amount by a scalar without rounding.
+    /// </summary>
+    /// <param name="left">The amount.</param>
+    /// <param name="right">The scalar.</param>
+    /// <returns>The full-precision product.</returns>
+    public static CalculatedMoney<TCurrency> operator *(CalculatedMoney<TCurrency> left, decimal right) =>
+        new(left._amount * right);
+
+    /// <summary>
+    /// Divides a high-precision amount by a scalar without rounding.
+    /// </summary>
+    /// <param name="left">The amount.</param>
+    /// <param name="right">The scalar divisor.</param>
+    /// <returns>The full-precision quotient.</returns>
+    /// <exception cref="DivideByZeroException"><paramref name="right" /> is zero.</exception>
+    public static CalculatedMoney<TCurrency> operator /(CalculatedMoney<TCurrency> left, decimal right) =>
+        new(left._amount / right);
+
+    /// <summary>
+    /// Materialises this high-precision amount as a settlement <see cref="Money{TCurrency}" />, rounding to
+    /// <c>TCurrency.MinorUnits</c> using <paramref name="context" />'s rounding strategy.
+    /// </summary>
+    /// <param name="context">The monetary context whose rounding strategy is applied; <see langword="null" /> selects
+    /// <see cref="MonetaryContext.Default" />.</param>
+    /// <returns>The settled <see cref="Money{TCurrency}" />.</returns>
+    public Money<TCurrency> RoundToMoney(MonetaryContext? context = null)
+    {
+        MonetaryContext effective = context ?? MonetaryContext.Default;
+        var minorUnits = CurrencyMetadata<TCurrency>.Value.MinorUnits;
+        return Money<TCurrency>.FromNormalizedAmount(effective.Rounding.Round(_amount, minorUnits));
+    }
+
+    /// <summary>
+    /// Materialises this high-precision amount as a settlement <see cref="Money{TCurrency}" />, rounding to
+    /// <c>TCurrency.MinorUnits</c> using the supplied midpoint rule.
+    /// </summary>
+    /// <param name="rounding">The midpoint-rounding rule.</param>
+    /// <returns>The settled <see cref="Money{TCurrency}" />.</returns>
+    public Money<TCurrency> RoundToMoney(MidpointRounding rounding) =>
+        RoundToMoney(MonetaryContext.Default with { Rounding = new MidpointRoundingStrategy(rounding) });
+
+    /// <summary>
+    /// Determines whether this value equals <paramref name="other" />.
+    /// </summary>
+    /// <param name="other">The value to compare against.</param>
+    /// <returns><see langword="true" /> when the amounts are equal.</returns>
+    public bool Equals(CalculatedMoney<TCurrency> other) =>
+        _amount == other._amount;
+
+    /// <inheritdoc />
+    public override bool Equals(object? obj) =>
+        obj is CalculatedMoney<TCurrency> other && Equals(other);
+
+    /// <inheritdoc />
+    public override int GetHashCode() =>
+        _amount.GetHashCode();
+
+    /// <summary>
+    /// Determines whether two values are equal.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> when equal.</returns>
+    public static bool operator ==(CalculatedMoney<TCurrency> left, CalculatedMoney<TCurrency> right) =>
+        left.Equals(right);
+
+    /// <summary>
+    /// Determines whether two values differ.
+    /// </summary>
+    /// <param name="left">The first value.</param>
+    /// <param name="right">The second value.</param>
+    /// <returns><see langword="true" /> when they differ.</returns>
+    public static bool operator !=(CalculatedMoney<TCurrency> left, CalculatedMoney<TCurrency> right) =>
+        !left.Equals(right);
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.Operators.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.Operators.cs
@@ -1,0 +1,119 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.Operators.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+public readonly partial struct CalculatedMoney
+{
+    /// <summary>
+    /// Adds two high-precision amounts denominated in the same currency, preserving full precision.
+    /// </summary>
+    /// <param name="left">The first amount.</param>
+    /// <param name="right">The second amount.</param>
+    /// <returns>The sum.</returns>
+    /// <exception cref="InvalidOperationException">The operands have different ISO codes.</exception>
+    public static CalculatedMoney operator +(CalculatedMoney left, CalculatedMoney right)
+    {
+        EnsureSameCurrency(left, right);
+        return left.WithAmount(left._amount + right._amount);
+    }
+
+    /// <summary>
+    /// Subtracts one high-precision amount from another in the same currency, preserving full precision.
+    /// </summary>
+    /// <param name="left">The minuend.</param>
+    /// <param name="right">The subtrahend.</param>
+    /// <returns>The difference.</returns>
+    /// <exception cref="InvalidOperationException">The operands have different ISO codes.</exception>
+    public static CalculatedMoney operator -(CalculatedMoney left, CalculatedMoney right)
+    {
+        EnsureSameCurrency(left, right);
+        return left.WithAmount(left._amount - right._amount);
+    }
+
+    /// <summary>
+    /// Negates a high-precision amount.
+    /// </summary>
+    /// <param name="value">The amount to negate.</param>
+    /// <returns>The negated amount.</returns>
+    public static CalculatedMoney operator -(CalculatedMoney value) =>
+        value.WithAmount(-value._amount);
+
+    /// <summary>
+    /// Returns the operand unchanged.
+    /// </summary>
+    /// <param name="value">The amount.</param>
+    /// <returns>The unchanged value.</returns>
+    public static CalculatedMoney operator +(CalculatedMoney value) =>
+        value;
+
+    /// <summary>
+    /// Multiplies a high-precision amount by a scalar without rounding.
+    /// </summary>
+    /// <param name="left">The amount.</param>
+    /// <param name="right">The scalar.</param>
+    /// <returns>The full-precision product.</returns>
+    public static CalculatedMoney operator *(CalculatedMoney left, decimal right) =>
+        left.WithAmount(left._amount * right);
+
+    /// <summary>
+    /// Multiplies a scalar by a high-precision amount without rounding.
+    /// </summary>
+    /// <param name="left">The scalar.</param>
+    /// <param name="right">The amount.</param>
+    /// <returns>The full-precision product.</returns>
+    public static CalculatedMoney operator *(decimal left, CalculatedMoney right) =>
+        right.WithAmount(left * right._amount);
+
+    /// <summary>
+    /// Divides a high-precision amount by a scalar without rounding.
+    /// </summary>
+    /// <param name="left">The amount.</param>
+    /// <param name="right">The scalar divisor.</param>
+    /// <returns>The full-precision quotient.</returns>
+    /// <exception cref="DivideByZeroException"><paramref name="right" /> is zero.</exception>
+    public static CalculatedMoney operator /(CalculatedMoney left, decimal right) =>
+        left.WithAmount(left._amount / right);
+
+    /// <summary>
+    /// Multiplies this amount by <paramref name="multiplier" /> without rounding.
+    /// </summary>
+    /// <param name="multiplier">The scalar multiplier.</param>
+    /// <returns>The full-precision product.</returns>
+    public CalculatedMoney Multiply(decimal multiplier) =>
+        WithAmount(_amount * multiplier);
+
+    /// <summary>
+    /// Divides this amount by <paramref name="divisor" /> without rounding.
+    /// </summary>
+    /// <param name="divisor">The scalar divisor.</param>
+    /// <returns>The full-precision quotient.</returns>
+    /// <exception cref="DivideByZeroException"><paramref name="divisor" /> is zero.</exception>
+    public CalculatedMoney Divide(decimal divisor) =>
+        WithAmount(_amount / divisor);
+
+    /// <summary>
+    /// Asserts that both operands carry a non-empty ISO code and that the two codes match.
+    /// </summary>
+    /// <param name="left">The first operand.</param>
+    /// <param name="right">The second operand.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Either operand carries no ISO code, or the two codes differ.
+    /// </exception>
+    private static void EnsureSameCurrency(CalculatedMoney left, CalculatedMoney right)
+    {
+        if (string.IsNullOrEmpty(left.IsoCode) || string.IsNullOrEmpty(right.IsoCode))
+            throw new InvalidOperationException(FinancialResourceStrings.Op_Invalid_MoneyRequiresCurrency);
+
+        if (!string.Equals(left.IsoCode, right.IsoCode, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Op_Invalid_MoneySameCurrencyRequired, left.IsoCode, right.IsoCode));
+        }
+    }
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.Properties.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.Properties.cs
@@ -1,0 +1,38 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.Properties.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public readonly partial struct CalculatedMoney
+{
+    /// <summary>
+    /// Gets the unrounded monetary amount in the major unit of the currency.
+    /// </summary>
+    /// <returns>The full-precision amount stored by this instance.</returns>
+    public decimal Amount =>
+        _amount;
+
+    /// <summary>
+    /// Gets the ISO 4217 alphabetic code identifying the currency, or an empty string for a default-initialised value.
+    /// </summary>
+    /// <returns>The currency's ISO code.</returns>
+    public string IsoCode =>
+        _isoCode ?? string.Empty;
+
+    /// <summary>
+    /// Gets a value indicating whether this amount is zero.
+    /// </summary>
+    /// <returns><see langword="true" /> when the amount is zero; otherwise <see langword="false" />.</returns>
+    public bool IsZero =>
+        _amount == 0m;
+
+    /// <summary>
+    /// Gets the sign of this amount.
+    /// </summary>
+    /// <returns><c>-1</c>, <c>0</c>, or <c>1</c>.</returns>
+    public int Sign =>
+        Math.Sign(_amount);
+}

--- a/Bodu.Financial/src/Financial/CalculatedMoney.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.cs
@@ -1,0 +1,77 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoney.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Represents a high-precision, runtime-tagged monetary amount whose rounding is deferred until it is converted back to
+/// a settlement <see cref="Money" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="CalculatedMoney" /> is the intermediate value used when a chain of monetary calculations must avoid the
+/// rounding error that per-step rounding of <see cref="Money" /> would accumulate — compound interest, unit-rate
+/// products, tax apportionment, and similar. Arithmetic preserves the full <see cref="decimal" /> precision; rounding
+/// happens once, at the settlement boundary, through <see cref="RoundToMoney(MonetaryContext?)" />.
+/// </para>
+/// <para>
+/// The currency is identified at runtime by ISO 4217 code, validated only for shape. Unlike <see cref="Money" />, the
+/// currency need not be registered to participate in a calculation; registration (or an explicit scale) is required
+/// only when materialising a settlement value.
+/// </para>
+/// </remarks>
+[DebuggerDisplay("{Amount} {IsoCode,nq} (unrounded)")]
+public readonly partial struct CalculatedMoney
+{
+    /// <summary>
+    /// The unrounded amount in the major unit of the currency identified by <see cref="_isoCode" />.
+    /// </summary>
+    private readonly decimal _amount;
+
+    /// <summary>
+    /// The ISO 4217 alphabetic code identifying the currency, or <see langword="null" /> for a default-initialised
+    /// value.
+    /// </summary>
+    private readonly string? _isoCode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CalculatedMoney" /> struct from an amount and ISO 4217 code,
+    /// preserving the amount's full precision.
+    /// </summary>
+    /// <param name="amount">The unrounded monetary amount in the major unit.</param>
+    /// <param name="isoCode">The ISO 4217 three-letter alphabetic code identifying the currency.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="isoCode" /> is not three uppercase ASCII letters.</exception>
+    public CalculatedMoney(decimal amount, string isoCode)
+    {
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(isoCode);
+
+        _amount = amount;
+        _isoCode = isoCode;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CalculatedMoney" /> struct from pre-validated field values.
+    /// </summary>
+    /// <param name="amount">The unrounded amount.</param>
+    /// <param name="isoCode">The ISO 4217 code, or <see langword="null" /> for a currency-less value.</param>
+    /// <param name="_">Discriminator that selects the pre-validated construction path.</param>
+    private CalculatedMoney(decimal amount, string? isoCode, bool _)
+    {
+        _amount = amount;
+        _isoCode = isoCode;
+    }
+
+    /// <summary>
+    /// Returns a copy of this value with a different amount, preserving the ISO code.
+    /// </summary>
+    /// <param name="amount">The replacement unrounded amount.</param>
+    /// <returns>The updated <see cref="CalculatedMoney" />.</returns>
+    private CalculatedMoney WithAmount(decimal amount) =>
+        new(amount, _isoCode, false);
+}

--- a/Bodu.Financial/src/Financial/CashRoundingPolicy.cs
+++ b/Bodu.Financial/src/Financial/CashRoundingPolicy.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CashRoundingPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies whether a <see cref="MonetaryContext" /> snaps results to the currency's physical cash denomination.
+/// </summary>
+public enum CashRoundingPolicy
+{
+    /// <summary>
+    /// Do not apply cash rounding; results are expressed at the resolved minor-unit scale.
+    /// </summary>
+    None = 0,
+
+    /// <summary>
+    /// Snap results to the currency's cash-rounding increment (for example, the Swiss 5-rappen increment).
+    /// </summary>
+    CurrencyCashIncrement = 1,
+}

--- a/Bodu.Financial/src/Financial/ConversionRoundingPolicy.cs
+++ b/Bodu.Financial/src/Financial/ConversionRoundingPolicy.cs
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ConversionRoundingPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies when a <see cref="MonetaryContext" /> rounds the result of a currency conversion.
+/// </summary>
+public enum ConversionRoundingPolicy
+{
+    /// <summary>
+    /// Round the converted amount to the target currency's scale immediately.
+    /// </summary>
+    RoundAtTarget = 0,
+
+    /// <summary>
+    /// Defer rounding, preserving the full-precision converted amount for further calculation.
+    /// </summary>
+    Defer = 1,
+}

--- a/Bodu.Financial/src/Financial/CurrencyDisplay.cs
+++ b/Bodu.Financial/src/Financial/CurrencyDisplay.cs
@@ -1,0 +1,33 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyDisplay.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies how <see cref="MoneyFormatter" /> renders the currency designator alongside the amount.
+/// </summary>
+public enum CurrencyDisplay
+{
+    /// <summary>
+    /// Render the ISO 4217 code (for example, <c>"USD 1,234.56"</c>).
+    /// </summary>
+    IsoCode = 0,
+
+    /// <summary>
+    /// Render the culture's native currency symbol where it matches the amount's currency.
+    /// </summary>
+    Symbol = 1,
+
+    /// <summary>
+    /// Render the currency's English-language name (for example, <c>"1,234.56 US Dollar"</c>).
+    /// </summary>
+    EnglishName = 2,
+
+    /// <summary>
+    /// Render the bare numeric amount with no currency designator.
+    /// </summary>
+    None = 3,
+}

--- a/Bodu.Financial/src/Financial/CurrencyInfo.cs
+++ b/Bodu.Financial/src/Financial/CurrencyInfo.cs
@@ -46,6 +46,43 @@ public sealed record CurrencyInfo(
     int NumericCode = 0)
 {
     /// <summary>
+    /// Gets the currency's primary symbol (for example, <c>"$"</c> or <c>"€"</c>), or an empty string when none is
+    /// supplied.
+    /// </summary>
+    /// <value>The display symbol associated with the currency.</value>
+    /// <returns>The currency symbol, or an empty string.</returns>
+    public string Symbol { get; init; } = "";
+
+    /// <summary>
+    /// Gets the currency's internationally disambiguated symbol (for example, <c>"US$"</c> or <c>"R$"</c>), or an empty
+    /// string when none is supplied.
+    /// </summary>
+    /// <value>The unambiguous symbol used where the bare <see cref="Symbol" /> would be ambiguous.</value>
+    /// <returns>The international symbol, or an empty string.</returns>
+    public string InternationalSymbol { get; init; } = "";
+
+    /// <summary>
+    /// Gets the currency's name in its primary native language, or an empty string when none is supplied.
+    /// </summary>
+    /// <value>The localized currency name.</value>
+    /// <returns>The native name, or an empty string.</returns>
+    public string NativeName { get; init; } = "";
+
+    /// <summary>
+    /// Gets the ISO 3166 region codes in which the currency is used.
+    /// </summary>
+    /// <value>The regions associated with the currency.</value>
+    /// <returns>A read-only list of region codes, empty when none are supplied.</returns>
+    public IReadOnlyList<string> RegionCodes { get; init; } = Array.Empty<string>();
+
+    /// <summary>
+    /// Gets alternative symbols that may also denote the currency.
+    /// </summary>
+    /// <value>The additional symbols recognised for the currency.</value>
+    /// <returns>A read-only list of alternative symbols, empty when none are supplied.</returns>
+    public IReadOnlyList<string> AlternativeSymbols { get; init; } = Array.Empty<string>();
+
+    /// <summary>
     /// Resolves a <see cref="CurrencyCode" /> enum value to its registered <see cref="CurrencyInfo" />.
     /// </summary>
     /// <param name="code">The active ISO 4217 currency code.</param>

--- a/Bodu.Financial/src/Financial/CurrencyInfoValidator.cs
+++ b/Bodu.Financial/src/Financial/CurrencyInfoValidator.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyInfoValidator.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Validates <see cref="CurrencyInfo" /> metadata supplied to <see cref="CurrencyRegistry" /> with the same rule set
+/// that <see cref="CurrencyMetadata{TCurrency}" /> applies to currency tag types, surfacing argument-style exceptions
+/// because the metadata arrives as a method argument rather than as type metadata.
+/// </summary>
+internal static class CurrencyInfoValidator
+{
+    /// <summary>
+    /// The maximum number of fractional digits a currency's minor unit may declare.
+    /// </summary>
+    private const int MaxMinorUnits = 28;
+
+    /// <summary>
+    /// The exclusive upper bound for an ISO 4217 three-digit numeric code.
+    /// </summary>
+    private const int NumericCodeUpperBound = 1000;
+
+    /// <summary>
+    /// Validates the structural and semantic integrity of <paramref name="info" />.
+    /// </summary>
+    /// <param name="info">The currency metadata to validate.</param>
+    /// <param name="paramName">The parameter name reported in argument exceptions.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="info" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    /// The ISO code is not three uppercase ASCII letters; the successor ISO code, when present, is malformed; the
+    /// cash-rounding increment is finer than the declared minor units; or the historic / successor fields are
+    /// inconsistent.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// The minor-unit precision is outside 0 to 28, the cash-rounding increment is negative, or the numeric code is
+    /// outside 0 to 999.
+    /// </exception>
+    public static void Validate(CurrencyInfo info, string? paramName = null)
+    {
+        ThrowHelper.ThrowIfNull(info, paramName);
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(info.IsoCode, paramName);
+
+        if ((uint)info.MinorUnits > MaxMinorUnits)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                info.MinorUnits,
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CurrencyInfoMinorUnits, info.IsoCode, info.MinorUnits));
+        }
+
+        if (info.CashRoundingIncrement < 0m)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                info.CashRoundingIncrement,
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CurrencyInfoCashRoundingNegative, info.IsoCode, info.CashRoundingIncrement));
+        }
+
+        if (info.CashRoundingIncrement != 0m)
+        {
+            var scaled = info.CashRoundingIncrement * MinorUnitFactor(info.MinorUnits);
+            if (scaled != decimal.Truncate(scaled))
+            {
+                throw new ArgumentException(
+                    string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_CurrencyInfoCashRoundingTooFine, info.IsoCode, info.CashRoundingIncrement, info.MinorUnits),
+                    paramName);
+            }
+        }
+
+        if ((uint)info.NumericCode >= NumericCodeUpperBound)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                info.NumericCode,
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CurrencyInfoNumericCode, info.IsoCode, info.NumericCode));
+        }
+
+        if (info.SuccessorIsoCode is not null)
+            FinancialThrowHelper.ThrowIfNotValidIsoCode(info.SuccessorIsoCode, paramName);
+
+        // A non-historic currency must not carry demonetization metadata; historicity and its supporting fields must
+        // agree so downstream consumers can trust the IsHistoric flag.
+        if (!info.IsHistoric && (info.DemonetizedOn is not null || info.SuccessorIsoCode is not null))
+        {
+            throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_CurrencyInfoHistoricInconsistent, info.IsoCode),
+                paramName);
+        }
+    }
+
+    /// <summary>
+    /// Computes <c>10 ^ minorUnits</c> as a <see cref="decimal" />.
+    /// </summary>
+    /// <param name="minorUnits">The validated minor-unit precision.</param>
+    /// <returns>The scale factor.</returns>
+    private static decimal MinorUnitFactor(int minorUnits)
+    {
+        var factor = 1m;
+        for (var i = 0; i < minorUnits; i++)
+            factor *= 10m;
+        return factor;
+    }
+}

--- a/Bodu.Financial/src/Financial/CurrencyLookupService.cs
+++ b/Bodu.Financial/src/Financial/CurrencyLookupService.cs
@@ -1,0 +1,222 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyLookupService.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Default <see cref="ICurrencyLookup" /> backed by <see cref="CurrencyRegistry" />. Reverse indexes for numeric code,
+/// symbol, and region are built lazily from a snapshot of the registry taken on first use.
+/// </summary>
+/// <remarks>
+/// The reverse indexes reflect the registry contents at the time of first access. Construct a new instance after
+/// registering custom currencies that must participate in symbol, numeric, or region lookups.
+/// </remarks>
+public sealed class CurrencyLookupService
+    : ICurrencyLookup
+{
+    /// <summary>
+    /// Lazily built numeric-code index; non-historic entries win on a numeric-code collision.
+    /// </summary>
+    private readonly Lazy<IReadOnlyDictionary<int, CurrencyInfo>> _byNumericCode;
+
+    /// <summary>
+    /// Lazily built symbol index, keyed by primary and alternative symbols.
+    /// </summary>
+    private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>>> _bySymbol;
+
+    /// <summary>
+    /// Lazily built region index, keyed by ISO 3166 region code.
+    /// </summary>
+    private readonly Lazy<IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>>> _byRegion;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CurrencyLookupService" /> class.
+    /// </summary>
+    public CurrencyLookupService()
+    {
+        _byNumericCode = new Lazy<IReadOnlyDictionary<int, CurrencyInfo>>(BuildNumericIndex);
+        _bySymbol = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>>>(BuildSymbolIndex);
+        _byRegion = new Lazy<IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>>>(BuildRegionIndex);
+    }
+
+    /// <inheritdoc />
+    public bool TryByIsoCode(string isoCode, out CurrencyInfo currency)
+    {
+        if (CurrencyRegistry.TryGet(isoCode, out CurrencyInfo? info) && info is not null)
+        {
+            currency = info;
+            return true;
+        }
+
+        currency = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryByCurrencyCode(CurrencyCode code, out CurrencyInfo currency)
+    {
+        if (Enum.IsDefined(code) && CurrencyRegistry.TryGet(code.ToString(), out CurrencyInfo? info) && info is not null)
+        {
+            currency = info;
+            return true;
+        }
+
+        currency = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryByNumericCode(int numericCode, out CurrencyInfo currency)
+    {
+        if (_byNumericCode.Value.TryGetValue(numericCode, out CurrencyInfo? info))
+        {
+            currency = info;
+            return true;
+        }
+
+        currency = null!;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryBySymbol(string symbol, out IReadOnlyList<CurrencyInfo> matches)
+    {
+        ThrowHelper.ThrowIfNull(symbol);
+
+        if (_bySymbol.Value.TryGetValue(symbol, out IReadOnlyList<CurrencyInfo>? found))
+        {
+            matches = found;
+            return true;
+        }
+
+        matches = Array.Empty<CurrencyInfo>();
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryByRegion(string regionCode, out IReadOnlyList<CurrencyInfo> matches)
+    {
+        ThrowHelper.ThrowIfNull(regionCode);
+
+        if (_byRegion.Value.TryGetValue(regionCode, out IReadOnlyList<CurrencyInfo>? found))
+        {
+            matches = found;
+            return true;
+        }
+
+        matches = Array.Empty<CurrencyInfo>();
+        return false;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<CurrencyInfo> ByCulture(CultureInfo culture)
+    {
+        ThrowHelper.ThrowIfNull(culture);
+
+        if (culture.IsNeutralCulture || string.IsNullOrEmpty(culture.Name))
+            return Array.Empty<CurrencyInfo>();
+
+        var region = new RegionInfo(culture.Name);
+        return TryByIsoCode(region.ISOCurrencySymbol, out CurrencyInfo currency)
+            ? new[] { currency }
+            : Array.Empty<CurrencyInfo>();
+    }
+
+    /// <summary>
+    /// Builds the numeric-code index, preferring non-historic entries on a collision.
+    /// </summary>
+    /// <returns>The numeric-code index.</returns>
+    private static IReadOnlyDictionary<int, CurrencyInfo> BuildNumericIndex()
+    {
+        Dictionary<int, CurrencyInfo> index = new();
+        foreach (CurrencyInfo info in CurrencyRegistry.All)
+        {
+            if (info.NumericCode == 0)
+                continue;
+
+            if (!index.TryGetValue(info.NumericCode, out CurrencyInfo? existing) || (existing.IsHistoric && !info.IsHistoric))
+                index[info.NumericCode] = info;
+        }
+
+        return index;
+    }
+
+    /// <summary>
+    /// Builds the symbol index from primary and alternative symbols.
+    /// </summary>
+    /// <returns>The symbol index.</returns>
+    private static IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>> BuildSymbolIndex()
+    {
+        Dictionary<string, List<CurrencyInfo>> index = new(StringComparer.Ordinal);
+        foreach (CurrencyInfo info in CurrencyRegistry.All)
+        {
+            if (!string.IsNullOrEmpty(info.Symbol))
+                Append(index, info.Symbol, info);
+            if (!string.IsNullOrEmpty(info.InternationalSymbol))
+                Append(index, info.InternationalSymbol, info);
+            foreach (var symbol in info.AlternativeSymbols)
+            {
+                if (!string.IsNullOrEmpty(symbol))
+                    Append(index, symbol, info);
+            }
+        }
+
+        return Freeze(index);
+    }
+
+    /// <summary>
+    /// Builds the region index from each currency's region codes.
+    /// </summary>
+    /// <returns>The region index.</returns>
+    private static IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>> BuildRegionIndex()
+    {
+        Dictionary<string, List<CurrencyInfo>> index = new(StringComparer.Ordinal);
+        foreach (CurrencyInfo info in CurrencyRegistry.All)
+        {
+            foreach (var region in info.RegionCodes)
+            {
+                if (!string.IsNullOrEmpty(region))
+                    Append(index, region, info);
+            }
+        }
+
+        return Freeze(index);
+    }
+
+    /// <summary>
+    /// Appends <paramref name="info" /> to the list stored under <paramref name="key" />, deduplicating repeated keys.
+    /// </summary>
+    /// <param name="index">The index being built.</param>
+    /// <param name="key">The lookup key.</param>
+    /// <param name="info">The currency to append.</param>
+    private static void Append(Dictionary<string, List<CurrencyInfo>> index, string key, CurrencyInfo info)
+    {
+        if (!index.TryGetValue(key, out List<CurrencyInfo>? list))
+        {
+            list = new List<CurrencyInfo>();
+            index[key] = list;
+        }
+
+        if (!list.Contains(info))
+            list.Add(info);
+    }
+
+    /// <summary>
+    /// Converts the mutable build index into a read-only projection.
+    /// </summary>
+    /// <param name="index">The build index.</param>
+    /// <returns>The read-only index.</returns>
+    private static IReadOnlyDictionary<string, IReadOnlyList<CurrencyInfo>> Freeze(Dictionary<string, List<CurrencyInfo>> index)
+    {
+        Dictionary<string, IReadOnlyList<CurrencyInfo>> frozen = new(index.Count, StringComparer.Ordinal);
+        foreach (KeyValuePair<string, List<CurrencyInfo>> entry in index)
+            frozen[entry.Key] = entry.Value;
+        return frozen;
+    }
+}

--- a/Bodu.Financial/src/Financial/CurrencyRegistrationConflictPolicy.cs
+++ b/Bodu.Financial/src/Financial/CurrencyRegistrationConflictPolicy.cs
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyRegistrationConflictPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies how <see cref="CurrencyRegistry" /> resolves an attempt to register a custom <see cref="CurrencyInfo" />
+/// for an ISO code that already carries a custom registration.
+/// </summary>
+public enum CurrencyRegistrationConflictPolicy
+{
+    /// <summary>
+    /// Throw an <see cref="System.InvalidOperationException" /> when a custom registration already exists.
+    /// </summary>
+    Throw = 0,
+
+    /// <summary>
+    /// Replace the existing custom registration with the new metadata.
+    /// </summary>
+    Replace = 1,
+
+    /// <summary>
+    /// Leave the existing custom registration in place and ignore the new metadata.
+    /// </summary>
+    Ignore = 2,
+}

--- a/Bodu.Financial/src/Financial/CurrencyRegistry.cs
+++ b/Bodu.Financial/src/Financial/CurrencyRegistry.cs
@@ -125,20 +125,56 @@ public static class CurrencyRegistry
     /// </summary>
     /// <param name="info">The currency metadata to register.</param>
     /// <exception cref="ArgumentNullException"><paramref name="info" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="info" /> carries invalid metadata.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="info" /> carries out-of-range metadata.</exception>
     /// <exception cref="InvalidOperationException">
     /// A custom registration already exists for <paramref name="info" />.<see cref="CurrencyInfo.IsoCode" />.
     /// </exception>
     /// <remarks>
-    /// Use <see cref="TryRegister(CurrencyInfo)" /> when conflicts should be silently ignored rather than raised.
+    /// The metadata is validated with the same rule set <see cref="CurrencyMetadata{TCurrency}" /> applies to tag
+    /// types. Use <see cref="TryRegister(CurrencyInfo)" /> when conflicts should be reported as <see langword="false" />
+    /// rather than raised, or <see cref="Register(CurrencyInfo, CurrencyRegistrationConflictPolicy)" /> to choose the
+    /// conflict behaviour explicitly.
     /// </remarks>
-    public static void Register(CurrencyInfo info)
-    {
-        ThrowHelper.ThrowIfNull(info);
+    public static void Register(CurrencyInfo info) =>
+        Register(info, CurrencyRegistrationConflictPolicy.Throw);
 
-        if (!s_custom.TryAdd(info.IsoCode, info))
+    /// <summary>
+    /// Registers a custom currency, resolving an existing registration for the same ISO code according to
+    /// <paramref name="conflictPolicy" />.
+    /// </summary>
+    /// <param name="info">The currency metadata to register.</param>
+    /// <param name="conflictPolicy">The behaviour applied when a custom registration already exists.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="info" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="info" /> carries invalid metadata.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="info" /> carries out-of-range metadata, or <paramref name="conflictPolicy" /> is not a defined
+    /// value.
+    /// </exception>
+    /// <exception cref="InvalidOperationException">
+    /// <paramref name="conflictPolicy" /> is <see cref="CurrencyRegistrationConflictPolicy.Throw" /> and a custom
+    /// registration already exists for <paramref name="info" />.<see cref="CurrencyInfo.IsoCode" />.
+    /// </exception>
+    public static void Register(CurrencyInfo info, CurrencyRegistrationConflictPolicy conflictPolicy)
+    {
+        CurrencyInfoValidator.Validate(info, nameof(info));
+        FinancialThrowHelper.ThrowIfCurrencyRegistrationConflictPolicyUndefined(conflictPolicy);
+
+        if (s_custom.TryAdd(info.IsoCode, info))
+            return;
+
+        switch (conflictPolicy)
         {
-            throw new InvalidOperationException(
-                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Op_Invalid_DuplicateCustomCurrency, info.IsoCode));
+            case CurrencyRegistrationConflictPolicy.Replace:
+                s_custom[info.IsoCode] = info;
+                break;
+
+            case CurrencyRegistrationConflictPolicy.Ignore:
+                break;
+
+            default:
+                throw new InvalidOperationException(
+                    string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Op_Invalid_DuplicateCustomCurrency, info.IsoCode));
         }
     }
 
@@ -148,10 +184,47 @@ public static class CurrencyRegistry
     /// <param name="info">The currency metadata to register.</param>
     /// <returns>
     /// <see langword="true" /> when the registration succeeded; <see langword="false" /> when <paramref name="info" />
-    /// is <see langword="null" /> or a custom registration with the same ISO code already exists.
+    /// is <see langword="null" />, carries invalid metadata, or a custom registration with the same ISO code already
+    /// exists.
     /// </returns>
-    public static bool TryRegister(CurrencyInfo info) =>
-        info is not null && s_custom.TryAdd(info.IsoCode, info);
+    public static bool TryRegister(CurrencyInfo info)
+    {
+        if (info is null || !IsValid(info))
+            return false;
+
+        return s_custom.TryAdd(info.IsoCode, info);
+    }
+
+    /// <summary>
+    /// Registers a custom currency, replacing any existing custom registration for the same ISO code.
+    /// </summary>
+    /// <param name="info">The currency metadata to register.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="info" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="info" /> carries invalid metadata.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="info" /> carries out-of-range metadata.</exception>
+    public static void Replace(CurrencyInfo info)
+    {
+        CurrencyInfoValidator.Validate(info, nameof(info));
+        s_custom[info.IsoCode] = info;
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="info" /> satisfies the registry's metadata rules without throwing.
+    /// </summary>
+    /// <param name="info">The currency metadata to test.</param>
+    /// <returns><see langword="true" /> when the metadata is valid; otherwise <see langword="false" />.</returns>
+    private static bool IsValid(CurrencyInfo info)
+    {
+        try
+        {
+            CurrencyInfoValidator.Validate(info, nameof(info));
+            return true;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
 
     /// <summary>
     /// Builds the frozen shipped catalogue from the source-generated registration list.

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -322,11 +322,29 @@ namespace Bodu.Financial {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to CurrencyDisplay &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_CurrencyDisplayUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CurrencyDisplayUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to CustomScale {0} is outside the supported range 0 to 28..
         /// </summary>
         internal static string Arg_OutOfRange_CustomScale {
             get {
                 return ResourceManager.GetString("Arg_OutOfRange_CustomScale", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to MoneyParseMode &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_MoneyParseModeUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_MoneyParseModeUndefined", resourceCulture);
             }
         }
 

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -266,7 +266,25 @@ namespace Bodu.Financial {
                 return ResourceManager.GetString("Arg_Null_ProviderAtIndex", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; is not registered. Register it via CurrencyRegistry or use Money.FromUnchecked / an explicit UnknownCurrencyPolicy to supply a minor-unit scale..
+        /// </summary>
+        internal static string Arg_Invalid_UnknownCurrencyRejected {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_UnknownCurrencyRejected", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; is not registered; UnknownCurrencyPolicy.AllowWithExplicitScale requires a minor-unit scale. Use Money.FromUnchecked to supply one..
+        /// </summary>
+        internal static string Arg_Invalid_UnknownCurrencyRequiresScale {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_UnknownCurrencyRequiresScale", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Exchange rate must be strictly positive..
         /// </summary>
@@ -302,7 +320,25 @@ namespace Bodu.Financial {
                 return ResourceManager.GetString("Arg_OutOfRange_UnsupportedMoneyBagRoundingPolicy", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Explicit minor-unit scale {0} for currency &apos;{1}&apos; is out of the supported range 0 to 28..
+        /// </summary>
+        internal static string Arg_OutOfRange_UnknownCurrencyMinorUnits {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_UnknownCurrencyMinorUnits", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to UnknownCurrencyPolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_UnknownCurrencyPolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_UnknownCurrencyPolicyUndefined", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to The format string &apos;{0}&apos; is not supported..
         /// </summary>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -286,6 +286,60 @@ namespace Bodu.Financial {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to ScalePolicy.Custom requires a non-null CustomScale value..
+        /// </summary>
+        internal static string Arg_Invalid_CustomScaleRequiresValue {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_CustomScaleRequiresValue", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to AllocationPolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_AllocationPolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_AllocationPolicyUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to CashRoundingPolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_CashRoundingPolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CashRoundingPolicyUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to ConversionRoundingPolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_ConversionRoundingPolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_ConversionRoundingPolicyUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to CustomScale {0} is outside the supported range 0 to 28..
+        /// </summary>
+        internal static string Arg_OutOfRange_CustomScale {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CustomScale", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to ScalePolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_ScalePolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_ScalePolicyUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Currency &apos;{0}&apos; is not historic but declares a demonetization date or successor ISO code..
         /// </summary>
         internal static string Arg_Invalid_CurrencyInfoHistoricInconsistent {

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -286,6 +286,24 @@ namespace Bodu.Financial {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Nanos {0} is outside the valid range -999999999 to 999999999..
+        /// </summary>
+        internal static string Arg_Invalid_MoneyDtoNanosRange {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_MoneyDtoNanosRange", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Units {0} and Nanos {1} must have the same sign..
+        /// </summary>
+        internal static string Arg_Invalid_MoneyDtoSignMismatch {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_MoneyDtoSignMismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to ScalePolicy.Custom requires a non-null CustomScale value..
         /// </summary>
         internal static string Arg_Invalid_CustomScaleRequiresValue {

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -277,6 +277,60 @@ namespace Bodu.Financial {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; cash-rounding increment {1} is finer than its declared minor-unit precision {2}..
+        /// </summary>
+        internal static string Arg_Invalid_CurrencyInfoCashRoundingTooFine {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_CurrencyInfoCashRoundingTooFine", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; is not historic but declares a demonetization date or successor ISO code..
+        /// </summary>
+        internal static string Arg_Invalid_CurrencyInfoHistoricInconsistent {
+            get {
+                return ResourceManager.GetString("Arg_Invalid_CurrencyInfoHistoricInconsistent", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; declares a negative cash-rounding increment {1}..
+        /// </summary>
+        internal static string Arg_OutOfRange_CurrencyInfoCashRoundingNegative {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CurrencyInfoCashRoundingNegative", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; declares minor-unit precision {1}, which is outside the supported range 0 to 28..
+        /// </summary>
+        internal static string Arg_OutOfRange_CurrencyInfoMinorUnits {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CurrencyInfoMinorUnits", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Currency &apos;{0}&apos; declares numeric code {1}, which is outside the supported range 0 to 999..
+        /// </summary>
+        internal static string Arg_OutOfRange_CurrencyInfoNumericCode {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CurrencyInfoNumericCode", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to CurrencyRegistrationConflictPolicy &apos;{0}&apos; is not a defined value..
+        /// </summary>
+        internal static string Arg_OutOfRange_CurrencyRegistrationConflictPolicyUndefined {
+            get {
+                return ResourceManager.GetString("Arg_OutOfRange_CurrencyRegistrationConflictPolicyUndefined", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Currency &apos;{0}&apos; is not registered; UnknownCurrencyPolicy.AllowWithExplicitScale requires a minor-unit scale. Use Money.FromUnchecked to supply one..
         /// </summary>
         internal static string Arg_Invalid_UnknownCurrencyRequiresScale {

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.Designer.cs
@@ -862,6 +862,15 @@ namespace Bodu.Financial {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Cannot convert {0} using exchange rate {1}-&gt;{2}: the rate&apos;s source currency does not match..
+        /// </summary>
+        internal static string Op_Invalid_ConversionRateDirectionMismatch {
+            get {
+                return ResourceManager.GetString("Op_Invalid_ConversionRateDirectionMismatch", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Cannot adopt ExchangeRate {0}-&gt;{1} as ExchangeRate&lt;{2}, {3}&gt;: ISO codes differ..
         /// </summary>
         internal static string Op_Invalid_ExchangeRateRuntimeMismatch {

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -87,6 +87,9 @@
   <data name="Arg_Invalid_CurrencyInfoCashRoundingTooFine" xml:space="preserve">
     <value>Currency '{0}' cash-rounding increment {1} is finer than its declared minor-unit precision {2}.</value>
   </data>
+  <data name="Arg_Invalid_CustomScaleRequiresValue" xml:space="preserve">
+    <value>ScalePolicy.Custom requires a non-null CustomScale value.</value>
+  </data>
   <data name="Arg_Invalid_CurrencyInfoHistoricInconsistent" xml:space="preserve">
     <value>Currency '{0}' is not historic but declares a demonetization date or successor ISO code.</value>
   </data>
@@ -144,8 +147,20 @@
   <data name="Arg_Null_ProviderAtIndex" xml:space="preserve">
     <value>Provider at index {0} is null.</value>
   </data>
+  <data name="Arg_OutOfRange_AllocationPolicyUndefined" xml:space="preserve">
+    <value>AllocationPolicy '{0}' is not a defined value.</value>
+  </data>
+  <data name="Arg_OutOfRange_CashRoundingPolicyUndefined" xml:space="preserve">
+    <value>CashRoundingPolicy '{0}' is not a defined value.</value>
+  </data>
+  <data name="Arg_OutOfRange_ConversionRoundingPolicyUndefined" xml:space="preserve">
+    <value>ConversionRoundingPolicy '{0}' is not a defined value.</value>
+  </data>
   <data name="Arg_OutOfRange_CurrencyInfoCashRoundingNegative" xml:space="preserve">
     <value>Currency '{0}' declares a negative cash-rounding increment {1}.</value>
+  </data>
+  <data name="Arg_OutOfRange_CustomScale" xml:space="preserve">
+    <value>CustomScale {0} is outside the supported range 0 to 28.</value>
   </data>
   <data name="Arg_OutOfRange_CurrencyInfoMinorUnits" xml:space="preserve">
     <value>Currency '{0}' declares minor-unit precision {1}, which is outside the supported range 0 to 28.</value>
@@ -161,6 +176,9 @@
   </data>
   <data name="Arg_OutOfRange_RateNotPositive" xml:space="preserve">
     <value>Rate must be greater than zero.</value>
+  </data>
+  <data name="Arg_OutOfRange_ScalePolicyUndefined" xml:space="preserve">
+    <value>ScalePolicy '{0}' is not a defined value.</value>
   </data>
   <data name="Arg_OutOfRange_UnsupportedMidpointRounding" xml:space="preserve">
     <value>Unsupported midpoint-rounding mode.</value>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -84,6 +84,12 @@
   <data name="Arg_Invalid_CurrencyCodeNotMapped" xml:space="preserve">
     <value>The CurrencyCode value '{0}' (numeric {1}) does not correspond to a registered currency.</value>
   </data>
+  <data name="Arg_Invalid_CurrencyInfoCashRoundingTooFine" xml:space="preserve">
+    <value>Currency '{0}' cash-rounding increment {1} is finer than its declared minor-unit precision {2}.</value>
+  </data>
+  <data name="Arg_Invalid_CurrencyInfoHistoricInconsistent" xml:space="preserve">
+    <value>Currency '{0}' is not historic but declares a demonetization date or successor ISO code.</value>
+  </data>
   <data name="Arg_Invalid_ExchangeRateBookDuplicateKey" xml:space="preserve">
     <value>ExchangeRateBook cannot contain two series with the same pair and provider; '{0}/{1}' from '{2}' is duplicated.</value>
   </data>
@@ -137,6 +143,18 @@
   </data>
   <data name="Arg_Null_ProviderAtIndex" xml:space="preserve">
     <value>Provider at index {0} is null.</value>
+  </data>
+  <data name="Arg_OutOfRange_CurrencyInfoCashRoundingNegative" xml:space="preserve">
+    <value>Currency '{0}' declares a negative cash-rounding increment {1}.</value>
+  </data>
+  <data name="Arg_OutOfRange_CurrencyInfoMinorUnits" xml:space="preserve">
+    <value>Currency '{0}' declares minor-unit precision {1}, which is outside the supported range 0 to 28.</value>
+  </data>
+  <data name="Arg_OutOfRange_CurrencyInfoNumericCode" xml:space="preserve">
+    <value>Currency '{0}' declares numeric code {1}, which is outside the supported range 0 to 999.</value>
+  </data>
+  <data name="Arg_OutOfRange_CurrencyRegistrationConflictPolicyUndefined" xml:space="preserve">
+    <value>CurrencyRegistrationConflictPolicy '{0}' is not a defined value.</value>
   </data>
   <data name="Arg_OutOfRange_ExchangeRateNotPositive" xml:space="preserve">
     <value>Exchange rate must be strictly positive.</value>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -135,6 +135,12 @@
   <data name="Arg_Invalid_RateSeriesEmpty" xml:space="preserve">
     <value>Series must contain at least one rate.</value>
   </data>
+  <data name="Arg_Invalid_MoneyDtoNanosRange" xml:space="preserve">
+    <value>Nanos {0} is outside the valid range -999999999 to 999999999.</value>
+  </data>
+  <data name="Arg_Invalid_MoneyDtoSignMismatch" xml:space="preserve">
+    <value>Units {0} and Nanos {1} must have the same sign.</value>
+  </data>
   <data name="Arg_Invalid_RateSeriesProviderConflict" xml:space="preserve">
     <value>Pair {0}/{1} has rates from multiple providers ('{2}' and '{3}'); use a composite provider to combine sources.</value>
   </data>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -330,6 +330,9 @@
   <data name="Op_Invalid_DuplicateCustomCurrency" xml:space="preserve">
     <value>A custom currency is already registered under '{0}'.</value>
   </data>
+  <data name="Op_Invalid_ConversionRateDirectionMismatch" xml:space="preserve">
+    <value>Cannot convert {0} using exchange rate {1}-&gt;{2}: the rate's source currency does not match.</value>
+  </data>
   <data name="Op_Invalid_ExchangeRateRuntimeMismatch" xml:space="preserve">
     <value>Cannot adopt ExchangeRate {0}-&gt;{1} as ExchangeRate&lt;{2}, {3}&gt;: ISO codes differ.</value>
   </data>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -159,8 +159,14 @@
   <data name="Arg_OutOfRange_CurrencyInfoCashRoundingNegative" xml:space="preserve">
     <value>Currency '{0}' declares a negative cash-rounding increment {1}.</value>
   </data>
+  <data name="Arg_OutOfRange_CurrencyDisplayUndefined" xml:space="preserve">
+    <value>CurrencyDisplay '{0}' is not a defined value.</value>
+  </data>
   <data name="Arg_OutOfRange_CustomScale" xml:space="preserve">
     <value>CustomScale {0} is outside the supported range 0 to 28.</value>
+  </data>
+  <data name="Arg_OutOfRange_MoneyParseModeUndefined" xml:space="preserve">
+    <value>MoneyParseMode '{0}' is not a defined value.</value>
   </data>
   <data name="Arg_OutOfRange_CurrencyInfoMinorUnits" xml:space="preserve">
     <value>Currency '{0}' declares minor-unit precision {1}, which is outside the supported range 0 to 28.</value>

--- a/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
+++ b/Bodu.Financial/src/Financial/FinancialResourceStrings.resx
@@ -129,6 +129,12 @@
   <data name="Arg_Invalid_RateSeriesProviderConflict" xml:space="preserve">
     <value>Pair {0}/{1} has rates from multiple providers ('{2}' and '{3}'); use a composite provider to combine sources.</value>
   </data>
+  <data name="Arg_Invalid_UnknownCurrencyRejected" xml:space="preserve">
+    <value>Currency '{0}' is not registered. Register it via CurrencyRegistry or use Money.FromUnchecked / an explicit UnknownCurrencyPolicy to supply a minor-unit scale.</value>
+  </data>
+  <data name="Arg_Invalid_UnknownCurrencyRequiresScale" xml:space="preserve">
+    <value>Currency '{0}' is not registered; UnknownCurrencyPolicy.AllowWithExplicitScale requires a minor-unit scale. Use Money.FromUnchecked to supply one.</value>
+  </data>
   <data name="Arg_Null_ProviderAtIndex" xml:space="preserve">
     <value>Provider at index {0} is null.</value>
   </data>
@@ -143,6 +149,12 @@
   </data>
   <data name="Arg_OutOfRange_UnsupportedMoneyBagRoundingPolicy" xml:space="preserve">
     <value>Unsupported MoneyBag conversion rounding policy.</value>
+  </data>
+  <data name="Arg_OutOfRange_UnknownCurrencyMinorUnits" xml:space="preserve">
+    <value>Explicit minor-unit scale {0} for currency '{1}' is out of the supported range 0 to 28.</value>
+  </data>
+  <data name="Arg_OutOfRange_UnknownCurrencyPolicyUndefined" xml:space="preserve">
+    <value>UnknownCurrencyPolicy '{0}' is not a defined value.</value>
   </data>
   <data name="Format_Invalid_FormatSpecifier" xml:space="preserve">
     <value>The format string '{0}' is not supported.</value>

--- a/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
+++ b/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
@@ -167,6 +167,33 @@ internal static partial class FinancialThrowHelper
     }
 
     /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="CurrencyRegistrationConflictPolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The conflict policy to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="policy" /> is not a defined value.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfCurrencyRegistrationConflictPolicyUndefined(
+        CurrencyRegistrationConflictPolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not CurrencyRegistrationConflictPolicy.Throw
+            and not CurrencyRegistrationConflictPolicy.Replace
+            and not CurrencyRegistrationConflictPolicy.Ignore)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                policy,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.Arg_OutOfRange_CurrencyRegistrationConflictPolicyUndefined,
+                    policy));
+        }
+    }
+
+    /// <summary>
     /// Throws when <paramref name="minorUnits" /> is outside the supported range 0 to 28.
     /// </summary>
     /// <param name="minorUnits">The candidate minor-unit scale to validate.</param>

--- a/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
+++ b/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
@@ -167,6 +167,66 @@ internal static partial class FinancialThrowHelper
     }
 
     /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="ScalePolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The scale policy to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="policy" /> is not a defined value.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfScalePolicyUndefined(
+        ScalePolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not ScalePolicy.CurrencyMinorUnits and not ScalePolicy.Unrounded and not ScalePolicy.Custom)
+            throw new ArgumentOutOfRangeException(paramName, policy, string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_ScalePolicyUndefined, policy));
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="CashRoundingPolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The cash-rounding policy to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="policy" /> is not a defined value.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfCashRoundingPolicyUndefined(
+        CashRoundingPolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not CashRoundingPolicy.None and not CashRoundingPolicy.CurrencyCashIncrement)
+            throw new ArgumentOutOfRangeException(paramName, policy, string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CashRoundingPolicyUndefined, policy));
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="AllocationPolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The allocation policy to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="policy" /> is not a defined value.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfAllocationPolicyUndefined(
+        AllocationPolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not AllocationPolicy.LargestRemainder)
+            throw new ArgumentOutOfRangeException(paramName, policy, string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_AllocationPolicyUndefined, policy));
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="ConversionRoundingPolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The conversion-rounding policy to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="policy" /> is not a defined value.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfConversionRoundingPolicyUndefined(
+        ConversionRoundingPolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not ConversionRoundingPolicy.RoundAtTarget and not ConversionRoundingPolicy.Defer)
+            throw new ArgumentOutOfRangeException(paramName, policy, string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_ConversionRoundingPolicyUndefined, policy));
+    }
+
+    /// <summary>
     /// Throws when <paramref name="policy" /> is not a defined <see cref="CurrencyRegistrationConflictPolicy" /> member.
     /// </summary>
     /// <param name="policy">The conflict policy to validate.</param>

--- a/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
+++ b/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
@@ -167,6 +167,24 @@ internal static partial class FinancialThrowHelper
     }
 
     /// <summary>
+    /// Throws when <paramref name="mode" /> is not a defined <see cref="MoneyParseMode" /> member.
+    /// </summary>
+    /// <param name="mode">The parse mode to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="mode" /> is not a defined value.</exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfMoneyParseModeUndefined(
+        MoneyParseMode mode,
+        [CallerArgumentExpression(nameof(mode))] string? paramName = null)
+    {
+        if (mode is not MoneyParseMode.StrictIso and not MoneyParseMode.CultureAware
+            and not MoneyParseMode.LenientImport and not MoneyParseMode.RoundTripOnly)
+        {
+            throw new ArgumentOutOfRangeException(paramName, mode, string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_MoneyParseModeUndefined, mode));
+        }
+    }
+
+    /// <summary>
     /// Throws when <paramref name="policy" /> is not a defined <see cref="ScalePolicy" /> member.
     /// </summary>
     /// <param name="policy">The scale policy to validate.</param>

--- a/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
+++ b/Bodu.Financial/src/Financial/FinancialThrowHelper.CallerExpression.cs
@@ -140,6 +140,61 @@ internal static partial class FinancialThrowHelper
     }
 
     /// <summary>
+    /// Throws when <paramref name="policy" /> is not a defined <see cref="UnknownCurrencyPolicy" /> member.
+    /// </summary>
+    /// <param name="policy">The policy value to validate.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="policy" /> is not a defined value.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfUnknownCurrencyPolicyUndefined(
+        UnknownCurrencyPolicy policy,
+        [CallerArgumentExpression(nameof(policy))] string? paramName = null)
+    {
+        if (policy is not UnknownCurrencyPolicy.Reject
+            and not UnknownCurrencyPolicy.AllowWithExplicitScale
+            and not UnknownCurrencyPolicy.AllowUnscaled)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                policy,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.Arg_OutOfRange_UnknownCurrencyPolicyUndefined,
+                    policy));
+        }
+    }
+
+    /// <summary>
+    /// Throws when <paramref name="minorUnits" /> is outside the supported range 0 to 28.
+    /// </summary>
+    /// <param name="minorUnits">The candidate minor-unit scale to validate.</param>
+    /// <param name="isoCode">The currency code reported in the exception message for context.</param>
+    /// <param name="paramName">The parameter name reported in the exception; inferred from the call site.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="minorUnits" /> is less than zero or greater than 28.
+    /// </exception>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static void ThrowIfMinorUnitsOutOfRange(
+        int minorUnits,
+        string isoCode,
+        [CallerArgumentExpression(nameof(minorUnits))] string? paramName = null)
+    {
+        if ((uint)minorUnits > 28u)
+        {
+            throw new ArgumentOutOfRangeException(
+                paramName,
+                minorUnits,
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.Arg_OutOfRange_UnknownCurrencyMinorUnits,
+                    minorUnits,
+                    isoCode));
+        }
+    }
+
+    /// <summary>
     /// Throws when <paramref name="policy" /> is not a defined <see cref="MoneyBagConversionRoundingPolicy" /> member.
     /// </summary>
     /// <param name="policy">The rounding policy to validate.</param>

--- a/Bodu.Financial/src/Financial/ICurrencyLookup.cs
+++ b/Bodu.Financial/src/Financial/ICurrencyLookup.cs
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ICurrencyLookup.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Resolves <see cref="CurrencyInfo" /> metadata by ISO code, numeric code, symbol, region, or culture, providing
+/// NodaMoney-style lookup ergonomics over the runtime currency catalogue without moving currency identity into culture.
+/// </summary>
+public interface ICurrencyLookup
+{
+    /// <summary>
+    /// Attempts to resolve a currency by its ISO 4217 alphabetic code.
+    /// </summary>
+    /// <param name="isoCode">The three-letter uppercase ISO code.</param>
+    /// <param name="currency">When this method returns <see langword="true" />, the matching currency.</param>
+    /// <returns><see langword="true" /> when a currency was found; otherwise <see langword="false" />.</returns>
+    bool TryByIsoCode(string isoCode, out CurrencyInfo currency);
+
+    /// <summary>
+    /// Attempts to resolve a currency by its <see cref="CurrencyCode" /> enum value.
+    /// </summary>
+    /// <param name="code">The active ISO 4217 currency code.</param>
+    /// <param name="currency">When this method returns <see langword="true" />, the matching currency.</param>
+    /// <returns><see langword="true" /> when a currency was found; otherwise <see langword="false" />.</returns>
+    bool TryByCurrencyCode(CurrencyCode code, out CurrencyInfo currency);
+
+    /// <summary>
+    /// Attempts to resolve a currency by its ISO 4217 numeric code.
+    /// </summary>
+    /// <param name="numericCode">The three-digit numeric code.</param>
+    /// <param name="currency">When this method returns <see langword="true" />, the matching currency.</param>
+    /// <returns><see langword="true" /> when a currency was found; otherwise <see langword="false" />.</returns>
+    bool TryByNumericCode(int numericCode, out CurrencyInfo currency);
+
+    /// <summary>
+    /// Attempts to resolve the currencies that use <paramref name="symbol" /> as a primary or alternative symbol.
+    /// </summary>
+    /// <param name="symbol">The currency symbol.</param>
+    /// <param name="matches">When this method returns <see langword="true" />, the matching currencies.</param>
+    /// <returns><see langword="true" /> when at least one currency was found; otherwise <see langword="false" />.</returns>
+    bool TryBySymbol(string symbol, out IReadOnlyList<CurrencyInfo> matches);
+
+    /// <summary>
+    /// Attempts to resolve the currencies used in the region identified by <paramref name="regionCode" />.
+    /// </summary>
+    /// <param name="regionCode">The ISO 3166 region code.</param>
+    /// <param name="matches">When this method returns <see langword="true" />, the matching currencies.</param>
+    /// <returns><see langword="true" /> when at least one currency was found; otherwise <see langword="false" />.</returns>
+    bool TryByRegion(string regionCode, out IReadOnlyList<CurrencyInfo> matches);
+
+    /// <summary>
+    /// Resolves the currencies associated with <paramref name="culture" />'s region.
+    /// </summary>
+    /// <param name="culture">The culture whose region currency is resolved.</param>
+    /// <returns>The matching currencies, or an empty list when none are found.</returns>
+    IReadOnlyList<CurrencyInfo> ByCulture(CultureInfo culture);
+}

--- a/Bodu.Financial/src/Financial/IRoundingStrategy.cs
+++ b/Bodu.Financial/src/Financial/IRoundingStrategy.cs
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="IRoundingStrategy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Rounds a raw monetary amount to a given number of fractional digits. Implementations encapsulate the rounding
+/// convention applied at operation boundaries — banker's rounding, away-from-zero, and so on.
+/// </summary>
+public interface IRoundingStrategy
+{
+    /// <summary>
+    /// Rounds <paramref name="value" /> to <paramref name="scale" /> fractional digits.
+    /// </summary>
+    /// <param name="value">The raw amount to round.</param>
+    /// <param name="scale">The number of fractional digits to round to.</param>
+    /// <returns>The rounded amount.</returns>
+    decimal Round(decimal value, int scale);
+}

--- a/Bodu.Financial/src/Financial/MidpointRoundingStrategy.cs
+++ b/Bodu.Financial/src/Financial/MidpointRoundingStrategy.cs
@@ -1,0 +1,50 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MidpointRoundingStrategy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// An <see cref="IRoundingStrategy" /> backed by a <see cref="MidpointRounding" /> mode, rounding via
+/// <see cref="decimal.Round(decimal, int, MidpointRounding)" />.
+/// </summary>
+public sealed class MidpointRoundingStrategy
+    : IRoundingStrategy
+{
+    /// <summary>
+    /// The shared banker's-rounding (<see cref="MidpointRounding.ToEven" />) strategy.
+    /// </summary>
+    public static readonly MidpointRoundingStrategy ToEven = new(MidpointRounding.ToEven);
+
+    /// <summary>
+    /// The shared away-from-zero (<see cref="MidpointRounding.AwayFromZero" />) strategy.
+    /// </summary>
+    public static readonly MidpointRoundingStrategy AwayFromZero = new(MidpointRounding.AwayFromZero);
+
+    /// <summary>
+    /// The midpoint-rounding mode applied by this strategy.
+    /// </summary>
+    private readonly MidpointRounding _mode;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MidpointRoundingStrategy" /> class.
+    /// </summary>
+    /// <param name="mode">The midpoint-rounding mode to apply.</param>
+    public MidpointRoundingStrategy(MidpointRounding mode)
+    {
+        _mode = mode;
+    }
+
+    /// <summary>
+    /// Gets the midpoint-rounding mode applied by this strategy.
+    /// </summary>
+    /// <returns>The configured <see cref="MidpointRounding" /> mode.</returns>
+    public MidpointRounding Mode =>
+        _mode;
+
+    /// <inheritdoc />
+    public decimal Round(decimal value, int scale) =>
+        decimal.Round(value, scale, _mode);
+}

--- a/Bodu.Financial/src/Financial/MonetaryContext.cs
+++ b/Bodu.Financial/src/Financial/MonetaryContext.cs
@@ -1,0 +1,141 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MonetaryContext.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Carries the rounding and scaling policy applied at a monetary operation boundary — multiplication, division,
+/// conversion, allocation, and the conversion of a high-precision calculation back to a settlement value.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="MonetaryContext" /> is supplied to operations rather than embedded in a <see cref="Money" /> value, so
+/// the same amount can participate in calculations under different policies without carrying mutable state. Operations
+/// that accept a nullable context treat <see langword="null" /> as <see cref="Default" />, preserving the historical
+/// banker's-rounding behaviour.
+/// </para>
+/// </remarks>
+public sealed record MonetaryContext
+{
+    /// <summary>
+    /// Gets the shared default context: banker's rounding to the currency's minor units, no cash rounding,
+    /// largest-remainder allocation, and rounding conversions at the target scale.
+    /// </summary>
+    /// <returns>The default <see cref="MonetaryContext" />.</returns>
+    public static MonetaryContext Default { get; } = new();
+
+    /// <summary>
+    /// Gets the rounding strategy applied when reducing a computed amount to the resolved scale.
+    /// </summary>
+    /// <value>The rounding strategy; never <see langword="null" />.</value>
+    /// <returns>The configured <see cref="IRoundingStrategy" />.</returns>
+    public IRoundingStrategy Rounding { get; init; } = MidpointRoundingStrategy.ToEven;
+
+    /// <summary>
+    /// Gets the policy that determines the fractional-digit scale results are rounded to.
+    /// </summary>
+    /// <returns>The configured <see cref="ScalePolicy" />.</returns>
+    public ScalePolicy ScalePolicy { get; init; } = ScalePolicy.CurrencyMinorUnits;
+
+    /// <summary>
+    /// Gets the explicit scale used when <see cref="ScalePolicy" /> is <see cref="ScalePolicy.Custom" />.
+    /// </summary>
+    /// <returns>The custom scale, or <see langword="null" /> when not applicable.</returns>
+    public int? CustomScale { get; init; }
+
+    /// <summary>
+    /// Gets the cash-rounding policy applied to results.
+    /// </summary>
+    /// <returns>The configured <see cref="CashRoundingPolicy" />.</returns>
+    public CashRoundingPolicy CashRounding { get; init; } = CashRoundingPolicy.None;
+
+    /// <summary>
+    /// Gets the allocation policy used when distributing an amount across shares.
+    /// </summary>
+    /// <returns>The configured <see cref="AllocationPolicy" />.</returns>
+    public AllocationPolicy Allocation { get; init; } = AllocationPolicy.LargestRemainder;
+
+    /// <summary>
+    /// Gets the policy that determines when a currency conversion is rounded.
+    /// </summary>
+    /// <returns>The configured <see cref="ConversionRoundingPolicy" />.</returns>
+    public ConversionRoundingPolicy ConversionRounding { get; init; } = ConversionRoundingPolicy.RoundAtTarget;
+
+    /// <summary>
+    /// Resolves the effective fractional-digit scale for a currency with <paramref name="currencyMinorUnits" /> minor
+    /// units.
+    /// </summary>
+    /// <param name="currencyMinorUnits">The currency's declared minor-unit precision.</param>
+    /// <returns>
+    /// The number of fractional digits to round to, or <c>-1</c> when <see cref="ScalePolicy.Unrounded" /> defers
+    /// rounding entirely.
+    /// </returns>
+    /// <exception cref="ArgumentOutOfRangeException"><see cref="ScalePolicy" /> is not a defined value.</exception>
+    /// <exception cref="ArgumentException">
+    /// <see cref="ScalePolicy" /> is <see cref="ScalePolicy.Custom" /> but <see cref="CustomScale" /> is
+    /// <see langword="null" />.
+    /// </exception>
+    public int ResolveScale(int currencyMinorUnits)
+    {
+        FinancialThrowHelper.ThrowIfScalePolicyUndefined(ScalePolicy);
+
+        return ScalePolicy switch
+        {
+            ScalePolicy.CurrencyMinorUnits => currencyMinorUnits,
+            ScalePolicy.Unrounded => -1,
+            _ => CustomScale ?? throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_CustomScaleRequiresValue, nameof(CustomScale)),
+        };
+    }
+
+    /// <summary>
+    /// Rounds <paramref name="value" /> for a currency with <paramref name="currencyMinorUnits" /> minor units using
+    /// this context's rounding strategy and resolved scale.
+    /// </summary>
+    /// <param name="value">The raw amount to round.</param>
+    /// <param name="currencyMinorUnits">The currency's declared minor-unit precision.</param>
+    /// <returns>
+    /// The rounded amount, or <paramref name="value" /> unchanged when <see cref="ScalePolicy.Unrounded" /> is in
+    /// effect.
+    /// </returns>
+    public decimal Round(decimal value, int currencyMinorUnits)
+    {
+        var scale = ResolveScale(currencyMinorUnits);
+        return scale < 0 ? value : Rounding.Round(value, scale);
+    }
+
+    /// <summary>
+    /// Validates that every policy member is a defined value and that <see cref="CustomScale" /> is supplied when
+    /// required.
+    /// </summary>
+    /// <exception cref="ArgumentOutOfRangeException">A policy member is not a defined value.</exception>
+    /// <exception cref="ArgumentException">
+    /// <see cref="ScalePolicy" /> is <see cref="ScalePolicy.Custom" /> but <see cref="CustomScale" /> is
+    /// <see langword="null" />, or it is out of the range 0 to 28.
+    /// </exception>
+    public void Validate()
+    {
+        FinancialThrowHelper.ThrowIfScalePolicyUndefined(ScalePolicy);
+        FinancialThrowHelper.ThrowIfCashRoundingPolicyUndefined(CashRounding);
+        FinancialThrowHelper.ThrowIfAllocationPolicyUndefined(Allocation);
+        FinancialThrowHelper.ThrowIfConversionRoundingPolicyUndefined(ConversionRounding);
+
+        if (ScalePolicy == ScalePolicy.Custom)
+        {
+            if (CustomScale is null)
+                throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_CustomScaleRequiresValue, nameof(CustomScale));
+
+            if ((uint)CustomScale.Value > 28u)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(CustomScale),
+                    CustomScale.Value,
+                    string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CustomScale, CustomScale.Value));
+            }
+        }
+    }
+}

--- a/Bodu.Financial/src/Financial/Money.Allocation.cs
+++ b/Bodu.Financial/src/Financial/Money.Allocation.cs
@@ -28,12 +28,11 @@ public readonly partial struct Money
         long sign = residual >= 0 ? 1 : -1;
         var residualMagnitude = Math.Abs(residual);
 
-        var iso = IsoCode;
         var result = new Money[parts];
         for (var i = 0; i < parts; i++)
         {
             var share = basePer + (i < residualMagnitude ? sign : 0);
-            result[i] = FromNormalized(share / factor, iso);
+            result[i] = WithAmount(share / factor);
         }
 
         return result;
@@ -86,10 +85,9 @@ public readonly partial struct Money
             }
         }
 
-        var iso = IsoCode;
         var result = new Money[ratios.Length];
         for (var i = 0; i < ratios.Length; i++)
-            result[i] = FromNormalized(shares[i] / factor, iso);
+            result[i] = WithAmount(shares[i] / factor);
 
         return result;
     }

--- a/Bodu.Financial/src/Financial/Money.Conversion.cs
+++ b/Bodu.Financial/src/Financial/Money.Conversion.cs
@@ -11,6 +11,20 @@ namespace Bodu.Financial;
 public readonly partial struct Money
 {
     /// <summary>
+    /// Returns a high-precision <see cref="CalculatedMoney" /> in the same currency, suitable for deferred-rounding
+    /// calculation chains.
+    /// </summary>
+    /// <returns>A <see cref="CalculatedMoney" /> carrying this value's amount and ISO code.</returns>
+    /// <exception cref="InvalidOperationException">This value carries no ISO code (default-initialised).</exception>
+    public CalculatedMoney ToCalculated()
+    {
+        if (string.IsNullOrEmpty(IsoCode))
+            throw new InvalidOperationException(FinancialResourceStrings.Op_Invalid_MoneyRequiresCurrency);
+
+        return new CalculatedMoney(_amount, IsoCode);
+    }
+
+    /// <summary>
     /// Converts this <see cref="Money" /> to a strongly-typed <see cref="Money{TCurrency}" /> when the runtime
     /// currency matches <typeparamref name="TCurrency" />.
     /// </summary>

--- a/Bodu.Financial/src/Financial/Money.Conversion.cs
+++ b/Bodu.Financial/src/Financial/Money.Conversion.cs
@@ -82,6 +82,57 @@ public readonly partial struct Money
         Convert(targetIsoCode, exchangeRate, MidpointRounding.ToEven);
 
     /// <summary>
+    /// Converts this amount using an auditable <see cref="ExchangeRate" /> quote, rounding to the target currency under
+    /// <paramref name="context" />.
+    /// </summary>
+    /// <param name="rate">The exchange-rate quote whose source currency must match this value's currency.</param>
+    /// <param name="context">The monetary context governing rounding; <see langword="null" /> selects
+    /// <see cref="MonetaryContext.Default" />.</param>
+    /// <returns>The converted <see cref="Money" /> in the rate's target currency.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The rate's source currency does not match this value's <see cref="IsoCode" />.
+    /// </exception>
+    /// <remarks>
+    /// Prefer this quote-first overload over the raw-decimal <see cref="Convert(string, decimal, MidpointRounding)" />
+    /// surface: it preserves the rate's direction, date, provider, and inversion metadata for downstream audit, and the
+    /// companion <see cref="ConvertWithResult(ExchangeRate, MonetaryContext?)" /> returns that metadata alongside the
+    /// rounding adjustment.
+    /// </remarks>
+    public Money Convert(ExchangeRate rate, MonetaryContext? context = null) =>
+        ConvertWithResult(rate, context).Target;
+
+    /// <summary>
+    /// Converts this amount using an auditable <see cref="ExchangeRate" /> quote and returns the full conversion result,
+    /// including the rate, context, and rounding adjustment.
+    /// </summary>
+    /// <param name="rate">The exchange-rate quote whose source currency must match this value's currency.</param>
+    /// <param name="context">The monetary context governing rounding; <see langword="null" /> selects
+    /// <see cref="MonetaryContext.Default" />.</param>
+    /// <returns>The <see cref="MoneyConversionResult" /> describing the conversion.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The rate's source currency does not match this value's <see cref="IsoCode" />.
+    /// </exception>
+    public MoneyConversionResult ConvertWithResult(ExchangeRate rate, MonetaryContext? context = null)
+    {
+        if (!string.Equals(rate.FromIsoCode, IsoCode, StringComparison.Ordinal))
+        {
+            throw new InvalidOperationException(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    FinancialResourceStrings.Op_Invalid_ConversionRateDirectionMismatch,
+                    IsoCode,
+                    rate.FromIsoCode,
+                    rate.ToIsoCode));
+        }
+
+        MonetaryContext effective = context ?? MonetaryContext.Default;
+        var raw = rate.Convert(_amount);
+        Money target = new CalculatedMoney(raw, rate.ToIsoCode).RoundToMoney(effective);
+
+        return new MoneyConversionResult(this, target, rate, effective, target.Amount - raw);
+    }
+
+    /// <summary>
     /// Converts this amount to a different currency at the supplied exchange rate, using the specified rounding rule.
     /// </summary>
     /// <param name="targetIsoCode">The ISO 4217 code of the destination currency.</param>

--- a/Bodu.Financial/src/Financial/Money.Helpers.cs
+++ b/Bodu.Financial/src/Financial/Money.Helpers.cs
@@ -27,6 +27,83 @@ public readonly partial struct Money
         new(amount, isoCode, rounding);
 
     /// <summary>
+    /// Creates a runtime-tagged <see cref="Money" /> from the supplied amount and ISO 4217 code, applying the given
+    /// <paramref name="policy" /> when the code is structurally valid but not registered in <see cref="CurrencyRegistry" />.
+    /// </summary>
+    /// <param name="amount">The monetary amount in the major unit.</param>
+    /// <param name="isoCode">The ISO 4217 three-letter alphabetic code identifying the currency.</param>
+    /// <param name="policy">The behaviour applied when the currency is unknown to the registry.</param>
+    /// <param name="rounding">The midpoint-rounding rule applied when normalising to the minor-unit precision.</param>
+    /// <returns>The constructed monetary value.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="isoCode" /> is not exactly three uppercase ASCII letters; or it is unregistered and
+    /// <paramref name="policy" /> is <see cref="UnknownCurrencyPolicy.Reject" />; or it is unregistered and
+    /// <paramref name="policy" /> is <see cref="UnknownCurrencyPolicy.AllowWithExplicitScale" /> (which requires a scale,
+    /// supplied through <see cref="FromUnchecked(decimal, string, int, MidpointRounding)" />).
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="policy" /> is not a defined <see cref="UnknownCurrencyPolicy" /> member.
+    /// </exception>
+    /// <remarks>
+    /// Registered currencies are rounded to the registry's minor units regardless of <paramref name="policy" />. The
+    /// policy governs only the unregistered case: <see cref="UnknownCurrencyPolicy.AllowUnscaled" /> stores the amount at
+    /// its source precision (reporting zero minor units), and <see cref="UnknownCurrencyPolicy.AllowWithExplicitScale" />
+    /// is rejected here because it needs an explicit scale — call
+    /// <see cref="FromUnchecked(decimal, string, int, MidpointRounding)" /> for that path.
+    /// </remarks>
+    public static Money From(
+        decimal amount,
+        string isoCode,
+        UnknownCurrencyPolicy policy,
+        MidpointRounding rounding = MidpointRounding.ToEven)
+    {
+        ThrowHelper.ThrowIfNull(isoCode);
+        FinancialThrowHelper.ThrowIfUnknownCurrencyPolicyUndefined(policy);
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(isoCode);
+
+        if (CurrencyRegistry.TryGet(isoCode, out CurrencyInfo? info) && info is not null)
+            return new Money(decimal.Round(amount, info.MinorUnits, rounding), isoCode, (byte)0);
+
+        return policy switch
+        {
+            UnknownCurrencyPolicy.AllowUnscaled => new Money(amount, isoCode, (byte)0),
+            UnknownCurrencyPolicy.AllowWithExplicitScale => throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_UnknownCurrencyRequiresScale, isoCode),
+                nameof(policy)),
+            _ => throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_UnknownCurrencyRejected, isoCode),
+                nameof(isoCode)),
+        };
+    }
+
+    /// <summary>
+    /// Creates a runtime-tagged <see cref="Money" /> for a currency that need not be registered, rounding the amount to
+    /// the caller-supplied minor-unit scale so the result reports that scale from <see cref="Money.MinorUnits" />.
+    /// </summary>
+    /// <param name="amount">The monetary amount in the major unit.</param>
+    /// <param name="isoCode">The ISO 4217 three-letter alphabetic code identifying the currency.</param>
+    /// <param name="minorUnits">The number of fractional digits to round to and report as the value's minor units.</param>
+    /// <param name="rounding">The midpoint-rounding rule applied when normalising to <paramref name="minorUnits" />.</param>
+    /// <returns>The constructed monetary value carrying an explicit scale.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException"><paramref name="isoCode" /> is not exactly three uppercase ASCII letters.</exception>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="minorUnits" /> is outside the range 0 to 28.</exception>
+    /// <remarks>
+    /// This is the explicit escape hatch for staging or custom currencies that are intentionally absent from
+    /// <see cref="CurrencyRegistry" />. Because the scale is supplied and stored, the resulting value never exhibits the
+    /// "source precision retained but zero minor units reported" inconsistency that ordinary unregistered construction
+    /// would otherwise produce.
+    /// </remarks>
+    public static Money FromUnchecked(decimal amount, string isoCode, int minorUnits, MidpointRounding rounding = MidpointRounding.ToEven)
+    {
+        FinancialThrowHelper.ThrowIfNotValidIsoCode(isoCode);
+        FinancialThrowHelper.ThrowIfMinorUnitsOutOfRange(minorUnits, isoCode);
+
+        return new Money(decimal.Round(amount, minorUnits, rounding), isoCode, (byte)(minorUnits + 1));
+    }
+
+    /// <summary>
     /// Creates a runtime-tagged <see cref="Money" /> from the supplied amount and currency metadata.
     /// </summary>
     /// <param name="amount">The monetary amount in the major unit.</param>

--- a/Bodu.Financial/src/Financial/Money.OfTCurrency.Conversion.cs
+++ b/Bodu.Financial/src/Financial/Money.OfTCurrency.Conversion.cs
@@ -24,6 +24,14 @@ public readonly partial struct Money<TCurrency>
         Money.FromNormalized(_amount, CurrencyMetadata<TCurrency>.Value.IsoCode);
 
     /// <summary>
+    /// Returns a high-precision <see cref="CalculatedMoney{TCurrency}" /> carrying this value's amount, suitable for
+    /// deferred-rounding calculation chains.
+    /// </summary>
+    /// <returns>A <see cref="CalculatedMoney{TCurrency}" /> with this value's amount.</returns>
+    public CalculatedMoney<TCurrency> ToCalculated() =>
+        new(_amount);
+
+    /// <summary>
     /// Implicitly converts a <see cref="Money{TCurrency}" /> to a runtime-tagged <see cref="Money" />.
     /// </summary>
     /// <param name="value">The strongly-typed money.</param>

--- a/Bodu.Financial/src/Financial/Money.OfTCurrency.Operators.cs
+++ b/Bodu.Financial/src/Financial/Money.OfTCurrency.Operators.cs
@@ -173,6 +173,28 @@ public readonly partial struct Money<TCurrency>
         new(_amount * multiplier, rounding);
 
     /// <summary>
+    /// Multiplies this amount by <paramref name="multiplier" /> and rounds the result to the currency's minor-unit
+    /// precision using <paramref name="context" />'s rounding strategy.
+    /// </summary>
+    /// <param name="multiplier">The scalar multiplier.</param>
+    /// <param name="context">The monetary context whose rounding strategy is applied at the settlement boundary.</param>
+    /// <returns>The product, rounded to <c>TCurrency.MinorUnits</c> using <paramref name="context" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="context" /> is <see langword="null" />.</exception>
+    /// <exception cref="OverflowException">The product falls outside the range of <see cref="decimal" />.</exception>
+    /// <remarks>
+    /// Because <see cref="Money{TCurrency}" /> is a settlement value, only the context's rounding strategy is honoured;
+    /// the scale is fixed to the currency's minor units. For deferred-rounding chains use a high-precision calculation
+    /// value and round once at the end.
+    /// </remarks>
+    public Money<TCurrency> Multiply(decimal multiplier, MonetaryContext context)
+    {
+        ThrowHelper.ThrowIfNull(context);
+
+        var minorUnits = CurrencyMetadata<TCurrency>.Value.MinorUnits;
+        return FromNormalizedAmount(context.Rounding.Round(_amount * multiplier, minorUnits));
+    }
+
+    /// <summary>
     /// Divides this amount by <paramref name="divisor" /> using banker's rounding, identical to the <c>/</c> operator.
     /// </summary>
     /// <param name="divisor">The scalar divisor.</param>

--- a/Bodu.Financial/src/Financial/Money.OfTCurrency.cs
+++ b/Bodu.Financial/src/Financial/Money.OfTCurrency.cs
@@ -50,6 +50,12 @@ namespace Bodu.Financial;
 /// the rounding constructor, so it is safe even when <typeparamref name="TCurrency" /> reports invalid minor-unit
 /// metadata.
 /// </para>
+/// <para>
+/// The type-level <see cref="JsonConverterAttribute" /> always serializes the canonical
+/// <see cref="Serialization.FinancialJsonPolicy.Strict" /> object shape; the compact and lenient shapes are opt-in only
+/// and must be selected through
+/// <see cref="Serialization.FinancialJsonSerializerOptionsExtensions.AddFinancialJsonConverters(System.Text.Json.JsonSerializerOptions, Serialization.FinancialJsonPolicy)" />.
+/// </para>
 /// </remarks>
 [Serializable]
 [DebuggerDisplay("{ToString(),nq}")]

--- a/Bodu.Financial/src/Financial/Money.Operators.cs
+++ b/Bodu.Financial/src/Financial/Money.Operators.cs
@@ -21,7 +21,7 @@ public readonly partial struct Money
     public static Money operator +(Money left, Money right)
     {
         EnsureSameCurrency(left, right);
-        return FromNormalized(left._amount + right._amount, left.IsoCode);
+        return left.WithAmount(left._amount + right._amount);
     }
 
     /// <summary>
@@ -37,7 +37,7 @@ public readonly partial struct Money
     public static Money operator -(Money left, Money right)
     {
         EnsureSameCurrency(left, right);
-        return FromNormalized(left._amount - right._amount, left.IsoCode);
+        return left.WithAmount(left._amount - right._amount);
     }
 
     /// <summary>
@@ -47,7 +47,7 @@ public readonly partial struct Money
     /// <returns>A <see cref="Money" /> with the same ISO code and negated amount.</returns>
     public static Money operator -(Money value)
     {
-        return FromNormalized(-value._amount, value.IsoCode);
+        return value.WithAmount(-value._amount);
     }
 
     /// <summary>
@@ -68,7 +68,7 @@ public readonly partial struct Money
     /// <returns>The product.</returns>
     public static Money operator *(Money left, decimal right)
     {
-        return new(left._amount * right, left.IsoCode);
+        return left.WithRoundedAmount(left._amount * right);
     }
 
     /// <summary>
@@ -79,7 +79,7 @@ public readonly partial struct Money
     /// <returns>The product.</returns>
     public static Money operator *(decimal left, Money right)
     {
-        return new(left * right._amount, right.IsoCode);
+        return right.WithRoundedAmount(left * right._amount);
     }
 
     /// <summary>
@@ -91,7 +91,7 @@ public readonly partial struct Money
     /// <exception cref="DivideByZeroException"><paramref name="right" /> is zero.</exception>
     public static Money operator /(Money left, decimal right)
     {
-        return new(left._amount / right, left.IsoCode);
+        return left.WithRoundedAmount(left._amount / right);
     }
 
     /// <summary>

--- a/Bodu.Financial/src/Financial/Money.Parse.cs
+++ b/Bodu.Financial/src/Financial/Money.Parse.cs
@@ -112,6 +112,11 @@ public readonly partial struct Money :
         result = default;
         if (numericPart.IsEmpty) return false;
 
+        // The strict parser only yields a value for currencies registered in CurrencyRegistry; an unregistered code is
+        // a parse failure here (it cannot be constructed under the default reject policy) rather than an exception.
+        if (!CurrencyRegistry.Contains(iso))
+            return false;
+
         IFormatProvider effective = provider ?? CultureInfo.CurrentCulture;
         if (!decimal.TryParse(numericPart, NumberStyles.Number | NumberStyles.AllowLeadingSign, effective, out var amount))
             return false;

--- a/Bodu.Financial/src/Financial/Money.ParseOptions.cs
+++ b/Bodu.Financial/src/Financial/Money.ParseOptions.cs
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="Money.ParseOptions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+public readonly partial struct Money
+{
+    /// <summary>
+    /// Parses a <see cref="Money" /> using the supplied <paramref name="options" />.
+    /// </summary>
+    /// <param name="s">The text to parse.</param>
+    /// <param name="options">The parse options controlling mode, culture, and unknown-currency handling.</param>
+    /// <returns>The parsed value.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="s" /> or <paramref name="options" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="FormatException">The input is not valid under <paramref name="options" />.</exception>
+    public static Money Parse(string s, MoneyParseOptions options)
+    {
+        ThrowHelper.ThrowIfNull(s);
+        ThrowHelper.ThrowIfNull(options);
+
+        return TryParse(s.AsSpan(), options, out Money result)
+            ? result
+            : throw new FormatException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Format_Invalid_MoneyString, s));
+    }
+
+    /// <summary>
+    /// Attempts to parse a <see cref="Money" /> using the supplied <paramref name="options" />.
+    /// </summary>
+    /// <param name="s">The text to parse.</param>
+    /// <param name="options">The parse options controlling mode, culture, and unknown-currency handling.</param>
+    /// <param name="result">When this method returns <see langword="true" />, the parsed value; otherwise the default.</param>
+    /// <returns><see langword="true" /> on success.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="options" />.<see cref="MoneyParseOptions.Mode" /> is not a defined value.
+    /// </exception>
+    public static bool TryParse(ReadOnlySpan<char> s, MoneyParseOptions options, out Money result)
+    {
+        ThrowHelper.ThrowIfNull(options);
+        FinancialThrowHelper.ThrowIfMoneyParseModeUndefined(options.Mode);
+
+        result = default;
+
+        IFormatProvider provider = options.FormatProvider
+            ?? (options.Mode == MoneyParseMode.RoundTripOnly ? CultureInfo.InvariantCulture : CultureInfo.CurrentCulture);
+
+        ReadOnlySpan<char> trimmed = s.Trim();
+        if (trimmed.IsEmpty)
+            return false;
+
+        if (TryExtractIso(trimmed, out ReadOnlySpan<char> numericPart, out var iso))
+        {
+            if (options.Mode == MoneyParseMode.LenientImport)
+                iso = iso.ToUpperInvariant();
+
+            return TryComposeWithPolicy(numericPart, iso, provider, options.UnknownCurrency, out result);
+        }
+
+        // No embedded ISO code: only culture-aware parsing can resolve a currency from a symbol.
+        if (options.Mode == MoneyParseMode.CultureAware
+            && TryExtractSymbol(trimmed, out ReadOnlySpan<char> symbolNumeric, out var symbol))
+        {
+            ICurrencyLookup lookup = options.CurrencyLookup ?? new CurrencyLookupService();
+            if (lookup.TryBySymbol(symbol, out IReadOnlyList<CurrencyInfo> matches) && matches.Count == 1)
+                return TryComposeWithPolicy(symbolNumeric, matches[0].IsoCode, provider, options.UnknownCurrency, out result);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts the numeric portion and three-letter ISO code from <paramref name="trimmed" /> when it is in prefix or
+    /// suffix form.
+    /// </summary>
+    /// <param name="trimmed">The trimmed input span.</param>
+    /// <param name="numericPart">The numeric portion of the input.</param>
+    /// <param name="iso">The detected ISO code.</param>
+    /// <returns><see langword="true" /> when an ISO code was located.</returns>
+    private static bool TryExtractIso(ReadOnlySpan<char> trimmed, out ReadOnlySpan<char> numericPart, out string iso)
+    {
+        // ISO prefix: "USD 19.99".
+        if (trimmed.Length >= 5 && trimmed[3] == ' '
+            && IsAsciiLetter(trimmed[0]) && IsAsciiLetter(trimmed[1]) && IsAsciiLetter(trimmed[2]))
+        {
+            iso = trimmed[..3].ToString();
+            numericPart = trimmed[4..].TrimStart();
+            return true;
+        }
+
+        // ISO suffix: "19.99 USD".
+        if (trimmed.Length >= 5 && trimmed[^4] == ' '
+            && IsAsciiLetter(trimmed[^3]) && IsAsciiLetter(trimmed[^2]) && IsAsciiLetter(trimmed[^1]))
+        {
+            iso = trimmed[^3..].ToString();
+            numericPart = trimmed[..^4].TrimEnd();
+            return true;
+        }
+
+        numericPart = default;
+        iso = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Extracts a leading or trailing currency symbol and the remaining numeric portion.
+    /// </summary>
+    /// <param name="trimmed">The trimmed input span.</param>
+    /// <param name="numericPart">The numeric portion of the input.</param>
+    /// <param name="symbol">The detected symbol.</param>
+    /// <returns><see langword="true" /> when a symbol was located.</returns>
+    private static bool TryExtractSymbol(ReadOnlySpan<char> trimmed, out ReadOnlySpan<char> numericPart, out string symbol)
+    {
+        var start = 0;
+        while (start < trimmed.Length && IsSymbolChar(trimmed[start]))
+            start++;
+
+        if (start > 0)
+        {
+            symbol = trimmed[..start].ToString();
+            numericPart = trimmed[start..].TrimStart();
+            return true;
+        }
+
+        var end = trimmed.Length;
+        while (end > 0 && IsSymbolChar(trimmed[end - 1]))
+            end--;
+
+        if (end < trimmed.Length)
+        {
+            symbol = trimmed[end..].ToString();
+            numericPart = trimmed[..end].TrimEnd();
+            return true;
+        }
+
+        numericPart = default;
+        symbol = string.Empty;
+        return false;
+    }
+
+    /// <summary>
+    /// Parses the numeric portion and constructs the value, honouring the unknown-currency policy.
+    /// </summary>
+    /// <param name="numericPart">The numeric span.</param>
+    /// <param name="iso">The ISO code.</param>
+    /// <param name="provider">The culture provider.</param>
+    /// <param name="unknownCurrency">The policy applied when the currency is unregistered.</param>
+    /// <param name="result">The constructed value.</param>
+    /// <returns><see langword="true" /> on success.</returns>
+    private static bool TryComposeWithPolicy(
+        ReadOnlySpan<char> numericPart,
+        string iso,
+        IFormatProvider provider,
+        UnknownCurrencyPolicy unknownCurrency,
+        out Money result)
+    {
+        result = default;
+
+        if (numericPart.IsEmpty || iso.Length != 3
+            || !IsUppercaseAscii(iso[0]) || !IsUppercaseAscii(iso[1]) || !IsUppercaseAscii(iso[2]))
+        {
+            return false;
+        }
+
+        if (!decimal.TryParse(numericPart, NumberStyles.Number | NumberStyles.AllowLeadingSign, provider, out var amount))
+            return false;
+
+        if (CurrencyRegistry.Contains(iso))
+        {
+            result = new Money(amount, iso);
+            return true;
+        }
+
+        // Unregistered: AllowUnscaled is the only policy that yields a value without a caller-supplied scale.
+        if (unknownCurrency == UnknownCurrencyPolicy.AllowUnscaled)
+        {
+            result = Money.From(amount, iso, UnknownCurrencyPolicy.AllowUnscaled);
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a character is an ASCII letter (either case).
+    /// </summary>
+    /// <param name="c">The character to test.</param>
+    /// <returns><see langword="true" /> when <paramref name="c" /> is in [A-Za-z].</returns>
+    private static bool IsAsciiLetter(char c) =>
+        c is (>= 'A' and <= 'Z') or (>= 'a' and <= 'z');
+
+    /// <summary>
+    /// Determines whether a character can form part of a currency symbol (neither digit, letter, nor white space).
+    /// </summary>
+    /// <param name="c">The character to test.</param>
+    /// <returns><see langword="true" /> when <paramref name="c" /> is a symbol character.</returns>
+    private static bool IsSymbolChar(char c) =>
+        !char.IsDigit(c) && !char.IsWhiteSpace(c) && c is not ('-' or '+' or '.' or ',' or '(' or ')');
+}

--- a/Bodu.Financial/src/Financial/Money.Properties.cs
+++ b/Bodu.Financial/src/Financial/Money.Properties.cs
@@ -23,14 +23,22 @@ public readonly partial struct Money
         _isoCode ?? string.Empty;
 
     /// <summary>
-    /// Gets the minor-unit precision of the currency, as reported by <see cref="CurrencyRegistry" />.
+    /// Gets the minor-unit precision of this value.
     /// </summary>
     /// <returns>
-    /// The number of fractional digits of the currency's minor unit, or zero when the currency is unknown to the
-    /// registry.
+    /// The explicit scale supplied at construction when this value carries one; otherwise the currency's minor-unit
+    /// precision as reported by <see cref="CurrencyRegistry" />, or zero when the currency is unknown to the registry.
     /// </returns>
+    /// <remarks>
+    /// A value constructed for an unregistered currency through
+    /// <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" /> reports the caller-supplied scale,
+    /// keeping the stored precision and the reported minor units self-consistent. Ordinary construction always resolves
+    /// the precision from the registry.
+    /// </remarks>
     public int MinorUnits =>
-        CurrencyRegistry.TryGet(IsoCode, out CurrencyInfo? info) ? info!.MinorUnits : 0;
+        _explicitScalePlusOne > 0
+            ? _explicitScalePlusOne - 1
+            : CurrencyRegistry.TryGet(IsoCode, out CurrencyInfo? info) ? info!.MinorUnits : 0;
 
     /// <summary>
     /// Gets a value indicating whether this amount is zero.
@@ -67,7 +75,7 @@ public readonly partial struct Money
     /// </summary>
     /// <returns>A <see cref="Money" /> with the same ISO code and a non-negative amount.</returns>
     public Money Abs =>
-        FromNormalized(Math.Abs(_amount), IsoCode);
+        WithAmount(Math.Abs(_amount));
 
     /// <summary>
     /// Returns a <see cref="Money" /> representing zero of the specified currency.

--- a/Bodu.Financial/src/Financial/Money.cs
+++ b/Bodu.Financial/src/Financial/Money.cs
@@ -25,9 +25,18 @@ namespace Bodu.Financial;
 /// </para>
 /// <para>
 /// The amount is rounded on construction to the minor-unit precision reported by <see cref="CurrencyRegistry" /> for
-/// the supplied ISO code, using banker's rounding by default. When the ISO code is not in the registry the amount is
-/// stored at its source precision; consumers can call <see cref="CurrencyRegistry.Register" /> to register custom
-/// currencies ahead of construction.
+/// the supplied ISO code, using banker's rounding by default. A structurally valid but unregistered ISO code is
+/// rejected; register custom currencies via <see cref="CurrencyRegistry.Register(CurrencyInfo)" /> ahead of
+/// construction, or use the explicit-scale escape hatches
+/// <see cref="FromUnchecked(decimal, string, int, MidpointRounding)" /> and
+/// <see cref="From(decimal, string, UnknownCurrencyPolicy, MidpointRounding)" />.
+/// </para>
+/// <para>
+/// The type-level <see cref="JsonConverterAttribute" /> always serializes the canonical
+/// <see cref="Serialization.FinancialJsonPolicy.Strict" /> object shape
+/// (<c>{ "amount": &lt;number&gt;, "currency": "&lt;ISO&gt;" }</c>). The compact and lenient shapes are opt-in only and
+/// must be selected through
+/// <see cref="Serialization.FinancialJsonSerializerOptionsExtensions.AddFinancialJsonConverters(System.Text.Json.JsonSerializerOptions, Serialization.FinancialJsonPolicy)" />.
 /// </para>
 /// </remarks>
 [Serializable]

--- a/Bodu.Financial/src/Financial/Money.cs
+++ b/Bodu.Financial/src/Financial/Money.cs
@@ -47,13 +47,27 @@ public readonly partial struct Money
     private readonly string? _isoCode;
 
     /// <summary>
+    /// The explicit minor-unit scale plus one, or <c>0</c> when no explicit scale is associated and the precision is
+    /// derived from <see cref="CurrencyRegistry" />.
+    /// </summary>
+    /// <remarks>
+    /// The "+1" bias lets a default-initialised <see cref="Money" /> (all-zero fields) mean "use the registry" rather
+    /// than "explicit scale 0". A value of <c>n + 1</c> denotes an explicit minor-unit scale of <c>n</c> in the range
+    /// <c>0</c>..<c>28</c>, set only by the explicit-scale escape hatches for unregistered currencies.
+    /// </remarks>
+    private readonly byte _explicitScalePlusOne;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="Money" /> struct from an amount and ISO 4217 code, rounding
     /// the amount to the currency's minor-unit precision using banker's rounding.
     /// </summary>
     /// <param name="amount">The monetary amount in the major unit.</param>
     /// <param name="isoCode">The ISO 4217 three-letter alphabetic code identifying the currency.</param>
     /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException"><paramref name="isoCode" /> is empty or whitespace.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="isoCode" /> is not exactly three uppercase ASCII letters, or it is not registered in
+    /// <see cref="CurrencyRegistry" />.
+    /// </exception>
     public Money(decimal amount, string isoCode)
         : this(amount, isoCode, MidpointRounding.ToEven)
     {
@@ -69,24 +83,32 @@ public readonly partial struct Money
     /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
     /// <exception cref="ArgumentException">
     /// <paramref name="isoCode" /> is not exactly three uppercase ASCII letters — empty, whitespace, the wrong length,
-    /// lowercase, or contains non-letter characters.
+    /// lowercase, or contains non-letter characters — or it is structurally valid but not registered in
+    /// <see cref="CurrencyRegistry" />.
     /// </exception>
     /// <remarks>
-    /// Currency integrity matches <see cref="Money{TCurrency}" />: the ISO code is validated to ISO 4217's
-    /// three-uppercase-ASCII-letters shape regardless of whether the code is in <see cref="CurrencyRegistry" />. For
-    /// codes that are registered, the amount is rounded to the registry's <c>MinorUnits</c>; for codes that are valid
-    /// in shape but not registered, the amount is stored at its source precision so consumer code that handles custom
-    /// or test currencies still works.
+    /// The ISO code is validated to ISO 4217's three-uppercase-ASCII-letters shape and must resolve to a registered
+    /// <see cref="CurrencyInfo" />; the amount is then rounded to the registry's <c>MinorUnits</c>. Structurally valid
+    /// but unregistered codes are rejected under <see cref="UnknownCurrencyPolicy.Reject" /> so a value can never store
+    /// a precision it cannot describe. Register custom currencies via <see cref="CurrencyRegistry.Register(CurrencyInfo)" />
+    /// ahead of construction, or use <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" /> /
+    /// <see cref="Money.From(decimal, string, UnknownCurrencyPolicy, MidpointRounding)" /> for staging scenarios.
     /// </remarks>
     public Money(decimal amount, string isoCode, MidpointRounding rounding)
     {
         ThrowHelper.ThrowIfNull(isoCode);
         ValidateIsoCode(isoCode);
 
+        if (!CurrencyRegistry.TryGet(isoCode, out CurrencyInfo? info) || info is null)
+        {
+            throw new ArgumentException(
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_Invalid_UnknownCurrencyRejected, isoCode),
+                nameof(isoCode));
+        }
+
+        _amount = decimal.Round(amount, info.MinorUnits, rounding);
         _isoCode = isoCode;
-        _amount = CurrencyRegistry.TryGet(isoCode, out CurrencyInfo? info) && info is not null
-            ? decimal.Round(amount, info.MinorUnits, rounding)
-            : amount;
+        _explicitScalePlusOne = 0;
     }
 
     /// <summary>
@@ -126,16 +148,19 @@ public readonly partial struct Money
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="Money" /> struct from an already-normalised amount and ISO
-    /// code, bypassing rounding.
+    /// Initializes a new instance of the <see cref="Money" /> struct from pre-computed field values, bypassing
+    /// validation and rounding.
     /// </summary>
-    /// <param name="amount">The pre-normalised amount.</param>
-    /// <param name="isoCode">The ISO 4217 code.</param>
-    /// <param name="_">Discriminator that selects the no-normalisation path.</param>
-    private Money(decimal amount, string isoCode, NormalizedTag _)
+    /// <param name="amount">The stored amount.</param>
+    /// <param name="isoCode">The ISO 4217 code, or <see langword="null" /> for a currency-less value.</param>
+    /// <param name="explicitScalePlusOne">
+    /// The explicit minor-unit scale plus one, or <c>0</c> to derive precision from <see cref="CurrencyRegistry" />.
+    /// </param>
+    private Money(decimal amount, string? isoCode, byte explicitScalePlusOne)
     {
         _amount = amount;
         _isoCode = isoCode;
+        _explicitScalePlusOne = explicitScalePlusOne;
     }
 
     /// <summary>
@@ -145,12 +170,22 @@ public readonly partial struct Money
     /// <param name="isoCode">The ISO 4217 code.</param>
     /// <returns>The wrapped <see cref="Money" />.</returns>
     internal static Money FromNormalized(decimal amount, string isoCode) =>
-        new(amount, isoCode, default(NormalizedTag));
+        new(amount, isoCode, (byte)0);
 
     /// <summary>
-    /// Private discriminator selecting the no-normalisation private constructor.
+    /// Returns a copy of this value with a different amount, preserving the ISO code and any explicit scale.
     /// </summary>
-    private readonly struct NormalizedTag
-    {
-    }
+    /// <param name="amount">The replacement amount, assumed to already be at this value's minor-unit precision.</param>
+    /// <returns>The updated <see cref="Money" />.</returns>
+    private Money WithAmount(decimal amount) =>
+        new(amount, _isoCode, _explicitScalePlusOne);
+
+    /// <summary>
+    /// Returns a copy of this value with <paramref name="amount" /> rounded to this value's minor-unit precision,
+    /// preserving the ISO code and any explicit scale.
+    /// </summary>
+    /// <param name="amount">The raw amount to round.</param>
+    /// <returns>The updated <see cref="Money" />.</returns>
+    private Money WithRoundedAmount(decimal amount) =>
+        new(decimal.Round(amount, MinorUnits, MidpointRounding.ToEven), _isoCode, _explicitScalePlusOne);
 }

--- a/Bodu.Financial/src/Financial/MoneyBag.Accessors.cs
+++ b/Bodu.Financial/src/Financial/MoneyBag.Accessors.cs
@@ -1,0 +1,78 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyBag.Accessors.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+public sealed partial class MoneyBag
+{
+    /// <summary>
+    /// Creates a <see cref="MoneyBag" /> from the supplied balances, summing amounts with the same ISO code.
+    /// </summary>
+    /// <param name="balances">The starting balances.</param>
+    /// <returns>The constructed bag.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="balances" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">A balance carries no ISO code (default-initialised).</exception>
+    public static MoneyBag Of(params Money[] balances)
+    {
+        ThrowHelper.ThrowIfNull(balances);
+        return new MoneyBag(balances);
+    }
+
+    /// <summary>
+    /// Creates a <see cref="MoneyBag" /> from a sequence of balances, summing amounts with the same ISO code.
+    /// </summary>
+    /// <param name="balances">The starting balances.</param>
+    /// <returns>The constructed bag.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="balances" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentException">A balance carries no ISO code (default-initialised).</exception>
+    public static MoneyBag FromBalances(IEnumerable<Money> balances) =>
+        new(balances);
+
+    /// <summary>
+    /// Attempts to retrieve the balance for the currency identified by <paramref name="isoCode" />.
+    /// </summary>
+    /// <param name="isoCode">The ISO 4217 code.</param>
+    /// <param name="balance">When this method returns <see langword="true" />, the runtime-tagged balance.</param>
+    /// <returns><see langword="true" /> when the bag has an entry for the currency; otherwise <see langword="false" />.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
+    public bool TryGetBalance(string isoCode, out Money balance)
+    {
+        ThrowHelper.ThrowIfNull(isoCode);
+
+        if (_balances.TryGetValue(isoCode, out var amount))
+        {
+            balance = Money.FromNormalized(amount, isoCode);
+            return true;
+        }
+
+        balance = default;
+        return false;
+    }
+
+    /// <summary>
+    /// Returns the balance for <paramref name="currency" />, or <see langword="null" /> when the bag has no entry for
+    /// that currency.
+    /// </summary>
+    /// <param name="currency">The currency metadata identifying the balance.</param>
+    /// <returns>The balance, or <see langword="null" /> when absent.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="currency" /> is <see langword="null" />.</exception>
+    public Money? GetBalance(CurrencyInfo currency)
+    {
+        ThrowHelper.ThrowIfNull(currency);
+        return GetBalance(currency.IsoCode);
+    }
+
+    /// <summary>
+    /// Returns the balance for the currency identified by <paramref name="code" />, or <see langword="null" /> when the
+    /// bag has no entry for that currency.
+    /// </summary>
+    /// <param name="code">The active ISO 4217 currency code.</param>
+    /// <returns>The balance, or <see langword="null" /> when absent.</returns>
+    public Money? GetBalance(CurrencyCode code) =>
+        GetBalance(code.ToString());
+}

--- a/Bodu.Financial/src/Financial/MoneyBag.cs
+++ b/Bodu.Financial/src/Financial/MoneyBag.cs
@@ -5,6 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Collections;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Text.Json.Serialization;
 using Bodu.Financial.Serialization;
@@ -43,16 +44,16 @@ public sealed partial class MoneyBag :
     public static readonly MoneyBag Empty = new();
 
     /// <summary>
-    /// The internal balance dictionary keyed by ISO 4217 code (case-sensitive).
+    /// The internal balance map keyed by ISO 4217 code (case-sensitive) and kept in ISO-code order.
     /// </summary>
-    private readonly Dictionary<string, decimal> _balances;
+    private readonly ImmutableSortedDictionary<string, decimal> _balances;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="MoneyBag" /> class.
     /// </summary>
     public MoneyBag()
     {
-        _balances = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        _balances = ImmutableSortedDictionary.Create<string, decimal>(StringComparer.Ordinal);
     }
 
     /// <summary>
@@ -65,43 +66,30 @@ public sealed partial class MoneyBag :
     {
         ThrowHelper.ThrowIfNull(balances);
 
-        _balances = new Dictionary<string, decimal>(StringComparer.Ordinal);
+        ImmutableSortedDictionary<string, decimal>.Builder builder =
+            ImmutableSortedDictionary.CreateBuilder<string, decimal>(StringComparer.Ordinal);
         foreach (Money balance in balances)
         {
             var iso = balance.IsoCode;
             if (string.IsNullOrEmpty(iso))
                 throw new ArgumentException(FinancialResourceStrings.Arg_Invalid_BalanceMissingIsoCode, nameof(balances));
 
-            if (_balances.TryGetValue(iso, out var existing))
-                _balances[iso] = existing + balance.Amount;
-            else
-                _balances[iso] = balance.Amount;
+            builder[iso] = builder.TryGetValue(iso, out var existing) ? existing + balance.Amount : balance.Amount;
         }
 
         // Prune zero balances introduced by mutual cancellation during the sum.
-        List<string>? toRemove = null;
-        foreach (KeyValuePair<string, decimal> entry in _balances)
-        {
-            if (entry.Value == 0m)
-            {
-                toRemove ??= new List<string>();
-                toRemove.Add(entry.Key);
-            }
-        }
+        foreach (var iso in builder.Where(entry => entry.Value == 0m).Select(entry => entry.Key).ToList())
+            builder.Remove(iso);
 
-        if (toRemove is not null)
-        {
-            foreach (var iso in toRemove)
-                _balances.Remove(iso);
-        }
+        _balances = builder.ToImmutable();
     }
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="MoneyBag" /> class from an already-built dictionary (internal fast
-    /// path used by mutators).
+    /// Initializes a new instance of the <see cref="MoneyBag" /> class from an already-built immutable map (internal
+    /// fast path used by factories and mutators).
     /// </summary>
-    /// <param name="source">The balance dictionary the new bag takes ownership of.</param>
-    private MoneyBag(Dictionary<string, decimal> source)
+    /// <param name="source">The balance map the new bag adopts.</param>
+    private MoneyBag(ImmutableSortedDictionary<string, decimal> source)
     {
         _balances = source;
     }
@@ -121,16 +109,15 @@ public sealed partial class MoneyBag :
         _balances.Count;
 
     /// <summary>
-    /// Gets a read-only snapshot of the balance dictionary keyed by ISO code.
+    /// Gets a read-only view of the balance map keyed by ISO code, in ISO-code order.
     /// </summary>
     /// <returns>
-    /// A genuinely read-only view of the balances. The returned dictionary is a
-    /// <see cref="System.Collections.ObjectModel.ReadOnlyDictionary{TKey, TValue}" /> wrapper around the internal
-    /// storage, so a consumer cannot bypass immutability by casting the result back to
-    /// <see cref="Dictionary{TKey, TValue}" /> and mutating it.
+    /// The immutable balance map. Because the backing store is an
+    /// <see cref="ImmutableSortedDictionary{TKey, TValue}" />, the view is genuinely read-only and is returned without
+    /// allocating a wrapper.
     /// </returns>
     public IReadOnlyDictionary<string, decimal> Balances =>
-        new System.Collections.ObjectModel.ReadOnlyDictionary<string, decimal>(_balances);
+        _balances;
 
     /// <summary>
     /// Enumerates the non-zero balances in ISO-code lexicographic order.
@@ -138,7 +125,7 @@ public sealed partial class MoneyBag :
     /// <returns>An enumerator over <see cref="Money" /> entries.</returns>
     public IEnumerator<Money> GetEnumerator()
     {
-        foreach (KeyValuePair<string, decimal> entry in _balances.OrderBy(p => p.Key, StringComparer.Ordinal))
+        foreach (KeyValuePair<string, decimal> entry in _balances)
             yield return Money.FromNormalized(entry.Value, entry.Key);
     }
 
@@ -163,21 +150,13 @@ public sealed partial class MoneyBag :
         if (amount.IsZero)
             return this;
 
-        Dictionary<string, decimal> copy = new(_balances, StringComparer.Ordinal);
-        if (copy.TryGetValue(iso, out var existing))
+        if (_balances.TryGetValue(iso, out var existing))
         {
             var sum = existing + amount.Amount;
-            if (sum == 0m)
-                copy.Remove(iso);
-            else
-                copy[iso] = sum;
-        }
-        else
-        {
-            copy[iso] = amount.Amount;
+            return new MoneyBag(sum == 0m ? _balances.Remove(iso) : _balances.SetItem(iso, sum));
         }
 
-        return new MoneyBag(copy);
+        return new MoneyBag(_balances.SetItem(iso, amount.Amount));
     }
 
     /// <summary>
@@ -223,24 +202,24 @@ public sealed partial class MoneyBag :
         if (IsEmpty)
             return other;
 
-        Dictionary<string, decimal> copy = new(_balances, StringComparer.Ordinal);
+        ImmutableSortedDictionary<string, decimal>.Builder builder = _balances.ToBuilder();
         foreach (KeyValuePair<string, decimal> entry in other._balances)
         {
-            if (copy.TryGetValue(entry.Key, out var existing))
+            if (builder.TryGetValue(entry.Key, out var existing))
             {
                 var sum = existing + entry.Value;
                 if (sum == 0m)
-                    copy.Remove(entry.Key);
+                    builder.Remove(entry.Key);
                 else
-                    copy[entry.Key] = sum;
+                    builder[entry.Key] = sum;
             }
             else
             {
-                copy[entry.Key] = entry.Value;
+                builder[entry.Key] = entry.Value;
             }
         }
 
-        return new MoneyBag(copy);
+        return new MoneyBag(builder.ToImmutable());
     }
 
     /// <summary>
@@ -299,7 +278,7 @@ public sealed partial class MoneyBag :
     public override int GetHashCode()
     {
         HashCode hash = default;
-        foreach (KeyValuePair<string, decimal> entry in _balances.OrderBy(p => p.Key, StringComparer.Ordinal))
+        foreach (KeyValuePair<string, decimal> entry in _balances)
         {
             hash.Add(entry.Key);
             hash.Add(entry.Value);

--- a/Bodu.Financial/src/Financial/MoneyBag.cs
+++ b/Bodu.Financial/src/Financial/MoneyBag.cs
@@ -24,6 +24,12 @@ namespace Bodu.Financial;
 /// Enumeration yields one <see cref="Money" /> per non-zero currency, in ISO-code lexicographic order so the
 /// iteration is stable and reproducible across runs.
 /// </para>
+/// <para>
+/// The type-level <see cref="JsonConverterAttribute" /> always serializes the canonical
+/// <see cref="Serialization.FinancialJsonPolicy.Strict" /> object shape; the compact and lenient shapes are opt-in only
+/// and must be selected through
+/// <see cref="Serialization.FinancialJsonSerializerOptionsExtensions.AddFinancialJsonConverters(System.Text.Json.JsonSerializerOptions, Serialization.FinancialJsonPolicy)" />.
+/// </para>
 /// </remarks>
 [DebuggerDisplay("{Count} currencies")]
 [JsonConverter(typeof(MoneyBagJsonConverter))]

--- a/Bodu.Financial/src/Financial/MoneyConversionResult.cs
+++ b/Bodu.Financial/src/Financial/MoneyConversionResult.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="MoneyConversionResult.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -7,20 +7,20 @@
 namespace Bodu.Financial;
 
 /// <summary>
-/// Bundles the result of a single end-to-end money conversion together with the exchange-rate metadata that produced
-/// it, so consumers can audit which observed rate was used.
+/// Captures the audit trail of a single runtime-tagged currency conversion: the source and settled target amounts, the
+/// exchange rate applied, the monetary context that governed rounding, and how much rounding moved the result.
 /// </summary>
-/// <typeparam name="TSource">The source currency.</typeparam>
-/// <typeparam name="TTarget">The destination currency.</typeparam>
-/// <param name="SourceAmount">The original source amount.</param>
-/// <param name="TargetAmount">The converted, rounded target amount.</param>
-/// <param name="ExchangeRate">
-/// The full lookup result, including provider, dates, and inversion flag, used to compute
-/// <paramref name="TargetAmount" />.
+/// <param name="Source">The original source amount.</param>
+/// <param name="Target">The converted amount, rounded according to <paramref name="Context" />.</param>
+/// <param name="Rate">The exchange rate applied to produce <paramref name="Target" />.</param>
+/// <param name="Context">The monetary context that governed rounding.</param>
+/// <param name="RoundingAdjustment">
+/// The signed difference between the rounded target amount and the exact (unrounded) converted amount, or
+/// <see langword="null" /> when rounding was deferred.
 /// </param>
-public readonly record struct MoneyConversionResult<TSource, TTarget>(
-    Money<TSource> SourceAmount,
-    Money<TTarget> TargetAmount,
-    ExchangeRateLookupResult ExchangeRate)
-    where TSource : ICurrency
-    where TTarget : ICurrency;
+public readonly record struct MoneyConversionResult(
+    Money Source,
+    Money Target,
+    ExchangeRate Rate,
+    MonetaryContext Context,
+    decimal? RoundingAdjustment);

--- a/Bodu.Financial/src/Financial/MoneyFormatOptions.cs
+++ b/Bodu.Financial/src/Financial/MoneyFormatOptions.cs
@@ -1,0 +1,54 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyFormatOptions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Configures how a <see cref="MoneyFormatter" /> renders a monetary value. Translates to the format-specifier
+/// vocabulary understood by <see cref="Money" /> and <see cref="Money{TCurrency}" />.
+/// </summary>
+public sealed record MoneyFormatOptions
+{
+    /// <summary>
+    /// Gets the shared default options: ISO-code designator, current-culture grouping, and the currency's natural
+    /// minor-unit precision.
+    /// </summary>
+    /// <returns>The default <see cref="MoneyFormatOptions" />.</returns>
+    public static MoneyFormatOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets how the currency designator is rendered.
+    /// </summary>
+    /// <returns>The configured <see cref="CurrencyDisplay" />.</returns>
+    public CurrencyDisplay CurrencyDisplay { get; init; } = CurrencyDisplay.IsoCode;
+
+    /// <summary>
+    /// Gets the culture used to render the numeric component, or <see langword="null" /> for the current culture.
+    /// </summary>
+    /// <returns>The configured format provider, or <see langword="null" />.</returns>
+    public IFormatProvider? FormatProvider { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether digit-group separators are emitted. Applies to the
+    /// <see cref="CurrencyDisplay.None" /> presentation; currency presentations group according to the culture.
+    /// </summary>
+    /// <returns><see langword="true" /> to include grouping.</returns>
+    public bool IncludeGrouping { get; init; } = true;
+
+    /// <summary>
+    /// Gets an explicit fractional-digit count overriding the currency's natural precision, or <see langword="null" />
+    /// to use the currency's minor units.
+    /// </summary>
+    /// <returns>The override precision, or <see langword="null" />.</returns>
+    public int? MinorUnitsOverride { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether the currency designator is elided when the formatting culture's region currency
+    /// matches the amount's currency.
+    /// </summary>
+    /// <returns><see langword="true" /> to elide the designator on a culture match.</returns>
+    public bool ElideWhenCultureMatches { get; init; }
+}

--- a/Bodu.Financial/src/Financial/MoneyFormatter.cs
+++ b/Bodu.Financial/src/Financial/MoneyFormatter.cs
@@ -1,0 +1,92 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyFormatter.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Renders <see cref="Money" /> and <see cref="Money{TCurrency}" /> values according to a fixed
+/// <see cref="MoneyFormatOptions" />, translating the options into the format-specifier vocabulary of the monetary
+/// types.
+/// </summary>
+public sealed class MoneyFormatter
+{
+    /// <summary>
+    /// The options governing this formatter's output.
+    /// </summary>
+    private readonly MoneyFormatOptions _options;
+
+    /// <summary>
+    /// The pre-computed format specifier derived from <see cref="_options" />.
+    /// </summary>
+    private readonly string _format;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MoneyFormatter" /> class.
+    /// </summary>
+    /// <param name="options">The formatting options.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="options" /> is <see langword="null" />.</exception>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="options" />.<see cref="MoneyFormatOptions.CurrencyDisplay" /> is not a defined value.
+    /// </exception>
+    public MoneyFormatter(MoneyFormatOptions options)
+    {
+        ThrowHelper.ThrowIfNull(options);
+
+        _options = options;
+        _format = BuildFormat(options);
+    }
+
+    /// <summary>
+    /// Formats a runtime-tagged <see cref="Money" /> value.
+    /// </summary>
+    /// <param name="money">The value to format.</param>
+    /// <returns>The formatted string.</returns>
+    public string Format(Money money) =>
+        money.ToString(_format, _options.FormatProvider ?? CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Formats a strongly-typed <see cref="Money{TCurrency}" /> value.
+    /// </summary>
+    /// <typeparam name="TCurrency">The currency type.</typeparam>
+    /// <param name="money">The value to format.</param>
+    /// <returns>The formatted string.</returns>
+    public string Format<TCurrency>(Money<TCurrency> money)
+        where TCurrency : ICurrency =>
+        money.ToString(_format, _options.FormatProvider ?? CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// Builds the format specifier string corresponding to <paramref name="options" />.
+    /// </summary>
+    /// <param name="options">The formatting options.</param>
+    /// <returns>The format specifier understood by the monetary types.</returns>
+    private static string BuildFormat(MoneyFormatOptions options)
+    {
+        var specifier = options.CurrencyDisplay switch
+        {
+            CurrencyDisplay.IsoCode => "G",
+            CurrencyDisplay.Symbol => "C",
+            CurrencyDisplay.EnglishName => "L",
+            CurrencyDisplay.None => options.IncludeGrouping ? "N" : "F",
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(options),
+                options.CurrencyDisplay,
+                string.Format(CultureInfo.InvariantCulture, FinancialResourceStrings.Arg_OutOfRange_CurrencyDisplayUndefined, options.CurrencyDisplay)),
+        };
+
+        // The "~" elide prefix and the numeric precision suffix apply only to designator-bearing specifiers.
+        var elide = options.ElideWhenCultureMatches && options.CurrencyDisplay is CurrencyDisplay.IsoCode or CurrencyDisplay.Symbol or CurrencyDisplay.EnglishName
+            ? "~"
+            : string.Empty;
+
+        var precision = options.MinorUnitsOverride is int p
+            ? p.ToString(CultureInfo.InvariantCulture)
+            : string.Empty;
+
+        return string.Concat(elide, specifier, precision);
+    }
+}

--- a/Bodu.Financial/src/Financial/MoneyFormatterBuilder.cs
+++ b/Bodu.Financial/src/Financial/MoneyFormatterBuilder.cs
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyFormatterBuilder.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Fluently composes a <see cref="MoneyFormatter" /> for complex formatting scenarios.
+/// </summary>
+public sealed class MoneyFormatterBuilder
+{
+    /// <summary>
+    /// The options accumulated by the builder.
+    /// </summary>
+    private MoneyFormatOptions _options = MoneyFormatOptions.Default;
+
+    /// <summary>
+    /// Renders the currency designator as the ISO 4217 code.
+    /// </summary>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithIsoCode()
+    {
+        _options = _options with { CurrencyDisplay = CurrencyDisplay.IsoCode };
+        return this;
+    }
+
+    /// <summary>
+    /// Renders the currency designator as the culture's native symbol.
+    /// </summary>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithSymbol()
+    {
+        _options = _options with { CurrencyDisplay = CurrencyDisplay.Symbol };
+        return this;
+    }
+
+    /// <summary>
+    /// Renders the currency designator as the English-language currency name.
+    /// </summary>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithEnglishName()
+    {
+        _options = _options with { CurrencyDisplay = CurrencyDisplay.EnglishName };
+        return this;
+    }
+
+    /// <summary>
+    /// Renders the bare numeric amount with no currency designator.
+    /// </summary>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithNumericOnly()
+    {
+        _options = _options with { CurrencyDisplay = CurrencyDisplay.None };
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the culture used to render the numeric component.
+    /// </summary>
+    /// <param name="formatProvider">The culture provider.</param>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithCulture(IFormatProvider formatProvider)
+    {
+        _options = _options with { FormatProvider = formatProvider };
+        return this;
+    }
+
+    /// <summary>
+    /// Sets whether digit-group separators are emitted for the numeric-only presentation.
+    /// </summary>
+    /// <param name="includeGrouping"><see langword="true" /> to include grouping.</param>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithGrouping(bool includeGrouping)
+    {
+        _options = _options with { IncludeGrouping = includeGrouping };
+        return this;
+    }
+
+    /// <summary>
+    /// Overrides the fractional-digit count.
+    /// </summary>
+    /// <param name="minorUnits">The explicit precision to render.</param>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder WithMinorUnits(int minorUnits)
+    {
+        _options = _options with { MinorUnitsOverride = minorUnits };
+        return this;
+    }
+
+    /// <summary>
+    /// Elides the currency designator when the formatting culture's region currency matches the amount's currency.
+    /// </summary>
+    /// <returns>This builder.</returns>
+    public MoneyFormatterBuilder ElideWhenCultureMatches()
+    {
+        _options = _options with { ElideWhenCultureMatches = true };
+        return this;
+    }
+
+    /// <summary>
+    /// Builds the configured <see cref="MoneyFormatter" />.
+    /// </summary>
+    /// <returns>The formatter.</returns>
+    public MoneyFormatter Build() =>
+        new(_options);
+}

--- a/Bodu.Financial/src/Financial/MoneyOfTCurrencyExchangeRateExtensions.cs
+++ b/Bodu.Financial/src/Financial/MoneyOfTCurrencyExchangeRateExtensions.cs
@@ -66,7 +66,7 @@ public static class MoneyOfTCurrencyExchangeRateExtensions
     /// The rounding mode applied to the converted amount. Defaults to <see cref="MidpointRounding.ToEven" />.
     /// </param>
     /// <returns>
-    /// A <see cref="MoneyConversionResult{TSource, TTarget}" /> containing the source, target, and rate metadata.
+    /// A <see cref="TypedMoneyConversionResult{TSource, TTarget}" /> containing the source, target, and rate metadata.
     /// </returns>
     /// <exception cref="ArgumentNullException">
     /// Thrown if <paramref name="provider" /> is <see langword="null" />.
@@ -74,7 +74,7 @@ public static class MoneyOfTCurrencyExchangeRateExtensions
     /// <exception cref="KeyNotFoundException">
     /// Thrown if no rate is available for the requested pair under the supplied options.
     /// </exception>
-    public static MoneyConversionResult<TSource, TTarget> ConvertToWithRate<TSource, TTarget>(
+    public static TypedMoneyConversionResult<TSource, TTarget> ConvertToWithRate<TSource, TTarget>(
         this Money<TSource> amount,
         IDatedExchangeRateProvider provider,
         DateOnly date,
@@ -92,6 +92,6 @@ public static class MoneyOfTCurrencyExchangeRateExtensions
             options);
 
         Money<TTarget> target = amount.Convert<TTarget>(lookup.Rate.Rate, rounding);
-        return new MoneyConversionResult<TSource, TTarget>(amount, target, lookup);
+        return new TypedMoneyConversionResult<TSource, TTarget>(amount, target, lookup);
     }
 }

--- a/Bodu.Financial/src/Financial/MoneyParseMode.cs
+++ b/Bodu.Financial/src/Financial/MoneyParseMode.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyParseMode.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies how <see cref="MoneyParseOptions" /> interprets monetary text.
+/// </summary>
+public enum MoneyParseMode
+{
+    /// <summary>
+    /// Accept only the canonical <c>"&lt;ISO&gt; &lt;amount&gt;"</c> or <c>"&lt;amount&gt; &lt;ISO&gt;"</c> forms with a
+    /// registered, uppercase ISO code. This is the default and matches the <see cref="IParsable{TSelf}" /> surface.
+    /// </summary>
+    StrictIso = 0,
+
+    /// <summary>
+    /// Accept user-facing input, resolving a currency symbol through the configured lookup when no ISO code is present.
+    /// </summary>
+    CultureAware = 1,
+
+    /// <summary>
+    /// Accept loosely formatted import data: surrounding white space is trimmed and a lower-case ISO code is normalised
+    /// to upper case before resolution.
+    /// </summary>
+    LenientImport = 2,
+
+    /// <summary>
+    /// Accept only the invariant round-trip form produced by the <c>"R"</c> format specifier.
+    /// </summary>
+    RoundTripOnly = 3,
+}

--- a/Bodu.Financial/src/Financial/MoneyParseOptions.cs
+++ b/Bodu.Financial/src/Financial/MoneyParseOptions.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyParseOptions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Configures how <see cref="Money.Parse(string, MoneyParseOptions)" /> and its <c>TryParse</c> counterpart interpret
+/// monetary text.
+/// </summary>
+public sealed record MoneyParseOptions
+{
+    /// <summary>
+    /// Gets the shared default options: strict ISO parsing, current-culture numeric interpretation, and rejection of
+    /// unregistered currencies.
+    /// </summary>
+    /// <returns>The default <see cref="MoneyParseOptions" />.</returns>
+    public static MoneyParseOptions Default { get; } = new();
+
+    /// <summary>
+    /// Gets the parse mode applied to the input.
+    /// </summary>
+    /// <returns>The configured <see cref="MoneyParseMode" />.</returns>
+    public MoneyParseMode Mode { get; init; } = MoneyParseMode.StrictIso;
+
+    /// <summary>
+    /// Gets the culture used to interpret the numeric component, or <see langword="null" /> to select the mode's
+    /// default (current culture, or invariant culture for <see cref="MoneyParseMode.RoundTripOnly" />).
+    /// </summary>
+    /// <returns>The configured format provider, or <see langword="null" />.</returns>
+    public IFormatProvider? FormatProvider { get; init; }
+
+    /// <summary>
+    /// Gets the policy applied when the parsed currency is structurally valid but not registered.
+    /// </summary>
+    /// <returns>The configured <see cref="UnknownCurrencyPolicy" />.</returns>
+    public UnknownCurrencyPolicy UnknownCurrency { get; init; } = UnknownCurrencyPolicy.Reject;
+
+    /// <summary>
+    /// Gets the currency lookup used to resolve symbols under <see cref="MoneyParseMode.CultureAware" />, or
+    /// <see langword="null" /> to use a default <see cref="CurrencyLookupService" />.
+    /// </summary>
+    /// <returns>The configured lookup, or <see langword="null" />.</returns>
+    public ICurrencyLookup? CurrencyLookup { get; init; }
+}

--- a/Bodu.Financial/src/Financial/ScalePolicy.cs
+++ b/Bodu.Financial/src/Financial/ScalePolicy.cs
@@ -1,0 +1,28 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="ScalePolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies the fractional-digit scale a <see cref="MonetaryContext" /> rounds to at an operation boundary.
+/// </summary>
+public enum ScalePolicy
+{
+    /// <summary>
+    /// Round to the currency's declared minor-unit precision.
+    /// </summary>
+    CurrencyMinorUnits = 0,
+
+    /// <summary>
+    /// Do not round; preserve the full precision of the computed amount.
+    /// </summary>
+    Unrounded = 1,
+
+    /// <summary>
+    /// Round to the caller-supplied <see cref="MonetaryContext.CustomScale" />.
+    /// </summary>
+    Custom = 2,
+}

--- a/Bodu.Financial/src/Financial/TypedMoneyConversionResult.cs
+++ b/Bodu.Financial/src/Financial/TypedMoneyConversionResult.cs
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="TypedMoneyConversionResult.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Bundles the result of a single end-to-end strongly-typed money conversion together with the exchange-rate metadata
+/// that produced it, so consumers can audit which observed rate was used.
+/// </summary>
+/// <typeparam name="TSource">The source currency.</typeparam>
+/// <typeparam name="TTarget">The destination currency.</typeparam>
+/// <param name="SourceAmount">The original source amount.</param>
+/// <param name="TargetAmount">The converted, rounded target amount.</param>
+/// <param name="ExchangeRate">
+/// The full lookup result, including provider, dates, and inversion flag, used to compute
+/// <paramref name="TargetAmount" />.
+/// </param>
+public readonly record struct TypedMoneyConversionResult<TSource, TTarget>(
+    Money<TSource> SourceAmount,
+    Money<TTarget> TargetAmount,
+    ExchangeRateLookupResult ExchangeRate)
+    where TSource : ICurrency
+    where TTarget : ICurrency;

--- a/Bodu.Financial/src/Financial/UnknownCurrencyPolicy.cs
+++ b/Bodu.Financial/src/Financial/UnknownCurrencyPolicy.cs
@@ -1,0 +1,46 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="UnknownCurrencyPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Specifies how <see cref="Money" /> construction treats an ISO 4217-shaped currency code that is not present in
+/// <see cref="CurrencyRegistry" />.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A code is "unknown" when it passes the structural check (three uppercase ASCII letters) but no shipped or custom
+/// <see cref="CurrencyInfo" /> is registered for it. The default behaviour rejects such codes so that a
+/// <see cref="Money" /> can never end up storing a sub-minor-unit precision it cannot describe — the failure mode the
+/// policy exists to prevent is a value that retains source precision on construction yet reports zero minor units.
+/// </para>
+/// <para>
+/// The non-default members are opt-in escape hatches for staging and import scenarios. They are reached through the
+/// explicit factory surface (<see cref="Money.From(decimal, string, UnknownCurrencyPolicy, System.MidpointRounding)" />
+/// and <see cref="Money.FromUnchecked(decimal, string, int, System.MidpointRounding)" />); the ordinary constructors
+/// always apply <see cref="Reject" />.
+/// </para>
+/// </remarks>
+public enum UnknownCurrencyPolicy
+{
+    /// <summary>
+    /// Reject the code by throwing an <see cref="System.ArgumentException" />. This is the default for all
+    /// <see cref="Money" /> constructors.
+    /// </summary>
+    Reject = 0,
+
+    /// <summary>
+    /// Accept the code only when the caller supplies an explicit minor-unit scale, rounding the amount to that scale so
+    /// the resulting value's reported minor units stay self-consistent.
+    /// </summary>
+    AllowWithExplicitScale = 1,
+
+    /// <summary>
+    /// Accept the code and store the amount at its source precision without an associated scale. Intended only for
+    /// loose import staging; the resulting value reports zero minor units by contract.
+    /// </summary>
+    AllowUnscaled = 2,
+}

--- a/Bodu.Financial/test/Financial.Serialization/AttributeBoundJsonContractTests.cs
+++ b/Bodu.Financial/test/Financial.Serialization/AttributeBoundJsonContractTests.cs
@@ -1,0 +1,79 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="AttributeBoundJsonContractTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json;
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial.Serialization;
+
+/// <summary>
+/// Verifies the frozen serialization contract of the type-level <c>[JsonConverter]</c> attributes: serializing without
+/// any registered options always produces the canonical <see cref="FinancialJsonPolicy.Strict" /> object shape, never
+/// the compact or lenient variants.
+/// </summary>
+[TestClass]
+public class AttributeBoundJsonContractTests
+{
+    /// <summary>
+    /// Verifies that serializing a <see cref="Money" /> through the attribute (no options) emits the Strict object
+    /// shape and round-trips.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Money_WhenSerializedViaAttribute_ShouldEmitStrictObjectShapeAndRoundTrip()
+    {
+        var value = new Money(19.99m, "USD");
+
+        var json = JsonSerializer.Serialize(value);
+
+        Assert.AreEqual("{\"amount\":19.99,\"currency\":\"USD\"}", json);
+        Assert.AreEqual(value, JsonSerializer.Deserialize<Money>(json));
+    }
+
+    /// <summary>
+    /// Verifies that serializing a <see cref="Money{TCurrency}" /> through the attribute (no options) emits the Strict
+    /// object shape and round-trips.
+    /// </summary>
+    [TestMethod]
+    public void MoneyOfTCurrency_WhenSerializedViaAttribute_ShouldEmitStrictObjectShapeAndRoundTrip()
+    {
+        var value = new Money<USD>(19.99m);
+
+        var json = JsonSerializer.Serialize(value);
+
+        Assert.AreEqual("{\"amount\":19.99,\"currency\":\"USD\"}", json);
+        Assert.AreEqual(value, JsonSerializer.Deserialize<Money<USD>>(json));
+    }
+
+    /// <summary>
+    /// Verifies that serializing a <see cref="MoneyBag" /> through the attribute (no options) emits the Strict
+    /// <c>balances</c> object shape and round-trips.
+    /// </summary>
+    [TestMethod]
+    public void MoneyBag_WhenSerializedViaAttribute_ShouldEmitStrictBalancesShapeAndRoundTrip()
+    {
+        MoneyBag bag = MoneyBag.Empty
+            .Add(new Money(10m, "USD"))
+            .Add(new Money(5m, "EUR"));
+
+        var json = JsonSerializer.Serialize(bag);
+
+        Assert.AreEqual("{\"balances\":{\"EUR\":5,\"USD\":10}}", json);
+        Assert.AreEqual(bag, JsonSerializer.Deserialize<MoneyBag>(json));
+    }
+
+    /// <summary>
+    /// Verifies that the attribute path never emits the compact string form for <see cref="Money" /> (which the compact
+    /// policy would otherwise produce).
+    /// </summary>
+    [TestMethod]
+    public void Money_WhenSerializedViaAttribute_ShouldNotEmitCompactString()
+    {
+        var json = JsonSerializer.Serialize(new Money(19.99m, "USD"));
+
+        Assert.IsTrue(json.StartsWith("{", StringComparison.Ordinal), $"Expected Strict object shape, got '{json}'.");
+    }
+}

--- a/Bodu.Financial/test/Financial.Serialization/MoneyDtoAdapterTests.cs
+++ b/Bodu.Financial/test/Financial.Serialization/MoneyDtoAdapterTests.cs
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyDtoAdapterTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial.Serialization;
+
+/// <summary>
+/// Verifies <see cref="MoneyDtoAdapter" /> converts between <see cref="Money" /> and the Google-compatible
+/// <see cref="MoneyDto" /> transport shape.
+/// </summary>
+[TestClass]
+public class MoneyDtoAdapterTests
+{
+    /// <summary>
+    /// Verifies that a fractional amount is split into whole units and nano-units.
+    /// </summary>
+    [TestMethod]
+    public void ToDto_WhenAmountHasFraction_ShouldSplitUnitsAndNanos()
+    {
+        MoneyDto dto = MoneyDtoAdapter.ToDto(new Money(19.99m, "USD"));
+
+        Assert.AreEqual("USD", dto.CurrencyCode);
+        Assert.AreEqual(19L, dto.Units);
+        Assert.AreEqual(990_000_000, dto.Nanos);
+    }
+
+    /// <summary>
+    /// Verifies that a negative amount produces consistently signed units and nanos.
+    /// </summary>
+    [TestMethod]
+    public void ToDto_WhenAmountNegative_ShouldSignBothComponents()
+    {
+        MoneyDto dto = MoneyDtoAdapter.ToDto(new Money(-19.99m, "USD"));
+
+        Assert.AreEqual(-19L, dto.Units);
+        Assert.AreEqual(-990_000_000, dto.Nanos);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MoneyDtoAdapter.ToMoney(MoneyDto, UnknownCurrencyPolicy)" /> reconstructs the amount.
+    /// </summary>
+    [TestMethod]
+    public void ToMoney_WhenValidDto_ShouldReconstructAmount()
+    {
+        Money money = MoneyDtoAdapter.ToMoney(new MoneyDto("USD", 19L, 990_000_000));
+
+        Assert.AreEqual(new Money(19.99m, "USD"), money);
+    }
+
+    /// <summary>
+    /// Verifies that conversion round-trips across a representative spread of amounts and currencies.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow("USD", 19.99)]
+    [DataRow("JPY", 1234.0)]
+    [DataRow("BHD", 1.234)]
+    [DataRow("USD", -0.50)]
+    [DataRow("EUR", 0.0)]
+    public void RoundTrip_WhenConvertingToDtoAndBack_ShouldPreserveValue(string iso, double amount)
+    {
+        Money original = new((decimal)amount, iso);
+
+        Money roundTripped = MoneyDtoAdapter.ToMoney(MoneyDtoAdapter.ToDto(original));
+
+        Assert.AreEqual(original, roundTripped);
+    }
+
+    /// <summary>
+    /// Verifies that an out-of-range nanos value is rejected.
+    /// </summary>
+    [TestMethod]
+    public void ToMoney_WhenNanosOutOfRange_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => _ = MoneyDtoAdapter.ToMoney(new MoneyDto("USD", 1L, 1_000_000_000)));
+    }
+
+    /// <summary>
+    /// Verifies that mismatched unit and nano signs are rejected.
+    /// </summary>
+    [TestMethod]
+    public void ToMoney_WhenSignsMismatch_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => _ = MoneyDtoAdapter.ToMoney(new MoneyDto("USD", 1L, -500_000_000)));
+    }
+
+    /// <summary>
+    /// Verifies that an unregistered currency is rejected under the default policy but accepted unscaled when opted in.
+    /// </summary>
+    [TestMethod]
+    public void ToMoney_WhenUnregisteredCurrency_ShouldFollowPolicy()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => _ = MoneyDtoAdapter.ToMoney(new MoneyDto("XYZ", 1L, 0)));
+
+        Money unscaled = MoneyDtoAdapter.ToMoney(new MoneyDto("XYZ", 1L, 500_000_000), UnknownCurrencyPolicy.AllowUnscaled);
+        Assert.AreEqual("XYZ", unscaled.IsoCode);
+        Assert.AreEqual(1.5m, unscaled.Amount);
+    }
+}

--- a/Bodu.Financial/test/Financial/CalculatedMoneyOfTCurrencyTests.cs
+++ b/Bodu.Financial/test/Financial/CalculatedMoneyOfTCurrencyTests.cs
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoneyOfTCurrencyTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies the strongly-typed <see cref="CalculatedMoney{TCurrency}" /> high-precision deferred-rounding value type.
+/// </summary>
+[TestClass]
+public class CalculatedMoneyOfTCurrencyTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Money{TCurrency}.ToCalculated" /> preserves the amount.
+    /// </summary>
+    [TestMethod]
+    public void ToCalculated_FromMoney_ShouldPreserveAmount()
+    {
+        CalculatedMoney<USD> calc = new Money<USD>(12.34m).ToCalculated();
+
+        Assert.AreEqual(12.34m, calc.Amount);
+        Assert.AreEqual("USD", CalculatedMoney<USD>.IsoCode);
+    }
+
+    /// <summary>
+    /// Verifies that arithmetic preserves full precision.
+    /// </summary>
+    [TestMethod]
+    public void Operators_WhenChained_ShouldPreserveFullPrecision()
+    {
+        CalculatedMoney<USD> value = new(1m);
+
+        Assert.AreEqual(1m / 3m, (value / 3m).Amount);
+    }
+
+    /// <summary>
+    /// Verifies that deferring rounding yields a more accurate settlement than eager per-step rounding.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenChainDefersRounding_ShouldBeMoreAccurateThanEagerRounding()
+    {
+        Money<USD> deferred = (new Money<USD>(1m).ToCalculated() / 3m * 3m).RoundToMoney();
+        Money<USD> eager = new Money<USD>(1m) / 3m * 3m;
+
+        Assert.AreEqual(new Money<USD>(1.00m), deferred);
+        Assert.AreEqual(new Money<USD>(0.99m), eager);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalculatedMoney{TCurrency}.RoundToMoney(MidpointRounding)" /> honours the supplied
+    /// midpoint rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenAwayFromZero_ShouldRoundMidpointAway()
+    {
+        CalculatedMoney<USD> calc = new(1.225m);
+
+        Assert.AreEqual(new Money<USD>(1.23m), calc.RoundToMoney(MidpointRounding.AwayFromZero));
+        Assert.AreEqual(new Money<USD>(1.22m), calc.RoundToMoney());
+    }
+}

--- a/Bodu.Financial/test/Financial/CalculatedMoneyTests.cs
+++ b/Bodu.Financial/test/Financial/CalculatedMoneyTests.cs
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CalculatedMoneyTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies the runtime-tagged <see cref="CalculatedMoney" /> high-precision deferred-rounding value type.
+/// </summary>
+[TestClass]
+public class CalculatedMoneyTests
+{
+    /// <summary>
+    /// Verifies that the constructor rejects a malformed ISO code.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenIsoCodeShapeInvalid_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() => _ = new CalculatedMoney(1m, "us"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.ToCalculated" /> preserves the amount and ISO code.
+    /// </summary>
+    [TestMethod]
+    public void ToCalculated_FromMoney_ShouldPreserveAmountAndIsoCode()
+    {
+        CalculatedMoney calc = new Money(12.34m, "USD").ToCalculated();
+
+        Assert.AreEqual(12.34m, calc.Amount);
+        Assert.AreEqual("USD", calc.IsoCode);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.ToCalculated" /> throws when the source carries no currency.
+    /// </summary>
+    [TestMethod]
+    public void ToCalculated_FromDefaultMoney_ShouldThrowInvalidOperationException()
+    {
+        Assert.ThrowsExactly<InvalidOperationException>(() => _ = default(Money).ToCalculated());
+    }
+
+    /// <summary>
+    /// Verifies that arithmetic preserves full precision rather than rounding to minor units.
+    /// </summary>
+    [TestMethod]
+    public void Operators_WhenChained_ShouldPreserveFullPrecision()
+    {
+        CalculatedMoney value = new(1m, "USD");
+
+        CalculatedMoney result = value / 3m;
+
+        Assert.AreEqual(1m / 3m, result.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that addition across different currencies throws <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Addition_WhenDifferentCurrencies_ShouldThrowInvalidOperationException()
+    {
+        CalculatedMoney usd = new(1m, "USD");
+        CalculatedMoney eur = new(1m, "EUR");
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => _ = usd + eur);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalculatedMoney.RoundToMoney(MonetaryContext?)" /> rounds to the registered currency's
+    /// minor units under the default context.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void RoundToMoney_WhenDefaultContext_ShouldRoundToRegistryMinorUnits()
+    {
+        CalculatedMoney calc = new(1.235m, "USD");
+
+        Money settled = calc.RoundToMoney();
+
+        Assert.AreEqual(new Money(1.24m, "USD"), settled);
+    }
+
+    /// <summary>
+    /// Verifies that deferring rounding through a calculation chain yields a more accurate settlement than rounding the
+    /// equivalent <see cref="Money" /> operations at each step.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenChainDefersRounding_ShouldBeMoreAccurateThanEagerRounding()
+    {
+        // 1/3 * 3 = 1.00 when rounding is deferred; eager per-step Money rounding yields 0.99.
+        Money deferred = (new Money(1m, "USD").ToCalculated() / 3m * 3m).RoundToMoney();
+        Money eager = new Money(1m, "USD") / 3m * 3m;
+
+        Assert.AreEqual(new Money(1.00m, "USD"), deferred);
+        Assert.AreEqual(new Money(0.99m, "USD"), eager);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalculatedMoney.RoundToMoney(MidpointRounding)" /> honours the supplied midpoint rule.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenAwayFromZero_ShouldRoundMidpointAway()
+    {
+        CalculatedMoney calc = new(1.225m, "USD");
+
+        Assert.AreEqual(new Money(1.23m, "USD"), calc.RoundToMoney(MidpointRounding.AwayFromZero));
+        Assert.AreEqual(new Money(1.22m, "USD"), calc.RoundToMoney());
+    }
+
+    /// <summary>
+    /// Verifies that an unregistered currency settles to the context's custom scale via the explicit-scale path.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenUnregisteredAndCustomScale_ShouldSettleWithExplicitScale()
+    {
+        CalculatedMoney calc = new(1.23456m, "XYZ");
+
+        Money settled = calc.RoundToMoney(MonetaryContext.Default with { ScalePolicy = ScalePolicy.Custom, CustomScale = 4 });
+
+        Assert.AreEqual(1.2346m, settled.Amount);
+        Assert.AreEqual(4, settled.MinorUnits);
+        Assert.AreEqual("XYZ", settled.IsoCode);
+    }
+
+    /// <summary>
+    /// Verifies value equality across amount and currency.
+    /// </summary>
+    [TestMethod]
+    public void Equality_WhenSameAmountAndCurrency_ShouldBeEqual()
+    {
+        Assert.AreEqual(new CalculatedMoney(1.5m, "USD"), new CalculatedMoney(1.5m, "USD"));
+        Assert.AreNotEqual(new CalculatedMoney(1.5m, "USD"), new CalculatedMoney(1.5m, "EUR"));
+    }
+}

--- a/Bodu.Financial/test/Financial/CurrencyInfoTests.MetadataFields.cs
+++ b/Bodu.Financial/test/Financial/CurrencyInfoTests.MetadataFields.cs
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyInfoTests.MetadataFields.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class CurrencyInfoTests
+{
+    /// <summary>
+    /// Verifies that the extended display-metadata members default to empty when not supplied, so the positional
+    /// constructor remains usable unchanged.
+    /// </summary>
+    [TestMethod]
+    public void MetadataFields_WhenNotSpecified_ShouldDefaultToEmpty()
+    {
+        CurrencyInfo info = new("USD", 2, 0m, false, null, null);
+
+        Assert.AreEqual("", info.Symbol);
+        Assert.AreEqual("", info.InternationalSymbol);
+        Assert.AreEqual("", info.NativeName);
+        Assert.AreEqual(0, info.RegionCodes.Count);
+        Assert.AreEqual(0, info.AlternativeSymbols.Count);
+    }
+
+    /// <summary>
+    /// Verifies that the extended display-metadata members can be supplied through a <c>with</c> expression and are
+    /// preserved on the resulting record.
+    /// </summary>
+    [TestMethod]
+    public void MetadataFields_WhenSetViaWithExpression_ShouldPreserveValues()
+    {
+        CurrencyInfo info = new CurrencyInfo("USD", 2, 0m, false, null, null, "United States Dollar", 840)
+        {
+            Symbol = "$",
+            InternationalSymbol = "US$",
+            NativeName = "US Dollar",
+            RegionCodes = new[] { "US", "EC" },
+            AlternativeSymbols = new[] { "US$" },
+        };
+
+        Assert.AreEqual("$", info.Symbol);
+        Assert.AreEqual("US$", info.InternationalSymbol);
+        Assert.AreEqual("US Dollar", info.NativeName);
+        CollectionAssert.AreEqual(new[] { "US", "EC" }, info.RegionCodes.ToArray());
+        CollectionAssert.AreEqual(new[] { "US$" }, info.AlternativeSymbols.ToArray());
+
+        // Positional fields are unaffected by the extended members.
+        Assert.AreEqual("USD", info.IsoCode);
+        Assert.AreEqual(840, info.NumericCode);
+    }
+}

--- a/Bodu.Financial/test/Financial/CurrencyLookupServiceTests.cs
+++ b/Bodu.Financial/test/Financial/CurrencyLookupServiceTests.cs
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyLookupServiceTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies <see cref="CurrencyLookupService" /> resolves currencies by ISO code, numeric code, symbol, region, and
+/// culture.
+/// </summary>
+[TestClass]
+public class CurrencyLookupServiceTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CurrencyLookupService.TryByIsoCode(string, out CurrencyInfo)" /> resolves a shipped
+    /// currency.
+    /// </summary>
+    [TestMethod]
+    public void TryByIsoCode_WhenShippedCurrency_ShouldResolve()
+    {
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        Assert.IsTrue(lookup.TryByIsoCode("USD", out CurrencyInfo usd));
+        Assert.AreEqual("USD", usd.IsoCode);
+        Assert.IsFalse(lookup.TryByIsoCode("ZZZ", out _));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CurrencyLookupService.TryByCurrencyCode(CurrencyCode, out CurrencyInfo)" /> resolves an
+    /// active enum value.
+    /// </summary>
+    [TestMethod]
+    public void TryByCurrencyCode_WhenActiveCode_ShouldResolve()
+    {
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        Assert.IsTrue(lookup.TryByCurrencyCode(CurrencyCode.EUR, out CurrencyInfo eur));
+        Assert.AreEqual("EUR", eur.IsoCode);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CurrencyLookupService.TryByNumericCode(int, out CurrencyInfo)" /> resolves a shipped
+    /// currency by its ISO 4217 numeric code.
+    /// </summary>
+    [TestMethod]
+    public void TryByNumericCode_WhenShippedNumericCode_ShouldResolve()
+    {
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        Assert.IsTrue(lookup.TryByNumericCode(840, out CurrencyInfo usd));
+        Assert.AreEqual("USD", usd.IsoCode);
+        Assert.IsFalse(lookup.TryByNumericCode(99999, out _));
+    }
+
+    /// <summary>
+    /// Verifies that symbol and region lookups resolve a custom currency registered with display metadata.
+    /// </summary>
+    [TestMethod]
+    public void TryBySymbolAndRegion_WhenCustomCurrencyRegistered_ShouldResolve()
+    {
+        CurrencyRegistry.Replace(new CurrencyInfo("XQS", 2, 0m, false, null, null)
+        {
+            Symbol = "Ξ",
+            RegionCodes = new[] { "QQ" },
+        });
+
+        // Build the service after registration so its lazy indexes include the custom entry.
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        Assert.IsTrue(lookup.TryBySymbol("Ξ", out IReadOnlyList<CurrencyInfo> bySymbol));
+        Assert.IsTrue(bySymbol.Any(c => c.IsoCode == "XQS"));
+
+        Assert.IsTrue(lookup.TryByRegion("QQ", out IReadOnlyList<CurrencyInfo> byRegion));
+        Assert.IsTrue(byRegion.Any(c => c.IsoCode == "XQS"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CurrencyLookupService.ByCulture(CultureInfo)" /> resolves the region currency for a
+    /// specific culture.
+    /// </summary>
+    [TestMethod]
+    public void ByCulture_WhenSpecificCulture_ShouldResolveRegionCurrency()
+    {
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        IReadOnlyList<CurrencyInfo> currencies = lookup.ByCulture(new CultureInfo("en-US"));
+
+        Assert.IsTrue(currencies.Any(c => c.IsoCode == "USD"));
+    }
+
+    /// <summary>
+    /// Verifies that every active currency's numeric code resolves back to itself, confirming numeric-code uniqueness
+    /// across the shipped catalogue.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void TryByNumericCode_WhenSweepingActiveCatalogue_ShouldResolveUniquely()
+    {
+        ICurrencyLookup lookup = new CurrencyLookupService();
+
+        foreach (CurrencyInfo info in CurrencyRegistry.All.Where(c => !c.IsHistoric && c.NumericCode != 0))
+        {
+            Assert.IsTrue(lookup.TryByNumericCode(info.NumericCode, out CurrencyInfo resolved), $"No match for numeric {info.NumericCode} ({info.IsoCode}).");
+            Assert.AreEqual(info.NumericCode, resolved.NumericCode);
+        }
+    }
+}

--- a/Bodu.Financial/test/Financial/CurrencyRegistryTests.Replace.cs
+++ b/Bodu.Financial/test/Financial/CurrencyRegistryTests.Replace.cs
@@ -1,0 +1,96 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyRegistryTests.Replace.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class CurrencyRegistryTests
+{
+    /// <summary>
+    /// Verifies that <see cref="CurrencyRegistry.Replace(CurrencyInfo)" /> overwrites an existing custom registration.
+    /// </summary>
+    [TestMethod]
+    public void Replace_WhenExistingCustom_ShouldOverwrite()
+    {
+        CurrencyRegistry.Register(new CurrencyInfo("XQF", 2, 0m, false, null, null));
+
+        CurrencyRegistry.Replace(new CurrencyInfo("XQF", 3, 0m, false, null, null));
+
+        Assert.IsTrue(CurrencyRegistry.TryGet("XQF", out CurrencyInfo? resolved));
+        Assert.AreEqual(3, resolved!.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that the conflict-policy overload keeps the existing registration under
+    /// <see cref="CurrencyRegistrationConflictPolicy.Ignore" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenConflictPolicyIgnore_ShouldKeepExisting()
+    {
+        CurrencyRegistry.Register(new CurrencyInfo("XQG", 2, 0m, false, null, null));
+
+        CurrencyRegistry.Register(new CurrencyInfo("XQG", 3, 0m, false, null, null), CurrencyRegistrationConflictPolicy.Ignore);
+
+        Assert.IsTrue(CurrencyRegistry.TryGet("XQG", out CurrencyInfo? resolved));
+        Assert.AreEqual(2, resolved!.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that the conflict-policy overload overwrites the existing registration under
+    /// <see cref="CurrencyRegistrationConflictPolicy.Replace" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenConflictPolicyReplace_ShouldOverwrite()
+    {
+        CurrencyRegistry.Register(new CurrencyInfo("XQI", 2, 0m, false, null, null));
+
+        CurrencyRegistry.Register(new CurrencyInfo("XQI", 3, 0m, false, null, null), CurrencyRegistrationConflictPolicy.Replace);
+
+        Assert.IsTrue(CurrencyRegistry.TryGet("XQI", out CurrencyInfo? resolved));
+        Assert.AreEqual(3, resolved!.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that the conflict-policy overload throws under <see cref="CurrencyRegistrationConflictPolicy.Throw" />
+    /// when a custom registration already exists.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenConflictPolicyThrow_ShouldThrowInvalidOperationException()
+    {
+        CurrencyRegistry.Register(new CurrencyInfo("XQJ", 2, 0m, false, null, null));
+
+        Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQJ", 3, 0m, false, null, null), CurrencyRegistrationConflictPolicy.Throw);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the conflict-policy overload rejects an undefined policy value with
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenConflictPolicyUndefined_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQK", 2, 0m, false, null, null), (CurrencyRegistrationConflictPolicy)99);
+        });
+
+        Assert.AreEqual("conflictPolicy", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CurrencyRegistry.Replace(CurrencyInfo)" /> validates metadata before storing it.
+    /// </summary>
+    [TestMethod]
+    public void Replace_WhenMetadataInvalid_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CurrencyRegistry.Replace(new CurrencyInfo("XQL", 29, 0m, false, null, null));
+        });
+    }
+}

--- a/Bodu.Financial/test/Financial/CurrencyRegistryTests.Validation.cs
+++ b/Bodu.Financial/test/Financial/CurrencyRegistryTests.Validation.cs
@@ -1,0 +1,137 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CurrencyRegistryTests.Validation.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class CurrencyRegistryTests
+{
+    /// <summary>
+    /// Verifies that registering a currency whose minor-unit precision is out of range throws
+    /// <see cref="ArgumentOutOfRangeException" /> and does not register the entry.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenMinorUnitsOutOfRange_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 29, 0m, false, null, null));
+        });
+
+        Assert.AreEqual("info", ex.ParamName);
+        Assert.IsFalse(CurrencyRegistry.Contains("XQV"));
+    }
+
+    /// <summary>
+    /// Verifies that registering a currency with a negative cash-rounding increment throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenCashRoundingNegative_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 2, -0.05m, false, null, null));
+        });
+
+        Assert.AreEqual("info", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that registering a currency whose cash-rounding increment is finer than its declared minor units throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenCashRoundingFinerThanMinorUnits_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 0, 0.05m, false, null, null));
+        });
+
+        Assert.AreEqual("info", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that registering a currency whose numeric code is out of range throws
+    /// <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenNumericCodeOutOfRange_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 2, 0m, false, null, null, "Test", 1000));
+        });
+
+        Assert.AreEqual("info", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that registering a currency whose ISO code is malformed throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenIsoCodeShapeInvalid_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("xq", 2, 0m, false, null, null));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that registering a historic currency whose successor ISO code is malformed throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenSuccessorIsoShapeInvalid_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 2, 0m, true, null, "eu"));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that registering a non-historic currency that nonetheless declares a successor throws
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenHistoricFieldsInconsistent_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            CurrencyRegistry.Register(new CurrencyInfo("XQV", 2, 0m, false, null, "EUR"));
+        });
+
+        Assert.AreEqual("info", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CurrencyRegistry.TryRegister(CurrencyInfo)" /> returns <see langword="false" /> for
+    /// invalid metadata rather than throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryRegister_WhenMetadataInvalid_ShouldReturnFalse()
+    {
+        Assert.IsFalse(CurrencyRegistry.TryRegister(new CurrencyInfo("XQV", 29, 0m, false, null, null)));
+        Assert.IsFalse(CurrencyRegistry.Contains("XQV"));
+    }
+
+    /// <summary>
+    /// Verifies that a consistent historic currency — historic, with a demonetization date and a valid successor —
+    /// registers successfully.
+    /// </summary>
+    [TestMethod]
+    public void Register_WhenHistoricMetadataConsistent_ShouldSucceed()
+    {
+        CurrencyInfo historic = new("XQH", 2, 0m, true, new DateOnly(2001, 1, 1), "EUR");
+
+        CurrencyRegistry.Register(historic);
+
+        Assert.IsTrue(CurrencyRegistry.TryGet("XQH", out CurrencyInfo? resolved));
+        Assert.AreEqual(historic, resolved);
+    }
+}

--- a/Bodu.Financial/test/Financial/CurrencyRegistryTests.cs
+++ b/Bodu.Financial/test/Financial/CurrencyRegistryTests.cs
@@ -11,7 +11,7 @@ namespace Bodu.Financial;
 /// enumeration, and thread safety.
 /// </summary>
 [TestClass]
-public class CurrencyRegistryTests
+public partial class CurrencyRegistryTests
 {
     /// <summary>
     /// Verifies that the shipped catalogue resolves representative currencies across all three minor-unit

--- a/Bodu.Financial/test/Financial/MidpointRoundingStrategyTests.cs
+++ b/Bodu.Financial/test/Financial/MidpointRoundingStrategyTests.cs
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MidpointRoundingStrategyTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies <see cref="MidpointRoundingStrategy" /> rounds according to its configured midpoint mode.
+/// </summary>
+[TestClass]
+public class MidpointRoundingStrategyTests
+{
+    /// <summary>
+    /// Verifies that the shared <see cref="MidpointRoundingStrategy.ToEven" /> instance rounds midpoints to even.
+    /// </summary>
+    [TestMethod]
+    public void ToEven_WhenRoundingMidpoint_ShouldRoundToEven()
+    {
+        Assert.AreEqual(1.22m, MidpointRoundingStrategy.ToEven.Round(1.225m, 2));
+        Assert.AreEqual(MidpointRounding.ToEven, MidpointRoundingStrategy.ToEven.Mode);
+    }
+
+    /// <summary>
+    /// Verifies that the shared <see cref="MidpointRoundingStrategy.AwayFromZero" /> instance rounds midpoints away
+    /// from zero.
+    /// </summary>
+    [TestMethod]
+    public void AwayFromZero_WhenRoundingMidpoint_ShouldRoundAway()
+    {
+        Assert.AreEqual(1.23m, MidpointRoundingStrategy.AwayFromZero.Round(1.225m, 2));
+        Assert.AreEqual(-1.23m, MidpointRoundingStrategy.AwayFromZero.Round(-1.225m, 2));
+    }
+}

--- a/Bodu.Financial/test/Financial/MonetaryContextTests.cs
+++ b/Bodu.Financial/test/Financial/MonetaryContextTests.cs
@@ -1,0 +1,112 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MonetaryContextTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies <see cref="MonetaryContext" /> — its defaults, scale resolution, rounding application, and validation.
+/// </summary>
+[TestClass]
+public class MonetaryContextTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MonetaryContext.Default" /> exposes the documented default policy values.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Default_WhenInspected_ShouldExposeDocumentedDefaults()
+    {
+        MonetaryContext context = MonetaryContext.Default;
+
+        Assert.AreEqual(ScalePolicy.CurrencyMinorUnits, context.ScalePolicy);
+        Assert.AreEqual(CashRoundingPolicy.None, context.CashRounding);
+        Assert.AreEqual(AllocationPolicy.LargestRemainder, context.Allocation);
+        Assert.AreEqual(ConversionRoundingPolicy.RoundAtTarget, context.ConversionRounding);
+        Assert.IsInstanceOfType<MidpointRoundingStrategy>(context.Rounding);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MonetaryContext.ResolveScale(int)" /> returns the currency's minor units under the
+    /// default scale policy.
+    /// </summary>
+    [TestMethod]
+    public void ResolveScale_WhenCurrencyMinorUnits_ShouldReturnCurrencyScale()
+    {
+        Assert.AreEqual(2, MonetaryContext.Default.ResolveScale(2));
+        Assert.AreEqual(0, MonetaryContext.Default.ResolveScale(0));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ScalePolicy.Unrounded" /> resolves to the deferred-rounding sentinel and leaves the
+    /// amount unchanged when rounding is applied.
+    /// </summary>
+    [TestMethod]
+    public void ResolveScale_WhenUnrounded_ShouldReturnNegativeOneAndNotRound()
+    {
+        MonetaryContext context = MonetaryContext.Default with { ScalePolicy = ScalePolicy.Unrounded };
+
+        Assert.AreEqual(-1, context.ResolveScale(2));
+        Assert.AreEqual(1.23456m, context.Round(1.23456m, 2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="ScalePolicy.Custom" /> rounds to the supplied custom scale.
+    /// </summary>
+    [TestMethod]
+    public void ResolveScale_WhenCustom_ShouldUseCustomScale()
+    {
+        MonetaryContext context = MonetaryContext.Default with { ScalePolicy = ScalePolicy.Custom, CustomScale = 4 };
+
+        Assert.AreEqual(4, context.ResolveScale(2));
+        Assert.AreEqual(1.2346m, context.Round(1.234567m, 2));
+    }
+
+    /// <summary>
+    /// Verifies that resolving a custom scale without a value throws <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void ResolveScale_WhenCustomWithoutValue_ShouldThrowArgumentException()
+    {
+        MonetaryContext context = MonetaryContext.Default with { ScalePolicy = ScalePolicy.Custom };
+
+        Assert.ThrowsExactly<ArgumentException>(() => _ = context.ResolveScale(2));
+    }
+
+    /// <summary>
+    /// Verifies that the rounding strategy honours the configured midpoint mode.
+    /// </summary>
+    [TestMethod]
+    public void Round_WhenAwayFromZeroStrategy_ShouldRoundMidpointAway()
+    {
+        MonetaryContext context = MonetaryContext.Default with { Rounding = MidpointRoundingStrategy.AwayFromZero };
+
+        Assert.AreEqual(1.23m, context.Round(1.225m, 2));
+        Assert.AreEqual(1.22m, MonetaryContext.Default.Round(1.225m, 2));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MonetaryContext.Validate" /> rejects an undefined scale policy.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenScalePolicyUndefined_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonetaryContext context = MonetaryContext.Default with { ScalePolicy = (ScalePolicy)99 };
+
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => context.Validate());
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MonetaryContext.Validate" /> rejects a custom scale outside the supported range.
+    /// </summary>
+    [TestMethod]
+    public void Validate_WhenCustomScaleOutOfRange_ShouldThrowArgumentOutOfRangeException()
+    {
+        MonetaryContext context = MonetaryContext.Default with { ScalePolicy = ScalePolicy.Custom, CustomScale = 99 };
+
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() => context.Validate());
+        Assert.AreEqual("CustomScale", ex.ParamName);
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyBagTests.Accessors.cs
+++ b/Bodu.Financial/test/Financial/MoneyBagTests.Accessors.cs
@@ -1,0 +1,75 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyBagTests.Accessors.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+public partial class MoneyBagTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.Of(Money[])" /> sums duplicate currencies.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Smoke")]
+    public void Of_WhenDuplicateCurrencies_ShouldSumBalances()
+    {
+        MoneyBag bag = MoneyBag.Of(new Money(10m, "USD"), new Money(5m, "USD"), new Money(2m, "EUR"));
+
+        Assert.AreEqual(new Money(15m, "USD"), bag.GetBalance("USD"));
+        Assert.AreEqual(new Money(2m, "EUR"), bag.GetBalance("EUR"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.FromBalances(IEnumerable{Money})" /> builds an equivalent bag.
+    /// </summary>
+    [TestMethod]
+    public void FromBalances_WhenGivenSequence_ShouldBuildBag()
+    {
+        MoneyBag bag = MoneyBag.FromBalances(new[] { new Money(10m, "USD"), new Money(2m, "EUR") });
+
+        Assert.AreEqual(2, bag.Count);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.TryGetBalance(string, out Money)" /> reports presence and absence without
+    /// throwing.
+    /// </summary>
+    [TestMethod]
+    public void TryGetBalance_WhenPresentAndAbsent_ShouldReflectMembership()
+    {
+        MoneyBag bag = MoneyBag.Of(new Money(10m, "USD"));
+
+        Assert.IsTrue(bag.TryGetBalance("USD", out Money usd));
+        Assert.AreEqual(new Money(10m, "USD"), usd);
+
+        Assert.IsFalse(bag.TryGetBalance("EUR", out Money eur));
+        Assert.AreEqual(default, eur);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.GetBalance(CurrencyInfo)" /> resolves the balance by currency metadata.
+    /// </summary>
+    [TestMethod]
+    public void GetBalance_WhenCurrencyInfo_ShouldResolveBalance()
+    {
+        MoneyBag bag = MoneyBag.Of(new Money(10m, "USD"));
+
+        Assert.AreEqual(new Money(10m, "USD"), bag.GetBalance(CurrencyRegistry.Get("USD")));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.GetBalance(CurrencyCode)" /> resolves the balance by ISO enum value.
+    /// </summary>
+    [TestMethod]
+    public void GetBalance_WhenCurrencyCode_ShouldResolveBalance()
+    {
+        MoneyBag bag = MoneyBag.Of(new Money(10m, "USD"));
+
+        Assert.AreEqual(new Money(10m, "USD"), bag.GetBalance(CurrencyCode.USD));
+        Assert.IsNull(bag.GetBalance(CurrencyCode.EUR));
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyBagTests.DatedConvert.cs
+++ b/Bodu.Financial/test/Financial/MoneyBagTests.DatedConvert.cs
@@ -53,8 +53,8 @@ public partial class MoneyBagTests
     [DataRow(MoneyBagConversionRoundingPolicy.RoundEachCurrencyThenSum, 0.00)]
     public void DatedConvertTo_WhenTwoSubMinorUnitLinesAggregate_ShouldHonourPolicy(MoneyBagConversionRoundingPolicy policy, double expected)
     {
-        // Use unregistered currency tags (valid ISO shape, not in the catalogue) so Money preserves the
-        // sub-cent source precision — same trick as the timeless-rate test.
+        // Use unregistered currency tags (valid ISO shape, not in the catalogue) with an explicit minor-unit scale so
+        // Money preserves the sub-cent source precision — same trick as the timeless-rate test.
         IDatedExchangeRateProvider rates = new FixedDatedExchangeRateProvider(
         [
             new ExchangeRate("XQT", "USD", s_asOf, 1m, "Test"),
@@ -62,8 +62,8 @@ public partial class MoneyBagTests
         ]);
 
         MoneyBag bag = MoneyBag.Empty
-            .Add(new Money(0.005m, "XQT"))
-            .Add(new Money(0.005m, "XQU"));
+            .Add(Money.FromUnchecked(0.005m, "XQT", 3))
+            .Add(Money.FromUnchecked(0.005m, "XQU", 3));
 
         Money<USD> total = bag.ConvertTo<USD>(rates, s_asOf, ExchangeRateLookupOptions.Exact, policy);
 

--- a/Bodu.Financial/test/Financial/MoneyBagTests.Storage.cs
+++ b/Bodu.Financial/test/Financial/MoneyBagTests.Storage.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyBagTests.Storage.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyBagTests
+{
+    /// <summary>
+    /// Verifies that <see cref="MoneyBag.Balances" /> returns the same immutable instance on repeated access rather than
+    /// allocating a new wrapper each call.
+    /// </summary>
+    [TestMethod]
+    public void Balances_WhenAccessedRepeatedly_ShouldReturnSameImmutableInstance()
+    {
+        MoneyBag bag = MoneyBag.Of(new Money(10m, "USD"), new Money(5m, "EUR"));
+
+        Assert.AreSame(bag.Balances, bag.Balances);
+    }
+
+    /// <summary>
+    /// Verifies that enumeration yields balances in stable ISO-code lexicographic order regardless of insertion order.
+    /// </summary>
+    [TestMethod]
+    public void Enumeration_WhenInsertedOutOfOrder_ShouldYieldIsoCodeOrder()
+    {
+        MoneyBag bag = MoneyBag.Empty
+            .Add(new Money(1m, "USD"))
+            .Add(new Money(2m, "AUD"))
+            .Add(new Money(3m, "EUR"));
+
+        CollectionAssert.AreEqual(
+            new[] { "AUD", "EUR", "USD" },
+            bag.Select(m => m.IsoCode).ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that two bags with the same balances are equal regardless of the order their balances were added.
+    /// </summary>
+    [TestMethod]
+    public void Equality_WhenSameBalancesDifferentInsertionOrder_ShouldBeEqual()
+    {
+        MoneyBag a = MoneyBag.Empty.Add(new Money(1m, "USD")).Add(new Money(2m, "EUR"));
+        MoneyBag b = MoneyBag.Empty.Add(new Money(2m, "EUR")).Add(new Money(1m, "USD"));
+
+        Assert.AreEqual(a, b);
+        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+    }
+
+    /// <summary>
+    /// Verifies that a balance reduced to zero is pruned from the bag.
+    /// </summary>
+    [TestMethod]
+    public void Add_WhenBalanceCancelsToZero_ShouldPruneCurrency()
+    {
+        MoneyBag bag = MoneyBag.Empty.Add(new Money(10m, "USD")).Add(new Money(-10m, "USD"));
+
+        Assert.IsTrue(bag.IsEmpty);
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyFormatterBuilderTests.cs
+++ b/Bodu.Financial/test/Financial/MoneyFormatterBuilderTests.cs
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyFormatterBuilderTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies <see cref="MoneyFormatterBuilder" /> composes a <see cref="MoneyFormatter" /> matching the configured
+/// options.
+/// </summary>
+[TestClass]
+public class MoneyFormatterBuilderTests
+{
+    /// <summary>
+    /// Verifies that the builder produces a formatter rendering the numeric-only, ungrouped form.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenNumericOnlyWithoutGrouping_ShouldRenderBareAmount()
+    {
+        MoneyFormatter formatter = new MoneyFormatterBuilder()
+            .WithNumericOnly()
+            .WithGrouping(false)
+            .WithCulture(CultureInfo.InvariantCulture)
+            .Build();
+
+        Assert.AreEqual("1234.56", formatter.Format(new Money(1234.56m, "USD")));
+    }
+
+    /// <summary>
+    /// Verifies that the builder's English-name configuration renders the currency name with overridden precision.
+    /// </summary>
+    [TestMethod]
+    public void Build_WhenEnglishNameWithMinorUnits_ShouldRenderNameAndPrecision()
+    {
+        MoneyFormatter formatter = new MoneyFormatterBuilder()
+            .WithEnglishName()
+            .WithMinorUnits(0)
+            .WithCulture(CultureInfo.InvariantCulture)
+            .Build();
+
+        Assert.AreEqual("1,235 US Dollar", formatter.Format(new Money(1234.56m, "USD")));
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyFormatterTests.cs
+++ b/Bodu.Financial/test/Financial/MoneyFormatterTests.cs
@@ -1,0 +1,100 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyFormatterTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+/// <summary>
+/// Verifies <see cref="MoneyFormatter" /> renders <see cref="Money" /> and <see cref="Money{TCurrency}" /> values
+/// according to its <see cref="MoneyFormatOptions" />.
+/// </summary>
+[TestClass]
+public class MoneyFormatterTests
+{
+    /// <summary>
+    /// Verifies that the ISO-code display renders the code and grouped amount.
+    /// </summary>
+    [TestMethod]
+    public void Format_WhenIsoCodeDisplay_ShouldRenderCodeAndGroupedAmount()
+    {
+        MoneyFormatter formatter = new(new MoneyFormatOptions { FormatProvider = CultureInfo.InvariantCulture });
+
+        Assert.AreEqual("USD 1,234.56", formatter.Format(new Money(1234.56m, "USD")));
+    }
+
+    /// <summary>
+    /// Verifies that the numeric-only display honours the grouping option.
+    /// </summary>
+    [TestMethod]
+    [DataRow(true, "1,234.56")]
+    [DataRow(false, "1234.56")]
+    public void Format_WhenNumericOnly_ShouldHonourGrouping(bool grouping, string expected)
+    {
+        MoneyFormatter formatter = new(new MoneyFormatOptions
+        {
+            CurrencyDisplay = CurrencyDisplay.None,
+            IncludeGrouping = grouping,
+            FormatProvider = CultureInfo.InvariantCulture,
+        });
+
+        Assert.AreEqual(expected, formatter.Format(new Money(1234.56m, "USD")));
+    }
+
+    /// <summary>
+    /// Verifies that the English-name display renders the amount followed by the currency name.
+    /// </summary>
+    [TestMethod]
+    public void Format_WhenEnglishNameDisplay_ShouldRenderName()
+    {
+        MoneyFormatter formatter = new(new MoneyFormatOptions
+        {
+            CurrencyDisplay = CurrencyDisplay.EnglishName,
+            FormatProvider = CultureInfo.InvariantCulture,
+        });
+
+        Assert.AreEqual("1,234.56 US Dollar", formatter.Format(new Money(1234.56m, "USD")));
+    }
+
+    /// <summary>
+    /// Verifies that the minor-units override changes the rendered precision.
+    /// </summary>
+    [TestMethod]
+    public void Format_WhenMinorUnitsOverride_ShouldChangePrecision()
+    {
+        MoneyFormatter formatter = new(new MoneyFormatOptions
+        {
+            MinorUnitsOverride = 0,
+            FormatProvider = CultureInfo.InvariantCulture,
+        });
+
+        Assert.AreEqual("USD 1,235", formatter.Format(new Money(1234.56m, "USD")));
+    }
+
+    /// <summary>
+    /// Verifies that the formatter also renders strongly-typed values.
+    /// </summary>
+    [TestMethod]
+    public void Format_WhenTypedMoney_ShouldRenderSameAsRuntime()
+    {
+        MoneyFormatter formatter = new(new MoneyFormatOptions { FormatProvider = CultureInfo.InvariantCulture });
+
+        Assert.AreEqual("USD 1,234.56", formatter.Format(new Money<USD>(1234.56m)));
+    }
+
+    /// <summary>
+    /// Verifies that an undefined currency-display value is rejected.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenCurrencyDisplayUndefined_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = new MoneyFormatter(new MoneyFormatOptions { CurrencyDisplay = (CurrencyDisplay)99 });
+        });
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyOfTCurrencyExchangeRateExtensionsTests.cs
+++ b/Bodu.Financial/test/Financial/MoneyOfTCurrencyExchangeRateExtensionsTests.cs
@@ -46,7 +46,7 @@ public partial class MoneyOfTCurrencyExchangeRateExtensionsTests
     {
         Money<Bodu.Financial.Currencies.USD> amount = new(100m);
 
-        MoneyConversionResult<Bodu.Financial.Currencies.USD, Bodu.Financial.Currencies.AUD> result = amount.ConvertToWithRate<Bodu.Financial.Currencies.USD, Bodu.Financial.Currencies.AUD>(
+        TypedMoneyConversionResult<Bodu.Financial.Currencies.USD, Bodu.Financial.Currencies.AUD> result = amount.ConvertToWithRate<Bodu.Financial.Currencies.USD, Bodu.Financial.Currencies.AUD>(
             BuildProvider(),
             s_d1,
             ExchangeRateLookupOptions.Exact);

--- a/Bodu.Financial/test/Financial/MoneyOfTCurrencyTests.MonetaryContext.cs
+++ b/Bodu.Financial/test/Financial/MoneyOfTCurrencyTests.MonetaryContext.cs
@@ -1,0 +1,41 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyOfTCurrencyTests.MonetaryContext.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using Bodu.Financial.Currencies;
+
+namespace Bodu.Financial;
+
+public partial class MoneyOfTCurrencyTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Money{TCurrency}.Multiply(decimal, MonetaryContext)" /> applies the context's rounding
+    /// strategy at the currency's minor units.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenContextUsesAwayFromZero_ShouldRoundMidpointAway()
+    {
+        // 2.45 * 0.5 = 1.225 produces the midpoint inside the multiplication, so the rounding strategy is observable.
+        Money<USD> value = new(2.45m);
+
+        Money<USD> banker = value.Multiply(0.5m, MonetaryContext.Default);
+        Money<USD> away = value.Multiply(0.5m, MonetaryContext.Default with { Rounding = MidpointRoundingStrategy.AwayFromZero });
+
+        Assert.AreEqual(new Money<USD>(1.22m), banker);
+        Assert.AreEqual(new Money<USD>(1.23m), away);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money{TCurrency}.Multiply(decimal, MonetaryContext)" /> throws
+    /// <see cref="ArgumentNullException" /> when the context is <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenContextIsNull_ShouldThrowArgumentNullException()
+    {
+        Money<USD> value = new(10m);
+
+        Assert.ThrowsExactly<ArgumentNullException>(() => _ = value.Multiply(2m, (MonetaryContext)null!));
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyOfTCurrencyTests.ReassessmentDefects.cs
+++ b/Bodu.Financial/test/Financial/MoneyOfTCurrencyTests.ReassessmentDefects.cs
@@ -467,11 +467,11 @@ public partial class MoneyOfTCurrencyTests
     [TestMethod]
     public void ConvertTo_WhenTwoSubMinorUnitLinesAggregate_ShouldDifferByRoundingPolicy()
     {
-        // Use unregistered currency tags (valid ISO shape, not in the catalogue) so the Money constructor
-        // preserves the sub-cent source precision instead of rounding it away.
+        // Use unregistered currency tags (valid ISO shape, not in the catalogue) with an explicit minor-unit scale so
+        // Money preserves the sub-cent source precision instead of rounding it away.
         MoneyBag bag = MoneyBag.Empty
-            .Add(new Money(0.005m, "XQT"))
-            .Add(new Money(0.005m, "XQU"));
+            .Add(Money.FromUnchecked(0.005m, "XQT", 3))
+            .Add(Money.FromUnchecked(0.005m, "XQU", 3));
 
         FixedExchangeRateTable rates = new(new Dictionary<(string From, string To), decimal>
         {

--- a/Bodu.Financial/test/Financial/MoneyTests.ConvertWithRate.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.ConvertWithRate.cs
@@ -1,0 +1,62 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.ConvertWithRate.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// The observation date used by the quote-first conversion tests.
+    /// </summary>
+    private static readonly DateOnly s_rateDate = new(2024, 1, 1);
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Convert(ExchangeRate, MonetaryContext?)" /> produces the target currency rounded
+    /// to its minor units.
+    /// </summary>
+    [TestMethod]
+    public void Convert_WhenRateSourceMatches_ShouldProduceTargetCurrency()
+    {
+        Money usd = new(100m, "USD");
+        ExchangeRate rate = new("USD", "AUD", s_rateDate, 1.5m, "Test");
+
+        Money aud = usd.Convert(rate);
+
+        Assert.AreEqual(new Money(150.00m, "AUD"), aud);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Convert(ExchangeRate, MonetaryContext?)" /> throws when the rate's source
+    /// currency does not match.
+    /// </summary>
+    [TestMethod]
+    public void Convert_WhenRateSourceMismatches_ShouldThrowInvalidOperationException()
+    {
+        Money eur = new(100m, "EUR");
+        ExchangeRate rate = new("USD", "AUD", s_rateDate, 1.5m, "Test");
+
+        Assert.ThrowsExactly<InvalidOperationException>(() => _ = eur.Convert(rate));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.ConvertWithResult(ExchangeRate, MonetaryContext?)" /> reports the source, target,
+    /// rate, and the signed rounding adjustment.
+    /// </summary>
+    [TestMethod]
+    public void ConvertWithResult_ShouldReportRoundingAdjustment()
+    {
+        Money usd = new(1m, "USD");
+        ExchangeRate rate = new("USD", "AUD", s_rateDate, 1.005m, "Test");
+
+        MoneyConversionResult result = usd.ConvertWithResult(rate);
+
+        // 1 * 1.005 = 1.005, banker's rounding to 2 dp = 1.00, so the adjustment is -0.005.
+        Assert.AreEqual(new Money(1.00m, "AUD"), result.Target);
+        Assert.AreEqual(usd, result.Source);
+        Assert.AreEqual(rate, result.Rate);
+        Assert.AreEqual(-0.005m, result.RoundingAdjustment);
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyTests.Core.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Core.cs
@@ -22,7 +22,6 @@ public partial class MoneyTests
     [DataRow("USD", 1.235, 1.24)]
     [DataRow("JPY", 99.6, 100.0)]
     [DataRow("BHD", 12.3456, 12.346)]
-    [DataRow("XQX", 1.234567, 1.234567)]   // unknown currency — no rounding
     public void Constructor_WhenAmountHasExcessPrecision_ShouldRoundToCurrencyMinorUnits(string iso, double amount, double expected)
     {
         var money = new Money((decimal)amount, iso);
@@ -94,7 +93,6 @@ public partial class MoneyTests
     [DataRow("USD", 2)]
     [DataRow("JPY", 0)]
     [DataRow("BHD", 3)]
-    [DataRow("XQR", 0)]    // unknown — registry returns 0
     public void MinorUnits_WhenInspected_ShouldMatchRegistry(string iso, int expected)
     {
         var money = new Money(0m, iso);

--- a/Bodu.Financial/test/Financial/MoneyTests.Formatting.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Formatting.cs
@@ -64,7 +64,7 @@ public partial class MoneyTests
     [TestMethod]
     public void ToString_WhenLSpecifierAndCurrencyNotRegistered_ShouldFallBackToIsoForm()
     {
-        var money = new Money(1234m, "ZZZ");
+        var money = Money.FromUnchecked(1234m, "ZZZ", 0);
 
         var actual = money.ToString("L", CultureInfo.InvariantCulture);
 

--- a/Bodu.Financial/test/Financial/MoneyTests.ParseOptions.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.ParseOptions.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.ParseOptions.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that strict-ISO parsing accepts the canonical prefix and suffix forms.
+    /// </summary>
+    [TestMethod]
+    [DataRow("USD 19.99")]
+    [DataRow("19.99 USD")]
+    public void ParseOptions_WhenStrictIso_ShouldParseCanonicalForms(string text)
+    {
+        MoneyParseOptions options = MoneyParseOptions.Default with { FormatProvider = CultureInfo.InvariantCulture };
+
+        Money money = Money.Parse(text, options);
+
+        Assert.AreEqual(new Money(19.99m, "USD"), money);
+    }
+
+    /// <summary>
+    /// Verifies that strict-ISO parsing rejects an unregistered currency.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenStrictIsoAndUnregistered_ShouldReturnFalse()
+    {
+        Assert.IsFalse(Money.TryParse("XYZ 5.00", MoneyParseOptions.Default, out _));
+    }
+
+    /// <summary>
+    /// Verifies that lenient-import parsing normalises a lower-case ISO code to upper case.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenLenientImport_ShouldNormaliseLowercaseIso()
+    {
+        MoneyParseOptions options = new() { Mode = MoneyParseMode.LenientImport, FormatProvider = CultureInfo.InvariantCulture };
+
+        Money money = Money.Parse("usd 19.99", options);
+
+        Assert.AreEqual(new Money(19.99m, "USD"), money);
+    }
+
+    /// <summary>
+    /// Verifies that lenient import with <see cref="UnknownCurrencyPolicy.AllowUnscaled" /> accepts an unregistered
+    /// currency at source precision.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenLenientImportAllowUnscaled_ShouldAcceptUnregistered()
+    {
+        MoneyParseOptions options = new()
+        {
+            Mode = MoneyParseMode.LenientImport,
+            FormatProvider = CultureInfo.InvariantCulture,
+            UnknownCurrency = UnknownCurrencyPolicy.AllowUnscaled,
+        };
+
+        Money money = Money.Parse("XYZ 1.2345", options);
+
+        Assert.AreEqual(1.2345m, money.Amount);
+        Assert.AreEqual("XYZ", money.IsoCode);
+        Assert.AreEqual(0, money.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that round-trip-only parsing interprets the invariant form without an explicit culture.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenRoundTripOnly_ShouldParseInvariantForm()
+    {
+        Money money = Money.Parse("USD 1234.56", new MoneyParseOptions { Mode = MoneyParseMode.RoundTripOnly });
+
+        Assert.AreEqual(new Money(1234.56m, "USD"), money);
+    }
+
+    /// <summary>
+    /// Verifies that culture-aware parsing resolves an unambiguous currency symbol through the lookup.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenCultureAwareWithUniqueSymbol_ShouldResolveCurrency()
+    {
+        CurrencyRegistry.Replace(new CurrencyInfo("XQP", 2, 0m, false, null, null) { Symbol = "Ω" });
+
+        MoneyParseOptions options = new()
+        {
+            Mode = MoneyParseMode.CultureAware,
+            FormatProvider = CultureInfo.InvariantCulture,
+            CurrencyLookup = new CurrencyLookupService(),
+        };
+
+        Money money = Money.Parse("Ω10.50", options);
+
+        Assert.AreEqual("XQP", money.IsoCode);
+        Assert.AreEqual(10.50m, money.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that an undefined parse mode is rejected with <see cref="ArgumentOutOfRangeException" />.
+    /// </summary>
+    [TestMethod]
+    public void ParseOptions_WhenModeUndefined_ShouldThrowArgumentOutOfRangeException()
+    {
+        Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = Money.TryParse("USD 1.00".AsSpan(), new MoneyParseOptions { Mode = (MoneyParseMode)99 }, out _);
+        });
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyTests.UnknownCurrencyPolicy.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.UnknownCurrencyPolicy.cs
@@ -1,0 +1,206 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.UnknownCurrencyPolicy.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that constructing a <see cref="Money" /> with a structurally valid but unregistered ISO code throws
+    /// <see cref="ArgumentException" /> under the default reject policy.
+    /// </summary>
+    [TestMethod]
+    public void Constructor_WhenIsoCodeIsUnregistered_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = new Money(12.3456m, "XYZ");
+        });
+
+        Assert.AreEqual("isoCode", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.From(decimal, string, MidpointRounding)" /> rejects an unregistered ISO code with
+    /// <see cref="ArgumentException" />.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenIsoCodeIsUnregistered_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.From(12.3456m, "XYZ");
+        });
+
+        Assert.AreEqual("isoCode", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that the policy overload rejects an unregistered ISO code under
+    /// <see cref="UnknownCurrencyPolicy.Reject" />.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenUnregisteredAndRejectPolicy_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.From(12.3456m, "XYZ", UnknownCurrencyPolicy.Reject);
+        });
+
+        Assert.AreEqual("isoCode", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnknownCurrencyPolicy.AllowWithExplicitScale" /> is rejected by the policy overload
+    /// because it requires an explicit scale that only <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" />
+    /// can supply.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenUnregisteredAndAllowWithExplicitScalePolicy_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.From(12.3456m, "XYZ", UnknownCurrencyPolicy.AllowWithExplicitScale);
+        });
+
+        Assert.AreEqual("policy", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="UnknownCurrencyPolicy.AllowUnscaled" /> stores the source precision and reports zero
+    /// minor units for an unregistered currency.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenUnregisteredAndAllowUnscaledPolicy_ShouldStoreSourcePrecisionAndReportZeroMinorUnits()
+    {
+        Money money = Money.From(12.3456m, "XYZ", UnknownCurrencyPolicy.AllowUnscaled);
+
+        Assert.AreEqual(12.3456m, money.Amount);
+        Assert.AreEqual("XYZ", money.IsoCode);
+        Assert.AreEqual(0, money.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that the policy overload still rounds a registered currency to its registry minor units regardless of
+    /// the supplied policy.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenRegisteredAndAllowUnscaledPolicy_ShouldRoundToRegistryMinorUnits()
+    {
+        Money money = Money.From(1.235m, "USD", UnknownCurrencyPolicy.AllowUnscaled);
+
+        Assert.AreEqual(1.24m, money.Amount);
+        Assert.AreEqual(2, money.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that the policy overload throws <see cref="ArgumentOutOfRangeException" /> for an undefined policy
+    /// value.
+    /// </summary>
+    [TestMethod]
+    public void From_WhenPolicyIsUndefined_ShouldThrowArgumentOutOfRangeException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = Money.From(10m, "USD", (UnknownCurrencyPolicy)99);
+        });
+
+        Assert.AreEqual("policy", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" /> rounds the amount to
+    /// the supplied scale and reports that scale from <see cref="Money.MinorUnits" />.
+    /// </summary>
+    [TestMethod]
+    public void FromUnchecked_WhenExplicitScaleSupplied_ShouldRoundAndReportScale()
+    {
+        Money money = Money.FromUnchecked(1.234567m, "XYZ", 4);
+
+        Assert.AreEqual(1.2346m, money.Amount);
+        Assert.AreEqual("XYZ", money.IsoCode);
+        Assert.AreEqual(4, money.MinorUnits);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" /> throws
+    /// <see cref="ArgumentOutOfRangeException" /> when the minor-unit scale is outside the range 0 to 28.
+    /// </summary>
+    [TestMethod]
+    [DataRow(-1)]
+    [DataRow(29)]
+    public void FromUnchecked_WhenScaleOutOfRange_ShouldThrowArgumentOutOfRangeException(int minorUnits)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentOutOfRangeException>(() =>
+        {
+            _ = Money.FromUnchecked(1m, "XYZ", minorUnits);
+        });
+
+        Assert.AreEqual("minorUnits", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.FromUnchecked(decimal, string, int, MidpointRounding)" /> validates the ISO-code
+    /// shape.
+    /// </summary>
+    [TestMethod]
+    public void FromUnchecked_WhenIsoCodeShapeInvalid_ShouldThrowArgumentException()
+    {
+        Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.FromUnchecked(1m, "us", 2);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that an explicit-scale value preserves its reported minor units through negation and absolute value.
+    /// </summary>
+    [TestMethod]
+    public void ExplicitScale_WhenNegatedAndAbs_ShouldPreserveMinorUnits()
+    {
+        Money money = Money.FromUnchecked(-1.2300m, "XYZ", 4);
+
+        Assert.AreEqual(4, (-money).MinorUnits);
+        Assert.AreEqual(4, money.Abs.MinorUnits);
+        Assert.AreEqual(1.23m, money.Abs.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that the strict parser reports failure (rather than throwing) for a structurally valid but unregistered
+    /// ISO code.
+    /// </summary>
+    [TestMethod]
+    public void TryParse_WhenIsoCodeIsUnregistered_ShouldReturnFalse()
+    {
+        var parsed = Money.TryParse("XYZ 10.00", System.Globalization.CultureInfo.InvariantCulture, out Money result);
+
+        Assert.IsFalse(parsed);
+        Assert.AreEqual(default, result);
+    }
+
+    /// <summary>
+    /// Verifies across a representative spread of registered currencies that construction rounds to the registry
+    /// minor-unit precision.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow("USD", 2)]
+    [DataRow("EUR", 2)]
+    [DataRow("GBP", 2)]
+    [DataRow("JPY", 0)]
+    [DataRow("KRW", 0)]
+    [DataRow("CLP", 0)]
+    [DataRow("BHD", 3)]
+    [DataRow("KWD", 3)]
+    [DataRow("OMR", 3)]
+    public void Constructor_WhenRegisteredCurrency_ShouldRoundAndReportRegistryMinorUnits(string iso, int expectedMinorUnits)
+    {
+        Money money = new(1.2345678m, iso);
+
+        Assert.AreEqual(expectedMinorUnits, money.MinorUnits);
+        Assert.AreEqual(decimal.Round(1.2345678m, expectedMinorUnits, MidpointRounding.ToEven), money.Amount);
+    }
+}

--- a/bodu.slnx
+++ b/bodu.slnx
@@ -46,6 +46,10 @@
     <Project Path="Bodu.Financial\src\Bodu.Financial.csproj" />
     <Project Path="Bodu.Financial\test\Bodu.Financial.Test.csproj" />
   </Folder>
+  <Folder Name="/Bodu.Financial.DependencyInjection/">
+    <Project Path="Bodu.Financial.DependencyInjection/src/Bodu.Financial.DependencyInjection.csproj" />
+    <Project Path="Bodu.Financial.DependencyInjection/test/Bodu.Financial.DependencyInjection.Test.csproj" />
+  </Folder>
   <Folder Name="/Bodu.Security.Cryptography/">
     <Project Path="Bodu.Security.Cryptography\src\Bodu.Security.Cryptography.csproj" />
     <Project Path="Bodu.Security.Cryptography\test\Bodu.Security.Cryptography.Test.csproj" />


### PR DESCRIPTION
Add UnknownCurrencyPolicy and route Money construction through it so a value
can never store source precision while reporting zero minor units (P0.3):

- Money ctors now reject structurally valid but unregistered ISO codes.
- Money.FromUnchecked(amount, iso, minorUnits) and From(amount, iso, policy)
  provide explicit-scale and unscaled staging escape hatches.
- Money carries a packed explicit-scale field; MinorUnits reports it when set,
  and operators/Abs/Allocate preserve it.
- Strict TryParse stays exception-free for unregistered codes.
- Migrate tests that used unregistered codes to the supported FromUnchecked path.