### PR TITLE
docs: fix double-escaped generics in DocFX TOC titles

### DIFF
--- a/.github/workflows/docfx-build-publish.yml
+++ b/.github/workflows/docfx-build-publish.yml
@@ -51,6 +51,12 @@ jobs:
           grep -rEn 'Standard, PureIni|"PureIni"|`PureIni`' docs/ --include='*.md'
           exit 1
         fi
+        echo "Checking for HTML-escaped characters in TOC/YAML files (use raw < > & instead)..."
+        if grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml' >/dev/null; then
+          echo "::error::Found HTML entities in docs/*.yml. DocFX HTML-encodes TOC 'name:' values, so pre-escaped entities are double-encoded and render literally (e.g. Fraction<T> shows as Fraction&lt;T&gt;). Use raw < > & characters."
+          grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml'
+          exit 1
+        fi
         echo "All content audits passed."
 
     - name: Validate generated API output

--- a/docs/guides/financial/toc.yml
+++ b/docs/guides/financial/toc.yml
@@ -1,6 +1,6 @@
 - name: Overview
   href: index.md
-- name: Working with Money&lt;TCurrency&gt;
+- name: Working with Money<TCurrency>
   href: money.md
 - name: Working with exchange rates
   href: exchange-rates.md

--- a/docs/guides/numerics/toc.yml
+++ b/docs/guides/numerics/toc.yml
@@ -1,8 +1,8 @@
 - name: Overview
   href: index.md
-- name: Working with Fraction&lt;T&gt;
+- name: Working with Fraction<T>
   href: fraction.md
-- name: Formatting and parsing Fraction&lt;T&gt;
+- name: Formatting and parsing Fraction<T>
   href: formatting-and-parsing.md
-- name: Working with Interval&lt;T&gt;
+- name: Working with Interval<T>
   href: interval.md

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -141,16 +141,16 @@
   items:
     - name: Overview
       href: numerics/index.md
-    - name: Working with Fraction&lt;T&gt;
+    - name: Working with Fraction<T>
       href: numerics/fraction.md
-    - name: Working with Interval&lt;T&gt;
+    - name: Working with Interval<T>
       href: numerics/interval.md
 - name: Bodu.Financial
   href: financial/
   items:
     - name: Overview
       href: financial/index.md
-    - name: Working with Money&lt;TCurrency&gt;
+    - name: Working with Money<TCurrency>
       href: financial/money.md
 - name: Bodu.Text.Encoding
   href: text-encoding/


### PR DESCRIPTION
TOC name fields used HTML entities (&lt;T&gt;) instead of raw angle
brackets. DocFX HTML-encodes name values when rendering navigation, so
the pre-escaped entities became &amp;lt;T&amp;gt; and displayed
literally as <T> on the published pages.

Use the raw characters (Fraction<T>, Interval<T>, Money<TCurrency>) so
DocFX encodes them exactly once, matching the page frontmatter titles
and headings which already use raw angle brackets.

https://claude.ai/code/session_01SRunDYAPtRZqjAowuiqVCy