### PR TITLE
Calendar v2: close functional-parity gaps (recurrence cadence, introspection, working week, non-working-day triggers)

### DIFF
--- a/.github/workflows/docfx-build-publish.yml
+++ b/.github/workflows/docfx-build-publish.yml
@@ -51,10 +51,10 @@ jobs:
           grep -rEn 'Standard, PureIni|"PureIni"|`PureIni`' docs/ --include='*.md'
           exit 1
         fi
-        echo "Checking for HTML-escaped characters in TOC/YAML files (use raw < > & instead)..."
-        if grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml' >/dev/null; then
-          echo "::error::Found HTML entities in docs/*.yml. DocFX HTML-encodes TOC 'name:' values, so pre-escaped entities are double-encoded and render literally (e.g. Fraction<T> shows as Fraction&lt;T&gt;). Use raw < > & characters."
-          grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml'
+        echo "Checking for HTML-escaped characters in hand-authored TOC/YAML files (use raw < > & instead)..."
+        if grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml' --exclude-dir=api >/dev/null; then
+          echo "::error::Found HTML entities in hand-authored docs/*.yml. DocFX HTML-encodes TOC 'name:' values, so pre-escaped entities are double-encoded and render literally (e.g. Fraction<T> shows as Fraction&lt;T&gt;). Use raw < > & characters. (The generated docs/api output is excluded: DocFX legitimately encodes < > & inside its code blocks there.)"
+          grep -rEn '&lt;|&gt;|&amp;|&quot;|&#[0-9]+;' docs/ --include='*.yml' --exclude-dir=api
           exit 1
         fi
         echo "All content audits passed."

--- a/Bodu.Globalization.Calendar2.Data.Americas/src/AmericasCalendarData.cs
+++ b/Bodu.Globalization.Calendar2.Data.Americas/src/AmericasCalendarData.cs
@@ -52,7 +52,7 @@ public static class AmericasCalendarData
                 string.Format(CultureInfo.InvariantCulture, "No Americas calendar resource for territory '{0}'.", territory),
                 nameof(territory));
 
-        return NotableDateResourceLoader.Load(stream);
+        return NotableDateResourceLoader.Load(stream, CommonNotableDateResources.Resolver);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2.Data.Americas/src/Resources/region-ca.xml
+++ b/Bodu.Globalization.Calendar2.Data.Americas/src/Resources/region-ca.xml
@@ -22,13 +22,26 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="CA">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="good-friday" territory="CA" />
+      <Use notableDateRef="easter-sunday" territory="CA" />
+      <Use notableDateRef="easter-monday" territory="CA" />
+      <Use notableDateRef="christmas-day" territory="CA">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+      <Use notableDateRef="boxing-day" territory="CA">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="valentines-day" displayName="Valentine's Day" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
@@ -63,21 +76,6 @@
     <NotableDate id="nova-scotia-heritage-day" displayName="Nova Scotia Heritage Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ns"><Applicability fromYear="2015"><Territory code="CA-NS" /></Applicability>
         <Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability fromYear="1583"><Territory code="CA" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="ca" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability fromYear="1583"><Territory code="CA" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability fromYear="1583"><Territory code="CA" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="ca" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="mothers-day" displayName="Mother's Day" category="Observance" defaultNonWorkingDay="false">
@@ -168,18 +166,6 @@
       <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
         <Strategy><Fixed month="November" day="11" /></Strategy>
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="boxing-day" displayName="Boxing Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="December" day="26" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.Americas/src/Resources/region-us.xml
+++ b/Bodu.Globalization.Calendar2.Data.Americas/src/Resources/region-us.xml
@@ -21,13 +21,23 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="US">
+        <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="US" />
+      <Use notableDateRef="good-friday" territory="US" category="Religious" nonWorking="false" />
+      <Use notableDateRef="christmas-eve" territory="US" />
+      <Use notableDateRef="christmas-day" territory="US">
+        <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="mlk-day" displayName="Birthday of Martin Luther King, Jr." category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="us"><Applicability fromYear="1986"><Territory code="US" /></Applicability>
@@ -47,16 +57,6 @@
     <NotableDate id="st-patricks-day" displayName="St. Patrick's Day" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
         <Strategy><Fixed month="March" day="17" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability fromYear="1583"><Territory code="US" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="us" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability fromYear="1583"><Territory code="US" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="earth-day" displayName="Earth Day" category="Observance" defaultNonWorkingDay="false">
@@ -145,17 +145,6 @@
     <NotableDate id="pearl-harbor-day" displayName="Pearl Harbor Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability fromYear="1994"><Territory code="US" /></Applicability>
         <Strategy><Fixed month="December" day="7" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
@@ -51,7 +51,7 @@ public static class AsiaPacificCalendarData
                 string.Format(CultureInfo.InvariantCulture, "No Asia-Pacific calendar resource for territory '{0}'.", territory),
                 nameof(territory));
 
-        return NotableDateResourceLoader.Load(stream);
+        return NotableDateResourceLoader.Load(stream, CommonNotableDateResources.Resolver);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-au.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-au.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Australian notable-date resource, migrated from the v1 region-au.xml to the v2 cookbook schema. Same-name
-  per-subdivision concepts (Labour Day, King's Birthday) become one concept with a rule per subdivision; weekend
-  substitution uses the conflict-aware MoveToNextWorkingDay action. Western Australia and the Northern Territory
-  observe an Anzac Day substitute via narrower rules that shadow the national rule.
+  Australian notable-date resource, migrated from the v1 region-au.xml to the v2 cookbook schema. Shared civil and
+  Christian observances (New Year's Day, Easter, Christmas, Boxing Day) are imported from the common catalogues with
+  per-territory overrides; the territory-specific rules remain inline. Same-name per-subdivision concepts (Labour Day,
+  King's Birthday) become one concept with a rule per subdivision; weekend substitution uses the conflict-aware
+  MoveToNextWorkingDay action. Western Australia and the Northern Territory observe an Anzac Day substitute via narrower
+  rules that shadow the national rule.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.au">
 
@@ -22,33 +24,31 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="AU">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="AU" />
+      <Use notableDateRef="good-friday" territory="AU" />
+      <Use notableDateRef="easter-monday" territory="AU" />
+      <Use notableDateRef="christmas-day" territory="AU">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+      <Use notableDateRef="boxing-day" territory="AU">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="au"><Applicability><Territory code="AU" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="australia-day" displayName="Australia Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="au"><Applicability><Territory code="AU" /></Applicability>
         <Strategy><Fixed month="January" day="26" /></Strategy>
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="au"><Applicability fromYear="1583"><Territory code="AU" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="au"><Applicability fromYear="1583"><Territory code="AU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="au" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="au"><Applicability fromYear="1583"><Territory code="AU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="au" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="anzac-day" displayName="Anzac Day" category="Remembrance" defaultNonWorkingDay="true">
@@ -87,18 +87,6 @@
     <NotableDate id="reconciliation-day" displayName="Reconciliation Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="act"><Applicability fromYear="2018"><Territory code="AU-ACT" /></Applicability>
         <Strategy><WeekdayNearDate month="May" day="27" dayOfWeek="Monday" direction="OnOrAfter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="au"><Applicability><Territory code="AU" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="boxing-day" displayName="Boxing Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="au"><Applicability><Territory code="AU" /></Applicability>
-        <Strategy><Fixed month="December" day="26" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-cn.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-cn.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Chinese notable-date resource, migrated from the v1 region-cn.xml to the v2 cookbook schema. The lunar festivals are
-  expressed as fixed dates in the Chinese lunisolar calendar (conventional month indices skip the intercalary leap
-  month); Qingming uses the astronomical solar-term algorithm; the Winter Solstice festival is approximated by its
-  fixed Gregorian date. Lunar New Year and National Day carry their seven-day statutory durationDays span.
+  Chinese notable-date resource, migrated from the v1 region-cn.xml to the v2 cookbook schema. The shared New Year's Day
+  is imported from the common global-core catalogue; the lunar festivals are expressed as fixed dates in the Chinese
+  lunisolar calendar (conventional month indices skip the intercalary leap month); Qingming uses the astronomical
+  solar-term algorithm; the Winter Solstice festival is approximated by its fixed Gregorian date. Lunar New Year and
+  National Day carry their seven-day statutory durationDays span.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.cn">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="CN" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cn"><Applicability><Territory code="CN" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="lunar-new-year" displayName="Lunar New Year" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="cn" durationDays="7"><Applicability calendar="ChineseLunisolar"><Territory code="CN" /></Applicability><Strategy><Fixed month="1" day="1" /></Strategy></Rule></Rules>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-in.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-in.xml
@@ -1,14 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Indian notable-date resource, migrated from the v1 region-in.xml to the v2 cookbook schema. National holidays are
-  Gregorian; the solar festivals Makar Sankranti and Pongal are fixed (14 January); the Islamic festivals use the
-  tabular Hijri calendar; Good Friday derives from Easter; and the Hindu lunisolar festivals are computed by the
-  solar-anchored lunar algorithm (accurate to within a day or two, with intercalary years handled). Onam is omitted
-  because it is fixed by a nakshatra rather than a tithi and is not modelled by the lunar algorithm.
+  Indian notable-date resource, migrated from the v1 region-in.xml to the v2 cookbook schema. The shared Christian
+  observances (Easter Sunday, Good Friday, Christmas) are imported from the common christian-western catalogue with
+  India's religious, non-public overrides. National holidays are Gregorian; the solar festivals Makar Sankranti and
+  Pongal are fixed (14 January); the Islamic festivals use the tabular Hijri calendar; and the Hindu lunisolar festivals
+  are computed by the solar-anchored lunar algorithm (accurate to within a day or two, with intercalary years handled).
+  Onam is omitted because it is fixed by a nakshatra rather than a tithi and is not modelled by the lunar algorithm.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.in">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
+
+  <Imports>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="IN" />
+      <Use notableDateRef="good-friday" territory="IN" category="Religious" nonWorking="false" />
+      <Use notableDateRef="christmas-day" territory="IN" category="Religious" nonWorking="false" />
+    </Import>
+  </Imports>
 
   <NotableDates>
 
@@ -38,14 +47,6 @@
 
     <NotableDate id="ram-navami" displayName="Ram Navami" category="Religious" defaultNonWorkingDay="false">
       <Rules><Rule id="in"><Applicability><Territory code="IN" /></Applicability><Strategy><Algorithm key="ram-navami" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="in"><Applicability fromYear="1583"><Territory code="IN" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="in" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="in"><Applicability fromYear="1583"><Territory code="IN" /></Applicability><Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="eid-al-fitr" displayName="Eid al-Fitr" category="Religious" defaultNonWorkingDay="false">
@@ -94,10 +95,6 @@
 
     <NotableDate id="eid-al-adha" displayName="Eid al-Adha" category="Religious" defaultNonWorkingDay="false">
       <Rules><Rule id="in"><Applicability calendar="Hijri"><Territory code="IN" /></Applicability><Strategy><Fixed month="12" day="10" sweepCalendarYears="true" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="in"><Applicability><Territory code="IN" /></Applicability><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-jp.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-jp.xml
@@ -1,19 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Japanese notable-date resource, migrated from the v1 region-jp.xml to the v2 cookbook schema. The Vernal and
-  Autumnal Equinox Days are computed astronomically in Japan Standard Time. The imported New Year and Bodhi Day are
-  flattened into explicit rules. The v1 multi-day "Golden Week" and "Obon" period markers (durationDays) are omitted
-  pending multi-day span support; their constituent public holidays remain individually defined.
+  Japanese notable-date resource, migrated from the v1 region-jp.xml to the v2 cookbook schema. The shared New Year's Day
+  is imported from the common global-core catalogue; Bodhi Day and the remaining national holidays are defined inline.
+  The Vernal and Autumnal Equinox Days are computed astronomically in Japan Standard Time. The v1 multi-day "Golden
+  Week" and "Obon" period markers (durationDays) are omitted pending multi-day span support; their constituent public
+  holidays remain individually defined.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.jp">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="JP" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="jp"><Applicability><Territory code="JP" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="coming-of-age-day" displayName="Coming of Age Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="jp"><Applicability fromYear="2000"><Territory code="JP" /></Applicability><Strategy><DayOfWeekInMonth month="January" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-kr.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-kr.xml
@@ -1,19 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  South Korean notable-date resource, migrated from the v1 region-kr.xml to the v2 cookbook schema. Seollal and Chuseok
-  are expressed as fixed dates in the Chinese lunisolar calendar; Buddha's Birthday is the eighth day of the fourth
-  lunar month (the Korean reckoning, more accurate here than the full-moon Vesak the v1 file imported). Seollal and
-  Chuseok carry their statutory three-day durationDays span.
+  South Korean notable-date resource, migrated from the v1 region-kr.xml to the v2 cookbook schema. The shared New Year's
+  Day and Christmas Day are imported from the common global-core and christian-western catalogues; the national and lunar
+  holidays remain inline. Seollal and Chuseok are expressed as fixed dates in the Chinese lunisolar calendar; Buddha's
+  Birthday is the eighth day of the fourth lunar month (the Korean reckoning, more accurate here than the full-moon Vesak
+  the v1 file imported). Seollal and Chuseok carry their statutory three-day durationDays span.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.kr">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="KR" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="christmas-day" territory="KR" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="kr"><Applicability><Territory code="KR" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="seollal" displayName="Seollal" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="kr" durationDays="3"><Applicability calendar="ChineseLunisolar"><Territory code="KR" /></Applicability><Strategy><Fixed month="1" day="1" /></Strategy></Rule></Rules>
@@ -53,10 +59,6 @@
 
     <NotableDate id="hangul-day" displayName="Hangul Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="kr"><Applicability><Territory code="KR" /></Applicability><Strategy><Fixed month="October" day="9" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="kr"><Applicability><Territory code="KR" /></Applicability><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-nz.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-nz.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  New Zealand notable-date resource, migrated from the v1 region-nz.xml to the v2 cookbook schema. Matariki uses the
-  gazetted-date algorithm. The paired New Year / Day after New Year's Day and Christmas / Boxing Day holidays use the
-  conflict-aware working-day substitute so the second advances past the first when both fall on a weekend; standalone
-  holidays use the simple weekend roll. Imported global, Christian, and family observances are flattened.
+  New Zealand notable-date resource, migrated from the v1 region-nz.xml to the v2 cookbook schema. Shared civil and
+  Christian observances (New Year's Day, Easter, Christmas, Boxing Day) are imported from the common catalogues with
+  per-territory overrides; the territory-specific holidays remain inline. Easter Saturday offsets from the imported
+  Easter Sunday rule (id "default"). Matariki uses the gazetted-date algorithm. The paired New Year / Day after New
+  Year's Day and Christmas / Boxing Day holidays use the conflict-aware working-day substitute so the second advances
+  past the first when both fall on a weekend; standalone holidays use the simple weekend roll.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.nz">
 
@@ -22,13 +24,26 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="NZ">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="NZ" />
+      <Use notableDateRef="good-friday" territory="NZ" />
+      <Use notableDateRef="easter-monday" territory="NZ" />
+      <Use notableDateRef="christmas-day" territory="NZ">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+      <Use notableDateRef="boxing-day" territory="NZ">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="day-after-new-years-day" displayName="Day after New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability>
@@ -46,24 +61,9 @@
       <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability><Strategy><Fixed month="February" day="14" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nz"><Applicability fromYear="1583"><Territory code="NZ" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nz" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="easter-saturday" displayName="Easter Saturday" category="Observance" defaultNonWorkingDay="false">
       <Rules><Rule id="nz"><Applicability fromYear="1583"><Territory code="NZ" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nz" offsetDays="-1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="nz"><Applicability fromYear="1583"><Territory code="NZ" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nz"><Applicability fromYear="1583"><Territory code="NZ" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nz" offsetDays="1" /></Strategy></Rule></Rules>
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="anzac-day" displayName="Anzac Day" category="Remembrance" defaultNonWorkingDay="true">
@@ -102,18 +102,6 @@
 
     <NotableDate id="remembrance-day" displayName="Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
       <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability><Strategy><Fixed month="November" day="11" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="boxing-day" displayName="Boxing Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nz"><Applicability><Territory code="NZ" /></Applicability>
-        <Strategy><Fixed month="December" day="26" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-sg.xml
+++ b/Bodu.Globalization.Calendar2.Data.AsiaPacific/src/Resources/region-sg.xml
@@ -1,19 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  Singapore notable-date resource, migrated from the v1 region-sg.xml to the v2 cookbook schema. Singapore's
-  multi-religious public holidays draw on four calendars: Gregorian, Chinese lunisolar (Chinese New Year), tabular
-  Hijri (the two Hari Raya festivals), and astronomical lunar/lunisolar algorithms (Vesak, Deepavali). Islamic and
-  lunisolar dates follow the engine's computed reckoning and may differ by a day or two from the gazetted dates.
+  Singapore notable-date resource, migrated from the v1 region-sg.xml to the v2 cookbook schema. The shared civil and
+  Christian observances (New Year's Day, Easter Sunday, Good Friday, Christmas) are imported from the common global-core
+  and christian-western catalogues; the remaining multi-religious public holidays draw on three further calendars:
+  Chinese lunisolar (Chinese New Year), tabular Hijri (the two Hari Raya festivals), and astronomical lunar/lunisolar
+  algorithms (Vesak, Deepavali). Islamic and lunisolar dates follow the engine's computed reckoning and may differ by a
+  day or two from the gazetted dates.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.sg">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="SG" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="SG" />
+      <Use notableDateRef="good-friday" territory="SG" />
+      <Use notableDateRef="christmas-day" territory="SG" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sg"><Applicability><Territory code="SG" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="chinese-new-year" displayName="Chinese New Year" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sg" durationDays="2"><Applicability calendar="ChineseLunisolar"><Territory code="SG" /></Applicability><Strategy><Fixed month="1" day="1" /></Strategy></Rule></Rules>
@@ -21,14 +30,6 @@
 
     <NotableDate id="hari-raya-puasa" displayName="Hari Raya Puasa" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sg"><Applicability calendar="Hijri"><Territory code="SG" /></Applicability><Strategy><Fixed month="10" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sg"><Applicability fromYear="1583"><Territory code="SG" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="sg" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="sg"><Applicability fromYear="1583"><Territory code="SG" /></Applicability><Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -49,10 +50,6 @@
 
     <NotableDate id="deepavali" displayName="Deepavali" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sg"><Applicability><Territory code="SG" /></Applicability><Strategy><Algorithm key="diwali" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sg"><Applicability><Territory code="SG" /></Applicability><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/EuropeCalendarData.cs
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/EuropeCalendarData.cs
@@ -55,7 +55,7 @@ public static class EuropeCalendarData
                 string.Format(CultureInfo.InvariantCulture, "No Europe calendar resource for territory '{0}'.", territory),
                 nameof(territory));
 
-        return NotableDateResourceLoader.Load(stream);
+        return NotableDateResourceLoader.Load(stream, CommonNotableDateResources.Resolver);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-at.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-at.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  AT notable-date resource, migrated from the v1 region-at.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  AT notable-date resource, migrated from the v1 region-at.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues with per-territory overrides; the
+  remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.at">
 
@@ -16,27 +16,28 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="AT">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="AT" />
+      <Use notableDateRef="easter-monday" territory="AT" />
+      <Use notableDateRef="ascension-day" territory="AT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-monday" territory="AT" />
+      <Use notableDateRef="corpus-christi" territory="AT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="all-saints-day" territory="AT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="AT" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="at"><Applicability fromYear="1583"><Territory code="AT" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability fromYear="1583"><Territory code="AT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="at" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="state-holiday" displayName="State Holiday" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -44,39 +45,14 @@
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability fromYear="1583"><Territory code="AT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="at" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability fromYear="1583"><Territory code="AT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="at" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability fromYear="1583"><Territory code="AT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="at" offsetDays="60" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="immaculate-conception" displayName="Immaculate Conception" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
         <Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="at"><Applicability><Territory code="AT" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-be.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-be.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  BE notable-date resource, migrated from the v1 region-be.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  BE notable-date resource, migrated from the v1 region-be.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.be">
 
@@ -16,52 +16,32 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="BE">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="BE" />
+      <Use notableDateRef="easter-monday" territory="BE" />
+      <Use notableDateRef="ascension-day" territory="BE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-monday" territory="BE" />
+      <Use notableDateRef="all-saints-day" territory="BE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="BE" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability><Territory code="BE" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="be"><Applicability fromYear="1583"><Territory code="BE" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability fromYear="1583"><Territory code="BE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="be" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="be"><Applicability><Territory code="BE" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability fromYear="1583"><Territory code="BE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="be" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability fromYear="1583"><Territory code="BE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="be" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="be"><Applicability><Territory code="BE" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability><Territory code="BE" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="be"><Applicability><Territory code="BE" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="belgian-national-day" displayName="Belgian National Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-bg.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-bg.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  BG notable-date resource, migrated from the v1 region-bg.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  BG notable-date resource, migrated from the v1 region-bg.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the Orthodox Easter cycle and the
+  remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.bg">
 
@@ -16,27 +16,23 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="BG">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="christmas-eve" territory="BG" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="BG" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="bg"><Applicability><Territory code="BG" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="bg"><Applicability><Territory code="BG" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="bg"><Applicability><Territory code="BG" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="bg"><Applicability><Territory code="BG" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-cy.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-cy.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  CY notable-date resource, migrated from the v1 region-cy.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  CY notable-date resource, migrated from the v1 region-cy.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the Orthodox Easter cycle and the
+  remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.cy">
 
@@ -16,13 +16,18 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="CY">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="christmas-day" territory="CY" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cy"><Applicability><Territory code="CY" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="cy"><Applicability><Territory code="CY" /></Applicability>
@@ -37,11 +42,6 @@
     <NotableDate id="dormition-of-the-mother-of-god" displayName="Dormition of the Mother of God" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="cy"><Applicability><Territory code="CY" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cy"><Applicability><Territory code="CY" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-cz.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-cz.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  CZ notable-date resource, migrated from the v1 region-cz.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  CZ notable-date resource, migrated from the v1 region-cz.xml to the v2 cookbook schema. Shared Christian observances
+  are imported from the christian-western catalogue; the remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.cz">
 
@@ -16,6 +15,16 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="CZ" />
+      <Use notableDateRef="good-friday" territory="CZ" />
+      <Use notableDateRef="easter-monday" territory="CZ" />
+      <Use notableDateRef="christmas-eve" territory="CZ" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="CZ" />
+    </Import>
+  </Imports>
+
   <NotableDates>
 
     <NotableDate id="restoration-day-of-the-independent-czech-state" displayName="Restoration Day of the Independent Czech State" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -24,34 +33,9 @@
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="cz"><Applicability fromYear="1583"><Territory code="CZ" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cz"><Applicability fromYear="1583"><Territory code="CZ" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="cz" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cz"><Applicability fromYear="1583"><Territory code="CZ" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="cz" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="cz"><Applicability><Territory code="CZ" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cz"><Applicability><Territory code="CZ" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="cz"><Applicability><Territory code="CZ" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-de.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-de.xml
@@ -1,18 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   German notable-date resource, migrated from the v1 region-de.xml to the v2 cookbook schema. Germany does not roll
-  weekend public holidays. Easter-derived holidays use offset-from-rule; imported global and Christian observances are
-  flattened. Several entries are statutory only in some federal states; they are modelled here at the national level.
+  weekend public holidays. Shared civil and Christian observances are imported from the global-core and christian-western
+  catalogues; the remaining entries are territory-local concepts defined inline. Several entries are statutory only in
+  some federal states; they are modelled here at the national level.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.de">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="DE" />
+      <Use notableDateRef="workers-day" territory="DE" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="good-friday" territory="DE" />
+      <Use notableDateRef="easter-sunday" territory="DE" />
+      <Use notableDateRef="easter-monday" territory="DE" />
+      <Use notableDateRef="ascension-day" territory="DE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-monday" territory="DE" />
+      <Use notableDateRef="corpus-christi" territory="DE" />
+      <Use notableDateRef="all-saints-day" territory="DE" />
+      <Use notableDateRef="christmas-day" territory="DE" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="Religious" defaultNonWorkingDay="false">
       <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
@@ -26,36 +40,8 @@
       <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="March" day="8" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="de" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="de" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="workers-day" displayName="International Workers' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="mothers-day" displayName="Mother's Day" category="Observance" defaultNonWorkingDay="false">
       <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Second" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="de" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="de" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="de"><Applicability fromYear="1583"><Territory code="DE" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="de" offsetDays="60" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="Religious" defaultNonWorkingDay="false">
@@ -70,16 +56,8 @@
       <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="October" day="31" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="repentance-day" displayName="Repentance and Prayer Day" category="Religious" defaultNonWorkingDay="false">
       <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><WeekdayNearDate month="November" day="22" dayOfWeek="Wednesday" direction="OnOrBefore" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="de"><Applicability><Territory code="DE" /></Applicability><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-dk.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-dk.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  DK notable-date resource, migrated from the v1 region-dk.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  DK notable-date resource, migrated from the v1 region-dk.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.dk">
 
@@ -16,57 +16,29 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="DK">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="DK" />
+      <Use notableDateRef="good-friday" territory="DK" />
+      <Use notableDateRef="easter-monday" territory="DK" />
+      <Use notableDateRef="ascension-day" territory="DK" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-sunday" territory="DK" />
+      <Use notableDateRef="whit-monday" territory="DK" />
+      <Use notableDateRef="maundy-thursday" territory="DK" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="DK" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability><Territory code="DK" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability><Territory code="DK" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="dk"><Applicability><Territory code="DK" /></Applicability>
         <Strategy><Fixed month="December" day="26" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="maundy-thursday" displayName="Maundy Thursday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="dk"><Applicability fromYear="1583"><Territory code="DK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="dk" offsetDays="-3" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="constitution-day" displayName="Constitution Day" category="Observance" defaultNonWorkingDay="false">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ee.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ee.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  EE notable-date resource, migrated from the v1 region-ee.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  EE notable-date resource, migrated from the v1 region-ee.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.ee">
 
@@ -16,42 +16,26 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="EE">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="EE" />
+      <Use notableDateRef="good-friday" territory="EE" />
+      <Use notableDateRef="whit-sunday" territory="EE" />
+      <Use notableDateRef="christmas-eve" territory="EE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="EE" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ee"><Applicability><Territory code="EE" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="ee"><Applicability fromYear="1583"><Territory code="EE" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ee"><Applicability fromYear="1583"><Territory code="EE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="ee" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="spring-day" displayName="Spring Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ee"><Applicability><Territory code="EE" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="ee"><Applicability fromYear="1583"><Territory code="EE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="ee" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ee"><Applicability><Territory code="EE" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ee"><Applicability><Territory code="EE" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-es.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-es.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  ES notable-date resource, migrated from the v1 region-es.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  ES notable-date resource, migrated from the v1 region-es.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.es">
 
@@ -16,27 +16,25 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="ES">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="ES" />
+      <Use notableDateRef="good-friday" territory="ES" />
+      <Use notableDateRef="all-saints-day" territory="ES" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="ES" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="es"><Applicability><Territory code="ES" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="es"><Applicability><Territory code="ES" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="es"><Applicability fromYear="1583"><Territory code="ES" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="es"><Applicability fromYear="1583"><Territory code="ES" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="es" offsetDays="-2" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -49,19 +47,9 @@
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="es"><Applicability><Territory code="ES" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="immaculate-conception" displayName="Immaculate Conception" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="es"><Applicability><Territory code="ES" /></Applicability>
         <Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="es"><Applicability><Territory code="ES" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="national-day-of-spain" displayName="National Day of Spain" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-fi.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-fi.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  FI notable-date resource, migrated from the v1 region-fi.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  FI notable-date resource, migrated from the v1 region-fi.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.fi">
 
@@ -16,57 +16,33 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="FI">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="FI" />
+      <Use notableDateRef="good-friday" territory="FI" />
+      <Use notableDateRef="easter-monday" territory="FI" />
+      <Use notableDateRef="ascension-day" territory="FI" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-sunday" territory="FI" />
+      <Use notableDateRef="christmas-eve" territory="FI" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="FI" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability><Territory code="FI" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="fi"><Applicability><Territory code="FI" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="fi"><Applicability fromYear="1583"><Territory code="FI" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability fromYear="1583"><Territory code="FI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fi" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability fromYear="1583"><Territory code="FI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fi" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="may-day" displayName="May Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="fi"><Applicability><Territory code="FI" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability fromYear="1583"><Territory code="FI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fi" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="fi"><Applicability fromYear="1583"><Territory code="FI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fi" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability><Territory code="FI" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fi"><Applicability><Territory code="FI" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-fr.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-fr.xml
@@ -1,18 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   French notable-date resource, migrated from the v1 region-fr.xml to the v2 cookbook schema. France does not roll
-  weekend public holidays, so no weekend adjustment is applied. Easter-derived holidays use offset-from-rule; imported
-  global and Christian observances are flattened.
+  weekend public holidays, so no weekend adjustment is applied. Shared civil and Christian observances are imported from
+  the global-core and christian-western catalogues; the remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.fr">
 
   <ResolutionPolicy duplicatePolicy="Error" sameDayCollisionPolicy="KeepAll" priorityDirection="HigherWins" />
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="FR" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="FR" />
+      <Use notableDateRef="easter-monday" territory="FR" />
+      <Use notableDateRef="ascension-day" territory="FR" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-monday" territory="FR" />
+      <Use notableDateRef="all-saints-day" territory="FR" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="FR" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="valentines-day" displayName="Valentine's Day" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="February" day="14" /></Strategy></Rule></Rules>
@@ -20,14 +30,6 @@
 
     <NotableDate id="womens-day" displayName="International Women's Day" category="Observance" defaultNonWorkingDay="false">
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="March" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="fr"><Applicability fromYear="1583"><Territory code="FR" /></Applicability><Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability fromYear="1583"><Territory code="FR" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fr" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Fête du Travail" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -42,14 +44,6 @@
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Last" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability fromYear="1583"><Territory code="FR" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fr" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability fromYear="1583"><Territory code="FR" /></Applicability><Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="fr" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="world-music-day" displayName="World Music Day" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="June" day="21" /></Strategy></Rule></Rules>
     </NotableDate>
@@ -62,16 +56,8 @@
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="armistice-day" displayName="Armistice Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="November" day="11" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="fr"><Applicability><Territory code="FR" /></Applicability><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-gb.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-gb.xml
@@ -3,7 +3,8 @@
   United Kingdom notable-date resource, migrated from the v1 region-gb.xml to the v2 cookbook schema. Bank holidays
   roll to the next weekday when they fall on a weekend; Christmas and Boxing Day use the conflict-aware working-day
   substitute. National patron-saint days and the Scottish/Northern Irish holidays are scoped to their subdivisions.
-  Imported global, Christian, and family observances are flattened.
+  Shared civil and Christian observances are imported from the global-core and christian-western catalogues; concepts
+  scoped to multiple subdivisions (Easter Monday) remain inline. The remaining entries are territory-local.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.gb">
 
@@ -22,13 +23,25 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="GB">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="good-friday" territory="GB" />
+      <Use notableDateRef="easter-sunday" territory="GB" />
+      <Use notableDateRef="christmas-day" territory="GB">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+      <Use notableDateRef="boxing-day" territory="GB">
+        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gb"><Applicability><Territory code="GB" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="day-after-new-years-day" displayName="2 January" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sct"><Applicability><Territory code="GB-SCT" /></Applicability>
@@ -60,22 +73,12 @@
 
     <NotableDate id="mothering-sunday" displayName="Mothering Sunday" category="Observance" defaultNonWorkingDay="false">
       <Rules><Rule id="gb"><Applicability fromYear="1583"><Territory code="GB" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="gb" offsetDays="-21" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gb"><Applicability fromYear="1583"><Territory code="GB" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="gb" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="gb"><Applicability fromYear="1583"><Territory code="GB" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-21" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ew"><Applicability fromYear="1583"><Territory code="GB-ENG" /><Territory code="GB-WLS" /><Territory code="GB-NIR" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="gb" offsetDays="1" /></Strategy></Rule></Rules>
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-georges-day" displayName="Saint George's Day" category="Cultural" defaultNonWorkingDay="false">
@@ -125,18 +128,6 @@
       <Rules><Rule id="sct"><Applicability><Territory code="GB-SCT" /></Applicability>
         <Strategy><Fixed month="November" day="30" /></Strategy>
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gb"><Applicability><Territory code="GB" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="boxing-day" displayName="Boxing Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gb"><Applicability><Territory code="GB" /></Applicability>
-        <Strategy><Fixed month="December" day="26" /></Strategy>
-        <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-gr.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-gr.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  GR notable-date resource, migrated from the v1 region-gr.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  GR notable-date resource, migrated from the v1 region-gr.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the Orthodox Easter cycle and the
+  remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.gr">
 
@@ -16,13 +16,18 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="GR">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="christmas-day" territory="GR" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gr"><Applicability><Territory code="GR" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="gr"><Applicability><Territory code="GR" /></Applicability>
@@ -37,11 +42,6 @@
     <NotableDate id="dormition-of-the-mother-of-god" displayName="Dormition of the Mother of God" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="gr"><Applicability><Territory code="GR" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="gr"><Applicability><Territory code="GR" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="synaxis-of-the-mother-of-god" displayName="Synaxis of the Mother of God" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-hr.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-hr.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  HR notable-date resource, migrated from the v1 region-hr.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  HR notable-date resource, migrated from the v1 region-hr.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.hr">
 
@@ -16,27 +16,26 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="HR">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="HR" />
+      <Use notableDateRef="easter-monday" territory="HR" />
+      <Use notableDateRef="corpus-christi" territory="HR" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="all-saints-day" territory="HR" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="HR" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hr"><Applicability><Territory code="HR" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="hr"><Applicability><Territory code="HR" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="hr"><Applicability fromYear="1583"><Territory code="HR" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hr"><Applicability fromYear="1583"><Territory code="HR" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hr" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -44,24 +43,9 @@
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hr"><Applicability fromYear="1583"><Territory code="HR" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hr" offsetDays="60" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="hr"><Applicability><Territory code="HR" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hr"><Applicability><Territory code="HR" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hr"><Applicability><Territory code="HR" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-hu.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-hu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  HU notable-date resource, migrated from the v1 region-hu.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  HU notable-date resource, migrated from the v1 region-hu.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.hu">
 
@@ -16,52 +16,28 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="HU">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="HU" />
+      <Use notableDateRef="good-friday" territory="HU" />
+      <Use notableDateRef="easter-monday" territory="HU" />
+      <Use notableDateRef="whit-sunday" territory="HU" />
+      <Use notableDateRef="whit-monday" territory="HU" />
+      <Use notableDateRef="all-saints-day" territory="HU" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="HU" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability><Territory code="HU" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="hu"><Applicability fromYear="1583"><Territory code="HU" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability fromYear="1583"><Territory code="HU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hu" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability fromYear="1583"><Territory code="HU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hu" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="hu"><Applicability><Territory code="HU" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="hu"><Applicability fromYear="1583"><Territory code="HU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hu" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability fromYear="1583"><Territory code="HU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="hu" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability><Territory code="HU" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="hu"><Applicability><Territory code="HU" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ie.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ie.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  IE notable-date resource, migrated from the v1 region-ie.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  IE notable-date resource, migrated from the v1 region-ie.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.ie">
 
@@ -16,29 +16,22 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="IE">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="IE" />
+      <Use notableDateRef="easter-monday" territory="IE" />
+      <Use notableDateRef="christmas-day" territory="IE">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ie"><Applicability><Territory code="IE" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="ie"><Applicability fromYear="1583"><Territory code="IE" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ie"><Applicability fromYear="1583"><Territory code="IE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="ie" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ie"><Applicability><Territory code="IE" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ie"><Applicability><Territory code="IE" /></Applicability>

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-it.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-it.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  IT notable-date resource, migrated from the v1 region-it.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  IT notable-date resource, migrated from the v1 region-it.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.it">
 
@@ -16,27 +16,25 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="IT">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="IT" />
+      <Use notableDateRef="easter-monday" territory="IT" />
+      <Use notableDateRef="all-saints-day" territory="IT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="IT" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="it"><Applicability><Territory code="IT" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="it"><Applicability><Territory code="IT" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="it"><Applicability fromYear="1583"><Territory code="IT" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="it"><Applicability fromYear="1583"><Territory code="IT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="it" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -49,19 +47,9 @@
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="it"><Applicability><Territory code="IT" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="immaculate-conception" displayName="Immaculate Conception" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="it"><Applicability><Territory code="IT" /></Applicability>
         <Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="it"><Applicability><Territory code="IT" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lt.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lt.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  LT notable-date resource, migrated from the v1 region-lt.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  LT notable-date resource, migrated from the v1 region-lt.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.lt">
 
@@ -16,23 +16,22 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="LT">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="LT" />
+      <Use notableDateRef="easter-monday" territory="LT" />
+      <Use notableDateRef="all-saints-day" territory="LT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-eve" territory="LT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="LT" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="lt"><Applicability fromYear="1583"><Territory code="LT" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lt"><Applicability fromYear="1583"><Territory code="LT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lt" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
@@ -44,24 +43,9 @@
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="all-souls-day" displayName="All Souls' Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
         <Strategy><Fixed month="November" day="2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lt"><Applicability><Territory code="LT" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lu.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lu.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  LU notable-date resource, migrated from the v1 region-lu.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  LU notable-date resource, migrated from the v1 region-lu.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.lu">
 
@@ -16,52 +16,32 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="LU">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="LU" />
+      <Use notableDateRef="easter-monday" territory="LU" />
+      <Use notableDateRef="ascension-day" territory="LU" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-monday" territory="LU" />
+      <Use notableDateRef="all-saints-day" territory="LU" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="LU" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability><Territory code="LU" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="lu"><Applicability fromYear="1583"><Territory code="LU" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability fromYear="1583"><Territory code="LU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lu" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lu"><Applicability><Territory code="LU" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability fromYear="1583"><Territory code="LU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lu" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability fromYear="1583"><Territory code="LU" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lu" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lu"><Applicability><Territory code="LU" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability><Territory code="LU" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lu"><Applicability><Territory code="LU" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lv.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-lv.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  LV notable-date resource, migrated from the v1 region-lv.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  LV notable-date resource, migrated from the v1 region-lv.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.lv">
 
@@ -16,52 +16,32 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="LV">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+      <Use notableDateRef="new-years-eve" territory="LV" category="PublicHoliday" nonWorking="true" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="LV" />
+      <Use notableDateRef="good-friday" territory="LV" />
+      <Use notableDateRef="easter-monday" territory="LV" />
+      <Use notableDateRef="christmas-eve" territory="LV" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="LV" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="lv"><Applicability fromYear="1583"><Territory code="LV" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability fromYear="1583"><Territory code="LV" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lv" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability fromYear="1583"><Territory code="LV" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="lv" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
         <Strategy><Fixed month="December" day="26" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="new-years-eve" displayName="New Year's Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="lv"><Applicability><Territory code="LV" /></Applicability>
-        <Strategy><Fixed month="December" day="31" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="restoration-of-independence-day" displayName="Restoration of Independence Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-mt.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-mt.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  MT notable-date resource, migrated from the v1 region-mt.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  MT notable-date resource, migrated from the v1 region-mt.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.mt">
 
@@ -16,28 +16,21 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="MT">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+      <Use notableDateRef="workers-day" territory="MT" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="MT" />
+      <Use notableDateRef="good-friday" territory="MT" />
+      <Use notableDateRef="christmas-day" territory="MT" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="mt"><Applicability><Territory code="MT" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="mt"><Applicability fromYear="1583"><Territory code="MT" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="mt"><Applicability fromYear="1583"><Territory code="MT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="mt" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="workers-day" displayName="Worker's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="mt"><Applicability><Territory code="MT" /></Applicability>
-        <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="feast-of-the-assumption-santa-marija" displayName="Feast of the Assumption (Santa Marija)" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="mt"><Applicability><Territory code="MT" /></Applicability>
@@ -47,11 +40,6 @@
     <NotableDate id="immaculate-conception" displayName="Immaculate Conception" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="mt"><Applicability><Territory code="MT" /></Applicability>
         <Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="mt"><Applicability><Territory code="MT" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="feast-of-saint-pauls-shipwreck" displayName="Feast of Saint Paul's Shipwreck" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-nl.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-nl.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  NL notable-date resource, migrated from the v1 region-nl.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  NL notable-date resource, migrated from the v1 region-nl.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.nl">
 
@@ -16,48 +16,24 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="NL">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="NL" />
+      <Use notableDateRef="good-friday" territory="NL" category="Observance" nonWorking="false" />
+      <Use notableDateRef="easter-monday" territory="NL" />
+      <Use notableDateRef="ascension-day" territory="NL" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-sunday" territory="NL" />
+      <Use notableDateRef="whit-monday" territory="NL" />
+      <Use notableDateRef="christmas-day" territory="NL" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nl"><Applicability><Territory code="NL" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nl" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nl" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nl" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nl" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nl"><Applicability fromYear="1583"><Territory code="NL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="nl" offsetDays="50" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="nl"><Applicability><Territory code="NL" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="nl"><Applicability><Territory code="NL" /></Applicability>

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-pl.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-pl.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  PL notable-date resource, migrated from the v1 region-pl.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  PL notable-date resource, migrated from the v1 region-pl.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.pl">
 
@@ -16,27 +16,27 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="PL">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="PL" />
+      <Use notableDateRef="easter-monday" territory="PL" />
+      <Use notableDateRef="whit-sunday" territory="PL" />
+      <Use notableDateRef="corpus-christi" territory="PL" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="all-saints-day" territory="PL" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="PL" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pl"><Applicability><Territory code="PL" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="pl"><Applicability><Territory code="PL" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="pl"><Applicability fromYear="1583"><Territory code="PL" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pl"><Applicability fromYear="1583"><Territory code="PL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="pl" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -44,29 +44,9 @@
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="pl"><Applicability fromYear="1583"><Territory code="PL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="pl" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pl"><Applicability fromYear="1583"><Territory code="PL" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="pl" offsetDays="60" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="pl"><Applicability><Territory code="PL" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pl"><Applicability><Territory code="PL" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pl"><Applicability><Territory code="PL" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-pt.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-pt.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  PT notable-date resource, migrated from the v1 region-pt.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  PT notable-date resource, migrated from the v1 region-pt.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.pt">
 
@@ -16,32 +16,26 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="PT">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="PT" />
+      <Use notableDateRef="good-friday" territory="PT" />
+      <Use notableDateRef="corpus-christi" territory="PT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="all-saints-day" territory="PT" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="PT" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pt"><Applicability><Territory code="PT" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="pt"><Applicability fromYear="1583"><Territory code="PT" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pt"><Applicability fromYear="1583"><Territory code="PT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="pt" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="pt"><Applicability><Territory code="PT" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pt"><Applicability fromYear="1583"><Territory code="PT" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="pt" offsetDays="60" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -49,19 +43,9 @@
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pt"><Applicability><Territory code="PT" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="immaculate-conception" displayName="Immaculate Conception" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="pt"><Applicability><Territory code="PT" /></Applicability>
         <Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="pt"><Applicability><Territory code="PT" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="freedom-day" displayName="Freedom Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ro.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-ro.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  RO notable-date resource, migrated from the v1 region-ro.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  RO notable-date resource, migrated from the v1 region-ro.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the Orthodox Easter cycle and the
+  remaining entries are territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.ro">
 
@@ -16,13 +16,18 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="RO">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="christmas-day" territory="RO" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ro"><Applicability><Territory code="RO" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ro"><Applicability><Territory code="RO" /></Applicability>
@@ -32,11 +37,6 @@
     <NotableDate id="dormition-of-the-mother-of-god" displayName="Dormition of the Mother of God" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ro"><Applicability><Territory code="RO" /></Applicability>
         <Strategy><Fixed month="August" day="15" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ro"><Applicability><Territory code="RO" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-se.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-se.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  SE notable-date resource, migrated from the v1 region-se.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  SE notable-date resource, migrated from the v1 region-se.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.se">
 
@@ -16,32 +16,29 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
-  <NotableDates>
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="SE">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+      <Use notableDateRef="new-years-eve" territory="SE" />
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="SE" />
+      <Use notableDateRef="good-friday" territory="SE" />
+      <Use notableDateRef="easter-monday" territory="SE" />
+      <Use notableDateRef="ascension-day" territory="SE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="whit-sunday" territory="SE" />
+      <Use notableDateRef="christmas-eve" territory="SE" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="SE" />
+    </Import>
+  </Imports>
 
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
+  <NotableDates>
 
     <NotableDate id="epiphany" displayName="Epiphany" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="se"><Applicability fromYear="1583"><Territory code="SE" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability fromYear="1583"><Territory code="SE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="se" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability fromYear="1583"><Territory code="SE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="se" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="may-day" displayName="May Day" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -49,34 +46,9 @@
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="ascension-day" displayName="Ascension Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability fromYear="1583"><Territory code="SE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="se" offsetDays="39" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="se"><Applicability fromYear="1583"><Territory code="SE" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="se" offsetDays="49" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="second-day-of-christmas" displayName="Second Day of Christmas" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
         <Strategy><Fixed month="December" day="26" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="new-years-eve" displayName="New Year's Eve" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="se"><Applicability><Territory code="SE" /></Applicability>
-        <Strategy><Fixed month="December" day="31" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="midsummer-day" displayName="Midsummer Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-si.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-si.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  SI notable-date resource, migrated from the v1 region-si.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  SI notable-date resource, migrated from the v1 region-si.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.si">
 
@@ -16,32 +16,25 @@
     </AdjustmentPolicy>
   </AdjustmentPolicies>
 
+  <Imports>
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" territory="SI">
+        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
+      </Use>
+    </Import>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="SI" />
+      <Use notableDateRef="easter-monday" territory="SI" />
+      <Use notableDateRef="whit-sunday" territory="SI" />
+      <Use notableDateRef="christmas-day" territory="SI" />
+    </Import>
+  </Imports>
+
   <NotableDates>
-
-    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="si"><Applicability><Territory code="SI" /></Applicability>
-        <Strategy><Fixed month="January" day="1" /></Strategy>
-        <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="si"><Applicability fromYear="1583"><Territory code="SI" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="si"><Applicability fromYear="1583"><Territory code="SI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="si" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="si"><Applicability><Territory code="SI" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="si"><Applicability fromYear="1583"><Territory code="SI" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="si" offsetDays="49" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="assumption-of-mary" displayName="Assumption of Mary" category="PublicHoliday" defaultNonWorkingDay="true">
@@ -52,11 +45,6 @@
     <NotableDate id="day-of-remembrance-of-the-dead" displayName="Day of Remembrance of the Dead" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="si"><Applicability><Territory code="SI" /></Applicability>
         <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="si"><Applicability><Territory code="SI" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="new-year-holiday" displayName="New Year Holiday" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-sk.xml
+++ b/Bodu.Globalization.Calendar2.Data.Europe/src/Resources/region-sk.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  SK notable-date resource, migrated from the v1 region-sk.xml to the v2 cookbook schema by
-  tools/migrate_europe.py. UseFrom imports (europe-common, Christian, and global observances) are flattened
-  into self-contained rules.
+  SK notable-date resource, migrated from the v1 region-sk.xml to the v2 cookbook schema. Shared civil and Christian
+  observances are imported from the global-core and christian-western catalogues; the remaining entries are
+  territory-local concepts defined inline.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.sk">
 
@@ -15,6 +15,17 @@
       <Emission mode="ObservedOnly" reason="Substitute public holiday" />
     </AdjustmentPolicy>
   </AdjustmentPolicies>
+
+  <Imports>
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" territory="SK" />
+      <Use notableDateRef="good-friday" territory="SK" />
+      <Use notableDateRef="easter-monday" territory="SK" />
+      <Use notableDateRef="all-saints-day" territory="SK" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-eve" territory="SK" category="PublicHoliday" nonWorking="true" />
+      <Use notableDateRef="christmas-day" territory="SK" />
+    </Import>
+  </Imports>
 
   <NotableDates>
 
@@ -29,39 +40,9 @@
         <Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
-      <Rules><Rule id="sk"><Applicability fromYear="1583"><Territory code="SK" /></Applicability>
-        <Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sk"><Applicability fromYear="1583"><Territory code="SK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="sk" offsetDays="-2" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sk"><Applicability fromYear="1583"><Territory code="SK" /></Applicability>
-        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="sk" offsetDays="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <NotableDate id="labour-day" displayName="Labour Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sk"><Applicability><Territory code="SK" /></Applicability>
         <Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sk"><Applicability><Territory code="SK" /></Applicability>
-        <Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sk"><Applicability><Territory code="SK" /></Applicability>
-        <Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="sk"><Applicability><Territory code="SK" /></Applicability>
-        <Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <NotableDate id="saint-stephens-day" displayName="Saint Stephen's Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/Bodu.Globalization.Calendar2/V1-TO-V2-TYPE-METHOD-AUDIT.md
+++ b/Bodu.Globalization.Calendar2/V1-TO-V2-TYPE-METHOD-AUDIT.md
@@ -25,6 +25,8 @@ The following are the **only confirmed gaps** — members present in v1 with no 
 
 > **Resolution status (2026-06-04):** **all eight gaps are now CLOSED** — A1, A2, A3, A4, and B3 first, then A5, B1, and B2 — each implemented with tests and marked ✅ in the tables below. Where a per-section detail table further down still carries an `⛔ [GAP — review]` marker for one of these items, treat that marker as **superseded by this banner**. There are no known remaining gaps between the v1 surface and v2.
 
+> **Second-pass addendum (2026-06-04):** a separate second-pass type-matrix review re-opened **four members this audit had filed under *deliberate omission*** (Section C) — `everyYears` recurrence, `INotableDateService.GetSupportedTerritories/Calendars`, the configurable working week, and the `IfNonWorkingDay` trigger. On review these were reclassified as genuine parity gaps and **implemented**; Section C, the affected per-member rows, and the new **Second-pass review** section below are updated to ✅. See that section for the rebuttal of the review's inflated headline count.
+
 ### A. Material capability gaps (a user-facing feature is absent)
 
 | # | v1 member(s) | What is lost | Where |
@@ -45,9 +47,33 @@ The following are the **only confirmed gaps** — members present in v1 with no 
 
 ### C. Deliberate omissions (documented design — not "missed")
 
-For completeness, the notable members intentionally dropped, each with a design rationale in the functional audit or an obvious replacement: the `IfNonWorkingDay` trigger (folded into `IfWeekend` + `skipNonWorkingDates`); `INotableDateRulePlugin` (v2 plugins contribute algorithms only, no rule providers); `NotableDateProvenance` and the whole `RangeResolution` pipeline (internal — replaced by the two-phase resolver); `NotableDateServiceOptions` (→ explicit ctor params); `INotableDateService.GetSupportedTerritories/Calendars`, `Invalidate`, `WorkingWeek` (immutable-resource / hard-coded weekend model); per-result `CalendarType` and `Comment` (carried on the rule); the v1 algorithm *provider* metadata and per-algorithm year-range guards (metadata authored on rules; guarding centralised to a 1–9999 clamp); CLR-typed algorithm references (`AlgorithmType`/`AlgorithmMonth`/`AlgorithmDay`); and `CalendarThrowHelper` (v2 uses `Bodu.ThrowHelper` + `Calendar2ResourceStrings`). Nakshatra-fixed **Onam** is the one intentionally unmodelled festival, and it never existed as a v1 type.
+For completeness, the notable members intentionally dropped, each with a design rationale in the functional audit or an obvious replacement: `INotableDateRulePlugin` (v2 plugins contribute algorithms only, no rule providers); `NotableDateProvenance` and the whole `RangeResolution` pipeline (internal — replaced by the two-phase resolver); `NotableDateServiceOptions` (→ explicit ctor params); `INotableDateService.Invalidate` (immutable-resource model); per-result `CalendarType` and `Comment` (carried on the rule); the v1 algorithm *provider* metadata and per-algorithm year-range guards (metadata authored on rules; guarding centralised to a 1–9999 clamp); CLR-typed algorithm references (`AlgorithmType`/`AlgorithmMonth`/`AlgorithmDay`); and `CalendarThrowHelper` (v2 uses `Bodu.ThrowHelper` + `Calendar2ResourceStrings`). Nakshatra-fixed **Onam** is the one intentionally unmodelled festival, and it never existed as a v1 type.
 
 > **Net:** of the entire v1 surface, eight members/families had no v2 equivalent, and **all eight are now closed**: A1 notable-date traversal, A2 non-working-day traversal, A3 `DateRange` set operations, A4 plugin trust policies, B3 territory-list parsing, A5 the code-first `INotableDateProvider` seam, B1 policy-level year scope, and B2 custom-handler parameters. Everything else migrated, was replaced by design, or is internal plumbing — there are no known remaining gaps.
+
+---
+
+## Second-pass review: rebuttal & reconciliation
+
+A separate **second-pass type-matrix report** (`calendar_second_pass_type_matrix_report.md`) re-compared the v1 surface against v2 and reported a large block of "absent" types. Most of that headline is a **measurement artifact**; but the review did correctly surface four genuine functional-parity omissions this audit had filed under *deliberate*, and those four are now implemented. This section records both so the two documents reconcile.
+
+### Measurement artifacts (not real gaps)
+
+1. **Missing projects in the compared snapshot.** The report measured against a v2 snapshot containing only the core assembly. The plugin types it flagged "absent" all ship in **`Bodu.Globalization.Calendar2.Plugins`**, and the territory data it flagged "absent" ships as the **`region-*.xml` packs across the three `Bodu.Globalization.Calendar2.Data.*` bundles** (Americas / AsiaPacific / Europe). Re-running the comparison against the full solution removes those rows.
+2. **Source-compatibility conflated with functional parity.** The report's PASS/FAIL keyed on a member surviving *by name and shape*. v2 deliberately reshapes the surface (`DateTime`→`DateOnly`, name-keyed→id-keyed identity, enum-discriminator→polymorphic strategy, ambient context→explicit service, inline adjustment→reusable policy). Counting each reshape as a FAIL inflates the count; the per-member dispositions in this audit already record these as ✅ *[reshaped]* / 🔵 *[replaced]*.
+
+### Genuine omissions it surfaced — now CLOSED (2026-06-04)
+
+The review's signal value was four items this audit had classified as **deliberate omissions** that, on maintainer review, were reclassified as genuine parity gaps and implemented with tests:
+
+| Item | v1 capability | v2 closure |
+|---|---|---|
+| **`everyYears` recurrence** | Periodic rule cadence (e.g. every fourth year) anchored to a base year. | `RuleApplicability` gained `everyYears` / `anchorYear` (XSD + JSON schema + both parsers); the cadence is enforced in `AppliesTo`. |
+| **`GetSupportedTerritories` / `GetSupportedCalendars`** | Service introspection of the scoped territory and calendar surface. | Re-added to `INotableDateService`, delegated through `ReloadableNotableDateService`. |
+| **Configurable working week** | A `WorkingWeek` (`WeekPattern`) so a non-Western territory can define its own weekend. | Resource-level `ResolutionPolicy.WorkingWeek` (`workingDays` Sunday-first pattern, default Mon–Fri); consumed by `IfWeekend` / `IfWeekday` and the working-day search instead of a hard-coded Saturday/Sunday. |
+| **`IfNonWorkingDay` trigger** | Trigger on "the occurrence lands on a non-working day", not only a fixed weekend. | Re-added to the `AdjustmentTrigger` enum (plus a symmetric `IfWorkingDay`), evaluated against the complete set of actual non-working dates so a holiday colliding with another holiday — not just a weekend — fires it. |
+
+Section C above and the affected per-member rows (`AdjustmentTrigger.IfNonWorkingDay`; `INotableDateService.WorkingWeek` / `GetSupported*`) are updated to ✅ to match.
 
 ---
 ## Core engine, model & adjustment
@@ -119,7 +145,7 @@ For completeness, the notable members intentionally dropped, each with a design 
 | v1 member | v2 disposition | Notes |
 |---|---|---|
 | `Always`, `IfDayOfWeek`, `IfWeekend`, `IfWeekday`, `IfBeforeFixedDate`, `IfAfterFixedDate`, `IfLeapYear`, `IfNthOccurrenceInMonth`, `Custom` | ✅ Migrated | All present in v2 (order differs). |
-| `IfNonWorkingDay` | 🔵 Replaced [deliberate] | Folded into `IfWeekend` + `skipNonWorkingDates` by design (functional audit area 8). |
+| `IfNonWorkingDay` | ✅ Migrated [reshaped] | Re-added to the v2 `AdjustmentTrigger` enum (2026-06-04). Fires when the occurrence falls outside the resource working week or on a day already claimed by another non-working occurrence; a symmetric `IfWorkingDay` was added alongside it. |
 
 ### CachingCalculationAnchorResolver (sealed class, internal)
 **Type disposition:** ⚪ Internal — performance plumbing (area 25); not reproduced. v2 resolves offset anchors inline via `StrategyResolutionContext.ResolveReference` (cycle-guarded `HashSet`, no caching).
@@ -152,7 +178,7 @@ For completeness, the notable members intentionally dropped, each with a design 
 | `ThrowIfKeyNullOrWhiteSpace` | 🔵 Replaced | v2 registries call `ThrowHelper.ThrowIfNull(key)` only (no whitespace guard). |
 | `ThrowIfAnchorRuleNameNullOrWhiteSpace` | ⛔ Not migrated [deliberate] | No anchor-by-name path in v2. |
 | `ThrowIfYearOutOfRange` | ⚪ Internal | No dedicated calendar year guard; year validation is implicit / via `DateOnly`. |
-| `ThrowIfWorkingWeekUndefined`, `ThrowIfWorkingWeekEmpty` | ⛔ Not migrated [deliberate] | v2 hard-codes Sat/Sun weekend; no `WorkingDaysOfWeek`/`WeekPattern` parameter. |
+| `ThrowIfWorkingWeekUndefined`, `ThrowIfWorkingWeekEmpty` | ⛔ Not migrated [deliberate] | v2 carries the working week as resource-level `ResolutionPolicy.WorkingWeek` (`WeekPattern`, default Mon–Fri) rather than a per-call parameter, so these argument guards have no call site. |
 | `ThrowIfUnsupportedCalendarType` | ⛔ Not migrated [deliberate] | v2 uses the `CalendarSystem` enum + `CalendarSystems`, not CLR calendar-type validation. |
 | `CalendarThrowHelper.NetStandard.cs` partial | ⛔ Not migrated [deliberate] | v2 targets `net8.0` only; no netstandard companion. |
 
@@ -237,7 +263,7 @@ For completeness, the notable members intentionally dropped, each with a design 
 
 | v1 member | v2 disposition | Notes |
 |---|---|---|
-| `WorkingWeek` (`WeekPattern`) property | ⛔ Not migrated [deliberate] | v2 has no configurable working week; Sat/Sun weekend hard-coded. |
+| `WorkingWeek` (`WeekPattern`) property | ✅ Migrated [moved→`ResolutionPolicy.WorkingWeek`] | Re-added (2026-06-04) as resource-level config (`workingDays` Sunday-first pattern; default Mon–Fri) consumed by the weekend triggers and the working-day search, rather than a mutable service property. |
 | `IsWeekend(DateTime)` | ✅ Migrated [moved→`NotableDate*Extensions`] | Working-day predicates moved off the service to extensions (area 20). |
 | `IsNonWorkingDay(DateTime, string?, Type?)` | ✅ Migrated [moved→extension] | Territory required, no `Type?` calendar param. |
 | `IsHolidayNonWorkingDay(...)` (default impl) | ✅ Migrated [moved→extension] | Covered by `IsNotableDate`/working-day extensions. |
@@ -246,8 +272,8 @@ For completeness, the notable members intentionally dropped, each with a design 
 | `GetNotableDates(DateTime date, …)` ×2 | ✅ Migrated [reshaped→`Resolve(DateOnly, territory[, filter])`] | On the interface. |
 | `Invalidate()` | ⛔ Not migrated [deliberate] | Immutable resource model; reload is a separate type. |
 | `Reload()` | ✅ Migrated [moved→`ReloadableNotableDateService.Reload` + `MutableNotableDateResourceProvider`] | Not on `INotableDateService` (area 16). |
-| `GetSupportedTerritories()` | ⛔ Not migrated [deliberate] | Functional audit area 3: "not exposed". |
-| `GetSupportedCalendars()` | ⛔ Not migrated [deliberate] | As above. |
+| `GetSupportedTerritories()` | ✅ Migrated [1:1] | Re-added to `INotableDateService` (2026-06-04): distinct scoped territory codes, case-insensitive ascending. |
+| `GetSupportedCalendars()` | ✅ Migrated [1:1] | Re-added (2026-06-04): distinct calendar systems any rule is expressed in, ascending. |
 
 ### NotableDate (sealed record, public)
 **Type disposition:** ✅ Migrated [reshaped: DateTime→DateOnly] — v2 `NotableDate` positional record.
@@ -341,7 +367,7 @@ For completeness, the notable members intentionally dropped, each with a design 
 | v1 member | v2 disposition | Notes |
 |---|---|---|
 | ctors (rule-provider chain + `WeekPattern`/`WorkingDaysOfWeek` + `NotableDateServiceOptions`) | ✅ Migrated [reshaped] | v2 ctors take a single immutable `NotableDateResource` + optional `INotableDateAlgorithmRegistry`/`INotableDateCollisionResolver`/`IAdjustmentHandlerRegistry`/`IAdjustmentTriggerHandlerRegistry` (5 overloads). No rule-provider chain, no working-week, no options bag. |
-| `GetNotableDates(...)` ×6, `IsWeekend`/`IsNonWorkingDay`/`IsHolidayNonWorkingDay`, `Invalidate`/`Reload`, `WorkingWeek`, `GetSupported*`, `Validate` | see `INotableDateService` rows | `Resolve` overloads + extensions; predicates → extensions; reload → `ReloadableNotableDateService`; supported-* dropped; validation → `NotableDateRuleValidator`. |
+| `GetNotableDates(...)` ×6, `IsWeekend`/`IsNonWorkingDay`/`IsHolidayNonWorkingDay`, `Invalidate`/`Reload`, `WorkingWeek`, `GetSupported*`, `Validate` | see `INotableDateService` rows | `Resolve` overloads + extensions; predicates → extensions; reload → `ReloadableNotableDateService`; working week → `ResolutionPolicy.WorkingWeek`; supported-* re-added on the interface; validation → `NotableDateRuleValidator`. |
 | (per-request range-pipeline cache) | ⚪ Internal | v2 resolves inline, two-phase, no cache (area 25). |
 
 ### NotableDateServiceOptions (sealed class, public)

--- a/Bodu.Globalization.Calendar2/src/Bodu.Globalization.Calendar2.csproj
+++ b/Bodu.Globalization.Calendar2/src/Bodu.Globalization.Calendar2.csproj
@@ -31,6 +31,9 @@
       <LogicalName>Bodu.Globalization.Calendar.V2.NotableDates.v2.schema.json</LogicalName>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="Globalization.Calendar.V2\Resources\*.xml">
+      <LogicalName>Bodu.Globalization.Calendar.V2.Resources.%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/AdjustmentPolicy.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/AdjustmentPolicy.cs
@@ -278,17 +278,24 @@ public sealed class AdjustmentPolicy
     public IReadOnlyDictionary<string, string> HandlerParameters { get; }
 
     /// <summary>
-    /// Determines whether the policy fires for an occurrence on the supplied date.
+    /// Determines whether the policy fires for an occurrence on the supplied date, evaluating weekend-sensitive
+    /// triggers against the supplied working week.
     /// </summary>
     /// <param name="date">The calculated occurrence date.</param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
     /// <returns><see langword="true" /> if the trigger fires; otherwise <see langword="false" />.</returns>
-    public bool IsTriggered(DateOnly date) =>
+    /// <remarks>
+    /// The <see cref="AdjustmentTrigger.IfNonWorkingDay" /> and <see cref="AdjustmentTrigger.IfWorkingDay" /> triggers
+    /// also depend on whether another non-working occurrence claims the date, which this method cannot determine alone;
+    /// they are evaluated by the resolving service and never fire here.
+    /// </remarks>
+    public bool IsTriggered(DateOnly date, WeekPattern workingWeek) =>
         this.Trigger switch
         {
             AdjustmentTrigger.Always => true,
             AdjustmentTrigger.IfDayOfWeek => this.TriggerWeekdays.Contains(date.DayOfWeek),
-            AdjustmentTrigger.IfWeekend => date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday,
-            AdjustmentTrigger.IfWeekday => date.DayOfWeek is not DayOfWeek.Saturday and not DayOfWeek.Sunday,
+            AdjustmentTrigger.IfWeekend => !workingWeek.Contains(date.DayOfWeek),
+            AdjustmentTrigger.IfWeekday => workingWeek.Contains(date.DayOfWeek),
             AdjustmentTrigger.IfLeapYear => DateTime.IsLeapYear(date.Year),
             AdjustmentTrigger.IfBeforeFixedDate => this.ComparesFixedDate(date, before: true),
             AdjustmentTrigger.IfAfterFixedDate => this.ComparesFixedDate(date, before: false),
@@ -330,15 +337,17 @@ public sealed class AdjustmentPolicy
     }
 
     /// <summary>
-    /// Applies the policy's action to the supplied occurrence date.
+    /// Applies the policy's action to the supplied occurrence date, evaluating weekend skips against the supplied
+    /// working week.
     /// </summary>
     /// <param name="date">The calculated occurrence date.</param>
     /// <param name="isOccupied">
     /// A predicate reporting whether a candidate day is already claimed by another non-working occurrence.
     /// </param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
     /// <returns>The transformed (observed) date; the input date when the action makes no change.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="isOccupied" /> is <see langword="null" />.</exception>
-    public DateOnly ApplyAction(DateOnly date, Func<DateOnly, bool> isOccupied)
+    public DateOnly ApplyAction(DateOnly date, Func<DateOnly, bool> isOccupied, WeekPattern workingWeek)
     {
         ThrowHelper.ThrowIfNull(isOccupied);
 
@@ -347,8 +356,8 @@ public sealed class AdjustmentPolicy
             AdjustmentAction.AddDays => date.AddDays(this.ActionDays),
             AdjustmentAction.MoveToNextWeekday => this.ActionWeekday is DayOfWeek next ? WeekdayMath.OnOrAfter(date, next) : date,
             AdjustmentAction.MoveToPreviousWeekday => this.ActionWeekday is DayOfWeek previous ? WeekdayMath.OnOrBefore(date, previous) : date,
-            AdjustmentAction.MoveToNextWorkingDay => this.SeekWorkingDay(date, step: 1, isOccupied),
-            AdjustmentAction.MoveToPreviousWorkingDay => this.SeekWorkingDay(date, step: -1, isOccupied),
+            AdjustmentAction.MoveToNextWorkingDay => this.SeekWorkingDay(date, step: 1, isOccupied, workingWeek),
+            AdjustmentAction.MoveToPreviousWorkingDay => this.SeekWorkingDay(date, step: -1, isOccupied, workingWeek),
             _ => date,
         };
     }
@@ -360,13 +369,14 @@ public sealed class AdjustmentPolicy
     /// <param name="date">The starting date.</param>
     /// <param name="step">The direction of travel: <c>+1</c> forward, <c>-1</c> backward.</param>
     /// <param name="isOccupied">A predicate reporting whether a candidate day is already claimed.</param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
     /// <returns>The first working day found, or the last scanned day when the bound is reached.</returns>
-    private DateOnly SeekWorkingDay(DateOnly date, int step, Func<DateOnly, bool> isOccupied)
+    private DateOnly SeekWorkingDay(DateOnly date, int step, Func<DateOnly, bool> isOccupied, WeekPattern workingWeek)
     {
         int bound = this.MaxSearchDays ?? DefaultMaxSearchDays;
 
         DateOnly cursor = date.AddDays(step);
-        for (int i = 0; i < bound && this.IsBlocked(cursor, isOccupied); i++)
+        for (int i = 0; i < bound && this.IsBlocked(cursor, isOccupied, workingWeek); i++)
             cursor = cursor.AddDays(step);
 
         return cursor;
@@ -377,8 +387,9 @@ public sealed class AdjustmentPolicy
     /// </summary>
     /// <param name="date">The candidate day.</param>
     /// <param name="isOccupied">A predicate reporting whether the day is already claimed.</param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
     /// <returns><see langword="true" /> if the day is blocked; otherwise <see langword="false" />.</returns>
-    private bool IsBlocked(DateOnly date, Func<DateOnly, bool> isOccupied) =>
-        (this.SkipWeekends && date.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)
+    private bool IsBlocked(DateOnly date, Func<DateOnly, bool> isOccupied, WeekPattern workingWeek) =>
+        (this.SkipWeekends && !workingWeek.Contains(date.DayOfWeek))
         || (this.SkipNonWorkingDates && isOccupied(date));
 }

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/AdjustmentTrigger.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/AdjustmentTrigger.cs
@@ -22,14 +22,28 @@ public enum AdjustmentTrigger
     IfDayOfWeek,
 
     /// <summary>
-    /// The adjustment applies when the calculated occurrence falls on a Saturday or Sunday.
+    /// The adjustment applies when the calculated occurrence falls on a weekend: a day outside the resource's working
+    /// week (Saturday or Sunday by default).
     /// </summary>
     IfWeekend,
 
     /// <summary>
-    /// The adjustment applies when the calculated occurrence falls on a Monday through Friday.
+    /// The adjustment applies when the calculated occurrence falls on a working day within the resource's working week
+    /// (Monday through Friday by default).
     /// </summary>
     IfWeekday,
+
+    /// <summary>
+    /// The adjustment applies when the calculated occurrence falls on a non-working day: a day outside the resource's
+    /// working week, or a day already claimed by another non-working occurrence.
+    /// </summary>
+    IfNonWorkingDay,
+
+    /// <summary>
+    /// The adjustment applies when the calculated occurrence falls on a working day within the resource's working week
+    /// that is not claimed by another non-working occurrence.
+    /// </summary>
+    IfWorkingDay,
 
     /// <summary>
     /// The adjustment applies when the calculated occurrence falls in a Gregorian leap year.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/CommonNotableDateResources.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/CommonNotableDateResources.cs
@@ -1,0 +1,69 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CommonNotableDateResources.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Concurrent;
+using System.Text;
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Provides the shared, reusable notable-date resources bundled with the library — the civil, Christian, and other
+/// thematic catalogues that define common observances (New Year's Day, Easter, Christmas, and the like) once for
+/// territory packs to import rather than redefine.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A territory resource imports a common catalogue by name through an <c>Import</c> directive, then cherry-picks the
+/// concepts it observes and supplies its own territory and adjustment overrides. The <see cref="Resolver" /> delegate
+/// is the bridge: pass it to <see cref="NotableDateResourceLoader.Load(System.IO.Stream, System.Func{string, string})" />
+/// so those imports resolve against the embedded catalogues.
+/// </para>
+/// <para>
+/// Resource names are the bare catalogue identifiers (for example <c>global-core</c> or <c>christian-western</c>),
+/// matching the file names without their extension. Lookups are case-insensitive and the resolved content is cached.
+/// </para>
+/// </remarks>
+public static class CommonNotableDateResources
+{
+    /// <summary>
+    /// The manifest-resource-name prefix shared by the embedded common catalogues.
+    /// </summary>
+    private const string ResourcePrefix = "Bodu.Globalization.Calendar.V2.Resources.";
+
+    /// <summary>
+    /// The cache of resolved catalogue content, keyed by case-insensitive resource name.
+    /// </summary>
+    private static readonly ConcurrentDictionary<string, string?> s_cache = new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Gets a resolver delegate that maps a common-catalogue name to its embedded XML content, suitable for passing to
+    /// the import-aware <see cref="NotableDateResourceLoader" /> overloads.
+    /// </summary>
+    /// <returns>A resolver over the embedded common catalogues that returns <see langword="null" /> for unknown names.</returns>
+    public static Func<string, string?> Resolver { get; } = Resolve;
+
+    /// <summary>
+    /// Resolves a common-catalogue name to its embedded XML content.
+    /// </summary>
+    /// <param name="resourceName">The catalogue name, without extension (for example <c>christian-western</c>).</param>
+    /// <returns>The catalogue XML, or <see langword="null" /> when no catalogue of that name is bundled.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="resourceName" /> is <see langword="null" />.</exception>
+    public static string? Resolve(string resourceName)
+    {
+        ThrowHelper.ThrowIfNull(resourceName);
+
+        return s_cache.GetOrAdd(resourceName, static name =>
+        {
+            using Stream? stream = typeof(CommonNotableDateResources).Assembly
+                .GetManifestResourceStream(ResourcePrefix + name + ".xml");
+            if (stream is null)
+                return null;
+
+            using StreamReader reader = new(stream, Encoding.UTF8);
+            return reader.ReadToEnd();
+        });
+    }
+}

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/INotableDateService.cs
@@ -48,4 +48,18 @@ public interface INotableDateService
     /// <param name="filter">The filter that emitted occurrences must satisfy.</param>
     /// <returns>The matching occurrences, ordered by date then identity.</returns>
     IReadOnlyList<NotableDate> Resolve(DateRange range, string territory, NotableDateFilter filter);
+
+    /// <summary>
+    /// Gets the distinct territories any rule in the resource is scoped to.
+    /// </summary>
+    /// <returns>
+    /// The scoped territory codes in case-insensitive ascending order; empty when every rule is global (unscoped).
+    /// </returns>
+    IReadOnlyList<string> GetSupportedTerritories();
+
+    /// <summary>
+    /// Gets the distinct calendar systems any rule in the resource is expressed in.
+    /// </summary>
+    /// <returns>The calendar systems in use, in ascending order.</returns>
+    IReadOnlyList<CalendarSystem> GetSupportedCalendars();
 }

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
@@ -344,7 +344,9 @@ internal static class NotableDateDocumentParser
             ParseNullableInt(element.Attribute("toYear")?.Value),
             element.Elements(s_ns + "Territory").Select(t => (string?)t.Attribute("code") ?? string.Empty),
             element.Elements(s_ns + "OnlyYear").Select(y => ParseInt(y.Attribute("value")?.Value, 0)),
-            element.Elements(s_ns + "ExceptYear").Select(y => ParseInt(y.Attribute("value")?.Value, 0)));
+            element.Elements(s_ns + "ExceptYear").Select(y => ParseInt(y.Attribute("value")?.Value, 0)),
+            ParseNullableInt(element.Attribute("everyYears")?.Value),
+            ParseNullableInt(element.Attribute("anchorYear")?.Value));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
@@ -144,8 +144,18 @@ internal static class NotableDateDocumentParser
             ParseEnum(element.Attribute("sameDayCollisionPolicy")?.Value, CollisionPolicy.KeepAll),
             ParseEnum(element.Attribute("spanCollisionPolicy")?.Value, CollisionPolicy.KeepAll),
             ParseEnum(element.Attribute("priorityDirection")?.Value, PriorityDirection.HigherWins),
-            ParseEnum(element.Attribute("observedDateRangePolicy")?.Value, ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion));
+            ParseEnum(element.Attribute("observedDateRangePolicy")?.Value, ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion),
+            ParseWorkingWeek(element.Attribute("workingDays")?.Value));
     }
+
+    /// <summary>
+    /// Parses a Sunday-first seven-character working-week pattern, falling back to the default working week when the
+    /// value is absent or blank.
+    /// </summary>
+    /// <param name="value">The working-week pattern, or <see langword="null" />.</param>
+    /// <returns>The parsed <see cref="WeekPattern" />, or <see langword="null" /> when unspecified.</returns>
+    private static WeekPattern? ParseWorkingWeek(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : WeekPattern.Parse(value);
 
     /// <summary>
     /// Parses the reusable adjustment policies declared by the resource.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateDocumentParser.cs
@@ -92,13 +92,31 @@ internal static class NotableDateDocumentParser
                     (string?)use.Attribute("as"),
                     (string?)use.Attribute("territory"),
                     ParseNullableEnum<NotableDateCategory>(use.Attribute("category")?.Value),
-                    ParseNullableBool(use.Attribute("nonWorking")?.Value)))
+                    ParseNullableBool(use.Attribute("nonWorking")?.Value),
+                    ParseUseAdjustments(use)))
                 .ToList();
 
             imports.Add(new NotableDateImport((string?)import.Attribute("resource") ?? string.Empty, uses));
         }
 
         return imports;
+    }
+
+    /// <summary>
+    /// Parses the optional adjustment override declared by an import <c>Use</c>, returning the replacement policy ids
+    /// when an <c>Adjustments</c> element is present and <see langword="null" /> when it is absent.
+    /// </summary>
+    /// <param name="use">The <c>Use</c> element.</param>
+    /// <returns>The replacement adjustment policy ids, or <see langword="null" /> to keep the source rules' adjustments.</returns>
+    private static IReadOnlyList<string>? ParseUseAdjustments(XElement use)
+    {
+        XElement? adjustments = use.Element(s_ns + "Adjustments");
+        if (adjustments is null)
+            return null;
+
+        return adjustments.Elements(s_ns + "Adjustment")
+            .Select(adjustment => (string?)adjustment.Attribute("policyRef") ?? string.Empty)
+            .ToList();
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateImportUse.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateImportUse.cs
@@ -16,9 +16,14 @@ namespace Bodu.Globalization.Calendar.V2;
 /// <param name="NonWorking">
 /// An override for the imported concept's default non-working flag, or <see langword="null" /> to keep it.
 /// </param>
+/// <param name="AdjustmentPolicyRefs">
+/// The adjustment policy ids that replace those on every rule of the imported concept, or <see langword="null" /> to
+/// keep the source rules' adjustments. An empty list clears the source adjustments.
+/// </param>
 internal sealed record NotableDateImportUse(
     string NotableDateRef,
     string? As,
     string? Territory,
     NotableDateCategory? Category,
-    bool? NonWorking);
+    bool? NonWorking,
+    IReadOnlyList<string>? AdjustmentPolicyRefs);

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
@@ -70,7 +70,10 @@ internal static class NotableDateJsonDocumentParser
                         GetString(use, "as"),
                         GetString(use, "territory"),
                         ParseNullableEnum<NotableDateCategory>(GetString(use, "category")),
-                        GetNullableBool(use, "nonWorking")));
+                        GetNullableBool(use, "nonWorking"),
+                        GetProperty(use, "adjustments") is JsonElement adjustments && adjustments.ValueKind == JsonValueKind.Array
+                            ? adjustments.EnumerateArray().Select(adjustment => adjustment.GetString() ?? string.Empty).ToList()
+                            : null));
                 }
             }
 

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
@@ -310,7 +310,9 @@ internal static class NotableDateJsonDocumentParser
             GetNullableInt(applicability, "toYear"),
             StringArray(applicability, "territories"),
             IntArray(applicability, "onlyYears"),
-            IntArray(applicability, "exceptYears"));
+            IntArray(applicability, "exceptYears"),
+            GetNullableInt(applicability, "everyYears"),
+            GetNullableInt(applicability, "anchorYear"));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateJsonDocumentParser.cs
@@ -114,8 +114,18 @@ internal static class NotableDateJsonDocumentParser
             ParseEnum(GetString(policy, "sameDayCollisionPolicy"), CollisionPolicy.KeepAll),
             ParseEnum(GetString(policy, "spanCollisionPolicy"), CollisionPolicy.KeepAll),
             ParseEnum(GetString(policy, "priorityDirection"), PriorityDirection.HigherWins),
-            ParseEnum(GetString(policy, "observedDateRangePolicy"), ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion));
+            ParseEnum(GetString(policy, "observedDateRangePolicy"), ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion),
+            ParseWorkingWeek(GetString(policy, "workingDays")));
     }
+
+    /// <summary>
+    /// Parses a Sunday-first seven-character working-week pattern, falling back to the default working week when the
+    /// value is absent or blank.
+    /// </summary>
+    /// <param name="value">The working-week pattern, or <see langword="null" />.</param>
+    /// <returns>The parsed <see cref="WeekPattern" />, or <see langword="null" /> when unspecified.</returns>
+    private static WeekPattern? ParseWorkingWeek(string? value) =>
+        string.IsNullOrWhiteSpace(value) ? null : WeekPattern.Parse(value);
 
     /// <summary>
     /// Parses the reusable adjustment policies declared by the resource.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateResourceLoader.cs
@@ -303,8 +303,11 @@ public static class NotableDateResourceLoader
         NotableDateCategory category = use.Category ?? concept.Category;
         bool nonWorking = use.NonWorking ?? concept.DefaultNonWorkingDay;
 
+        bool overrideTerritory = !string.IsNullOrEmpty(use.Territory);
+        bool overrideAdjustments = use.AdjustmentPolicyRefs is not null;
+
         IReadOnlyList<NotableDateRule> rules = concept.Rules;
-        if (!string.IsNullOrEmpty(use.Territory))
+        if (overrideTerritory || overrideAdjustments)
         {
             rules = concept.Rules
                 .Select(r => new NotableDateRule(
@@ -313,9 +316,19 @@ public static class NotableDateResourceLoader
                     r.Category,
                     r.NonWorking,
                     r.DurationDays,
-                    new RuleApplicability(r.Applicability.Calendar, r.Applicability.FromYear, r.Applicability.ToYear, new[] { use.Territory! }, r.Applicability.OnlyYears, r.Applicability.ExceptYears),
+                    overrideTerritory
+                        ? new RuleApplicability(
+                            r.Applicability.Calendar,
+                            r.Applicability.FromYear,
+                            r.Applicability.ToYear,
+                            new[] { use.Territory! },
+                            r.Applicability.OnlyYears,
+                            r.Applicability.ExceptYears,
+                            r.Applicability.EveryYears,
+                            r.Applicability.AnchorYear)
+                        : r.Applicability,
                     r.Strategy,
-                    r.AdjustmentPolicyRefs,
+                    overrideAdjustments ? use.AdjustmentPolicyRefs! : r.AdjustmentPolicyRefs,
                     r.Tags))
                 .ToList();
         }

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateResourceLoader.cs
@@ -102,6 +102,24 @@ public static class NotableDateResourceLoader
         Load(ReadToEnd(stream));
 
     /// <summary>
+    /// Loads and validates a notable-date document from a stream of XML content, resolving imports through the supplied
+    /// resolver.
+    /// </summary>
+    /// <param name="stream">The stream containing the notable-date document XML.</param>
+    /// <param name="resourceResolver">A delegate mapping a resource name to its XML or JSON content, or <see langword="null" /> when missing.</param>
+    /// <returns>The loaded and validated <see cref="NotableDateResource" />.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// <paramref name="stream" /> or <paramref name="resourceResolver" /> is <see langword="null" />.
+    /// </exception>
+    /// <exception cref="ArgumentException">The stream content is empty or white-space.</exception>
+    /// <exception cref="FormatException">The stream content is not well-formed XML.</exception>
+    /// <exception cref="NotableDateValidationException">
+    /// The notable-date document produced one or more error diagnostics.
+    /// </exception>
+    public static NotableDateResource Load(Stream stream, Func<string, string?> resourceResolver) =>
+        Load(ReadToEnd(stream), resourceResolver);
+
+    /// <summary>
     /// Loads and validates a notable-date document from its JSON content.
     /// </summary>
     /// <param name="json">The notable-date document JSON content.</param>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateService.cs
@@ -372,9 +372,18 @@ public sealed class NotableDateService : INotableDateService
     /// <param name="lastYear">The last civil year to scan.</param>
     /// <param name="occupied">The occupied-day set to seed.</param>
     /// <returns>The calculated candidates.</returns>
+    /// <remarks>
+    /// The phase runs in two sub-passes so that the non-working-day triggers evaluate against the complete picture.
+    /// The first sub-pass enumerates every applicable occurrence, seeding the occupied-day set and tallying the actual
+    /// dates of non-working occurrences. The second sub-pass selects the firing adjustment policy for each occurrence,
+    /// at which point a <see cref="AdjustmentTrigger.IfNonWorkingDay" /> or <see cref="AdjustmentTrigger.IfWorkingDay" />
+    /// trigger can see every other holiday that shares the actual date, regardless of enumeration order.
+    /// </remarks>
     private List<ResolutionCandidate> GatherCandidates(StrategyResolutionContext context, string territory, int firstYear, int lastYear, HashSet<DateOnly> occupied)
     {
         List<ResolutionCandidate> candidates = new();
+        List<(NotableDateDefinition Definition, NotableDateRule Rule)> sources = new();
+        Dictionary<DateOnly, int> actualNonWorkingCounts = new();
 
         foreach (NotableDateDefinition definition in this._resource.NotableDates)
         {
@@ -407,14 +416,32 @@ public sealed class NotableDateService : INotableDateService
 
                     foreach (DateOnly baseDate in EnumerateBaseDates(rule.Strategy, year, context))
                     {
-                        AdjustmentPolicy? policy = this.SelectAdjustmentPolicy(definition, rule, category, baseDate, territory, context);
-                        candidates.Add(new ResolutionCandidate(identity, definition.DisplayName, category, baseDate, policy, rule.Priority, nonWorking, durationDays, tags));
+                        candidates.Add(new ResolutionCandidate(identity, definition.DisplayName, category, baseDate, null, rule.Priority, nonWorking, durationDays, tags));
+                        sources.Add((definition, rule));
 
                         if (nonWorking)
+                        {
                             occupied.Add(baseDate);
+                            actualNonWorkingCounts[baseDate] = actualNonWorkingCounts.GetValueOrDefault(baseDate) + 1;
+                        }
                     }
                 }
             }
+        }
+
+        WeekPattern workingWeek = this._resource.ResolutionPolicy.WorkingWeek;
+        for (int i = 0; i < candidates.Count; i++)
+        {
+            ResolutionCandidate candidate = candidates[i];
+            (NotableDateDefinition definition, NotableDateRule rule) = sources[i];
+
+            // A day is occupied "by another" when a non-working occurrence other than this one shares the date; the
+            // candidate's own contribution to the tally is discounted so a lone holiday never collides with itself.
+            bool OccupiedByAnother(DateOnly day) =>
+                actualNonWorkingCounts.GetValueOrDefault(day) > (candidate.NonWorking && day == candidate.BaseDate ? 1 : 0);
+
+            AdjustmentPolicy? policy = this.SelectAdjustmentPolicy(definition, rule, candidate.Category, candidate.BaseDate, territory, context, workingWeek, OccupiedByAnother);
+            candidates[i] = candidate with { Policy = policy };
         }
 
         return candidates;
@@ -531,7 +558,7 @@ public sealed class NotableDateService : INotableDateService
         {
             AdjustmentAction.ReplaceWithRule => ResolveReplacementDate(policy, candidate, context),
             AdjustmentAction.Custom => this.InvokeCustomHandler(policy, candidate, territory, occupied, context),
-            _ => policy.ApplyAction(candidate.BaseDate, occupied.Contains),
+            _ => policy.ApplyAction(candidate.BaseDate, occupied.Contains, this._resource.ResolutionPolicy.WorkingWeek),
         };
 
     /// <summary>
@@ -604,6 +631,10 @@ public sealed class NotableDateService : INotableDateService
     /// <param name="baseDate">The calculated (actual) occurrence date.</param>
     /// <param name="territory">The requested territory code.</param>
     /// <param name="context">The resolution context exposed to custom triggers.</param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
+    /// <param name="occupiedByAnother">
+    /// A predicate reporting whether a non-working occurrence other than this one falls on the supplied date.
+    /// </param>
     /// <returns>The winning <see cref="AdjustmentPolicy" />, or <see langword="null" /> when none fires.</returns>
     private AdjustmentPolicy? SelectAdjustmentPolicy(
         NotableDateDefinition definition,
@@ -611,7 +642,9 @@ public sealed class NotableDateService : INotableDateService
         NotableDateCategory category,
         DateOnly baseDate,
         string territory,
-        StrategyResolutionContext context)
+        StrategyResolutionContext context,
+        WeekPattern workingWeek,
+        Func<DateOnly, bool> occupiedByAnother)
     {
         List<AdjustmentPolicy> candidates = new();
 
@@ -627,36 +660,56 @@ public sealed class NotableDateService : INotableDateService
 
         return candidates
             .OrderBy(p => p.Priority)
-            .FirstOrDefault(p => this.IsPolicyTriggered(p, baseDate, territory, context));
+            .FirstOrDefault(p => this.IsPolicyTriggered(p, baseDate, territory, context, workingWeek, occupiedByAnother));
     }
 
     /// <summary>
-    /// Determines whether a policy fires for a base date, dispatching to a registered
-    /// <see cref="IAdjustmentTriggerHandler" /> for the <see cref="AdjustmentTrigger.Custom" /> trigger and to the
-    /// policy's built-in evaluation otherwise.
+    /// Determines whether a policy fires for a base date, dispatching the non-working-day triggers and the
+    /// <see cref="AdjustmentTrigger.Custom" /> trigger to the resolver state they depend on, and the remaining triggers
+    /// to the policy's built-in evaluation.
     /// </summary>
     /// <param name="policy">The candidate policy.</param>
     /// <param name="baseDate">The calculated (actual) occurrence date.</param>
     /// <param name="territory">The requested territory code.</param>
     /// <param name="context">The resolution context exposed to a custom trigger handler.</param>
+    /// <param name="workingWeek">The working week that defines which weekdays are working days.</param>
+    /// <param name="occupiedByAnother">
+    /// A predicate reporting whether a non-working occurrence other than this one falls on the supplied date.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> if the policy fires; otherwise <see langword="false" />. A custom trigger whose handler
     /// is unregistered does not fire.
     /// </returns>
-    private bool IsPolicyTriggered(AdjustmentPolicy policy, DateOnly baseDate, string territory, StrategyResolutionContext context)
+    private bool IsPolicyTriggered(
+        AdjustmentPolicy policy,
+        DateOnly baseDate,
+        string territory,
+        StrategyResolutionContext context,
+        WeekPattern workingWeek,
+        Func<DateOnly, bool> occupiedByAnother)
     {
-        if (policy.Trigger != AdjustmentTrigger.Custom)
-            return policy.IsTriggered(baseDate);
-
-        if (string.IsNullOrEmpty(policy.TriggerHandlerKey)
-            || this._triggerHandlers is null
-            || !this._triggerHandlers.TryGet(policy.TriggerHandlerKey, out IAdjustmentTriggerHandler? handler)
-            || handler is null)
+        switch (policy.Trigger)
         {
-            return false;
-        }
+            case AdjustmentTrigger.IfNonWorkingDay:
+                return !workingWeek.Contains(baseDate.DayOfWeek) || occupiedByAnother(baseDate);
 
-        return handler.ShouldAdjust(new AdjustmentTriggerContext(baseDate, territory, policy, context));
+            case AdjustmentTrigger.IfWorkingDay:
+                return workingWeek.Contains(baseDate.DayOfWeek) && !occupiedByAnother(baseDate);
+
+            case AdjustmentTrigger.Custom:
+                if (string.IsNullOrEmpty(policy.TriggerHandlerKey)
+                    || this._triggerHandlers is null
+                    || !this._triggerHandlers.TryGet(policy.TriggerHandlerKey, out IAdjustmentTriggerHandler? handler)
+                    || handler is null)
+                {
+                    return false;
+                }
+
+                return handler.ShouldAdjust(new AdjustmentTriggerContext(baseDate, territory, policy, context));
+
+            default:
+                return policy.IsTriggered(baseDate, workingWeek);
+        }
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDateService.cs
@@ -343,6 +343,25 @@ public sealed class NotableDateService : INotableDateService
         return this.Resolve(range, territory).Where(filter.Matches).ToArray();
     }
 
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetSupportedTerritories() =>
+        this._resource.NotableDates
+            .SelectMany(definition => definition.Rules)
+            .SelectMany(rule => rule.Applicability.Territories)
+            .Where(territory => !string.IsNullOrWhiteSpace(territory))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(territory => territory, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+    /// <inheritdoc />
+    public IReadOnlyList<CalendarSystem> GetSupportedCalendars() =>
+        this._resource.NotableDates
+            .SelectMany(definition => definition.Rules)
+            .Select(rule => rule.Applicability.Calendar)
+            .Distinct()
+            .OrderBy(calendar => calendar)
+            .ToArray();
+
     /// <summary>
     /// Phase one: calculates every applicable actual occurrence and seeds the occupied-day set with the actual dates of
     /// non-working occurrences.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.schema.json
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.schema.json
@@ -142,7 +142,9 @@
         "toYear": { "type": "integer", "minimum": 0, "maximum": 65535 },
         "territories": { "type": "array", "items": { "$ref": "#/$defs/territoryCode" } },
         "onlyYears": { "type": "array", "items": { "type": "integer" } },
-        "exceptYears": { "type": "array", "items": { "type": "integer" } }
+        "exceptYears": { "type": "array", "items": { "type": "integer" } },
+        "everyYears": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "anchorYear": { "type": "integer", "minimum": 0, "maximum": 65535 }
       }
     },
     "fixedStrategy": {

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.schema.json
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.schema.json
@@ -56,7 +56,8 @@
     "emissionMode": {
       "enum": [ "ActualOnly", "ObservedOnly", "ActualAndObserved", "ObservedAsAdditional", "Suppress" ]
     },
-    "adjustmentTrigger": { "enum": [ "Always", "IfDayOfWeek", "IfWeekend", "IfWeekday" ] },
+    "adjustmentTrigger": { "enum": [ "Always", "IfDayOfWeek", "IfWeekend", "IfWeekday", "IfNonWorkingDay", "IfWorkingDay" ] },
+    "weekPattern": { "type": "string", "pattern": "^[01]{7}$" },
     "weekOrdinal": { "enum": [ "First", "Second", "Third", "Fourth", "Fifth", "Last" ] },
     "weekdayProximity": { "enum": [ "Before", "OnOrBefore", "Nearest", "OnOrAfter", "After" ] },
     "adjustmentAction": {
@@ -76,7 +77,8 @@
         "sameDayCollisionPolicy": { "$ref": "#/$defs/collisionPolicy" },
         "spanCollisionPolicy": { "$ref": "#/$defs/collisionPolicy" },
         "priorityDirection": { "$ref": "#/$defs/priorityDirection" },
-        "observedDateRangePolicy": { "$ref": "#/$defs/observedDateRangePolicy" }
+        "observedDateRangePolicy": { "$ref": "#/$defs/observedDateRangePolicy" },
+        "workingDays": { "$ref": "#/$defs/weekPattern" }
       }
     },
     "adjustmentScope": {

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
@@ -199,6 +199,8 @@
     <xs:attribute name="calendar" type="nd:calendarName" use="optional" default="Gregorian" />
     <xs:attribute name="fromYear" type="xs:unsignedShort" use="optional" />
     <xs:attribute name="toYear" type="xs:unsignedShort" use="optional" />
+    <xs:attribute name="everyYears" type="xs:positiveInteger" use="optional" />
+    <xs:attribute name="anchorYear" type="xs:unsignedShort" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="Strategy">

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
@@ -141,6 +141,9 @@
   </xs:complexType>
 
   <xs:complexType name="ImportUse">
+    <xs:sequence>
+      <xs:element name="Adjustments" type="nd:RuleAdjustments" minOccurs="0" maxOccurs="1" />
+    </xs:sequence>
     <xs:attribute name="notableDateRef" type="nd:identifier" use="required" />
     <xs:attribute name="as" type="nd:identifier" use="optional" />
     <xs:attribute name="territory" type="nd:territoryCode" use="optional" />

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
@@ -45,6 +45,7 @@
     <xs:attribute name="spanCollisionPolicy" type="nd:collisionPolicy" use="optional" default="KeepAll" />
     <xs:attribute name="priorityDirection" type="nd:priorityDirection" use="optional" default="HigherWins" />
     <xs:attribute name="observedDateRangePolicy" type="nd:observedDateRangePolicy" use="optional" default="ObservedOccurrenceControlsInclusion" />
+    <xs:attribute name="workingDays" type="nd:weekPattern" use="optional" />
   </xs:complexType>
 
   <xs:complexType name="AdjustmentPolicies">
@@ -402,11 +403,26 @@
       <xs:enumeration value="IfDayOfWeek" />
       <xs:enumeration value="IfWeekend" />
       <xs:enumeration value="IfWeekday" />
+      <xs:enumeration value="IfNonWorkingDay" />
+      <xs:enumeration value="IfWorkingDay" />
       <xs:enumeration value="IfLeapYear" />
       <xs:enumeration value="IfBeforeFixedDate" />
       <xs:enumeration value="IfAfterFixedDate" />
       <xs:enumeration value="IfNthOccurrenceInMonth" />
       <xs:enumeration value="Custom" />
+    </xs:restriction>
+  </xs:simpleType>
+
+  <xs:simpleType name="weekPattern">
+    <xs:annotation>
+      <xs:documentation>
+        A seven-character working-week pattern in Sunday-first binary form, where each position from Sunday to Saturday
+        is '1' for a working day and '0' for a non-working (weekend) day. For example "0111110" denotes a
+        Monday-to-Friday working week and "1111100" a Sunday-to-Thursday working week.
+      </xs:documentation>
+    </xs:annotation>
+    <xs:restriction base="xs:string">
+      <xs:pattern value="[01]{7}" />
     </xs:restriction>
   </xs:simpleType>
 

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/NotableDates.v2.xsd
@@ -4,9 +4,10 @@
 
   Models fixed-date, DayOfWeekInMonth, WeekdayNearDate, RelativeWeekdayInMonth,
   OffsetFromRule, and Algorithm strategies; reusable adjustment policies with explicit
-  trigger, action, and emission; territory filtering; and ID-targeted override
-  operations. Imports, inline adjustments, and non-Gregorian calendars are reserved for
-  a later phase.
+  trigger, action, and emission; territory and year filtering; cross-resource imports;
+  non-Gregorian calendars (Hijri, Umm al-Qura, Hebrew, Persian, Chinese lunisolar); and
+  ID-targeted override operations. Adjustments are referenced by policy id; inline
+  per-rule adjustment definitions are intentionally not modelled.
 -->
 <xs:schema
   xmlns:xs="http://www.w3.org/2001/XMLSchema"

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/ReloadableNotableDateService.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/ReloadableNotableDateService.cs
@@ -133,6 +133,14 @@ public sealed class ReloadableNotableDateService : INotableDateService
     public IReadOnlyList<NotableDate> Resolve(DateRange range, string territory, NotableDateFilter filter) =>
         this.Current().Resolve(range, territory, filter);
 
+    /// <inheritdoc />
+    public IReadOnlyList<string> GetSupportedTerritories() =>
+        this.Current().GetSupportedTerritories();
+
+    /// <inheritdoc />
+    public IReadOnlyList<CalendarSystem> GetSupportedCalendars() =>
+        this.Current().GetSupportedCalendars();
+
     /// <summary>
     /// Returns the inner service for the resource currently in effect, rebuilding it when the provider has reloaded.
     /// </summary>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/ResolutionPolicy.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/ResolutionPolicy.cs
@@ -30,18 +30,24 @@ public sealed class ResolutionPolicy
     /// </param>
     /// <param name="priorityDirection">The direction in which numeric priority is interpreted.</param>
     /// <param name="observedDateRangePolicy">The occurrence that controls range-query inclusion.</param>
+    /// <param name="workingWeek">
+    /// The working week that defines which weekdays are working days, or <see langword="null" /> for the default
+    /// Monday-to-Friday working week (a Saturday and Sunday weekend).
+    /// </param>
     public ResolutionPolicy(
         DuplicatePolicy duplicatePolicy = DuplicatePolicy.Error,
         CollisionPolicy sameDayCollisionPolicy = CollisionPolicy.KeepAll,
         CollisionPolicy spanCollisionPolicy = CollisionPolicy.KeepAll,
         PriorityDirection priorityDirection = PriorityDirection.HigherWins,
-        ObservedDateRangePolicy observedDateRangePolicy = ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion)
+        ObservedDateRangePolicy observedDateRangePolicy = ObservedDateRangePolicy.ObservedOccurrenceControlsInclusion,
+        WeekPattern? workingWeek = null)
     {
         this.DuplicatePolicy = duplicatePolicy;
         this.SameDayCollisionPolicy = sameDayCollisionPolicy;
         this.SpanCollisionPolicy = spanCollisionPolicy;
         this.PriorityDirection = priorityDirection;
         this.ObservedDateRangePolicy = observedDateRangePolicy;
+        this.WorkingWeek = workingWeek ?? WeekPattern.MondayToFriday;
     }
 
     /// <summary>
@@ -73,6 +79,16 @@ public sealed class ResolutionPolicy
     /// </summary>
     /// <returns>The configured <see cref="V2.ObservedDateRangePolicy" />.</returns>
     public ObservedDateRangePolicy ObservedDateRangePolicy { get; }
+
+    /// <summary>
+    /// Gets the working week that defines which weekdays are working days, and therefore which are weekend
+    /// (non-working) days for weekend-sensitive triggers and working-day searches.
+    /// </summary>
+    /// <returns>
+    /// The configured working-week pattern; <see cref="WeekPattern.MondayToFriday" /> when the resource leaves it
+    /// unspecified.
+    /// </returns>
+    public WeekPattern WorkingWeek { get; }
 
     /// <summary>
     /// Gets a <see cref="ResolutionPolicy" /> populated with the recommended default values.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/README.md
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/README.md
@@ -1,0 +1,77 @@
+# Common notable-date catalogues
+
+These XML files are the shared, reusable notable-date catalogues bundled with
+`Bodu.Globalization.Calendar2`, mirroring the v1
+`Bodu.Globalization.Calendar/src/Globalization.Calendar.Resources` set on the v2
+cookbook schema. They define common observances **once** so territory packs can
+*inherit* them instead of redefining each date inline.
+
+All files in this folder are embedded as manifest resources
+(`Bodu.Globalization.Calendar.V2.Resources.<name>.xml`) via the `Resources\*.xml`
+wildcard in the project file, and are resolved by name through
+`CommonNotableDateResources.Resolver`.
+
+## Catalogues
+
+| Catalogue | Contents |
+|---|---|
+| `global-core` | Civil core: New Year's Day, International Workers' Day, New Year's Eve. |
+| `christian-western` | Western (Gregorian) Christian feasts: the Easter Sunday anchor plus Good Friday, Maundy Thursday, Easter Monday, Ascension, Whit Sunday/Monday, Corpus Christi, All Saints', Christmas Eve/Day, Boxing Day. |
+| `christian-orthodox` | Orthodox Easter anchor and its derived feasts, plus fixed Orthodox observances. |
+| `global-islamic`, `global-islamic-umm-al-qura` | Hijri and Umm al-Qura festivals (Ramadan, Eid al-Fitr, Eid al-Adha, …). |
+| `global-jewish` | Hebrew-calendar festivals (Passover, Rosh Hashanah, Yom Kippur, Hanukkah, …). |
+| `global-hindu` | Solar-anchored lunar festivals (Diwali, Holi, Navaratri, …). |
+| `global-buddhist` | Vesak, Asalha Puja, Losar, and related observances. |
+| `global-lunar` | Chinese lunisolar festivals and solar terms (Lunar New Year, Qingming, Mid-Autumn, …). |
+| `global-persian` | Persian-calendar observances (Nowruz, Sizdah Bedar, Yalda). |
+| `global-anchors` | Cross-tradition anchors (Lunar New Year, Ramadan start, Orthodox Easter) for offset rules. |
+| `global-cultural`, `global-un`, `global-remembrance`, `global-health`, `global-food`, `global-science`, `global-environment`, `global-education`, `global-social`, `global-family`, `global-family-social`, `global-animals`, `global-multiday-normalization` | Gregorian observance families. |
+| `global-all` | Aggregate that imports every catalogue above. |
+| `default-minimal` | Single-concept bootstrap (New Year's Day). |
+
+## How a territory pack inherits
+
+A territory resource imports the concepts it observes and supplies its own
+territory scope, category, non-working flag, and weekend adjustment through the
+import `<Use>` directive. The shared concept carries the bare calculation
+strategy under the stable rule id `default`; the territory specializes it:
+
+```xml
+<Imports>
+  <Import resource="global-core">
+    <Use notableDateRef="new-years-day" territory="US">
+      <Adjustments>
+        <Adjustment policyRef="saturday-to-friday" />
+        <Adjustment policyRef="sunday-to-monday" />
+      </Adjustments>
+    </Use>
+  </Import>
+  <Import resource="christian-western">
+    <Use notableDateRef="good-friday" territory="US" category="Religious" nonWorking="false" />
+    <Use notableDateRef="christmas-day" territory="US">
+      <Adjustments>
+        <Adjustment policyRef="saturday-to-friday" />
+        <Adjustment policyRef="sunday-to-monday" />
+      </Adjustments>
+    </Use>
+  </Import>
+</Imports>
+```
+
+This is what lets one shared Christmas be observed differently per territory
+(United States Saturday→Friday / Sunday→Monday, United Kingdom next-working-day).
+A rule that remains local but offsets from an imported concept references it by
+the shared rule id, for example
+`<OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-3" />`.
+
+## Loading
+
+Pass the resolver so imports resolve against these catalogues:
+
+```csharp
+NotableDateResource resource = NotableDateResourceLoader.Load(xml, CommonNotableDateResources.Resolver);
+```
+
+The data packs (`Bodu.Globalization.Calendar2.Data.*`) do this for every region
+resource. The `CommonResourcesTests.AllBundledCatalogues_LoadAndValidate` test
+loads and validates every catalogue here on each build.

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/christian-orthodox.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/christian-orthodox.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Eastern Orthodox Christian notable-date catalogue, migrated from the v1 christian-orthodox.xml to the v2 cookbook
+  schema. Orthodox Easter Sunday is the computed anchor (algorithm key "orthodox-easter", the Julian paschalion returned
+  on the civil Gregorian calendar, valid from the 1583 Gregorian reform); the movable feasts are offsets from it, and the
+  fixed-date observances of the Orthodox Christmas and Theophany cycle are plain Gregorian dates. This catalogue is
+  self-contained: the offset rules reference the local orthodox-easter-sunday anchor with rule id "default". A territory
+  pack imports the concepts it observes and supplies its own territory scope, category, non-working flag, and adjustments.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.christian-orthodox">
+
+  <NotableDates>
+
+    <NotableDate id="orthodox-easter-sunday" displayName="Orthodox Easter Sunday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><Algorithm key="orthodox-easter" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-christmas-eve" displayName="Orthodox Christmas Eve" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="6" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-christmas-day" displayName="Orthodox Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="7" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-new-year" displayName="Orthodox New Year" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-epiphany" displayName="Orthodox Epiphany" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="19" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-clean-monday" displayName="Orthodox Clean Monday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-48" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-lazarus-saturday" displayName="Orthodox Lazarus Saturday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-palm-sunday" displayName="Orthodox Palm Sunday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-7" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-holy-thursday" displayName="Orthodox Holy Thursday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-3" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-good-friday" displayName="Orthodox Good Friday" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-holy-saturday" displayName="Orthodox Holy Saturday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="-1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-bright-week" displayName="Orthodox Bright Week" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="0" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-easter-monday" displayName="Orthodox Easter Monday" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-ascension-day" displayName="Orthodox Ascension Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="39" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-pentecost" displayName="Orthodox Pentecost" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="49" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-pentecost-monday" displayName="Orthodox Pentecost Monday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="orthodox-easter-sunday" ruleRef="default" offsetDays="50" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/christian-western.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/christian-western.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Western (Gregorian) Christian notable-date catalogue, migrated from the v1 christian-gregorian.xml to the v2 cookbook
+  schema. Easter Sunday is the computed anchor (valid from the 1583 Gregorian reform); the surrounding feasts are
+  offsets from it. A territory pack imports the concepts it observes and supplies its own territory scope, category,
+  non-working flag, and weekend adjustment through the import <Use> directive. The shared rules use the stable rule id
+  "default", so a territory-local rule that offsets from Easter references <OffsetFromRule ... ruleRef="default" />.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.christian-western">
+
+  <NotableDates>
+
+    <NotableDate id="easter-sunday" displayName="Easter Sunday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" /><Strategy><Algorithm key="western-easter" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="good-friday" displayName="Good Friday" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="maundy-thursday" displayName="Maundy Thursday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-3" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="easter-monday" displayName="Easter Monday" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="ascension-day" displayName="Ascension Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="39" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="whit-sunday" displayName="Whit Sunday" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="49" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="whit-monday" displayName="Whit Monday" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="50" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="corpus-christi" displayName="Corpus Christi" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="60" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="all-saints-day" displayName="All Saints' Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="christmas-eve" displayName="Christmas Eve" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="24" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="christmas-day" displayName="Christmas Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="25" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="boxing-day" displayName="Boxing Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="26" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/default-minimal.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/default-minimal.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Default minimal notable-date catalogue, migrated from the v1 default-minimal.xml to the v2 cookbook schema. It provides
+  a single, country-neutral concept (New Year's Day) so a consumer has a usable catalogue without referencing a region
+  pack. Following the common-catalogue convention, the concept carries only the bare calculation strategy with the stable
+  rule id "default"; a territory pack supplies its own non-working flag and any weekend-roll adjustment through the import
+  <Use> directive.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.default-minimal">
+
+  <NotableDates>
+
+    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-all.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-all.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Aggregate notable-date catalogue, migrated from the v1 global-all.xml to the v2 cookbook schema. It imports every other
+  bundled common catalogue with no <Use> directives, so each import contributes its full concept set, producing a broad,
+  country-neutral catalogue for consumers that want every shared observance at once. As in v1, this aggregate is the
+  appropriate place for import-all because it is intentionally broad; territory packs should cherry-pick individual
+  concepts instead. Concept identifiers that appear in more than one source (for example the Hijri festivals shared by the
+  tabular and Umm al-Qura Islamic catalogues, or Lunar New Year shared by the anchors and lunar catalogues) are
+  deduplicated on import, first source winning. The local <NotableDates /> is intentionally empty.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-all">
+
+  <Imports>
+    <Import resource="global-core" />
+    <Import resource="global-anchors" />
+    <Import resource="christian-western" />
+    <Import resource="christian-orthodox" />
+    <Import resource="global-cultural" />
+    <Import resource="global-education" />
+    <Import resource="global-environment" />
+    <Import resource="global-family" />
+    <Import resource="global-family-social" />
+    <Import resource="global-food" />
+    <Import resource="global-health" />
+    <Import resource="global-remembrance" />
+    <Import resource="global-science" />
+    <Import resource="global-social" />
+    <Import resource="global-un" />
+    <Import resource="global-animals" />
+    <Import resource="global-multiday-normalization" />
+    <Import resource="global-lunar" />
+    <Import resource="global-islamic" />
+    <Import resource="global-islamic-umm-al-qura" />
+    <Import resource="global-jewish" />
+    <Import resource="global-hindu" />
+    <Import resource="global-buddhist" />
+    <Import resource="global-persian" />
+    <Import resource="default-minimal" />
+  </Imports>
+
+  <NotableDates />
+
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-anchors.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-anchors.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Anchor notable-date catalogue, migrated from the v1 global-anchors.xml to the v2 cookbook schema. These concepts
+  define base dates intended for use as OffsetFromRule anchors in other catalogues, and as stand-alone reference dates.
+  Orthodox Easter is the computed Julian paschalion anchor (algorithm key "orthodox-easter"); Lunar New Year is the
+  first day of the first month of the Chinese lunisolar calendar (its fifteen-day festival span carried as durationDays);
+  Ramadan Start is the first day of the ninth month of the tabular Hijri calendar, swept onto the requested Gregorian
+  year. A territory pack imports the concepts it needs and supplies its own territory scope and overrides.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-anchors">
+
+  <NotableDates>
+
+    <NotableDate id="lunar-new-year" displayName="Lunar New Year" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="15"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="1" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="ramadan-start" displayName="Ramadan Start" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="30"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="9" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="orthodox-easter" displayName="Orthodox Easter" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1583" />
+        <Strategy><Algorithm key="orthodox-easter" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-animals.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-animals.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global animal and wildlife notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-animals.xml to the v2 cookbook schema. These are internationally recognized animal welfare and wildlife
+  conservation observances; they are not universally public holidays. A territory pack imports only the concepts it
+  observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through the import
+  <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-animals">
+
+  <NotableDates>
+
+    <NotableDate id="world-wildlife-day" displayName="World Wildlife Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2014" /><Strategy><Fixed month="March" day="3" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-bee-day" displayName="World Bee Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2018" /><Strategy><Fixed month="May" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-tiger-day" displayName="International Tiger Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2010" /><Strategy><Fixed month="July" day="29" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-cat-day" displayName="International Cat Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2002" /><Strategy><Fixed month="August" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-elephant-day" displayName="World Elephant Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2012" /><Strategy><Fixed month="August" day="12" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-dog-day" displayName="International Dog Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="August" day="26" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-animal-day" displayName="World Animal Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1931" /><Strategy><Fixed month="October" day="4" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-buddhist.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-buddhist.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Buddhist notable-date catalogue, migrated from the v1 global-buddhist.xml to the v2 cookbook schema. The Theravada
+  full-moon observances Vesak and Asalha Puja and the Tibetan New Year Losar are computed astronomically by the engine's
+  lunar-phase algorithms (the same keys the shipping region packs use). Parinirvana Day and Bodhi Day follow their most
+  widely observed fixed Gregorian conventions. Vassa (the Rains Retreat) begins the day after Asalha Puja and is authored
+  as a one-day OffsetFromRule from the local asalha-puja anchor, so this catalogue is self-contained. A territory pack
+  imports the concepts it observes and supplies its own territory scope, category, non-working flag, and duration.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-buddhist">
+
+  <NotableDates>
+
+    <NotableDate id="parinirvana-day" displayName="Parinirvana Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="February" day="15" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="losar" displayName="Losar" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="3"><Strategy><Algorithm key="losar" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="vesak" displayName="Vesak" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="vesak" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="asalha-puja" displayName="Asalha Puja" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="asalha-puja" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="vassa" displayName="Vassa" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="90">
+        <Strategy><OffsetFromRule notableDateRef="asalha-puja" ruleRef="default" offsetDays="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="bodhi-day" displayName="Bodhi Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-core.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-core.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global civil notable-date catalogue (Western / Gregorian calendar), migrated from the v1 global-core.xml to the v2
+  cookbook schema. These are commonly recognized civil observances, not universally public holidays. A territory pack
+  imports only the concepts it observes and supplies its own territory scope, category, non-working flag, and weekend
+  adjustment through the import <Use> directive; the shared concepts therefore carry the bare calculation strategy and
+  a representative default, never a territory-specific adjustment.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-core">
+
+  <NotableDates>
+
+    <NotableDate id="new-years-day" displayName="New Year's Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="workers-day" displayName="International Workers' Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="default"><Strategy><Fixed month="May" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="new-years-eve" displayName="New Year's Eve" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="31" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-cultural.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-cultural.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global cultural notable-date catalogue (Western / Gregorian calendar), migrated from the v1 global-cultural.xml to
+  the v2 cookbook schema. These are commonly recognized cultural observances, not universally public holidays. A
+  territory pack imports only the concepts it observes and supplies its own territory scope, category, non-working
+  flag, and weekend adjustment through the import <Use> directive; the shared concepts therefore carry the bare
+  calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-cultural">
+
+  <NotableDates>
+
+    <NotableDate id="valentines-day" displayName="Valentine's Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="February" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-mother-language-day" displayName="International Mother Language Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2000" /><Strategy><Fixed month="February" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-poetry-day" displayName="World Poetry Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1999" /><Strategy><Fixed month="March" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-theatre-day" displayName="World Theatre Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1962" /><Strategy><Fixed month="March" day="27" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="april-fools-day" displayName="April Fool's Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="April" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-jazz-day" displayName="International Jazz Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2012" /><Strategy><Fixed month="April" day="30" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="star-wars-day" displayName="Star Wars Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="May" day="4" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-music-day" displayName="World Music Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1982" /><Strategy><Fixed month="June" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-friendship-day" displayName="International Friendship Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2011" /><Strategy><Fixed month="July" day="30" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="halloween" displayName="Halloween" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="October" day="31" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-education.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-education.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global education and literacy notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-education.xml to the v2 cookbook schema. These are internationally recognized education, literacy, and
+  knowledge-related observances; they are not universally public holidays. A territory pack imports only the concepts
+  it observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through the
+  import <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id
+  "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-education">
+
+  <NotableDates>
+
+    <NotableDate id="international-day-of-education" displayName="International Day of Education" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2019" /><Strategy><Fixed month="January" day="24" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-book-and-copyright-day" displayName="World Book and Copyright Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="April" day="23" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-literacy-day" displayName="International Literacy Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="September" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-teachers-day" displayName="World Teachers' Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="October" day="5" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="safer-internet-day" displayName="Safer Internet Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2004" /><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Tuesday" weekOrdinal="Second" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-environment.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-environment.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global environmental notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-environment.xml to the v2 cookbook schema. These are internationally recognized environmental and
+  sustainability-related observances; they are not universally public holidays. A territory pack imports only the
+  concepts it observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through
+  the import <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id
+  "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-environment">
+
+  <NotableDates>
+
+    <NotableDate id="world-wetlands-day" displayName="World Wetlands Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1997" /><Strategy><Fixed month="February" day="2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-forests" displayName="International Day of Forests" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2013" /><Strategy><Fixed month="March" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-water-day" displayName="World Water Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="March" day="22" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="earth-hour" displayName="Earth Hour" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2007" /><Strategy><DayOfWeekInMonth month="March" dayOfWeek="Saturday" weekOrdinal="Last" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="earth-day" displayName="Earth Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="April" day="22" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-for-biological-diversity" displayName="International Day for Biological Diversity" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2001" /><Strategy><Fixed month="May" day="22" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-environment-day" displayName="World Environment Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="June" day="5" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-oceans-day" displayName="World Oceans Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="June" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-day-to-combat-desertification-and-drought" displayName="World Day to Combat Desertification and Drought" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1995" /><Strategy><Fixed month="June" day="17" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-soil-day" displayName="World Soil Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2014" /><Strategy><Fixed month="December" day="5" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="plastic-free-july" displayName="Plastic Free July" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="31"><Applicability fromYear="2011" /><Strategy><Fixed month="July" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="clean-up-the-world-weekend" displayName="Clean Up the World Weekend" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="3"><Applicability fromYear="1993" /><Strategy><DayOfWeekInMonth month="September" dayOfWeek="Friday" weekOrdinal="Third" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-family-social.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-family-social.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global family-social notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-family-social.xml to the v2 cookbook schema. These are widely observed family and social community days. A
+  territory pack imports only the concepts it observes and supplies its own territory scope, category, non-working
+  flag, and weekend adjustment through the import <Use> directive; the shared concepts therefore carry the bare
+  calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-family-social">
+
+  <NotableDates>
+
+    <NotableDate id="friendship-day" displayName="Friendship Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><DayOfWeekInMonth month="August" dayOfWeek="Sunday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="grandparents-day" displayName="Grandparents Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><DayOfWeekInMonth month="September" dayOfWeek="Sunday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-family.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-family.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global family observances notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-family.xml to the v2 cookbook schema. These are the most widely observed forms of Mother's Day (second Sunday
+  in May) and Father's Day (third Sunday in June); regional variants are handled in the corresponding territory packs.
+  A territory pack imports only the concepts it observes and supplies its own territory scope, category, non-working
+  flag, and weekend adjustment through the import <Use> directive; the shared concepts therefore carry the bare
+  calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-family">
+
+  <NotableDates>
+
+    <NotableDate id="mothers-day" displayName="Mother's Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Second" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="fathers-day" displayName="Father's Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><DayOfWeekInMonth month="June" dayOfWeek="Sunday" weekOrdinal="Third" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-food.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-food.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global food and agriculture notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-food.xml to the v2 cookbook schema. These are internationally recognized food security, agriculture,
+  nutrition, and dietary observances; they are not universally public holidays. A territory pack imports only the
+  concepts it observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through
+  the import <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id
+  "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-food">
+
+  <NotableDates>
+
+    <NotableDate id="world-pulses-day" displayName="World Pulses Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2019" /><Strategy><Fixed month="February" day="10" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-tea-day" displayName="International Tea Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2020" /><Strategy><Fixed month="May" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-food-safety-day" displayName="World Food Safety Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2019" /><Strategy><Fixed month="June" day="7" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-beer-day" displayName="International Beer Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2007" /><Strategy><DayOfWeekInMonth month="August" dayOfWeek="Friday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-coffee-day" displayName="International Coffee Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2015" /><Strategy><Fixed month="October" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-vegetarian-day" displayName="World Vegetarian Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1977" /><Strategy><Fixed month="October" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-food-day" displayName="World Food Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1979" /><Strategy><Fixed month="October" day="16" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-vegan-day" displayName="World Vegan Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1994" /><Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-health.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-health.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global health notable-date catalogue (Western / Gregorian calendar), migrated from the v1 global-health.xml to the v2
+  cookbook schema. These are internationally recognized health and public-health observances; they are not universally
+  public holidays. A territory pack imports only the concepts it observes and supplies its own territory scope,
+  category, non-working flag, and weekend adjustment through the import <Use> directive; the shared concepts therefore
+  carry the bare calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-health">
+
+  <NotableDates>
+
+    <NotableDate id="world-cancer-day" displayName="World Cancer Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2000" /><Strategy><Fixed month="February" day="4" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-autism-awareness-day" displayName="World Autism Awareness Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2008" /><Strategy><Fixed month="April" day="2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-health-day" displayName="World Health Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="April" day="7" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-no-tobacco-day" displayName="World No Tobacco Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1987" /><Strategy><Fixed month="May" day="31" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-blood-donor-day" displayName="World Blood Donor Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="June" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-hepatitis-day" displayName="World Hepatitis Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2008" /><Strategy><Fixed month="July" day="28" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-suicide-prevention-day" displayName="World Suicide Prevention Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2003" /><Strategy><Fixed month="September" day="10" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-mental-health-day" displayName="World Mental Health Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="October" day="10" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-diabetes-day" displayName="World Diabetes Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1991" /><Strategy><Fixed month="November" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-aids-day" displayName="World AIDS Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="breast-cancer-awareness-month" displayName="Breast Cancer Awareness Month" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="31"><Strategy><Fixed month="October" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="movember" displayName="Movember" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="30"><Applicability fromYear="2003" /><Strategy><Fixed month="November" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-hindu.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-hindu.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Hindu notable-date catalogue, migrated from the v1 global-hindu.xml to the v2 cookbook schema. The solar harvest
+  festivals Makar Sankranti and Pongal are fixed on 14 January by modern civil-calendar convention; the lunisolar
+  festivals are computed by the engine's solar-anchored Hindu lunar algorithm (accurate to within a day or two, with
+  intercalary years handled), reusing the algorithm keys proven by the shipping India region pack. Saraswati Puja is
+  observed on Vasant Panchami and therefore uses the vasant-panchami algorithm. Onam is omitted because it is fixed by a
+  nakshatra rather than a tithi and is not modelled by the lunar algorithm. A territory pack imports what it observes.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-hindu">
+
+  <NotableDates>
+
+    <NotableDate id="makar-sankranti" displayName="Makar Sankranti" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="pongal" displayName="Pongal" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="4"><Strategy><Fixed month="January" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="saraswati-puja" displayName="Saraswati Puja" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="vasant-panchami" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="maha-shivaratri" displayName="Maha Shivaratri" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="maha-shivaratri" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="holi" displayName="Holi" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="2"><Strategy><Algorithm key="holi" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="ram-navami" displayName="Ram Navami" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="ram-navami" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="raksha-bandhan" displayName="Raksha Bandhan" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="raksha-bandhan" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="janmashtami" displayName="Janmashtami" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="janmashtami" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="ganesh-chaturthi" displayName="Ganesh Chaturthi" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="10"><Strategy><Algorithm key="ganesh-chaturthi" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="navaratri" displayName="Navaratri" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="9"><Strategy><Algorithm key="navaratri" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="dussehra" displayName="Dussehra" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="dussehra" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="karva-chauth" displayName="Karva Chauth" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="karva-chauth" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="diwali" displayName="Diwali" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="5"><Strategy><Algorithm key="diwali" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-islamic-umm-al-qura.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-islamic-umm-al-qura.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Islamic (Hijri) notable-date catalogue, Umm al-Qura variant, migrated from the v1 global-islamic-umm-al-qura.xml to the
+  v2 cookbook schema. It declares the same six observances as global-islamic but resolves them against the Saudi Arabian
+  Umm al-Qura calendar (System.Globalization.UmAlQuraCalendar), the calendar of record for the Arabian Peninsula. Each
+  observance is a fixed date swept onto the requested Gregorian year. Consumers wanting tabular/portable Hijri dates use
+  global-islamic; consumers serving the Gulf region use this catalogue. A territory pack imports the concepts it observes.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-islamic-umm-al-qura">
+
+  <NotableDates>
+
+    <NotableDate id="ramadan" displayName="Ramadan" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="30"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="9" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="eid-al-fitr" displayName="Eid al-Fitr" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="3"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="10" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="eid-al-adha" displayName="Eid al-Adha" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="4"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="12" day="10" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="islamic-new-year" displayName="Islamic New Year" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="1" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="day-of-ashura" displayName="Day of Ashura" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="1" day="10" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="mawlid-al-nabi" displayName="Mawlid al-Nabi" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="UmmAlQura" />
+        <Strategy><Fixed month="3" day="12" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-islamic.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-islamic.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Islamic (Hijri) notable-date catalogue, migrated from the v1 global-islamic.xml to the v2 cookbook schema. The
+  principal observances of the Islamic lunar calendar are expressed as fixed dates in the tabular Hijri calendar
+  (System.Globalization.HijriCalendar) and swept onto the requested Gregorian year, so the dates follow the engine's
+  tabular reckoning rather than local moon-sighting and may differ from gazetted dates by up to two days. A territory
+  pack imports the concepts it observes and supplies its own territory scope, category, non-working flag, and duration.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-islamic">
+
+  <NotableDates>
+
+    <NotableDate id="ramadan" displayName="Ramadan" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="30"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="9" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="eid-al-fitr" displayName="Eid al-Fitr" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="3"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="10" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="eid-al-adha" displayName="Eid al-Adha" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="4"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="12" day="10" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="islamic-new-year" displayName="Islamic New Year" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="1" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="day-of-ashura" displayName="Day of Ashura" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="1" day="10" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="mawlid-al-nabi" displayName="Mawlid al-Nabi" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Hijri" />
+        <Strategy><Fixed month="3" day="12" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-jewish.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-jewish.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Jewish (Hebrew) notable-date catalogue, migrated from the v1 global-jewish.xml to the v2 cookbook schema. Four
+  observances anchor the catalogue as fixed dates in the Hebrew lunisolar calendar (System.Globalization.HebrewCalendar)
+  swept onto the requested Gregorian year: Rosh Hashanah, Passover, Purim (the LastAdar alias resolves to Adar II in leap
+  years and Adar I otherwise), and Hanukkah. Three further observances are exact, invariant Hebrew-calendar offsets and
+  are authored as OffsetFromRule rules from those anchors so the dependent date cannot drift. The durationDays values
+  follow the traditional diaspora observance; a territory pack may override them. This catalogue is self-contained.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-jewish">
+
+  <NotableDates>
+
+    <NotableDate id="purim" displayName="Purim" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Hebrew" />
+        <Strategy><Fixed month="LastAdar" day="14" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="passover" displayName="Passover" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability calendar="Hebrew" />
+        <Strategy><Fixed month="Nisan" day="15" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="rosh-hashanah" displayName="Rosh Hashanah" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="2"><Applicability calendar="Hebrew" />
+        <Strategy><Fixed month="Tishri" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="hanukkah" displayName="Hanukkah" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="8"><Applicability calendar="Hebrew" />
+        <Strategy><Fixed month="Kislev" day="25" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="shavuot" displayName="Shavuot" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default">
+        <Strategy><OffsetFromRule notableDateRef="passover" ruleRef="default" offsetDays="50" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="yom-kippur" displayName="Yom Kippur" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default">
+        <Strategy><OffsetFromRule notableDateRef="rosh-hashanah" ruleRef="default" offsetDays="9" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="sukkot" displayName="Sukkot" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7">
+        <Strategy><OffsetFromRule notableDateRef="rosh-hashanah" ruleRef="default" offsetDays="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-lunar.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-lunar.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Chinese and East Asian lunisolar notable-date catalogue, migrated from the v1 global-lunar.xml to the v2 cookbook
+  schema. The lunar festivals are expressed as fixed dates in the Chinese lunisolar calendar
+  (System.Globalization.ChineseLunisolarCalendar); skipLeapMonth advances the conventional ordinal month past any
+  intercalary leap month in the same year. Qingming uses the engine's astronomical solar-term algorithm; the Winter
+  Solstice festival is approximated by its most frequent civil Gregorian date. Lantern Festival is a fixed fourteen-day
+  OffsetFromRule from the local Lunar New Year anchor, so this catalogue is self-contained. These patterns and the
+  qingming key are the same ones the shipping China region pack uses. A territory pack imports what it observes.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-lunar">
+
+  <NotableDates>
+
+    <NotableDate id="lunar-new-year" displayName="Lunar New Year" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="1" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="lantern-festival" displayName="Lantern Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default">
+        <Strategy><OffsetFromRule notableDateRef="lunar-new-year" ruleRef="default" offsetDays="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="qingming-festival" displayName="Qingming Festival" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Algorithm key="qingming" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="dragon-boat-festival" displayName="Dragon Boat Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="5" day="5" skipLeapMonth="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="qixi-festival" displayName="Qixi Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="7" day="7" skipLeapMonth="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="hungry-ghost-festival" displayName="Hungry Ghost Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="7" day="15" skipLeapMonth="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="mid-autumn-festival" displayName="Mid-Autumn Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="8" day="15" skipLeapMonth="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="double-ninth-festival" displayName="Double Ninth Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="ChineseLunisolar" />
+        <Strategy><Fixed month="9" day="9" skipLeapMonth="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="winter-solstice-festival" displayName="Winter Solstice Festival" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="22" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-multiday-normalization.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-multiday-normalization.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Multi-day normalization catalogue (Western / Gregorian calendar), migrated from the v1 global-multiday-normalization.xml
+  to the v2 cookbook schema. Holds shared multi-day observance definitions not already owned by a more specific thematic
+  catalogue; prefer the source thematic file when a multi-day observance already exists there. Convention: durationDays
+  is inclusive of the resolved start date, so durationDays="7" spans the start date plus the next six calendar days. A
+  territory pack imports only the concepts it observes and supplies its own territory scope, category, non-working flag,
+  and weekend adjustment through the import <Use> directive; the shared concepts therefore carry the bare calculation
+  strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-multiday-normalization">
+
+  <NotableDates>
+
+    <NotableDate id="naidoc-week" displayName="NAIDOC Week" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability><Territory code="AU" /></Applicability><Strategy><DayOfWeekInMonth month="July" dayOfWeek="Sunday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-space-week" displayName="World Space Week" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability fromYear="1999" /><Strategy><Fixed month="October" day="4" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-persian.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-persian.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Persian (Solar Hijri) notable-date catalogue, migrated from the v1 global-persian.xml to the v2 cookbook schema. The
+  observances are expressed as fixed dates in the Persian calendar (System.Globalization.PersianCalendar) swept onto the
+  requested Gregorian year; sweepCalendarYears is required because the Persian year number differs from the Gregorian
+  year number by roughly 621. The .NET PersianCalendar yields the correct vernal-equinox-aligned date across the years
+  that matter to most consumers (roughly 1925-2088 CE). A territory pack imports the concepts it observes and supplies
+  its own territory scope, category, non-working flag, and duration.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-persian">
+
+  <NotableDates>
+
+    <NotableDate id="nowruz" displayName="Nowruz" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="13"><Applicability calendar="Persian" />
+        <Strategy><Fixed month="1" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="sizdah-bedar" displayName="Sizdah Bedar" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Persian" />
+        <Strategy><Fixed month="1" day="13" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="yalda-night" displayName="Yalda Night" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability calendar="Persian" />
+        <Strategy><Fixed month="9" day="30" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-remembrance.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-remembrance.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global remembrance notable-date catalogue (Western / Gregorian calendar), migrated from the v1 global-remembrance.xml
+  to the v2 cookbook schema. These are internationally recognized remembrance observances; they are not universally
+  public holidays. A territory pack imports only the concepts it observes and supplies its own territory scope,
+  category, non-working flag, and weekend adjustment through the import <Use> directive; the shared concepts therefore
+  carry the bare calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-remembrance">
+
+  <NotableDates>
+
+    <NotableDate id="international-holocaust-remembrance-day" displayName="International Holocaust Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="January" day="27" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-for-the-elimination-of-racial-discrimination" displayName="International Day for the Elimination of Racial Discrimination" category="Remembrance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1966" /><Strategy><Fixed month="March" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-for-the-remembrance-of-the-slave-trade-and-its-abolition" displayName="International Day for the Remembrance of the Slave Trade and its Abolition" category="Remembrance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1998" /><Strategy><Fixed month="August" day="23" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="remembrance-day" displayName="Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="November" day="11" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-science.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-science.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global science and technology notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-science.xml to the v2 cookbook schema. These are internationally recognized science, technology, and
+  innovation observances; they are not universally public holidays. A territory pack imports only the concepts it
+  observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through the import
+  <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-science">
+
+  <NotableDates>
+
+    <NotableDate id="international-day-of-women-and-girls-in-science" displayName="International Day of Women and Girls in Science" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2016" /><Strategy><Fixed month="February" day="11" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-mathematics" displayName="International Day of Mathematics" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2020" /><Strategy><Fixed month="March" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-meteorological-day" displayName="World Meteorological Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1961" /><Strategy><Fixed month="March" day="23" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-intellectual-property-day" displayName="World Intellectual Property Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2000" /><Strategy><Fixed month="April" day="26" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-light" displayName="International Day of Light" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2018" /><Strategy><Fixed month="May" day="16" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="pi-day" displayName="Pi Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1988" /><Strategy><Fixed month="March" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-space-week" displayName="World Space Week" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability fromYear="1999" /><Strategy><Fixed month="October" day="4" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-science-day-for-peace-and-development" displayName="World Science Day for Peace and Development" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2002" /><Strategy><Fixed month="November" day="10" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-social.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-social.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global social and humanitarian notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-social.xml to the v2 cookbook schema. These are internationally recognized social, humanitarian, and
+  community-related observances; they are not universally public holidays. A territory pack imports only the concepts
+  it observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through the
+  import <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id
+  "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-social">
+
+  <NotableDates>
+
+    <NotableDate id="world-day-of-social-justice" displayName="World Day of Social Justice" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2009" /><Strategy><Fixed month="February" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-families" displayName="International Day of Families" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="May" day="15" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-against-homophobia-biphobia-and-transphobia" displayName="International Day Against Homophobia, Biphobia and Transphobia" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2005" /><Strategy><Fixed month="May" day="17" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="pride-month" displayName="Pride Month" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="30"><Strategy><Fixed month="June" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-day-against-child-labour" displayName="World Day Against Child Labour" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2002" /><Strategy><Fixed month="June" day="12" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-refugee-day" displayName="World Refugee Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="June" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="nelson-mandela-international-day" displayName="Nelson Mandela International Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2010" /><Strategy><Fixed month="July" day="18" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-charity" displayName="International Day of Charity" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2012" /><Strategy><Fixed month="September" day="5" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-older-persons" displayName="International Day of Older Persons" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="October" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-the-girl-child" displayName="International Day of the Girl Child" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2012" /><Strategy><Fixed month="October" day="11" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-kindness-day" displayName="World Kindness Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1998" /><Strategy><Fixed month="November" day="13" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-mens-day" displayName="International Men's Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1999" /><Strategy><Fixed month="November" day="19" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="universal-childrens-day" displayName="Universal Children's Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1954" /><Strategy><Fixed month="November" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-persons-with-disabilities" displayName="International Day of Persons with Disabilities" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="3" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-un.xml
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/Resources/global-un.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Global international and United Nations notable-date catalogue (Western / Gregorian calendar), migrated from the v1
+  global-un.xml to the v2 cookbook schema. These are internationally recognized observances, including United
+  Nations-designated days; they are not universally public holidays. A territory pack imports only the concepts it
+  observes and supplies its own territory scope, category, non-working flag, and weekend adjustment through the import
+  <Use> directive; the shared concepts therefore carry the bare calculation strategy with the stable rule id "default".
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.global-un">
+
+  <NotableDates>
+
+    <NotableDate id="international-womens-day" displayName="International Women's Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="March" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-happiness" displayName="International Day of Happiness" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="March" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-youth-day" displayName="International Youth Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="August" day="12" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-peace" displayName="International Day of Peace" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="September" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="united-nations-day" displayName="United Nations Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="October" day="24" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="human-rights-day" displayName="Human Rights Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="December" day="10" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-interfaith-harmony-week" displayName="World Interfaith Harmony Week" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default" durationDays="7"><Applicability fromYear="2011" /><Strategy><Fixed month="February" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-press-freedom-day" displayName="World Press Freedom Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1993" /><Strategy><Fixed month="May" day="3" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="international-day-of-democracy" displayName="International Day of Democracy" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="2008" /><Strategy><Fixed month="September" day="15" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <NotableDate id="world-habitat-day" displayName="World Habitat Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Applicability fromYear="1986" /><Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/RuleApplicability.cs
+++ b/Bodu.Globalization.Calendar2/src/Globalization.Calendar.V2/RuleApplicability.cs
@@ -30,6 +30,11 @@ public sealed class RuleApplicability
     /// <param name="territories">The explicit territories the rule applies to.</param>
     /// <param name="onlyYears">The explicit inclusion years, or an empty sequence for no restriction.</param>
     /// <param name="exceptYears">The explicit exclusion years, or an empty sequence for no exclusions.</param>
+    /// <param name="everyYears">The recurrence interval in years, or <see langword="null" /> for an annual rule.</param>
+    /// <param name="anchorYear">
+    /// The year the recurrence interval is measured from, or <see langword="null" /> to anchor on
+    /// <paramref name="fromYear" /> (or year zero when also unbounded).
+    /// </param>
     /// <exception cref="ArgumentNullException">
     /// <paramref name="territories" />, <paramref name="onlyYears" />, or <paramref name="exceptYears" /> is
     /// <see langword="null" />.
@@ -40,7 +45,9 @@ public sealed class RuleApplicability
         int? toYear,
         IEnumerable<string> territories,
         IEnumerable<int> onlyYears,
-        IEnumerable<int> exceptYears)
+        IEnumerable<int> exceptYears,
+        int? everyYears = null,
+        int? anchorYear = null)
     {
         ThrowHelper.ThrowIfNull(territories);
         ThrowHelper.ThrowIfNull(onlyYears);
@@ -52,6 +59,8 @@ public sealed class RuleApplicability
         this.Territories = territories.ToArray();
         this.OnlyYears = onlyYears.ToArray();
         this.ExceptYears = exceptYears.ToArray();
+        this.EveryYears = everyYears;
+        this.AnchorYear = anchorYear;
     }
 
     /// <summary>
@@ -91,6 +100,23 @@ public sealed class RuleApplicability
     public IReadOnlyList<int> ExceptYears { get; }
 
     /// <summary>
+    /// Gets the recurrence interval in years.
+    /// </summary>
+    /// <returns>
+    /// The cadence (for example <c>4</c> for every fourth year), or <see langword="null" /> for an annual rule.
+    /// </returns>
+    public int? EveryYears { get; }
+
+    /// <summary>
+    /// Gets the anchor year the recurrence interval is measured from.
+    /// </summary>
+    /// <returns>
+    /// The anchor year, or <see langword="null" /> to anchor on <see cref="FromYear" /> (or year zero when also
+    /// unbounded).
+    /// </returns>
+    public int? AnchorYear { get; }
+
+    /// <summary>
     /// Determines whether the rule applies to the supplied territory and Gregorian year.
     /// </summary>
     /// <param name="territory">The requested territory code.</param>
@@ -111,6 +137,13 @@ public sealed class RuleApplicability
 
         if (this.ExceptYears.Contains(year))
             return false;
+
+        if (this.EveryYears is int interval && interval > 1)
+        {
+            int anchor = this.AnchorYear ?? this.FromYear ?? 0;
+            if ((((year - anchor) % interval) + interval) % interval != 0)
+                return false;
+        }
 
         return this.MatchesTerritory(territory);
     }

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/CommonResourcesTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/CommonResourcesTests.cs
@@ -80,4 +80,30 @@ public sealed class CommonResourcesTests
         Assert.IsTrue(newYear.IsObserved);
         Assert.AreEqual(new DateOnly(2023, 1, 1), newYear.ActualDate);
     }
+
+    /// <summary>
+    /// Verifies that every bundled common catalogue parses and passes semantic validation when loaded through the
+    /// shared resolver, so an authoring error in any catalogue fails the build.
+    /// </summary>
+    [TestMethod]
+    public void AllBundledCatalogues_LoadAndValidate()
+    {
+        System.Reflection.Assembly assembly = typeof(CommonNotableDateResources).Assembly;
+        const string prefix = "Bodu.Globalization.Calendar.V2.Resources.";
+        List<string> catalogues = assembly.GetManifestResourceNames()
+            .Where(name => name.StartsWith(prefix, StringComparison.Ordinal) && name.EndsWith(".xml", StringComparison.Ordinal))
+            .Select(name => name[prefix.Length..^4])
+            .ToList();
+
+        Assert.IsTrue(catalogues.Count >= 2, "expected the bundled catalogues to be embedded");
+
+        foreach (string catalogue in catalogues)
+        {
+            string? content = CommonNotableDateResources.Resolve(catalogue);
+            Assert.IsNotNull(content, $"catalogue '{catalogue}' did not resolve");
+
+            NotableDateResource resource = NotableDateResourceLoader.Load(content!, CommonNotableDateResources.Resolver);
+            Assert.IsTrue(resource.NotableDates.Count > 0, $"catalogue '{catalogue}' has no concepts");
+        }
+    }
 }

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/CommonResourcesTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/CommonResourcesTests.cs
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="CommonResourcesTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Verifies the bundled common notable-date catalogues and their resolver: that the embedded catalogues are
+/// discoverable and that a territory resource can import the shared concepts and specialize them with its own
+/// territory scope, category, non-working flag, and weekend adjustments.
+/// </summary>
+[TestClass]
+public sealed class CommonResourcesTests
+{
+    /// <summary>
+    /// Verifies that the resolver returns content for a bundled catalogue and <see langword="null" /> for an unknown
+    /// name.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_ForBundledCatalogue_ReturnsContentForKnownAndNullForUnknown()
+    {
+        Assert.IsNotNull(CommonNotableDateResources.Resolve("global-core"));
+        Assert.IsNotNull(CommonNotableDateResources.Resolve("christian-western"));
+        Assert.IsNull(CommonNotableDateResources.Resolve("no-such-catalogue"));
+    }
+
+    /// <summary>
+    /// Verifies that a territory resource importing the bundled catalogues resolves the shared dates, computes the
+    /// Easter-anchored offsets, and applies the territory's own adjustment and category overrides.
+    /// </summary>
+    [TestMethod]
+    public void Import_FromBundledCatalogues_ResolvesSharedDatesWithTerritoryOverrides()
+    {
+        const string Region = """
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.demo">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+          <AdjustmentPolicies>
+            <AdjustmentPolicy id="sat-to-fri" priority="100">
+              <Trigger type="IfDayOfWeek"><Weekday value="Saturday" /></Trigger>
+              <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
+              <Emission mode="ObservedOnly" reason="Observed Friday" />
+            </AdjustmentPolicy>
+            <AdjustmentPolicy id="sun-to-mon" priority="100">
+              <Trigger type="IfDayOfWeek"><Weekday value="Sunday" /></Trigger>
+              <Action type="MoveToNextWeekday" dayOfWeek="Monday" />
+              <Emission mode="ObservedOnly" reason="Observed Monday" />
+            </AdjustmentPolicy>
+          </AdjustmentPolicies>
+          <Imports>
+            <Import resource="global-core">
+              <Use notableDateRef="new-years-day" territory="ZZ">
+                <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
+              </Use>
+            </Import>
+            <Import resource="christian-western">
+              <Use notableDateRef="easter-sunday" territory="ZZ" />
+              <Use notableDateRef="good-friday" territory="ZZ" category="Religious" nonWorking="false" />
+              <Use notableDateRef="christmas-day" territory="ZZ">
+                <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
+              </Use>
+            </Import>
+          </Imports>
+          <NotableDates />
+        </NotableDateResource>
+        """;
+
+        NotableDateService service = new(NotableDateResourceLoader.Load(Region, CommonNotableDateResources.Resolver));
+        DateRange year2024 = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        // Easter Sunday 2024 is 31 March; the imported Good Friday offset resolves to 29 March.
+        Assert.AreEqual(new DateOnly(2024, 3, 31), service.Resolve(year2024, "ZZ").Single(r => r.NotableDateId == "easter-sunday").Date);
+        NotableDate goodFriday = service.Resolve(new DateOnly(2024, 3, 29), "ZZ").Single(r => r.NotableDateId == "good-friday");
+        Assert.AreEqual(NotableDateCategory.Religious, goodFriday.Category, "category override applied");
+        Assert.IsFalse(goodFriday.IsNonWorkingDay, "non-working override applied");
+
+        // New Year's Day 2023 falls on a Sunday; the sun-to-mon override observes it on Monday 2 January.
+        NotableDate newYear = service.Resolve(new DateOnly(2023, 1, 2), "ZZ").Single(r => r.NotableDateId == "new-years-day");
+        Assert.IsTrue(newYear.IsObserved);
+        Assert.AreEqual(new DateOnly(2023, 1, 1), newYear.ActualDate);
+    }
+}

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/Fixtures/invalid-unknown-trigger.xml
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/Fixtures/invalid-unknown-trigger.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-  An adjustment policy whose trigger uses the v1 token "IfNonWorkingDay", which is not part of the v2
-  adjustmentTrigger enumeration. The document fails schema validation with BODU-CAL2-SCHEMA.
+  An adjustment policy whose trigger uses the token "IfFullMoon", which is not part of the v2 adjustmentTrigger
+  enumeration. The document fails schema validation with BODU-CAL2-SCHEMA.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="test.invalid.unknown-trigger">
   <AdjustmentPolicies>
     <AdjustmentPolicy id="p">
-      <Trigger type="IfNonWorkingDay" />
+      <Trigger type="IfFullMoon" />
       <Action type="MoveToNextWeekday" dayOfWeek="Monday" />
       <Emission mode="ObservedOnly" />
     </AdjustmentPolicy>

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ImportResolutionTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ImportResolutionTests.cs
@@ -111,6 +111,80 @@ public sealed class ImportResolutionTests
     }
 
     /// <summary>
+    /// Verifies that an import use's adjustment override replaces the source rule's adjustments, so the imported
+    /// concept observes the territory's own substitute rather than the source's.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenUseOverridesAdjustments_ReplacesSourceAdjustment()
+    {
+        const string Region = """
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+          <AdjustmentPolicies>
+            <AdjustmentPolicy id="prev-friday" priority="100">
+              <Trigger type="IfWeekend" />
+              <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
+              <Emission mode="ObservedOnly" reason="Observed Friday" />
+            </AdjustmentPolicy>
+          </AdjustmentPolicies>
+          <Imports>
+            <Import resource="global">
+              <Use notableDateRef="christmas" territory="US">
+                <Adjustments><Adjustment policyRef="prev-friday" /></Adjustments>
+              </Use>
+            </Import>
+          </Imports>
+          <NotableDates />
+        </NotableDateResource>
+        """;
+
+        NotableDateService service = new(NotableDateResourceLoader.Load(Region, Resolver(("global", Global))));
+
+        // 25 December 2021 is a Saturday; the override moves the observance back to Friday 24 December rather than the
+        // source weekend-roll's next-working-day Monday 27 December.
+        NotableDate christmas = service.Resolve(new DateOnly(2021, 12, 24), "US").Single(r => r.NotableDateId == "christmas");
+        Assert.IsTrue(christmas.IsObserved);
+        Assert.AreEqual(new DateOnly(2021, 12, 25), christmas.ActualDate);
+        Assert.AreEqual(0, service.Resolve(new DateOnly(2021, 12, 27), "US").Count(r => r.NotableDateId == "christmas"), "source weekend-roll replaced");
+    }
+
+    /// <summary>
+    /// Verifies that two territories importing the same shared concept can each supply their own adjustment override,
+    /// so the shared Christmas observes on different days per territory.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenRegionsOverrideAdjustmentsDifferently_EachObservesItsOwn()
+    {
+        static string Make(string territory, string policyId, string action, string dayOfWeek) => $$"""
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+          <AdjustmentPolicies>
+            <AdjustmentPolicy id="{{policyId}}" priority="100">
+              <Trigger type="IfWeekend" />
+              <Action type="{{action}}" dayOfWeek="{{dayOfWeek}}" />
+              <Emission mode="ObservedOnly" reason="Observed" />
+            </AdjustmentPolicy>
+          </AdjustmentPolicies>
+          <Imports>
+            <Import resource="global">
+              <Use notableDateRef="christmas" territory="{{territory}}">
+                <Adjustments><Adjustment policyRef="{{policyId}}" /></Adjustments>
+              </Use>
+            </Import>
+          </Imports>
+          <NotableDates />
+        </NotableDateResource>
+        """;
+
+        NotableDateService us = new(NotableDateResourceLoader.Load(Make("US", "prev-friday", "MoveToPreviousWeekday", "Friday"), Resolver(("global", Global))));
+        NotableDateService gb = new(NotableDateResourceLoader.Load(Make("GB", "next-monday", "MoveToNextWeekday", "Monday"), Resolver(("global", Global))));
+
+        // The shared Christmas (Saturday 25 December 2021) rolls back to Friday in the US and forward to Monday in GB.
+        Assert.AreEqual(new DateOnly(2021, 12, 24), us.Resolve(new DateOnly(2021, 12, 24), "US").Single(r => r.NotableDateId == "christmas").Date);
+        Assert.AreEqual(new DateOnly(2021, 12, 27), gb.Resolve(new DateOnly(2021, 12, 27), "GB").Single(r => r.NotableDateId == "christmas").Date);
+    }
+
+    /// <summary>
     /// Verifies that an import cycle fails the load with a validation error.
     /// </summary>
     [TestMethod]

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/NonWorkingDayTriggerTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/NonWorkingDayTriggerTests.cs
@@ -1,0 +1,174 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="NonWorkingDayTriggerTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Verifies the <see cref="AdjustmentTrigger.IfNonWorkingDay" /> and <see cref="AdjustmentTrigger.IfWorkingDay" />
+/// triggers, which extend the weekend triggers by also accounting for a day already claimed by another non-working
+/// occurrence. The fixture anchors each example on a distinct day in January 2026 (1 Jan Thu, 3 Jan Sat, 8 Jan Thu,
+/// 10 Jan Sat, 15 Jan Thu) so the cases never interfere.
+/// </summary>
+[TestClass]
+public sealed class NonWorkingDayTriggerTests
+{
+    private const string Territory = "ZZ";
+
+    /// <summary>
+    /// A fixture exercising every non-working-day and working-day trigger branch under the default Monday-to-Friday
+    /// working week.
+    /// </summary>
+    private const string Xml = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="test.nonworkingday">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <AdjustmentPolicies>
+        <AdjustmentPolicy id="non-working-next-working-day" priority="100">
+          <Trigger type="IfNonWorkingDay" />
+          <Action type="MoveToNextWorkingDay" maxSearchDays="7" skipWeekends="true" skipNonWorkingDates="true" />
+          <Emission mode="ObservedOnly" reason="Observed next working day" />
+        </AdjustmentPolicy>
+        <AdjustmentPolicy id="working-day-shift-two" priority="100">
+          <Trigger type="IfWorkingDay" />
+          <Action type="AddDays" days="2" />
+          <Emission mode="ObservedOnly" reason="Shifted on working day" />
+        </AdjustmentPolicy>
+      </AdjustmentPolicies>
+      <NotableDates>
+        <NotableDate id="collide-a" displayName="Collide A" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-1"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="1" /></Strategy></Rule>
+          </Rules>
+        </NotableDate>
+        <NotableDate id="collide-b" displayName="Collide B" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-1"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="1" /></Strategy>
+              <Adjustments><Adjustment policyRef="non-working-next-working-day" /></Adjustments></Rule>
+          </Rules>
+        </NotableDate>
+        <NotableDate id="weekend-holiday" displayName="Weekend Holiday" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-3"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="3" /></Strategy>
+              <Adjustments><Adjustment policyRef="non-working-next-working-day" /></Adjustments></Rule>
+          </Rules>
+        </NotableDate>
+        <NotableDate id="lone-working" displayName="Lone Working" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-8"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="8" /></Strategy>
+              <Adjustments><Adjustment policyRef="non-working-next-working-day" /></Adjustments></Rule>
+          </Rules>
+        </NotableDate>
+        <NotableDate id="working-shift" displayName="Working Shift" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-15"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="15" /></Strategy>
+              <Adjustments><Adjustment policyRef="working-day-shift-two" /></Adjustments></Rule>
+          </Rules>
+        </NotableDate>
+        <NotableDate id="weekend-no-shift" displayName="Weekend No Shift" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules>
+            <Rule id="jan-10"><Applicability><Territory code="ZZ" /></Applicability>
+              <Strategy><Fixed month="January" day="10" /></Strategy>
+              <Adjustments><Adjustment policyRef="working-day-shift-two" /></Adjustments></Rule>
+          </Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Builds a service over the fixture.
+    /// </summary>
+    /// <returns>A service over the fixture.</returns>
+    private static INotableDateService Build() =>
+        new NotableDateService(NotableDateResourceLoader.Load(Xml));
+
+    /// <summary>
+    /// Verifies that a non-working holiday colliding with another non-working holiday on a working day fires the
+    /// non-working-day trigger and is observed on the next free working day.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenCollidingWithAnotherHoliday_ShouldObserveOnNextWorkingDay()
+    {
+        INotableDateService service = Build();
+
+        // Collide A keeps the contested Thursday; Collide B does not appear on it.
+        IReadOnlyList<NotableDate> thursday = service.Resolve(new DateOnly(2026, 1, 1), Territory);
+        Assert.IsTrue(thursday.Any(n => n.NotableDateId == "collide-a" && !n.IsObserved), "Collide A on its actual day");
+        Assert.IsFalse(thursday.Any(n => n.NotableDateId == "collide-b"), "Collide B moved off the contested day");
+
+        // Collide B is observed on the next working day (Friday 2 January).
+        IReadOnlyList<NotableDate> friday = service.Resolve(new DateOnly(2026, 1, 2), Territory);
+        NotableDate observed = friday.Single(n => n.NotableDateId == "collide-b");
+        Assert.IsTrue(observed.IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 1), observed.ActualDate);
+    }
+
+    /// <summary>
+    /// Verifies that the non-working-day trigger fires for a holiday falling on a weekend and moves it to the next
+    /// working day, skipping the weekend.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenHolidayFallsOnWeekend_ShouldObserveOnNextWorkingDay()
+    {
+        INotableDateService service = Build();
+
+        Assert.IsFalse(
+            service.Resolve(new DateOnly(2026, 1, 3), Territory).Any(n => n.NotableDateId == "weekend-holiday"),
+            "Saturday actual suppressed");
+
+        NotableDate observed = service.Resolve(new DateOnly(2026, 1, 5), Territory).Single(n => n.NotableDateId == "weekend-holiday");
+        Assert.IsTrue(observed.IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 3), observed.ActualDate);
+    }
+
+    /// <summary>
+    /// Verifies that the non-working-day trigger does not fire for a lone holiday on a working day, so the holiday is
+    /// emitted on its actual date.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenLoneHolidayOnWorkingDay_ShouldEmitActualDate()
+    {
+        NotableDate actual = Build().Resolve(new DateOnly(2026, 1, 8), Territory).Single(n => n.NotableDateId == "lone-working");
+
+        Assert.IsFalse(actual.IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 8), actual.Date);
+    }
+
+    /// <summary>
+    /// Verifies that the working-day trigger fires for a lone holiday on a working day and shifts it by the configured
+    /// number of days.
+    /// </summary>
+    [TestMethod]
+    public void IfWorkingDay_WhenHolidayOnWorkingDay_ShouldShiftOccurrence()
+    {
+        INotableDateService service = Build();
+
+        Assert.IsFalse(
+            service.Resolve(new DateOnly(2026, 1, 15), Territory).Any(n => n.NotableDateId == "working-shift"),
+            "actual Thursday suppressed by observed-only");
+
+        NotableDate observed = service.Resolve(new DateOnly(2026, 1, 17), Territory).Single(n => n.NotableDateId == "working-shift");
+        Assert.IsTrue(observed.IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 15), observed.ActualDate);
+    }
+
+    /// <summary>
+    /// Verifies that the working-day trigger does not fire for a holiday on a weekend, so the holiday is emitted on its
+    /// actual date.
+    /// </summary>
+    [TestMethod]
+    public void IfWorkingDay_WhenHolidayOnWeekend_ShouldEmitActualDate()
+    {
+        NotableDate actual = Build().Resolve(new DateOnly(2026, 1, 10), Territory).Single(n => n.NotableDateId == "weekend-no-shift");
+
+        Assert.IsFalse(actual.IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 10), actual.Date);
+    }
+}

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ParserEnumSurfaceTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ParserEnumSurfaceTests.cs
@@ -92,6 +92,8 @@ public sealed class ParserEnumSurfaceTests
     [DataRow("IfDayOfWeek", AdjustmentTrigger.IfDayOfWeek)]
     [DataRow("IfWeekend", AdjustmentTrigger.IfWeekend)]
     [DataRow("IfWeekday", AdjustmentTrigger.IfWeekday)]
+    [DataRow("IfNonWorkingDay", AdjustmentTrigger.IfNonWorkingDay)]
+    [DataRow("IfWorkingDay", AdjustmentTrigger.IfWorkingDay)]
     [DataRow("IfLeapYear", AdjustmentTrigger.IfLeapYear)]
     [DataRow("IfBeforeFixedDate", AdjustmentTrigger.IfBeforeFixedDate)]
     [DataRow("IfAfterFixedDate", AdjustmentTrigger.IfAfterFixedDate)]

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ParserValidationTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/ParserValidationTests.cs
@@ -172,8 +172,7 @@ public sealed class ParserValidationTests
     }
 
     /// <summary>
-    /// Verifies that an unknown adjustment trigger token (the v1-only <c>IfNonWorkingDay</c>) is rejected with a schema
-    /// diagnostic.
+    /// Verifies that an unknown adjustment trigger token (<c>IfFullMoon</c>) is rejected with a schema diagnostic.
     /// </summary>
     [TestMethod]
     public void Load_WhenTriggerIsUnknown_ShouldThrowSchemaDiagnostic()

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/RecurrenceCadenceTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/RecurrenceCadenceTests.cs
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="RecurrenceCadenceTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Verifies the periodic recurrence cadence (<c>everyYears</c>/<c>anchorYear</c>) on <see cref="RuleApplicability" />,
+/// which restores v1's <c>OccurrenceYears</c> modulo behaviour so a rule can recur every N years from an anchor without
+/// enumerating each year.
+/// </summary>
+[TestClass]
+public sealed class RecurrenceCadenceTests
+{
+    private const string Territory = "XX";
+
+    /// <summary>
+    /// Builds an applicability with the supplied cadence and bounds.
+    /// </summary>
+    /// <param name="fromYear">The lower year bound, or <see langword="null" />.</param>
+    /// <param name="everyYears">The recurrence interval, or <see langword="null" />.</param>
+    /// <param name="anchorYear">The cadence anchor, or <see langword="null" />.</param>
+    /// <returns>The applicability.</returns>
+    private static RuleApplicability App(int? fromYear, int? everyYears, int? anchorYear) =>
+        new(CalendarSystem.Gregorian, fromYear, null, Array.Empty<string>(), Array.Empty<int>(), Array.Empty<int>(), everyYears, anchorYear);
+
+    /// <summary>
+    /// Verifies that a cadence anchored on <c>fromYear</c> applies only on the on-cadence years.
+    /// </summary>
+    [TestMethod]
+    public void AppliesTo_EveryFourYearsFromYear_ShouldApplyOnCadenceOnly()
+    {
+        RuleApplicability a = App(2024, 4, null);
+
+        Assert.IsTrue(a.AppliesTo(Territory, 2024));
+        Assert.IsFalse(a.AppliesTo(Territory, 2025));
+        Assert.IsFalse(a.AppliesTo(Territory, 2026));
+        Assert.IsFalse(a.AppliesTo(Territory, 2027));
+        Assert.IsTrue(a.AppliesTo(Territory, 2028));
+        Assert.IsFalse(a.AppliesTo(Territory, 2023), "below fromYear");
+    }
+
+    /// <summary>
+    /// Verifies that a cadence without a lower bound anchors on year zero.
+    /// </summary>
+    [TestMethod]
+    public void AppliesTo_EveryFourYearsWithoutFromYear_ShouldAnchorOnZero()
+    {
+        RuleApplicability a = App(null, 4, null);
+
+        Assert.IsTrue(a.AppliesTo(Territory, 2020));
+        Assert.IsFalse(a.AppliesTo(Territory, 2021));
+        Assert.IsFalse(a.AppliesTo(Territory, 2022));
+        Assert.IsFalse(a.AppliesTo(Territory, 2023));
+        Assert.IsTrue(a.AppliesTo(Territory, 2024));
+    }
+
+    /// <summary>
+    /// Verifies that an explicit anchor year sets the cadence phase, including years before the anchor.
+    /// </summary>
+    [TestMethod]
+    public void AppliesTo_EveryFourYearsWithExplicitAnchor_ShouldAnchorThere()
+    {
+        RuleApplicability a = App(null, 4, 2024);
+
+        Assert.IsTrue(a.AppliesTo(Territory, 2024));
+        Assert.IsTrue(a.AppliesTo(Territory, 2028));
+        Assert.IsTrue(a.AppliesTo(Territory, 2020));
+        Assert.IsFalse(a.AppliesTo(Territory, 2025));
+    }
+
+    /// <summary>
+    /// Verifies that a cadence of one (or zero) imposes no restriction, applying every year.
+    /// </summary>
+    [DataRow(1)]
+    [DataRow(0)]
+    [TestMethod]
+    public void AppliesTo_EveryYearsOfOneOrZero_ShouldApplyAnnually(int everyYears)
+    {
+        RuleApplicability a = App(null, everyYears, null);
+
+        Assert.IsTrue(a.AppliesTo(Territory, 2024));
+        Assert.IsTrue(a.AppliesTo(Territory, 2025));
+    }
+
+    /// <summary>
+    /// A quadrennial fixed-date rule authored with <c>everyYears</c>.
+    /// </summary>
+    private const string Xml = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.cadence">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <NotableDates>
+        <NotableDate id="quad-games" displayName="Quad Games" category="Observance">
+          <Rules><Rule id="x"><Applicability fromYear="2024" everyYears="4" /><Strategy><Fixed month="July" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that a quadrennial rule resolves end to end through the service only on its on-cadence years.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_QuadrennialRule_ShouldEmitOnlyOnCadenceYears()
+    {
+        INotableDateService service = new NotableDateService(NotableDateResourceLoader.Load(Xml));
+
+        Assert.AreEqual(1, service.Resolve(new DateOnly(2024, 7, 1), Territory).Count, "2024 on cadence");
+        Assert.AreEqual(0, service.Resolve(new DateOnly(2025, 7, 1), Territory).Count, "2025 off cadence");
+        Assert.AreEqual(1, service.Resolve(new DateOnly(2028, 7, 1), Territory).Count, "2028 on cadence");
+    }
+}

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/SupportedDiscoveryTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/SupportedDiscoveryTests.cs
@@ -1,0 +1,93 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="SupportedDiscoveryTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Verifies the resource-introspection APIs <see cref="INotableDateService.GetSupportedTerritories" /> and
+/// <see cref="INotableDateService.GetSupportedCalendars" />, restoring the v1 discovery surface.
+/// </summary>
+[TestClass]
+public sealed class SupportedDiscoveryTests
+{
+    /// <summary>
+    /// A resource mixing a global rule, three territory-scoped rules, and two non-Gregorian-calendar rules.
+    /// </summary>
+    private const string Xml = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.discovery">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <NotableDates>
+        <NotableDate id="global" displayName="Global" category="Observance">
+          <Rules><Rule id="x"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+        <NotableDate id="au" displayName="AU" category="PublicHoliday">
+          <Rules><Rule id="x"><Applicability><Territory code="US" /></Applicability><Strategy><Fixed month="July" day="4" /></Strategy></Rule></Rules>
+        </NotableDate>
+        <NotableDate id="nsw" displayName="NSW" category="PublicHoliday">
+          <Rules><Rule id="x"><Applicability><Territory code="AU-NSW" /></Applicability><Strategy><Fixed month="August" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+        <NotableDate id="auday" displayName="AU Day" category="PublicHoliday">
+          <Rules><Rule id="x"><Applicability><Territory code="AU" /></Applicability><Strategy><Fixed month="January" day="26" /></Strategy></Rule></Rules>
+        </NotableDate>
+        <NotableDate id="hijri" displayName="Hijri" category="Religious">
+          <Rules><Rule id="x"><Applicability calendar="Hijri" /><Strategy><Fixed month="9" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+        </NotableDate>
+        <NotableDate id="hebrew" displayName="Hebrew" category="Religious">
+          <Rules><Rule id="x"><Applicability calendar="Hebrew" /><Strategy><Fixed month="Tishri" day="1" sweepCalendarYears="true" /></Strategy></Rule></Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Builds a service over the supplied resource XML.
+    /// </summary>
+    /// <param name="xml">The resource XML.</param>
+    /// <returns>A service over the resource.</returns>
+    private static INotableDateService Build(string xml) =>
+        new NotableDateService(NotableDateResourceLoader.Load(xml));
+
+    /// <summary>
+    /// Verifies that the supported territories are the distinct scoped codes in case-insensitive ascending order, and
+    /// that global rules contribute nothing.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_ShouldReturnScopedCodesSorted()
+    {
+        CollectionAssert.AreEqual(new[] { "AU", "AU-NSW", "US" }, Build(Xml).GetSupportedTerritories().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that the supported calendars are the distinct calendar systems in ascending order, including Gregorian.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedCalendars_ShouldReturnDistinctSorted()
+    {
+        CollectionAssert.AreEqual(
+            new[] { CalendarSystem.Gregorian, CalendarSystem.Hijri, CalendarSystem.Hebrew },
+            Build(Xml).GetSupportedCalendars().ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that a resource whose rules are all global reports no supported territories.
+    /// </summary>
+    [TestMethod]
+    public void GetSupportedTerritories_WhenAllRulesGlobal_ShouldReturnEmpty()
+    {
+        const string xml = """
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.discovery-global">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+          <NotableDates>
+            <NotableDate id="n" displayName="N" category="Observance">
+              <Rules><Rule id="x"><Strategy><Fixed month="January" day="1" /></Strategy></Rule></Rules>
+            </NotableDate>
+          </NotableDates>
+        </NotableDateResource>
+        """;
+
+        Assert.AreEqual(0, Build(xml).GetSupportedTerritories().Count);
+    }
+}

--- a/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/WorkingWeekResolutionTests.cs
+++ b/Bodu.Globalization.Calendar2/test/Globalization.Calendar.V2/WorkingWeekResolutionTests.cs
@@ -1,0 +1,124 @@
+// ---------------------------------------------------------------------------------------------------------------
+// <copyright file="WorkingWeekResolutionTests.cs" company="Bodu Pty. Ltd.">
+// Copyright (c) Bodu Pty. Ltd. All rights reserved.
+// </copyright>
+// ---------------------------------------------------------------------------------------------------------------
+
+namespace Bodu.Globalization.Calendar.V2;
+
+/// <summary>
+/// Verifies that a resource's configured working week drives weekend-sensitive resolution: the
+/// <see cref="AdjustmentTrigger.IfWeekend" /> trigger and the working-day search both treat the days outside the
+/// configured working week as the weekend, rather than a hard-coded Saturday and Sunday.
+/// </summary>
+/// <remarks>
+/// The fixture anchors a single holiday on Friday 2 January 2026. Under a Sunday-to-Thursday working week that Friday
+/// is a weekend day; under the default Monday-to-Friday working week it is a working day.
+/// </remarks>
+[TestClass]
+public sealed class WorkingWeekResolutionTests
+{
+    private const string Territory = "ZZ";
+
+    /// <summary>
+    /// Builds a service over a fixture whose single holiday falls on Friday 2 January 2026 and moves to the next
+    /// working day when it falls on a weekend.
+    /// </summary>
+    /// <param name="resolutionPolicyAttributes">Additional attributes to splice onto the <c>ResolutionPolicy</c> element.</param>
+    /// <returns>A service over the constructed resource.</returns>
+    private static INotableDateService Build(string resolutionPolicyAttributes) =>
+        new NotableDateService(NotableDateResourceLoader.Load($$"""
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="test.workingweek">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" {{resolutionPolicyAttributes}} />
+          <AdjustmentPolicies>
+            <AdjustmentPolicy id="weekend-next-working-day" priority="100">
+              <Trigger type="IfWeekend" />
+              <Action type="MoveToNextWorkingDay" maxSearchDays="7" skipWeekends="true" skipNonWorkingDates="true" />
+              <Emission mode="ObservedOnly" reason="Observed next working day" />
+            </AdjustmentPolicy>
+          </AdjustmentPolicies>
+          <NotableDates>
+            <NotableDate id="friday-holiday" displayName="Friday Holiday" category="PublicHoliday" defaultNonWorkingDay="true">
+              <Rules>
+                <Rule id="jan-2"><Applicability><Territory code="ZZ" /></Applicability>
+                  <Strategy><Fixed month="January" day="2" /></Strategy>
+                  <Adjustments><Adjustment policyRef="weekend-next-working-day" /></Adjustments></Rule>
+              </Rules>
+            </NotableDate>
+          </NotableDates>
+        </NotableDateResource>
+        """));
+
+    /// <summary>
+    /// Verifies that under a Sunday-to-Thursday working week a Friday holiday is treated as a weekend occurrence and is
+    /// observed on the following Sunday, skipping the configured Friday and Saturday weekend.
+    /// </summary>
+    [TestMethod]
+    public void IfWeekend_WhenWorkingWeekIsSundayToThursday_ForFridayHoliday_ShouldObserveOnFollowingSunday()
+    {
+        INotableDateService service = Build("workingDays=\"1111100\"");
+
+        Assert.AreEqual(0, service.Resolve(new DateOnly(2026, 1, 2), Territory).Count, "Friday actual suppressed");
+
+        IReadOnlyList<NotableDate> observed = service.Resolve(new DateOnly(2026, 1, 4), Territory);
+        Assert.AreEqual(1, observed.Count);
+        Assert.IsTrue(observed[0].IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 2), observed[0].ActualDate);
+        Assert.AreEqual(new DateOnly(2026, 1, 4), observed[0].Date);
+    }
+
+    /// <summary>
+    /// Verifies that under the default Monday-to-Friday working week a Friday holiday is a working-day occurrence, so
+    /// the weekend trigger does not fire and the holiday is emitted on its actual Friday date.
+    /// </summary>
+    [TestMethod]
+    public void IfWeekend_WhenDefaultWorkingWeek_ForFridayHoliday_ShouldEmitActualDate()
+    {
+        INotableDateService service = Build(string.Empty);
+
+        IReadOnlyList<NotableDate> actual = service.Resolve(new DateOnly(2026, 1, 2), Territory);
+        Assert.AreEqual(1, actual.Count);
+        Assert.IsFalse(actual[0].IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 2), actual[0].Date);
+
+        Assert.AreEqual(0, service.Resolve(new DateOnly(2026, 1, 4), Territory).Count, "no observed occurrence emitted");
+    }
+
+    /// <summary>
+    /// Verifies that the configured weekend leaves the default behavior intact: under the default Monday-to-Friday
+    /// working week the move-to-next-working-day search still skips Saturday and Sunday.
+    /// </summary>
+    [TestMethod]
+    public void MoveToNextWorkingDay_WhenDefaultWorkingWeek_ShouldSkipSaturdayAndSunday()
+    {
+        // The base fixture holiday is on a Friday; under the default working week the weekend trigger never fires, so
+        // build a parallel fixture whose holiday lands on Saturday 3 January 2026 to exercise the working-day search.
+        INotableDateService service = new NotableDateService(NotableDateResourceLoader.Load("""
+        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="test.workingweek.saturday">
+          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+          <AdjustmentPolicies>
+            <AdjustmentPolicy id="weekend-next-working-day" priority="100">
+              <Trigger type="IfWeekend" />
+              <Action type="MoveToNextWorkingDay" maxSearchDays="7" skipWeekends="true" skipNonWorkingDates="true" />
+              <Emission mode="ObservedOnly" reason="Observed next working day" />
+            </AdjustmentPolicy>
+          </AdjustmentPolicies>
+          <NotableDates>
+            <NotableDate id="saturday-holiday" displayName="Saturday Holiday" category="PublicHoliday" defaultNonWorkingDay="true">
+              <Rules>
+                <Rule id="jan-3"><Applicability><Territory code="ZZ" /></Applicability>
+                  <Strategy><Fixed month="January" day="3" /></Strategy>
+                  <Adjustments><Adjustment policyRef="weekend-next-working-day" /></Adjustments></Rule>
+              </Rules>
+            </NotableDate>
+          </NotableDates>
+        </NotableDateResource>
+        """));
+
+        IReadOnlyList<NotableDate> observed = service.Resolve(new DateOnly(2026, 1, 5), Territory);
+        Assert.AreEqual(1, observed.Count);
+        Assert.IsTrue(observed[0].IsObserved);
+        Assert.AreEqual(new DateOnly(2026, 1, 3), observed[0].ActualDate);
+        Assert.AreEqual(new DateOnly(2026, 1, 5), observed[0].Date);
+    }
+}


### PR DESCRIPTION
## Summary

Continues from the merged #402. A second-pass review of the v1 surface against `Bodu.Globalization.Calendar2` surfaced four genuine functional-parity omissions — items the type/method audit had filed under *deliberate omission*. On review they were reclassified as real gaps and are implemented here, each with tests. The net diff is the four gaps plus a documentation reconciliation.

> Note for reviewers: because #402 was squash-merged, the commits tab lists the whole branch history, but the **diff is the focused parity-gap changeset** (19 files) — that is the actual scope of this PR.

## The four gaps

| Gap | Capability | Implementation |
|---|---|---|
| **1 — `everyYears` recurrence** | Periodic rule cadence (e.g. every fourth year) anchored to a base year. | `RuleApplicability` gains `everyYears` / `anchorYear` (XSD + JSON schema + both parsers); the cadence is enforced in `AppliesTo`. |
| **2 — supported-* introspection** | Enumerate the scoped territory and calendar surface of a resource. | `GetSupportedTerritories()` / `GetSupportedCalendars()` re-added to `INotableDateService`, delegated through `ReloadableNotableDateService`. |
| **3 — configurable working week** | Let a non-Western territory define its own weekend. | Resource-level `ResolutionPolicy.WorkingWeek` (`Bodu.Core` `WeekPattern`, default Mon–Fri), authored via a Sunday-first `workingDays` pattern. `IfWeekend` / `IfWeekday` and the working-day search now consult it instead of a hard-coded Saturday/Sunday. |
| **4 — non-working-day triggers** | Trigger on "lands on a non-working day", not just a fixed weekend. | Adds `IfNonWorkingDay` and a symmetric `IfWorkingDay` to `AdjustmentTrigger`. Phase one of resolution now runs in two sub-passes so these triggers evaluate against the complete set of actual non-working dates — a holiday colliding with **another holiday**, not only a weekend, fires `IfNonWorkingDay`. |

Schema changes are additive (one optional `workingDays` attribute/property; two new trigger enum values), so existing resources and the bundled `region-*.xml` data packs remain valid.

## Documentation

`V1-TO-V2-TYPE-METHOD-AUDIT.md` gains a **Second-pass review: rebuttal & reconciliation** section. It documents the second-pass report's two measurement artifacts (it compared against a core-only snapshot, so the `.Plugins` types and `.Data.*` region packs read as "absent"; and it scored reshaped members as FAIL, conflating source-compatibility with functional parity) and records the four genuine omissions, now closed. The affected per-member rows and Section C are flipped from "deliberate omission" to ✅ to keep the document internally consistent.

## Testing

- New: `RecurrenceCadenceTests`, `SupportedDiscoveryTests`, `WorkingWeekResolutionTests`, `NonWorkingDayTriggerTests`.
- The previously-`IfNonWorkingDay` "unknown trigger" negative fixture is repointed to a genuinely unknown token (it is now valid); the trigger round-trip matrix is extended.
- `Bodu.Globalization.Calendar2` regression suite: **1665 passing**. Dependent projects green: Plugins (19), DependencyInjection (5), Data.Americas (25), Data.AsiaPacific (47), Data.Europe (25).

https://claude.ai/code/session_01FsN7CaeR2kG115kiSnxUMg

---
_Generated by [Claude Code](https://claude.ai/code/session_01FsN7CaeR2kG115kiSnxUMg)_