### PR TITLE
docs(financial): add exchange-type usage catalogue and worked lookup-option guide

### DIFF
--- a/docs/guides/financial/exchange-rate-lookups.md
+++ b/docs/guides/financial/exchange-rate-lookups.md
@@ -1,0 +1,363 @@
+---
+title: Exchange-rate lookups on a known dataset
+---
+
+# Exchange-rate lookups on a known dataset
+
+A dated exchange-rate lookup rarely lands on the exact date you ask
+for. Markets close on weekends and holidays, feeds skip days, and
+accounting periods end on dates no rate was ever published for.
+[`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions)
+is the single knob that decides *what happens on a miss* — which
+neighbouring observation (if any) answers the request, and how far
+the lookup is allowed to reach.
+
+This page pins one small dataset and walks the **same requests**
+through **every option**, so you can see exactly how each setting
+changes the result. For the narrative tour of the provider stack, see
+[Working with exchange rates](exchange-rates.md); for the type-by-type
+"which one do I reach for" catalogue, see
+[Exchange-rate types](exchange-types.md).
+
+## The dataset
+
+Four `USD → EUR` observations from one provider (`"ECB"`), with two
+deliberate gaps — a four-day gap that brackets a weekend, and a
+three-day gap at the end:
+
+| # | Date | Weekday | Rate |
+|---|---|---|---|
+| 0 | `2024-06-10` | Monday | `0.9250` |
+| 1 | `2024-06-14` | Friday | `0.9280` |
+| 2 | `2024-06-18` | Tuesday | `0.9300` |
+| 3 | `2024-06-21` | Friday | `0.9330` |
+
+```csharp
+using Bodu.Financial;
+
+ExchangeRate[] observations =
+{
+    new("USD", "EUR", new DateOnly(2024, 6, 10), 0.9250m, "ECB"),
+    new("USD", "EUR", new DateOnly(2024, 6, 14), 0.9280m, "ECB"),
+    new("USD", "EUR", new DateOnly(2024, 6, 18), 0.9300m, "ECB"),
+    new("USD", "EUR", new DateOnly(2024, 6, 21), 0.9330m, "ECB"),
+};
+
+FixedDatedExchangeRateProvider provider = new(observations);
+```
+
+Every example below calls
+[`provider.TryGetRate(...)`](xref:Bodu.Financial.IDatedExchangeRateProvider)
+or its throwing sibling
+[`GetRate(...)`](xref:Bodu.Financial.IDatedExchangeRateProvider).
+A successful call returns an
+[`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult);
+a miss either returns `false` (`TryGetRate`) or throws
+`KeyNotFoundException` (`GetRate`).
+
+## How resolution works in one paragraph
+
+A lookup first does a binary search for the **exact** requested date.
+On a hit it returns immediately — the policy and tolerance are never
+consulted. On a miss it identifies the two bracketing observations
+(`previous` = the nearest earlier date, `next` = the nearest later
+date), the
+[`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution)
+policy picks one of them (or neither), and *finally* the chosen
+candidate's distance from the requested date is compared against
+`ToleranceDays`. If the candidate is farther than the tolerance, the
+lookup fails. The tolerance is checked **after** selection — a policy
+never switches to the other side because its first choice was out of
+range.
+
+## The six date-resolution policies
+
+[`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution)
+has six members. The four common shapes have static factories on
+[`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions);
+the two strict-`Nearest` variants are reached by constructing the
+options directly.
+
+| Policy | Factory | On a miss it selects… |
+|---|---|---|
+| `Exact` | `ExchangeRateLookupOptions.Exact` | nothing — exact date or fail. |
+| `PreviousOnOrBefore` | `PreviousWithin(days)` | the nearest **earlier** observation. |
+| `NextOnOrAfter` | `NextWithin(days)` | the nearest **later** observation. |
+| `Nearest` | *(construct directly)* | the closer of the two; an exact tie **fails**. |
+| `NearestPreferPrevious` | `NearestWithin(days)` | the closer of the two; a tie picks the **earlier**. |
+| `NearestPreferNext` | *(construct directly)* | the closer of the two; a tie picks the **later**. |
+
+```csharp
+// The four factories (tolerance window in days):
+ExchangeRateLookupOptions.Exact;            // exact date only
+ExchangeRateLookupOptions.PreviousWithin(7);
+ExchangeRateLookupOptions.NextWithin(7);
+ExchangeRateLookupOptions.NearestWithin(7); // == NearestPreferPrevious
+
+// The two strict-Nearest variants, constructed directly:
+new ExchangeRateLookupOptions(ExchangeRateDateResolution.Nearest, toleranceDays: 7);
+new ExchangeRateLookupOptions(ExchangeRateDateResolution.NearestPreferNext, toleranceDays: 7);
+```
+
+> [!NOTE]
+> `Exact` requires `ToleranceDays == 0` — a non-zero tolerance with
+> `Exact` throws `ArgumentException` from
+> [`ExchangeRateLookupOptions.Validate()`](xref:Bodu.Financial.ExchangeRateLookupOptions).
+> The factories enforce this for you.
+
+## The results matrix
+
+Five requested dates against the dataset, each run through all six
+policies with a tolerance wide enough not to interfere (`7` days). A
+cell shows the **resolved observation → rate**; `—` means the lookup
+fails (returns `false` / throws).
+
+| Requested date | `Exact` | `PreviousOnOrBefore` | `NextOnOrAfter` | `Nearest` | `NearestPreferPrevious` | `NearestPreferNext` |
+|---|---|---|---|---|---|---|
+| **`06-14`** Fri — exact hit | `06-14` → `0.9280` | `06-14` → `0.9280` | `06-14` → `0.9280` | `06-14` → `0.9280` | `06-14` → `0.9280` | `06-14` → `0.9280` |
+| **`06-15`** Sat — prev 1d / next 3d | — | `06-14` → `0.9280` | `06-18` → `0.9300` | `06-14` → `0.9280` | `06-14` → `0.9280` | `06-14` → `0.9280` |
+| **`06-16`** Sun — tie 2d / 2d | — | `06-14` → `0.9280` | `06-18` → `0.9300` | **—** *(tie)* | `06-14` → `0.9280` | `06-18` → `0.9300` |
+| **`06-08`** Sat — before first | — | **—** *(no earlier)* | `06-10` → `0.9250` | `06-10` → `0.9250` | `06-10` → `0.9250` | `06-10` → `0.9250` |
+| **`06-25`** Tue — after last | — | `06-21` → `0.9330` | **—** *(no later)* | `06-21` → `0.9330` | `06-21` → `0.9330` | `06-21` → `0.9330` |
+
+Three rows carry the whole lesson:
+
+- **`06-15`** sits closer to the earlier observation (1 day vs 3). All
+  three `Nearest*` policies therefore land on `06-14` — when the two
+  sides are *unequal*, the preference is irrelevant and the genuinely
+  closer date always wins.
+- **`06-16`** is the exact midpoint of the four-day gap. This is the
+  only place the three `Nearest*` policies diverge: plain `Nearest`
+  refuses to guess and **fails**, `NearestPreferPrevious` takes the
+  earlier rate, `NearestPreferNext` takes the later one.
+- **`06-08`** and **`06-25`** fall outside the data on either end. A
+  one-directional policy has nothing to select and fails;
+  `PreviousOnOrBefore` cannot reach forward to the first observation,
+  and `NextOnOrAfter` cannot reach back to the last.
+
+### Reading it from the result object
+
+The matrix is just the resolved date and rate; the
+[`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult)
+carries the rest of the story so an audit trail never has to recompute
+it:
+
+```csharp
+ExchangeRateLookupResult r = provider.GetRate(
+    "USD", "EUR",
+    new DateOnly(2024, 6, 15),                  // Saturday — no observation
+    ExchangeRateLookupOptions.PreviousWithin(7));
+
+r.Rate.Rate;          // 0.9280m
+r.ResolvedDate;       // 2024-06-14   (== r.Rate.Date)
+r.RequestedDate;      // 2024-06-15
+r.Resolution;         // PreviousOnOrBefore
+r.OffsetDays;         // 1            (absolute distance)
+r.SignedOffsetDays;   // -1           (negative => resolved date is earlier)
+r.IsExactDate;        // false
+r.IsPreviousDate;     // true
+r.IsFutureDate;       // false
+r.Rate.Provider;      // "ECB"
+r.Rate.IsInverted;    // false
+```
+
+`SignedOffsetDays` (and the `IsPreviousDate` / `IsFutureDate` flags)
+let accounting and tax workflows distinguish a *historical* fallback
+from a *forward-looking* one — often a policy requirement, and the
+reason `PreviousWithin` is the usual choice for ledger postings.
+
+## Tolerance: how far the reach extends
+
+`ToleranceDays` is the maximum distance, in days, the *selected*
+candidate may sit from the requested date. It is applied after the
+policy chooses, so it only ever **shrinks** the matrix above — it never
+changes *which* side is picked, only whether that pick is accepted.
+
+Request `06-16` (the tie midpoint, 2 days from either neighbour):
+
+| Options | Selected candidate | Distance | Result |
+|---|---|---|---|
+| `PreviousWithin(1)` | `06-14` | 2 | **—** (2 > 1) |
+| `PreviousWithin(2)` | `06-14` | 2 | `06-14` → `0.9280` |
+| `NearestWithin(1)` | `06-14` (tie → earlier) | 2 | **—** (2 > 1) |
+| `NearestWithin(2)` | `06-14` (tie → earlier) | 2 | `06-14` → `0.9280` |
+
+```csharp
+var tight = provider.TryGetRate(
+    "USD", "EUR", new DateOnly(2024, 6, 16),
+    ExchangeRateLookupOptions.PreviousWithin(1), out _);   // false — 2 days > 1
+
+var ok = provider.TryGetRate(
+    "USD", "EUR", new DateOnly(2024, 6, 16),
+    ExchangeRateLookupOptions.PreviousWithin(2), out var hit); // true
+// hit.Rate.Rate == 0.9280m, hit.OffsetDays == 2
+```
+
+### Tolerance does not let a policy switch sides
+
+This is the subtlety worth internalising. Request `06-13` (Thursday):
+it is **3 days** after the `06-10` observation but only **1 day**
+before `06-14`.
+
+```csharp
+// PreviousOnOrBefore selects 06-10 (distance 3) and never looks forward.
+provider.TryGetRate(
+    "USD", "EUR", new DateOnly(2024, 6, 13),
+    ExchangeRateLookupOptions.PreviousWithin(2), out _);   // false — 3 > 2
+
+// Nearest picks the genuinely closer 06-14 (distance 1) and fits easily.
+provider.TryGetRate(
+    "USD", "EUR", new DateOnly(2024, 6, 13),
+    ExchangeRateLookupOptions.NearestWithin(2), out var near); // true
+// near.ResolvedDate == 2024-06-14, near.OffsetDays == 1
+```
+
+`PreviousWithin(2)` fails even though a rate sits one day away —
+because `PreviousOnOrBefore` is a *directional* policy that committed
+to the earlier side before the tolerance was checked. If "closest
+within N days, either direction" is what you mean, use
+`NearestWithin(N)`.
+
+## Inverse fallback: a direction switch, not a date switch
+
+`AllowInverse` (default `true`) lets a lookup answer a pair it has no
+data for by consulting the **reverse** pair and returning the
+reciprocal. The dataset holds only `USD → EUR`, so a `EUR → USD`
+request succeeds only through the inverse:
+
+```csharp
+var r = provider.GetRate(
+    "EUR", "USD", new DateOnly(2024, 6, 14),
+    ExchangeRateLookupOptions.Exact);
+
+r.Rate.Rate;        // 1m / 0.9280m  ≈ 1.07758621
+r.Rate.FromIsoCode; // "EUR"
+r.Rate.ToIsoCode;   // "USD"
+r.Rate.IsInverted;  // true   — derived from the reverse pair
+r.Rate.Provider;    // "ECB"
+r.OffsetDays;       // 0      — date resolution still ran on the USD/EUR series
+
+// Turn it off and the same request fails:
+var found = provider.TryGetRate(
+    "EUR", "USD", new DateOnly(2024, 6, 14),
+    new ExchangeRateLookupOptions(ExchangeRateDateResolution.Exact, allowInverse: false),
+    out _);                                                  // false
+```
+
+Two points decide how this composes with the date policy:
+
+- The inverse is consulted **only after the direct pair has fully
+  failed**, including its own date-resolution and tolerance. It is a
+  fallback in the *direction* dimension, not a second date search.
+- Date resolution and tolerance still apply, but to whichever series
+  actually holds the data. Here `06-14` exists on the `USD/EUR`
+  series, so even `Exact` succeeds and reports `OffsetDays == 0`,
+  flagging only `IsInverted == true`.
+
+## Identity short-circuit: same-currency requests
+
+`AllowSameCurrencyIdentityRate` (default `true`) makes a lookup whose
+source and destination codes are equal return a synthetic rate of `1`
+**before** any table is consulted — so it succeeds even for a pair the
+provider has never seen:
+
+```csharp
+var r = provider.GetRate(
+    "USD", "USD", new DateOnly(2024, 6, 16),                 // a gap date — irrelevant
+    ExchangeRateLookupOptions.Exact);
+
+r.Rate.Rate;      // 1m
+r.Rate.Provider;  // "Identity"  (== FixedDatedExchangeRateProvider.IdentityProviderName)
+r.OffsetDays;     // 0
+r.IsExactDate;    // true
+```
+
+The well-known provider label `"Identity"` lets an audit consumer
+filter out pass-throughs without a magic string. Turn the flag off
+(`allowSameCurrencyIdentityRate: false`) and a `USD → USD` request
+falls through to the table like any other — failing unless a literal
+same-currency series was loaded.
+
+## Stacking providers: the composite
+
+[`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider)
+applies the *same* `ExchangeRateLookupOptions` to an ordered list of
+providers and returns the **first** success. The lookup options decide
+the date behaviour within each provider; the composite decides the
+order they are tried.
+
+```csharp
+CompositeDatedExchangeRateProvider stack = new(new IDatedExchangeRateProvider[]
+{
+    primaryEcbFeed,        // tried first
+    backupOandaFeed,       // tried only if the primary misses
+    lastKnownGoodTable,    // final fallback
+});
+
+ExchangeRateLookupResult r = stack.GetRate(
+    "USD", "GBP", new DateOnly(2024, 6, 15),
+    ExchangeRateLookupOptions.PreviousWithin(7));
+
+r.Rate.Provider;   // identifies which underlying provider answered
+```
+
+The selection is **first-available**, not best-available: if the
+primary returns a four-day-old `PreviousOnOrBefore` hit, that wins even
+when a lower-priority provider has the exact date. The
+[`ExchangeRateProviderSelectionPolicy`](xref:Bodu.Financial.ExchangeRateProviderSelectionPolicy)
+enum names the alternative strategies (exact-before-fallback,
+smallest-offset-first), but only `ProviderPriorityFirst` is
+implemented in v1.0 — the others throw `NotSupportedException` so the
+intent is expressible without yet being silently approximated.
+
+## Pinning one date everywhere: the adapter
+
+When a consumer only accepts the timeless
+[`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider)
+surface — for example
+[`MoneyBag.ConvertTo<TTarget>(IExchangeRateProvider)`](xref:Bodu.Financial.MoneyBag) —
+but the rate should still come from a dated source resolved with a
+fixed policy,
+[`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter)
+pins the date and options once:
+
+```csharp
+IExchangeRateProvider periodEnd = new DatedExchangeRateProviderAdapter(
+    inner:   provider,
+    date:    new DateOnly(2024, 6, 30),                       // reporting period end
+    options: ExchangeRateLookupOptions.PreviousWithin(14));
+
+decimal rate = periodEnd.GetRate("USD", "EUR");              // 0.9330 — 06-21, 9 days before 06-30
+```
+
+Every `GetRate(from, to)` call now resolves against `2024-06-30` under
+`PreviousWithin(14)` — the window has to span the nine-day gap back to
+the last observation (`06-21`), a reminder that the pinned tolerance
+must be sized for the worst expected gap. The adapter returns only the
+raw `decimal` — when
+you need the provenance (which date, how far off, which provider), call
+the dated provider directly and read the
+[`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult).
+
+## Choosing the option for the job
+
+| Workflow | Options | Why |
+|---|---|---|
+| Strict reconciliation; missing data is an error | `Exact` | Fails fast rather than substituting a neighbour. |
+| Ledger posting, tax report, period-end valuation | `PreviousWithin(n)` | Never selects a *future* rate; `SignedOffsetDays` stays ≤ 0. |
+| Forward pricing / earliest-available quote | `NextWithin(n)` | Reaches forward to the next published rate. |
+| General "closest rate within a window" | `NearestWithin(n)` | Closest either way; ties resolve to the earlier date. |
+| Closest, but ties must favour the newer rate | `new(NearestPreferNext, n)` | Same as above, tie-break reversed. |
+| Closest, but a tie must be a hard error | `new(Nearest, n)` | Refuses to guess at an exact midpoint. |
+| One currency converting to itself | leave `AllowSameCurrencyIdentityRate` on | Returns `1` tagged `"Identity"` without table data. |
+| Only forward-direction pairs are stored | leave `AllowInverse` on | Reverse requests answered via the reciprocal. |
+
+## See also
+
+- [Working with exchange rates](exchange-rates.md) — the full provider-stack walkthrough.
+- [Exchange-rate types](exchange-types.md) — which exchange type to reach for, by scenario.
+- [Bodu.Financial — Core concepts](../../docs/financial/concepts.md) — the vocabulary these pages assume.
+- Lookup metadata — [`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions), [`ExchangeRateDateResolution`](xref:Bodu.Financial.ExchangeRateDateResolution), [`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult).
+- Providers — [`FixedDatedExchangeRateProvider`](xref:Bodu.Financial.FixedDatedExchangeRateProvider), [`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider), [`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter).
+</content>
+</invoke>

--- a/docs/guides/financial/exchange-rates.md
+++ b/docs/guides/financial/exchange-rates.md
@@ -24,7 +24,12 @@ reports, and multi-source feeds that carry their provenance.
 - **Lookup result** — `ExchangeRateLookupResult` carries the rate, requested date, resolution policy, and offset-day distance.
 
 See the [core concepts page](../../docs/financial/concepts.md) for
-the long-form treatment of every `ExchangeRateDateResolution` policy.
+the long-form treatment of every `ExchangeRateDateResolution` policy,
+the [exchange-rate types catalogue](exchange-types.md) for a
+scenario-driven map of every type below, and
+[Exchange-rate lookups on a known dataset](exchange-rate-lookups.md)
+for a worked results matrix showing how each lookup option changes the
+answer.
 
 ## A minimal in-memory provider
 

--- a/docs/guides/financial/exchange-types.md
+++ b/docs/guides/financial/exchange-types.md
@@ -1,0 +1,312 @@
+---
+title: Exchange-rate types — a usage-scenario catalogue
+---
+
+# Exchange-rate types — a usage-scenario catalogue
+
+`Bodu.Financial` ships roughly a dozen foreign-exchange types. They are
+not interchangeable layers of the same idea — each one exists for a
+specific job, and the fastest way to use the library well is to start
+from *the scenario you are in* and let it point at the type. This page
+is that map. For the conversion mechanics and the lookup-option
+behaviour, see [Working with exchange rates](exchange-rates.md) and
+[Exchange-rate lookups on a known dataset](exchange-rate-lookups.md).
+
+## The one-line map
+
+| You have / want… | Reach for | Kind |
+|---|---|---|
+| A single observed rate to pass around | [`ExchangeRate`](xref:Bodu.Financial.ExchangeRate) | value (record struct) |
+| A direction-typed rate checked at compile time | [`ExchangeRate<TBase, TQuote>`](xref:Bodu.Financial.ExchangeRate`2) | value (struct) |
+| A `(from, to)` dictionary key | [`ExchangeRatePair`](xref:Bodu.Financial.ExchangeRatePair) | value (record struct) |
+| A bare `(date, rate)` point | [`ExchangeRateObservation`](xref:Bodu.Financial.ExchangeRateObservation) | value (record struct) |
+| Every dated rate for one pair + provider | [`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries) | immutable store |
+| To build or edit a series imperatively | [`ExchangeRateSeriesBuilder`](xref:Bodu.Financial.ExchangeRateSeriesBuilder) | mutable builder |
+| A pair + provider key for many series | [`ExchangeRateSeriesKey`](xref:Bodu.Financial.ExchangeRateSeriesKey) | value (record struct) |
+| Many series in one immutable store | [`ExchangeRateBook`](xref:Bodu.Financial.ExchangeRateBook) | immutable store |
+| To import across many pairs/providers | [`ExchangeRateTableBuilder`](xref:Bodu.Financial.ExchangeRateTableBuilder) | mutable builder |
+| A "current rate" lookup, no dates | [`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider) + [`FixedExchangeRateTable`](xref:Bodu.Financial.FixedExchangeRateTable) | contract + impl |
+| A dated lookup with audit metadata | [`IDatedExchangeRateProvider`](xref:Bodu.Financial.IDatedExchangeRateProvider) + [`FixedDatedExchangeRateProvider`](xref:Bodu.Financial.FixedDatedExchangeRateProvider) | contract + impl |
+| A primary feed with fallbacks | [`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider) | composite |
+| To expose a dated source as timeless | [`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter) | adapter |
+| The rules applied on a date miss | [`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions) | options |
+| The outcome of a dated lookup | [`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult) | value (record struct) |
+| A converted amount + its rate provenance | [`TypedMoneyConversionResult<,>`](xref:Bodu.Financial.TypedMoneyConversionResult`2) | value (record struct) |
+
+The rest of this page groups these by the role they play.
+
+## Rate values — the things you observe and pass
+
+### `ExchangeRate` — the runtime observation
+
+[`ExchangeRate`](xref:Bodu.Financial.ExchangeRate) is the immutable
+record struct every provider returns: source ISO, destination ISO,
+observation date, a strictly-positive multiplier, the publishing
+provider's name, and an `IsInverted` flag. **Reach for it** whenever
+the direction is *data* — bank feeds, broker exports, a flat list of
+quotes to load into a provider. It deliberately does **not** round;
+the destination currency's minor-unit precision is applied only when
+the rate meets a `Money` at the conversion boundary.
+
+```csharp
+var rate = new ExchangeRate("USD", "EUR", new DateOnly(2024, 6, 14), 0.928m, "ECB");
+decimal eurAmount = rate.Convert(100m);   // 92.80 — unrounded
+```
+
+### `ExchangeRate<TBase, TQuote>` — the compile-time-typed rate
+
+When a contract, desk, or account is pinned to one specific direction,
+[`ExchangeRate<TBase, TQuote>`](xref:Bodu.Financial.ExchangeRate`2)
+encodes the direction in the type parameters. Applying it the wrong
+way round, or to the wrong currency, is a **build error** rather than a
+runtime surprise. **Reach for it** for `Money<TCurrency>` conversions
+where both ends are known at the call site.
+
+```csharp
+var typed = new ExchangeRate<USD, EUR>(0.928m, new DateOnly(2024, 6, 14), "ECB");
+Money<EUR> eur = Money.Of<USD>(100m).Convert(typed);   // typed Convert overload
+ExchangeRate<EUR, USD> reverse = typed.Inverse();      // reciprocal, still typed
+
+// Bridge to/from the runtime form:
+ExchangeRate runtime = typed.ToRuntime();
+var back = ExchangeRate<USD, EUR>.FromRuntime(runtime); // throws on ISO mismatch
+```
+
+### `ExchangeRatePair` — the directional key
+
+[`ExchangeRatePair`](xref:Bodu.Financial.ExchangeRatePair) is an
+immutable `(FromIsoCode, ToIsoCode)` record struct that validates both
+codes at construction and exposes `Inverse()`. **Reach for it** instead
+of a `(string, string)` tuple anywhere a currency direction is used as
+a dictionary key or method argument — the named fields make the
+direction unambiguous and centralise ISO validation.
+
+### `ExchangeRateObservation` — the bare data point
+
+[`ExchangeRateObservation`](xref:Bodu.Financial.ExchangeRateObservation)
+is the lightweight `(Date, Rate)` carrier used for series enumeration,
+builder mutation, and bulk import. It carries **no** provider or
+inversion metadata — those belong to the enclosing series — so it is
+the right shape when you are streaming points into a series and the
+provider is already fixed by context.
+
+## Storing dated rates — series, key, and book
+
+### `ExchangeRateSeries` — one pair, one provider, every date
+
+[`ExchangeRateSeries`](xref:Bodu.Financial.ExchangeRateSeries) holds
+every observation for a single `(pair, provider)` in two parallel
+sorted arrays (day numbers and rates), giving allocation-free
+`O(log n)` resolution and good cache locality versus a
+`SortedDictionary`. It is **immutable** and thread-safe to share after
+construction. **Reach for it** as the read-side store behind a dated
+provider; `GetObservations()` enumerates in ascending date order, and
+the copy-on-write helpers `WithRate(date, rate)` / `WithoutRate(date)`
+return a fresh series for single edits.
+
+### `ExchangeRateSeriesBuilder` — the mutable companion
+
+[`ExchangeRateSeriesBuilder`](xref:Bodu.Financial.ExchangeRateSeriesBuilder)
+is how you construct or edit a series imperatively while keeping the
+"strictly ascending unique dates, strictly positive rates" invariant.
+The three explicit shapes encode intent:
+
+- `Add(date, rate)` — throws if the date already exists (the data is wrong).
+- `Set(date, rate)` — throws if the date is missing (you expected it).
+- `Upsert(date, rate)` — insert-or-replace, the merge shape.
+
+Each has a `Try`-prefixed boolean sibling; bulk import uses `AddRange`
+(rejects duplicates) and `UpsertRange` (replaces existing dates) with
+atomic rollback — a mid-batch failure leaves the builder untouched.
+`ToSeries()` snapshots an immutable series; it throws on an empty
+builder because a series must hold at least one observation.
+
+```csharp
+var builder = new ExchangeRateSeriesBuilder(new ExchangeRatePair("USD", "AUD"), "RBA");
+builder.Add(new DateOnly(2026, 6, 1), 1.50m);
+builder.Upsert(new DateOnly(2026, 6, 1), 1.51m);   // replace
+ExchangeRateSeries series = builder.ToSeries();
+```
+
+### `ExchangeRateSeriesKey` and `ExchangeRateBook`
+
+[`ExchangeRateSeriesKey`](xref:Bodu.Financial.ExchangeRateSeriesKey)
+is the `(pair, provider)` record struct that keys a series when the
+same pair carries rates from more than one source.
+[`ExchangeRateBook`](xref:Bodu.Financial.ExchangeRateBook) is the
+immutable, frozen-dictionary store of many series keyed by that key —
+the bridge between the mutable build side and the read-side providers.
+It permits multiple providers per pair; the provider layered on top
+decides which one answers.
+
+### `ExchangeRateTableBuilder` — multi-pair, multi-provider import
+
+[`ExchangeRateTableBuilder`](xref:Bodu.Financial.ExchangeRateTableBuilder)
+owns one `ExchangeRateSeriesBuilder` per `(pair, provider)` key.
+**Reach for it** when ingest data arrives flat — many pairs from many
+providers — and you want to accumulate before producing immutable
+snapshots. `Upsert(pair, provider, date, rate)` is the per-point entry
+point, `GetOrAddSeries(...)` exposes a builder for bulk work,
+`ToSeries()` snapshots every non-empty series, and `ToBook()`
+materialises the whole `ExchangeRateBook` ready to hand to a provider.
+
+```csharp
+var table = new ExchangeRateTableBuilder();
+table.Upsert(new ExchangeRatePair("USD", "AUD"), "RBA", new DateOnly(2026, 6, 1), 1.50m);
+table.Upsert(new ExchangeRatePair("USD", "JPY"), "BoJ", new DateOnly(2026, 6, 1), 110m);
+
+var provider = new FixedDatedExchangeRateProvider(table.ToBook());
+```
+
+## Looking rates up — the provider stack
+
+### Timeless vs. dated: the two contracts
+
+[`IExchangeRateProvider`](xref:Bodu.Financial.IExchangeRateProvider)
+exposes a single `GetRate(from, to)` returning a `decimal`. **Reach for
+it** when the rate is simply "current" and the date is not part of what
+you record — a unit-test fixture, a daily snapshot, a live ticker.
+
+[`IDatedExchangeRateProvider`](xref:Bodu.Financial.IDatedExchangeRateProvider)
+takes a `DateOnly` and
+[`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions)
+and returns an
+[`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult)
+with full provenance. **Reach for it** when the *date* of the rate is
+part of the audit trail — ledger postings, tax reports, regulatory
+filings. It provides both `GetRate` (throws `KeyNotFoundException`) and
+allocation-free `TryGetRate` (`bool`); the timeless contract has only
+the throwing form.
+
+| | `IExchangeRateProvider` | `IDatedExchangeRateProvider` |
+|---|---|---|
+| Input | `from, to` | `from, to, date, options` |
+| Output | `decimal` | `ExchangeRateLookupResult` |
+| Date in audit trail | no | yes |
+| Try-pattern | no | yes |
+| Default impl | `FixedExchangeRateTable` | `FixedDatedExchangeRateProvider` |
+
+### `FixedExchangeRateTable` — the smallest timeless provider
+
+[`FixedExchangeRateTable`](xref:Bodu.Financial.FixedExchangeRateTable)
+implements the timeless contract from a flat `(from, to) → rate`
+dictionary. Same-currency lookups short-circuit to `1m`, a missing pair
+falls back to the inverse (returning `1 / rate`), and a pair missing in
+both directions throws `KeyNotFoundException`.
+
+```csharp
+var table = new FixedExchangeRateTable(new Dictionary<(string, string), decimal>
+{
+    { ("USD", "EUR"), 0.93m },
+});
+table.GetRate("USD", "EUR");  // 0.93
+table.GetRate("EUR", "USD");  // 1 / 0.93   (inverse fallback)
+table.GetRate("USD", "USD");  // 1m         (identity)
+```
+
+### `FixedDatedExchangeRateProvider` — the in-memory dated provider
+
+[`FixedDatedExchangeRateProvider`](xref:Bodu.Financial.FixedDatedExchangeRateProvider)
+implements the dated contract over an `ExchangeRateBook`. Construct it
+from a flat `IEnumerable<ExchangeRate>`, from a book, or from a book
+plus a provider-priority list when a pair carries more than one source.
+This is the workhorse store behind dated lookups; its behaviour under
+every `ExchangeRateLookupOptions` setting is the subject of the
+[worked-dataset page](exchange-rate-lookups.md).
+
+### `CompositeDatedExchangeRateProvider` — primary plus fallbacks
+
+[`CompositeDatedExchangeRateProvider`](xref:Bodu.Financial.CompositeDatedExchangeRateProvider)
+wraps an ordered set of dated providers and returns the first success,
+in construction order. **Reach for it** to stack a primary feed over a
+backup over a last-known-good table. Selection is deterministic
+first-available; the
+[`ExchangeRateProviderSelectionPolicy`](xref:Bodu.Financial.ExchangeRateProviderSelectionPolicy)
+enum names richer strategies, but only `ProviderPriorityFirst` ships in
+v1.0.
+
+### `DatedExchangeRateProviderAdapter` — dated source, timeless surface
+
+[`DatedExchangeRateProviderAdapter`](xref:Bodu.Financial.DatedExchangeRateProviderAdapter)
+exposes a dated provider through `IExchangeRateProvider` by pinning a
+fixed valuation date and options. **Reach for it** when an existing
+consumer — such as `MoneyBag.ConvertTo<TTarget>(IExchangeRateProvider)`
+— accepts only the timeless contract but the rates must come from a
+dated source resolved with one consistent policy (a reporting-period
+end-date, say).
+
+## Lookup configuration and outcome
+
+### `ExchangeRateLookupOptions` — the rules on a miss
+
+[`ExchangeRateLookupOptions`](xref:Bodu.Financial.ExchangeRateLookupOptions)
+bundles the date-resolution policy, the tolerance window, and the
+`AllowInverse` / `AllowSameCurrencyIdentityRate` switches. It is a
+reference type so `null` means "use the safe `Exact` default". Use the
+static factories (`Exact`, `PreviousWithin`, `NextWithin`,
+`NearestWithin`) for the common shapes. Every detail of how these
+change a result is in the
+[worked-dataset page](exchange-rate-lookups.md).
+
+### `ExchangeRateLookupResult` — the answer with provenance
+
+[`ExchangeRateLookupResult`](xref:Bodu.Financial.ExchangeRateLookupResult)
+carries the resolved `ExchangeRate`, the `RequestedDate`, the
+`Resolution` that fired, and `OffsetDays`, plus the derived
+`ResolvedDate`, `SignedOffsetDays`, `IsExactDate`, `IsPreviousDate`,
+and `IsFutureDate`. It is everything needed to explain *which* observed
+value was selected and *how far* from the request — without re-querying
+the table.
+
+### `TypedMoneyConversionResult<TSource, TTarget>` — convert + audit
+
+[`TypedMoneyConversionResult<,>`](xref:Bodu.Financial.TypedMoneyConversionResult`2)
+is what `Money<T>.ConvertToWithRate<TSource, TTarget>(...)` returns: the
+source amount, the rounded target amount, and the full
+`ExchangeRateLookupResult` that produced it. **Reach for it** for a
+ledger entry that must record both the converted figure and the rate
+provenance in a single value.
+
+```csharp
+TypedMoneyConversionResult<USD, EUR> audited = Money.Of<USD>(100m)
+    .ConvertToWithRate<USD, EUR>(provider, new DateOnly(2024, 6, 15),
+        ExchangeRateLookupOptions.PreviousWithin(3));
+
+audited.SourceAmount;                // Money<USD> 100.00
+audited.TargetAmount;                // Money<EUR>  92.80
+audited.ExchangeRate.Rate.Provider;  // "ECB"
+audited.ExchangeRate.OffsetDays;     // 1
+```
+
+`Money` has the analogous runtime-tagged `ConvertTo` / `ConvertToWithRate`
+extensions, and `MoneyBag.ConvertToWithAudit<TTarget>(...)` returns one
+line of provenance per source currency alongside the total.
+
+## A decision walk-through
+
+1. **Does the date matter to your records?** No → timeless
+   (`IExchangeRateProvider` / `FixedExchangeRateTable` /
+   `DatedExchangeRateProviderAdapter`). Yes → dated
+   (`IDatedExchangeRateProvider` / `FixedDatedExchangeRateProvider`).
+2. **One source or several?** One → a single provider. Several →
+   `CompositeDatedExchangeRateProvider`, or one
+   `FixedDatedExchangeRateProvider` over a multi-provider
+   `ExchangeRateBook` with a priority list.
+3. **How do you build the data?** A one-shot literal → construct the
+   provider from `IEnumerable<ExchangeRate>`. Incremental or merged →
+   `ExchangeRateSeriesBuilder` (one pair) or
+   `ExchangeRateTableBuilder` (many) → `ToBook()`.
+4. **Is the conversion direction fixed at compile time?** Yes →
+   `Money<TCurrency>` + `ExchangeRate<TBase, TQuote>`. No →
+   `Money` + `ExchangeRate`.
+5. **Do you need to record provenance per conversion?** Yes →
+   `ConvertToWithRate(...)` → `TypedMoneyConversionResult<,>`. No →
+   `ConvertTo(...)`.
+
+## See also
+
+- [Exchange-rate lookups on a known dataset](exchange-rate-lookups.md) — every option, worked end to end.
+- [Working with exchange rates](exchange-rates.md) — the provider-stack walkthrough and editing surface.
+- [Working with `Money<TCurrency>`](money.md) — the money types these rates convert.
+- [Bodu.Financial — Core concepts](../../docs/financial/concepts.md) — the shared vocabulary.
+</content>

--- a/docs/guides/financial/index.md
+++ b/docs/guides/financial/index.md
@@ -56,6 +56,13 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
   `ExchangeRateLookupResult`, the composite fallback stack, the
   `TypedMoneyConversionResult<,>` audit record, and the
   `ExchangeRateSeriesBuilder` + `ExchangeRateTableBuilder` editing surface.
+- [Exchange-rate types — a usage-scenario catalogue](exchange-types.md) —
+  every FX type mapped to the scenario it was defined for, with a
+  one-line "reach for this when…" map and a decision walk-through.
+- [Exchange-rate lookups on a known dataset](exchange-rate-lookups.md) —
+  one fixed dataset run through every `ExchangeRateDateResolution`
+  policy, tolerance window, and the inverse / identity switches, with a
+  results matrix showing exactly how each option changes the answer.
 
 ## See also
 

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -44,6 +44,10 @@
       href: financial/money.md
     - name: Working with exchange rates
       href: financial/exchange-rates.md
+    - name: Exchange-rate types (usage catalogue)
+      href: financial/exchange-types.md
+    - name: Exchange-rate lookups (worked dataset)
+      href: financial/exchange-rate-lookups.md
 - name: Bodu.Globalization.Calendar
   items:
     - name: Overview


### PR DESCRIPTION
Add two DocFX guide pages covering the foreign-exchange types in
Bodu.Financial:

- exchange-types.md — a scenario-driven catalogue mapping every FX type
  (ExchangeRate, ExchangeRate<TBase,TQuote>, pair, observation, series,
  builder, book, table builder, the timeless/dated provider stack,
  lookup options/result, and TypedMoneyConversionResult) to the usage
  scenario it was defined for, with a one-line "reach for this when…"
  map and a decision walk-through.

- exchange-rate-lookups.md — pins one known USD/EUR dataset and runs the
  same requests through every ExchangeRateDateResolution policy,
  tolerance window, and the AllowInverse / AllowSameCurrencyIdentityRate
  switches, with a results matrix showing exactly how each option
  changes the resolved date and rate (including the Nearest tie, the
  out-of-range ends, and why tolerance cannot make a directional policy
  switch sides).

Wire both into guides/toc.yml and cross-link from the existing
exchange-rates.md and financial/index.md. Verified with
`docfx docs/docfx.json --warningsAsErrors` (clean build, 0 warnings).