### PR TITLE
Consolidate Americas shared observances into americas-common hub

### DIFF
--- a/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/AmericasCalendarData.cs
@@ -5,7 +5,7 @@
 // ---------------------------------------------------------------------------------------------------------------
 
 using System.Globalization;
-using System.Reflection;
+using System.Text;
 
 namespace Bodu.Globalization.Calendar.Data;
 
@@ -52,8 +52,35 @@ public static class AmericasCalendarData
                 string.Format(CultureInfo.InvariantCulture, "No Americas calendar resource for territory '{0}'.", territory),
                 nameof(territory));
 
-        return NotableDateResourceLoader.Load(stream, CommonNotableDateResources.Resolver);
+        return NotableDateResourceLoader.Load(stream, ResolveResource);
     }
+
+    /// <summary>
+    /// Resolves an imported resource name to its content. The pan-American <c>americas-common</c> hub is served from
+    /// this pack's embedded resources; every other name (the shared catalogues such as <c>christian-western</c> and
+    /// <c>global-core</c>, including those that <c>americas-common</c> itself imports) is delegated to
+    /// <see cref="CommonNotableDateResources" />.
+    /// </summary>
+    /// <param name="resourceName">The imported resource name, without extension.</param>
+    /// <returns>The resource XML, or <see langword="null" /> when no resource of that name is available.</returns>
+    private static string? ResolveResource(string resourceName) =>
+        string.Equals(resourceName, "americas-common", StringComparison.OrdinalIgnoreCase)
+            ? s_americasCommon.Value
+            : CommonNotableDateResources.Resolve(resourceName);
+
+    /// <summary>
+    /// The lazily-read XML content of the embedded <c>americas-common</c> hub resource.
+    /// </summary>
+    private static readonly Lazy<string?> s_americasCommon = new(static () =>
+    {
+        using Stream? stream = typeof(AmericasCalendarData).Assembly
+            .GetManifestResourceStream("Bodu.Globalization.Calendar.Data.Resources.americas-common.xml");
+        if (stream is null)
+            return null;
+
+        using StreamReader reader = new(stream, Encoding.UTF8);
+        return reader.ReadToEnd();
+    });
 
     /// <summary>
     /// Builds a resolver over the resource for the country owning the supplied territory.

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Bodu.Globalization.Calendar.Data.Americas.csproj
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Bodu.Globalization.Calendar.Data.Americas.csproj
@@ -20,16 +20,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Remove="Resources\region-ca.xml" />
-    <None Remove="Resources\region-us.xml" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Include="Resources\region-ca.xml">
-      <LogicalName>Bodu.Globalization.Calendar.Data.Resources.region-ca.xml</LogicalName>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Resources\region-us.xml">
-      <LogicalName>Bodu.Globalization.Calendar.Data.Resources.region-us.xml</LogicalName>
+    <None Remove="Resources\*.xml" />
+    <!-- Region packs and the shared americas-common hub they import from. -->
+    <EmbeddedResource Include="Resources\*.xml">
+      <LogicalName>Bodu.Globalization.Calendar.Data.Resources.%(Filename)%(Extension)</LogicalName>
     </EmbeddedResource>
   </ItemGroup>
 

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/americas-common.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/americas-common.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ================================================================================================================
+  americas-common — pan-American common notable-date hub
+  ================================================================================================================
+
+  The single consolidation point the Americas region packs (region-us, region-ca, and any future Americas pack)
+  import their shared observances from, mirroring the europe-common hub. It exists so a concept observed across the
+  region is defined exactly once and imported, never re-declared in two region files.
+
+  How this resource is built:
+
+    * The shared civil, Western Christian, Catholic patron-saint, family, cultural, and environmental concepts are
+      RE-EXPORTED here from the common catalogues (global-core, christian-western, catholic, global-family,
+      global-cultural, global-environment, global-un). They carry their catalogue defaults (category, non-working
+      flag, calculation strategy); a region pack supplies its own territory scope and, where required, overrides the
+      category, non-working flag, or weekend adjustment on its own import <Use> directive. The v2 import resolver
+      resolves this hub's own imports transitively, so a region that imports a concept from here receives the fully
+      resolved catalogue rule.
+
+    * Concepts that are pan-American but not international enough to belong in the common library are DEFINED INLINE
+      here as the single regional source of truth:
+        - Groundhog Day (2 February), a North-American cultural observance shared by the US and Canada.
+        - Thanksgiving, which is genuinely shared but calculated differently in each country: the United States
+          observes it on the fourth Thursday of November and Canada on the second Monday of October. Rather than
+          declaring two separate concepts, it is defined once here carrying one territory-scoped rule per country;
+          territory containment selects the right rule, and each region imports the single concept (without a
+          territory override, so both rules are preserved).
+
+  Anchor note: any Easter-derived date a region adopts (Good Friday, Easter Monday, Mardi Gras / Shrove Tuesday)
+  resolves against the Easter Sunday anchor, which is re-exported here too. Importing an offset feast pulls the
+  anchor transitively.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.americas-common">
+
+  <Imports>
+    <!-- Civil core. New Year's Day and New Year's Eve, re-exported under their global canonical names. -->
+    <Import resource="global-core">
+      <Use notableDateRef="new-years-day" />
+      <Use notableDateRef="new-years-eve" />
+    </Import>
+    <!--
+      Western Christian feasts and the Easter anchor. Re-exported with their catalogue defaults: the public holidays
+      (Good Friday, Easter Monday, Christmas Day, Boxing Day) carry nonWorking="true"; the rest are working
+      observances. Shrove Tuesday (Mardi Gras) and Ash Wednesday support the Gulf-coast carnival observances.
+    -->
+    <Import resource="christian-western">
+      <Use notableDateRef="easter-sunday" />
+      <Use notableDateRef="good-friday" />
+      <Use notableDateRef="easter-monday" />
+      <Use notableDateRef="shrove-tuesday" />
+      <Use notableDateRef="ash-wednesday" />
+      <Use notableDateRef="christmas-eve" />
+      <Use notableDateRef="christmas-day" />
+      <Use notableDateRef="boxing-day" />
+    </Import>
+    <!-- Catholic patron-saint feast days (working religious observances by default; a region re-scopes as needed). -->
+    <Import resource="catholic">
+      <Use notableDateRef="st-patricks-day" />
+      <Use notableDateRef="st-georges-day" />
+    </Import>
+    <!-- Family observances (recognition-only working days): the second-Sunday-May / third-Sunday-June North-American forms. -->
+    <Import resource="global-family">
+      <Use notableDateRef="mothers-day" />
+      <Use notableDateRef="fathers-day" />
+    </Import>
+    <!-- Cultural observances (recognition-only). -->
+    <Import resource="global-cultural">
+      <Use notableDateRef="valentines-day" />
+      <Use notableDateRef="cinco-de-mayo" />
+      <Use notableDateRef="halloween" />
+    </Import>
+    <!-- Environmental observance. -->
+    <Import resource="global-environment">
+      <Use notableDateRef="earth-day" />
+    </Import>
+    <!-- United Nations international day observed in Canada. -->
+    <Import resource="global-un">
+      <Use notableDateRef="international-womens-day" />
+    </Import>
+  </Imports>
+
+  <NotableDates>
+
+    <!--
+      Pan-American concepts defined here once as the single regional source of truth, so both region packs import
+      them rather than each re-declaring them.
+    -->
+
+    <!-- Groundhog Day — 2 February; a North-American folk tradition forecasting the arrival of spring. A working cultural observance, observed in both the US and Canada. Strategy: Fixed day-of-month. -->
+    <NotableDate id="groundhog-day" displayName="Groundhog Day" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="February" day="2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Thanksgiving — shared by the US and Canada but on different days. One concept, one territory-scoped rule per
+      country: the United States observes the fourth Thursday of November (rule "us"); Canada observes the second
+      Monday of October (rule "ca"). Each region imports this concept without a territory override so both rules are
+      preserved, and containment resolves the correct one. The US retail days (Black Friday, Cyber Monday) offset
+      from the "us" rule. Strategy: DayOfWeekInMonth.
+    -->
+    <NotableDate id="thanksgiving" displayName="Thanksgiving Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules>
+        <Rule id="us"><Applicability><Territory code="US" /></Applicability><Strategy><DayOfWeekInMonth month="November" dayOfWeek="Thursday" weekOrdinal="Fourth" /></Strategy></Rule>
+        <Rule id="ca"><Applicability><Territory code="CA" /></Applicability><Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule>
+      </Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
@@ -4,16 +4,18 @@
   Canada (CA) — notable-date resource pack
   ================================================================================================================
 
-  Migrated from the v1 region-ca.xml to the v2 cookbook schema. National rules are scoped to territory "CA";
-  provincial and territorial rules use their ISO 3166-2 subdivision codes (CA-AB, CA-BC, CA-MB, CA-NB, CA-NS,
-  CA-NU, CA-ON, CA-PE, CA-QC, CA-SK, CA-YT).
+  National rules are scoped to territory "CA"; provincial and territorial rules use their ISO 3166-2 subdivision
+  codes (CA-AB, CA-BC, CA-MB, CA-NB, CA-NL, CA-NS, CA-NT, CA-NU, CA-ON, CA-PE, CA-QC, CA-SK, CA-YT). Because a
+  subdivision query inherits every rule scoped to "CA", all provinces and territories receive the national
+  statutory holidays automatically; the subdivision-scoped rules add the provincial/territorial holidays.
 
   How this resource is built:
 
-    * Shared civil, Western Christian, and family observances (New Year's Day, the Easter feasts, Christmas, Boxing
-      Day, Mother's/Father's Day) are IMPORTED from the common catalogues (global-core, christian-western) and given
-      a CA territory scope, plus a weekend-substitution policy where the statutory holiday rolls in lieu. The v1
-      UseFrom imports are flattened into explicit rules.
+    * Shared civil, Western Christian, Catholic, family, and cultural observances (New Year's Day, the Easter
+      feasts, Christmas, Boxing Day, Mother's/Father's Day, Valentine's Day, Halloween, International Women's Day,
+      Thanksgiving) are IMPORTED from the americas-common hub and given a CA territory scope, plus a
+      weekend-substitution policy where the statutory holiday rolls in lieu. Concepts are defined once in the hub
+      (or the common library it re-exports) and never re-declared here.
 
     * Canada-specific concepts (Canada Day, the provincial statutory holidays, and the national observances) are
       declared INLINE below.
@@ -39,8 +41,7 @@
   <AdjustmentPolicies>
     <!--
       Plain weekend roll: when the actual date is a weekend, observe it on the next working day. skipNonWorkingDates
-      is false, so the substitute may share a day with another holiday. Used by the standalone statutory holidays
-      (New Year's Day, Canada Day, Fete nationale, Nunavut Day, Truth and Reconciliation Day, Remembrance Day).
+      is false, so the substitute may share a day with another holiday. Used by the standalone statutory holidays.
       Emission is ObservedOnly, so the holiday is substituted (moved), not duplicated.
     -->
     <AdjustmentPolicy id="weekend-roll" priority="100">
@@ -62,23 +63,27 @@
 
   <Imports>
     <!--
-      Civil core. New Year's Day is a national statutory holiday with a weekend roll to the next working day.
+      Shared observances imported from the americas-common hub and scoped to Canada. New Year's Day and Canada's
+      statutory Easter feasts carry the catalogue defaults (Good Friday and Easter Monday are non-working public
+      holidays). Christmas Day and Boxing Day fall on consecutive days, so they use the conflict-aware substitute to
+      keep their in-lieu days from colliding. Thanksgiving is imported without a territory override so its Canadian
+      rule (second Monday of October) is preserved. Valentine's Day, Halloween, International Women's Day, and the
+      family observances are working cultural/observance days.
     -->
-    <Import resource="global-core">
+    <Import resource="americas-common">
       <Use notableDateRef="new-years-day" territory="CA">
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments>
       </Use>
-    </Import>
-    <!--
-      Western Christian feasts. Good Friday and Easter Monday derive from the Easter Sunday anchor (an OffsetFromRule
-      strategy in the shared catalogue); Easter Saturday (the offset source) is imported too. Christmas Day and
-      Boxing Day fall on consecutive days, so they use the conflict-aware substitute to keep their in-lieu days from
-      colliding.
-    -->
-    <Import resource="christian-western">
+      <Use notableDateRef="groundhog-day" territory="CA" />
+      <Use notableDateRef="valentines-day" territory="CA" />
+      <Use notableDateRef="international-womens-day" territory="CA" />
       <Use notableDateRef="good-friday" territory="CA" />
       <Use notableDateRef="easter-sunday" territory="CA" />
       <Use notableDateRef="easter-monday" territory="CA" />
+      <Use notableDateRef="mothers-day" territory="CA" />
+      <Use notableDateRef="fathers-day" territory="CA" />
+      <Use notableDateRef="thanksgiving" />
+      <Use notableDateRef="halloween" territory="CA" />
       <Use notableDateRef="christmas-eve" territory="CA" />
       <Use notableDateRef="christmas-day" territory="CA">
         <Adjustments><Adjustment policyRef="working-day-substitute" /></Adjustments>
@@ -91,18 +96,6 @@
 
   <NotableDates>
 
-    <!-- Valentine's Day — 14 February, a cultural observance (not a statutory holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="valentines-day" displayName="Valentine's Day" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="February" day="14" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!-- International Women's Day — 8 March, an observance. Strategy: Fixed day-of-month. -->
-    <NotableDate id="womens-day" displayName="International Women's Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="March" day="8" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <!--
       ============================================================================================================
       Provincial third-Monday-in-February statutory holidays (one concept per province, year-gated by adoption)
@@ -111,9 +104,7 @@
 
     <!--
       Family Day — the third Monday in February. One concept carrying a rule per province that observes it, each
-      gated by the year the province adopted the holiday (AB 1990, SK 2007, ON 2008, BC 2013, NB 2018). The engine
-      matches the rule whose territory equals the requested subdivision AND whose year bound includes the query, so
-      a "CA" national query returns none of these, and a province returns nothing before its adoption year. The same
+      gated by the year the province adopted the holiday (AB 1990, SK 2007, ON 2008, BC 2013, NB 2018). The same
       third-Monday-in-February slot appears under different provincial names below (Islander Day, Louis Riel Day,
       Nova Scotia Heritage Day). Strategy: DayOfWeekInMonth (third Monday).
     -->
@@ -128,8 +119,8 @@
     </NotableDate>
 
     <!--
-      Islander Day — Prince Edward Island's name for the third-Monday-in-February holiday, observed from 2009. The
-      fromYear bound excludes earlier years. Strategy: DayOfWeekInMonth (third Monday).
+      Islander Day — Prince Edward Island's name for the third-Monday-in-February holiday, observed from 2009.
+      Strategy: DayOfWeekInMonth (third Monday).
     -->
     <NotableDate id="island-day" displayName="Islander Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="pe"><Applicability fromYear="2009"><Territory code="CA-PE" /></Applicability>
@@ -156,15 +147,55 @@
 
     <!--
       ============================================================================================================
+      Newfoundland and Labrador commemorative holidays (CA-NL)
+      ============================================================================================================
+      Newfoundland observes several commemorative days on the Monday nearest the underlying date. St. Patrick's Day
+      and St. George's Day are imported as the Catholic feast dates and re-scoped to a provincial public holiday;
+      Discovery Day and Orangemen's Day are declared inline on the nearest Monday, and Memorial Day shares 1 July
+      with Canada Day.
+    -->
+
+    <!--
+      Newfoundland Memorial Day — 1 July, commemorating the Royal Newfoundland Regiment's losses at Beaumont-Hamel
+      in 1916; observed alongside Canada Day. Strategy: Fixed day-of-month.
+    -->
+    <NotableDate id="nl-memorial-day" displayName="Memorial Day (Newfoundland and Labrador)" category="Remembrance" defaultNonWorkingDay="true">
+      <Rules><Rule id="nl"><Applicability fromYear="1917"><Territory code="CA-NL" /></Applicability>
+        <Strategy><Fixed month="July" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      St. George's Day (Newfoundland and Labrador) — observed on the Monday nearest 23 April. Strategy:
+      WeekdayNearDate (Monday nearest 23 April).
+    -->
+    <NotableDate id="nl-st-georges-day" displayName="St. George's Day (Newfoundland and Labrador)" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="nl"><Applicability><Territory code="CA-NL" /></Applicability>
+        <Strategy><WeekdayNearDate month="April" day="23" dayOfWeek="Monday" direction="Nearest" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Discovery Day (Newfoundland and Labrador) — observed on the Monday nearest 24 June, marking John Cabot's 1497
+      landfall. Distinct from Yukon's August Discovery Day below. Strategy: WeekdayNearDate (Monday nearest 24 June).
+    -->
+    <NotableDate id="nl-discovery-day" displayName="Discovery Day (Newfoundland and Labrador)" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="nl"><Applicability><Territory code="CA-NL" /></Applicability>
+        <Strategy><WeekdayNearDate month="June" day="24" dayOfWeek="Monday" direction="Nearest" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Orangemen's Day (Newfoundland and Labrador) — observed on the Monday nearest 12 July. Strategy:
+      WeekdayNearDate (Monday nearest 12 July).
+    -->
+    <NotableDate id="orangemens-day" displayName="Orangemen's Day (Newfoundland and Labrador)" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="nl"><Applicability><Territory code="CA-NL" /></Applicability>
+        <Strategy><WeekdayNearDate month="July" day="12" dayOfWeek="Monday" direction="Nearest" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      ============================================================================================================
       National statutory holidays and observances
       ============================================================================================================
     -->
-
-    <!-- Mother's Day — second Sunday in May, an observance. Strategy: DayOfWeekInMonth (second Sunday). -->
-    <NotableDate id="mothers-day" displayName="Mother's Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Second" /></Strategy></Rule></Rules>
-    </NotableDate>
 
     <!--
       Victoria Day — the Monday on or before 24 May (so the penultimate Monday of May), a national statutory
@@ -176,28 +207,25 @@
     </NotableDate>
 
     <!--
-      National Indigenous Peoples Day — 21 June, an observance held since 1996, so the fromYear bound excludes
-      earlier years. Strategy: Fixed day-of-month.
+      National Indigenous Peoples Day — 21 June. A national observance held since 1996 (working day), and a
+      statutory non-working holiday in the Northwest Territories (from 2022) and Yukon. Territory shadowing returns
+      the territorial rule for CA-NT/CA-YT and the national observance rule elsewhere. Strategy: Fixed day-of-month.
     -->
     <NotableDate id="national-indigenous-peoples-day" displayName="National Indigenous Peoples Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability fromYear="1996"><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="June" day="21" /></Strategy></Rule></Rules>
+      <Rules>
+        <Rule id="ca"><Applicability fromYear="1996"><Territory code="CA" /></Applicability><Strategy><Fixed month="June" day="21" /></Strategy></Rule>
+        <Rule id="nt-yt" category="PublicHoliday" nonWorking="true"><Applicability fromYear="2022"><Territory code="CA-NT" /><Territory code="CA-YT" /></Applicability><Strategy><Fixed month="June" day="21" /></Strategy></Rule>
+      </Rules>
     </NotableDate>
 
     <!--
-      Fete nationale du Quebec (Saint-Jean-Baptiste Day) — 24 June, a Quebec-only statutory holiday with a weekend
+      Fête nationale du Québec (Saint-Jean-Baptiste Day) — 24 June, a Quebec-only statutory holiday with a weekend
       roll. Subdivision-scoped, so a national "CA" query returns nothing. Strategy: Fixed day-of-month.
     -->
     <NotableDate id="fete-nationale-quebec" displayName="Fête nationale du Québec" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="qc"><Applicability><Territory code="CA-QC" /></Applicability>
         <Strategy><Fixed month="June" day="24" /></Strategy>
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <!-- Father's Day — third Sunday in June, an observance. Strategy: DayOfWeekInMonth (third Sunday). -->
-    <NotableDate id="fathers-day" displayName="Father's Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="June" dayOfWeek="Sunday" weekOrdinal="Third" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!-- Canada Day — 1 July, the national statutory holiday, with a weekend roll. Strategy: Fixed day-of-month. -->
@@ -233,11 +261,11 @@
 
     <!--
       Civic Holiday — first Monday in August, the generic name used where no province-specific name applies. A
-      single rule lists every applicable subdivision (ON, MB, SK, NU); the engine matches any of them. Strategy:
+      single rule lists every applicable subdivision (ON, MB, SK, NU, NT); the engine matches any of them. Strategy:
       DayOfWeekInMonth (first Monday).
     -->
     <NotableDate id="civic-holiday" displayName="Civic Holiday" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="general"><Applicability><Territory code="CA-ON" /><Territory code="CA-MB" /><Territory code="CA-SK" /><Territory code="CA-NU" /></Applicability>
+      <Rules><Rule id="general"><Applicability><Territory code="CA-ON" /><Territory code="CA-MB" /><Territory code="CA-SK" /><Territory code="CA-NU" /><Territory code="CA-NT" /></Applicability>
         <Strategy><DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="First" /></Strategy></Rule></Rules>
     </NotableDate>
 
@@ -258,9 +286,10 @@
 
     <!--
       Discovery Day — third Monday in August, Yukon only (commemorating the 1896 Klondike gold discovery; distinct
-      from the first-Monday August holiday). Strategy: DayOfWeekInMonth (third Monday).
+      from the first-Monday August holiday and from Newfoundland's June Discovery Day). Strategy: DayOfWeekInMonth
+      (third Monday).
     -->
-    <NotableDate id="discovery-day" displayName="Discovery Day" category="PublicHoliday" defaultNonWorkingDay="true">
+    <NotableDate id="discovery-day" displayName="Discovery Day (Yukon)" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="yt"><Applicability><Territory code="CA-YT" /></Applicability>
         <Strategy><DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule></Rules>
     </NotableDate>
@@ -285,21 +314,6 @@
       <Rules><Rule id="ca"><Applicability fromYear="2021"><Territory code="CA" /></Applicability>
         <Strategy><Fixed month="September" day="30" /></Strategy>
         <Adjustments><Adjustment policyRef="weekend-roll" /></Adjustments></Rule></Rules>
-    </NotableDate>
-
-    <!--
-      Thanksgiving — second Monday in October (earlier than the US fourth-Thursday-in-November date). A national
-      statutory holiday. Strategy: DayOfWeekInMonth (second Monday).
-    -->
-    <NotableDate id="thanksgiving" displayName="Thanksgiving" category="PublicHoliday" defaultNonWorkingDay="true">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!-- Halloween — 31 October, a cultural observance (not a statutory holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="halloween" displayName="Halloween" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
-        <Strategy><Fixed month="October" day="31" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!--

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-ca.xml
@@ -104,16 +104,19 @@
 
     <!--
       Family Day — the third Monday in February. One concept carrying a rule per province that observes it, each
-      gated by the year the province adopted the holiday (AB 1990, SK 2007, ON 2008, BC 2013, NB 2018). The same
+      gated by the year the province adopted the holiday (AB 1990, SK 2007, ON 2008, BC 2013, NB 2018). British
+      Columbia is the exception: it observed Family Day on the SECOND Monday from 2013 to 2018, then moved to the
+      third Monday from 2019 to align with the other provinces, so it carries two date-bounded rules. The same
       third-Monday-in-February slot appears under different provincial names below (Islander Day, Louis Riel Day,
-      Nova Scotia Heritage Day). Strategy: DayOfWeekInMonth (third Monday).
+      Nova Scotia Heritage Day). Strategy: DayOfWeekInMonth (second/third Monday).
     -->
     <NotableDate id="family-day" displayName="Family Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules>
         <Rule id="ab"><Applicability fromYear="1990"><Territory code="CA-AB" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
         <Rule id="sk"><Applicability fromYear="2007"><Territory code="CA-SK" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
         <Rule id="on"><Applicability fromYear="2008"><Territory code="CA-ON" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
-        <Rule id="bc"><Applicability fromYear="2013"><Territory code="CA-BC" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
+        <Rule id="bc-early"><Applicability fromYear="2013" toYear="2018"><Territory code="CA-BC" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule>
+        <Rule id="bc"><Applicability fromYear="2019"><Territory code="CA-BC" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
         <Rule id="nb"><Applicability fromYear="2018"><Territory code="CA-NB" /></Applicability><Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
       </Rules>
     </NotableDate>
@@ -165,6 +168,15 @@
     </NotableDate>
 
     <!--
+      St. Patrick's Day (Newfoundland and Labrador) — observed on the Monday nearest 17 March. Strategy:
+      WeekdayNearDate (Monday nearest 17 March).
+    -->
+    <NotableDate id="nl-st-patricks-day" displayName="St. Patrick's Day (Newfoundland and Labrador)" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="nl"><Applicability><Territory code="CA-NL" /></Applicability>
+        <Strategy><WeekdayNearDate month="March" day="17" dayOfWeek="Monday" direction="Nearest" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
       St. George's Day (Newfoundland and Labrador) — observed on the Monday nearest 23 April. Strategy:
       WeekdayNearDate (Monday nearest 23 April).
     -->
@@ -203,6 +215,16 @@
     -->
     <NotableDate id="victoria-day" displayName="Victoria Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="ca"><Applicability><Territory code="CA" /></Applicability>
+        <Strategy><WeekdayNearDate month="May" day="24" dayOfWeek="Monday" direction="OnOrBefore" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      National Patriots' Day (Journée nationale des patriotes) — the Monday on or before 24 May; Quebec observes
+      this in place of Victoria Day on the same date. Subdivision-scoped, so it resolves only for a CA-QC query.
+      Strategy: WeekdayNearDate (Monday on or before 24 May).
+    -->
+    <NotableDate id="national-patriots-day" displayName="National Patriots' Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="qc"><Applicability fromYear="2003"><Territory code="CA-QC" /></Applicability>
         <Strategy><WeekdayNearDate month="May" day="24" dayOfWeek="Monday" direction="OnOrBefore" /></Strategy></Rule></Rules>
     </NotableDate>
 

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
@@ -4,23 +4,28 @@
   United States (US) — notable-date resource pack
   ================================================================================================================
 
-  Migrated from the v1 region-us.xml to the v2 cookbook schema. All rules are national: there are no subdivision
-  (ISO 3166-2) rules in this pack, so every concept is scoped to territory "US". The v1 UseFrom imports (global and
-  Christian observances) are flattened into explicit, self-contained rules.
+  National (federal) rules are scoped to territory "US"; state and District of Columbia rules use their ISO 3166-2
+  subdivision codes (US-AL … US-WY, US-DC). Because a subdivision query inherits every rule scoped to its parent
+  country, all 50 states and DC automatically receive the federal holidays; the subdivision-scoped rules below add
+  the further holidays established under individual state law.
 
   How this resource is built:
 
-    * Shared civil and Western Christian observances (New Year's Day, Easter Sunday, Good Friday, Christmas Eve,
-      Christmas Day) are IMPORTED from the common catalogues (global-core, christian-western) and given a US
-      territory scope, plus a weekend-substitution policy where the federal holiday is observed in lieu.
+    * Shared civil, Western Christian, Catholic, family, cultural, and environmental observances (New Year's Day,
+      Groundhog Day, Valentine's Day, St. Patrick's Day, Easter, Good Friday, Cinco de Mayo, Mother's/Father's Day,
+      Earth Day, Halloween, Thanksgiving, Christmas Eve, Christmas Day) are IMPORTED from the americas-common hub
+      and given a US territory scope, plus a weekend-substitution policy where the federal holiday is observed in
+      lieu. Concepts are defined once in the hub (or the common library it re-exports) and never re-declared here.
 
-    * United States-specific concepts (the federal Monday holidays, the cultural and civic observances, and the
-      Thanksgiving-anchored retail days) are declared INLINE below.
+    * United States federal concepts that are specific to the country (the Monday holidays, the civic and cultural
+      observances, and the Thanksgiving-anchored retail days) are declared INLINE, scoped to "US".
 
-  Weekend substitution: federal practice observes a holiday in lieu when it lands on a weekend — Saturday is observed
-  on the PRECEDING Friday, and Sunday on the FOLLOWING Monday. These are two separate one-directional policies (the
-  AU/CA/NZ packs instead use a single forward "weekend roll"); a single-day federal holiday carries both so either
-  weekend day resolves correctly.
+    * State-specific statutory holidays and observances are declared INLINE, scoped to their US-XX subdivision codes
+      and, where datable, gated by the year the state adopted them. Politically contested observances are excluded.
+
+  Weekend substitution: federal practice observes a holiday in lieu when it lands on a weekend — Saturday is
+  observed on the PRECEDING Friday, and Sunday on the FOLLOWING Monday. These are two separate one-directional
+  policies; a single-day federal holiday carries both so either weekend day resolves correctly.
 -->
 <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.us">
 
@@ -54,24 +59,29 @@
 
   <Imports>
     <!--
-      Civil core. New Year's Day is a federal holiday observed in lieu when 1 January lands on a weekend (both the
-      Saturday and Sunday substitute policies apply).
+      Shared observances imported from the americas-common hub and scoped to the United States. New Year's Day and
+      Christmas Day are federal holidays observed in lieu when they land on a weekend (both substitute policies
+      apply). Good Friday is re-categorized as a working religious observance (it is not a federal holiday).
+      St. Patrick's Day, Cinco de Mayo, Groundhog Day, Valentine's Day, Halloween, Christmas Eve, and the family
+      observances are working cultural/observance days. Easter Sunday is the imported anchor used by the inline
+      Mardi Gras offset. Thanksgiving is imported without a territory override so its US rule is preserved (the hub
+      also carries a Canadian rule that never matches a US query); the retail days below offset from that rule.
     -->
-    <Import resource="global-core">
+    <Import resource="americas-common">
       <Use notableDateRef="new-years-day" territory="US">
         <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments>
       </Use>
-    </Import>
-
-    <!--
-      Western Christian feasts, re-scoped to the US. Easter Sunday is the computed anchor (used by no offset here but
-      imported for completeness). Good Friday is re-categorized Religious and made a working day (nonWorking="false")
-      because it is not a federal holiday. Christmas Eve is imported as-is. Christmas Day is a federal holiday and
-      carries both weekend-substitute policies.
-    -->
-    <Import resource="christian-western">
+      <Use notableDateRef="groundhog-day" territory="US" />
+      <Use notableDateRef="valentines-day" territory="US" />
+      <Use notableDateRef="st-patricks-day" territory="US" category="Cultural" />
       <Use notableDateRef="easter-sunday" territory="US" />
       <Use notableDateRef="good-friday" territory="US" category="Religious" nonWorking="false" />
+      <Use notableDateRef="cinco-de-mayo" territory="US" />
+      <Use notableDateRef="mothers-day" territory="US" />
+      <Use notableDateRef="fathers-day" territory="US" />
+      <Use notableDateRef="earth-day" territory="US" />
+      <Use notableDateRef="halloween" territory="US" />
+      <Use notableDateRef="thanksgiving" />
       <Use notableDateRef="christmas-eve" territory="US" />
       <Use notableDateRef="christmas-day" territory="US">
         <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments>
@@ -83,7 +93,7 @@
 
     <!--
       ============================================================================================================
-      Federal public holidays (the Monday holidays and fixed-date federal holidays)
+      Federal public holidays and observances (scoped to "US"; inherited by every state and DC)
       ============================================================================================================
     -->
 
@@ -96,40 +106,10 @@
         <Strategy><DayOfWeekInMonth month="January" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <!-- Valentine's Day — 14 February, a cultural observance (not a federal holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="valentines-day" displayName="Valentine's Day" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="February" day="14" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!--
-      Presidents' Day (Washington's Birthday) — third Monday in February. Federal holiday. Strategy: DayOfWeekInMonth
-      (third Monday).
-    -->
+    <!-- Presidents' Day (Washington's Birthday) — third Monday in February. Federal holiday. Strategy: DayOfWeekInMonth (third Monday). -->
     <NotableDate id="presidents-day" displayName="Presidents' Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
         <Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!-- St. Patrick's Day — 17 March, a cultural observance (not a federal holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="st-patricks-day" displayName="St. Patrick's Day" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="March" day="17" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!--
-      Earth Day — 22 April, an environmental observance first held in 1970, so the fromYear bound excludes earlier
-      years. Strategy: Fixed day-of-month.
-    -->
-    <NotableDate id="earth-day" displayName="Earth Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability fromYear="1970"><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="April" day="22" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!-- Mother's Day — second Sunday in May, an observance. Strategy: DayOfWeekInMonth (second Sunday). -->
-    <NotableDate id="mothers-day" displayName="Mother's Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="May" dayOfWeek="Sunday" weekOrdinal="Second" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!--
@@ -141,22 +121,9 @@
         <Strategy><DayOfWeekInMonth month="May" dayOfWeek="Monday" weekOrdinal="Last" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <!-- Flag Day — 14 June, an observance (not a federal holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="flag-day" displayName="Flag Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="June" day="14" /></Strategy></Rule></Rules>
-    </NotableDate>
-
-    <!-- Father's Day — third Sunday in June, an observance. Strategy: DayOfWeekInMonth (third Sunday). -->
-    <NotableDate id="fathers-day" displayName="Father's Day" category="Observance" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="June" dayOfWeek="Sunday" weekOrdinal="Third" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <!--
       Juneteenth National Independence Day — 19 June. The newest federal holiday (established 2021), so the fromYear
-      bound returns nothing before 2021. Carries both weekend-substitute policies (Saturday to Friday, Sunday to
-      Monday). Strategy: Fixed day-of-month.
+      bound returns nothing before 2021. Carries both weekend-substitute policies. Strategy: Fixed day-of-month.
     -->
     <NotableDate id="juneteenth" displayName="Juneteenth National Independence Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="us"><Applicability fromYear="2021"><Territory code="US" /></Applicability>
@@ -165,8 +132,7 @@
     </NotableDate>
 
     <!--
-      Independence Day — 4 July. Federal holiday with both weekend-substitute policies (Saturday observed on the
-      preceding Friday, Sunday on the following Monday). Strategy: Fixed day-of-month.
+      Independence Day — 4 July. Federal holiday with both weekend-substitute policies. Strategy: Fixed day-of-month.
     -->
     <NotableDate id="independence-day" displayName="Independence Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
@@ -196,16 +162,10 @@
         <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <!-- Halloween — 31 October, a cultural observance (not a federal holiday). Strategy: Fixed day-of-month. -->
-    <NotableDate id="halloween" displayName="Halloween" category="Cultural" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="October" day="31" /></Strategy></Rule></Rules>
-    </NotableDate>
-
     <!--
-      Election Day — the Tuesday after the first Monday in November (so the first Tuesday that is not 1 November).
-      A civic observance, fixed in federal law since 1845; the fromYear bound excludes earlier years. Strategy:
-      RelativeWeekdayInMonth — the Tuesday positioned After the first Monday in November.
+      Election Day — the Tuesday after the first Monday in November. A civic observance, fixed in federal law since
+      1845; the fromYear bound excludes earlier years. Strategy: RelativeWeekdayInMonth — the Tuesday positioned
+      After the first Monday in November.
     -->
     <NotableDate id="election-day" displayName="Election Day" category="Civic" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability fromYear="1845"><Territory code="US" /></Applicability>
@@ -213,8 +173,8 @@
     </NotableDate>
 
     <!--
-      Veterans Day — 11 November. Federal holiday with both weekend-substitute policies (Saturday to Friday, Sunday
-      to Monday). Strategy: Fixed day-of-month.
+      Veterans Day — 11 November. Federal holiday with both weekend-substitute policies. Strategy: Fixed
+      day-of-month.
     -->
     <NotableDate id="veterans-day" displayName="Veterans Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
@@ -222,46 +182,222 @@
         <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments></Rule></Rules>
     </NotableDate>
 
-    <!--
-      Thanksgiving Day — fourth Thursday in November. Federal holiday and the anchor for the retail days below.
-      Strategy: DayOfWeekInMonth (fourth Thursday).
-    -->
-    <NotableDate id="thanksgiving" displayName="Thanksgiving Day" category="PublicHoliday" defaultNonWorkingDay="true">
+    <!-- Flag Day — 14 June, an observance (not a federal holiday). Strategy: Fixed day-of-month. -->
+    <NotableDate id="flag-day" displayName="Flag Day" category="Observance" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
-        <Strategy><DayOfWeekInMonth month="November" dayOfWeek="Thursday" weekOrdinal="Fourth" /></Strategy></Rule></Rules>
+        <Strategy><Fixed month="June" day="14" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Pearl Harbor Remembrance Day — 7 December, a remembrance day designated in federal law from 1994. Strategy:
+      Fixed day-of-month.
+    -->
+    <NotableDate id="pearl-harbor-day" displayName="Pearl Harbor Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
+      <Rules><Rule id="us"><Applicability fromYear="1994"><Territory code="US" /></Applicability>
+        <Strategy><Fixed month="December" day="7" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!--
       ============================================================================================================
-      Thanksgiving-anchored retail days and remaining observances
+      Thanksgiving-anchored retail days (scoped to "US")
       ============================================================================================================
     -->
 
-    <!--
-      Black Friday — the day after Thanksgiving, the traditional start of the holiday shopping season. Strategy:
-      OffsetFromRule, one day after the Thanksgiving rule (the Friday).
-    -->
+    <!-- Black Friday — the day after Thanksgiving, the traditional start of the holiday shopping season. Strategy: OffsetFromRule, one day after the imported US Thanksgiving rule (the Friday). -->
     <NotableDate id="black-friday" displayName="Black Friday" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
         <Strategy><OffsetFromRule notableDateRef="thanksgiving" ruleRef="us" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
-    <!--
-      Cyber Monday — the Monday after Thanksgiving (four days after the Thursday). Strategy: OffsetFromRule, four
-      days after the Thanksgiving rule.
-    -->
+    <!-- Cyber Monday — the Monday after Thanksgiving (four days after the Thursday). Strategy: OffsetFromRule, four days after the imported US Thanksgiving rule. -->
     <NotableDate id="cyber-monday" displayName="Cyber Monday" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="us"><Applicability><Territory code="US" /></Applicability>
         <Strategy><OffsetFromRule notableDateRef="thanksgiving" ruleRef="us" offsetDays="4" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!--
-      Pearl Harbor Remembrance Day — 7 December, a remembrance day designated in federal law from 1994, so the
-      fromYear bound excludes earlier years. Strategy: Fixed day-of-month.
+      ============================================================================================================
+      State and District of Columbia statutory holidays (scoped to US-XX subdivisions)
+      ============================================================================================================
+      Concepts that share a single date across several states list every applicable subdivision on one rule; where
+      states adopted the same slot in different years, one rule per state carries its own fromYear bound. A national
+      "US" query resolves none of these subdivision-scoped rules.
     -->
-    <NotableDate id="pearl-harbor-day" displayName="Pearl Harbor Remembrance Day" category="Remembrance" defaultNonWorkingDay="false">
-      <Rules><Rule id="us"><Applicability fromYear="1994"><Territory code="US" /></Applicability>
-        <Strategy><Fixed month="December" day="7" /></Strategy></Rule></Rules>
+
+    <!--
+      Inauguration Day — 20 January, every fourth year following a presidential election; a public holiday for the
+      District of Columbia (and federal employees in the capital region). everyYears="4" with anchorYear="1937"
+      recurs on 1937, 1941, … 2021, 2025; the year is skipped in between. Strategy: Fixed day-of-month.
+    -->
+    <NotableDate id="inauguration-day" displayName="Inauguration Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="dc"><Applicability fromYear="1937" everyYears="4" anchorYear="1937"><Territory code="US-DC" /></Applicability>
+        <Strategy><Fixed month="January" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Lincoln's Birthday — 12 February; a public holiday in several states (Connecticut, Illinois, Missouri, and
+      New York). Strategy: Fixed day-of-month.
+    -->
+    <NotableDate id="lincolns-birthday" displayName="Lincoln's Birthday" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="states"><Applicability><Territory code="US-CT" /><Territory code="US-IL" /><Territory code="US-MO" /><Territory code="US-NY" /></Applicability>
+        <Strategy><Fixed month="February" day="12" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Mardi Gras (Shrove Tuesday) — the day before Lent; a statutory holiday in Louisiana and Alabama. Strategy:
+      OffsetFromRule, 47 days before the imported Easter Sunday anchor.
+    -->
+    <NotableDate id="mardi-gras" displayName="Mardi Gras" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="states"><Applicability fromYear="1583"><Territory code="US-LA" /><Territory code="US-AL" /></Applicability>
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-47" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Texas Independence Day — 2 March; a Texas state holiday commemorating the 1836 declaration of independence. Strategy: Fixed day-of-month. -->
+    <NotableDate id="texas-independence-day" displayName="Texas Independence Day" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="tx"><Applicability fromYear="1874"><Territory code="US-TX" /></Applicability>
+        <Strategy><Fixed month="March" day="2" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Town Meeting Day — the first Tuesday in March; a Vermont state holiday for local town meetings. Strategy: DayOfWeekInMonth (first Tuesday). -->
+    <NotableDate id="town-meeting-day" displayName="Town Meeting Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="vt"><Applicability><Territory code="US-VT" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="March" dayOfWeek="Tuesday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Casimir Pulaski Day — the first Monday in March; an Illinois commemorative holiday honoring the Revolutionary War general. Strategy: DayOfWeekInMonth (first Monday). -->
+    <NotableDate id="casimir-pulaski-day" displayName="Casimir Pulaski Day" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="il"><Applicability fromYear="1986"><Territory code="US-IL" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="First" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Prince Jonah Kuhio Kalanianaole Day — 26 March; a Hawaii state holiday honoring the prince and delegate. Strategy: Fixed day-of-month. -->
+    <NotableDate id="prince-kuhio-day" displayName="Prince Jonah Kuhio Kalanianaole Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="hi"><Applicability fromYear="1949"><Territory code="US-HI" /></Applicability>
+        <Strategy><Fixed month="March" day="26" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Seward's Day — the last Monday in March; an Alaska state holiday marking the 1867 treaty to purchase Alaska. Strategy: DayOfWeekInMonth (last Monday). -->
+    <NotableDate id="sewards-day" displayName="Seward's Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="ak"><Applicability fromYear="1959"><Territory code="US-AK" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="March" dayOfWeek="Monday" weekOrdinal="Last" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Cesar Chavez Day — 31 March; a state holiday in California and Texas honoring the labor leader. Strategy: Fixed day-of-month. -->
+    <NotableDate id="cesar-chavez-day" displayName="Cesar Chavez Day" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="states"><Applicability fromYear="1995"><Territory code="US-CA" /><Territory code="US-TX" /></Applicability>
+        <Strategy><Fixed month="March" day="31" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Emancipation Day — 16 April; a District of Columbia public holiday marking the 1862 abolition of slavery in
+      the capital, carrying both weekend-substitute policies. Strategy: Fixed day-of-month.
+    -->
+    <NotableDate id="emancipation-day-dc" displayName="Emancipation Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="dc"><Applicability fromYear="2005"><Territory code="US-DC" /></Applicability>
+        <Strategy><Fixed month="April" day="16" /></Strategy>
+        <Adjustments><Adjustment policyRef="saturday-to-friday" /><Adjustment policyRef="sunday-to-monday" /></Adjustments></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Patriots' Day — the third Monday in April; a state holiday in Massachusetts (from 1894) and Maine (from
+      1907), commemorating the battles of Lexington and Concord. Strategy: DayOfWeekInMonth (third Monday).
+    -->
+    <NotableDate id="patriots-day" displayName="Patriots' Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules>
+        <Rule id="ma"><Applicability fromYear="1894"><Territory code="US-MA" /></Applicability><Strategy><DayOfWeekInMonth month="April" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
+        <Rule id="me"><Applicability fromYear="1907"><Territory code="US-ME" /></Applicability><Strategy><DayOfWeekInMonth month="April" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule>
+      </Rules>
+    </NotableDate>
+
+    <!-- San Jacinto Day — 21 April; a Texas state holiday marking the 1836 battle that secured Texan independence. Strategy: Fixed day-of-month. -->
+    <NotableDate id="san-jacinto-day" displayName="San Jacinto Day" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="tx"><Applicability fromYear="1874"><Territory code="US-TX" /></Applicability>
+        <Strategy><Fixed month="April" day="21" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Harry S. Truman Day — 8 May; a Missouri state holiday honoring the president's birthday. Strategy: Fixed day-of-month. -->
+    <NotableDate id="truman-day" displayName="Harry S. Truman Day" category="PublicHoliday" defaultNonWorkingDay="false">
+      <Rules><Rule id="mo"><Applicability fromYear="1949"><Territory code="US-MO" /></Applicability>
+        <Strategy><Fixed month="May" day="8" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Kamehameha Day — 11 June; a Hawaii state holiday honoring King Kamehameha I. Strategy: Fixed day-of-month. -->
+    <NotableDate id="kamehameha-day" displayName="Kamehameha Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="hi"><Applicability fromYear="1872"><Territory code="US-HI" /></Applicability>
+        <Strategy><Fixed month="June" day="11" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- West Virginia Day — 20 June; a state holiday marking West Virginia's 1863 admission to the Union. Strategy: Fixed day-of-month. -->
+    <NotableDate id="west-virginia-day" displayName="West Virginia Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="wv"><Applicability fromYear="1927"><Territory code="US-WV" /></Applicability>
+        <Strategy><Fixed month="June" day="20" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Pioneer Day — 24 July; a Utah state holiday commemorating the 1847 arrival of the Mormon pioneers in the Salt Lake Valley. Strategy: Fixed day-of-month. -->
+    <NotableDate id="pioneer-day" displayName="Pioneer Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="ut"><Applicability fromYear="1849"><Territory code="US-UT" /></Applicability>
+        <Strategy><Fixed month="July" day="24" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Victory Day — the second Monday in August; a Rhode Island state holiday marking the end of the Second World War in the Pacific. Strategy: DayOfWeekInMonth (second Monday). -->
+    <NotableDate id="victory-day" displayName="Victory Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="ri"><Applicability fromYear="1948"><Territory code="US-RI" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="August" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Bennington Battle Day — 16 August; a Vermont state holiday marking the 1777 Revolutionary War battle. Strategy: Fixed day-of-month. -->
+    <NotableDate id="bennington-battle-day" displayName="Bennington Battle Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="vt"><Applicability fromYear="1894"><Territory code="US-VT" /></Applicability>
+        <Strategy><Fixed month="August" day="16" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Statehood Day (Hawaii) — the third Friday in August; a Hawaii state holiday marking 1959 admission to the Union. Strategy: DayOfWeekInMonth (third Friday). -->
+    <NotableDate id="statehood-day-hi" displayName="Statehood Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="hi"><Applicability fromYear="1959"><Territory code="US-HI" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="August" dayOfWeek="Friday" weekOrdinal="Third" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- California Admission Day — 9 September; a California state holiday marking 1850 admission to the Union. Strategy: Fixed day-of-month. -->
+    <NotableDate id="california-admission-day" displayName="California Admission Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="ca"><Applicability fromYear="1850"><Territory code="US-CA" /></Applicability>
+        <Strategy><Fixed month="September" day="9" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Native American Day (California) — the fourth Friday in September; a California observance honoring Native Americans. Strategy: DayOfWeekInMonth (fourth Friday). -->
+    <NotableDate id="native-american-day-ca" displayName="Native American Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="ca"><Applicability fromYear="1998"><Territory code="US-CA" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="September" dayOfWeek="Friday" weekOrdinal="Fourth" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Native Americans' Day (South Dakota) — the second Monday in October; South Dakota observes this in place of Columbus Day. Strategy: DayOfWeekInMonth (second Monday). -->
+    <NotableDate id="native-americans-day-sd" displayName="Native Americans' Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="sd"><Applicability fromYear="1990"><Territory code="US-SD" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Nevada Day — the last Friday in October; a Nevada state holiday marking 1864 admission to the Union (moved to the last Friday from 2000). Strategy: DayOfWeekInMonth (last Friday). -->
+    <NotableDate id="nevada-day" displayName="Nevada Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="nv"><Applicability fromYear="2000"><Territory code="US-NV" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Friday" weekOrdinal="Last" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Alaska Day — 18 October; an Alaska state holiday marking the 1867 formal transfer of Alaska to the United States. Strategy: Fixed day-of-month. -->
+    <NotableDate id="alaska-day" displayName="Alaska Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="ak"><Applicability fromYear="1959"><Territory code="US-AK" /></Applicability>
+        <Strategy><Fixed month="October" day="18" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
+      Day after Thanksgiving — the Friday after Thanksgiving, a state-government holiday in many states (distinct
+      from the cultural Black Friday at "US" scope, which both resolve under KeepAll). One rule lists the states
+      that observe it as a paid state holiday. Strategy: OffsetFromRule, one day after the imported US Thanksgiving
+      rule.
+    -->
+    <NotableDate id="day-after-thanksgiving" displayName="Day After Thanksgiving" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="states"><Applicability>
+          <Territory code="US-CA" /><Territory code="US-DE" /><Territory code="US-FL" /><Territory code="US-GA" /><Territory code="US-IN" /><Territory code="US-KY" /><Territory code="US-ME" /><Territory code="US-MD" /><Territory code="US-MI" /><Territory code="US-NV" /><Territory code="US-NH" /><Territory code="US-NM" /><Territory code="US-NC" /><Territory code="US-OK" /><Territory code="US-PA" /><Territory code="US-SC" /><Territory code="US-TN" /><Territory code="US-TX" /><Territory code="US-VA" /><Territory code="US-WV" />
+        </Applicability>
+        <Strategy><OffsetFromRule notableDateRef="thanksgiving" ruleRef="us" offsetDays="1" /></Strategy></Rule></Rules>
     </NotableDate>
 
   </NotableDates>

--- a/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
+++ b/Bodu.Globalization.Calendar.Data.Americas/src/Resources/region-us.xml
@@ -189,6 +189,16 @@
     </NotableDate>
 
     <!--
+      Arbor Day — the last Friday in April; a national observance promoting tree planting (originated in Nebraska in
+      1872, where it is a state holiday). Recognized nationally as a working observance. Strategy: DayOfWeekInMonth
+      (last Friday).
+    -->
+    <NotableDate id="arbor-day" displayName="Arbor Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="us"><Applicability fromYear="1872"><Territory code="US" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="April" dayOfWeek="Friday" weekOrdinal="Last" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!--
       Pearl Harbor Remembrance Day — 7 December, a remembrance day designated in federal law from 1994. Strategy:
       Fixed day-of-month.
     -->
@@ -241,6 +251,12 @@
     <NotableDate id="lincolns-birthday" displayName="Lincoln's Birthday" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="states"><Applicability><Territory code="US-CT" /><Territory code="US-IL" /><Territory code="US-MO" /><Territory code="US-NY" /></Applicability>
         <Strategy><Fixed month="February" day="12" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Daisy Gatson Bates Day — the third Monday in February (observed alongside Presidents' Day); an Arkansas state holiday honoring the civil-rights leader. Strategy: DayOfWeekInMonth (third Monday). -->
+    <NotableDate id="daisy-bates-day" displayName="Daisy Gatson Bates Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="ar"><Applicability fromYear="2001"><Territory code="US-AR" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="February" dayOfWeek="Monday" weekOrdinal="Third" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!--
@@ -351,6 +367,12 @@
         <Strategy><Fixed month="August" day="16" /></Strategy></Rule></Rules>
     </NotableDate>
 
+    <!-- Lyndon Baines Johnson Day — 27 August; an optional Texas state holiday marking the president's birthday. Strategy: Fixed day-of-month. -->
+    <NotableDate id="lbj-day" displayName="Lyndon Baines Johnson Day" category="Observance" defaultNonWorkingDay="false">
+      <Rules><Rule id="tx"><Applicability fromYear="1973"><Territory code="US-TX" /></Applicability>
+        <Strategy><Fixed month="August" day="27" /></Strategy></Rule></Rules>
+    </NotableDate>
+
     <!-- Statehood Day (Hawaii) — the third Friday in August; a Hawaii state holiday marking 1959 admission to the Union. Strategy: DayOfWeekInMonth (third Friday). -->
     <NotableDate id="statehood-day-hi" displayName="Statehood Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="hi"><Applicability fromYear="1959"><Territory code="US-HI" /></Applicability>
@@ -373,6 +395,12 @@
     <NotableDate id="native-americans-day-sd" displayName="Native Americans' Day" category="PublicHoliday" defaultNonWorkingDay="true">
       <Rules><Rule id="sd"><Applicability fromYear="1990"><Territory code="US-SD" /></Applicability>
         <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="Second" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Cabrini Day — the first Monday in October; a Colorado state holiday honoring Mother Cabrini, adopted in 2020 in place of Columbus Day. Strategy: DayOfWeekInMonth (first Monday). -->
+    <NotableDate id="cabrini-day" displayName="Cabrini Day" category="PublicHoliday" defaultNonWorkingDay="true">
+      <Rules><Rule id="co"><Applicability fromYear="2020"><Territory code="US-CO" /></Applicability>
+        <Strategy><DayOfWeekInMonth month="October" dayOfWeek="Monday" weekOrdinal="First" /></Strategy></Rule></Rules>
     </NotableDate>
 
     <!-- Nevada Day — the last Friday in October; a Nevada state holiday marking 1864 admission to the Union (moved to the last Friday from 2000). Strategy: DayOfWeekInMonth (last Friday). -->
@@ -401,4 +429,23 @@
     </NotableDate>
 
   </NotableDates>
+
+  <!--
+    ============================================================================================================
+    State overrides
+    ============================================================================================================
+    Good Friday is imported above as a nationwide working religious observance. A number of states additionally
+    observe it as a statutory non-working holiday; this adds a subdivision-scoped rule (offsetting from the same
+    imported Easter Sunday anchor) that marks it non-working in those states. Both occurrences resolve for a state
+    query under KeepAll — the national observance and the state holiday — mirroring the territorial-shadow pattern
+    used for National Indigenous Peoples Day in the Canadian pack.
+  -->
+  <Overrides>
+    <AddRule notableDateRef="good-friday">
+      <Rule id="state-statutory" category="PublicHoliday" nonWorking="true">
+        <Applicability fromYear="1583"><Territory code="US-CT" /><Territory code="US-DE" /><Territory code="US-HI" /><Territory code="US-IN" /><Territory code="US-KY" /><Territory code="US-LA" /><Territory code="US-NJ" /><Territory code="US-NC" /><Territory code="US-ND" /><Territory code="US-TN" /></Applicability>
+        <Strategy><OffsetFromRule notableDateRef="easter-sunday" ruleRef="default" offsetDays="-2" /></Strategy>
+      </Rule>
+    </AddRule>
+  </Overrides>
 </NotableDateResource>

--- a/Bodu.Globalization.Calendar.Data.Americas/test/AmericasCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/test/AmericasCalendarDataTests.cs
@@ -101,6 +101,7 @@ public sealed class AmericasCalendarDataTests
     [DataRow("US-WV", 2024, "west-virginia-day", "2024-06-20")]
     [DataRow("US-IL", 2024, "lincolns-birthday", "2024-02-12")]
     [DataRow("US-VT", 2024, "bennington-battle-day", "2024-08-16")]
+    [DataRow("US-TX", 2024, "lbj-day", "2024-08-27")]
     public void Resolve_UnitedStatesStateHoliday_MatchesKnownAnswer(string territory, int year, string notableDateId, string expected)
     {
         NotableDate match = Single(territory, year, notableDateId);
@@ -141,12 +142,21 @@ public sealed class AmericasCalendarDataTests
     [DataRow("US-HI", 2024, "statehood-day-hi", "2024-08-16")]
     [DataRow("US-NV", 2024, "nevada-day", "2024-10-25")]
     [DataRow("US-AK", 2024, "sewards-day", "2024-03-25")]
+    [DataRow("US", 2024, "arbor-day", "2024-04-26")]
+    [DataRow("US-CO", 2024, "cabrini-day", "2024-10-07")]
+    [DataRow("US-AR", 2024, "daisy-bates-day", "2024-02-19")]
+
+    // British Columbia Family Day moved from the second to the third Monday in February in 2019.
+    [DataRow("CA-BC", 2016, "family-day", "2016-02-08")]
+    [DataRow("CA-BC", 2019, "family-day", "2019-02-18")]
 
     // Nearest-weekday (WeekdayNearDate), Canada.
     [DataRow("CA", 2031, "victoria-day", "2031-05-19")]
+    [DataRow("CA-QC", 2024, "national-patriots-day", "2024-05-20")]
     [DataRow("CA-NL", 2024, "nl-discovery-day", "2024-06-24")]
     [DataRow("CA-NL", 2025, "nl-discovery-day", "2025-06-23")]
     [DataRow("CA-NL", 2024, "nl-st-georges-day", "2024-04-22")]
+    [DataRow("CA-NL", 2024, "nl-st-patricks-day", "2024-03-18")]
     public void Resolve_FloatingHoliday_MatchesKnownAnswer(string territory, int year, string notableDateId, string expected)
     {
         NotableDate match = Single(territory, year, notableDateId);
@@ -192,6 +202,21 @@ public sealed class AmericasCalendarDataTests
             .ToList();
 
         Assert.IsTrue(matches.Any(r => r.RuleId == "nt-yt" && r.IsNonWorkingDay), "expected a non-working territorial rule");
+    }
+
+    /// <summary>
+    /// Verifies that Good Friday resolves as a non-working statutory holiday in a state that observes it (the state
+    /// override rule), while remaining a working religious observance nationally.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_StateGoodFriday_IsStatutoryHoliday()
+    {
+        List<NotableDate> matches = AmericasCalendarData.CreateService("US-LA")
+            .Resolve(new DateRange(new DateOnly(2024, 3, 29), new DateOnly(2024, 3, 29)), "US-LA")
+            .Where(r => r.NotableDateId == "good-friday")
+            .ToList();
+
+        Assert.IsTrue(matches.Any(r => r.RuleId == "state-statutory" && r.IsNonWorkingDay), "expected a non-working state rule");
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data.Americas/test/AmericasCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data.Americas/test/AmericasCalendarDataTests.cs
@@ -79,7 +79,124 @@ public sealed class AmericasCalendarDataTests
     }
 
     /// <summary>
-    /// Verifies that a holiday introduced in a later year does not resolve before its first applicable year.
+    /// Verifies that each fixed-date state and District of Columbia statutory holiday resolves for its subdivision
+    /// to the known emitted date.
+    /// </summary>
+    /// <param name="territory">The requested subdivision code.</param>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="notableDateId">The notable-date id to resolve.</param>
+    /// <param name="expected">The expected emitted date in ISO format.</param>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow("US-UT", 2024, "pioneer-day", "2024-07-24")]
+    [DataRow("US-DC", 2024, "emancipation-day-dc", "2024-04-16")]
+    [DataRow("US-DC", 2025, "inauguration-day", "2025-01-20")]
+    [DataRow("US-DC", 2021, "inauguration-day", "2021-01-20")]
+    [DataRow("US-TX", 2024, "texas-independence-day", "2024-03-02")]
+    [DataRow("US-TX", 2024, "san-jacinto-day", "2024-04-21")]
+    [DataRow("US-TX", 2024, "day-after-thanksgiving", "2024-11-29")]
+    [DataRow("US-AK", 2024, "alaska-day", "2024-10-18")]
+    [DataRow("US-HI", 2024, "kamehameha-day", "2024-06-11")]
+    [DataRow("US-MO", 2024, "truman-day", "2024-05-08")]
+    [DataRow("US-WV", 2024, "west-virginia-day", "2024-06-20")]
+    [DataRow("US-IL", 2024, "lincolns-birthday", "2024-02-12")]
+    [DataRow("US-VT", 2024, "bennington-battle-day", "2024-08-16")]
+    public void Resolve_UnitedStatesStateHoliday_MatchesKnownAnswer(string territory, int year, string notableDateId, string expected)
+    {
+        NotableDate match = Single(territory, year, notableDateId);
+
+        Assert.AreEqual(DateOnly.Parse(expected, CultureInfo.InvariantCulture), match.Date, "emitted date");
+    }
+
+    /// <summary>
+    /// Verifies that holidays whose date floats from year to year resolve to independently-known reference dates
+    /// across both historical and future years — the Easter-derived offsets, the nth-weekday-in-month rules, and the
+    /// nearest-weekday rules — so the moving feasts are pinned, not merely structurally validated.
+    /// </summary>
+    /// <param name="territory">The requested territory code.</param>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="notableDateId">The notable-date id to resolve.</param>
+    /// <param name="expected">The expected emitted date in ISO format.</param>
+    [TestMethod]
+    [TestCategory("Regression")]
+
+    // Easter-derived (Algorithm + OffsetFromRule), historical and future.
+    [DataRow("US", 2008, "easter-sunday", "2008-03-23")]
+    [DataRow("US", 2030, "easter-sunday", "2030-04-21")]
+    [DataRow("US", 2038, "easter-sunday", "2038-04-25")]
+    [DataRow("US", 2008, "good-friday", "2008-03-21")]
+    [DataRow("US", 2021, "good-friday", "2021-04-02")]
+    [DataRow("US-LA", 2021, "mardi-gras", "2021-02-16")]
+    [DataRow("US-LA", 2024, "mardi-gras", "2024-02-13")]
+
+    // Nth-weekday-in-month, historical and future.
+    [DataRow("US", 2024, "mlk-day", "2024-01-15")]
+    [DataRow("US", 2031, "mlk-day", "2031-01-20")]
+    [DataRow("US", 2031, "memorial-day", "2031-05-26")]
+    [DataRow("US", 2024, "thanksgiving", "2024-11-28")]
+    [DataRow("US", 2030, "thanksgiving", "2030-11-28")]
+    [DataRow("CA", 2031, "thanksgiving", "2031-10-13")]
+    [DataRow("US-MA", 2024, "patriots-day", "2024-04-15")]
+    [DataRow("US-MA", 2031, "patriots-day", "2031-04-21")]
+    [DataRow("US-HI", 2024, "statehood-day-hi", "2024-08-16")]
+    [DataRow("US-NV", 2024, "nevada-day", "2024-10-25")]
+    [DataRow("US-AK", 2024, "sewards-day", "2024-03-25")]
+
+    // Nearest-weekday (WeekdayNearDate), Canada.
+    [DataRow("CA", 2031, "victoria-day", "2031-05-19")]
+    [DataRow("CA-NL", 2024, "nl-discovery-day", "2024-06-24")]
+    [DataRow("CA-NL", 2025, "nl-discovery-day", "2025-06-23")]
+    [DataRow("CA-NL", 2024, "nl-st-georges-day", "2024-04-22")]
+    public void Resolve_FloatingHoliday_MatchesKnownAnswer(string territory, int year, string notableDateId, string expected)
+    {
+        NotableDate match = Single(territory, year, notableDateId);
+
+        Assert.AreEqual(DateOnly.Parse(expected, CultureInfo.InvariantCulture), match.Date, "emitted date");
+    }
+
+    /// <summary>
+    /// Verifies that the shared observances consolidated in the americas-common hub resolve for both the United
+    /// States and Canada from their single hub/common-library definition.
+    /// </summary>
+    /// <param name="territory">The requested territory code.</param>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="notableDateId">The notable-date id to resolve.</param>
+    /// <param name="expected">The expected emitted date in ISO format.</param>
+    [TestMethod]
+    [TestCategory("Regression")]
+    [DataRow("US", 2024, "groundhog-day", "2024-02-02")]
+    [DataRow("CA", 2024, "groundhog-day", "2024-02-02")]
+    [DataRow("US", 2024, "st-patricks-day", "2024-03-17")]
+    [DataRow("US", 2024, "cinco-de-mayo", "2024-05-05")]
+    [DataRow("US", 2024, "earth-day", "2024-04-22")]
+    [DataRow("US", 2024, "valentines-day", "2024-02-14")]
+    [DataRow("CA", 2024, "valentines-day", "2024-02-14")]
+    [DataRow("CA", 2024, "international-womens-day", "2024-03-08")]
+    public void Resolve_HubSharedObservance_MatchesKnownAnswer(string territory, int year, string notableDateId, string expected)
+    {
+        NotableDate match = Single(territory, year, notableDateId);
+
+        Assert.AreEqual(DateOnly.Parse(expected, CultureInfo.InvariantCulture), match.Date, "emitted date");
+    }
+
+    /// <summary>
+    /// Verifies that National Indigenous Peoples Day resolves as a non-working statutory holiday in the Northwest
+    /// Territories (the territorial rule) while remaining a working observance nationally.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_NorthwestTerritoriesIndigenousPeoplesDay_IsStatutoryHoliday()
+    {
+        List<NotableDate> matches = AmericasCalendarData.CreateService("CA-NT")
+            .Resolve(new DateRange(new DateOnly(2024, 6, 21), new DateOnly(2024, 6, 21)), "CA-NT")
+            .Where(r => r.NotableDateId == "national-indigenous-peoples-day")
+            .ToList();
+
+        Assert.IsTrue(matches.Any(r => r.RuleId == "nt-yt" && r.IsNonWorkingDay), "expected a non-working territorial rule");
+    }
+
+    /// <summary>
+    /// Verifies that a holiday does not resolve in a year outside its applicability — before its first applicable
+    /// year, or (for the quadrennial Inauguration Day) in a non-inauguration year.
     /// </summary>
     /// <param name="territory">The requested territory code.</param>
     /// <param name="year">The Gregorian year.</param>
@@ -88,6 +205,10 @@ public sealed class AmericasCalendarDataTests
     [DataRow("US", 2020, "juneteenth")]
     [DataRow("CA", 2020, "truth-and-reconciliation-day")]
     [DataRow("CA-ON", 2007, "family-day")]
+    [DataRow("US-DC", 2004, "emancipation-day-dc")]
+    [DataRow("US-SD", 1989, "native-americans-day-sd")]
+    [DataRow("US-DC", 2023, "inauguration-day")]
+    [DataRow("US-DC", 2024, "inauguration-day")]
     public void Resolve_WhenBeforeFirstYear_ReturnsNoResult(string territory, int year, string notableDateId)
     {
         int count = AmericasCalendarData.CreateService(territory)

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/catholic.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/catholic.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ================================================================================================================
+  catholic — Catholic patron-saint feast-day catalogue (Western / Gregorian calendar)
+  ================================================================================================================
+
+  A common-library catalogue of fixed-date Catholic patron-saint feast days, a sibling to christian-western (the
+  Easter cluster and the major fixed feasts) and christian-orthodox. These are the saints' days that territory
+  packs observe as national or cultural days — most famously Saint Patrick's Day — so they are defined here once
+  for territory packs to import rather than each pack re-declaring them.
+
+  Convention (matching the other common catalogues): each concept carries the bare calculation strategy under the
+  stable rule id "default" with no territory scope. A territory pack imports the concept it observes through an
+  <Import><Use> directive and supplies its own territory scope, category, non-working flag, and any weekend
+  adjustment there. The catalogue default category is Religious (these are liturgical feast days); a pack that
+  observes one as a secular cultural day or a public holiday overrides category/nonWorking on its own <Use>.
+-->
+<NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="common.catholic">
+
+  <NotableDates>
+
+    <!-- Saint David's Day — 1 March; feast of Saint David, patron saint of Wales. Strategy: Fixed day-of-month. -->
+    <NotableDate id="st-davids-day" displayName="Saint David's Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="March" day="1" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Saint Patrick's Day — 17 March; feast of Saint Patrick, patron saint of Ireland, widely observed as a cultural day across the Irish diaspora (a public holiday in Ireland). Strategy: Fixed day-of-month. -->
+    <NotableDate id="st-patricks-day" displayName="Saint Patrick's Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="March" day="17" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Saint George's Day — 23 April; feast of Saint George, patron saint of England (and observed in Newfoundland and Labrador on the nearest Monday). Strategy: Fixed day-of-month. -->
+    <NotableDate id="st-georges-day" displayName="Saint George's Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="April" day="23" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+    <!-- Saint Andrew's Day — 30 November; feast of Saint Andrew, patron saint of Scotland. Strategy: Fixed day-of-month. -->
+    <NotableDate id="st-andrews-day" displayName="Saint Andrew's Day" category="Religious" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="November" day="30" /></Strategy></Rule></Rules>
+    </NotableDate>
+
+  </NotableDates>
+</NotableDateResource>

--- a/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/global-cultural.xml
+++ b/Bodu.Globalization.Calendar/src/Globalization.Calendar/Resources/global-cultural.xml
@@ -52,6 +52,11 @@
       <Rules><Rule id="default"><Strategy><Fixed month="May" day="4" /></Strategy></Rule></Rules>
     </NotableDate>
 
+    <!-- Cinco de Mayo — 5 May; commemorates the 1862 Mexican victory at the Battle of Puebla, widely observed as a celebration of Mexican-American culture. Strategy: Fixed day-of-month. -->
+    <NotableDate id="cinco-de-mayo" displayName="Cinco de Mayo" category="Cultural" defaultNonWorkingDay="false">
+      <Rules><Rule id="default"><Strategy><Fixed month="May" day="5" /></Strategy></Rule></Rules>
+    </NotableDate>
+
     <!-- World Music Day (Fête de la Musique) — 21 June; originated in France (from 1982). -->
     <NotableDate id="world-music-day" displayName="World Music Day" category="Cultural" defaultNonWorkingDay="false">
       <Rules><Rule id="default"><Applicability fromYear="1982" /><Strategy><Fixed month="June" day="21" /></Strategy></Rule></Rules>


### PR DESCRIPTION
## Summary

Refactors the US and Canada calendar resource packs to import shared observances from a new `americas-common` hub rather than declaring them inline. This eliminates duplication and establishes a single source of truth for pan-American holidays and observances.

## Key Changes

- **New `americas-common.xml` hub**: Created a regional consolidation point that re-exports shared civil, Western Christian, Catholic, family, cultural, and environmental observances from the common catalogues (`global-core`, `christian-western`, `catholic`, `global-family`, `global-cultural`, `global-environment`, `global-un`). Defines two pan-American concepts inline:
  - Groundhog Day (2 February) — shared North American observance
  - Thanksgiving — single concept with territory-scoped rules for both US (fourth Thursday of November) and Canada (second Monday of October)

- **New `catholic.xml` common catalogue**: Extracted Catholic patron-saint feast days (St. Patrick's Day, St. George's Day) as a reusable library, mirroring the structure of `christian-western` and other common catalogues.

- **Refactored `region-us.xml`**: 
  - Changed imports from `global-core` and `christian-western` to the new `americas-common` hub
  - Removed inline declarations of Valentine's Day, St. Patrick's Day, Groundhog Day, Earth Day, Mother's/Father's Day, Halloween, and Thanksgiving (now imported from hub)
  - Added comprehensive state and DC subdivision rules (US-AL through US-WY, US-DC) with statutory holidays, observances, and year-gated adoption dates
  - Reorganized documentation to explain federal vs. state-scoped rules and subdivision inheritance
  - Expanded test coverage for state-specific holidays and floating-date calculations

- **Refactored `region-ca.xml`**:
  - Changed imports from `global-core` and `christian-western` to `americas-common`
  - Removed inline declarations of Valentine's Day and International Women's Day (now imported from hub)
  - Updated documentation to clarify provincial/territorial rule inheritance from national rules
  - Corrected British Columbia Family Day date transition (second Monday 2013–2018, third Monday from 2019)

- **Updated `AmericasCalendarData.cs`**: Added `ResolveResource` method to serve the `americas-common` hub from the Americas pack's embedded resources while delegating other catalogue imports to `CommonNotableDateResources`.

- **Updated project file**: Embedded all XML resources (region packs and the americas-common hub) with appropriate logical names.

- **Enhanced test coverage**: Added regression tests for state holidays, floating-date calculations (Easter-derived, nth-weekday-in-month, nearest-weekday), shared hub observances, and territorial rule overrides (e.g., Good Friday as statutory holiday in Louisiana, Indigenous Peoples Day in Northwest Territories).

## Notable Implementation Details

- The `americas-common` hub uses transitive import resolution: regions import the hub without territory overrides, preserving all territory-scoped rules defined there (e.g., both US and Canadian Thanksgiving rules).
- State/provincial rules inherit federal/national rules automatically via territory containment; subdivision-scoped rules add further holidays without duplication.
- Year-gated adoption dates (`fromYear`, `toYear`, `everyYears`) gate state holidays to their legislative effective dates.
- Politically contested observances are excluded from state rules per documentation guidance.

https://claude.ai/code/session_01KNAbvcLbJytt4epD2ZfcK3