### PR TITLE
calendar v2: notable-date catalogue generator and DocFX pages

### DIFF
--- a/Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1
+++ b/Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1
@@ -1,0 +1,793 @@
+<#
+.SYNOPSIS
+    Generates the v2 notable-date catalogue documentation pages under docs/guides/calendar/catalogue/.
+
+.DESCRIPTION
+    Parses every v2 notable-date XML resource (the common catalogues in Bodu.Globalization.Calendar2 plus the
+    three Calendar2.Data.* region packs and the europe-common hub), resolves the import graph the same way the
+    runtime loader does (NotableDateResourceLoader.ResolveImports / SelectImportedConcepts / ApplyUse), and
+    renders a small set of crisp DocFX markdown pages. The pages catalogue WHAT notable dates exist (by theme
+    and by region) and HOW regions and territories differ — deliberately without restating the calculation
+    recipe logic: dates are summarised with a one-phrase "when" gloss (anchor name + signed offset, or the
+    algorithm key verbatim), never the underlying math.
+
+    The script is run locally; its markdown output is committed as documentation source and built by the
+    existing docfx workflow. It mirrors the tools/Generate-CrcDocs.ps1 pattern.
+
+.PARAMETER CommonResourcesPath
+    Path to the v2 common-catalogue Resources directory.
+
+.PARAMETER AmericasPath
+    Path to the Americas data-pack Resources directory.
+
+.PARAMETER AsiaPacificPath
+    Path to the Asia-Pacific data-pack Resources directory.
+
+.PARAMETER EuropePath
+    Path to the Europe data-pack Resources directory (also hosts europe-common.xml).
+
+.PARAMETER OutputDir
+    Directory the generated catalogue markdown pages are written to.
+
+.PARAMETER TocPath
+    Path to docs/guides/toc.yml; the script surgically inserts/updates the catalogue group under the calendar node.
+
+.PARAMETER XsdPath
+    Path to NotableDates.v2.xsd, used only when -ValidateXsd is supplied.
+
+.PARAMETER ValidateXsd
+    When set, validates every resource against the v2 schema and reports violations (off by default).
+
+.PARAMETER AwarenessSampleCap
+    Maximum number of sample observances listed per awareness catalogue before collapsing to "+N more".
+
+.EXAMPLE
+    pwsh ./Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1
+
+.NOTES
+    Requires PowerShell 7+. Output is UTF-8 (no BOM), LF line endings, matching the committed docs.
+#>
+#Requires -Version 7
+[CmdletBinding()]
+param(
+    [string]$CommonResourcesPath = (Join-Path $PSScriptRoot 'src' 'Globalization.Calendar.V2' 'Resources'),
+    [string]$AmericasPath        = (Join-Path $PSScriptRoot '..' 'Bodu.Globalization.Calendar2.Data.Americas'    'src' 'Resources'),
+    [string]$AsiaPacificPath     = (Join-Path $PSScriptRoot '..' 'Bodu.Globalization.Calendar2.Data.AsiaPacific' 'src' 'Resources'),
+    [string]$EuropePath          = (Join-Path $PSScriptRoot '..' 'Bodu.Globalization.Calendar2.Data.Europe'      'src' 'Resources'),
+    [string]$OutputDir           = (Join-Path $PSScriptRoot '..' 'docs' 'guides' 'calendar' 'catalogue'),
+    [string]$TocPath             = (Join-Path $PSScriptRoot '..' 'docs' 'guides' 'toc.yml'),
+    [string]$XsdPath             = (Join-Path $PSScriptRoot 'src' 'Globalization.Calendar.V2' 'NotableDates.v2.xsd'),
+    [switch]$ValidateXsd,
+    [int]$AwarenessSampleCap = 12
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# ---------------------------------------------------------------------------------------------------------------
+# Static configuration: namespace, theme grouping, bundle order, vocabulary maps.
+# ---------------------------------------------------------------------------------------------------------------
+
+$Ns = 'urn:bodu:globalization:calendar'
+
+# Theme pages: ordered list of { File; Title; Catalogues[] }. Each catalogue is a filename stem.
+$ThemePages = @(
+    @{ File = 'theme-civil-and-christian.md';     Title = 'Civil and Christian catalogues'
+       Catalogues = @('global-core', 'christian-western', 'christian-orthodox', 'default-minimal', 'europe-common') }
+    @{ File = 'theme-religious-non-gregorian.md';  Title = 'Non-Gregorian religious catalogues'
+       Catalogues = @('global-anchors', 'global-islamic', 'global-islamic-umm-al-qura', 'global-jewish', 'global-hindu', 'global-buddhist', 'global-lunar', 'global-persian') }
+    @{ File = 'theme-cultural-and-family.md';      Title = 'Cultural, family, and remembrance catalogues'
+       Catalogues = @('global-cultural', 'global-family', 'global-family-social', 'global-remembrance') }
+    @{ File = 'theme-awareness.md';                Title = 'Awareness and themed observances'
+       Catalogues = @('global-un', 'global-health', 'global-environment', 'global-education', 'global-science', 'global-social', 'global-food', 'global-animals') }
+    @{ File = 'theme-aggregates.md';               Title = 'Aggregate and utility catalogues'
+       Catalogues = @('global-all', 'global-multiday-normalization') }
+)
+# Catalogues rendered in collapsed/sample form (recognition-only awareness noise).
+$AwarenessCatalogues = [System.Collections.Generic.HashSet[string]]::new([string[]]@(
+    'global-un', 'global-health', 'global-environment', 'global-education', 'global-science', 'global-social', 'global-food', 'global-animals'
+), [System.StringComparer]::Ordinal)
+
+# Region bundles: ordered { File; Title; Bundle; PathVar }.
+$RegionPages = @(
+    @{ File = 'region-americas.md';     Title = 'Americas region packs';     Bundle = 'Americas' }
+    @{ File = 'region-asia-pacific.md'; Title = 'Asia-Pacific region packs'; Bundle = 'AsiaPacific' }
+    @{ File = 'region-europe.md';       Title = 'Europe region packs';       Bundle = 'Europe' }
+)
+
+# Category display order / rank for grouping within a region.
+$CategoryOrder = @('PublicHoliday', 'BankHoliday', 'Religious', 'Cultural', 'Observance', 'Remembrance', 'Civic', 'Seasonal', 'School', 'Regional', 'Other', 'None')
+
+$MonthAbbrev = @{
+    'January' = 'Jan'; 'February' = 'Feb'; 'March' = 'Mar'; 'April' = 'Apr'; 'May' = 'May'; 'June' = 'Jun'
+    'July' = 'Jul'; 'August' = 'Aug'; 'September' = 'Sep'; 'October' = 'Oct'; 'November' = 'Nov'; 'December' = 'Dec'
+}
+$MonthNumber = @{
+    'January' = 1; 'February' = 2; 'March' = 3; 'April' = 4; 'May' = 5; 'June' = 6
+    'July' = 7; 'August' = 8; 'September' = 9; 'October' = 10; 'November' = 11; 'December' = 12
+}
+$DayAbbrev = @{ 'Monday' = 'Mon'; 'Tuesday' = 'Tue'; 'Wednesday' = 'Wed'; 'Thursday' = 'Thu'; 'Friday' = 'Fri'; 'Saturday' = 'Sat'; 'Sunday' = 'Sun' }
+$OrdinalAbbrev = @{ 'First' = '1st'; 'Second' = '2nd'; 'Third' = '3rd'; 'Fourth' = '4th'; 'Fifth' = '5th'; 'Last' = 'last' }
+$ProximityWord = @{ 'Before' = 'before'; 'OnOrBefore' = 'on/before'; 'Nearest' = 'nearest'; 'OnOrAfter' = 'on/after'; 'After' = 'after' }
+# Islamic (Hijri / Umm al-Qura) month names for non-Gregorian Fixed glosses.
+$HijriMonths = @{ '1' = 'Muharram'; '2' = 'Safar'; '3' = 'Rabi I'; '4' = 'Rabi II'; '5' = 'Jumada I'; '6' = 'Jumada II'
+    '7' = 'Rajab'; '8' = 'Shaban'; '9' = 'Ramadan'; '10' = 'Shawwal'; '11' = 'Dhu al-Qadah'; '12' = 'Dhu al-Hijja' }
+# Friendly short names for common offset anchors.
+$AnchorShort = @{ 'easter-sunday' = 'Easter'; 'orthodox-easter-sunday' = 'Orthodox Easter'; 'lunar-new-year' = 'Lunar New Year'; 'ramadan' = 'Ramadan' }
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section A — resource index (filename stem -> full path), across all four v2 resource directories.
+# ---------------------------------------------------------------------------------------------------------------
+
+$script:Warnings = [System.Collections.Generic.List[string]]::new()
+function Add-Warn([string]$msg) { [void]$script:Warnings.Add($msg); Write-Warning $msg }
+
+$ResourceDirs = [ordered]@{
+    Common      = $CommonResourcesPath
+    Americas    = $AmericasPath
+    AsiaPacific = $AsiaPacificPath
+    Europe      = $EuropePath
+}
+foreach ($kv in $ResourceDirs.GetEnumerator()) {
+    if (-not (Test-Path -LiteralPath $kv.Value)) {
+        throw "Resource directory '$($kv.Key)' not found at '$($kv.Value)'. Point the script at the v2 (Calendar2) resources."
+    }
+}
+
+# stem -> [pscustomobject]{ Path; Dir; Bundle }
+$script:Index = @{}
+$BundleOfDir = @{ Common = $null; Americas = 'Americas'; AsiaPacific = 'AsiaPacific'; Europe = 'Europe' }
+foreach ($kv in $ResourceDirs.GetEnumerator()) {
+    foreach ($f in (Get-ChildItem -LiteralPath $kv.Value -Filter '*.xml' -File | Sort-Object Name)) {
+        $stem = [System.IO.Path]::GetFileNameWithoutExtension($f.Name)
+        if ($script:Index.ContainsKey($stem)) {
+            throw "Duplicate resource stem '$stem' in '$($f.FullName)' and '$($script:Index[$stem].Path)'."
+        }
+        $script:Index[$stem] = [pscustomobject]@{ Path = $f.FullName; DirKey = $kv.Key; Bundle = $BundleOfDir[$kv.Key] }
+    }
+}
+
+# Region stems = "region-*" packs; everything else is a catalogue/hub.
+$script:RegionStems = @($script:Index.Keys | Where-Object { $_ -like 'region-*' } | Sort-Object)
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section B — memoized parse into a resource model (namespace-aware via XmlNamespaceManager).
+# ---------------------------------------------------------------------------------------------------------------
+
+$script:ResourceCache = @{}
+
+function Get-Resource([string]$stem) {
+    if ($script:ResourceCache.ContainsKey($stem)) { return $script:ResourceCache[$stem] }
+    if (-not $script:Index.ContainsKey($stem)) { throw "Resource '$stem' is not in the index (referenced but not found)." }
+
+    $path = $script:Index[$stem].Path
+    $xml = [xml](Get-Content -LiteralPath $path -Raw)   # throws on malformed XML — the well-formedness gate
+    $nsmgr = [System.Xml.XmlNamespaceManager]::new($xml.NameTable)
+    $nsmgr.AddNamespace('nd', $Ns)
+    $root = $xml.DocumentElement
+
+    $imports = [System.Collections.Generic.List[object]]::new()
+    foreach ($imp in $root.SelectNodes('nd:Imports/nd:Import', $nsmgr)) {
+        $uses = [System.Collections.Generic.List[object]]::new()
+        foreach ($u in $imp.SelectNodes('nd:Use', $nsmgr)) {
+            [void]$uses.Add([pscustomobject]@{
+                Ref        = $u.GetAttribute('notableDateRef')
+                As         = $u.GetAttribute('as')
+                Territory  = $u.GetAttribute('territory')
+                Category   = $u.GetAttribute('category')
+                NonWorking = $u.GetAttribute('nonWorking')
+            })
+        }
+        [void]$imports.Add([pscustomobject]@{ Resource = $imp.GetAttribute('resource'); Uses = $uses.ToArray() })
+    }
+
+    $concepts = [System.Collections.Generic.List[object]]::new()
+    foreach ($nd in $root.SelectNodes('nd:NotableDates/nd:NotableDate', $nsmgr)) {
+        $rules = [System.Collections.Generic.List[object]]::new()
+        foreach ($r in $nd.SelectNodes('nd:Rules/nd:Rule', $nsmgr)) {
+            $app = $r.SelectSingleNode('nd:Applicability', $nsmgr)
+            $territories = @()
+            $calendar = ''; $fromYear = ''; $toYear = ''
+            if ($app) {
+                $calendar = $app.GetAttribute('calendar'); $fromYear = $app.GetAttribute('fromYear'); $toYear = $app.GetAttribute('toYear')
+                $territories = @($app.SelectNodes('nd:Territory', $nsmgr) | ForEach-Object { $_.GetAttribute('code') })
+            }
+            $strat = $r.SelectSingleNode('nd:Strategy', $nsmgr)
+            $kind = ''; $attrs = @{}
+            if ($strat) {
+                $se = @($strat.ChildNodes | Where-Object { $_.NodeType -eq 'Element' }) | Select-Object -First 1
+                if ($se) { $kind = $se.LocalName; foreach ($a in $se.Attributes) { $attrs[$a.Name] = $a.Value } }
+            }
+            [void]$rules.Add([pscustomobject]@{
+                Id = $r.GetAttribute('id'); Category = $r.GetAttribute('category'); NonWorking = $r.GetAttribute('nonWorking')
+                DurationDays = $r.GetAttribute('durationDays'); Calendar = $calendar; FromYear = $fromYear; ToYear = $toYear
+                Territories = $territories; StrategyKind = $kind; StrategyAttrs = $attrs
+            })
+        }
+        [void]$concepts.Add([pscustomobject]@{
+            Id = $nd.GetAttribute('id'); DisplayName = $nd.GetAttribute('displayName'); Category = $nd.GetAttribute('category')
+            DefaultNonWorking = $nd.GetAttribute('defaultNonWorkingDay'); DefaultDuration = $nd.GetAttribute('defaultDurationDays')
+            Rules = $rules.ToArray(); Source = 'inline'
+        })
+    }
+
+    $model = [pscustomobject]@{
+        Stem = $stem; ResourceId = $root.GetAttribute('resourceId'); Bundle = $script:Index[$stem].Bundle
+        Imports = $imports.ToArray(); Concepts = $concepts.ToArray()
+    }
+    $script:ResourceCache[$stem] = $model
+    return $model
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section C — recursive import resolver. Mirrors NotableDateResourceLoader.ResolveImports / SelectImportedConcepts
+# / ApplyUse: recurse into each <Import> (all source concepts when bare, else cherry-pick by ref), apply per-Use
+# overrides, dedup imported first-source-wins, then local-wins merge. Bare (no-Use) resolution is memoized per stem.
+# ---------------------------------------------------------------------------------------------------------------
+
+$script:ResolvedCache = @{}
+
+function Copy-Concept($c, [string]$id, [string]$category, [string]$nonWorking, [string]$territory, [string]$source) {
+    # Produces a fresh concept; rules are cloned only when a territory override is applied (territory replaces, not merges).
+    $rules = $c.Rules
+    if ($territory) {
+        $rules = @($c.Rules | ForEach-Object {
+            [pscustomobject]@{ Id = $_.Id; Category = $_.Category; NonWorking = $_.NonWorking; DurationDays = $_.DurationDays
+                Calendar = $_.Calendar; FromYear = $_.FromYear; ToYear = $_.ToYear; Territories = @($territory)
+                StrategyKind = $_.StrategyKind; StrategyAttrs = $_.StrategyAttrs }
+        })
+    }
+    [pscustomobject]@{
+        Id = $id; DisplayName = $c.DisplayName; Category = $category; DefaultNonWorking = $nonWorking
+        DefaultDuration = $c.DefaultDuration; Rules = $rules; Source = $source
+    }
+}
+
+function Select-Imported($import, $sourceConcepts) {
+    if ($import.Uses.Count -eq 0) {
+        return @($sourceConcepts | ForEach-Object { Copy-Concept $_ $_.Id $_.Category $_.DefaultNonWorking '' $import.Resource })
+    }
+    $out = [System.Collections.Generic.List[object]]::new()
+    foreach ($use in $import.Uses) {
+        $c = $sourceConcepts | Where-Object { $_.Id -eq $use.Ref } | Select-Object -First 1
+        if (-not $c) { Add-Warn "Import '$($import.Resource)' references unknown concept '$($use.Ref)'."; continue }
+        $id = if ($use.As) { $use.As } else { $c.Id }
+        $cat = if ($use.Category) { $use.Category } else { $c.Category }
+        $nw = if ($use.NonWorking) { $use.NonWorking } else { $c.DefaultNonWorking }
+        [void]$out.Add((Copy-Concept $c $id $cat $nw $use.Territory $import.Resource))
+    }
+    return $out.ToArray()
+}
+
+function Resolve-Bare([string]$stem, [System.Collections.Generic.HashSet[string]]$visiting) {
+    if ($script:ResolvedCache.ContainsKey($stem)) { return $script:ResolvedCache[$stem] }
+    if (-not $visiting.Add($stem)) { Add-Warn "Import cycle detected at '$stem'."; return @() }
+
+    $res = Get-Resource $stem
+    $imported = [System.Collections.Generic.List[object]]::new()
+    $importedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($imp in $res.Imports) {
+        $src = Resolve-Bare $imp.Resource $visiting
+        foreach ($c in (Select-Imported $imp $src)) {
+            if ($importedIds.Add($c.Id)) { [void]$imported.Add($c) }
+        }
+    }
+    $localIds = [System.Collections.Generic.HashSet[string]]::new([string[]]@($res.Concepts | ForEach-Object { $_.Id }), [System.StringComparer]::Ordinal)
+    $result = @($imported | Where-Object { -not $localIds.Contains($_.Id) }) + @($res.Concepts)
+    [void]$visiting.Remove($stem)
+    $script:ResolvedCache[$stem] = $result
+    return $result
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section "when"-gloss + territory-scope summary helpers (no recipe math).
+# ---------------------------------------------------------------------------------------------------------------
+
+function Get-WhenGloss($rule) {
+    $a = $rule.StrategyAttrs
+    switch ($rule.StrategyKind) {
+        'Fixed' {
+            $m = [string]$a['month']; $d = [string]$a['day']
+            if ($rule.Calendar -and $rule.Calendar -ne 'Gregorian') {
+                $mn = if (($rule.Calendar -in 'Hijri', 'UmmAlQura') -and $HijriMonths.ContainsKey($m)) { $HijriMonths[$m] } else { "month $m" }
+                return "$d $mn ($($rule.Calendar))"
+            }
+            $ma = if ($MonthAbbrev.ContainsKey($m)) { $MonthAbbrev[$m] } else { $m }
+            return "Fixed $d $ma"
+        }
+        'OffsetFromRule' {
+            $anchor = [string]$a['notableDateRef']
+            $short = if ($AnchorShort.ContainsKey($anchor)) { $AnchorShort[$anchor] } else { $anchor }
+            $off = [int]([string]$a['offsetDays'])
+            $sign = if ($off -ge 0) { "+$off" } else { "$off" }
+            return "$short $sign"
+        }
+        'DayOfWeekInMonth' {
+            $ord = $OrdinalAbbrev[[string]$a['weekOrdinal']]; $dw = $DayAbbrev[[string]$a['dayOfWeek']]; $mo = $MonthAbbrev[[string]$a['month']]
+            return "$ord $dw $mo"
+        }
+        'WeekdayNearDate' {
+            $dw = $DayAbbrev[[string]$a['dayOfWeek']]; $dir = $ProximityWord[[string]$a['direction']]
+            $mo = $MonthAbbrev[[string]$a['month']]; $d = [string]$a['day']
+            return "$dw $dir $d $mo"
+        }
+        'RelativeWeekdayInMonth' {
+            $ord = $OrdinalAbbrev[[string]$a['weekOrdinal']]; $dw = $DayAbbrev[[string]$a['dayOfWeek']]; $mo = $MonthAbbrev[[string]$a['month']]
+            return "$ord $dw $mo (relative)"
+        }
+        'Algorithm' { return "Algorithm: $([string]$a['key'])" }
+        default { return '—' }
+    }
+}
+
+function Get-SortKey($concept) {
+    # Representative rule = national-ish (no territory) first, else first rule.
+    $rule = ($concept.Rules | Where-Object { $_.Territories.Count -eq 0 } | Select-Object -First 1)
+    if (-not $rule) { $rule = $concept.Rules | Select-Object -First 1 }
+    if (-not $rule) { return @{ M = 13; D = 32; Rule = $null } }
+    $m = 13; $d = 32
+    if ($rule.StrategyKind -eq 'Fixed' -and (-not $rule.Calendar -or $rule.Calendar -eq 'Gregorian')) {
+        $mn = [string]$rule.StrategyAttrs['month']
+        if ($MonthNumber.ContainsKey($mn)) { $m = $MonthNumber[$mn] }
+        $d = [int]([string]$rule.StrategyAttrs['day'])
+    }
+    elseif ($rule.StrategyKind -in 'DayOfWeekInMonth', 'WeekdayNearDate', 'RelativeWeekdayInMonth') {
+        $mn = [string]$rule.StrategyAttrs['month']
+        if ($MonthNumber.ContainsKey($mn)) { $m = $MonthNumber[$mn]; $d = 15 }
+    }
+    return @{ M = $m; D = $d; Rule = $rule }
+}
+
+function Get-TerritoryScope($concept, [string]$country) {
+    $subs = [System.Collections.Generic.List[string]]::new()
+    $hasNational = $false
+    foreach ($r in $concept.Rules) {
+        if ($r.Territories.Count -eq 0) { $hasNational = $true; continue }
+        foreach ($t in $r.Territories) {
+            if ($t -eq $country) { $hasNational = $true }
+            elseif ($t -like "$country-*") { [void]$subs.Add($t.Substring($country.Length + 1)) }
+            else { [void]$subs.Add($t) }   # foreign/other code (rare)
+        }
+    }
+    $subList = ($subs | Select-Object -Unique) -join ', '
+    if ($hasNational -and $subList) { return "National + $subList" }
+    if ($subList) { return $subList }
+    return 'National'
+}
+
+function Get-IsNonWorking($concept) {
+    # Effective non-working: any rule's nonWorking override, else the concept default. "true"/"false" strings.
+    foreach ($r in $concept.Rules) { if ($r.NonWorking) { if ($r.NonWorking -eq 'true') { return $true } } }
+    return ($concept.DefaultNonWorking -eq 'true')
+}
+
+function Get-Calendar($concept) {
+    foreach ($r in $concept.Rules) { if ($r.Calendar -and $r.Calendar -ne 'Gregorian') { return $r.Calendar } }
+    return 'Gregorian'
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section D — per-region effective concept model (region inline + imported-with-overrides, local wins).
+# ---------------------------------------------------------------------------------------------------------------
+
+function Build-RegionModel([string]$regionStem) {
+    $res = Get-Resource $regionStem
+    $country = ($regionStem -replace '^region-', '').ToUpperInvariant()
+    $imported = [System.Collections.Generic.List[object]]::new()
+    $importedIds = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($imp in $res.Imports) {
+        $src = Resolve-Bare $imp.Resource ([System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal))
+        foreach ($c in (Select-Imported $imp $src)) {
+            if ($importedIds.Add($c.Id)) { [void]$imported.Add($c) }
+        }
+    }
+    $localIds = [System.Collections.Generic.HashSet[string]]::new([string[]]@($res.Concepts | ForEach-Object { $_.Id }), [System.StringComparer]::Ordinal)
+    $all = @($imported | Where-Object { -not $localIds.Contains($_.Id) }) + @($res.Concepts)
+
+    # Subdivisions present anywhere in the file (for the call-out).
+    $subs = [System.Collections.Generic.SortedSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($c in $all) { foreach ($r in $c.Rules) { foreach ($t in $r.Territories) { if ($t -like "$country-*") { [void]$subs.Add($t) } } } }
+
+    [pscustomobject]@{ Country = $country; Stem = $regionStem; ResourceId = $res.ResourceId; Subdivisions = @($subs); Concepts = $all }
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section G — rendering helpers.
+# ---------------------------------------------------------------------------------------------------------------
+
+$RegeneratedUtc = (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ')
+
+function Esc([string]$s) { if ($null -eq $s) { return '' } return ($s -replace '\|', '\|') }
+function YesNo([bool]$b) { if ($b) { 'Yes' } else { '—' } }
+function Format-Anchor([string]$heading) {
+    # markdig heading-slug: lower, spaces->-, drop non-alnum/-.
+    $s = $heading.ToLowerInvariant() -replace "[^a-z0-9 \-]", '' -replace '\s+', '-'
+    return ($s -replace '-+', '-').Trim('-')
+}
+
+function New-Header([string]$title) {
+    $l = [System.Collections.Generic.List[string]]::new()
+    [void]$l.Add('---'); [void]$l.Add("title: $title"); [void]$l.Add('---'); [void]$l.Add('')
+    return , $l   # unary comma prevents PowerShell from unrolling the List to an array
+}
+function New-Footer {
+    $l = [System.Collections.Generic.List[string]]::new()
+    [void]$l.Add('---'); [void]$l.Add('')
+    [void]$l.Add('*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. ' +
+        "Regenerated (UTC): $RegeneratedUtc.* " +
+        'For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), ' +
+        '[Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); ' +
+        'for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.')
+    [void]$l.Add('')
+    return , $l
+}
+
+# Render one catalogue's concept table (theme pages). Returns lines. $observedBy = list of region links.
+function Render-CatalogueSection([string]$stem, [string]$themeFile) {
+    $l = [System.Collections.Generic.List[string]]::new()
+    $res = Get-Resource $stem
+    [void]$l.Add("## $stem")
+    [void]$l.Add('')
+
+    if ($stem -eq 'global-all') {
+        [void]$l.Add("Aggregate catalogue (`$($res.ResourceId)`): imports every other catalogue with no cherry-picks, so each contributes its full concept set. Identifiers shared across sources are de-duplicated first-source-wins. Intended for consumers that want every shared observance at once; territory packs cherry-pick instead.")
+        [void]$l.Add('')
+        [void]$l.Add('| Imports catalogue |')
+        [void]$l.Add('|---|')
+        foreach ($imp in $res.Imports) { [void]$l.Add("| ``$($imp.Resource)`` |") }
+        [void]$l.Add('')
+        return $l
+    }
+    if ($stem -eq 'europe-common') {
+        [void]$l.Add("Pan-European hub (`$($res.ResourceId)`): re-exports the common civil, Christian, family, and cultural concepts from the catalogues below, and defines the two Catholic feasts the catalogues do not carry. The 28 European region packs import their shared observances from here.")
+        [void]$l.Add('')
+        $reexp = @($res.Imports | ForEach-Object { $_.Resource } | Select-Object -Unique | ForEach-Object { '`' + $_ + '`' })
+        $reexpList = $reexp -join ', '
+        [void]$l.Add("Re-exports from: $reexpList.")
+        [void]$l.Add('')
+        [void]$l.Add('Defines inline:')
+        [void]$l.Add('')
+        [void]$l.Add('| Concept | Category | When |')
+        [void]$l.Add('|---|---|---|')
+        foreach ($c in $res.Concepts) {
+            $sk = Get-SortKey $c
+            $when = if ($sk.Rule) { Get-WhenGloss $sk.Rule } else { '—' }
+            [void]$l.Add("| $(Esc $c.DisplayName) | $($c.Category) | $when |")
+        }
+        [void]$l.Add('')
+        return $l
+    }
+
+    $concepts = @($res.Concepts)
+    $anyNonGreg = @($concepts | Where-Object { (Get-Calendar $_) -ne 'Gregorian' }).Count -gt 0
+
+    if ($AwarenessCatalogues.Contains($stem)) {
+        $sorted = @($concepts | Sort-Object @{ E = { (Get-SortKey $_).M } }, @{ E = { (Get-SortKey $_).D } }, DisplayName)
+        $sample = @($sorted | Select-Object -First $AwarenessSampleCap)
+        [void]$l.Add("$($concepts.Count) recognition-only observance(s). Sample (see ``${stem}.xml`` for the full list):")
+        [void]$l.Add('')
+        [void]$l.Add('| Observance | When |')
+        [void]$l.Add('|---|---|')
+        foreach ($c in $sample) {
+            $sk = Get-SortKey $c; $when = if ($sk.Rule) { Get-WhenGloss $sk.Rule } else { '—' }
+            [void]$l.Add("| $(Esc $c.DisplayName) | $when |")
+        }
+        if ($concepts.Count -gt $sample.Count) { [void]$l.Add("| _+ $($concepts.Count - $sample.Count) more_ | |") }
+        [void]$l.Add('')
+        return $l
+    }
+
+    $sorted = @($concepts | Sort-Object @{ E = { (Get-SortKey $_).M } }, @{ E = { (Get-SortKey $_).D } }, DisplayName)
+    if ($anyNonGreg) {
+        [void]$l.Add('| Concept | Category | Non-working | Calendar | When |')
+        [void]$l.Add('|---|---|---|---|---|')
+    } else {
+        [void]$l.Add('| Concept | Category | Non-working | When |')
+        [void]$l.Add('|---|---|---|---|')
+    }
+    foreach ($c in $sorted) {
+        $sk = Get-SortKey $c; $when = if ($sk.Rule) { Get-WhenGloss $sk.Rule } else { '—' }
+        $nw = YesNo (Get-IsNonWorking $c)
+        if ($anyNonGreg) { [void]$l.Add("| $(Esc $c.DisplayName) | $($c.Category) | $nw | $(Get-Calendar $c) | $when |") }
+        else { [void]$l.Add("| $(Esc $c.DisplayName) | $($c.Category) | $nw | $when |") }
+    }
+    [void]$l.Add('')
+    return $l
+}
+
+function Render-ThemePage($page, $observedByMap) {
+    $l = New-Header $page.Title
+    [void]$l.Add("# $($page.Title)")
+    [void]$l.Add('')
+    [void]$l.Add('Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.')
+    [void]$l.Add('')
+    foreach ($stem in $page.Catalogues) {
+        if (-not $script:Index.ContainsKey($stem)) { Add-Warn "Theme '$($page.Title)' lists missing catalogue '$stem'."; continue }
+        $l.AddRange([System.Collections.Generic.List[string]](Render-CatalogueSection $stem $page.File))
+        if ($observedByMap.ContainsKey($stem) -and $observedByMap[$stem].Count -gt 0) {
+            $links = @($observedByMap[$stem] | Sort-Object | ForEach-Object { "[$_]($($RegionFileOf[$_]))" }) -join ', '
+            [void]$l.Add("_Observed by:_ $links")
+            [void]$l.Add('')
+        }
+    }
+    $l.AddRange((New-Footer))
+    return $l
+}
+
+function Render-RegionPage($page, $models) {
+    $l = New-Header $page.Title
+    [void]$l.Add("# $($page.Title)")
+    [void]$l.Add('')
+    [void]$l.Add("Notable dates observed by each country in the **$($page.Bundle)** v2 data pack, grouped by category. **Territory scope** shows national vs subdivision scoping; **Source** is the direct origin (``inline`` or the imported catalogue/hub). See the [comparison matrix](comparison-matrix.md) for a cross-region overview.")
+    [void]$l.Add('')
+    foreach ($m in $models) {
+        [void]$l.Add("## $($m.Country)")
+        [void]$l.Add('')
+        if ($m.Subdivisions.Count -gt 0) {
+            [void]$l.Add("**Subdivisions:** $($m.Subdivisions -join ', '). A national ``$($m.Country)`` query does not return subdivision-only rules.")
+            [void]$l.Add('')
+        }
+        $anyNonGreg = @($m.Concepts | Where-Object { (Get-Calendar $_) -ne 'Gregorian' }).Count -gt 0
+        $byCat = $m.Concepts | Group-Object { if ($_.Category) { $_.Category } else { 'Other' } } | Sort-Object @{ E = { $i = $CategoryOrder.IndexOf($_.Name); if ($i -lt 0) { 99 } else { $i } } }
+        foreach ($g in $byCat) {
+            [void]$l.Add("### $($g.Name)")
+            [void]$l.Add('')
+            if ($anyNonGreg) {
+                [void]$l.Add('| Concept | Non-working | Territory scope | Calendar | Source | When |')
+                [void]$l.Add('|---|---|---|---|---|---|')
+            } else {
+                [void]$l.Add('| Concept | Non-working | Territory scope | Source | When |')
+                [void]$l.Add('|---|---|---|---|---|')
+            }
+            $rows = @($g.Group | Sort-Object @{ E = { (Get-SortKey $_).M } }, @{ E = { (Get-SortKey $_).D } }, DisplayName)
+            foreach ($c in $rows) {
+                $sk = Get-SortKey $c; $when = if ($sk.Rule) { Get-WhenGloss $sk.Rule } else { '—' }
+                $nw = YesNo (Get-IsNonWorking $c)
+                $scope = Get-TerritoryScope $c $m.Country
+                $src = if ($c.Source -eq 'inline') { 'inline' } else { "[← $($c.Source)]($(Get-SourceLink $c.Source))" }
+                if ($anyNonGreg) { [void]$l.Add("| $(Esc $c.DisplayName) | $nw | $scope | $(Get-Calendar $c) | $src | $when |") }
+                else { [void]$l.Add("| $(Esc $c.DisplayName) | $nw | $scope | $src | $when |") }
+            }
+            [void]$l.Add('')
+        }
+    }
+    $l.AddRange((New-Footer))
+    return $l
+}
+
+# Map a source catalogue stem to a "themeFile#anchor" link (for region Source column).
+$script:ThemeOfCatalogue = @{}
+foreach ($tp in $ThemePages) { foreach ($cat in $tp.Catalogues) { $script:ThemeOfCatalogue[$cat] = $tp.File } }
+function Get-SourceLink([string]$stem) {
+    if ($script:ThemeOfCatalogue.ContainsKey($stem)) { return "$($script:ThemeOfCatalogue[$stem])#$(Format-Anchor $stem)" }
+    return "index.md"
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Build region models, then the observed-by map and matrix.
+# ---------------------------------------------------------------------------------------------------------------
+
+$RegionFileOf = @{}   # country code -> region page file
+foreach ($rp in $RegionPages) {
+    foreach ($stem in ($script:RegionStems | Where-Object { $script:Index[$_].Bundle -eq $rp.Bundle })) {
+        $RegionFileOf[($stem -replace '^region-', '').ToUpperInvariant()] = $rp.File
+    }
+}
+
+$AllModels = @{}
+foreach ($stem in $script:RegionStems) { $AllModels[$stem] = Build-RegionModel $stem }
+
+# Observed-by: catalogue stem -> set of country codes whose region imports a concept from it (direct hop).
+$ObservedBy = @{}
+foreach ($stem in $script:RegionStems) {
+    $m = $AllModels[$stem]
+    $srcset = [System.Collections.Generic.HashSet[string]]::new([System.StringComparer]::Ordinal)
+    foreach ($c in $m.Concepts) { if ($c.Source -ne 'inline') { [void]$srcset.Add($c.Source) } }
+    foreach ($s in $srcset) {
+        if (-not $ObservedBy.ContainsKey($s)) { $ObservedBy[$s] = [System.Collections.Generic.List[string]]::new() }
+        [void]$ObservedBy[$s].Add($m.Country)
+    }
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section F — comparison matrix (selective: top-N most-observed concepts, three per-bundle tables).
+# ---------------------------------------------------------------------------------------------------------------
+
+function Get-CellState($concept, [string]$country) {
+    if (Get-IsNonWorking $concept) { return 'N' }
+    $scope = Get-TerritoryScope $concept $country
+    if ($scope -ne 'National' -and $scope -notlike 'National*') { return 'S' }
+    return 'O'
+}
+
+function Build-Matrix {
+    # concept id -> @{ Display; Countries = @{ CC = state }; Count }
+    $tally = @{}
+    foreach ($stem in $script:RegionStems) {
+        $m = $AllModels[$stem]
+        foreach ($c in $m.Concepts) {
+            # pscustomobject (not hashtable) so the 'Count' note-property is not shadowed by Hashtable.Count.
+            if (-not $tally.ContainsKey($c.Id)) { $tally[$c.Id] = [pscustomobject]@{ Display = $c.DisplayName; Countries = @{}; Count = 0 } }
+            $tally[$c.Id].Countries[$m.Country] = (Get-CellState $c $m.Country)
+        }
+    }
+    foreach ($k in @($tally.Keys)) { $tally[$k].Count = $tally[$k].Countries.Count }
+    return $tally
+}
+
+function Render-MatrixPage($tally, [int]$topN) {
+    $l = New-Header 'Cross-region comparison matrix'
+    [void]$l.Add('# Cross-region comparison matrix')
+    [void]$l.Add('')
+    [void]$l.Add("The most widely-shared notable dates across the v2 region packs, by bundle. Cells: **N** non-working public holiday · **O** observed (working) · **S** subdivision-only · **—** not in the pack. The top $topN concepts by country count are shown; per-country detail is on the [region pages](index.md#by-region), concept definitions on the [theme pages](index.md#by-theme).")
+    [void]$l.Add('')
+    $top = @($tally.GetEnumerator() | Sort-Object @{ E = { -$_.Value.Count } }, @{ E = { $_.Value.Display } } | Select-Object -First $topN)
+    foreach ($rp in $RegionPages) {
+        $countries = @($script:RegionStems | Where-Object { $script:Index[$_].Bundle -eq $rp.Bundle } | ForEach-Object { ($_ -replace '^region-', '').ToUpperInvariant() } | Sort-Object)
+        [void]$l.Add("## $($rp.Bundle)")
+        [void]$l.Add('')
+        [void]$l.Add("| Concept | $($countries -join ' | ') |")
+        [void]$l.Add("|---|$(($countries | ForEach-Object { ':--:' }) -join '|')|")
+        foreach ($e in $top) {
+            $cells = @($countries | ForEach-Object { $cc = $_; if ($e.Value.Countries.ContainsKey($cc)) { $e.Value.Countries[$cc] } else { '—' } })
+            [void]$l.Add("| $(Esc $e.Value.Display) | $($cells -join ' | ') |")
+        }
+        [void]$l.Add('')
+    }
+    $l.AddRange((New-Footer))
+    return $l
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Render the overview index page.
+# ---------------------------------------------------------------------------------------------------------------
+
+function Render-IndexPage([int]$catCount, [int]$regionCount, [int]$conceptCount, [int]$matrixRows) {
+    $l = New-Header 'Notable-date catalogue'
+    [void]$l.Add('# Notable-date catalogue')
+    [void]$l.Add('')
+    [void]$l.Add('What notable dates the **v2** calendar data ships, and how regions and territories differ. This catalogue is generated from the `Bodu.Globalization.Calendar2` XML resources; it lists the dates and their scope, not the calculation recipes (for those, see the linked guides).')
+    [void]$l.Add('')
+    [void]$l.Add('Concepts are authored once in a **shared catalogue** and a **region pack** imports the ones it observes, supplying its own territory scope and non-working status. European packs import through the `europe-common` hub, which itself re-exports from the catalogues. The pages below present the same data along two axes.')
+    [void]$l.Add('')
+    [void]$l.Add('## How to read these pages')
+    [void]$l.Add('')
+    [void]$l.Add('| Column | Meaning |')
+    [void]$l.Add('|---|---|')
+    [void]$l.Add('| Category | `PublicHoliday`, `Religious`, `Cultural`, `Observance`, `Remembrance`, … |')
+    [void]$l.Add('| Non-working | `Yes` = a non-working public holiday for the scope shown; `—` = a working observance |')
+    [void]$l.Add('| Territory scope | `National`, a subdivision list (e.g. `ENG, WLS, NIR`), or `National + …` |')
+    [void]$l.Add('| Calendar | shown only when non-Gregorian (`Hijri`, `Hebrew`, `Persian`, `ChineseLunisolar`, …) |')
+    [void]$l.Add('| Source | `inline` (defined in the region pack) or `← catalogue` (the direct import) |')
+    [void]$l.Add('| When | a one-phrase gloss: `Fixed 25 Dec`, `Easter +1`, `1st Mon May`, `Algorithm: western-easter` — never the recipe |')
+    [void]$l.Add('')
+    [void]$l.Add('## By theme')
+    [void]$l.Add('')
+    [void]$l.Add('| Page | Catalogues |')
+    [void]$l.Add('|---|---|')
+    foreach ($tp in $ThemePages) {
+        $cats = @($tp.Catalogues | ForEach-Object { "``$_``" }) -join ', '
+        [void]$l.Add("| [$($tp.Title)]($($tp.File)) | $cats |")
+    }
+    [void]$l.Add('')
+    [void]$l.Add('## By region')
+    [void]$l.Add('')
+    [void]$l.Add('| Page | Countries |')
+    [void]$l.Add('|---|---|')
+    foreach ($rp in $RegionPages) {
+        $ccs = @($script:RegionStems | Where-Object { $script:Index[$_].Bundle -eq $rp.Bundle } | ForEach-Object { ($_ -replace '^region-', '').ToUpperInvariant() } | Sort-Object) -join ', '
+        [void]$l.Add("| [$($rp.Title)]($($rp.File)) | $ccs |")
+    }
+    [void]$l.Add('')
+    [void]$l.Add("See also the [cross-region comparison matrix](comparison-matrix.md).")
+    [void]$l.Add('')
+    [void]$l.Add('## Coverage')
+    [void]$l.Add('')
+    [void]$l.Add("- **Catalogues:** $catCount")
+    [void]$l.Add("- **Region packs:** $regionCount")
+    [void]$l.Add("- **Distinct concepts (catalogues):** $conceptCount")
+    [void]$l.Add("- **Comparison-matrix rows:** $matrixRows")
+    [void]$l.Add("- **This page regenerated (UTC):** $RegeneratedUtc")
+    [void]$l.Add('')
+    $l.AddRange((New-Footer))
+    return $l
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section I — optional XSD validation.
+# ---------------------------------------------------------------------------------------------------------------
+
+if ($ValidateXsd) {
+    if (-not (Test-Path -LiteralPath $XsdPath)) { throw "XSD not found at '$XsdPath'." }
+    $schemas = [System.Xml.Schema.XmlSchemaSet]::new()
+    [void]$schemas.Add($Ns, $XsdPath)
+    foreach ($stem in ($script:Index.Keys | Sort-Object)) {
+        $doc = [xml](Get-Content -LiteralPath $script:Index[$stem].Path -Raw)
+        $doc.Schemas = $schemas
+        try { $doc.Validate({ param($s, $e) Add-Warn "XSD ($stem): $($e.Message)" }) }
+        catch { Add-Warn "XSD ($stem): $($_.Exception.Message)" }
+    }
+}
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section J — write pages.
+# ---------------------------------------------------------------------------------------------------------------
+
+if (-not (Test-Path -LiteralPath $OutputDir)) { New-Item -ItemType Directory -Path $OutputDir -Force | Out-Null }
+
+function Write-Page([string]$file, $lines) {
+    $path = Join-Path $OutputDir $file
+    Set-Content -LiteralPath $path -Value (($lines -join "`n") + "`n") -Encoding utf8 -NoNewline
+    Write-Host "  wrote $file"
+}
+
+$catCount = @($script:Index.Keys | Where-Object { $_ -notlike 'region-*' }).Count
+$conceptCount = (@($script:Index.Keys | Where-Object { $_ -notlike 'region-*' } | ForEach-Object { (Get-Resource $_).Concepts.Count }) | Measure-Object -Sum).Sum
+$matrix = Build-Matrix
+$matrixRows = [Math]::Min(18, $matrix.Count)
+
+Write-Host "Generating notable-date catalogue ($($script:RegionStems.Count) regions, $catCount catalogues):"
+Write-Page 'index.md' (Render-IndexPage $catCount $script:RegionStems.Count $conceptCount $matrixRows)
+foreach ($tp in $ThemePages) { Write-Page $tp.File (Render-ThemePage $tp $ObservedBy) }
+foreach ($rp in $RegionPages) {
+    $models = @($script:RegionStems | Where-Object { $script:Index[$_].Bundle -eq $rp.Bundle } | Sort-Object | ForEach-Object { $AllModels[$_] })
+    Write-Page $rp.File (Render-RegionPage $rp $models)
+}
+Write-Page 'comparison-matrix.md' (Render-MatrixPage $matrix $matrixRows)
+
+# ---------------------------------------------------------------------------------------------------------------
+# Section H — surgical, idempotent TOC update. Insert/replace the catalogue group under the calendar node.
+# ---------------------------------------------------------------------------------------------------------------
+
+$tocEntries = @(
+    [pscustomobject]@{ Name = 'Catalogue overview'; Href = 'index.md' }
+    [pscustomobject]@{ Name = 'Civil and Christian catalogues'; Href = 'theme-civil-and-christian.md' }
+    [pscustomobject]@{ Name = 'Non-Gregorian religious catalogues'; Href = 'theme-religious-non-gregorian.md' }
+    [pscustomobject]@{ Name = 'Cultural, family, and remembrance catalogues'; Href = 'theme-cultural-and-family.md' }
+    [pscustomobject]@{ Name = 'Awareness and themed observances'; Href = 'theme-awareness.md' }
+    [pscustomobject]@{ Name = 'Aggregate and utility catalogues'; Href = 'theme-aggregates.md' }
+    [pscustomobject]@{ Name = 'Americas region packs'; Href = 'region-americas.md' }
+    [pscustomobject]@{ Name = 'Asia-Pacific region packs'; Href = 'region-asia-pacific.md' }
+    [pscustomobject]@{ Name = 'Europe region packs'; Href = 'region-europe.md' }
+    [pscustomobject]@{ Name = 'Cross-region comparison matrix'; Href = 'comparison-matrix.md' }
+)
+$groupName = 'Bodu.Globalization.Calendar.V2 — Notable-date catalogue'
+$grp = [System.Collections.Generic.List[string]]::new()
+[void]$grp.Add("    - name: $groupName")
+[void]$grp.Add('      items:')
+foreach ($e in $tocEntries) {
+    [void]$grp.Add("        - name: $($e.Name)")
+    [void]$grp.Add("          href: calendar/catalogue/$($e.Href)")
+}
+
+$tocLines = [System.Collections.Generic.List[string]](Get-Content -LiteralPath $TocPath)
+# Remove any prior generated group (sentinel = the group name line through to the next line at <=4-space indent).
+$startIdx = -1
+for ($i = 0; $i -lt $tocLines.Count; $i++) { if ($tocLines[$i].TrimEnd() -eq "    - name: $groupName") { $startIdx = $i; break } }
+if ($startIdx -ge 0) {
+    $endIdx = $tocLines.Count
+    for ($i = $startIdx + 1; $i -lt $tocLines.Count; $i++) {
+        $line = $tocLines[$i]
+        if ($line -match '^\S' -or $line -match '^    - name: ' -or $line -match '^- name: ') { $endIdx = $i; break }
+    }
+    $tocLines.RemoveRange($startIdx, $endIdx - $startIdx)
+} else { $startIdx = -1 }
+
+# Insert after the calendar Data.* node: find "- name: Bodu.Globalization.Calendar" top-level node, then the next
+# top-level "- name:" sibling, and insert just before it (end of the calendar node's children).
+$calNode = -1
+for ($i = 0; $i -lt $tocLines.Count; $i++) { if ($tocLines[$i] -eq '- name: Bodu.Globalization.Calendar') { $calNode = $i; break } }
+if ($calNode -lt 0) { throw "Could not find the 'Bodu.Globalization.Calendar' node in $TocPath." }
+$insertAt = $tocLines.Count
+for ($i = $calNode + 1; $i -lt $tocLines.Count; $i++) { if ($tocLines[$i] -match '^- name: ') { $insertAt = $i; break } }
+$tocLines.InsertRange($insertAt, $grp)
+Set-Content -LiteralPath $TocPath -Value (($tocLines -join "`n") + "`n") -Encoding utf8 -NoNewline
+Write-Host "  updated $TocPath"
+
+# ---------------------------------------------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------------------------------------------
+
+Write-Host ''
+Write-Host "Done. Pages: $($ThemePages.Count + $RegionPages.Count + 2). Catalogues: $catCount. Regions: $($script:RegionStems.Count). Catalogue concepts: $conceptCount. Matrix rows: $matrixRows."
+if ($script:Warnings.Count -gt 0) { Write-Host "Warnings: $($script:Warnings.Count) (see above)." } else { Write-Host 'Warnings: 0.' }

--- a/docs/guides/calendar/catalogue/comparison-matrix.md
+++ b/docs/guides/calendar/catalogue/comparison-matrix.md
@@ -1,0 +1,81 @@
+---
+title: Cross-region comparison matrix
+---
+
+# Cross-region comparison matrix
+
+The most widely-shared notable dates across the v2 region packs, by bundle. Cells: **N** non-working public holiday · **O** observed (working) · **S** subdivision-only · **—** not in the pack. The top 18 concepts by country count are shown; per-country detail is on the [region pages](index.md#by-region), concept definitions on the [theme pages](index.md#by-theme).
+
+## Americas
+
+| Concept | CA | US |
+|---|:--:|:--:|
+| Christmas Day | N | N |
+| New Year's Day | N | N |
+| Easter Sunday | O | O |
+| Easter Monday | N | — |
+| Good Friday | N | O |
+| Labour Day | N | — |
+| All Saints' Day | — | — |
+| Christmas Eve | O | O |
+| Second Day of Christmas | — | — |
+| Assumption of Mary | — | — |
+| Epiphany | — | — |
+| Ascension Day | — | — |
+| Saint Stephen's Day | — | — |
+| Whit Sunday | — | — |
+| Independence Day | — | N |
+| Whit Monday | — | — |
+| Father's Day | O | O |
+| Valentine's Day | O | O |
+
+## AsiaPacific
+
+| Concept | AU | CN | IN | JP | KR | MY | NZ | SG |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Christmas Day | N | — | O | — | N | — | N | N |
+| New Year's Day | N | N | — | N | N | — | N | N |
+| Easter Sunday | O | — | O | — | — | — | O | O |
+| Easter Monday | N | — | — | — | — | — | N | — |
+| Good Friday | N | — | O | — | — | — | N | N |
+| Labour Day | N | N | — | — | — | — | N | N |
+| All Saints' Day | — | — | — | — | — | — | — | — |
+| Christmas Eve | O | — | — | — | — | — | — | — |
+| Second Day of Christmas | — | — | — | — | — | — | — | — |
+| Assumption of Mary | — | — | — | — | — | — | — | — |
+| Epiphany | — | — | — | — | — | — | — | — |
+| Ascension Day | — | — | — | — | — | — | — | — |
+| Saint Stephen's Day | — | — | — | — | — | — | — | — |
+| Whit Sunday | — | — | — | — | — | — | — | — |
+| Independence Day | — | — | N | — | — | — | — | — |
+| Whit Monday | — | — | — | — | — | — | — | — |
+| Father's Day | O | — | — | — | — | — | O | — |
+| Valentine's Day | O | — | — | — | — | — | O | — |
+
+## Europe
+
+| Concept | AT | BE | BG | CY | CZ | DE | DK | EE | ES | FI | FR | GB | GR | HR | HU | IE | IT | LT | LU | LV | MT | NL | PL | PT | RO | SE | SI | SK |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Christmas Day | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N |
+| New Year's Day | N | N | N | N | — | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | N | — |
+| Easter Sunday | O | O | — | — | O | O | O | O | O | O | O | O | — | O | O | O | O | O | O | O | O | O | O | O | — | O | O | O |
+| Easter Monday | N | N | — | — | N | N | N | — | — | N | N | N | — | N | N | N | N | N | N | N | — | N | N | — | — | N | N | N |
+| Good Friday | — | — | N | — | N | N | N | N | N | N | N | N | — | — | N | — | — | — | — | N | N | O | — | N | N | N | — | N |
+| Labour Day | — | N | N | N | N | — | — | — | N | — | N | — | N | N | N | — | N | N | N | N | — | — | N | N | N | — | N | N |
+| All Saints' Day | N | N | — | — | — | N | — | — | N | N | N | — | — | N | N | — | N | N | N | — | — | — | N | N | — | N | — | N |
+| Christmas Eve | — | — | N | — | N | O | — | N | — | N | O | O | — | — | — | — | — | N | — | N | — | — | — | — | — | N | — | N |
+| Second Day of Christmas | — | — | N | N | — | N | N | N | — | — | — | — | — | — | N | — | — | N | — | N | — | N | N | — | N | N | — | — |
+| Assumption of Mary | N | N | — | — | — | N | — | — | N | — | N | — | — | N | — | — | — | N | N | — | — | — | N | N | — | — | N | — |
+| Epiphany | N | — | — | N | — | N | — | — | N | N | — | — | N | N | — | — | N | — | — | — | — | — | N | — | — | N | — | N |
+| Ascension Day | N | N | — | — | — | N | N | — | — | N | N | — | — | — | — | — | — | — | N | — | — | N | — | — | — | N | — | — |
+| Saint Stephen's Day | N | — | — | — | N | — | — | — | — | N | N | — | — | N | — | N | N | — | N | — | — | — | — | — | — | — | — | N |
+| Whit Sunday | — | — | — | — | — | — | O | O | — | O | O | — | — | — | O | — | — | — | — | — | — | O | O | — | — | O | O | — |
+| Independence Day | — | — | N | — | — | — | — | N | — | N | — | — | N | — | — | — | — | — | — | — | N | — | N | — | — | — | — | — |
+| Whit Monday | N | N | — | — | — | N | N | — | — | — | N | — | — | — | N | — | — | — | N | — | — | N | — | — | — | — | — | — |
+| Father's Day | — | — | — | — | — | O | — | — | — | — | O | O | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+| Valentine's Day | — | — | — | — | — | O | — | — | — | — | O | O | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — | — |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/index.md
+++ b/docs/guides/calendar/catalogue/index.md
@@ -1,0 +1,53 @@
+---
+title: Notable-date catalogue
+---
+
+# Notable-date catalogue
+
+What notable dates the **v2** calendar data ships, and how regions and territories differ. This catalogue is generated from the `Bodu.Globalization.Calendar2` XML resources; it lists the dates and their scope, not the calculation recipes (for those, see the linked guides).
+
+Concepts are authored once in a **shared catalogue** and a **region pack** imports the ones it observes, supplying its own territory scope and non-working status. European packs import through the `europe-common` hub, which itself re-exports from the catalogues. The pages below present the same data along two axes.
+
+## How to read these pages
+
+| Column | Meaning |
+|---|---|
+| Category | `PublicHoliday`, `Religious`, `Cultural`, `Observance`, `Remembrance`, … |
+| Non-working | `Yes` = a non-working public holiday for the scope shown; `—` = a working observance |
+| Territory scope | `National`, a subdivision list (e.g. `ENG, WLS, NIR`), or `National + …` |
+| Calendar | shown only when non-Gregorian (`Hijri`, `Hebrew`, `Persian`, `ChineseLunisolar`, …) |
+| Source | `inline` (defined in the region pack) or `← catalogue` (the direct import) |
+| When | a one-phrase gloss: `Fixed 25 Dec`, `Easter +1`, `1st Mon May`, `Algorithm: western-easter` — never the recipe |
+
+## By theme
+
+| Page | Catalogues |
+|---|---|
+| [Civil and Christian catalogues](theme-civil-and-christian.md) | `global-core`, `christian-western`, `christian-orthodox`, `default-minimal`, `europe-common` |
+| [Non-Gregorian religious catalogues](theme-religious-non-gregorian.md) | `global-anchors`, `global-islamic`, `global-islamic-umm-al-qura`, `global-jewish`, `global-hindu`, `global-buddhist`, `global-lunar`, `global-persian` |
+| [Cultural, family, and remembrance catalogues](theme-cultural-and-family.md) | `global-cultural`, `global-family`, `global-family-social`, `global-remembrance` |
+| [Awareness and themed observances](theme-awareness.md) | `global-un`, `global-health`, `global-environment`, `global-education`, `global-science`, `global-social`, `global-food`, `global-animals` |
+| [Aggregate and utility catalogues](theme-aggregates.md) | `global-all`, `global-multiday-normalization` |
+
+## By region
+
+| Page | Countries |
+|---|---|
+| [Americas region packs](region-americas.md) | CA, US |
+| [Asia-Pacific region packs](region-asia-pacific.md) | AU, CN, IN, JP, KR, MY, NZ, SG |
+| [Europe region packs](region-europe.md) | AT, BE, BG, CY, CZ, DE, DK, EE, ES, FI, FR, GB, GR, HR, HU, IE, IT, LT, LU, LV, MT, NL, PL, PT, RO, SE, SI, SK |
+
+See also the [cross-region comparison matrix](comparison-matrix.md).
+
+## Coverage
+
+- **Catalogues:** 27
+- **Region packs:** 38
+- **Distinct concepts (catalogues):** 192
+- **Comparison-matrix rows:** 18
+- **This page regenerated (UTC):** 2026-06-05T03:58:56Z
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/region-americas.md
+++ b/docs/guides/calendar/catalogue/region-americas.md
@@ -1,0 +1,129 @@
+---
+title: Americas region packs
+---
+
+# Americas region packs
+
+Notable dates observed by each country in the **Americas** v2 data pack, grouped by category. **Territory scope** shows national vs subdivision scoping; **Source** is the direct origin (`inline` or the imported catalogue/hub). See the [comparison matrix](comparison-matrix.md) for a cross-region overview.
+
+## CA
+
+**Subdivisions:** CA-AB, CA-BC, CA-MB, CA-NB, CA-NS, CA-NU, CA-ON, CA-PE, CA-QC, CA-SK, CA-YT. A national `CA` query does not return subdivision-only rules.
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Family Day | Yes | AB, SK, ON, BC, NB | inline | 3rd Mon Feb |
+| Islander Day | Yes | PE | inline | 3rd Mon Feb |
+| Louis Riel Day | Yes | MB | inline | 3rd Mon Feb |
+| Nova Scotia Heritage Day | Yes | NS | inline | 3rd Mon Feb |
+| Victoria Day | Yes | National | inline | Mon on/before 24 May |
+| Fête nationale du Québec | Yes | QC | inline | Fixed 24 Jun |
+| Canada Day | Yes | National | inline | Fixed 1 Jul |
+| Nunavut Day | Yes | NU | inline | Fixed 9 Jul |
+| British Columbia Day | Yes | BC | inline | 1st Mon Aug |
+| Civic Holiday | Yes | ON, MB, SK, NU | inline | 1st Mon Aug |
+| Discovery Day | Yes | YT | inline | 3rd Mon Aug |
+| New Brunswick Day | Yes | NB | inline | 1st Mon Aug |
+| Labour Day | Yes | National | inline | 1st Mon Sep |
+| National Day for Truth and Reconciliation | Yes | National | inline | Fixed 30 Sep |
+| Thanksgiving | Yes | National | inline | 2nd Mon Oct |
+| Christmas Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Boxing Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter +1 |
+| Good Friday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | inline | Fixed 14 Feb |
+| Halloween | — | National | inline | Fixed 31 Oct |
+| Christmas Eve | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 24 Dec |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| International Women's Day | — | National | inline | Fixed 8 Mar |
+| Mother's Day | — | National | inline | 2nd Sun May |
+| Father's Day | — | National | inline | 3rd Sun Jun |
+| National Indigenous Peoples Day | — | National | inline | Fixed 21 Jun |
+| Heritage Day | — | AB | inline | 1st Mon Aug |
+
+### Remembrance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Remembrance Day | Yes | National | inline | Fixed 11 Nov |
+
+## US
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Birthday of Martin Luther King, Jr. | Yes | National | inline | 3rd Mon Jan |
+| Presidents' Day | Yes | National | inline | 3rd Mon Feb |
+| Memorial Day | Yes | National | inline | last Mon May |
+| Juneteenth National Independence Day | Yes | National | inline | Fixed 19 Jun |
+| Independence Day | Yes | National | inline | Fixed 4 Jul |
+| Labor Day | Yes | National | inline | 1st Mon Sep |
+| Columbus Day | Yes | National | inline | 2nd Mon Oct |
+| Veterans Day | Yes | National | inline | Fixed 11 Nov |
+| Thanksgiving Day | Yes | National | inline | 4th Thu Nov |
+| Christmas Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+| Good Friday | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | inline | Fixed 14 Feb |
+| St. Patrick's Day | — | National | inline | Fixed 17 Mar |
+| Halloween | — | National | inline | Fixed 31 Oct |
+| Christmas Eve | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 24 Dec |
+| Black Friday | — | National | inline | thanksgiving +1 |
+| Cyber Monday | — | National | inline | thanksgiving +4 |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Earth Day | — | National | inline | Fixed 22 Apr |
+| Mother's Day | — | National | inline | 2nd Sun May |
+| Flag Day | — | National | inline | Fixed 14 Jun |
+| Father's Day | — | National | inline | 3rd Sun Jun |
+| Indigenous Peoples' Day | — | National | inline | 2nd Mon Oct |
+
+### Remembrance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Pearl Harbor Remembrance Day | — | National | inline | Fixed 7 Dec |
+
+### Civic
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Election Day | — | National | inline | 1st Mon Nov (relative) |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/region-asia-pacific.md
+++ b/docs/guides/calendar/catalogue/region-asia-pacific.md
@@ -1,0 +1,285 @@
+---
+title: Asia-Pacific region packs
+---
+
+# Asia-Pacific region packs
+
+Notable dates observed by each country in the **AsiaPacific** v2 data pack, grouped by category. **Territory scope** shows national vs subdivision scoping; **Source** is the direct origin (`inline` or the imported catalogue/hub). See the [comparison matrix](comparison-matrix.md) for a cross-region overview.
+
+## AU
+
+**Subdivisions:** AU-ACT, AU-NSW, AU-NT, AU-QLD, AU-SA, AU-TAS, AU-VIC, AU-WA. A national `AU` query does not return subdivision-only rules.
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Australia Day | Yes | National | inline | Fixed 26 Jan |
+| Adelaide Cup Day | Yes | SA | inline | 2nd Mon Mar |
+| Canberra Day | Yes | ACT | inline | 2nd Mon Mar |
+| Eight Hours Day | Yes | TAS | inline | 2nd Mon Mar |
+| May Day | Yes | NT | inline | 1st Mon May |
+| Reconciliation Day | Yes | ACT | inline | Mon on/after 27 May |
+| King's Birthday | Yes | NSW, VIC, SA, TAS, NT, ACT, WA, QLD | inline | 2nd Mon Jun |
+| Western Australia Day | Yes | WA | inline | 1st Mon Jun |
+| Picnic Day | Yes | NT | inline | 1st Mon Aug |
+| AFL Grand Final Friday | Yes | VIC | inline | last Fri Sep |
+| Labour Day | Yes | NSW, ACT, SA, QLD, VIC, WA | inline | 1st Mon Oct |
+| Melbourne Cup Day | Yes | VIC | inline | 1st Tue Nov |
+| Christmas Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Boxing Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 26 Dec |
+| Proclamation Day | Yes | SA | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter +1 |
+| Easter Saturday | Yes | National | inline | Easter -1 |
+| Good Friday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+
+### BankHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Bank Holiday | — | NSW | inline | 1st Mon Aug |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | [← global-cultural](theme-cultural-and-family.md#global-cultural) | Fixed 14 Feb |
+| April Fool's Day | — | National | [← global-cultural](theme-cultural-and-family.md#global-cultural) | Fixed 1 Apr |
+| Halloween | — | National | [← global-cultural](theme-cultural-and-family.md#global-cultural) | Fixed 31 Oct |
+| Christmas Eve | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 24 Dec |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Harmony Day | — | National | inline | Fixed 21 Mar |
+| Mother's Day | — | National | [← global-family](theme-cultural-and-family.md#global-family) | 2nd Sun May |
+| National Reconciliation Week | — | National | inline | Fixed 27 May |
+| NAIDOC Week | — | National | inline | 1st Sun Jul |
+| Father's Day | — | National | inline | 1st Sun Sep |
+| R U OK? Day | — | National | inline | 2nd Thu Sep |
+
+### Remembrance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Anzac Day | Yes | National + WA, NT, NSW | inline | Fixed 25 Apr |
+| National Sorry Day | — | National | inline | Fixed 26 May |
+| Mabo Day | — | National | inline | Fixed 3 Jun |
+| Remembrance Day | — | National | [← global-remembrance](theme-cultural-and-family.md#global-remembrance) | Fixed 11 Nov |
+
+### Regional
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Royal Queensland Show | Yes | QLD | inline | 2nd Wed Aug |
+| Recreation Day | Yes | TAS | inline | 1st Mon Nov |
+
+## CN
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| New Year's Day | Yes | National | Gregorian | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| International Labour Day | Yes | National | Gregorian | inline | Fixed 1 May |
+| National Day | Yes | National | Gregorian | inline | Fixed 1 Oct |
+| Dragon Boat Festival | Yes | National | ChineseLunisolar | inline | 5 month 5 (ChineseLunisolar) |
+| Lunar New Year | Yes | National | ChineseLunisolar | inline | 1 month 1 (ChineseLunisolar) |
+| Mid-Autumn Festival | Yes | National | ChineseLunisolar | inline | 15 month 8 (ChineseLunisolar) |
+| Qingming Festival | Yes | National | Gregorian | inline | Algorithm: qingming |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Winter Solstice Festival | — | National | Gregorian | inline | Fixed 22 Dec |
+| Double Ninth Festival | — | National | ChineseLunisolar | inline | 9 month 9 (ChineseLunisolar) |
+| Hungry Ghost Festival | — | National | ChineseLunisolar | inline | 15 month 7 (ChineseLunisolar) |
+| Lantern Festival | — | National | Gregorian | inline | Lunar New Year +14 |
+| Qixi Festival | — | National | ChineseLunisolar | inline | 7 month 7 (ChineseLunisolar) |
+
+## IN
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Republic Day | Yes | National | Gregorian | inline | Fixed 26 Jan |
+| Independence Day | Yes | National | Gregorian | inline | Fixed 15 Aug |
+| Gandhi Jayanti | Yes | National | Gregorian | inline | Fixed 2 Oct |
+| Diwali | Yes | National | Gregorian | inline | Algorithm: diwali |
+| Dussehra | Yes | National | Gregorian | inline | Algorithm: dussehra |
+| Holi | Yes | National | Gregorian | inline | Algorithm: holi |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Makar Sankranti | — | National | Gregorian | inline | Fixed 14 Jan |
+| Pongal | — | National | Gregorian | inline | Fixed 14 Jan |
+| Christmas Day | — | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Day of Ashura | — | National | Hijri | inline | 10 Muharram (Hijri) |
+| Easter Sunday | — | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+| Eid al-Adha | — | National | Hijri | inline | 10 Dhu al-Hijja (Hijri) |
+| Eid al-Fitr | — | National | Hijri | inline | 1 Shawwal (Hijri) |
+| Ganesh Chaturthi | — | National | Gregorian | inline | Algorithm: ganesh-chaturthi |
+| Good Friday | — | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+| Janmashtami | — | National | Gregorian | inline | Algorithm: janmashtami |
+| Karva Chauth | — | National | Gregorian | inline | Algorithm: karva-chauth |
+| Maha Shivaratri | Yes | National | Gregorian | inline | Algorithm: maha-shivaratri |
+| Navaratri | — | National | Gregorian | inline | Algorithm: navaratri |
+| Raksha Bandhan | — | National | Gregorian | inline | Algorithm: raksha-bandhan |
+| Ram Navami | — | National | Gregorian | inline | Algorithm: ram-navami |
+| Vasant Panchami | — | National | Gregorian | inline | Algorithm: vasant-panchami |
+
+## JP
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Coming of Age Day | Yes | National | inline | 2nd Mon Jan |
+| National Foundation Day | Yes | National | inline | Fixed 11 Feb |
+| Emperor's Birthday | Yes | National | inline | Fixed 23 Feb |
+| Showa Day | Yes | National | inline | Fixed 29 Apr |
+| Constitution Memorial Day | Yes | National | inline | Fixed 3 May |
+| Greenery Day | Yes | National | inline | Fixed 4 May |
+| Children's Day | Yes | National | inline | Fixed 5 May |
+| Marine Day | Yes | National | inline | 3rd Mon Jul |
+| Mountain Day | Yes | National | inline | Fixed 11 Aug |
+| Respect for the Aged Day | Yes | National | inline | 3rd Mon Sep |
+| Sports Day | Yes | National | inline | 2nd Mon Oct |
+| Culture Day | Yes | National | inline | Fixed 3 Nov |
+| Labour Thanksgiving Day | Yes | National | inline | Fixed 23 Nov |
+| Autumnal Equinox Day | Yes | National | inline | Algorithm: jp-autumnal-equinox |
+| Vernal Equinox Day | Yes | National | inline | Algorithm: jp-vernal-equinox |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Bodhi Day | — | National | inline | Fixed 8 Dec |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Setsubun | — | National | inline | Fixed 3 Feb |
+| Golden Week | — | National | inline | Fixed 29 Apr |
+| Obon | — | National | inline | Fixed 13 Aug |
+
+## KR
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| New Year's Day | Yes | National | Gregorian | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Independence Movement Day | Yes | National | Gregorian | inline | Fixed 1 Mar |
+| Children's Day | Yes | National | Gregorian | inline | Fixed 5 May |
+| Memorial Day | Yes | National | Gregorian | inline | Fixed 6 Jun |
+| Liberation Day | Yes | National | Gregorian | inline | Fixed 15 Aug |
+| National Foundation Day | Yes | National | Gregorian | inline | Fixed 3 Oct |
+| Hangul Day | Yes | National | Gregorian | inline | Fixed 9 Oct |
+| Christmas Day | Yes | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Buddha's Birthday | Yes | National | ChineseLunisolar | inline | 8 month 4 (ChineseLunisolar) |
+| Chuseok | Yes | National | ChineseLunisolar | inline | 15 month 8 (ChineseLunisolar) |
+| Seollal | Yes | National | ChineseLunisolar | inline | 1 month 1 (ChineseLunisolar) |
+
+### Civic
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Constitution Day | — | National | Gregorian | inline | Fixed 17 Jul |
+
+## MY
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Hari Raya Aidiladha | Yes | National | Hijri | inline | 10 Dhu al-Hijja (Hijri) |
+| Hari Raya Aidilfitri | Yes | National | Hijri | inline | 1 Shawwal (Hijri) |
+
+## NZ
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Day after New Year's Day | Yes | National | inline | Fixed 2 Jan |
+| Waitangi Day | Yes | National | inline | Fixed 6 Feb |
+| King's Birthday | Yes | National | inline | 1st Mon Jun |
+| Labour Day | Yes | National | inline | 4th Mon Oct |
+| Christmas Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Boxing Day | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter +1 |
+| Good Friday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+| Matariki | Yes | National | inline | Algorithm: matariki |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | inline | Fixed 14 Feb |
+| Halloween | — | National | inline | Fixed 31 Oct |
+| Guy Fawkes Night | — | National | inline | Fixed 5 Nov |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Mother's Day | — | National | inline | 2nd Sun May |
+| Father's Day | — | National | inline | 1st Sun Sep |
+| Easter Saturday | — | National | inline | Easter -1 |
+
+### Remembrance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Anzac Day | Yes | National | inline | Fixed 25 Apr |
+| Remembrance Day | — | National | inline | Fixed 11 Nov |
+
+## SG
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| New Year's Day | Yes | National | Gregorian | [← global-core](theme-civil-and-christian.md#global-core) | Fixed 1 Jan |
+| Labour Day | Yes | National | Gregorian | inline | Fixed 1 May |
+| National Day | Yes | National | Gregorian | inline | Fixed 9 Aug |
+| Christmas Day | Yes | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Fixed 25 Dec |
+| Chinese New Year | Yes | National | ChineseLunisolar | inline | 1 month 1 (ChineseLunisolar) |
+| Deepavali | Yes | National | Gregorian | inline | Algorithm: diwali |
+| Good Friday | Yes | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -2 |
+| Hari Raya Haji | Yes | National | Hijri | inline | 10 Dhu al-Hijja (Hijri) |
+| Hari Raya Puasa | Yes | National | Hijri | inline | 1 Shawwal (Hijri) |
+| Vesak Day | Yes | National | Gregorian | inline | Algorithm: vesak |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Calendar | Source | When |
+|---|---|---|---|---|---|
+| Easter Sunday | — | National | Gregorian | [← christian-western](theme-civil-and-christian.md#christian-western) | Algorithm: western-easter |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/region-europe.md
+++ b/docs/guides/calendar/catalogue/region-europe.md
@@ -1,0 +1,807 @@
+---
+title: Europe region packs
+---
+
+# Europe region packs
+
+Notable dates observed by each country in the **Europe** v2 data pack, grouped by category. **Territory scope** shows national vs subdivision scoping; **Source** is the direct origin (`inline` or the imported catalogue/hub). See the [comparison matrix](comparison-matrix.md) for a cross-region overview.
+
+## AT
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| State Holiday | Yes | National | inline | Fixed 1 May |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| National Day | Yes | National | inline | Fixed 26 Oct |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Immaculate Conception | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 8 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Corpus Christi | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +60 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## BE
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Belgian National Day | Yes | National | inline | Fixed 21 Jul |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Armistice Day | Yes | National | inline | Fixed 11 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## BG
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Liberation Day | Yes | National | inline | Fixed 3 Mar |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Saint George's Day | Yes | National | inline | Fixed 6 May |
+| Bulgarian Education and Culture and Slavonic Literature Day | Yes | National | inline | Fixed 24 May |
+| Unification Day | Yes | National | inline | Fixed 6 Sep |
+| Independence Day | Yes | National | inline | Fixed 22 Sep |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Good Friday | Yes | National | inline | Orthodox Easter -2 |
+| Holy Saturday | Yes | National | inline | Orthodox Easter -1 |
+| Orthodox Easter Monday | Yes | National | inline | Orthodox Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Orthodox Easter Sunday | — | National | inline | Algorithm: orthodox-easter |
+
+## CY
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Greek Independence Day | Yes | National | inline | Fixed 25 Mar |
+| Cyprus National Day | Yes | National | inline | Fixed 1 Apr |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Dormition of the Mother of God | Yes | National | inline | Fixed 15 Aug |
+| Cyprus Independence Day | Yes | National | inline | Fixed 1 Oct |
+| Ochi Day | Yes | National | inline | Fixed 28 Oct |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Green Monday | Yes | National | inline | Orthodox Easter -48 |
+| Holy Spirit Monday | Yes | National | inline | Orthodox Easter +50 |
+| Orthodox Easter Monday | Yes | National | inline | Orthodox Easter +1 |
+| Orthodox Good Friday | Yes | National | inline | Orthodox Easter -2 |
+| Orthodox Holy Saturday | Yes | National | inline | Orthodox Easter -1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Orthodox Easter Sunday | — | National | inline | Algorithm: orthodox-easter |
+
+## CZ
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Restoration Day of the Independent Czech State | Yes | National | inline | Fixed 1 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Victory Day | Yes | National | inline | Fixed 8 May |
+| Saints Cyril and Methodius Day | Yes | National | inline | Fixed 5 Jul |
+| Jan Hus Day | Yes | National | inline | Fixed 6 Jul |
+| Statehood Day | Yes | National | inline | Fixed 28 Sep |
+| Independent Czechoslovak State Day | Yes | National | inline | Fixed 28 Oct |
+| Struggle for Freedom and Democracy Day | Yes | National | inline | Fixed 17 Nov |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## DE
+
+**Subdivisions:** DE-BB, DE-BE, DE-BW, DE-BY, DE-HB, DE-HE, DE-HH, DE-MV, DE-NI, DE-NW, DE-RP, DE-SH, DE-SL, DE-SN, DE-ST, DE-TH. A national `DE` query does not return subdivision-only rules.
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | BW, BY, ST | inline | Fixed 6 Jan |
+| International Workers' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 May |
+| Assumption of Mary | Yes | BY, SL | inline | Fixed 15 Aug |
+| German Unity Day | Yes | National | inline | Fixed 3 Oct |
+| Reformation Day | Yes | BB, HB, HH, MV, NI, SN, ST, SH, TH | inline | Fixed 31 Oct |
+| All Saints' Day | Yes | BW, BY, NW, RP, SL | inline | Fixed 1 Nov |
+| Repentance and Prayer Day | Yes | SN | inline | Wed on/before 22 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Corpus Christi | Yes | BW, BY, HE, NW, RP, SL | inline | Easter +60 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 14 Feb |
+| Christmas Eve | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| International Women's Day | Yes | National + BE, MV | inline | Fixed 8 Mar |
+| Mother's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | 2nd Sun May |
+| Father's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | 3rd Sun Jun |
+
+## DK
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+| Maundy Thursday | Yes | National | [← christian-western](theme-civil-and-christian.md#christian-western) | Easter -3 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Constitution Day | — | National | inline | Fixed 5 Jun |
+
+## EE
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Independence Day | Yes | National | inline | Fixed 24 Feb |
+| Spring Day | Yes | National | inline | Fixed 1 May |
+| Victory Day | Yes | National | inline | Fixed 23 Jun |
+| Midsummer Day | Yes | National | inline | Fixed 24 Jun |
+| Day of Restoration of Independence | Yes | National | inline | Fixed 20 Aug |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+## ES
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| National Day of Spain | Yes | National | inline | Fixed 12 Oct |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Constitution Day | Yes | National | inline | Fixed 6 Dec |
+| Immaculate Conception | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 8 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## FI
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| May Day | Yes | National | inline | Fixed 1 May |
+| Midsummer Day | Yes | National | inline | Sat on/after 20 Jun |
+| All Saints' Day | Yes | National | inline | Sat on/after 31 Oct |
+| Independence Day | Yes | National | inline | Fixed 6 Dec |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+## FR
+
+**Subdivisions:** FR-57, FR-67, FR-68. A national `FR` query does not return subdivision-only rules.
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Fête du Travail | Yes | National | inline | Fixed 1 May |
+| Victory in Europe Day | Yes | National | inline | Fixed 8 May |
+| Bastille Day | Yes | National | inline | Fixed 14 Jul |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Armistice Day | Yes | National | inline | Fixed 11 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | 67, 68, 57 | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | 67, 68, 57 | inline | Easter -2 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Valentine's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 14 Feb |
+| April Fool's Day | — | National | [← global-cultural](theme-cultural-and-family.md#global-cultural) | Fixed 1 Apr |
+| World Music Day | — | National | inline | Fixed 21 Jun |
+| Christmas Eve | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| International Women's Day | — | National | inline | Fixed 8 Mar |
+| Mother's Day | — | National | inline | last Sun May |
+| Father's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | 3rd Sun Jun |
+
+## GB
+
+**Subdivisions:** GB-ENG, GB-NIR, GB-SCT, GB-WLS. A national `GB` query does not return subdivision-only rules.
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| 2 January | Yes | SCT | inline | Fixed 2 Jan |
+| Saint Patrick's Day | Yes | NIR | inline | Fixed 17 Mar |
+| Early May Bank Holiday | Yes | National | inline | 1st Mon May |
+| Spring Bank Holiday | Yes | National | inline | last Mon May |
+| Battle of the Boyne | Yes | NIR | inline | Fixed 12 Jul |
+| Summer Bank Holiday | Yes | ENG, WLS, NIR | inline | last Mon Aug |
+| Summer Bank Holiday (Scotland) | Yes | SCT | inline | 1st Mon Aug |
+| Saint Andrew's Day | Yes | SCT | inline | Fixed 30 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Boxing Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 26 Dec |
+| Easter Monday | Yes | ENG, WLS, NIR | inline | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Burns Night | — | SCT | inline | Fixed 25 Jan |
+| Valentine's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 14 Feb |
+| Saint David's Day | — | WLS | inline | Fixed 1 Mar |
+| April Fool's Day | — | National | [← global-all](theme-aggregates.md#global-all) | Fixed 1 Apr |
+| Saint George's Day | — | ENG | inline | Fixed 23 Apr |
+| Halloween | — | National | inline | Fixed 31 Oct |
+| Bonfire Night | — | National | inline | Fixed 5 Nov |
+| Christmas Eve | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| International Women's Day | — | National | inline | Fixed 8 Mar |
+| Father's Day | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | 3rd Sun Jun |
+| Mothering Sunday | — | National | inline | Easter -21 |
+
+### Remembrance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Remembrance Day | — | National | [← global-all](theme-aggregates.md#global-all) | Fixed 11 Nov |
+| Remembrance Sunday | — | National | inline | 2nd Sun Nov |
+
+## GR
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Independence Day | Yes | National | inline | Fixed 25 Mar |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Dormition of the Mother of God | Yes | National | inline | Fixed 15 Aug |
+| Ochi Day | Yes | National | inline | Fixed 28 Oct |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Synaxis of the Mother of God | Yes | National | inline | Fixed 26 Dec |
+| Holy Spirit Monday | Yes | National | inline | Orthodox Easter +50 |
+| Orthodox Clean Monday | Yes | National | inline | Orthodox Easter -48 |
+| Orthodox Easter Monday | Yes | National | inline | Orthodox Easter +1 |
+| Orthodox Good Friday | Yes | National | inline | Orthodox Easter -2 |
+| Orthodox Holy Saturday | Yes | National | inline | Orthodox Easter -1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Orthodox Easter Sunday | — | National | inline | Algorithm: orthodox-easter |
+
+## HR
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Statehood Day | Yes | National | inline | Fixed 30 May |
+| Anti-Fascist Struggle Day | Yes | National | inline | Fixed 22 Jun |
+| Victory and Homeland Thanksgiving Day | Yes | National | inline | Fixed 5 Aug |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Remembrance Day | Yes | National | inline | Fixed 18 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Corpus Christi | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +60 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## HU
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| 1848 Revolution Memorial Day | Yes | National | inline | Fixed 15 Mar |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| State Foundation Day | Yes | National | inline | Fixed 20 Aug |
+| 1956 Revolution Memorial Day | Yes | National | inline | Fixed 23 Oct |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+## IE
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Saint Brigid's Day | Yes | National | inline | 1st Mon Feb |
+| Saint Patrick's Day | Yes | National | inline | Fixed 17 Mar |
+| May Day | Yes | National | inline | 1st Mon May |
+| June Bank Holiday | Yes | National | inline | 1st Mon Jun |
+| August Bank Holiday | Yes | National | inline | 1st Mon Aug |
+| October Bank Holiday | Yes | National | inline | last Mon Oct |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## IT
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Liberation Day | Yes | National | inline | Fixed 25 Apr |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Republic Day | Yes | National | inline | Fixed 2 Jun |
+| Assumption of Mary (Ferragosto) | Yes | National | inline | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Immaculate Conception | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 8 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## LT
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Day of Restoration of the State | Yes | National | inline | Fixed 16 Feb |
+| Day of Restoration of Independence | Yes | National | inline | Fixed 11 Mar |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Saint John's Day | Yes | National | inline | Fixed 24 Jun |
+| Statehood Day | Yes | National | inline | Fixed 6 Jul |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| All Souls' Day | Yes | National | inline | Fixed 2 Nov |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## LU
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Europe Day | Yes | National | inline | Fixed 9 May |
+| National Day | Yes | National | inline | Fixed 23 Jun |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## LV
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Restoration of Independence Day | Yes | National | inline | Fixed 4 May |
+| Midsummer Eve | Yes | National | inline | Fixed 23 Jun |
+| Saint John's Day | Yes | National | inline | Fixed 24 Jun |
+| Proclamation Day of the Republic of Latvia | Yes | National | inline | Fixed 18 Nov |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| New Year's Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 31 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## MT
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Feast of Saint Paul's Shipwreck | Yes | National | inline | Fixed 10 Feb |
+| Feast of Saint Joseph | Yes | National | inline | Fixed 19 Mar |
+| Freedom Day | Yes | National | inline | Fixed 31 Mar |
+| International Workers' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 May |
+| Sette Giugno | Yes | National | inline | Fixed 7 Jun |
+| Feast of Saint Peter and Saint Paul | Yes | National | inline | Fixed 29 Jun |
+| Feast of the Assumption (Santa Marija) | Yes | National | inline | Fixed 15 Aug |
+| Victory Day | Yes | National | inline | Fixed 8 Sep |
+| Independence Day | Yes | National | inline | Fixed 21 Sep |
+| Immaculate Conception | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 8 Dec |
+| Republic Day | Yes | National | inline | Fixed 13 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## NL
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| King's Day | Yes | National | inline | Fixed 27 Apr |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Whit Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+### Observance
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Liberation Day | — | National | inline | Fixed 5 May |
+| Good Friday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+## PL
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Constitution Day | Yes | National | inline | Fixed 3 May |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Independence Day | Yes | National | inline | Fixed 11 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Corpus Christi | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +60 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+## PT
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Freedom Day | Yes | National | inline | Fixed 25 Apr |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Portugal Day | Yes | National | inline | Fixed 10 Jun |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| Republic Day | Yes | National | inline | Fixed 5 Oct |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Restoration of Independence | Yes | National | inline | Fixed 1 Dec |
+| Immaculate Conception | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 8 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Corpus Christi | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +60 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+## RO
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Day after New Year's Day | Yes | National | inline | Fixed 2 Jan |
+| Union Day | Yes | National | inline | Fixed 24 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Children's Day | Yes | National | inline | Fixed 1 Jun |
+| Dormition of the Mother of God | Yes | National | inline | Fixed 15 Aug |
+| Saint Andrew's Day | Yes | National | inline | Fixed 30 Nov |
+| Great Union Day | Yes | National | inline | Fixed 1 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Good Friday | Yes | National | inline | Orthodox Easter -2 |
+| Orthodox Easter Monday | Yes | National | inline | Orthodox Easter +1 |
+| Pentecost | Yes | National | inline | Orthodox Easter +49 |
+| Pentecost Monday | Yes | National | inline | Orthodox Easter +50 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Orthodox Easter Sunday | — | National | inline | Algorithm: orthodox-easter |
+
+## SE
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| May Day | Yes | National | inline | Fixed 1 May |
+| National Day of Sweden | Yes | National | inline | Fixed 6 Jun |
+| Midsummer Day | Yes | National | inline | Sat on/after 20 Jun |
+| All Saints' Day | Yes | National | inline | Sat on/after 31 Oct |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Second Day of Christmas | Yes | National | inline | Fixed 26 Dec |
+| Ascension Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +39 |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+### Cultural
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Eve | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 31 Dec |
+
+## SI
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| New Year's Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Jan |
+| New Year Holiday | Yes | National | inline | Fixed 2 Jan |
+| Prešeren Day | Yes | National | inline | Fixed 8 Feb |
+| Day of Uprising Against Occupation | Yes | National | inline | Fixed 27 Apr |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Labour Day Holiday | Yes | National | inline | Fixed 2 May |
+| Statehood Day | Yes | National | inline | Fixed 25 Jun |
+| Assumption of Mary | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 15 Aug |
+| Reformation Day | Yes | National | inline | Fixed 31 Oct |
+| Day of Remembrance of the Dead | Yes | National | inline | Fixed 1 Nov |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Independence and Unity Day | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+| Whit Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +49 |
+
+## SK
+
+### PublicHoliday
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Day of the Establishment of the Slovak Republic | Yes | National | inline | Fixed 1 Jan |
+| Epiphany | Yes | National | inline | Fixed 6 Jan |
+| Labour Day | Yes | National | inline | Fixed 1 May |
+| Day of Victory over Fascism | Yes | National | inline | Fixed 8 May |
+| Saints Cyril and Methodius Day | Yes | National | inline | Fixed 5 Jul |
+| Slovak National Uprising Anniversary | Yes | National | inline | Fixed 29 Aug |
+| Constitution Day | Yes | National | inline | Fixed 1 Sep |
+| Day of Our Lady of Sorrows | Yes | National | inline | Fixed 15 Sep |
+| All Saints' Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 1 Nov |
+| Struggle for Freedom and Democracy Day | Yes | National | inline | Fixed 17 Nov |
+| Christmas Eve | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 24 Dec |
+| Christmas Day | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Fixed 25 Dec |
+| Saint Stephen's Day | Yes | National | inline | Fixed 26 Dec |
+| Easter Monday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter +1 |
+| Good Friday | Yes | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Easter -2 |
+
+### Religious
+
+| Concept | Non-working | Territory scope | Source | When |
+|---|---|---|---|---|
+| Easter Sunday | — | National | [← europe-common](theme-civil-and-christian.md#europe-common) | Algorithm: western-easter |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/theme-aggregates.md
+++ b/docs/guides/calendar/catalogue/theme-aggregates.md
@@ -1,0 +1,53 @@
+---
+title: Aggregate and utility catalogues
+---
+
+# Aggregate and utility catalogues
+
+Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.
+
+## global-all
+
+Aggregate catalogue ($(@{Stem=global-all; ResourceId=common.global-all; Bundle=; Imports=System.Object[]; Concepts=System.Object[]}.ResourceId)): imports every other catalogue with no cherry-picks, so each contributes its full concept set. Identifiers shared across sources are de-duplicated first-source-wins. Intended for consumers that want every shared observance at once; territory packs cherry-pick instead.
+
+| Imports catalogue |
+|---|
+| `global-core` |
+| `global-anchors` |
+| `christian-western` |
+| `christian-orthodox` |
+| `global-cultural` |
+| `global-education` |
+| `global-environment` |
+| `global-family` |
+| `global-family-social` |
+| `global-food` |
+| `global-health` |
+| `global-remembrance` |
+| `global-science` |
+| `global-social` |
+| `global-un` |
+| `global-animals` |
+| `global-multiday-normalization` |
+| `global-lunar` |
+| `global-islamic` |
+| `global-islamic-umm-al-qura` |
+| `global-jewish` |
+| `global-hindu` |
+| `global-buddhist` |
+| `global-persian` |
+| `default-minimal` |
+
+_Observed by:_ [GB](region-europe.md)
+
+## global-multiday-normalization
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| NAIDOC Week | Observance | — | 1st Sun Jul |
+| World Space Week | Observance | — | Fixed 4 Oct |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/theme-awareness.md
+++ b/docs/guides/calendar/catalogue/theme-awareness.md
@@ -1,0 +1,143 @@
+---
+title: Awareness and themed observances
+---
+
+# Awareness and themed observances
+
+Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.
+
+## global-un
+
+10 recognition-only observance(s). Sample (see `global-un.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Interfaith Harmony Week | Fixed 1 Feb |
+| International Women's Day | Fixed 8 Mar |
+| International Day of Happiness | Fixed 20 Mar |
+| World Press Freedom Day | Fixed 3 May |
+| International Youth Day | Fixed 12 Aug |
+| International Day of Democracy | Fixed 15 Sep |
+| International Day of Peace | Fixed 21 Sep |
+| World Habitat Day | 1st Mon Oct |
+| United Nations Day | Fixed 24 Oct |
+| Human Rights Day | Fixed 10 Dec |
+
+## global-health
+
+12 recognition-only observance(s). Sample (see `global-health.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Cancer Day | Fixed 4 Feb |
+| World Autism Awareness Day | Fixed 2 Apr |
+| World Health Day | Fixed 7 Apr |
+| World No Tobacco Day | Fixed 31 May |
+| World Blood Donor Day | Fixed 14 Jun |
+| World Hepatitis Day | Fixed 28 Jul |
+| World Suicide Prevention Day | Fixed 10 Sep |
+| Breast Cancer Awareness Month | Fixed 1 Oct |
+| World Mental Health Day | Fixed 10 Oct |
+| Movember | Fixed 1 Nov |
+| World Diabetes Day | Fixed 14 Nov |
+| World AIDS Day | Fixed 1 Dec |
+
+## global-environment
+
+12 recognition-only observance(s). Sample (see `global-environment.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Wetlands Day | Fixed 2 Feb |
+| Earth Hour | last Sat Mar |
+| International Day of Forests | Fixed 21 Mar |
+| World Water Day | Fixed 22 Mar |
+| Earth Day | Fixed 22 Apr |
+| International Day for Biological Diversity | Fixed 22 May |
+| World Environment Day | Fixed 5 Jun |
+| World Oceans Day | Fixed 8 Jun |
+| World Day to Combat Desertification and Drought | Fixed 17 Jun |
+| Plastic Free July | Fixed 1 Jul |
+| Clean Up the World Weekend | 3rd Fri Sep |
+| World Soil Day | Fixed 5 Dec |
+
+## global-education
+
+5 recognition-only observance(s). Sample (see `global-education.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| International Day of Education | Fixed 24 Jan |
+| Safer Internet Day | 2nd Tue Feb |
+| World Book and Copyright Day | Fixed 23 Apr |
+| International Literacy Day | Fixed 8 Sep |
+| World Teachers' Day | Fixed 5 Oct |
+
+## global-science
+
+8 recognition-only observance(s). Sample (see `global-science.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| International Day of Women and Girls in Science | Fixed 11 Feb |
+| International Day of Mathematics | Fixed 14 Mar |
+| Pi Day | Fixed 14 Mar |
+| World Meteorological Day | Fixed 23 Mar |
+| World Intellectual Property Day | Fixed 26 Apr |
+| International Day of Light | Fixed 16 May |
+| World Space Week | Fixed 4 Oct |
+| World Science Day for Peace and Development | Fixed 10 Nov |
+
+## global-social
+
+14 recognition-only observance(s). Sample (see `global-social.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Day of Social Justice | Fixed 20 Feb |
+| International Day of Families | Fixed 15 May |
+| International Day Against Homophobia, Biphobia and Transphobia | Fixed 17 May |
+| Pride Month | Fixed 1 Jun |
+| World Day Against Child Labour | Fixed 12 Jun |
+| World Refugee Day | Fixed 20 Jun |
+| Nelson Mandela International Day | Fixed 18 Jul |
+| International Day of Charity | Fixed 5 Sep |
+| International Day of Older Persons | Fixed 1 Oct |
+| International Day of the Girl Child | Fixed 11 Oct |
+| World Kindness Day | Fixed 13 Nov |
+| International Men's Day | Fixed 19 Nov |
+| _+ 2 more_ | |
+
+## global-food
+
+8 recognition-only observance(s). Sample (see `global-food.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Pulses Day | Fixed 10 Feb |
+| International Tea Day | Fixed 21 May |
+| World Food Safety Day | Fixed 7 Jun |
+| International Beer Day | 1st Fri Aug |
+| International Coffee Day | Fixed 1 Oct |
+| World Vegetarian Day | Fixed 1 Oct |
+| World Food Day | Fixed 16 Oct |
+| World Vegan Day | Fixed 1 Nov |
+
+## global-animals
+
+7 recognition-only observance(s). Sample (see `global-animals.xml` for the full list):
+
+| Observance | When |
+|---|---|
+| World Wildlife Day | Fixed 3 Mar |
+| World Bee Day | Fixed 20 May |
+| International Tiger Day | Fixed 29 Jul |
+| International Cat Day | Fixed 8 Aug |
+| World Elephant Day | Fixed 12 Aug |
+| International Dog Day | Fixed 26 Aug |
+| World Animal Day | Fixed 4 Oct |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/theme-civil-and-christian.md
+++ b/docs/guides/calendar/catalogue/theme-civil-and-christian.md
@@ -1,0 +1,92 @@
+---
+title: Civil and Christian catalogues
+---
+
+# Civil and Christian catalogues
+
+Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.
+
+## global-core
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| New Year's Day | PublicHoliday | Yes | Fixed 1 Jan |
+| International Workers' Day | PublicHoliday | Yes | Fixed 1 May |
+| New Year's Eve | Cultural | — | Fixed 31 Dec |
+
+_Observed by:_ [AU](region-asia-pacific.md), [CA](region-americas.md), [CN](region-asia-pacific.md), [JP](region-asia-pacific.md), [KR](region-asia-pacific.md), [NZ](region-asia-pacific.md), [SG](region-asia-pacific.md), [US](region-americas.md)
+
+## christian-western
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Epiphany | Religious | — | Fixed 6 Jan |
+| Candlemas | Religious | — | Fixed 2 Feb |
+| Annunciation | Religious | — | Fixed 25 Mar |
+| All Saints' Day | Religious | — | Fixed 1 Nov |
+| All Souls' Day | Religious | — | Fixed 2 Nov |
+| Christmas Eve | Cultural | — | Fixed 24 Dec |
+| Christmas Day | PublicHoliday | Yes | Fixed 25 Dec |
+| Boxing Day | PublicHoliday | Yes | Fixed 26 Dec |
+| Ascension Day | Religious | — | Easter +39 |
+| Ash Wednesday | Religious | — | Easter -46 |
+| Corpus Christi | Religious | — | Easter +60 |
+| Easter Monday | PublicHoliday | Yes | Easter +1 |
+| Easter Sunday | Religious | — | Algorithm: western-easter |
+| Good Friday | PublicHoliday | Yes | Easter -2 |
+| Holy Saturday | Religious | — | Easter -1 |
+| Maundy Thursday | Religious | — | Easter -3 |
+| Palm Sunday | Religious | — | Easter -7 |
+| Shrove Tuesday | Religious | — | Easter -47 |
+| Trinity Sunday | Religious | — | Easter +56 |
+| Whit Monday | PublicHoliday | Yes | Easter +50 |
+| Whit Sunday | Religious | — | Easter +49 |
+
+_Observed by:_ [AU](region-asia-pacific.md), [CA](region-americas.md), [DK](region-europe.md), [IN](region-asia-pacific.md), [KR](region-asia-pacific.md), [NZ](region-asia-pacific.md), [SG](region-asia-pacific.md), [US](region-americas.md)
+
+## christian-orthodox
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Orthodox Christmas Eve | Observance | — | Fixed 6 Jan |
+| Orthodox Christmas Day | PublicHoliday | Yes | Fixed 7 Jan |
+| Orthodox New Year | Observance | — | Fixed 14 Jan |
+| Orthodox Epiphany | Observance | — | Fixed 19 Jan |
+| Orthodox Ascension Day | Religious | — | Orthodox Easter +39 |
+| Orthodox Bright Week | Religious | — | Orthodox Easter +0 |
+| Orthodox Clean Monday | Religious | — | Orthodox Easter -48 |
+| Orthodox Easter Monday | PublicHoliday | — | Orthodox Easter +1 |
+| Orthodox Easter Sunday | Religious | — | Algorithm: orthodox-easter |
+| Orthodox Good Friday | PublicHoliday | — | Orthodox Easter -2 |
+| Orthodox Holy Saturday | Religious | — | Orthodox Easter -1 |
+| Orthodox Holy Thursday | Religious | — | Orthodox Easter -3 |
+| Orthodox Lazarus Saturday | Religious | — | Orthodox Easter -8 |
+| Orthodox Palm Sunday | Religious | — | Orthodox Easter -7 |
+| Orthodox Pentecost | Religious | — | Orthodox Easter +49 |
+| Orthodox Pentecost Monday | Religious | — | Orthodox Easter +50 |
+
+## default-minimal
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| New Year's Day | PublicHoliday | Yes | Fixed 1 Jan |
+
+## europe-common
+
+Pan-European hub ($(@{Stem=europe-common; ResourceId=data.europe-common; Bundle=Europe; Imports=System.Object[]; Concepts=System.Object[]}.ResourceId)): re-exports the common civil, Christian, family, and cultural concepts from the catalogues below, and defines the two Catholic feasts the catalogues do not carry. The 28 European region packs import their shared observances from here.
+
+Re-exports from: `global-core`, `christian-western`, `global-family`, `global-cultural`.
+
+Defines inline:
+
+| Concept | Category | When |
+|---|---|---|
+| Assumption of Mary | Religious | Fixed 15 Aug |
+| Immaculate Conception | Religious | Fixed 8 Dec |
+
+_Observed by:_ [AT](region-europe.md), [BE](region-europe.md), [BG](region-europe.md), [CY](region-europe.md), [CZ](region-europe.md), [DE](region-europe.md), [DK](region-europe.md), [EE](region-europe.md), [ES](region-europe.md), [FI](region-europe.md), [FR](region-europe.md), [GB](region-europe.md), [GR](region-europe.md), [HR](region-europe.md), [HU](region-europe.md), [IE](region-europe.md), [IT](region-europe.md), [LT](region-europe.md), [LU](region-europe.md), [LV](region-europe.md), [MT](region-europe.md), [NL](region-europe.md), [PL](region-europe.md), [PT](region-europe.md), [RO](region-europe.md), [SE](region-europe.md), [SI](region-europe.md), [SK](region-europe.md)
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/theme-cultural-and-family.md
+++ b/docs/guides/calendar/catalogue/theme-cultural-and-family.md
@@ -1,0 +1,56 @@
+---
+title: Cultural, family, and remembrance catalogues
+---
+
+# Cultural, family, and remembrance catalogues
+
+Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.
+
+## global-cultural
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Valentine's Day | Cultural | — | Fixed 14 Feb |
+| International Mother Language Day | Cultural | — | Fixed 21 Feb |
+| World Poetry Day | Cultural | — | Fixed 21 Mar |
+| World Theatre Day | Cultural | — | Fixed 27 Mar |
+| April Fool's Day | Cultural | — | Fixed 1 Apr |
+| International Jazz Day | Cultural | — | Fixed 30 Apr |
+| Star Wars Day | Cultural | — | Fixed 4 May |
+| World Music Day | Cultural | — | Fixed 21 Jun |
+| International Friendship Day | Cultural | — | Fixed 30 Jul |
+| Halloween | Cultural | — | Fixed 31 Oct |
+
+_Observed by:_ [AU](region-asia-pacific.md), [FR](region-europe.md)
+
+## global-family
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Mother's Day | Observance | — | 2nd Sun May |
+| Father's Day | Observance | — | 3rd Sun Jun |
+
+_Observed by:_ [AU](region-asia-pacific.md)
+
+## global-family-social
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Friendship Day | Observance | — | 1st Sun Aug |
+| Grandparents Day | Observance | — | 1st Sun Sep |
+
+## global-remembrance
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| International Holocaust Remembrance Day | Remembrance | — | Fixed 27 Jan |
+| International Day for the Elimination of Racial Discrimination | Remembrance | — | Fixed 21 Mar |
+| International Day for the Remembrance of the Slave Trade and its Abolition | Remembrance | — | Fixed 23 Aug |
+| Remembrance Day | Remembrance | — | Fixed 11 Nov |
+
+_Observed by:_ [AU](region-asia-pacific.md)
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/catalogue/theme-religious-non-gregorian.md
+++ b/docs/guides/calendar/catalogue/theme-religious-non-gregorian.md
@@ -1,0 +1,105 @@
+---
+title: Non-Gregorian religious catalogues
+---
+
+# Non-Gregorian religious catalogues
+
+Concepts defined by the shared v2 catalogues in this theme. A region pack imports the concepts it observes and supplies its own territory scope and non-working status — see the [region pages](index.md#by-region). The **When** column is a one-phrase gloss, not the calculation recipe.
+
+## global-anchors
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Lunar New Year | Cultural | — | ChineseLunisolar | 1 month 1 (ChineseLunisolar) |
+| Orthodox Easter | Religious | — | Gregorian | Algorithm: orthodox-easter |
+| Ramadan Start | Religious | — | Hijri | 1 Ramadan (Hijri) |
+
+## global-islamic
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Day of Ashura | Religious | — | Hijri | 10 Muharram (Hijri) |
+| Eid al-Adha | Religious | — | Hijri | 10 Dhu al-Hijja (Hijri) |
+| Eid al-Fitr | Religious | — | Hijri | 1 Shawwal (Hijri) |
+| Islamic New Year | Religious | — | Hijri | 1 Muharram (Hijri) |
+| Mawlid al-Nabi | Religious | — | Hijri | 12 Rabi I (Hijri) |
+| Ramadan | Religious | — | Hijri | 1 Ramadan (Hijri) |
+
+## global-islamic-umm-al-qura
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Day of Ashura | Religious | — | UmmAlQura | 10 Muharram (UmmAlQura) |
+| Eid al-Adha | Religious | — | UmmAlQura | 10 Dhu al-Hijja (UmmAlQura) |
+| Eid al-Fitr | Religious | — | UmmAlQura | 1 Shawwal (UmmAlQura) |
+| Islamic New Year | Religious | — | UmmAlQura | 1 Muharram (UmmAlQura) |
+| Mawlid al-Nabi | Religious | — | UmmAlQura | 12 Rabi I (UmmAlQura) |
+| Ramadan | Religious | — | UmmAlQura | 1 Ramadan (UmmAlQura) |
+
+## global-jewish
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Hanukkah | Religious | — | Hebrew | 25 month Kislev (Hebrew) |
+| Passover | Religious | — | Hebrew | 15 month Nisan (Hebrew) |
+| Purim | Religious | — | Hebrew | 14 month LastAdar (Hebrew) |
+| Rosh Hashanah | Religious | — | Hebrew | 1 month Tishri (Hebrew) |
+| Shavuot | Religious | — | Gregorian | passover +50 |
+| Sukkot | Religious | — | Gregorian | rosh-hashanah +14 |
+| Yom Kippur | Religious | — | Gregorian | rosh-hashanah +9 |
+
+## global-hindu
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Makar Sankranti | Cultural | — | Fixed 14 Jan |
+| Pongal | Cultural | — | Fixed 14 Jan |
+| Diwali | Religious | — | Algorithm: diwali |
+| Dussehra | Religious | — | Algorithm: dussehra |
+| Ganesh Chaturthi | Religious | — | Algorithm: ganesh-chaturthi |
+| Holi | Religious | — | Algorithm: holi |
+| Janmashtami | Religious | — | Algorithm: janmashtami |
+| Karva Chauth | Cultural | — | Algorithm: karva-chauth |
+| Maha Shivaratri | Religious | — | Algorithm: maha-shivaratri |
+| Navaratri | Religious | — | Algorithm: navaratri |
+| Raksha Bandhan | Cultural | — | Algorithm: raksha-bandhan |
+| Ram Navami | Religious | — | Algorithm: ram-navami |
+| Saraswati Puja | Religious | — | Algorithm: vasant-panchami |
+
+## global-buddhist
+
+| Concept | Category | Non-working | When |
+|---|---|---|---|
+| Parinirvana Day | Religious | — | Fixed 15 Feb |
+| Bodhi Day | Religious | — | Fixed 8 Dec |
+| Asalha Puja | Religious | — | Algorithm: asalha-puja |
+| Losar | Religious | — | Algorithm: losar |
+| Vassa | Religious | — | asalha-puja +1 |
+| Vesak | Religious | — | Algorithm: vesak |
+
+## global-lunar
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Winter Solstice Festival | Cultural | — | Gregorian | Fixed 22 Dec |
+| Double Ninth Festival | Cultural | — | ChineseLunisolar | 9 month 9 (ChineseLunisolar) |
+| Dragon Boat Festival | Cultural | — | ChineseLunisolar | 5 month 5 (ChineseLunisolar) |
+| Hungry Ghost Festival | Cultural | — | ChineseLunisolar | 15 month 7 (ChineseLunisolar) |
+| Lantern Festival | Cultural | — | Gregorian | Lunar New Year +14 |
+| Lunar New Year | Cultural | — | ChineseLunisolar | 1 month 1 (ChineseLunisolar) |
+| Mid-Autumn Festival | Cultural | — | ChineseLunisolar | 15 month 8 (ChineseLunisolar) |
+| Qingming Festival | Observance | — | Gregorian | Algorithm: qingming |
+| Qixi Festival | Cultural | — | ChineseLunisolar | 7 month 7 (ChineseLunisolar) |
+
+## global-persian
+
+| Concept | Category | Non-working | Calendar | When |
+|---|---|---|---|---|
+| Nowruz | Cultural | — | Persian | 1 month 1 (Persian) |
+| Sizdah Bedar | Cultural | — | Persian | 13 month 1 (Persian) |
+| Yalda Night | Cultural | — | Persian | 30 month 9 (Persian) |
+
+---
+
+*Generated from the v2 notable-date XML resources by `Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`. Regenerated (UTC): 2026-06-05T03:58:56Z.* For the calculation recipes deliberately omitted here, see [Territories and regional composition](../territories.md), [Working with non-Gregorian calendars](../non-gregorian-calendars.md), and [Holiday patterns](../holiday-patterns.md); for the API, the <xref:Bodu.Globalization.Calendar.V2> namespace.
+

--- a/docs/guides/calendar/index.md
+++ b/docs/guides/calendar/index.md
@@ -8,6 +8,8 @@ Recipe-style walk-throughs for **Bodu.Globalization.Calendar**, organized by nam
 
 If you are new to the library, start with the [introduction](../../docs/calendar/index.md), the [Core concepts](../../docs/calendar/concepts.md) glossary, and the [getting-started page](../../docs/calendar/getting-started.md). For the auto-generated API reference, see the [Bodu.Globalization.Calendar namespace page](xref:Bodu.Globalization.Calendar).
 
+> **Looking for the data?** The [Notable-date catalogue](catalogue/index.md) lists what notable dates the **v2** calendar resources include and how regions and territories differ — generated from the XML, organized by theme and by region, with a cross-region comparison matrix.
+
 ## How the library works
 
 ![NotableDateService resolution pipeline](../../images/diagrams/calendar-resolution-pipeline.svg)

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -92,6 +92,28 @@
       items:
         - name: Calendar data packs
           href: calendar/data-packs.md
+    - name: Bodu.Globalization.Calendar.V2 — Notable-date catalogue
+      items:
+        - name: Catalogue overview
+          href: calendar/catalogue/index.md
+        - name: Civil and Christian catalogues
+          href: calendar/catalogue/theme-civil-and-christian.md
+        - name: Non-Gregorian religious catalogues
+          href: calendar/catalogue/theme-religious-non-gregorian.md
+        - name: Cultural, family, and remembrance catalogues
+          href: calendar/catalogue/theme-cultural-and-family.md
+        - name: Awareness and themed observances
+          href: calendar/catalogue/theme-awareness.md
+        - name: Aggregate and utility catalogues
+          href: calendar/catalogue/theme-aggregates.md
+        - name: Americas region packs
+          href: calendar/catalogue/region-americas.md
+        - name: Asia-Pacific region packs
+          href: calendar/catalogue/region-asia-pacific.md
+        - name: Europe region packs
+          href: calendar/catalogue/region-europe.md
+        - name: Cross-region comparison matrix
+          href: calendar/catalogue/comparison-matrix.md
 - name: Bodu.IO.Hashing
   items:
     - name: Overview


### PR DESCRIPTION
## Summary

Adds a PowerShell 7 generator and the DocFX pages it produces, cataloguing the **v2** notable-date data (currently undocumented — the existing calendar guides describe v1).

`Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1` parses the v2 XML corpus (26 common catalogues + the 3 `Calendar2.Data.*` region packs + the `europe-common` hub), resolves the import graph the same way `NotableDateResourceLoader` does (transitive re-export, cherry-pick, local-wins, first-source dedup), and emits 10 crisp pages under `docs/guides/calendar/catalogue/`.

The pages tell a consumer **what** notable dates exist and **how** regions/territories differ — without restating the calculation recipes. Dates carry a one-phrase "when" gloss only (`Fixed 25 Dec`, `Easter +1`, `Algorithm: western-easter`), never the math.

## Pages (hybrid: theme axis + region axis + matrix)

- **Overview** — two-axis hub, column/cell legends, coverage counts.
- **5 theme pages** — catalogues grouped (civil & Christian · non-Gregorian religious · cultural & family · awareness *(sampled/capped)* · aggregates).
- **3 region pages** — per bundle (Americas / Asia-Pacific / Europe); each country grouped by category, with subdivision call-outs (GB/DE/AU/CA), a Territory-scope column, and inline-vs-imported **Source** links into the theme pages.
- **Comparison matrix** — top-18 most-shared dates × countries, cells `N` (non-working) / `O` (observed) / `S` (subdivision-only) / `—` (not in pack).

Wires a "Notable-date catalogue" group into `docs/guides/toc.yml` and adds one link from the calendar guides index.

## Generation & verification

- Mirrors `tools/Generate-CrcDocs.ps1`: PowerShell 7, UTF-8 no-BOM / LF, a regeneration stamp, deterministic ordering. Refresh with `pwsh ./Bodu.Globalization.Calendar2/Generate-NotableDateCatalogue.ps1`.
- **Idempotent** — re-running is byte-stable except the timestamp; the toc update is surgical and idempotent.
- `docfx docs/docfx.json --warningsAsErrors` **builds clean** (exit 0, zero warnings; the `Bodu.Globalization.Calendar.V2` xref resolves).

Generated markdown is committed as documentation source (built by the existing docfx workflow); the script is run locally, matching the repo's CRC-catalogue pattern.

https://claude.ai/code/session_01VHZY1Jj6b3WKht5Yh8Lotx

---
_Generated by [Claude Code](https://claude.ai/code/session_01VHZY1Jj6b3WKht5Yh8Lotx)_