### PR TITLE
Fix DocFX UidNotFound for renamed MoneyConversionResult generic

### DIFF
--- a/docs/apidoc/Bodu.Financial.md
+++ b/docs/apidoc/Bodu.Financial.md
@@ -38,7 +38,7 @@ Reach for this library when you need monetary arithmetic that the compiler valid
 - <xref:Bodu.Financial.ExchangeRateSeriesBuilder>, <xref:Bodu.Financial.ExchangeRateSeriesKey>, <xref:Bodu.Financial.ExchangeRateTableBuilder> — mutable companion for building or editing a series, the (pair, provider) key, and a higher-level multi-series editor for import workflows.
 - <xref:Bodu.Financial.ExchangeRateLookupOptions>, <xref:Bodu.Financial.ExchangeRateLookupResult>, <xref:Bodu.Financial.ExchangeRateDateResolution> — resolution policy options and the audit-grade lookup result.
 - <xref:Bodu.Financial.FixedExchangeRateTable>, <xref:Bodu.Financial.FixedDatedExchangeRateProvider>, <xref:Bodu.Financial.CompositeDatedExchangeRateProvider>, <xref:Bodu.Financial.DatedExchangeRateProviderAdapter> — in-memory provider implementations, a composite stack for prioritised fallback, and an adapter that pins a date to a dated provider for codebases that don't need the dated surface.
-- <xref:Bodu.Financial.MoneyConversionResult`2> — audit record bundling source and target money with the full lookup result.
+- <xref:Bodu.Financial.TypedMoneyConversionResult`2> — audit record bundling source and target money with the full lookup result.
 
 **Related namespaces**
 

--- a/docs/docs/financial/concepts.md
+++ b/docs/docs/financial/concepts.md
@@ -158,9 +158,9 @@ More elaborate cross-provider policies (such as preferring an exact-date hit fro
 
 <xref:Bodu.Financial.FixedDatedExchangeRateProvider> implements the dated <xref:Bodu.Financial.IDatedExchangeRateProvider> from a flat sequence of <xref:Bodu.Financial.ExchangeRate> observations grouped into one <xref:Bodu.Financial.ExchangeRateSeries> per pair. Each pair is described by exactly one series and therefore one provider, so composing rates from multiple publishing sources is done by stacking several tables behind a `CompositeDatedExchangeRateProvider` rather than mixing providers in a single table. Identity (same-currency) results carry the well-known `FixedDatedExchangeRateProvider.IdentityProviderName` label so audit consumers can filter by it.
 
-## `MoneyConversionResult<TSource, TTarget>`
+## `TypedMoneyConversionResult<TSource, TTarget>`
 
-<xref:Bodu.Financial.MoneyConversionResult`2> is the audit record returned by the `ConvertTo<TTarget>(IDatedExchangeRateProvider, …)` extension methods on `Money<T>`, `Money`, and `MoneyBag`. It bundles the original source amount, the rounded target amount, and the full <xref:Bodu.Financial.ExchangeRateLookupResult> that produced it — so the consumer sees both the answer and the provenance of the rate in a single value, without a second lookup.
+<xref:Bodu.Financial.TypedMoneyConversionResult`2> is the audit record returned by the `ConvertTo<TTarget>(IDatedExchangeRateProvider, …)` extension methods on `Money<T>`, `Money`, and `MoneyBag`. It bundles the original source amount, the rounded target amount, and the full <xref:Bodu.Financial.ExchangeRateLookupResult> that produced it — so the consumer sees both the answer and the provenance of the rate in a single value, without a second lookup.
 
 ## `MoneyBag`
 

--- a/docs/docs/financial/index.md
+++ b/docs/docs/financial/index.md
@@ -25,7 +25,7 @@ The package depends on `Bodu.Numerics` so `Money<TCurrency>` can round-trip thro
 | <xref:Bodu.Financial.ExchangeRateSeriesBuilder>, <xref:Bodu.Financial.ExchangeRateSeriesKey>, <xref:Bodu.Financial.ExchangeRateTableBuilder> | Mutable companion to `ExchangeRateSeries` for building or editing observations, the `(pair, provider)` key, and a higher-level multi-series editor for import workflows. |
 | <xref:Bodu.Financial.IExchangeRateProvider>, <xref:Bodu.Financial.IDatedExchangeRateProvider> | Timeless and dated provider contracts. The dated form returns an <xref:Bodu.Financial.ExchangeRateLookupResult> with provenance metadata (offset days, resolution policy, provider name). |
 | <xref:Bodu.Financial.FixedExchangeRateTable>, <xref:Bodu.Financial.FixedDatedExchangeRateProvider>, <xref:Bodu.Financial.CompositeDatedExchangeRateProvider> | In-memory provider implementations and a composite stack for prioritised fallback across multiple FX sources. |
-| <xref:Bodu.Financial.MoneyConversionResult`2> | Audit record returned by extension methods that convert through a dated provider — pairs source and target amount with the full lookup result. |
+| <xref:Bodu.Financial.TypedMoneyConversionResult`2> | Audit record returned by extension methods that convert through a dated provider — pairs source and target amount with the full lookup result. |
 
 ### `Bodu.Financial.Currencies`
 

--- a/docs/guides/financial/exchange-rates.md
+++ b/docs/guides/financial/exchange-rates.md
@@ -266,7 +266,7 @@ resolve the rate, apply it, and return either the converted amount
 ```csharp
 Money<USD> price = new(100m);
 
-MoneyConversionResult<USD, EUR> audited = price.ConvertToWithRate<USD, EUR>(
+TypedMoneyConversionResult<USD, EUR> audited = price.ConvertToWithRate<USD, EUR>(
     provider, new DateOnly(2024, 6, 15),
     ExchangeRateLookupOptions.PreviousWithin(3));
 
@@ -289,7 +289,7 @@ extension methods for runtime-tagged amounts. For bags, see
 | In-memory table where the date matters | `FixedDatedExchangeRateProvider` + `ExchangeRateLookupOptions.PreviousWithin(...)` |
 | Primary feed plus fallbacks | `CompositeDatedExchangeRateProvider` over multiple dated providers |
 | Reporting period that pins one date everywhere | `DatedExchangeRateProviderAdapter` over the period-end date |
-| Ledger entry that records the rate provenance | `Money<T>.ConvertToWithRate<,>(provider, date, options)` returning `MoneyConversionResult<,>` |
+| Ledger entry that records the rate provenance | `Money<T>.ConvertToWithRate<,>(provider, date, options)` returning `TypedMoneyConversionResult<,>` |
 | Runtime-tagged amount via a dated provider | `MoneyExchangeRateExtensions.ConvertToWithRate(...)` |
 | Aggregate-then-convert a bag with per-line provenance | `MoneyBag.ConvertToWithAudit<TTarget>(provider, date, options)` |
 | Build a new series imperatively, or merge incoming observations into an existing one | `ExchangeRateSeriesBuilder` + `Add` / `Upsert` / `AddRange` / `UpsertRange` |
@@ -303,4 +303,4 @@ extension methods for runtime-tagged amounts. For bags, see
 - Values — [`ExchangeRate`](xref:Bodu.Financial.ExchangeRate), [`ExchangeRatePair`](xref:Bodu.Financial.ExchangeRatePair), [`ExchangeRateObservation`](xref:Bodu.Financial.ExchangeRateObservation), [`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries)
 - Editing — [`ExchangeRateSeriesBuilder`](xref:Bodu.Financial.ExchangeRateSeriesBuilder), [`ExchangeRateSeriesKey`](xref:Bodu.Financial.ExchangeRateSeriesKey), [`ExchangeRateTableBuilder`](xref:Bodu.Financial.ExchangeRateTableBuilder), [`ExchangeRateBook`](xref:Bodu.Financial.ExchangeRateBook)
 - Providers — [`FixedExchangeRateTable`](xref:Bodu.Financial.FixedExchangeRateTable), [`FixedDatedExchangeRateProvider`](xref:Bodu.Financial.FixedDatedExchangeRateProvider), [`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider), [`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter)
-- Lookup metadata — [`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions), [`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult), [`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution), [`MoneyConversionResult<TSource, TTarget>`](xref:Bodu.Financial.MoneyConversionResult`2)
+- Lookup metadata — [`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions), [`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult), [`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution), [`TypedMoneyConversionResult<TSource, TTarget>`](xref:Bodu.Financial.TypedMoneyConversionResult`2)

--- a/docs/guides/financial/index.md
+++ b/docs/guides/financial/index.md
@@ -54,7 +54,7 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
 - [Working with exchange rates](exchange-rates.md) — the FX provider
   stack: timeless vs. dated contracts, the audit-grade
   `ExchangeRateLookupResult`, the composite fallback stack, the
-  `MoneyConversionResult<,>` audit record, and the
+  `TypedMoneyConversionResult<,>` audit record, and the
   `ExchangeRateSeriesBuilder` + `ExchangeRateTableBuilder` editing surface.
 
 ## See also


### PR DESCRIPTION
## Problem

The **Build and Publish DocFX Sites** workflow runs `docfx docs/docfx.json --warningsAsErrors` and is failing on `master` ([run 26855187393](https://github.com/bslater/bodu/actions/runs/26855187393/job/79196511702)) with 4 `UidNotFound` warnings — all the same invalid cross reference:

```
<xref:Bodu.Financial.MoneyConversionResult`2>
```

## Cause

The two-type-parameter audit record was renamed from `MoneyConversionResult<TSource, TTarget>` to **`TypedMoneyConversionResult<TSource, TTarget>`**. `MoneyConversionResult` now exists only as a *separate non-generic* `record struct`, so the arity-2 UID no longer resolves and DocFX can't build the xref.

## Fix

Point the four cross references at `Bodu.Financial.TypedMoneyConversionResult\`2` and bring the surrounding documentation in line with the current type name:

- `docs/apidoc/Bodu.Financial.md`, `docs/docs/financial/index.md`, `docs/docs/financial/concepts.md` (heading + xref), `docs/guides/financial/exchange-rates.md` (see-also xref) — the four UidNotFound sites.
- `docs/guides/financial/exchange-rates.md` — also corrected the worked example, which declared `MoneyConversionResult<USD, EUR>` for the result of `ConvertToWithRate<USD, EUR>(...)` (that overload returns `TypedMoneyConversionResult<,>`, and the example then reads `.SourceAmount` / `.TargetAmount` / `.ExchangeRate`, which are `TypedMoneyConversionResult`'s members) — so it would not have compiled.
- `docs/guides/financial/index.md` — prose mention of the audit record.

The bare `MoneyConversionResult` reference in `docs/images/diagrams/financial-namespace-map.svg` is intentionally left unchanged: it refers to the still-existing non-generic type.

## Verification

`TypedMoneyConversionResult<TSource, TTarget>` is a public `readonly record struct`, so the UID `Bodu.Financial.TypedMoneyConversionResult\`2` resolves. A repo-wide sweep confirms no bare (non-`Typed`) `MoneyConversionResult\`2` xref remains. These were the only DocFX warnings reported, so the site build should pass under `--warningsAsErrors`.

https://claude.ai/code/session_01C63JspkbGgoGDp64nCHU63

---
_Generated by [Claude Code](https://claude.ai/code/session_01C63JspkbGgoGDp64nCHU63)_