### PR TITLE
docs(calendar): add examples, seealso, and usage guidance to consumer entry points

### DIFF
--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/AdjustmentPolicyBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/AdjustmentPolicyBuilder.cs
@@ -12,6 +12,29 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// Provides a fluent surface for authoring a reusable adjustment policy: its scope, the trigger that activates it, the
 /// action it performs, the emission mode of the resulting occurrence, and any custom handler parameters.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A policy reads as a sentence: <c>When</c> a trigger holds, <c>Then</c> perform an action, and <c>Emit</c> the
+/// resulting occurrence in the chosen mode. Configure the builder inside
+/// <see cref="NotableDateDocumentBuilder.AddAdjustmentPolicy(string, System.Action{AdjustmentPolicyBuilder})" /> and
+/// reference the policy from a rule with <see cref="NotableDateRuleBuilder.WithAdjustment(string)" />.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // "If the holiday lands on a weekend, move it to the next working day and emit only the observed date."
+/// builder.AddAdjustmentPolicy("weekend-roll", p => p
+///     .When(AdjustmentTrigger.IfWeekend)
+///     .Then(AdjustmentAction.MoveToNextWorkingDay)
+///     .SkipNonWorkingDates()
+///     .Emit(EmissionMode.ObservedOnly)
+///     .WithReason("Observed (weekend roll-forward)"));
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateDocumentBuilder" />
+/// <seealso cref="NotableDateRuleBuilder" />
 public sealed class AdjustmentPolicyBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/AdjustmentPolicyBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/AdjustmentPolicyBuilder.cs
@@ -35,6 +35,7 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// </example>
 /// <seealso cref="NotableDateDocumentBuilder" />
 /// <seealso cref="NotableDateRuleBuilder" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public sealed class AdjustmentPolicyBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDefinitionBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDefinitionBuilder.cs
@@ -10,6 +10,29 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// Provides a fluent surface for authoring a notable-date concept: its identity, default category, duration and
 /// non-working flags, concept-level tags, and one or more calculation rules.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A concept groups the rules that express the same notable date across territories or eras — for example a national
+/// rule and a regional variant that calculate the same holiday differently. Set concept-level defaults (category,
+/// duration, non-working) once, then add each variant with
+/// <see cref="AddRule(string, System.Action{NotableDateRuleBuilder})" />; a rule may override the defaults it needs to.
+/// Configure the builder inside
+/// <see cref="NotableDateDocumentBuilder.AddNotableDate(string, string, NotableDateCategory, System.Action{NotableDateDefinitionBuilder})" />.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// document.AddNotableDate("anzac-day", "Anzac Day", NotableDateCategory.PublicHoliday, c => c
+///     .AsNonWorkingByDefault()
+///     .AddTag("Remembrance")
+///     .AddRule("au", r => r.ForTerritory("AU").Fixed(4, 25))
+///     .AddRule("nz", r => r.ForTerritory("NZ").Fixed(4, 25)));
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateDocumentBuilder" />
+/// <seealso cref="NotableDateRuleBuilder" />
 public sealed class NotableDateDefinitionBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDefinitionBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDefinitionBuilder.cs
@@ -33,6 +33,7 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// </example>
 /// <seealso cref="NotableDateDocumentBuilder" />
 /// <seealso cref="NotableDateRuleBuilder" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class NotableDateDefinitionBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
@@ -21,7 +21,45 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// XML form expresses every feature of the schema, whereas the JSON form rendered by <see cref="ToJson" /> is
 /// restricted to the subset the companion JSON schema can represent.
 /// </para>
+/// <para>
+/// <strong>Workflow.</strong> Obtain a builder with <see cref="Create()" /> or <see cref="Create(string, string)" />,
+/// declare reusable adjustment policies with <see cref="AddAdjustmentPolicy(string, Action{AdjustmentPolicyBuilder})" />,
+/// add each notable-date concept with
+/// <see cref="AddNotableDate(string, string, NotableDateCategory, Action{NotableDateDefinitionBuilder})" />, then
+/// terminate by materializing a <see cref="NotableDateResource" /> with <see cref="Build()" />, serializing with
+/// <see cref="ToXml" /> / <see cref="ToJson" /> / <see cref="Save(string)" />, or wrapping the result with
+/// <see cref="ToProvider" />.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// NotableDateResource resource = NotableDateDocumentBuilder.Create("contoso-holidays")
+///     .AddAdjustmentPolicy("weekend-roll", p => p
+///         .When(AdjustmentTrigger.IfWeekend)
+///         .Then(AdjustmentAction.MoveToNextWorkingDay)
+///         .Emit(EmissionMode.ObservedOnly))
+///     .AddNotableDate("christmas", "Christmas Day", NotableDateCategory.PublicHoliday, c => c
+///         .AsNonWorkingByDefault()
+///         .AddRule("fixed", r => r
+///             .Fixed(12, 25)
+///             .WithAdjustment("weekend-roll")))
+///     .Build();
+///
+/// NotableDateService service = new(resource);
+///
+/// // The same model serializes to XML or JSON for storage or distribution.
+/// NotableDateDocumentBuilder builder = NotableDateDocumentBuilder.Create("contoso-holidays")
+///     .AddNotableDate("new-year", "New Year's Day", NotableDateCategory.PublicHoliday, c => c
+///         .AddRule("fixed", r => r.Fixed(1, 1)));
+/// string xml = builder.ToXml();
+/// string json = builder.ToJson();
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateResource" />
+/// <seealso cref="NotableDateResourceLoader" />
+/// <seealso cref="NotableDateService" />
 public sealed partial class NotableDateDocumentBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateDocumentBuilder.cs
@@ -60,6 +60,8 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// <seealso cref="NotableDateResource" />
 /// <seealso cref="NotableDateResourceLoader" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/notable-date-builder.html">Authoring with the notable-date builder (guide)</seealso>
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed partial class NotableDateDocumentBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
@@ -36,6 +36,8 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// </example>
 /// <seealso cref="NotableDateDefinitionBuilder" />
 /// <seealso cref="AdjustmentPolicyBuilder" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
+/// <seealso href="../guides/calendar/rule-reference.html">NotableDateRule and adjustment-policy reference (guide)</seealso>
 public sealed class NotableDateRuleBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
+++ b/Bodu.Globalization.Calendar.Builder/src/Globalization.Calendar.Builder/NotableDateRuleBuilder.cs
@@ -12,6 +12,30 @@ namespace Bodu.Globalization.Calendar.Builder;
 /// Provides a fluent surface for authoring a single rule: its selection scalars, applicability scope, exactly one
 /// calculation strategy, rule-specific tags, and the adjustment policies applied to its occurrences.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A rule must declare exactly one calculation strategy — for example <see cref="Fixed(int, int, bool, bool)" />,
+/// <see cref="DayOfWeekInMonth(int, DayOfWeek, WeekOrdinal)" />,
+/// <see cref="WeekdayNearDate(int, int, DayOfWeek, WeekdayProximity)" />,
+/// <see cref="OffsetFromRule(string, int, string)" />, or <see cref="Algorithm(string)" />. Scope the rule to a
+/// calendar, territories, or a year window with the <c>For…</c> / <c>…Year(s)</c> members, and attach reusable
+/// adjustment policies with <see cref="WithAdjustment(string)" />. Configure the builder inside
+/// <see cref="NotableDateDefinitionBuilder.AddRule(string, System.Action{NotableDateRuleBuilder})" />.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // U.S. Thanksgiving: the fourth Thursday of November, scoped to the United States.
+/// definition.AddRule("us", r => r
+///     .ForTerritory("US")
+///     .DayOfWeekInMonth(11, DayOfWeek.Thursday, WeekOrdinal.Fourth)
+///     .AsNonWorking());
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateDefinitionBuilder" />
+/// <seealso cref="AdjustmentPolicyBuilder" />
 public sealed class NotableDateRuleBuilder
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
@@ -19,7 +19,27 @@ namespace Bodu.Globalization.Calendar.Data;
 /// subdivision (<c>CA-ON</c>); the subdivision selects the same country resource, and the resolver filters by the full
 /// territory at query time.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Call <see cref="CreateService(string)" /> for a ready-to-query
+/// <see cref="NotableDateService" />, or <see cref="LoadResource(string)" /> when you need the underlying
+/// <see cref="NotableDateResource" /> to compose with custom collaborators or providers.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Query United States federal holidays for a year.
+/// NotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+/// IReadOnlyList<NotableDate> holidays = service.Resolve(year, "US");
+///
+/// // A subdivision sees its province's rules layered over the country's.
+/// NotableDateService ontario = AmericasCalendarData.CreateService("CA-ON");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateService" />
+/// <seealso cref="NotableDateResource" />
 public static class AmericasCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
@@ -40,6 +40,7 @@ namespace Bodu.Globalization.Calendar.Data;
 /// </example>
 /// <seealso cref="NotableDateService" />
 /// <seealso cref="NotableDateResource" />
+/// <seealso href="../guides/calendar/data-packs.html">Calendar data packs (guide)</seealso>
 public static class AmericasCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
@@ -36,6 +36,7 @@ namespace Bodu.Globalization.Calendar.Data;
 /// </example>
 /// <seealso cref="NotableDateService" />
 /// <seealso cref="NotableDateResource" />
+/// <seealso href="../guides/calendar/data-packs.html">Calendar data packs (guide)</seealso>
 public static class AsiaPacificCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.AsiaPacific/src/AsiaPacificCalendarData.cs
@@ -18,7 +18,24 @@ namespace Bodu.Globalization.Calendar.Data;
 /// subdivision (<c>AU-WA</c>); the subdivision selects the same country resource, and the resolver filters by the full
 /// territory at query time.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Call <see cref="CreateService(string)" /> for a ready-to-query
+/// <see cref="NotableDateService" />, or <see cref="LoadResource(string)" /> when you need the underlying
+/// <see cref="NotableDateResource" /> to compose with custom collaborators or providers.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Query public holidays for Western Australia.
+/// NotableDateService service = AsiaPacificCalendarData.CreateService("AU-WA");
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+/// IReadOnlyList<NotableDate> holidays = service.Resolve(year, "AU-WA");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateService" />
+/// <seealso cref="NotableDateResource" />
 public static class AsiaPacificCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
@@ -19,7 +19,24 @@ namespace Bodu.Globalization.Calendar.Data;
 /// subdivision (<c>GB-SCT</c>); the subdivision selects the same country resource, and the resolver filters by the full
 /// territory at query time.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Call <see cref="CreateService(string)" /> for a ready-to-query
+/// <see cref="NotableDateService" />, or <see cref="LoadResource(string)" /> when you need the underlying
+/// <see cref="NotableDateResource" /> to compose with custom collaborators or providers.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Scotland observes a different bank-holiday set from the rest of Great Britain.
+/// NotableDateService service = EuropeCalendarData.CreateService("GB-SCT");
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+/// IReadOnlyList<NotableDate> holidays = service.Resolve(year, "GB-SCT");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateService" />
+/// <seealso cref="NotableDateResource" />
 public static class EuropeCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Europe/src/EuropeCalendarData.cs
@@ -37,6 +37,7 @@ namespace Bodu.Globalization.Calendar.Data;
 /// </example>
 /// <seealso cref="NotableDateService" />
 /// <seealso cref="NotableDateResource" />
+/// <seealso href="../guides/calendar/data-packs.html">Calendar data packs (guide)</seealso>
 public static class EuropeCalendarData
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
@@ -17,7 +17,30 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// The service is registered as a singleton because a <see cref="NotableDateResource" /> is immutable and the resolver
 /// holds no shared mutable state, so a single instance can be shared across the application safely.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Use <see cref="AddNotableDateService(IServiceCollection, NotableDateResource)" /> when
+/// the resource is available at startup, the factory overload when it must be built from other registered services, and
+/// <see cref="AddReloadableNotableDateService(IServiceCollection, NotableDateResource)" /> when the data must be
+/// swapped at runtime without restarting the host.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Register a service over a bundled data pack at application startup.
+/// builder.Services.AddNotableDateService(AmericasCalendarData.LoadResource("US"));
+///
+/// // Consume it anywhere through constructor injection.
+/// public sealed class PayrollCalendar(INotableDateService notableDates)
+/// {
+///     public bool IsBankHoliday(DateOnly date) =>
+///         notableDates.Resolve(date, "US").Any(n => n.Category == NotableDateCategory.BankHoliday);
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDateResource" />
 public static class NotableDateServiceCollectionExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/src/NotableDateServiceCollectionExtensions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Extensions.DependencyInjection;
 /// </example>
 /// <seealso cref="INotableDateService" />
 /// <seealso cref="NotableDateResource" />
+/// <seealso href="../guides/calendar/dependency-injection.html">Calendar dependency injection (guide)</seealso>
 public static class NotableDateServiceCollectionExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Plugins/src/INotableDateAlgorithmPlugin.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/INotableDateAlgorithmPlugin.cs
@@ -41,6 +41,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// </example>
 /// <seealso cref="NotableDatePluginAttribute" />
 /// <seealso cref="NotableDatePluginLoader" />
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public interface INotableDateAlgorithmPlugin : INotableDatePlugin
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Plugins/src/INotableDateAlgorithmPlugin.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/INotableDateAlgorithmPlugin.cs
@@ -12,6 +12,35 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// A plugin that contributes one or more custom <see cref="INotableDateAlgorithm" /> implementations keyed by algorithm
 /// key, which a host registers with a <see cref="NotableDateAlgorithmRegistry" />.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Implement this interface on the plugin's entry-point type, declare that type with an assembly-level
+/// <see cref="NotableDatePluginAttribute" />, and return each algorithm under the key its referencing rules use. A host
+/// activates the plugin through <see cref="NotableDatePluginLoader" /> and registers the algorithms with
+/// <see cref="NotableDatePluginLoader.RegisterAlgorithms" />.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // The plugin entry point, declared at assembly level.
+/// [assembly: NotableDatePlugin(typeof(ContosoCalendarPlugin))]
+///
+/// public sealed class ContosoCalendarPlugin : INotableDateAlgorithmPlugin
+/// {
+///     public string Name => "Contoso Calendar";
+///     public Version Version => new(1, 0, 0);
+///
+///     public IEnumerable<KeyValuePair<string, INotableDateAlgorithm>> GetAlgorithms()
+///     {
+///         yield return new("contoso.march-equinox", new MarchEquinoxAlgorithm());
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDatePluginAttribute" />
+/// <seealso cref="NotableDatePluginLoader" />
 public interface INotableDateAlgorithmPlugin : INotableDatePlugin
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Plugins/src/INotableDatePlugin.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/INotableDatePlugin.cs
@@ -7,19 +7,29 @@
 namespace Bodu.Globalization.Calendar.Plugins;
 
 /// <summary>
-/// The base contract implemented by every notable-date plugin, exposing identity used by hosts for diagnostics and
-/// logging.
+/// The base contract implemented by every notable-date plugin, exposing the identity a host uses for diagnostics,
+/// logging, and version reporting.
 /// </summary>
+/// <remarks>
+/// <para>
+/// This is the marker every plugin shares; capability-specific contracts derive from it — for example
+/// <see cref="INotableDateAlgorithmPlugin" />, which contributes custom algorithms. A host activates the plugin through
+/// <see cref="NotableDatePluginLoader" /> and reads <see cref="Name" /> and <see cref="Version" /> purely for reporting;
+/// neither participates in trust evaluation, which is governed entirely by the <see cref="IPluginTrustPolicy" />.
+/// </para>
+/// </remarks>
+/// <seealso cref="INotableDateAlgorithmPlugin" />
+/// <seealso cref="NotableDatePluginLoader" />
 public interface INotableDatePlugin
 {
     /// <summary>
-    /// Gets the human-readable name of the plugin.
+    /// Gets the human-readable name of the plugin, used by hosts for diagnostics and logging.
     /// </summary>
     /// <returns>The plugin name.</returns>
     string Name { get; }
 
     /// <summary>
-    /// Gets the version of the plugin.
+    /// Gets the version of the plugin, used by hosts for diagnostics and compatibility reporting.
     /// </summary>
     /// <returns>The plugin version.</returns>
     Version Version { get; }

--- a/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
@@ -49,6 +49,7 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// <seealso cref="IPluginTrustPolicy" />
 /// <seealso cref="INotableDateAlgorithmPlugin" />
 /// <seealso cref="NotableDateAlgorithmRegistry" />
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public static class NotableDatePluginLoader
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
+++ b/Bodu.Globalization.Calendar.Plugins/src/NotableDatePluginLoader.cs
@@ -21,7 +21,34 @@ namespace Bodu.Globalization.Calendar.Plugins;
 /// Trust is evaluated before the plugin's entry-point type is activated, so an untrusted assembly's constructor never
 /// runs. The file-path overload loads the assembly into a dedicated <see cref="AssemblyLoadContext" />.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Load a plugin with one of the <c>LoadFrom</c> overloads, register its contributed
+/// algorithms into a <see cref="NotableDateAlgorithmRegistry" /> with <see cref="RegisterAlgorithms" />, then pass that
+/// registry to both <see cref="NotableDateResourceLoader" /> (so documents may reference the plugin's algorithm keys
+/// during validation) and the <see cref="NotableDateService" /> (so they resolve at query time). Always supply a
+/// production-grade <see cref="IPluginTrustPolicy" /> — <see cref="AllowAllPluginTrustPolicy" /> is for development
+/// only.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Gate activation behind a strong-name trust policy, then register the plugin's algorithms.
+/// IPluginTrustPolicy trust = new StrongNamePluginTrustPolicy(new[] { "c0ffee1234567890" });
+/// INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom("Contoso.Calendar.Plugin.dll", trust);
+///
+/// NotableDateAlgorithmRegistry registry = new();
+/// int registered = NotableDatePluginLoader.RegisterAlgorithms(plugin, registry);
+///
+/// // Wire the registry into the load and resolve pipeline so rules can reference the plugin keys.
+/// NotableDateResource resource = NotableDateResourceLoader.Load(documentXml, _ => null, registry);
+/// NotableDateService service = new(resource, registry);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="IPluginTrustPolicy" />
+/// <seealso cref="INotableDateAlgorithmPlugin" />
+/// <seealso cref="NotableDateAlgorithmRegistry" />
 public static class NotableDatePluginLoader
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateFiscalExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateFiscalExtensions.cs
@@ -34,6 +34,7 @@ namespace Bodu.Extensions;
 /// </example>
 /// <seealso cref="NotableDateOnlyExtensions" />
 /// <seealso cref="INotableDateService" />
+/// <seealso href="../guides/calendar/working-days.html">Working-day arithmetic (guide)</seealso>
 public static class NotableDateFiscalExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateFiscalExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateFiscalExtensions.cs
@@ -17,6 +17,23 @@ namespace Bodu.Extensions;
 /// or inside the boundary, found by snapping the period's first day forward and its last day backward.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateOnly anyDay = new(2026, 9, 15);
+///
+/// // United States federal fiscal year begins 1 October.
+/// DateOnly fyOpen = anyDay.FirstWorkingDayOfFiscalYear(10, service, "US");
+/// DateOnly fyClose = anyDay.LastWorkingDayOfFiscalYear(10, service, "US");
+///
+/// // The working-day bounds of the containing fiscal quarter.
+/// DateOnly qOpen = anyDay.FirstWorkingDayOfFiscalQuarter(10, service, "US");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateOnlyExtensions" />
+/// <seealso cref="INotableDateService" />
 public static class NotableDateFiscalExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateOnlyExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateOnlyExtensions.cs
@@ -50,6 +50,7 @@ namespace Bodu.Extensions;
 /// <seealso cref="NotableDate" />
 /// <seealso cref="NotableDateFilter" />
 /// <seealso cref="WeekPattern" />
+/// <seealso href="../guides/calendar/working-days.html">Working-day arithmetic (guide)</seealso>
 public static class NotableDateOnlyExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateOnlyExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateOnlyExtensions.cs
@@ -15,9 +15,41 @@ namespace Bodu.Extensions;
 /// A working day is a day that is neither outside the working week nor a non-working notable date. The working week
 /// defaults to Monday through Friday and can be overridden with a <see cref="WeekPattern" />. The traversal and
 /// counting methods resolve each candidate day through the service, so prefer the range-based
-/// <see cref="EnumerateNotableDates" /> for large windows.
+/// <see cref="EnumerateNotableDates(DateOnly, DateOnly, INotableDateService, string, NotableDateFilter)" /> for large
+/// windows.
+/// </para>
+/// <para>
+/// <strong>Method groups.</strong> <c>IsWeekend</c> / <c>IsWorkingDay</c> / <c>IsNonWorkingDay</c> /
+/// <c>IsNotableDate</c> test a single day; <c>NextWorkingDay</c> / <c>PreviousWorkingDay</c> / <c>SnapToWorkingDay</c>
+/// (and the <c>NonWorkingDay</c> / <c>NotableDate</c> variants) traverse to a nearby day; <c>AddWorkingDays</c> /
+/// <c>WorkingDaysBetween</c> count working days; and <c>EnumerateWorkingDays</c> / <c>EnumerateNonWorkingDays</c> /
+/// <c>EnumerateNotableDates</c> stream a window.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateOnly date = new(2026, 7, 3); // Friday, observed Independence Day in the US
+///
+/// // Is this a working day?
+/// bool working = date.IsWorkingDay(service, "US"); // false
+///
+/// // Settlement date three working days out, skipping weekends and holidays.
+/// DateOnly settles = date.AddWorkingDays(3, service, "US");
+///
+/// // The next working day on or after a candidate date.
+/// DateOnly resume = date.SnapToWorkingDay(service, "US");
+///
+/// // Every notable date in July 2026.
+/// IReadOnlyList<NotableDate> july = date.GetNotableDatesInMonth(service, "US");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDate" />
+/// <seealso cref="NotableDateFilter" />
+/// <seealso cref="WeekPattern" />
 public static class NotableDateOnlyExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeExtensions.cs
@@ -31,6 +31,7 @@ namespace Bodu.Extensions;
 /// </example>
 /// <seealso cref="NotableDateOnlyExtensions" />
 /// <seealso cref="INotableDateService" />
+/// <seealso href="../guides/calendar/working-days.html">Working-day arithmetic (guide)</seealso>
 public static class NotableDateTimeExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeExtensions.cs
@@ -16,6 +16,21 @@ namespace Bodu.Extensions;
 /// <see cref="DateTime" /> preserve the original time-of-day and <see cref="DateTime.Kind" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateTime stamp = new(2026, 12, 25, 9, 30, 0, DateTimeKind.Local); // Christmas morning
+///
+/// bool working = stamp.IsWorkingDay(service, "US"); // false
+///
+/// // The next working day keeps the original 09:30 local time-of-day.
+/// DateTime resume = stamp.NextWorkingDay(service, "US");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateOnlyExtensions" />
+/// <seealso cref="INotableDateService" />
 public static class NotableDateTimeExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeOffsetExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeOffsetExtensions.cs
@@ -17,6 +17,21 @@ namespace Bodu.Extensions;
 /// <see cref="DateTimeOffset.Offset" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateTimeOffset stamp = new(2026, 7, 3, 14, 0, 0, TimeSpan.FromHours(-5)); // observed Independence Day
+///
+/// bool working = stamp.IsWorkingDay(service, "US"); // false
+///
+/// // The next working day keeps the original time-of-day and -05:00 offset.
+/// DateTimeOffset resume = stamp.NextWorkingDay(service, "US");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateOnlyExtensions" />
+/// <seealso cref="INotableDateService" />
 public static class NotableDateTimeOffsetExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeOffsetExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Extensions/NotableDateTimeOffsetExtensions.cs
@@ -32,6 +32,7 @@ namespace Bodu.Extensions;
 /// </example>
 /// <seealso cref="NotableDateOnlyExtensions" />
 /// <seealso cref="INotableDateService" />
+/// <seealso href="../guides/calendar/working-days.html">Working-day arithmetic (guide)</seealso>
 public static class NotableDateTimeOffsetExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentAction.cs
@@ -11,10 +11,14 @@ namespace Bodu.Globalization.Calendar;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Working-day aware actions treat Saturday and Sunday as non-working days. A pluggable non-working-day calendar that
-/// also skips holidays is reserved for a later phase.
+/// Working-day aware actions treat the days outside the resource's working week as non-working. Whether they also step
+/// over days already claimed by other non-working occurrences is controlled by the owning policy's
+/// <see cref="AdjustmentPolicy.SkipNonWorkingDates" /> flag.
 /// </para>
 /// </remarks>
+/// <seealso cref="AdjustmentTrigger" />
+/// <seealso cref="AdjustmentPolicy" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public enum AdjustmentAction
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentPolicy.cs
@@ -22,6 +22,10 @@ namespace Bodu.Globalization.Calendar;
 /// substitute past a day already taken by another holiday.
 /// </para>
 /// </remarks>
+/// <seealso cref="AdjustmentScope" />
+/// <seealso cref="AdjustmentTrigger" />
+/// <seealso cref="AdjustmentAction" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public sealed class AdjustmentPolicy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentScope.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentScope.cs
@@ -17,6 +17,8 @@ namespace Bodu.Globalization.Calendar;
 /// satisfy every populated dimension.
 /// </para>
 /// </remarks>
+/// <seealso cref="AdjustmentPolicy" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public sealed class AdjustmentScope
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/AdjustmentTrigger.cs
@@ -9,6 +9,9 @@ namespace Bodu.Globalization.Calendar;
 /// <summary>
 /// Identifies the condition that determines whether an adjustment policy applies to a calculated occurrence.
 /// </summary>
+/// <seealso cref="AdjustmentAction" />
+/// <seealso cref="AdjustmentPolicy" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public enum AdjustmentTrigger
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/AlgorithmDateStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/AlgorithmDateStrategy.cs
@@ -17,6 +17,9 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// zone appropriate to the observance (for example Japan Standard Time for the Japanese equinox holidays).
 /// </para>
 /// </remarks>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso cref="INotableDateAlgorithm" />
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public sealed class AlgorithmDateStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/DayOfWeekInMonthStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/DayOfWeekInMonthStrategy.cs
@@ -10,6 +10,8 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// Calculates a notable date that falls on the nth (or last) occurrence of a weekday within a month, such as the fourth
 /// Thursday of November or the last Monday of May.
 /// </summary>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class DayOfWeekInMonthStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/FixedDateStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/FixedDateStrategy.cs
@@ -18,6 +18,10 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// leap-month skip (for the Chinese lunisolar calendar).
 /// </para>
 /// </remarks>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso cref="CalendarSystem" />
+/// <seealso href="../guides/calendar/non-gregorian-calendars.html">Working with non-Gregorian calendars (guide)</seealso>
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class FixedDateStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/IDateCalculationStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/IDateCalculationStrategy.cs
@@ -12,8 +12,12 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The first cut of the v2 engine ships a single implementation, <see cref="FixedDateStrategy" />. The interface is the
-/// extension point through which later phases add weekday-based, offset, and algorithm strategies.
+/// The engine ships a strategy per authoring shape — among them <see cref="FixedDateStrategy" />,
+/// <see cref="DayOfWeekInMonthStrategy" />, <see cref="RelativeWeekdayInMonthStrategy" />,
+/// <see cref="WeekdayNearDateStrategy" />, <see cref="OffsetFromRuleStrategy" />, and
+/// <see cref="AlgorithmDateStrategy" /> (which dispatches to a registered <see cref="INotableDateAlgorithm" />). A
+/// strategy is selected per rule when a document is loaded; consumers extend the catalogue through
+/// <see cref="INotableDateAlgorithm" /> rather than by implementing this interface directly.
 /// </para>
 /// </remarks>
 public interface IDateCalculationStrategy

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/IDateCalculationStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/IDateCalculationStrategy.cs
@@ -20,6 +20,9 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// <see cref="INotableDateAlgorithm" /> rather than by implementing this interface directly.
 /// </para>
 /// </remarks>
+/// <seealso cref="INotableDateAlgorithm" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public interface IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/INotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/INotableDateAlgorithm.cs
@@ -16,7 +16,29 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// Implementations must be deterministic, side-effect-free, and thread-safe, and should return <see langword="null" />
 /// for a year outside their supported range rather than throwing.
 /// </para>
+/// <para>
+/// <strong>When to implement.</strong> Provide a custom algorithm when a notable date follows a computation the
+/// built-in strategies do not cover — for example an astronomical event or a bespoke ecclesiastical rule. Register the
+/// implementation under a key in an <see cref="INotableDateAlgorithmRegistry" />, pass that registry to the loader and
+/// the <see cref="NotableDateService" />, and reference the key from a rule's algorithm strategy.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // A custom algorithm returning the March equinox (UTC) for the supplied year.
+/// public sealed class MarchEquinoxAlgorithm : INotableDateAlgorithm
+/// {
+///     public DateOnly? Calculate(int year) =>
+///         year is >= 1900 and <= 2100
+///             ? DateOnly.FromDateTime(AstronomyTables.MarchEquinox(year))
+///             : null; // unsupported year: return null rather than throw
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateAlgorithmRegistry" />
+/// <seealso cref="AlgorithmDateStrategy" />
 public interface INotableDateAlgorithm
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/INotableDateAlgorithm.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/INotableDateAlgorithm.cs
@@ -39,6 +39,7 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// </example>
 /// <seealso cref="INotableDateAlgorithmRegistry" />
 /// <seealso cref="AlgorithmDateStrategy" />
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public interface INotableDateAlgorithm
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/NotableDateAlgorithmRegistry.cs
@@ -14,7 +14,26 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// Keys are matched ordinally and are case-sensitive, mirroring the engine's built-in algorithm keys. Registering a key
 /// that is already present replaces the previous algorithm.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Populate a registry with custom <see cref="INotableDateAlgorithm" /> implementations,
+/// then pass it to <see cref="NotableDateResourceLoader" /> (so a document may reference the keys during validation) and
+/// to the <see cref="NotableDateService" /> (so they resolve at query time).
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// NotableDateAlgorithmRegistry registry = new NotableDateAlgorithmRegistry()
+///     .Register("contoso.march-equinox", new MarchEquinoxAlgorithm())
+///     .Register("contoso.harvest-moon", new HarvestMoonAlgorithm());
+///
+/// NotableDateResource resource = NotableDateResourceLoader.Load(documentXml, _ => null, registry);
+/// NotableDateService service = new(resource, registry);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateAlgorithm" />
+/// <seealso cref="NotableDateService" />
 public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/NotableDateAlgorithmRegistry.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/NotableDateAlgorithmRegistry.cs
@@ -34,6 +34,7 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// </example>
 /// <seealso cref="INotableDateAlgorithm" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/algorithms.html">Date calculation algorithms (guide)</seealso>
 public sealed class NotableDateAlgorithmRegistry : INotableDateAlgorithmRegistry
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/OffsetFromRuleStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/OffsetFromRuleStrategy.cs
@@ -16,6 +16,8 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// produces no occurrence; the loader reports the unresolved or ambiguous reference as a validation error.
 /// </para>
 /// </remarks>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class OffsetFromRuleStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/RelativeWeekdayInMonthStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/RelativeWeekdayInMonthStrategy.cs
@@ -10,6 +10,8 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// Calculates a notable date that falls on a weekday relative to an anchor weekday occurrence within a month, such as
 /// the Tuesday after the first Monday of November (United States general election day).
 /// </summary>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class RelativeWeekdayInMonthStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/WeekdayNearDateStrategy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Algorithms/WeekdayNearDateStrategy.cs
@@ -10,6 +10,8 @@ namespace Bodu.Globalization.Calendar.Algorithms;
 /// Calculates a notable date that falls on a weekday on, before, after, or nearest to a fixed month and day, such as
 /// the Monday on or after 24 May.
 /// </summary>
+/// <seealso cref="IDateCalculationStrategy" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class WeekdayNearDateStrategy : IDateCalculationStrategy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarSystem.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/CalendarSystem.cs
@@ -16,6 +16,8 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="System.Globalization.Calendar" /> provided by the base class library.
 /// </para>
 /// </remarks>
+/// <seealso cref="FixedDateStrategy" />
+/// <seealso href="../guides/calendar/non-gregorian-calendars.html">Working with non-Gregorian calendars (guide)</seealso>
 public enum CalendarSystem
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/DateRange.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/DateRange.cs
@@ -11,6 +11,27 @@ namespace Bodu.Globalization.Calendar;
 /// </summary>
 /// <param name="StartDate">The first day of the range, inclusive.</param>
 /// <param name="EndDate">The last day of the range, inclusive.</param>
+/// <remarks>
+/// <para>
+/// Both endpoints are inclusive, so a range whose start equals its end spans a single day and reports a
+/// <see cref="DayCount" /> of one. The struct does not enforce ordering at construction; <see cref="IsValid" /> reports
+/// whether the start is on or before the end, and the containment and overlap members return <see langword="false" />
+/// for an ill-formed range rather than throwing.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // The whole of 2026, passed to a service query.
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+/// int days = year.DayCount;                       // 365
+/// bool inRange = year.Contains(new DateOnly(2026, 7, 4)); // true
+///
+/// IReadOnlyList<NotableDate> occurrences = service.Resolve(year, "US");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
 public readonly record struct DateRange(DateOnly StartDate, DateOnly EndDate)
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
@@ -38,6 +38,7 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="AdjustmentHandlerContext" />
 /// <seealso cref="AdjustmentAction" />
 /// <seealso cref="IAdjustmentHandlerRegistry" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public interface IAdjustmentHandler
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentHandler.cs
@@ -17,6 +17,27 @@ namespace Bodu.Globalization.Calendar;
 /// it can resolve other rules or test whether candidate days are already claimed by non-working occurrences.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Move the occurrence to the next day that is not already claimed by another non-working date.
+/// public sealed class NextFreeDayHandler : IAdjustmentHandler
+/// {
+///     public DateOnly? Adjust(AdjustmentHandlerContext context)
+///     {
+///         DateOnly date = context.BaseDate;
+///         while (context.IsOccupied(date))
+///             date = date.AddDays(1);
+///
+///         return date == context.BaseDate ? null : date; // null leaves it on the calculated date
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="AdjustmentHandlerContext" />
+/// <seealso cref="AdjustmentAction" />
+/// <seealso cref="IAdjustmentHandlerRegistry" />
 public interface IAdjustmentHandler
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentTriggerHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentTriggerHandler.cs
@@ -17,6 +17,26 @@ namespace Bodu.Globalization.Calendar;
 /// resolution context, so it can resolve other rules for the same year when deciding whether to fire.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Fire only in leap years, reading a policy parameter for the toggle.
+/// public sealed class LeapYearTriggerHandler : IAdjustmentTriggerHandler
+/// {
+///     public bool ShouldAdjust(AdjustmentTriggerContext context)
+///     {
+///         bool enabled = !context.Parameters.TryGetValue("enabled", out string? flag)
+///             || bool.Parse(flag);
+///
+///         return enabled && DateTime.IsLeapYear(context.BaseDate.Year);
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="AdjustmentTriggerContext" />
+/// <seealso cref="AdjustmentTrigger" />
+/// <seealso cref="IAdjustmentTriggerHandlerRegistry" />
 public interface IAdjustmentTriggerHandler
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentTriggerHandler.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/IAdjustmentTriggerHandler.cs
@@ -37,6 +37,7 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="AdjustmentTriggerContext" />
 /// <seealso cref="AdjustmentTrigger" />
 /// <seealso cref="IAdjustmentTriggerHandlerRegistry" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public interface IAdjustmentTriggerHandler
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
@@ -62,6 +62,7 @@ namespace Bodu.Globalization.Calendar;
 /// </example>
 /// <seealso cref="NotableDate" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
 public interface INotableDateProvider
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateProvider.cs
@@ -24,6 +24,44 @@ namespace Bodu.Globalization.Calendar;
 /// provider that needs observed-date shifting must compute it itself.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Contribute a company founding anniversary that is not expressible as an authored rule.
+/// public sealed class FoundingDayProvider : INotableDateProvider
+/// {
+///     public IEnumerable<NotableDate> GetNotableDates(DateRange range, string territory)
+///     {
+///         for (int year = range.StartDate.Year; year <= range.EndDate.Year; year++)
+///         {
+///             DateOnly date = new(year, 6, 15);
+///             yield return new NotableDate(
+///                 Date: date,
+///                 ActualDate: date,
+///                 IsObserved: false,
+///                 Identity: new NotableDateRuleIdentity("company", "company-founding", "fixed"),
+///                 DisplayName: "Company Founding Day",
+///                 TerritoryCode: territory,
+///                 Category: NotableDateCategory.Observance,
+///                 Priority: 0,
+///                 DurationDays: 1,
+///                 IsNonWorkingDay: false,
+///                 Tags: Array.Empty<string>(),
+///                 AdjustmentPolicyId: null,
+///                 AdjustmentReason: null);
+///         }
+///     }
+/// }
+///
+/// // Register the provider through the collaborator-aware constructor.
+/// NotableDateService service = new(
+///     resource, algorithms: null, collisionResolver: null, handlers: null,
+///     triggerHandlers: null, providers: new[] { new FoundingDayProvider() });
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDate" />
+/// <seealso cref="NotableDateService" />
 public interface INotableDateProvider
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -7,8 +7,56 @@
 namespace Bodu.Globalization.Calendar;
 
 /// <summary>
-/// Resolves notable-date occurrences for a requested territory and day or date range.
+/// Resolves notable-date occurrences — public holidays, observances, and other named dates — for a requested territory
+/// and a single day or an inclusive date range.
 /// </summary>
+/// <remarks>
+/// <para>
+/// An implementation draws its occurrences from a loaded <see cref="NotableDateResource" /> and applies the resource's
+/// resolution policy: it calculates each rule's actual date, places any observed (substitute) date, resolves same-day
+/// collisions, and emits the surviving <see cref="NotableDate" /> occurrences. The canonical implementation is
+/// <see cref="NotableDateService" />.
+/// </para>
+/// <para>
+/// <strong>Territory.</strong> The <c>territory</c> argument is a country code (<c>US</c>) or a subdivision
+/// (<c>CA-ON</c>, <c>AU-NSW</c>). A subdivision sees both its own rules and the broader rules of its parent country,
+/// with the most specific rule winning for a shared concept.
+/// </para>
+/// <para>
+/// <strong>Inclusion by emitted date.</strong> An occurrence is included when its emitted (observed) date falls on the
+/// requested day or within the requested range, so a single-day query and a range query covering the same dates return
+/// consistent results.
+/// </para>
+/// <para>
+/// <strong>When to use.</strong> Resolve a service from a data pack (for example the <c>AmericasCalendarData</c>
+/// bundle) or from a document loaded with
+/// <see cref="NotableDateResourceLoader" />, then query it directly; or call the working-day extension methods in
+/// <c>Bodu.Extensions</c> (such as <c>IsWorkingDay</c> / <c>NextWorkingDay</c>), which delegate to this surface.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Resolve a service over a country's bundled rules.
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+///
+/// // Every notable date emitted on a single day.
+/// IReadOnlyList<NotableDate> newYear = service.Resolve(new DateOnly(2026, 1, 1), "US");
+///
+/// // Non-working public holidays across a whole year, restricted by a filter.
+/// NotableDateFilter holidays = NotableDateFilter
+///     .ForCategory(NotableDateCategory.PublicHoliday)
+///     .And(NotableDateFilter.IsNonWorkingDay());
+///
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+/// IReadOnlyList<NotableDate> publicHolidays = service.Resolve(year, "US", holidays);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateService" />
+/// <seealso cref="NotableDate" />
+/// <seealso cref="NotableDateFilter" />
+/// <seealso cref="NotableDateResourceLoader" />
 public interface INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/INotableDateService.cs
@@ -57,6 +57,8 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="NotableDate" />
 /// <seealso cref="NotableDateFilter" />
 /// <seealso cref="NotableDateResourceLoader" />
+/// <seealso href="../guides/calendar/notable-dates.html">Using NotableDateService (guide)</seealso>
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
 public interface INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
@@ -32,6 +32,7 @@ namespace Bodu.Globalization.Calendar;
 /// </example>
 /// <seealso cref="ReloadableNotableDateService" />
 /// <seealso cref="INotableDateResourceProvider" />
+/// <seealso href="../guides/calendar/dependency-injection.html">Calendar dependency injection (guide)</seealso>
 public sealed class MutableNotableDateResourceProvider : INotableDateResourceProvider
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/MutableNotableDateResourceProvider.cs
@@ -18,6 +18,20 @@ namespace Bodu.Globalization.Calendar;
 /// <see cref="NotableDateResource" /> and passing it to <see cref="Reload" />.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// MutableNotableDateResourceProvider provider = new(NotableDateResourceLoader.Load(initialXml));
+/// INotableDateService service = new ReloadableNotableDateService(provider);
+///
+/// // Later, when the source document changes, swap in fresh data; the service picks it up
+/// // on its next query without being rebuilt.
+/// provider.Reload(NotableDateResourceLoader.Load(updatedXml));
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="ReloadableNotableDateService" />
+/// <seealso cref="INotableDateResourceProvider" />
 public sealed class MutableNotableDateResourceProvider : INotableDateResourceProvider
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDate.cs
@@ -27,6 +27,9 @@ namespace Bodu.Globalization.Calendar;
 /// The identifier of the adjustment policy that produced the observed date, if any.
 /// </param>
 /// <param name="AdjustmentReason">The reason recorded by the adjustment policy, if any.</param>
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDateRuleIdentity" />
+/// <seealso href="../guides/calendar/notable-dates.html">Using NotableDateService (guide)</seealso>
 public sealed record NotableDate(
     DateOnly Date,
     DateOnly? ActualDate,

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateCategory.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateCategory.cs
@@ -15,6 +15,8 @@ namespace Bodu.Globalization.Calendar;
 /// notable dates may share a category freely. A rule may override the category inherited from its parent notable date.
 /// </para>
 /// </remarks>
+/// <seealso cref="NotableDateFilter" />
+/// <seealso href="../guides/calendar/notable-dates.html">Using NotableDateService (guide)</seealso>
 public enum NotableDateCategory
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateDefinition.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateDefinition.cs
@@ -16,6 +16,8 @@ namespace Bodu.Globalization.Calendar;
 /// merely share a display name — coexist as distinct, independently addressable rules rather than collapsing.
 /// </para>
 /// </remarks>
+/// <seealso cref="NotableDateRule" />
+/// <seealso href="../guides/calendar/rule-reference.html">NotableDateRule and adjustment-policy reference (guide)</seealso>
 public sealed class NotableDateDefinition
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -9,15 +9,55 @@ namespace Bodu.Globalization.Calendar;
 /// <summary>
 /// Represents a composable predicate over resolved <see cref="NotableDate" /> occurrences, used to restrict the results
 /// returned by <see cref="INotableDateService" /> to those matching a category, tag, name, duration, or observed-state
-/// criterion.
+/// criterion. This class cannot be inherited.
 /// </summary>
 /// <remarks>
 /// <para>
-/// Filters are immutable and may be combined with <see cref="And(NotableDateFilter)" />,
-/// <see cref="Or(NotableDateFilter)" />, <see cref="AllOf(NotableDateFilter[])" />, and
-/// <see cref="AnyOf(NotableDateFilter[])" /> to express compound criteria.
+/// <strong>Construction.</strong> A filter is created through the static factory methods on this class — for example
+/// <see cref="ForCategory(NotableDateCategory)" />, <see cref="WithTag(string)" />,
+/// <see cref="IsNonWorkingDay()" />, and <see cref="InDateRange(DateOnly, DateOnly)" />. There is no public
+/// constructor; every factory returns an immutable instance.
+/// </para>
+/// <para>
+/// <strong>Composition.</strong> Filters combine through the instance operators <see cref="And(NotableDateFilter)" />,
+/// <see cref="Or(NotableDateFilter)" />, and <see cref="Not()" />, and the variadic factories
+/// <see cref="AllOf(NotableDateFilter[])" /> and <see cref="AnyOf(NotableDateFilter[])" />. Because every instance is
+/// immutable, composition always produces a new filter and never mutates an operand, so a filter can be cached and
+/// reused across queries and threads.
+/// </para>
+/// <para>
+/// <strong>Evaluation.</strong> A filter is evaluated against each materialized occurrence after resolution: pass a
+/// filter to one of the <c>Resolve</c> overloads on <see cref="INotableDateService" /> (which keeps only the
+/// occurrences for which <see cref="Matches(NotableDate)" /> returns <see langword="true" />), or call
+/// <see cref="Matches(NotableDate)" /> directly to test a single occurrence.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+/// DateRange year = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
+///
+/// // Non-working public holidays only.
+/// NotableDateFilter publicHolidays = NotableDateFilter
+///     .ForCategory(NotableDateCategory.PublicHoliday)
+///     .And(NotableDateFilter.IsNonWorkingDay());
+///
+/// IReadOnlyList<NotableDate> holidays = service.Resolve(year, "US", publicHolidays);
+///
+/// // Religious or cultural dates tagged "Christian", excluding observed substitutes.
+/// NotableDateFilter christian = NotableDateFilter
+///     .ForAnyCategory(NotableDateCategory.Religious, NotableDateCategory.Cultural)
+///     .And(NotableDateFilter.WithTag("Christian"))
+///     .And(NotableDateFilter.WasAdjusted().Not());
+///
+/// IReadOnlyList<NotableDate> observances = service.Resolve(year, "US", christian);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDate" />
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDateCategory" />
 public sealed class NotableDateFilter
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateFilter.cs
@@ -58,6 +58,7 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="NotableDate" />
 /// <seealso cref="INotableDateService" />
 /// <seealso cref="NotableDateCategory" />
+/// <seealso href="../guides/calendar/notable-dates.html">Using NotableDateService (guide)</seealso>
 public sealed class NotableDateFilter
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateLocalizationExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateLocalizationExtensions.cs
@@ -12,6 +12,26 @@ namespace Bodu.Globalization.Calendar;
 /// Provides extension methods that apply an <see cref="INotableDateNameLocalizer" /> to resolved occurrences, replacing
 /// each display name with its culture-specific form.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Resolution always emits the authored (invariant) display name; localization is a separate, opt-in step applied to
+/// the results. When the localizer supplies no name for an occurrence in the requested culture, that occurrence is
+/// returned unchanged so the invariant name remains as a fallback.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// IReadOnlyList<NotableDate> dates = service.Resolve(2026, "CA-QC");
+///
+/// // Replace display names with their French-Canadian forms where the localizer has them.
+/// INotableDateNameLocalizer localizer = new NotableDateNameLocalizer(translations);
+/// IReadOnlyList<NotableDate> localized = dates.Localize(localizer, CultureInfo.GetCultureInfo("fr-CA"));
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateNameLocalizer" />
+/// <seealso cref="NotableDate" />
 public static class NotableDateLocalizationExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResource.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResource.cs
@@ -23,6 +23,7 @@ namespace Bodu.Globalization.Calendar;
 /// </remarks>
 /// <seealso cref="NotableDateResourceLoader" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
 public sealed class NotableDateResource
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResource.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResource.cs
@@ -15,7 +15,14 @@ namespace Bodu.Globalization.Calendar;
 /// A resource is immutable once loaded. Imports and override operations are applied during loading, so the concepts and
 /// rules exposed here are the effective set used by the resolver.
 /// </para>
+/// <para>
+/// <strong>How obtained.</strong> A resource is normally produced by <see cref="NotableDateResourceLoader" />, a data
+/// pack factory, or <c>NotableDateDocumentBuilder.Build</c>, then handed to a <see cref="NotableDateService" />. The
+/// public constructor exists for advanced code-first assembly; most consumers never call it directly.
+/// </para>
 /// </remarks>
+/// <seealso cref="NotableDateResourceLoader" />
+/// <seealso cref="NotableDateService" />
 public sealed class NotableDateResource
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
@@ -24,7 +24,38 @@ namespace Bodu.Globalization.Calendar;
 /// The overloads without a resolver cannot satisfy imports; a document declaring <c>Imports</c> must be loaded with the
 /// resolver overload, whose delegate maps a resource name to that resource's XML or JSON content.
 /// </para>
+/// <para>
+/// <strong>When to use.</strong> Call <see cref="Load(string)" /> / <see cref="LoadJson(string)" /> (or the
+/// <see cref="Stream" /> overloads) for a self-contained document, and the resolver overloads when the document imports
+/// shared concepts or adjustment policies from other resources. For the bundled territory packs prefer the data-pack
+/// factories (for example the <c>AmericasCalendarData</c> bundle), which load and wire the
+/// embedded resources for you.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // A self-contained document with no imports.
+/// NotableDateResource resource = NotableDateResourceLoader.Load(documentXml);
+/// NotableDateService service = new(resource);
+///
+/// // A document that imports shared concepts: map each import name to its content.
+/// var library = new Dictionary<string, string>(StringComparer.Ordinal)
+/// {
+///     ["common-christian"] = christianXml,
+/// };
+/// NotableDateResource composed = NotableDateResourceLoader.Load(
+///     documentXml,
+///     name => library.TryGetValue(name, out string? content) ? content : null);
+///
+/// // The same pipeline accepts the JSON projection of the schema.
+/// NotableDateResource fromJson = NotableDateResourceLoader.LoadJson(documentJson);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateResource" />
+/// <seealso cref="NotableDateService" />
+/// <seealso cref="NotableDateValidationException" />
 public static class NotableDateResourceLoader
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateResourceLoader.cs
@@ -56,6 +56,7 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="NotableDateResource" />
 /// <seealso cref="NotableDateService" />
 /// <seealso cref="NotableDateValidationException" />
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
 public static class NotableDateResourceLoader
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateRule.cs
@@ -17,6 +17,9 @@ namespace Bodu.Globalization.Calendar;
 /// concept; when <see langword="null" /> the parent value applies.
 /// </para>
 /// </remarks>
+/// <seealso cref="NotableDateDefinition" />
+/// <seealso href="../guides/calendar/rule-reference.html">NotableDateRule and adjustment-policy reference (guide)</seealso>
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public sealed class NotableDateRule
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -52,6 +52,8 @@ namespace Bodu.Globalization.Calendar;
 /// <seealso cref="NotableDateResource" />
 /// <seealso cref="NotableDateResourceLoader" />
 /// <seealso cref="NotableDateFilter" />
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
+/// <seealso href="../guides/calendar/resolution-pipeline.html">The resolution pipeline (guide)</seealso>
 public sealed class NotableDateService : INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateService.cs
@@ -8,7 +8,7 @@ namespace Bodu.Globalization.Calendar;
 
 /// <summary>
 /// Resolves notable-date occurrences from a loaded <see cref="NotableDateResource" /> for a requested territory and day
-/// or date range.
+/// or date range. This class cannot be inherited.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -22,7 +22,36 @@ namespace Bodu.Globalization.Calendar;
 /// return consistent results. To capture occurrences whose actual date lies just outside the requested window but whose
 /// observed date falls inside it, the service scans one civil year either side of the window.
 /// </para>
+/// <para>
+/// <strong>Thread safety.</strong> The service is immutable once constructed and holds no per-query mutable state, so a
+/// single instance is safe to share across threads. Prefer reusing one instance per resource rather than reconstructing
+/// it per query, since each query re-scans the resource.
+/// </para>
+/// <para>
+/// <strong>When to use.</strong> Construct directly from a <see cref="NotableDateResource" /> when you load documents
+/// yourself with <see cref="NotableDateResourceLoader" />; use a data pack's
+/// <c>CreateService</c> factory (for example the <c>AmericasCalendarData</c> bundle) for
+/// bundled rules; or register the service through the dependency-injection extensions for application hosting. Pass the
+/// optional collaborator overloads only when a document references custom algorithms, collision resolvers, or
+/// adjustment handlers.
+/// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Load a document and build a service over it.
+/// NotableDateResource resource = NotableDateResourceLoader.Load(documentXml);
+/// NotableDateService service = new(resource);
+///
+/// // Resolve the occurrences emitted on Christmas Day for Ontario, Canada.
+/// IReadOnlyList<NotableDate> christmas = service.Resolve(new DateOnly(2026, 12, 25), "CA-ON");
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDateResource" />
+/// <seealso cref="NotableDateResourceLoader" />
+/// <seealso cref="NotableDateFilter" />
 public sealed class NotableDateService : INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceExtensions.cs
@@ -10,6 +10,24 @@ namespace Bodu.Globalization.Calendar;
 /// Provides convenience query extension methods over <see cref="INotableDateService" />, including a by-year overload
 /// that resolves a full civil year.
 /// </summary>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// INotableDateService service = AmericasCalendarData.CreateService("US");
+///
+/// // Resolve a whole civil year in one call.
+/// IReadOnlyList<NotableDate> all = service.Resolve(2026, "US");
+///
+/// // Or restrict to non-working public holidays.
+/// NotableDateFilter holidays = NotableDateFilter
+///     .ForCategory(NotableDateCategory.PublicHoliday)
+///     .And(NotableDateFilter.IsNonWorkingDay());
+/// IReadOnlyList<NotableDate> publicHolidays = service.Resolve(2026, "US", holidays);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
+/// <seealso cref="NotableDateFilter" />
 public static class NotableDateServiceExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceExtensions.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateServiceExtensions.cs
@@ -28,6 +28,7 @@ namespace Bodu.Globalization.Calendar;
 /// </example>
 /// <seealso cref="INotableDateService" />
 /// <seealso cref="NotableDateFilter" />
+/// <seealso href="../guides/calendar/notable-dates.html">Using NotableDateService (guide)</seealso>
 public static class NotableDateServiceExtensions
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateValidationException.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateValidationException.cs
@@ -34,6 +34,7 @@ namespace Bodu.Globalization.Calendar;
 /// </example>
 /// <seealso cref="NotableDateValidationDiagnostic" />
 /// <seealso cref="NotableDateResourceLoader" />
+/// <seealso href="../guides/calendar/building-the-service.html">Building and extending the service (guide)</seealso>
 public sealed class NotableDateValidationException : Exception
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateValidationException.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/NotableDateValidationException.cs
@@ -8,8 +8,32 @@ namespace Bodu.Globalization.Calendar;
 
 /// <summary>
 /// The exception thrown when a notable-date document resource fails to load because one or more error-severity
-/// validation diagnostics were produced.
+/// validation diagnostics were produced. This class cannot be inherited.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The <see cref="Diagnostics" /> property carries the full diagnostic set — both the errors that caused the failure
+/// and any warnings gathered along the way — so a caller can report every problem at once rather than discovering them
+/// one load at a time.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// try
+/// {
+///     NotableDateResource resource = NotableDateResourceLoader.Load(documentXml);
+/// }
+/// catch (NotableDateValidationException ex)
+/// {
+///     foreach (NotableDateValidationDiagnostic diagnostic in ex.Diagnostics)
+///         Console.WriteLine($"{diagnostic.Severity} {diagnostic.Code}: {diagnostic.Message}");
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="NotableDateValidationDiagnostic" />
+/// <seealso cref="NotableDateResourceLoader" />
 public sealed class NotableDateValidationException : Exception
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/CollisionPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/CollisionPolicy.cs
@@ -12,9 +12,12 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// <remarks>
 /// <para>
 /// The recommended default is <see cref="KeepAll" />, because multiple notable dates can legitimately occur on the same
-/// day. The first cut of the v2 engine retains all resolved occurrences.
+/// day. The other policies thin a same-day group by priority or category, or defer to an
+/// <see cref="INotableDateCollisionResolver" /> when set to <see cref="Custom" />.
 /// </para>
 /// </remarks>
+/// <seealso cref="INotableDateCollisionResolver" />
+/// <seealso href="../guides/calendar/identity-and-resolution.html">Rule identity, priority, and observed-date resolution (guide)</seealso>
 public enum CollisionPolicy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/DuplicatePolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/DuplicatePolicy.cs
@@ -14,6 +14,8 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// The recommended default is <see cref="Error" />, which surfaces accidental rule collapse rather than hiding it.
 /// </para>
 /// </remarks>
+/// <seealso cref="ResolutionPolicy" />
+/// <seealso href="../guides/calendar/identity-and-resolution.html">Rule identity, priority, and observed-date resolution (guide)</seealso>
 public enum DuplicatePolicy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/EmissionMode.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/EmissionMode.cs
@@ -17,6 +17,8 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// by the emitted occurrence, not by the query shape.
 /// </para>
 /// </remarks>
+/// <seealso cref="AdjustmentPolicy" />
+/// <seealso href="../guides/calendar/adjustment-rules.html">Observance adjustment rules (guide)</seealso>
 public enum EmissionMode
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/INotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/INotableDateCollisionResolver.cs
@@ -38,6 +38,7 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// </example>
 /// <seealso cref="CollisionPolicy" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/identity-and-resolution.html">Rule identity, priority, and observed-date resolution (guide)</seealso>
 public interface INotableDateCollisionResolver
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/INotableDateCollisionResolver.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/INotableDateCollisionResolver.cs
@@ -10,6 +10,34 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// Resolves a set of notable-date occurrences that share the same emitted date, used when the resource's same-day
 /// collision policy is <see cref="CollisionPolicy.Custom" />.
 /// </summary>
+/// <remarks>
+/// <para>
+/// The resolver is consulted once per group of two or more occurrences that land on the same emitted date. It returns
+/// the subset to keep, in the order they should appear; returning an empty list suppresses the date entirely. Pass an
+/// implementation to the collaborator-aware <see cref="NotableDateService" /> constructor, and set the resource's
+/// same-day collision policy to <see cref="CollisionPolicy.Custom" /> so the resolver is invoked.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Keep only the highest-priority occurrence on a contested day, breaking ties by name.
+/// public sealed class HighestPriorityResolver : INotableDateCollisionResolver
+/// {
+///     public IReadOnlyList<NotableDate> Resolve(DateOnly date, IReadOnlyList<NotableDate> colliding)
+///     {
+///         int best = colliding.Max(n => n.Priority);
+///         return colliding
+///             .Where(n => n.Priority == best)
+///             .OrderBy(n => n.DisplayName, StringComparer.Ordinal)
+///             .ToList();
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="CollisionPolicy" />
+/// <seealso cref="NotableDateService" />
 public interface INotableDateCollisionResolver
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/ObservedDateRangePolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/ObservedDateRangePolicy.cs
@@ -16,6 +16,8 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// inside the requested window.
 /// </para>
 /// </remarks>
+/// <seealso cref="ResolutionPolicy" />
+/// <seealso href="../guides/calendar/identity-and-resolution.html">Rule identity, priority, and observed-date resolution (guide)</seealso>
 public enum ObservedDateRangePolicy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/ResolutionPolicy.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RangeResolution/ResolutionPolicy.cs
@@ -16,6 +16,9 @@ namespace Bodu.Globalization.Calendar.RangeResolution;
 /// occurrences, higher priority wins, and the observed (emitted) occurrence controls range inclusion.
 /// </para>
 /// </remarks>
+/// <seealso cref="CollisionPolicy" />
+/// <seealso cref="DuplicatePolicy" />
+/// <seealso href="../guides/calendar/identity-and-resolution.html">Rule identity, priority, and observed-date resolution (guide)</seealso>
 public sealed class ResolutionPolicy
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
@@ -32,6 +32,7 @@ namespace Bodu.Globalization.Calendar;
 /// </example>
 /// <seealso cref="MutableNotableDateResourceProvider" />
 /// <seealso cref="NotableDateService" />
+/// <seealso href="../guides/calendar/dependency-injection.html">Calendar dependency injection (guide)</seealso>
 public sealed class ReloadableNotableDateService : INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/ReloadableNotableDateService.cs
@@ -18,6 +18,20 @@ namespace Bodu.Globalization.Calendar;
 /// constructed. Construction is cheap, so reloads are inexpensive.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// MutableNotableDateResourceProvider provider = new(NotableDateResourceLoader.Load(initialXml));
+/// INotableDateService service = new ReloadableNotableDateService(provider);
+///
+/// IReadOnlyList<NotableDate> before = service.Resolve(2026, "US");
+/// provider.Reload(NotableDateResourceLoader.Load(updatedXml));
+/// IReadOnlyList<NotableDate> after = service.Resolve(2026, "US"); // reflects the reloaded data
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="MutableNotableDateResourceProvider" />
+/// <seealso cref="NotableDateService" />
 public sealed class ReloadableNotableDateService : INotableDateService
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleApplicability.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/RuleApplicability.cs
@@ -17,6 +17,8 @@ namespace Bodu.Globalization.Calendar;
 /// scoped to its parent territory (<c>AU</c>), but a national query does not match a subnational-only rule.
 /// </para>
 /// </remarks>
+/// <seealso cref="NotableDateRule" />
+/// <seealso href="../guides/calendar/territories.html">Territories and regional composition (guide)</seealso>
 public sealed class RuleApplicability
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
@@ -41,6 +41,7 @@ namespace Bodu.Globalization.Calendar;
 /// </code>
 /// </example>
 /// <seealso cref="INotableDateService" />
+/// <seealso href="../guides/calendar/territories.html">Territories and regional composition (guide)</seealso>
 public readonly struct TerritoryCode : IEquatable<TerritoryCode>
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/TerritoryCode.cs
@@ -24,6 +24,23 @@ namespace Bodu.Globalization.Calendar;
 /// and renders as the empty string.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// TerritoryCode nsw = TerritoryCode.Parse("AU-NSW");
+/// TerritoryCode au = nsw.Parent;          // AU
+/// bool contains = au.Contains(nsw);        // true — a country contains its subdivisions
+///
+/// // The implicit string conversion feeds the resolution surface directly.
+/// IReadOnlyList<NotableDate> dates = service.Resolve(2026, nsw);
+///
+/// // Lenient parsing for untrusted input.
+/// if (TerritoryCode.TryParse(userInput, out TerritoryCode code))
+///     dates = service.Resolve(2026, code);
+///]]>
+/// </code>
+/// </example>
+/// <seealso cref="INotableDateService" />
 public readonly struct TerritoryCode : IEquatable<TerritoryCode>
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/WeekOrdinal.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/WeekOrdinal.cs
@@ -9,6 +9,8 @@ namespace Bodu.Globalization.Calendar;
 /// <summary>
 /// Identifies which occurrence of a weekday within a month a strategy selects.
 /// </summary>
+/// <seealso cref="WeekdayProximity" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public enum WeekOrdinal
 {
     /// <summary>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/WeekdayProximity.cs
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/WeekdayProximity.cs
@@ -9,6 +9,8 @@ namespace Bodu.Globalization.Calendar;
 /// <summary>
 /// Identifies the direction and inclusivity used when seeking a weekday relative to an anchor date.
 /// </summary>
+/// <seealso cref="WeekOrdinal" />
+/// <seealso href="../guides/calendar/rule-authoring.html">Authoring notable date rules (guide)</seealso>
 public enum WeekdayProximity
 {
     /// <summary>


### PR DESCRIPTION
Bring the consumer-facing surface of the calendar libraries up to the v1 archive
bar and align with the Bodu.Security.Cryptography house style: add CDATA <example>
blocks, <seealso> cross-links, and 'When to use' guidance remarks across the primary
entry points.

- Core: INotableDateService, NotableDateService, NotableDateFilter (bold-header
  remarks + chaining example), NotableDateResourceLoader, DateRange, the four
  working-day extension classes, and the consumer-implementable extension points
  (INotableDateAlgorithm, INotableDateCollisionResolver, INotableDateProvider,
  IAdjustmentHandler, IAdjustmentTriggerHandler). Corrected a stale remark on
  IDateCalculationStrategy.
- Builder: NotableDateDocumentBuilder (end-to-end build example + workflow),
  NotableDateDefinitionBuilder, NotableDateRuleBuilder, AdjustmentPolicyBuilder.
- Plugins: NotableDatePluginLoader, INotableDatePlugin, INotableDateAlgorithmPlugin.
- DependencyInjection: NotableDateServiceCollectionExtensions.
- Data packs: Americas/AsiaPacific/Europe CreateService examples.

All examples validated against the current v2 API. Builds clean (0 errors).