### PR TITLE
Resolve merge conflict in Money.cs and Money.Conversion.cs

### DIFF
--- a/Bodu.Financial/src/Financial/Money.Conversion.cs
+++ b/Bodu.Financial/src/Financial/Money.Conversion.cs
@@ -11,10 +11,6 @@ namespace Bodu.Financial;
 public readonly partial struct Money
 {
     /// <summary>
-<<<<<<< HEAD
-    /// Converts this <see cref="Money" /> to a strongly-typed <see cref="Money{TCurrency}" /> when the runtime currency
-    /// matches <typeparamref name="TCurrency" />.
-=======
     /// Returns a high-precision <see cref="CalculatedMoney" /> in the same currency, suitable for deferred-rounding
     /// calculation chains.
     /// </summary>
@@ -31,7 +27,6 @@ public readonly partial struct Money
     /// <summary>
     /// Converts this <see cref="Money" /> to a strongly-typed <see cref="Money{TCurrency}" /> when the runtime
     /// currency matches <typeparamref name="TCurrency" />.
->>>>>>> 066692f232b4d4e9e85dd58b3fc6144c4d8d78ff
     /// </summary>
     /// <typeparam name="TCurrency">The target currency type.</typeparam>
     /// <returns>The strongly-typed monetary value.</returns>

--- a/Bodu.Financial/src/Financial/Money.cs
+++ b/Bodu.Financial/src/Financial/Money.cs
@@ -57,10 +57,6 @@ public readonly partial struct Money
     private readonly string? _isoCode;
 
     /// <summary>
-<<<<<<< HEAD
-    /// Initializes a new instance of the <see cref="Money" /> struct from an amount and ISO 4217 code, rounding the
-    /// amount to the currency's minor-unit precision using banker's rounding.
-=======
     /// The explicit minor-unit scale plus one, or <c>0</c> when no explicit scale is associated and the precision is
     /// derived from <see cref="CurrencyRegistry" />.
     /// </summary>
@@ -74,7 +70,6 @@ public readonly partial struct Money
     /// <summary>
     /// Initializes a new instance of the <see cref="Money" /> struct from an amount and ISO 4217 code, rounding
     /// the amount to the currency's minor-unit precision using banker's rounding.
->>>>>>> 066692f232b4d4e9e85dd58b3fc6144c4d8d78ff
     /// </summary>
     /// <param name="amount">The monetary amount in the major unit.</param>
     /// <param name="isoCode">The ISO 4217 three-letter alphabetic code identifying the currency.</param>
@@ -164,13 +159,8 @@ public readonly partial struct Money
     }
 
     /// <summary>
-<<<<<<< HEAD
-    /// Initializes a new instance of the <see cref="Money" /> struct from an already-normalised amount and ISO code,
-    /// bypassing rounding.
-=======
     /// Initializes a new instance of the <see cref="Money" /> struct from pre-computed field values, bypassing
     /// validation and rounding.
->>>>>>> 066692f232b4d4e9e85dd58b3fc6144c4d8d78ff
     /// </summary>
     /// <param name="amount">The stored amount.</param>
     /// <param name="isoCode">The ISO 4217 code, or <see langword="null" /> for a currency-less value.</param>


### PR DESCRIPTION
## Summary

Resolves merge conflict markers in `Money.cs` and `Money.Conversion.cs` by accepting the incoming changes from the `066692f` commit. The conflict arose from concurrent modifications to XML documentation comments in the `Money` struct.

## Changes

- **Money.cs**: Removed conflicting documentation blocks and retained the cleaner, more precise XML doc comments for the internal constructor and validation helper method.
- **Money.Conversion.cs**: Removed conflicting documentation blocks and retained the XML doc comment for the `ToCalculated()` method conversion documentation.

## Details

The merge conflict involved overlapping edits to XML documentation in two files:
- Constructor documentation in `Money.cs` (lines 60–76)
- Internal constructor documentation in `Money.cs` (lines 162–168)  
- Conversion method documentation in `Money.Conversion.cs` (lines 14–34)

All conflict markers (`<<<<<<<`, `=======`, `>>>>>>>`) have been removed, and the codebase now uses the incoming branch's documentation style consistently.

https://claude.ai/code/session_01NT3ZLtzSRGm96FDsQiQu5i