### PR TITLE
Harden Bodu.Financial: allocation, default(Money), rounding, docs

### DIFF
--- a/Bodu.Financial/README.md
+++ b/Bodu.Financial/README.md
@@ -78,6 +78,18 @@ Highlights:
 
 Bridge between them: typed → runtime is implicit (lossless); runtime → typed is explicit via `As<T>()` / `TryAs<T>(...)` / `(Money<T>)money`.
 
+### Settlement vs calculation
+
+There are three precision models; pick by how rounding should behave:
+
+| Type | Purpose | Precision | Rounding boundary |
+|---|---|---|---|
+| `Money` / `Money<TCurrency>` | Settlement amount — safe to persist, display, post | Rounded to the currency's minor units | At every construction/operation |
+| `CalculatedMoney` | Intermediate calculation chain (interest, unit-rate, apportionment) | High-precision `decimal` (not exact rational) | Once, at `RoundToMoney(...)` |
+| `Fraction` APIs (`Money<TCurrency>.FromFraction` / `MultiplyExact`) | Calculations that must be mathematically exact | Exact rational | Once, on conversion to `Money<TCurrency>` |
+
+Scalar `*` and `/` on `Money` use banker's rounding (`MidpointRounding.ToEven`); use `Multiply(factor, rounding)` / `Divide(divisor, rounding)` for any other rule.
+
 ## `CurrencyInfo` and `CurrencyCode`
 
 `CurrencyInfo` is the canonical runtime metadata record: ISO 4217 alphabetic and numeric codes, minor-unit precision, cash-rounding increment, historicity flag, demonetization date, English name. Looked up via `CurrencyRegistry.Get("AUD")` / `TryGet(...)`; custom currencies register via `CurrencyRegistry.Register(...)`.

--- a/Bodu.Financial/src/Financial/CalculatedMoney.cs
+++ b/Bodu.Financial/src/Financial/CalculatedMoney.cs
@@ -24,6 +24,17 @@ namespace Bodu.Financial;
 /// currency need not be registered to participate in a calculation; registration (or an explicit scale) is required
 /// only when materialising a settlement value.
 /// </para>
+/// <para>
+/// <see cref="CalculatedMoney" /> carries <em>high-precision <see cref="decimal" /></em> arithmetic with deferred
+/// rounding — it is not an exact rational type. Division such as one-third is held to <see cref="decimal" />'s 28-29
+/// significant digits, not exactly. When a calculation must be mathematically exact (for example, apportioning by an
+/// exact fraction before settlement), use the exact-rational escape hatches on the strongly typed form —
+/// <see cref="Money{TCurrency}.FromFraction(Bodu.Numerics.Fraction{System.Numerics.BigInteger}, MidpointRounding)" />
+/// and <see cref="Money{TCurrency}.MultiplyExact(Bodu.Numerics.Fraction{System.Numerics.BigInteger}, MidpointRounding)" />
+/// — which compute in <see cref="Bodu.Numerics.Fraction{T}" /> and round once at the settlement boundary. In short:
+/// <see cref="Money" />/<see cref="Money{TCurrency}" /> are rounded settlement values, <see cref="CalculatedMoney" />
+/// is deferred-rounding decimal, and the <c>Fraction</c> APIs are exact rational.
+/// </para>
 /// </remarks>
 [DebuggerDisplay("{Amount} {IsoCode,nq} (unrounded)")]
 public readonly partial struct CalculatedMoney

--- a/Bodu.Financial/src/Financial/ExchangeRateSeries.cs
+++ b/Bodu.Financial/src/Financial/ExchangeRateSeries.cs
@@ -189,6 +189,12 @@ public sealed class ExchangeRateSeries
     /// <exception cref="ArgumentOutOfRangeException">
     /// Thrown if <paramref name="rate" /> is zero or negative.
     /// </exception>
+    /// <remarks>
+    /// Each call materialises a complete new immutable series, so this method is intended for occasional,
+    /// functional-style single updates. For bulk import or repeated mutation, accumulate observations in an
+    /// <see cref="ExchangeRateSeriesBuilder" /> and build the series once rather than calling <see cref="WithRate" />
+    /// in a loop.
+    /// </remarks>
     public ExchangeRateSeries WithRate(DateOnly date, decimal rate)
     {
         FinancialThrowHelper.ThrowIfExchangeRateNotPositive(rate);

--- a/Bodu.Financial/src/Financial/Money.Allocation.cs
+++ b/Bodu.Financial/src/Financial/Money.Allocation.cs
@@ -1,4 +1,4 @@
-﻿// ---------------------------------------------------------------------------------------------------------------
+// ---------------------------------------------------------------------------------------------------------------
 // <copyright file="Money.Allocation.cs" company="Bodu Pty. Ltd.">
 // Copyright (c) Bodu Pty. Ltd. All rights reserved.
 // </copyright>
@@ -14,11 +14,16 @@ public readonly partial struct Money
     /// </summary>
     /// <param name="parts">The number of shares to allocate.</param>
     /// <returns>The per-share allocation.</returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
     /// <exception cref="ArgumentOutOfRangeException">
     /// <paramref name="parts" /> is less than or equal to zero.
     /// </exception>
+    /// <exception cref="OverflowException">
+    /// The scaled minor-unit count exceeds the range of a 64-bit signed integer.
+    /// </exception>
     public Money[] Allocate(int parts)
     {
+        EnsureHasCurrency();
         ThrowHelper.ThrowIfLessThanOrEqual(parts, 0);
 
         var factor = MinorUnitFactor();
@@ -42,10 +47,19 @@ public readonly partial struct Money
     /// Distributes this amount across the supplied non-negative ratios in proportion to their magnitudes.
     /// </summary>
     /// <param name="ratios">The non-negative weights.</param>
-    /// <returns>The per-ratio allocation.</returns>
+    /// <returns>
+    /// The per-ratio allocation, whose sum equals this instance. Residual minor units are distributed by the
+    /// <i>largest-remainder method</i> — each slot receives one extra unit in descending order of its fractional
+    /// remainder, with ties broken by stable input order. Zero-ratio slots never receive residual.
+    /// </returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
     /// <exception cref="ArgumentException">The ratios are empty, contain a negative value, or sum to zero.</exception>
+    /// <exception cref="OverflowException">
+    /// The scaled minor-unit count exceeds the range of a 64-bit signed integer.
+    /// </exception>
     public Money[] Allocate(ReadOnlySpan<decimal> ratios)
     {
+        EnsureHasCurrency();
         FinancialThrowHelper.ThrowIfAllocationRatiosInvalid(ratios);
 
         var totalWeight = 0m;
@@ -53,41 +67,54 @@ public readonly partial struct Money
             totalWeight += ratios[i];
 
         var factor = MinorUnitFactor();
-        var minorTotal = decimal.ToInt64(_amount * factor);
+        var minorTotalSigned = decimal.ToInt64(_amount * factor);
+        long sign = minorTotalSigned >= 0 ? 1 : -1;
+        var minorTotal = Math.Abs(minorTotalSigned);
 
+        // Compute floored shares over absolute minor units; track each slot's fractional remainder so the
+        // residual can go to the slot with the largest remainder (Hamilton / largest-remainder method).
         var shares = new long[ratios.Length];
+        var remainders = new decimal[ratios.Length];
         long allocated = 0;
         for (var i = 0; i < ratios.Length; i++)
         {
-            var exactShare = minorTotal * ratios[i] / totalWeight;
-            var flooredShare = (long)decimal.Truncate(exactShare);
-            shares[i] = flooredShare;
-            allocated += flooredShare;
+            var exact = minorTotal * ratios[i] / totalWeight;
+            var floored = decimal.Truncate(exact);
+            shares[i] = (long)floored;
+            remainders[i] = exact - floored;
+            allocated += shares[i];
         }
 
         var residual = minorTotal - allocated;
-        long sign = residual >= 0 ? 1 : -1;
-        var residualMagnitude = Math.Abs(residual);
-
-        if (residualMagnitude > 0)
+        if (residual > 0)
         {
-            var cursor = 0;
-            long distributed = 0;
-            while (distributed < residualMagnitude)
-            {
-                if (ratios[cursor] > 0m)
-                {
-                    shares[cursor] += sign;
-                    distributed++;
-                }
+            // Sort indices by (descending remainder, ascending index) so ties fall back to stable input order.
+            var order = new int[ratios.Length];
+            for (var i = 0; i < ratios.Length; i++)
+                order[i] = i;
 
-                cursor = (cursor + 1) % ratios.Length;
+            var remaindersLocal = remainders;
+            Array.Sort(order, (a, b) =>
+            {
+                var cmp = remaindersLocal[b].CompareTo(remaindersLocal[a]);
+                return cmp != 0 ? cmp : a.CompareTo(b);
+            });
+
+            long distributed = 0;
+            for (var k = 0; k < order.Length && distributed < residual; k++)
+            {
+                var idx = order[k];
+                if (ratios[idx] <= 0m)
+                    continue;     // never give residual to a zero-ratio slot
+
+                shares[idx]++;
+                distributed++;
             }
         }
 
         var result = new Money[ratios.Length];
         for (var i = 0; i < ratios.Length; i++)
-            result[i] = WithAmount(shares[i] / factor);
+            result[i] = WithAmount(sign * shares[i] / factor);
 
         return result;
     }

--- a/Bodu.Financial/src/Financial/Money.OfTCurrency.cs
+++ b/Bodu.Financial/src/Financial/Money.OfTCurrency.cs
@@ -39,9 +39,10 @@ namespace Bodu.Financial;
 /// </para>
 /// <para>
 /// Scalar multiplication and division round their result to <c>TCurrency.MinorUnits</c>. For chains where rounding at
-/// each step would accumulate error — compound interest, unit-rate products, percentages — perform the calculation in
-/// <see cref="Bodu.Numerics.Fraction{T}" /> via <see cref="ToFraction" />, then snap to <see cref="Money{TCurrency}" />
-/// only at the final settlement boundary with
+/// each step would accumulate error — compound interest, unit-rate products, percentages — defer rounding: use
+/// <see cref="CalculatedMoney" /> for high-precision <see cref="decimal" /> calculation rounded once at settlement, or,
+/// when the calculation must be mathematically exact, perform it in <see cref="Bodu.Numerics.Fraction{T}" /> via
+/// <see cref="ToFraction" /> and snap to <see cref="Money{TCurrency}" /> only at the final settlement boundary with
 /// <see cref="FromFraction(Bodu.Numerics.Fraction{System.Numerics.BigInteger}, MidpointRounding)" /> or the
 /// <see cref="MultiplyExact(Bodu.Numerics.Fraction{System.Numerics.BigInteger}, MidpointRounding)" /> shortcut.
 /// </para>

--- a/Bodu.Financial/src/Financial/Money.Operators.cs
+++ b/Bodu.Financial/src/Financial/Money.Operators.cs
@@ -45,8 +45,10 @@ public readonly partial struct Money
     /// </summary>
     /// <param name="value">The amount to negate.</param>
     /// <returns>A <see cref="Money" /> with the same ISO code and negated amount.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="value" /> is a default-initialised, currency-less <see cref="Money" />.</exception>
     public static Money operator -(Money value)
     {
+        value.EnsureHasCurrency();
         return value.WithAmount(-value._amount);
     }
 
@@ -61,37 +63,122 @@ public readonly partial struct Money
     }
 
     /// <summary>
-    /// Multiplies a monetary value by a scalar, rounding to the currency's minor-unit precision.
+    /// Multiplies a monetary value by a scalar, rounding the product to the currency's minor-unit precision using
+    /// banker's rounding (<see cref="MidpointRounding.ToEven" />).
     /// </summary>
     /// <param name="left">The amount.</param>
     /// <param name="right">The scalar.</param>
-    /// <returns>The product.</returns>
+    /// <returns>The product, rounded to the currency's minor units using banker's rounding.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="left" /> is a default-initialised, currency-less <see cref="Money" />.</exception>
+    /// <remarks>
+    /// Use <see cref="Multiply(decimal, MidpointRounding)" /> when a rounding rule other than banker's rounding is
+    /// required; the operator cannot accept a rounding-mode parameter.
+    /// </remarks>
     public static Money operator *(Money left, decimal right)
     {
+        left.EnsureHasCurrency();
         return left.WithRoundedAmount(left._amount * right);
     }
 
     /// <summary>
-    /// Multiplies a scalar by a monetary value.
+    /// Multiplies a scalar by a monetary value, rounding the product to the currency's minor-unit precision using
+    /// banker's rounding (<see cref="MidpointRounding.ToEven" />).
     /// </summary>
     /// <param name="left">The scalar.</param>
     /// <param name="right">The amount.</param>
-    /// <returns>The product.</returns>
+    /// <returns>The product, rounded to the currency's minor units using banker's rounding.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="right" /> is a default-initialised, currency-less <see cref="Money" />.</exception>
+    /// <remarks>
+    /// Use <see cref="Multiply(decimal, MidpointRounding)" /> when a rounding rule other than banker's rounding is
+    /// required; the operator cannot accept a rounding-mode parameter.
+    /// </remarks>
     public static Money operator *(decimal left, Money right)
     {
+        right.EnsureHasCurrency();
         return right.WithRoundedAmount(left * right._amount);
     }
 
     /// <summary>
-    /// Divides a monetary value by a scalar.
+    /// Divides a monetary value by a scalar, rounding the quotient to the currency's minor-unit precision using
+    /// banker's rounding (<see cref="MidpointRounding.ToEven" />).
     /// </summary>
     /// <param name="left">The amount.</param>
     /// <param name="right">The scalar divisor.</param>
-    /// <returns>The quotient.</returns>
+    /// <returns>The quotient, rounded to the currency's minor units using banker's rounding.</returns>
+    /// <exception cref="InvalidOperationException"><paramref name="left" /> is a default-initialised, currency-less <see cref="Money" />.</exception>
     /// <exception cref="DivideByZeroException"><paramref name="right" /> is zero.</exception>
+    /// <remarks>
+    /// Use <see cref="Divide(decimal, MidpointRounding)" /> when a rounding rule other than banker's rounding is
+    /// required; the operator cannot accept a rounding-mode parameter.
+    /// </remarks>
     public static Money operator /(Money left, decimal right)
     {
+        left.EnsureHasCurrency();
         return left.WithRoundedAmount(left._amount / right);
+    }
+
+    /// <summary>
+    /// Multiplies this amount by <paramref name="multiplier" /> using banker's rounding, identical to the <c>*</c>
+    /// operator.
+    /// </summary>
+    /// <param name="multiplier">The scalar multiplier.</param>
+    /// <returns>The product, rounded to the currency's minor units using banker's rounding.</returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
+    public Money Multiply(decimal multiplier)
+    {
+        EnsureHasCurrency();
+        return WithRoundedAmount(_amount * multiplier);
+    }
+
+    /// <summary>
+    /// Multiplies this amount by <paramref name="multiplier" /> and rounds the result to the currency's minor-unit
+    /// precision using the supplied rule.
+    /// </summary>
+    /// <param name="multiplier">The scalar multiplier.</param>
+    /// <param name="rounding">The midpoint-rounding rule applied to the product.</param>
+    /// <returns>The product, rounded to the currency's minor units using <paramref name="rounding" />.</returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
+    /// <remarks>
+    /// Use this overload when a non-default rounding rule (for example, <see cref="MidpointRounding.AwayFromZero" />
+    /// for retail-tax workflows) must be applied. The <c>*</c> operator forces banker's rounding because operator
+    /// signatures cannot accept a rounding-mode parameter.
+    /// </remarks>
+    public Money Multiply(decimal multiplier, MidpointRounding rounding)
+    {
+        EnsureHasCurrency();
+        return WithRoundedAmount(_amount * multiplier, rounding);
+    }
+
+    /// <summary>
+    /// Divides this amount by <paramref name="divisor" /> using banker's rounding, identical to the <c>/</c> operator.
+    /// </summary>
+    /// <param name="divisor">The scalar divisor.</param>
+    /// <returns>The quotient, rounded to the currency's minor units using banker's rounding.</returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
+    /// <exception cref="DivideByZeroException"><paramref name="divisor" /> is zero.</exception>
+    public Money Divide(decimal divisor)
+    {
+        EnsureHasCurrency();
+        return WithRoundedAmount(_amount / divisor);
+    }
+
+    /// <summary>
+    /// Divides this amount by <paramref name="divisor" /> and rounds the result to the currency's minor-unit precision
+    /// using the supplied rule.
+    /// </summary>
+    /// <param name="divisor">The scalar divisor.</param>
+    /// <param name="rounding">The midpoint-rounding rule applied to the quotient.</param>
+    /// <returns>The quotient, rounded to the currency's minor units using <paramref name="rounding" />.</returns>
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
+    /// <exception cref="DivideByZeroException"><paramref name="divisor" /> is zero.</exception>
+    /// <remarks>
+    /// Use this overload when a non-default rounding rule must be applied. The <c>/</c> operator forces banker's
+    /// rounding because operator signatures cannot accept a rounding-mode parameter.
+    /// </remarks>
+    public Money Divide(decimal divisor, MidpointRounding rounding)
+    {
+        EnsureHasCurrency();
+        return WithRoundedAmount(_amount / divisor, rounding);
     }
 
     /// <summary>

--- a/Bodu.Financial/src/Financial/Money.Properties.cs
+++ b/Bodu.Financial/src/Financial/Money.Properties.cs
@@ -23,6 +23,32 @@ public readonly partial struct Money
         _isoCode ?? string.Empty;
 
     /// <summary>
+    /// Gets a value indicating whether this value is a default-initialised, currency-less <see cref="Money" />.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> when this value was produced by <c>default(Money)</c> and therefore carries no
+    /// currency; otherwise <see langword="false" />.
+    /// </returns>
+    /// <remarks>
+    /// A default-initialised <see cref="Money" /> is the unavoidable zero value of the struct, not a valid financial
+    /// zero. It carries no ISO code and is rejected by every arithmetic, allocation, and conversion operation; use
+    /// <see cref="Zero(string)" /> to obtain a usable zero for a specific currency. Equality, hashing, and formatting
+    /// remain safe to call so diagnostic surfaces do not throw.
+    /// </remarks>
+    public bool IsDefault =>
+        _isoCode is null;
+
+    /// <summary>
+    /// Gets a value indicating whether this value carries a currency and can participate in financial operations.
+    /// </summary>
+    /// <returns>
+    /// <see langword="true" /> when this value carries an ISO code; otherwise <see langword="false" /> for a
+    /// default-initialised value.
+    /// </returns>
+    public bool HasCurrency =>
+        _isoCode is not null;
+
+    /// <summary>
     /// Gets the minor-unit precision of this value.
     /// </summary>
     /// <returns>
@@ -74,8 +100,15 @@ public readonly partial struct Money
     /// Gets the absolute value of this amount.
     /// </summary>
     /// <returns>A <see cref="Money" /> with the same ISO code and a non-negative amount.</returns>
-    public Money Abs =>
-        WithAmount(Math.Abs(_amount));
+    /// <exception cref="InvalidOperationException">This value is a default-initialised, currency-less <see cref="Money" />.</exception>
+    public Money Abs
+    {
+        get
+        {
+            EnsureHasCurrency();
+            return WithAmount(Math.Abs(_amount));
+        }
+    }
 
     /// <summary>
     /// Returns a <see cref="Money" /> representing zero of the specified currency.
@@ -83,7 +116,10 @@ public readonly partial struct Money
     /// <param name="isoCode">The ISO 4217 code.</param>
     /// <returns>A zero <see cref="Money" /> in <paramref name="isoCode" />.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="isoCode" /> is <see langword="null" />.</exception>
-    /// <exception cref="ArgumentException"><paramref name="isoCode" /> is empty or whitespace.</exception>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="isoCode" /> is not exactly three uppercase ASCII letters, or is structurally valid but not
+    /// registered in <see cref="CurrencyRegistry" />.
+    /// </exception>
     public static Money Zero(string isoCode) =>
         new(0m, isoCode);
 }

--- a/Bodu.Financial/src/Financial/Money.cs
+++ b/Bodu.Financial/src/Financial/Money.cs
@@ -197,4 +197,28 @@ public readonly partial struct Money
     /// <returns>The updated <see cref="Money" />.</returns>
     private Money WithRoundedAmount(decimal amount) =>
         new(decimal.Round(amount, MinorUnits, MidpointRounding.ToEven), _isoCode, _explicitScalePlusOne);
+
+    /// <summary>
+    /// Returns a copy of this value with <paramref name="amount" /> rounded to this value's minor-unit precision using
+    /// the supplied <paramref name="rounding" /> rule, preserving the ISO code and any explicit scale.
+    /// </summary>
+    /// <param name="amount">The raw amount to round.</param>
+    /// <param name="rounding">The midpoint-rounding rule applied to <paramref name="amount" />.</param>
+    /// <returns>The updated <see cref="Money" />.</returns>
+    private Money WithRoundedAmount(decimal amount, MidpointRounding rounding) =>
+        new(decimal.Round(amount, MinorUnits, rounding), _isoCode, _explicitScalePlusOne);
+
+    /// <summary>
+    /// Throws when this value is a default-initialised, currency-less <see cref="Money" /> that must not participate in
+    /// a financial operation.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">This value carries no ISO code (a default-initialised <see cref="Money" />).</exception>
+    private void EnsureHasCurrency()
+    {
+        if (_isoCode is null)
+        {
+            throw new InvalidOperationException(
+                FinancialResourceStrings.Op_Invalid_MoneyRequiresCurrency);
+        }
+    }
 }

--- a/Bodu.Financial/test/Financial/CalculatedMoneyTests.cs
+++ b/Bodu.Financial/test/Financial/CalculatedMoneyTests.cs
@@ -133,4 +133,36 @@ public class CalculatedMoneyTests
         Assert.AreEqual(new CalculatedMoney(1.5m, "USD"), new CalculatedMoney(1.5m, "USD"));
         Assert.AreNotEqual(new CalculatedMoney(1.5m, "USD"), new CalculatedMoney(1.5m, "EUR"));
     }
+
+    /// <summary>
+    /// Verifies the documented settlement-versus-calculation distinction: a per-step <see cref="Money" /> chain rounds
+    /// at every operation and accumulates error, whereas the equivalent <see cref="CalculatedMoney" /> chain defers
+    /// rounding to a single settlement boundary and recovers the exact result. Splitting 10.00 USD into a third and
+    /// recombining yields 9.99 through <see cref="Money" /> but 10.00 through <see cref="CalculatedMoney" />.
+    /// </summary>
+    [TestMethod]
+    public void RoundToMoney_WhenChainDefersRounding_ShouldAvoidPerStepRoundingError()
+    {
+        Money perStep = Money.From(10.00m, "USD") * 0.3333m * 3m;
+
+        CalculatedMoney deferred = new Money(10.00m, "USD").ToCalculated() * 0.3333m * 3m;
+        Money settled = deferred.RoundToMoney();
+
+        Assert.AreEqual(9.99m, perStep.Amount);
+        Assert.AreEqual(10.00m, settled.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="CalculatedMoney" /> carries high-precision <see cref="decimal" /> rather than an exact
+    /// rational: one third stored and read back equals the 28-29 digit <see cref="decimal" /> quotient, not the exact
+    /// mathematical value (which would require the <c>Fraction</c>-based exact APIs).
+    /// </summary>
+    [TestMethod]
+    public void Amount_WhenStoringOneThird_ShouldBeDecimalPrecisionNotExactRational()
+    {
+        CalculatedMoney third = new CalculatedMoney(1m, "USD") / 3m;
+
+        Assert.AreEqual(1m / 3m, third.Amount);
+        Assert.AreNotEqual(1m, third.Amount * 3m);
+    }
 }

--- a/Bodu.Financial/test/Financial/MoneyTests.Allocation.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Allocation.cs
@@ -1,0 +1,152 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.Allocation.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that allocating ten cents into three equal shares distributes the residual to the leading shares and
+    /// sums to the original amount.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenTenCentsIntoThreeShares_ShouldSumToOriginal()
+    {
+        Money[] shares = Money.From(0.10m, "USD").Allocate(3);
+
+        Assert.AreEqual(3, shares.Length);
+        Assert.AreEqual(Money.From(0.04m, "USD"), shares[0]);
+        Assert.AreEqual(Money.From(0.03m, "USD"), shares[1]);
+        Assert.AreEqual(Money.From(0.03m, "USD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation awards residual minor units by largest fractional remainder rather than by input
+    /// order. With ratios <c>[3, 2, 2]</c> over ten cents the exact shares are <c>4.29, 2.86, 2.86</c>; the two largest
+    /// remainders belong to the second and third slots, so the result is <c>[0.04, 0.03, 0.03]</c> — not the
+    /// input-order result <c>[0.05, 0.03, 0.02]</c>.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenResidualFavoursLargerRemainders_ShouldUseLargestRemainderMethod()
+    {
+        Money[] shares = Money.From(0.10m, "USD").Allocate(new[] { 3m, 2m, 2m });
+
+        Assert.AreEqual(Money.From(0.04m, "USD"), shares[0]);
+        Assert.AreEqual(Money.From(0.03m, "USD"), shares[1]);
+        Assert.AreEqual(Money.From(0.03m, "USD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation breaks ties in fractional remainder by ascending input order, so the earlier slot
+    /// receives the residual when two remainders are equal.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenRemaindersTie_ShouldBreakTieByInputOrder()
+    {
+        Money[] shares = Money.From(0.05m, "USD").Allocate(new[] { 1m, 1m, 1m });
+
+        // Exact shares are 1.667 each; floored to [1,1,1], residual 2, all remainders equal => slots 0 and 1.
+        Assert.AreEqual(Money.From(0.02m, "USD"), shares[0]);
+        Assert.AreEqual(Money.From(0.02m, "USD"), shares[1]);
+        Assert.AreEqual(Money.From(0.01m, "USD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that a zero-weight slot never receives residual minor units.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenRatioIsZero_ShouldNotReceiveResidual()
+    {
+        Money[] shares = Money.From(0.10m, "USD").Allocate(new[] { 1m, 0m, 1m });
+
+        Assert.AreEqual(Money.From(0.05m, "USD"), shares[0]);
+        Assert.AreEqual(Money.From(0.00m, "USD"), shares[1]);
+        Assert.AreEqual(Money.From(0.05m, "USD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation of a negative amount preserves the sign and still sums to the original amount.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenAmountIsNegative_ShouldPreserveSignAndSum()
+    {
+        Money[] shares = Money.From(-0.10m, "USD").Allocate(new[] { 3m, 2m, 2m });
+
+        Assert.AreEqual(Money.From(-0.04m, "USD"), shares[0]);
+        Assert.AreEqual(Money.From(-0.03m, "USD"), shares[1]);
+        Assert.AreEqual(Money.From(-0.03m, "USD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation honours a zero-minor-unit currency, distributing whole major units by largest
+    /// remainder.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenCurrencyHasZeroMinorUnits_ShouldAllocateWholeUnits()
+    {
+        Money[] shares = Money.From(10m, "JPY").Allocate(new[] { 3m, 2m, 2m });
+
+        Assert.AreEqual(Money.From(4m, "JPY"), shares[0]);
+        Assert.AreEqual(Money.From(3m, "JPY"), shares[1]);
+        Assert.AreEqual(Money.From(3m, "JPY"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation honours a three-minor-unit currency, distributing the residual fils by largest
+    /// remainder.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenCurrencyHasThreeMinorUnits_ShouldAllocateThousandths()
+    {
+        Money[] shares = Money.From(0.010m, "BHD").Allocate(new[] { 3m, 2m, 2m });
+
+        Assert.AreEqual(Money.From(0.004m, "BHD"), shares[0]);
+        Assert.AreEqual(Money.From(0.003m, "BHD"), shares[1]);
+        Assert.AreEqual(Money.From(0.003m, "BHD"), shares[2]);
+    }
+
+    /// <summary>
+    /// Verifies that ratio allocation never places a share more than one minor unit away from its exact proportional
+    /// value, and that the shares sum to the original amount.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenUnevenRatios_ShouldStayWithinOneMinorUnitOfExactShare()
+    {
+        decimal[] ratios = { 17m, 5m, 3m, 11m, 1m };
+        Money original = Money.From(1.23m, "USD");
+
+        Money[] shares = original.Allocate(ratios);
+
+        decimal totalWeight = 0m;
+        foreach (decimal r in ratios)
+            totalWeight += r;
+
+        Money sum = Money.From(0m, "USD");
+        for (int i = 0; i < ratios.Length; i++)
+        {
+            sum += shares[i];
+            decimal exact = original.Amount * ratios[i] / totalWeight;
+            Assert.IsTrue(Math.Abs(shares[i].Amount - exact) <= 0.01m);
+        }
+
+        Assert.AreEqual(original, sum);
+    }
+
+    /// <summary>
+    /// Verifies that allocating an amount whose scaled minor-unit count exceeds the range of a 64-bit signed integer
+    /// throws <see cref="OverflowException" />.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenAmountExceedsInt64MinorUnits_ShouldThrowOverflowException()
+    {
+        Money huge = Money.From(100_000_000_000_000_000m, "USD");
+
+        _ = Assert.ThrowsExactly<OverflowException>(() =>
+        {
+            _ = huge.Allocate(new[] { 1m, 1m });
+        });
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyTests.Arithmetic.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Arithmetic.cs
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.Arithmetic.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that the <c>*</c> operator rounds the product to the currency's minor units using banker's rounding,
+    /// so a midpoint product (<c>0.125</c>) rounds to the even neighbour <c>0.12</c>.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenUsingOperator_ShouldRoundToEven()
+    {
+        Money result = Money.From(0.05m, "USD") * 2.5m;
+
+        Assert.AreEqual(0.12m, result.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Multiply(decimal, MidpointRounding)" /> honours the supplied rounding rule, so a
+    /// midpoint product rounds away from zero to <c>0.13</c> rather than to the even neighbour produced by the operator.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenRoundingAwayFromZero_ShouldRoundAwayFromZero()
+    {
+        Money result = Money.From(0.05m, "USD").Multiply(2.5m, MidpointRounding.AwayFromZero);
+
+        Assert.AreEqual(0.13m, result.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Multiply(decimal)" /> rounds with banker's rounding, matching the <c>*</c>
+    /// operator.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenNoRoundingMode_ShouldMatchOperator()
+    {
+        Money result = Money.From(0.05m, "USD").Multiply(2.5m);
+
+        Assert.AreEqual(0.12m, result.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Divide(decimal, MidpointRounding)" /> honours the supplied rounding rule, so a
+    /// midpoint quotient rounds away from zero to <c>0.13</c>.
+    /// </summary>
+    [TestMethod]
+    public void Divide_WhenRoundingAwayFromZero_ShouldRoundAwayFromZero()
+    {
+        Money result = Money.From(0.05m, "USD").Divide(0.4m, MidpointRounding.AwayFromZero);
+
+        Assert.AreEqual(0.13m, result.Amount);
+    }
+
+    /// <summary>
+    /// Verifies that the <c>/</c> operator rounds the quotient with banker's rounding, so a midpoint quotient rounds to
+    /// the even neighbour <c>0.12</c>.
+    /// </summary>
+    [TestMethod]
+    public void Divide_WhenUsingOperator_ShouldRoundToEven()
+    {
+        Money result = Money.From(0.05m, "USD") / 0.4m;
+
+        Assert.AreEqual(0.12m, result.Amount);
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyTests.Default.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Default.cs
@@ -1,0 +1,139 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.Default.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that a default-initialised <see cref="Money" /> reports <see cref="Money.IsDefault" /> as
+    /// <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void IsDefault_WhenDefaultInitialised_ShouldReturnTrue()
+    {
+        Money money = default;
+
+        Assert.IsTrue(money.IsDefault);
+        Assert.IsFalse(money.HasCurrency);
+    }
+
+    /// <summary>
+    /// Verifies that a constructed <see cref="Money" /> reports <see cref="Money.IsDefault" /> as
+    /// <see langword="false" /> and <see cref="Money.HasCurrency" /> as <see langword="true" />.
+    /// </summary>
+    [TestMethod]
+    public void IsDefault_WhenConstructed_ShouldReturnFalse()
+    {
+        Money money = Money.From(0m, "USD");
+
+        Assert.IsFalse(money.IsDefault);
+        Assert.IsTrue(money.HasCurrency);
+    }
+
+    /// <summary>
+    /// Verifies that multiplying a default-initialised, currency-less <see cref="Money" /> throws
+    /// <see cref="InvalidOperationException" /> rather than silently producing a currency-less value.
+    /// </summary>
+    [TestMethod]
+    public void Multiply_WhenDefault_ShouldThrowInvalidOperationException()
+    {
+        Money money = default;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = money * 2m;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that dividing a default-initialised, currency-less <see cref="Money" /> throws
+    /// <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Divide_WhenDefault_ShouldThrowInvalidOperationException()
+    {
+        Money money = default;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = money / 2m;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that negating a default-initialised, currency-less <see cref="Money" /> throws
+    /// <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Negate_WhenDefault_ShouldThrowInvalidOperationException()
+    {
+        Money money = default;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = -money;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that taking the absolute value of a default-initialised, currency-less <see cref="Money" /> throws
+    /// <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Abs_WhenDefault_ShouldThrowInvalidOperationException()
+    {
+        Money money = default;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = money.Abs;
+        });
+    }
+
+    /// <summary>
+    /// Verifies that allocating a default-initialised, currency-less <see cref="Money" /> throws
+    /// <see cref="InvalidOperationException" />.
+    /// </summary>
+    [TestMethod]
+    public void Allocate_WhenDefault_ShouldThrowInvalidOperationException()
+    {
+        Money money = default;
+
+        _ = Assert.ThrowsExactly<InvalidOperationException>(() =>
+        {
+            _ = money.Allocate(3);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that equality remains usable on default-initialised values: two defaults compare equal and neither
+    /// comparison throws.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenBothDefault_ShouldReturnTrue()
+    {
+        Money left = default;
+        Money right = default;
+
+        Assert.AreEqual(left, right);
+        Assert.IsTrue(left == right);
+    }
+
+    /// <summary>
+    /// Verifies that formatting a default-initialised value does not throw, so diagnostic surfaces (debugger, logging)
+    /// remain safe.
+    /// </summary>
+    [TestMethod]
+    public void ToString_WhenDefault_ShouldNotThrow()
+    {
+        Money money = default;
+
+        string text = money.ToString();
+
+        Assert.IsNotNull(text);
+    }
+}

--- a/Bodu.Financial/test/Financial/MoneyTests.Zero.cs
+++ b/Bodu.Financial/test/Financial/MoneyTests.Zero.cs
@@ -1,0 +1,72 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="MoneyTests.Zero.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Financial;
+
+public partial class MoneyTests
+{
+    /// <summary>
+    /// Verifies that <see cref="Money.Zero(string)" /> returns a zero amount carrying the supplied registered currency.
+    /// </summary>
+    [TestMethod]
+    public void Zero_WhenIsoCodeValid_ShouldReturnZeroForCurrency()
+    {
+        Money money = Money.Zero("USD");
+
+        Assert.AreEqual(0m, money.Amount);
+        Assert.AreEqual("USD", money.IsoCode);
+        Assert.IsTrue(money.HasCurrency);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Zero(string)" /> throws <see cref="ArgumentNullException" /> when the ISO code is
+    /// <see langword="null" />.
+    /// </summary>
+    [TestMethod]
+    public void Zero_WhenIsoCodeNull_ShouldThrowArgumentNullException()
+    {
+        _ = Assert.ThrowsExactly<ArgumentNullException>(() =>
+        {
+            _ = Money.Zero(null!);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Zero(string)" /> throws <see cref="ArgumentException" /> when the ISO code is not
+    /// exactly three uppercase ASCII letters, rather than only rejecting empty or whitespace input.
+    /// </summary>
+    /// <param name="isoCode">The malformed ISO code under test.</param>
+    [TestMethod]
+    [DataRow("")]
+    [DataRow("US")]
+    [DataRow("usd")]
+    [DataRow("US1")]
+    [DataRow("USDD")]
+    public void Zero_WhenIsoCodeWrongShape_ShouldThrowArgumentException(string isoCode)
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.Zero(isoCode);
+        });
+
+        Assert.AreEqual("isoCode", ex.ParamName);
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="Money.Zero(string)" /> throws <see cref="ArgumentException" /> when the ISO code is
+    /// structurally valid but is not registered in <see cref="CurrencyRegistry" />.
+    /// </summary>
+    [TestMethod]
+    public void Zero_WhenIsoCodeUnregistered_ShouldThrowArgumentException()
+    {
+        var ex = Assert.ThrowsExactly<ArgumentException>(() =>
+        {
+            _ = Money.Zero("QQQ");
+        });
+
+        Assert.AreEqual("isoCode", ex.ParamName);
+    }
+}


### PR DESCRIPTION
Acts on the valid findings from the architecture/source/test review;
each fix is preceded by a test that reproduces the issue.

- Allocation (Finding 3): runtime Money.Allocate(ratios) distributed the
  residual by input order, contradicting the documented largest-remainder
  method (the typed Money<TCurrency> form was already correct). Replace with
  the Hamilton/largest-remainder algorithm (abs minor units, sort by
  descending remainder then ascending index, skip zero-ratio slots, reapply
  sign). Document OverflowException on both runtime overloads (Finding 10).

- default(Money) (Finding 5): add IsDefault / HasCurrency and an
  EnsureHasCurrency guard so a currency-less default cannot silently flow
  through scalar *, /, unary -, Abs, or Allocate; equality, hashing and
  formatting stay safe. Reuses the existing Op_Invalid_MoneyRequiresCurrency
  resource.

- Rounding policy (Finding 9): add Money.Multiply/Divide(decimal) and
  (decimal, MidpointRounding) so callers can override the operators' banker's
  rounding; clarify the operator docs.

- Calculation model (Finding 4): document that CalculatedMoney is
  high-precision decimal with deferred rounding (not exact rational) and
  point exact-rational needs at the Fraction APIs; cross-reference from
  Money<TCurrency> and add a settlement-vs-calculation table to the README.

- Docs: correct the Money.Zero exception contract (Finding 12) and note
  ExchangeRateSeries.WithRate vs the builder for bulk mutation (Finding 11).

Findings 2 (MoneyValue) and 6 (GPL license) were not actioned: neither
exists in the repository. Findings 1 (JSON converter attributes) and 7
(folder layout) are intentional design, left unchanged.

https://claude.ai/code/session_01L2hGFRAk7v5HodPpKgZkpR