### PR TITLE
Make Globalization.Calendar tests binary (atomic + data-driven)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 *.userosscache
 *.sln.docstates
 
+# Claude Code agent worktrees (transient, per-session)
+.claude/worktrees/
+
 # MonoDevelop / Xamarin
 *.userprefs
 

--- a/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/AdjustmentPolicyBuilderTests.cs
+++ b/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/AdjustmentPolicyBuilderTests.cs
@@ -47,7 +47,8 @@ public class AdjustmentPolicyBuilderTests
         // 25 April 2027 is a Sunday; the policy observes it on Monday 26 April.
         NotableDate anzac = new NotableDateService(resource).Resolve(2027, "AU").Single();
 
-        Assert.IsTrue(anzac.IsObserved);
-        Assert.AreEqual(new DateOnly(2027, 4, 26), anzac.Date);
+        Assert.AreEqual(
+            (new DateOnly(2027, 4, 26), true),
+            (anzac.Date, anzac.IsObserved));
     }
 }

--- a/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Build.cs
+++ b/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Build.cs
@@ -17,10 +17,9 @@ public partial class NotableDateDocumentBuilderTests
     {
         NotableDateResource resource = SampleDocument().Build();
 
-        Assert.AreEqual("demo.sample", resource.ResourceId);
-        Assert.HasCount(4, resource.NotableDates);
-        Assert.AreEqual(RangeResolution.DuplicatePolicy.KeepFirst, resource.ResolutionPolicy.DuplicatePolicy);
-        Assert.HasCount(1, resource.AdjustmentPolicies);
+        Assert.AreEqual(
+            ("demo.sample", 4, RangeResolution.DuplicatePolicy.KeepFirst, 1),
+            (resource.ResourceId, resource.NotableDates.Count, resource.ResolutionPolicy.DuplicatePolicy, resource.AdjustmentPolicies.Count));
     }
 
     /// <summary>
@@ -33,8 +32,9 @@ public partial class NotableDateDocumentBuilderTests
 
         NotableDate newYear = service.Resolve(2026, "US").Single(n => n.NotableDateId == "new-years-day");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 1), newYear.Date);
-        Assert.AreEqual("New Year's Day", newYear.DisplayName);
+        Assert.AreEqual(
+            (new DateOnly(2026, 1, 1), "New Year's Day"),
+            (newYear.Date, newYear.DisplayName));
     }
 
     /// <summary>
@@ -88,9 +88,9 @@ public partial class NotableDateDocumentBuilderTests
         // 1 January 2028 falls on a Saturday; the weekend-to-monday policy moves it to Monday 3 January.
         NotableDate newYear = service.Resolve(2028, "US").Single(n => n.NotableDateId == "new-years-day");
 
-        Assert.IsTrue(newYear.IsObserved);
-        Assert.AreEqual(new DateOnly(2028, 1, 1), newYear.ActualDate);
-        Assert.AreEqual(new DateOnly(2028, 1, 3), newYear.Date);
+        Assert.AreEqual(
+            (new DateOnly(2028, 1, 3), (DateOnly?)new DateOnly(2028, 1, 1), true),
+            (newYear.Date, newYear.ActualDate, newYear.IsObserved));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Clone.cs
+++ b/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Clone.cs
@@ -20,7 +20,9 @@ public partial class NotableDateDocumentBuilderTests
         clone.AddNotableDate("independence-day", "Independence Day", NotableDateCategory.PublicHoliday, d => d
             .AddRule("default", r => r.ForTerritory("US").Fixed(7, 4)));
 
-        Assert.HasCount(4, original.Build().NotableDates);
-        Assert.HasCount(5, clone.Build().NotableDates);
+        // The original keeps its four definitions while the mutated clone gains the fifth.
+        Assert.AreEqual(
+            (4, 5),
+            (original.Build().NotableDates.Count, clone.Build().NotableDates.Count));
     }
 }

--- a/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.SaveLoad.cs
+++ b/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.SaveLoad.cs
@@ -18,8 +18,8 @@ public partial class NotableDateDocumentBuilderTests
         try
         {
             SampleDocument().Save(path);
-            Assert.IsTrue(File.Exists(path));
 
+            // Load fails loudly if Save did not write the file, so the round-trip assertion alone is sufficient.
             var loaded = NotableDateDocumentBuilder.Load(path);
 
             CollectionAssert.AreEqual(ResolvedSample(SampleDocument().Build()), ResolvedSample(loaded.Build()));
@@ -40,8 +40,8 @@ public partial class NotableDateDocumentBuilderTests
         try
         {
             SampleDocument().Save(path);
-            Assert.IsTrue(File.Exists(path));
 
+            // Load fails loudly if Save did not write the file, so the round-trip assertion alone is sufficient.
             var loaded = NotableDateDocumentBuilder.Load(path);
 
             CollectionAssert.AreEqual(ResolvedSample(SampleDocument().Build()), ResolvedSample(loaded.Build()));

--- a/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Serialization.cs
+++ b/Bodu.Globalization.Calendar.Builder/test/Globalization.Calendar.Builder/NotableDateDocumentBuilderTests.Serialization.cs
@@ -22,8 +22,9 @@ public partial class NotableDateDocumentBuilderTests
         var document = SampleDocument().ToXDocument();
 
         Assert.IsNotNull(document.Root);
-        Assert.AreEqual(SchemaNamespace + "NotableDateResource", document.Root!.Name);
-        Assert.AreEqual("demo.sample", (string?)document.Root.Attribute("resourceId"));
+        Assert.AreEqual(
+            (SchemaNamespace + "NotableDateResource", (string?)"demo.sample"),
+            (document.Root!.Name, (string?)document.Root.Attribute("resourceId")));
         Assert.IsNotNull(document.Root.Attribute("schemaVersion"));
     }
 
@@ -39,8 +40,9 @@ public partial class NotableDateDocumentBuilderTests
         NotableDateResource fromXml = NotableDateResourceLoader.Load(builder.ToXml());
         NotableDateResource direct = builder.Build();
 
-        Assert.AreEqual(direct.ResourceId, fromXml.ResourceId);
-        Assert.HasCount(direct.NotableDates.Count, fromXml.NotableDates);
+        Assert.AreEqual(
+            (direct.ResourceId, direct.NotableDates.Count),
+            (fromXml.ResourceId, fromXml.NotableDates.Count));
     }
 
     /// <summary>
@@ -53,8 +55,9 @@ public partial class NotableDateDocumentBuilderTests
 
         NotableDateResource fromJson = NotableDateResourceLoader.LoadJson(builder.ToJson());
 
-        Assert.AreEqual("demo.sample", fromJson.ResourceId);
-        Assert.HasCount(4, fromJson.NotableDates);
+        Assert.AreEqual(
+            ("demo.sample", 4),
+            (fromJson.ResourceId, fromJson.NotableDates.Count));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/AfricaCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Africa/test/AfricaCalendarDataTests.cs
@@ -105,25 +105,35 @@ public sealed class AfricaCalendarDataTests
     }
 
     /// <summary>
-    /// Verifies that a South African holiday falling on a Sunday is observed on the following Monday with the observed
-    /// flag, while a holiday on a Saturday is not moved.
+    /// Verifies that a South African holiday falling on a Sunday is observed on the following Monday and carries the
+    /// observed flag. Youth Day (16 June) fell on a Sunday in 2024 and is observed on Monday 17 June.
     /// </summary>
     [TestMethod]
     public void Resolve_WhenSouthAfricanHolidayFallsOnSunday_IsObservedOnMonday()
     {
-        // Youth Day (16 June) fell on a Sunday in 2024 and is observed on Monday 17 June.
         NotableDate moved = AfricaCalendarData.CreateService("ZA")
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "ZA")
             .Single(r => r.NotableDateId == "youth-day");
-        Assert.AreEqual(new DateOnly(2024, 6, 17), moved.Date, "Sunday holiday is observed on the Monday");
-        Assert.IsTrue(moved.IsObserved, "the moved holiday carries the observed flag");
 
-        // Freedom Day (27 April) fell on a Saturday in 2024 and is not moved.
+        Assert.AreEqual(
+            (new DateOnly(2024, 6, 17), true),
+            (moved.Date, moved.IsObserved));
+    }
+
+    /// <summary>
+    /// Verifies that a South African holiday falling on a Saturday is not moved and remains unobserved. Freedom Day
+    /// (27 April) fell on a Saturday in 2024 and stays on its calendar date.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_WhenSouthAfricanHolidayFallsOnSaturday_IsNotMoved()
+    {
         NotableDate notMoved = AfricaCalendarData.CreateService("ZA")
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "ZA")
             .Single(r => r.NotableDateId == "freedom-day");
-        Assert.AreEqual(new DateOnly(2024, 4, 27), notMoved.Date, "Saturday holiday is not moved");
-        Assert.IsFalse(notMoved.IsObserved, "a Saturday holiday is not an in-lieu observation");
+
+        Assert.AreEqual(
+            (new DateOnly(2024, 4, 27), false),
+            (notMoved.Date, notMoved.IsObserved));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/AmericasCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Americas/test/AmericasCalendarDataTests.cs
@@ -411,34 +411,54 @@ public sealed class AmericasCalendarDataTests
     }
 
     /// <summary>
-    /// Verifies that a Colombian Emiliani-law holiday is observed on the following Monday when its calendar date is
-    /// not a Monday (carrying the observed flag), and on its calendar date when it already falls on a Monday.
+    /// Verifies that a Colombian Emiliani-law holiday whose calendar date is not a Monday is observed on the following
+    /// Monday and carries the observed flag. Epiphany 2024 fell on a Saturday and is observed on Monday 8 January.
     /// </summary>
     [TestMethod]
-    public void Resolve_ColombianEmilianiHoliday_IsObservedOnFollowingMonday()
+    public void Resolve_ColombianEmilianiHoliday_WhenNotOnMonday_IsObservedOnFollowingMonday()
     {
         NotableDate moved = Single("CO", 2024, "epiphany");
-        Assert.AreEqual(new DateOnly(2024, 1, 8), moved.Date, "Epiphany 2024 fell on a Saturday and is observed the following Monday");
-        Assert.IsTrue(moved.IsObserved, "the moved Emiliani holiday should carry the observed flag");
 
-        NotableDate notMoved = Single("CO", 2025, "epiphany");
-        Assert.AreEqual(new DateOnly(2025, 1, 6), notMoved.Date, "Epiphany 2025 already falls on a Monday");
-        Assert.IsFalse(notMoved.IsObserved, "a holiday already on a Monday is not moved");
+        Assert.AreEqual(
+            (new DateOnly(2024, 1, 8), true),
+            (moved.Date, moved.IsObserved));
     }
 
     /// <summary>
-    /// Verifies that a Brazilian state holiday resolves for its state but not for a plain national query, confirming
-    /// subdivision scoping.
+    /// Verifies that a Colombian Emiliani-law holiday already falling on a Monday is not moved and remains unobserved.
+    /// Epiphany 2025 already falls on Monday 6 January.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_ColombianEmilianiHoliday_WhenAlreadyOnMonday_IsNotMoved()
+    {
+        NotableDate notMoved = Single("CO", 2025, "epiphany");
+
+        Assert.AreEqual(
+            (new DateOnly(2025, 1, 6), false),
+            (notMoved.Date, notMoved.IsObserved));
+    }
+
+    /// <summary>
+    /// Verifies that the São Paulo Constitutionalist Revolution holiday resolves for the São Paulo subdivision query.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_WhenBrazilianStateHolidayQueriedForState_ReturnsSingleResult()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        Assert.AreEqual(1, AmericasCalendarData.CreateService("BR-SP").Resolve(year, "BR-SP").Count(r => r.NotableDateId == "constitutionalist-revolution"));
+    }
+
+    /// <summary>
+    /// Verifies that the São Paulo Constitutionalist Revolution holiday does not resolve for a plain national Brazil
+    /// query, confirming subdivision scoping.
     /// </summary>
     [TestMethod]
     public void Resolve_WhenBrazilianStateHolidayQueriedNationally_ReturnsNoResult()
     {
         DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
-        Assert.AreEqual(1, AmericasCalendarData.CreateService("BR-SP").Resolve(year, "BR-SP").Count(r => r.NotableDateId == "constitutionalist-revolution"),
-            "São Paulo should observe the Constitutionalist Revolution");
-        Assert.AreEqual(0, AmericasCalendarData.CreateService("BR").Resolve(year, "BR").Count(r => r.NotableDateId == "constitutionalist-revolution"),
-            "a plain national Brazil query should not");
+        Assert.AreEqual(0, AmericasCalendarData.CreateService("BR").Resolve(year, "BR").Count(r => r.NotableDateId == "constitutionalist-revolution"));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/AsiaPacificCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.AsiaPacific/test/AsiaPacificCalendarDataTests.cs
@@ -137,9 +137,9 @@ public sealed class AsiaPacificCalendarDataTests
             .Resolve(new DateRange(new DateOnly(2020, 1, 1), new DateOnly(2020, 12, 31)), "AU-WA")
             .Single(r => r.NotableDateId == "anzac-day");
 
-        Assert.AreEqual(new DateOnly(2020, 4, 27), wa.Date);
-        Assert.IsTrue(wa.IsObserved);
-        Assert.AreEqual("wa", wa.RuleId);
+        Assert.AreEqual(
+            (new DateOnly(2020, 4, 27), true, "wa"),
+            (wa.Date, wa.IsObserved, wa.RuleId));
     }
 
     /// <summary>
@@ -269,9 +269,9 @@ public sealed class AsiaPacificCalendarDataTests
             .ToList();
 
         Assert.HasCount(1, matches, "a day inside the span returns the occurrence");
-        Assert.AreEqual(new DateOnly(2024, 2, 10), matches[0].Date, "span start");
-        Assert.AreEqual(7, matches[0].DurationDays, "duration");
-        Assert.AreEqual(new DateOnly(2024, 2, 16), matches[0].EndDate, "span end");
+        Assert.AreEqual(
+            (new DateOnly(2024, 2, 10), 7, new DateOnly(2024, 2, 16)),
+            (matches[0].Date, matches[0].DurationDays, matches[0].EndDate));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/EuropeCalendarDataTests.cs
+++ b/Bodu.Globalization.Calendar.Data/Bodu.Globalization.Calendar.Europe/test/EuropeCalendarDataTests.cs
@@ -144,51 +144,114 @@ public sealed class EuropeCalendarDataTests
     }
 
     /// <summary>
-    /// Verifies that the Alsace-Moselle Good Friday resolves for a département query but not for a plain national
-    /// France query, and that the restored Assumption of Mary is a non-working public holiday in France.
+    /// Verifies that the Alsace-Moselle Good Friday resolves for a département query (FR-67), confirming the
+    /// subdivision-scoped rule applies for the départements that observe it.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
-    public void Resolve_FrenchAlsaceMoselleAndRestoredEntries_RespectScopeAndStatus()
+    public void Resolve_FrenchAlsaceMoselleGoodFriday_WhenQueriedForDepartement_ReturnsSingleResult()
     {
         DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
-        Assert.ContainsSingle(r => r.NotableDateId == "good-friday",
-EuropeCalendarData.CreateService("FR-67").Resolve(year, "FR-67"), "Good Friday should resolve for Alsace-Moselle (FR-67)");
-        Assert.AreEqual(0, EuropeCalendarData.CreateService("FR").Resolve(year, "FR").Count(r => r.NotableDateId == "good-friday"),
-            "Good Friday should not resolve for a plain national France query");
-
-        // The Assumption (15 August) is a statutory non-working public holiday in France — checked on the occurrence
-        // flag rather than the IsNonWorkingDay extension, which also treats weekends as non-working.
-        NotableDate assumption = EuropeCalendarData.CreateService("FR").Resolve(year, "FR").Single(r => r.NotableDateId == "assumption-of-mary");
-        Assert.IsTrue(assumption.IsNonWorkingDay, "the Assumption should be a non-working public holiday in France");
+        Assert.ContainsSingle(r => r.NotableDateId == "good-friday", EuropeCalendarData.CreateService("FR-67").Resolve(year, "FR-67"));
     }
 
     /// <summary>
-    /// Verifies that the German federal-state religious feasts resolve as non-working public holidays for the Länder
-    /// that observe them but not for a plain national query or a non-observing state, confirming the audit re-scoping.
+    /// Verifies that the Alsace-Moselle Good Friday does not resolve for a plain national France query, confirming the
+    /// subdivision scoping.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
-    public void Resolve_GermanStateFeasts_AreScopedToTheirLaender()
+    public void Resolve_FrenchAlsaceMoselleGoodFriday_WhenQueriedNationally_ReturnsNoResult()
     {
         DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
-        // Epiphany (6 Jan) is a non-working public holiday in Bavaria, but resolves for neither a plain national
-        // query (DE-BW/BY/ST does not match "DE") nor a non-observing state (Berlin).
-        NotableDate bavarianEpiphany = EuropeCalendarData.CreateService("DE-BY").Resolve(year, "DE-BY").Single(r => r.NotableDateId == "epiphany");
-        Assert.IsTrue(bavarianEpiphany.IsNonWorkingDay, "Epiphany should be a non-working public holiday in Bavaria");
-        Assert.AreEqual(0, EuropeCalendarData.CreateService("DE").Resolve(year, "DE").Count(r => r.NotableDateId == "epiphany"),
-            "Epiphany should not resolve for a plain national Germany query");
-        Assert.AreEqual(0, EuropeCalendarData.CreateService("DE-BE").Resolve(year, "DE-BE").Count(r => r.NotableDateId == "epiphany"),
-            "Epiphany should not resolve for Berlin");
+        Assert.AreEqual(0, EuropeCalendarData.CreateService("FR").Resolve(year, "FR").Count(r => r.NotableDateId == "good-friday"));
+    }
 
-        // International Women's Day (8 Mar) is a non-working public holiday in Berlin but a working observance
-        // nationally — the two-rule concept with territory shadowing returns the state rule for BE and the national
-        // rule for a plain DE query.
+    /// <summary>
+    /// Verifies that the restored Assumption of Mary (15 August) is a non-working public holiday in France — checked on
+    /// the occurrence flag rather than the IsNonWorkingDay extension, which also treats weekends as non-working.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_FrenchAssumptionOfMary_IsNonWorkingPublicHoliday()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        NotableDate assumption = EuropeCalendarData.CreateService("FR").Resolve(year, "FR").Single(r => r.NotableDateId == "assumption-of-mary");
+
+        Assert.IsTrue(assumption.IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that Epiphany (6 January) is a non-working public holiday in Bavaria, confirming the Länder-scoped feast
+    /// resolves for a state that observes it.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_GermanEpiphany_WhenQueriedForBavaria_IsNonWorkingPublicHoliday()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        NotableDate bavarianEpiphany = EuropeCalendarData.CreateService("DE-BY").Resolve(year, "DE-BY").Single(r => r.NotableDateId == "epiphany");
+
+        Assert.IsTrue(bavarianEpiphany.IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that Epiphany does not resolve for a plain national Germany query, confirming the feast is scoped to the
+    /// observing Länder rather than the nation.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_GermanEpiphany_WhenQueriedNationally_ReturnsNoResult()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        Assert.AreEqual(0, EuropeCalendarData.CreateService("DE").Resolve(year, "DE").Count(r => r.NotableDateId == "epiphany"));
+    }
+
+    /// <summary>
+    /// Verifies that Epiphany does not resolve for Berlin (a non-observing state), confirming the feast is scoped to the
+    /// Länder that observe it.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_GermanEpiphany_WhenQueriedForNonObservingState_ReturnsNoResult()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
+        Assert.AreEqual(0, EuropeCalendarData.CreateService("DE-BE").Resolve(year, "DE-BE").Count(r => r.NotableDateId == "epiphany"));
+    }
+
+    /// <summary>
+    /// Verifies that International Women's Day (8 March) is a non-working public holiday in Berlin, confirming the state
+    /// rule shadows the national rule for a Berlin query.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_GermanWomensDay_WhenQueriedForBerlin_IsNonWorkingPublicHoliday()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
         NotableDate berlinWomensDay = EuropeCalendarData.CreateService("DE-BE").Resolve(year, "DE-BE").Single(r => r.NotableDateId == "womens-day");
-        Assert.IsTrue(berlinWomensDay.IsNonWorkingDay, "Women's Day should be a non-working public holiday in Berlin");
+
+        Assert.IsTrue(berlinWomensDay.IsNonWorkingDay);
+    }
+
+    /// <summary>
+    /// Verifies that International Women's Day is a working observance for a plain national Germany query, confirming the
+    /// national rule applies where no shadowing state rule matches.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_GermanWomensDay_WhenQueriedNationally_IsWorkingObservance()
+    {
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
+
         NotableDate nationalWomensDay = EuropeCalendarData.CreateService("DE").Resolve(year, "DE").Single(r => r.NotableDateId == "womens-day");
-        Assert.IsFalse(nationalWomensDay.IsNonWorkingDay, "Women's Day should be a working observance nationally");
+
+        Assert.IsFalse(nationalWomensDay.IsNonWorkingDay);
     }
 }

--- a/Bodu.Globalization.Calendar.DependencyInjection/test/NotableDateServiceCollectionExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar.DependencyInjection/test/NotableDateServiceCollectionExtensionsTests.cs
@@ -42,8 +42,9 @@ public sealed class NotableDateServiceCollectionExtensionsTests
         INotableDateService service = provider.GetRequiredService<INotableDateService>();
         IReadOnlyList<NotableDate> holidays = service.Resolve(new DateOnly(2026, 1, 1), "XX");
 
-        Assert.HasCount(1, holidays);
-        Assert.AreEqual("new-years-day", holidays[0].NotableDateId);
+        CollectionAssert.AreEqual(
+            new[] { ("new-years-day", new DateOnly(2026, 1, 1)) },
+            holidays.Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>
@@ -90,8 +91,24 @@ public sealed class NotableDateServiceCollectionExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that the reloadable registration resolves a service whose results follow a runtime reload performed
-    /// through the registered provider.
+    /// Verifies that the reloadable registration resolves the initially-loaded resource before any reload, emitting the
+    /// 1 January occurrence from the January document.
+    /// </summary>
+    [TestMethod]
+    public void AddReloadableNotableDateService_BeforeReload_ResolvesInitialResource()
+    {
+        ServiceProvider provider = new ServiceCollection()
+            .AddReloadableNotableDateService(NotableDateResourceLoader.Load(Xml))
+            .BuildServiceProvider();
+
+        INotableDateService service = provider.GetRequiredService<INotableDateService>();
+
+        Assert.AreEqual(new DateOnly(2026, 1, 1), service.Resolve(new DateRange(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)), "XX").Single().Date);
+    }
+
+    /// <summary>
+    /// Verifies that, after a runtime reload performed through the registered provider, the resolved service reflects the
+    /// new resource, emitting the 1 February occurrence from the reloaded document.
     /// </summary>
     [TestMethod]
     public void AddReloadableNotableDateService_AfterProviderReload_ReflectsNewResource()
@@ -112,8 +129,6 @@ public sealed class NotableDateServiceCollectionExtensionsTests
             .BuildServiceProvider();
 
         INotableDateService service = provider.GetRequiredService<INotableDateService>();
-        Assert.AreEqual(new DateOnly(2026, 1, 1), service.Resolve(new DateRange(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)), "XX").Single().Date);
-
         provider.GetRequiredService<MutableNotableDateResourceProvider>().Reload(NotableDateResourceLoader.Load(februaryXml));
 
         Assert.AreEqual(new DateOnly(2026, 2, 1), service.Resolve(new DateRange(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)), "XX").Single().Date);

--- a/Bodu.Globalization.Calendar.Plugins/test/NotableDatePluginLoaderTests.cs
+++ b/Bodu.Globalization.Calendar.Plugins/test/NotableDatePluginLoaderTests.cs
@@ -59,21 +59,35 @@ public sealed class NotableDatePluginLoaderTests
         INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy());
 
         Assert.IsInstanceOfType<TestPlugin>(plugin);
-        Assert.AreEqual("Test Plugin", plugin.Name);
-        Assert.AreEqual(new Version(1, 2, 3), plugin.Version);
+        Assert.AreEqual(
+            ("Test Plugin", new Version(1, 2, 3)),
+            (plugin.Name, plugin.Version));
     }
 
     /// <summary>
-    /// Verifies that registering the plugin's algorithms makes its key resolvable by the engine.
+    /// Verifies that registering a plugin contributing a single algorithm reports one registered algorithm.
     /// </summary>
     [TestMethod]
-    public void RegisterAlgorithms_MakesThePluginKeyResolvable()
+    public void RegisterAlgorithms_WhenPluginHasOneAlgorithm_ReturnsRegisteredCount()
     {
         INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy());
         NotableDateAlgorithmRegistry registry = new();
 
         var count = NotableDatePluginLoader.RegisterAlgorithms(plugin, registry);
+
         Assert.AreEqual(1, count);
+    }
+
+    /// <summary>
+    /// Verifies that, once the plugin's algorithms are registered, the engine resolves a notable date that references
+    /// the plugin's key to the algorithm-computed occurrence (1 July).
+    /// </summary>
+    [TestMethod]
+    public void RegisterAlgorithms_WhenKeyRegistered_ResolvesPluginAlgorithmOccurrence()
+    {
+        INotableDatePlugin plugin = NotableDatePluginLoader.LoadFrom(TestAssembly, new AllowAllPluginTrustPolicy());
+        NotableDateAlgorithmRegistry registry = new();
+        _ = NotableDatePluginLoader.RegisterAlgorithms(plugin, registry);
 
         const string Xml = """
         <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.plugin">
@@ -162,7 +176,8 @@ public sealed class NotableDatePluginLoaderTests
             : Convert.ToHexString(tokenBytes).ToLowerInvariant();
 
         Assert.IsNotNull(captured);
-        Assert.AreEqual(TestAssembly.GetName().Name, captured!.AssemblyName);
-        Assert.AreEqual(expectedToken, captured.PublicKeyToken);
+        Assert.AreEqual(
+            (TestAssembly.GetName().Name, (string?)expectedToken),
+            ((string?)captured!.AssemblyName, captured.PublicKeyToken));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjacentHolidayTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjacentHolidayTests.cs
@@ -34,14 +34,14 @@ public sealed class AdjacentHolidayTests
             .Resolve(new DateRange(new DateOnly(2021, 12, 20), new DateOnly(2021, 12, 31)), "AU");
 
         NotableDate christmas = Single(results, "christmas-day");
-        Assert.AreEqual(new DateOnly(2021, 12, 27), christmas.Date, "Christmas observed Monday");
-        Assert.AreEqual(new DateOnly(2021, 12, 25), christmas.ActualDate);
-        Assert.IsTrue(christmas.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2021, 12, 27), (DateOnly?)new DateOnly(2021, 12, 25), true),
+            (christmas.Date, christmas.ActualDate, christmas.IsObserved));
 
         NotableDate boxing = Single(results, "boxing-day");
-        Assert.AreEqual(new DateOnly(2021, 12, 28), boxing.Date, "Boxing Day advances to Tuesday");
-        Assert.AreEqual(new DateOnly(2021, 12, 26), boxing.ActualDate);
-        Assert.IsTrue(boxing.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2021, 12, 28), (DateOnly?)new DateOnly(2021, 12, 26), true),
+            (boxing.Date, boxing.ActualDate, boxing.IsObserved));
     }
 
     /// <summary>
@@ -55,29 +55,45 @@ public sealed class AdjacentHolidayTests
             .Resolve(new DateRange(new DateOnly(2016, 12, 20), new DateOnly(2016, 12, 31)), "AU");
 
         NotableDate christmas = Single(results, "christmas-day");
-        Assert.AreEqual(new DateOnly(2016, 12, 27), christmas.Date, "Christmas substitute skips Boxing Day's Monday");
-        Assert.AreEqual(new DateOnly(2016, 12, 25), christmas.ActualDate);
-        Assert.IsTrue(christmas.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2016, 12, 27), (DateOnly?)new DateOnly(2016, 12, 25), true),
+            (christmas.Date, christmas.ActualDate, christmas.IsObserved));
 
         NotableDate boxing = Single(results, "boxing-day");
-        Assert.AreEqual(new DateOnly(2016, 12, 26), boxing.Date, "Boxing Day keeps its Monday");
-        Assert.IsFalse(boxing.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2016, 12, 26), false),
+            (boxing.Date, boxing.IsObserved));
     }
 
     /// <summary>
-    /// Verifies that single-day queries agree with the range result and that the suppressed weekend actuals are not
-    /// emitted. (2021)
+    /// Verifies that a single-day query agrees with the range result, emitting the expected observed concept on its
+    /// substitute day. In 2021 Christmas is observed on Monday 27 December and Boxing Day on Tuesday 28 December.
     /// </summary>
+    /// <param name="month">The queried month.</param>
+    /// <param name="day">The queried day of December 2021.</param>
+    /// <param name="expectedId">The concept id expected on that day.</param>
     [TestMethod]
-    public void Resolve_WhenQueriedByDay_IsConsistentWithRangeAndSuppressesActuals()
+    [DataRow(12, 27, "christmas-day")]  // Christmas observed Monday
+    [DataRow(12, 28, "boxing-day")]     // Boxing Day observed Tuesday
+    public void Resolve_WhenQueriedByDay_EmitsExpectedConcept(int month, int day, string expectedId)
     {
-        NotableDateService service = CreateService();
+        NotableDate match = Single(CreateService().Resolve(new DateOnly(2021, month, day), "AU"), expectedId);
 
-        Assert.AreEqual("christmas-day", Single(service.Resolve(new DateOnly(2021, 12, 27), "AU"), "christmas-day").NotableDateId);
-        Assert.AreEqual("boxing-day", Single(service.Resolve(new DateOnly(2021, 12, 28), "AU"), "boxing-day").NotableDateId);
+        Assert.AreEqual(expectedId, match.NotableDateId);
+    }
 
-        Assert.IsEmpty(service.Resolve(new DateOnly(2021, 12, 25), "AU"), "Christmas Saturday actual suppressed");
-        Assert.IsEmpty(service.Resolve(new DateOnly(2021, 12, 26), "AU"), "Boxing Day Sunday actual suppressed");
+    /// <summary>
+    /// Verifies that a weekend actual date suppressed by an observed-only substitution emits nothing. In 2021 the Saturday
+    /// 25 December Christmas actual and the Sunday 26 December Boxing Day actual are both suppressed.
+    /// </summary>
+    /// <param name="month">The queried month.</param>
+    /// <param name="day">The queried day of December 2021.</param>
+    [TestMethod]
+    [DataRow(12, 25)]  // Christmas Saturday actual suppressed
+    [DataRow(12, 26)]  // Boxing Day Sunday actual suppressed
+    public void Resolve_WhenQueriedOnSuppressedWeekendActual_EmitsNothing(int month, int day)
+    {
+        Assert.IsEmpty(CreateService().Resolve(new DateOnly(2021, month, day), "AU"));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentActionMatrixTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentActionMatrixTests.cs
@@ -116,8 +116,9 @@ public sealed class AdjustmentActionMatrixTests
     {
         NotableDate match = Single(AddDaysService(0), "probe", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 1));
 
-        Assert.AreEqual(new DateOnly(2026, 7, 1), match.Date);
-        Assert.AreEqual("shift", match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 7, 1), (string?)"shift"),
+            (match.Date, match.AdjustmentPolicyId));
     }
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -342,8 +343,9 @@ public sealed class AdjustmentActionMatrixTests
         // Probe anchor Wed 23 Dec → step to Thu 24 Dec (occupied by blocker, skipped) → Fri 25 Dec (free working day).
         NotableDate probe = Single(service, "probe", new DateOnly(2026, 12, 1), new DateOnly(2026, 12, 31));
 
-        Assert.AreEqual(new DateOnly(2026, 12, 25), probe.Date);
-        Assert.AreEqual(new DateOnly(2026, 12, 23), probe.ActualDate);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 25), (DateOnly?)new DateOnly(2026, 12, 23)),
+            (probe.Date, probe.ActualDate));
     }
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -382,9 +384,9 @@ public sealed class AdjustmentActionMatrixTests
 
         NotableDate match = Single(service, "replacement", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 31));
 
-        Assert.AreEqual(new DateOnly(2026, 7, 15), match.Date);
-        Assert.AreEqual(new DateOnly(2026, 7, 1), match.ActualDate);
-        Assert.IsTrue(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2026, 7, 15), (DateOnly?)new DateOnly(2026, 7, 1), true),
+            (match.Date, match.ActualDate, match.IsObserved));
     }
 
     /// <summary>
@@ -416,8 +418,8 @@ public sealed class AdjustmentActionMatrixTests
 
         NotableDate match = Single(service, "probe", new DateOnly(2026, 7, 1), new DateOnly(2026, 7, 5));
 
-        Assert.AreEqual(new DateOnly(2026, 7, 1), match.Date);
-        Assert.IsFalse(match.IsObserved);
-        Assert.IsNull(match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 7, 1), false, (string?)null),
+            (match.Date, match.IsObserved, match.AdjustmentPolicyId));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentEmissionMatrixTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentEmissionMatrixTests.cs
@@ -68,9 +68,9 @@ public sealed class AdjustmentEmissionMatrixTests
         IReadOnlyList<NotableDate> results = ResolveNewYear(EmissionService("ActualOnly"), 2022);
 
         Assert.HasCount(1, results);
-        Assert.AreEqual(new DateOnly(2022, 1, 1), results[0].Date);
-        Assert.IsFalse(results[0].IsObserved);
-        Assert.IsNull(results[0].AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2022, 1, 1), false, (string?)null),
+            (results[0].Date, results[0].IsObserved, results[0].AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -83,10 +83,9 @@ public sealed class AdjustmentEmissionMatrixTests
         IReadOnlyList<NotableDate> results = ResolveNewYear(EmissionService("ObservedOnly"), 2022);
 
         Assert.HasCount(1, results);
-        Assert.AreEqual(new DateOnly(2022, 1, 3), results[0].Date);
-        Assert.AreEqual(new DateOnly(2022, 1, 1), results[0].ActualDate);
-        Assert.IsTrue(results[0].IsObserved);
-        Assert.AreEqual("mondayise", results[0].AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2022, 1, 3), (DateOnly?)new DateOnly(2022, 1, 1), true, (string?)"mondayise"),
+            (results[0].Date, results[0].ActualDate, results[0].IsObserved, results[0].AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -98,9 +97,9 @@ public sealed class AdjustmentEmissionMatrixTests
     {
         IReadOnlyList<NotableDate> results = ResolveNewYear(EmissionService("ActualAndObserved"), 2022);
 
-        Assert.HasCount(2, results);
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 1) && !r.IsObserved, results, "actual occurrence");
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 3) && r.IsObserved, results, "observed occurrence");
+        CollectionAssert.AreEqual(
+            new[] { (new DateOnly(2022, 1, 1), false), (new DateOnly(2022, 1, 3), true) },
+            results.OrderBy(r => r.Date).Select(r => (r.Date, r.IsObserved)).ToArray());
     }
 
     /// <summary>
@@ -112,9 +111,9 @@ public sealed class AdjustmentEmissionMatrixTests
     {
         IReadOnlyList<NotableDate> results = ResolveNewYear(EmissionService("ObservedAsAdditional"), 2022);
 
-        Assert.HasCount(2, results);
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 1) && !r.IsObserved, results, "actual occurrence");
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 3) && r.IsObserved, results, "additional observed occurrence");
+        CollectionAssert.AreEqual(
+            new[] { (new DateOnly(2022, 1, 1), false), (new DateOnly(2022, 1, 3), true) },
+            results.OrderBy(r => r.Date).Select(r => (r.Date, r.IsObserved)).ToArray());
     }
 
     /// <summary>
@@ -212,8 +211,9 @@ public sealed class AdjustmentEmissionMatrixTests
             .Resolve(new DateRange(new DateOnly(2026, 12, 25), new DateOnly(2026, 12, 31)), Territory)
             .Single(r => r.NotableDateId == "probe");
 
-        Assert.AreEqual(new DateOnly(2026, 12, 26), match.Date);
-        Assert.AreEqual("shift-one", match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 26), (string?)"shift-one"),
+            (match.Date, match.AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -227,8 +227,9 @@ public sealed class AdjustmentEmissionMatrixTests
             .Resolve(new DateRange(new DateOnly(2026, 12, 25), new DateOnly(2026, 12, 31)), Territory)
             .Single(r => r.NotableDateId == "probe");
 
-        Assert.AreEqual(new DateOnly(2026, 12, 28), match.Date);
-        Assert.AreEqual("shift-three", match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 28), (string?)"shift-three"),
+            (match.Date, match.AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -276,8 +277,9 @@ public sealed class AdjustmentEmissionMatrixTests
             .Resolve(new DateRange(new DateOnly(2026, 12, 26), new DateOnly(2026, 12, 31)), Territory)
             .Single(r => r.NotableDateId == "probe");
 
-        Assert.AreEqual(new DateOnly(2026, 12, 28), match.Date);
-        Assert.AreEqual("weekend-only", match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 28), (string?)"weekend-only"),
+            (match.Date, match.AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -311,8 +313,8 @@ public sealed class AdjustmentEmissionMatrixTests
             .Resolve(new DateRange(new DateOnly(2026, 12, 26), new DateOnly(2026, 12, 31)), Territory)
             .Single(r => r.NotableDateId == "probe");
 
-        Assert.AreEqual(new DateOnly(2026, 12, 26), match.Date);
-        Assert.IsFalse(match.IsObserved);
-        Assert.IsNull(match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 26), false, (string?)null),
+            (match.Date, match.IsObserved, match.AdjustmentPolicyId));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentPolicyYearScopeTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentPolicyYearScopeTests.cs
@@ -55,60 +55,80 @@ public sealed class AdjustmentPolicyYearScopeTests
         service.Resolve(new DateRange(new DateOnly(year, 1, 1), new DateOnly(year, 1, 7)), Territory).Single();
 
     /// <summary>
-    /// Verifies that a <c>fromYear</c> scope applies the substitution from that year onward but not before.
+    /// Verifies that a <c>fromYear="2022"</c> scope applies the substitution from that year onward but not before,
+    /// emitting the observed Monday in scope and the unshifted Saturday actual date out of scope. 1 January is a
+    /// Saturday in both 2011 and 2022.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedObserved">Whether the substitution applies in that year.</param>
+    /// <param name="expectedMonth">The expected emitted month.</param>
+    /// <param name="expectedDay">The expected emitted day.</param>
     [TestMethod]
-    public void FromYear_AppliesFromThatYearOnward()
+    [DataRow(2022, true, 1, 3)]    // in scope -> observed Monday 3 January
+    [DataRow(2011, false, 1, 1)]   // before fromYear -> unshifted Saturday 1 January
+    public void FromYear_AppliesFromThatYearOnward(int year, bool expectedObserved, int expectedMonth, int expectedDay)
     {
         INotableDateService service = Build("""<Scope fromYear="2022" />""");
 
-        NotableDate applied = ResolveNewYear(service, 2022);
-        Assert.IsTrue(applied.IsObserved);
-        Assert.AreEqual(new DateOnly(2022, 1, 3), applied.Date);
+        NotableDate occurrence = ResolveNewYear(service, year);
 
-        // 1 January 2011 is also a Saturday, but it precedes the policy's fromYear, so no substitution applies.
-        NotableDate notApplied = ResolveNewYear(service, 2011);
-        Assert.IsFalse(notApplied.IsObserved);
-        Assert.AreEqual(new DateOnly(2011, 1, 1), notApplied.Date);
+        Assert.AreEqual(
+            (expectedObserved, new DateOnly(year, expectedMonth, expectedDay)),
+            (occurrence.IsObserved, occurrence.Date));
     }
 
     /// <summary>
-    /// Verifies that a <c>toYear</c> scope applies the substitution up to that year but not after.
+    /// Verifies that a <c>toYear="2022"</c> scope applies the substitution up to that year but not after, emitting the
+    /// observed Monday in scope and the unshifted weekend actual date out of scope. 1 January is a Saturday in 2022 and
+    /// a Sunday in 2023.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedObserved">Whether the substitution applies in that year.</param>
+    /// <param name="expectedMonth">The expected emitted month.</param>
+    /// <param name="expectedDay">The expected emitted day.</param>
     [TestMethod]
-    public void ToYear_AppliesUpToThatYear()
+    [DataRow(2022, true, 1, 3)]    // in scope -> observed Monday 3 January
+    [DataRow(2023, false, 1, 1)]   // after toYear -> unshifted Sunday 1 January
+    public void ToYear_AppliesUpToThatYear(int year, bool expectedObserved, int expectedMonth, int expectedDay)
     {
         INotableDateService service = Build("""<Scope toYear="2022" />""");
 
-        Assert.IsTrue(ResolveNewYear(service, 2022).IsObserved);
+        NotableDate occurrence = ResolveNewYear(service, year);
 
-        NotableDate after = ResolveNewYear(service, 2023);
-        Assert.IsFalse(after.IsObserved);
-        Assert.AreEqual(new DateOnly(2023, 1, 1), after.Date);
+        Assert.AreEqual(
+            (expectedObserved, new DateOnly(year, expectedMonth, expectedDay)),
+            (occurrence.IsObserved, occurrence.Date));
     }
 
     /// <summary>
-    /// Verifies that an <c>OnlyYear</c> scope applies the substitution only in the listed year.
+    /// Verifies that an <c>OnlyYear="2022"</c> scope applies the substitution only in the listed year.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedObserved">Whether the substitution applies in that year.</param>
     [TestMethod]
-    public void OnlyYears_AppliesOnlyInListedYears()
+    [DataRow(2022, true)]   // listed year -> observed
+    [DataRow(2023, false)]  // unlisted year -> not observed
+    public void OnlyYears_AppliesOnlyInListedYears(int year, bool expectedObserved)
     {
         INotableDateService service = Build("""<Scope><OnlyYear value="2022" /></Scope>""");
 
-        Assert.IsTrue(ResolveNewYear(service, 2022).IsObserved);
-        Assert.IsFalse(ResolveNewYear(service, 2023).IsObserved);
+        Assert.AreEqual(expectedObserved, ResolveNewYear(service, year).IsObserved);
     }
 
     /// <summary>
-    /// Verifies that an <c>ExceptYear</c> scope suppresses the substitution in the listed year while applying elsewhere.
+    /// Verifies that an <c>ExceptYear="2022"</c> scope suppresses the substitution in the listed year while applying
+    /// elsewhere.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedObserved">Whether the substitution applies in that year.</param>
     [TestMethod]
-    public void ExceptYears_SuppressesListedYears()
+    [DataRow(2022, false)]  // excluded year -> not observed
+    [DataRow(2023, true)]   // other year -> observed
+    public void ExceptYears_SuppressesListedYears(int year, bool expectedObserved)
     {
         INotableDateService service = Build("""<Scope><ExceptYear value="2022" /></Scope>""");
 
-        Assert.IsFalse(ResolveNewYear(service, 2022).IsObserved);
-        Assert.IsTrue(ResolveNewYear(service, 2023).IsObserved);
+        Assert.AreEqual(expectedObserved, ResolveNewYear(service, year).IsObserved);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentTests.cs
@@ -24,20 +24,28 @@ public sealed class AdjustmentTests
         NotableDateFixtures.Resolver("adjustments.xml");
 
     /// <summary>
-    /// Verifies that the observed-only emission emits only the Monday observance and suppresses the weekend actual date.
+    /// Verifies that the observed-only emission suppresses the weekend actual date, emitting nothing on 1 January 2022 (a
+    /// Saturday).
+    /// </summary>
+    [TestMethod]
+    public void Emission_ObservedOnly_WhenWeekendActualDate_ShouldSuppressActual()
+    {
+        Assert.AreEqual(0, Count(CreateResolver().Resolve(new DateOnly(2022, 1, 1), Territory), "observed-only"));
+    }
+
+    /// <summary>
+    /// Verifies that the observed-only emission emits the observed Monday occurrence carrying the actual date and the
+    /// adjustment-policy id. 1 January 2022 (a Saturday) is observed on Monday 3 January.
     /// </summary>
     [TestMethod]
     [TestCategory("Smoke")]
-    public void Emission_ObservedOnly_EmitsObservedAndSuppressesActual()
+    public void Emission_ObservedOnly_WhenObservedMonday_ShouldEmitObservedWithPolicy()
     {
-        NotableDateService resolver = CreateResolver();
+        NotableDate observed = Single(CreateResolver().Resolve(new DateOnly(2022, 1, 3), Territory), "observed-only");
 
-        Assert.AreEqual(0, Count(resolver.Resolve(new DateOnly(2022, 1, 1), Territory), "observed-only"), "actual suppressed");
-
-        NotableDate observed = Single(resolver.Resolve(new DateOnly(2022, 1, 3), Territory), "observed-only");
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2022, 1, 1), observed.ActualDate);
-        Assert.AreEqual("weekend-next-monday-observed", observed.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2022, 1, 1), (string?)"weekend-next-monday-observed"),
+            (observed.IsObserved, observed.ActualDate, observed.AdjustmentPolicyId));
     }
 
     /// <summary>
@@ -51,9 +59,9 @@ public sealed class AdjustmentTests
             .Where(r => r.NotableDateId == "actual-and-observed")
             .ToList();
 
-        Assert.HasCount(2, results);
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 1) && !r.IsObserved, results, "actual occurrence");
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 3) && r.IsObserved, results, "observed occurrence");
+        CollectionAssert.AreEqual(
+            new[] { (new DateOnly(2022, 1, 1), false), (new DateOnly(2022, 1, 3), true) },
+            results.OrderBy(r => r.Date).Select(r => (r.Date, r.IsObserved)).ToArray());
     }
 
     /// <summary>
@@ -67,54 +75,78 @@ public sealed class AdjustmentTests
             .Where(r => r.NotableDateId == "observed-additional")
             .ToList();
 
-        Assert.HasCount(2, results);
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 1) && !r.IsObserved, results, "actual occurrence");
-        Assert.Contains(r => r.Date == new DateOnly(2022, 1, 3) && r.IsObserved, results, "additional observed occurrence");
+        CollectionAssert.AreEqual(
+            new[] { (new DateOnly(2022, 1, 1), false), (new DateOnly(2022, 1, 3), true) },
+            results.OrderBy(r => r.Date).Select(r => (r.Date, r.IsObserved)).ToArray());
     }
 
     /// <summary>
-    /// Verifies that the actual-only emission keeps the weekend actual date and emits nothing on the computed Monday.
+    /// Verifies that the actual-only emission keeps the weekend actual date as an unobserved occurrence carrying no
+    /// adjustment-policy id.
     /// </summary>
     [TestMethod]
-    public void Emission_ActualOnly_KeepsActualAndIgnoresObserved()
+    public void Emission_ActualOnly_WhenWeekendActualDate_ShouldKeepUnobservedActual()
     {
-        NotableDateService resolver = CreateResolver();
+        NotableDate actual = Single(CreateResolver().Resolve(new DateOnly(2022, 1, 1), Territory), "actual-only");
 
-        NotableDate actual = Single(resolver.Resolve(new DateOnly(2022, 1, 1), Territory), "actual-only");
-        Assert.IsFalse(actual.IsObserved);
-        Assert.IsNull(actual.AdjustmentPolicyId);
-
-        Assert.AreEqual(0, Count(resolver.Resolve(new DateOnly(2022, 1, 3), Territory), "actual-only"), "no observed emitted");
+        Assert.AreEqual(
+            (false, (string?)null),
+            (actual.IsObserved, actual.AdjustmentPolicyId));
     }
 
     /// <summary>
-    /// Verifies that the suppress emission removes the occurrence on a weekend but leaves it on a weekday.
+    /// Verifies that the actual-only emission emits nothing on the computed Monday substitute.
     /// </summary>
     [TestMethod]
-    public void Emission_Suppress_RemovesWeekendOccurrenceOnly()
+    public void Emission_ActualOnly_WhenComputedMonday_ShouldNotEmitObserved()
     {
-        NotableDateService resolver = CreateResolver();
-
-        Assert.AreEqual(0, Count(resolver.Resolve(new DateOnly(2022, 1, 1), Territory), "suppress-weekend"), "weekend suppressed");
-
-        NotableDate weekday = Single(resolver.Resolve(new DateOnly(2026, 1, 1), Territory), "suppress-weekend");
-        Assert.IsFalse(weekday.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 1), weekday.Date);
+        Assert.AreEqual(0, Count(CreateResolver().Resolve(new DateOnly(2022, 1, 3), Territory), "actual-only"));
     }
 
     /// <summary>
-    /// Verifies that an always trigger with an add-days action shifts every occurrence by the configured number of days.
+    /// Verifies that the suppress emission removes the occurrence when 1 January falls on a weekend (2022, a Saturday).
     /// </summary>
     [TestMethod]
-    public void Action_AddDays_WithAlwaysTrigger_ShiftsEveryOccurrence()
+    public void Emission_Suppress_WhenWeekend_ShouldRemoveOccurrence()
     {
-        NotableDateService resolver = CreateResolver();
+        Assert.AreEqual(0, Count(CreateResolver().Resolve(new DateOnly(2022, 1, 1), Territory), "suppress-weekend"));
+    }
 
-        NotableDate observed = Single(resolver.Resolve(new DateOnly(2026, 1, 2), Territory), "always-shift");
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 1), observed.ActualDate);
+    /// <summary>
+    /// Verifies that the suppress emission leaves the occurrence in place when 1 January falls on a weekday (2026, a
+    /// Thursday), emitting the unobserved actual date.
+    /// </summary>
+    [TestMethod]
+    public void Emission_Suppress_WhenWeekday_ShouldKeepOccurrence()
+    {
+        NotableDate weekday = Single(CreateResolver().Resolve(new DateOnly(2026, 1, 1), Territory), "suppress-weekend");
 
-        Assert.AreEqual(0, Count(resolver.Resolve(new DateOnly(2026, 1, 1), Territory), "always-shift"), "actual suppressed by observed-only");
+        Assert.AreEqual(
+            (false, new DateOnly(2026, 1, 1)),
+            (weekday.IsObserved, weekday.Date));
+    }
+
+    /// <summary>
+    /// Verifies that an always trigger with an add-days action shifts the occurrence forward by the configured day,
+    /// emitting an observed 2 January 2026 that carries the 1 January actual date.
+    /// </summary>
+    [TestMethod]
+    public void Action_AddDays_WithAlwaysTrigger_WhenShifted_ShouldEmitObservedWithActualDate()
+    {
+        NotableDate observed = Single(CreateResolver().Resolve(new DateOnly(2026, 1, 2), Territory), "always-shift");
+
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 1)),
+            (observed.IsObserved, observed.ActualDate));
+    }
+
+    /// <summary>
+    /// Verifies that the add-days shift, emitted observed-only, suppresses the unshifted 1 January actual date.
+    /// </summary>
+    [TestMethod]
+    public void Action_AddDays_WithAlwaysTrigger_WhenActualDate_ShouldSuppressActual()
+    {
+        Assert.AreEqual(0, Count(CreateResolver().Resolve(new DateOnly(2026, 1, 1), Territory), "always-shift"));
     }
 
     /// <summary>
@@ -126,21 +158,26 @@ public sealed class AdjustmentTests
     {
         NotableDate observed = Single(CreateResolver().Resolve(new DateOnly(2022, 12, 30), Territory), "prev-friday");
 
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2022, 12, 30), observed.Date);
-        Assert.AreEqual(new DateOnly(2023, 1, 1), observed.ActualDate);
+        Assert.AreEqual(
+            (true, new DateOnly(2022, 12, 30), (DateOnly?)new DateOnly(2023, 1, 1)),
+            (observed.IsObserved, observed.Date, observed.ActualDate));
     }
 
     /// <summary>
-    /// Verifies that the move-to-next-working-day action moves weekend occurrences forward to Monday.
+    /// Verifies that the move-to-next-working-day action moves a weekend 1 January occurrence forward to the following
+    /// Monday. 1 January 2022 (a Saturday) is observed on Monday 3 January; 1 January 2023 (a Sunday) on Monday 2 January.
     /// </summary>
+    /// <param name="year">The observed Monday year.</param>
+    /// <param name="month">The observed Monday month.</param>
+    /// <param name="day">The observed Monday day.</param>
     [TestMethod]
-    public void Action_MoveToNextWorkingDay_MovesWeekendForwardToMonday()
+    [DataRow(2022, 1, 3)]  // 1 Jan 2022 Saturday -> Monday 3 Jan
+    [DataRow(2023, 1, 2)]  // 1 Jan 2023 Sunday -> Monday 2 Jan
+    public void Action_MoveToNextWorkingDay_WhenWeekendOccurrence_ShouldMoveToMonday(int year, int month, int day)
     {
-        NotableDateService resolver = CreateResolver();
+        DateOnly monday = new(year, month, day);
 
-        Assert.AreEqual(new DateOnly(2022, 1, 3), Single(resolver.Resolve(new DateOnly(2022, 1, 3), Territory), "next-working-day").Date);
-        Assert.AreEqual(new DateOnly(2023, 1, 2), Single(resolver.Resolve(new DateOnly(2023, 1, 2), Territory), "next-working-day").Date);
+        Assert.AreEqual(monday, Single(CreateResolver().Resolve(monday, Territory), "next-working-day").Date);
     }
 
     /// <summary>
@@ -151,24 +188,35 @@ public sealed class AdjustmentTests
     {
         NotableDate observed = Single(CreateResolver().Resolve(new DateOnly(2021, 12, 31), Territory), "prev-working-day");
 
-        Assert.AreEqual(new DateOnly(2021, 12, 31), observed.Date);
-        Assert.AreEqual(new DateOnly(2022, 1, 1), observed.ActualDate);
+        Assert.AreEqual(
+            (new DateOnly(2021, 12, 31), (DateOnly?)new DateOnly(2022, 1, 1)),
+            (observed.Date, observed.ActualDate));
     }
 
     /// <summary>
-    /// Verifies that the if-weekday trigger fires only on weekdays.
+    /// Verifies that the if-weekday trigger fires on a weekday occurrence, emitting an observed 3 January 2026 that carries
+    /// the 1 January actual date.
     /// </summary>
     [TestMethod]
-    public void Trigger_IfWeekday_FiresOnWeekdaysOnly()
+    public void Trigger_IfWeekday_WhenWeekday_ShouldFireAndShift()
     {
-        NotableDateService resolver = CreateResolver();
+        NotableDate weekday = Single(CreateResolver().Resolve(new DateOnly(2026, 1, 3), Territory), "weekday-shift");
 
-        NotableDate weekday = Single(resolver.Resolve(new DateOnly(2026, 1, 3), Territory), "weekday-shift");
-        Assert.IsTrue(weekday.IsObserved, "weekday occurrence shifted");
-        Assert.AreEqual(new DateOnly(2026, 1, 1), weekday.ActualDate);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 1)),
+            (weekday.IsObserved, weekday.ActualDate));
+    }
 
-        NotableDate weekend = Single(resolver.Resolve(new DateOnly(2022, 1, 1), Territory), "weekday-shift");
-        Assert.IsFalse(weekend.IsObserved, "weekend occurrence unchanged");
+    /// <summary>
+    /// Verifies that the if-weekday trigger does not fire on a weekend occurrence, leaving 1 January 2022 (a Saturday)
+    /// unobserved.
+    /// </summary>
+    [TestMethod]
+    public void Trigger_IfWeekday_WhenWeekend_ShouldNotFire()
+    {
+        NotableDate weekend = Single(CreateResolver().Resolve(new DateOnly(2022, 1, 1), Territory), "weekday-shift");
+
+        Assert.IsFalse(weekend.IsObserved);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentTriggerMatrixTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AdjustmentTriggerMatrixTests.cs
@@ -320,18 +320,18 @@ public sealed class AdjustmentTriggerMatrixTests
     /// non-leap occurrence year, so <see cref="AdjustmentTrigger.IfBeforeFixedDate" /> evaluates without overflow: an
     /// occurrence on 28 February 2026 is not strictly before the clamped 28 February pivot. 2026 is not a leap year.
     /// </summary>
+    /// <param name="strategyDay">The day of February 2026 the holiday's fixed strategy resolves to.</param>
+    /// <param name="expectedFire">Whether the trigger is expected to fire against the clamped 28 February pivot.</param>
     [TestMethod]
-    public void IfBeforeFixedDate_WhenComparisonIsFeb29InNonLeapYear_ShouldClampToFeb28()
+    [DataRow(15, true)]   // 15 Feb is strictly before the clamped 28 Feb pivot → fire
+    [DataRow(28, false)]  // 28 Feb equals the clamped pivot, not strictly before → no fire
+    public void IfBeforeFixedDate_WhenComparisonIsFeb29InNonLeapYear_ShouldClampToFeb28(int strategyDay, bool expectedFire)
     {
-        // Occurrence on 15 Feb 2026 → strictly before the clamped 28 Feb pivot → fires.
-        Assert.IsTrue(FixedDateService("IfBeforeFixedDate", "February", 29, "February", 15)
+        NotableDate match = FixedDateService("IfBeforeFixedDate", "February", 29, "February", strategyDay)
             .Resolve(new DateRange(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)), Territory)
-            .Single(r => r.NotableDateId == "probe").IsObserved);
+            .Single(r => r.NotableDateId == "probe");
 
-        // Occurrence on 28 Feb 2026 → equals the clamped pivot, not strictly before → does not fire.
-        Assert.IsFalse(FixedDateService("IfBeforeFixedDate", "February", 29, "February", 28)
-            .Resolve(new DateRange(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31)), Territory)
-            .Single(r => r.NotableDateId == "probe").IsObserved);
+        Assert.AreEqual(expectedFire, match.IsObserved);
     }
 
     // -----------------------------------------------------------------------------------------------------------------
@@ -413,7 +413,8 @@ public sealed class AdjustmentTriggerMatrixTests
             .Resolve(new DateRange(new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30)), Territory)
             .Single(r => r.NotableDateId == "probe");
 
-        Assert.IsFalse(match.IsObserved);
-        Assert.IsNull(match.AdjustmentPolicyId);
+        Assert.AreEqual(
+            (false, (string?)null),
+            (match.IsObserved, match.AdjustmentPolicyId));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustraliaKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/AustraliaKnownAnswerTests.cs
@@ -119,20 +119,22 @@ public sealed class AustraliaKnownAnswerTests
     public void Resolve_WhenSubdivisionRuleExists_ShadowsNationalRuleForThatTerritory()
     {
         NotableDate westernAustralia = SingleForYear("AU-WA", 2026, "anzac-day");
-        Assert.AreEqual(new DateOnly(2026, 4, 27), westernAustralia.Date, "WA substitute date");
-        Assert.IsTrue(westernAustralia.IsObserved, "WA substitute is observed");
-        Assert.AreEqual("wa", westernAustralia.RuleId, "WA rule shadows the national rule");
+        Assert.AreEqual(
+            (new DateOnly(2026, 4, 27), true, "wa"),
+            (westernAustralia.Date, westernAustralia.IsObserved, westernAustralia.RuleId),
+            "WA substitute date, observed, shadows the national rule");
 
         NotableDate victoria = SingleForYear("AU-VIC", 2026, "anzac-day");
-        Assert.AreEqual(new DateOnly(2026, 4, 25), victoria.Date, "VIC falls back to the national rule");
-        Assert.IsFalse(victoria.IsObserved, "national rule has no substitute");
-        Assert.AreEqual("au", victoria.RuleId, "VIC inherits the national rule");
+        Assert.AreEqual(
+            (new DateOnly(2026, 4, 25), false, "au"),
+            (victoria.Date, victoria.IsObserved, victoria.RuleId),
+            "VIC falls back to the national rule with no substitute");
     }
 
     /// <summary>
     /// Verifies the New South Wales Anzac Day trial (2026-2027 only): when 25 April falls on a weekend the NSW rule
-    /// emits both the actual 25 April Anzac Day and an additional observed Monday public holiday. Outside the trial
-    /// window AU-NSW falls back to the national single-occurrence rule.
+    /// emits both the actual 25 April Anzac Day and an additional observed Monday public holiday, both from the trial
+    /// rule.
     /// </summary>
     [TestMethod]
     public void Resolve_WhenAnzacDayInNewSouthWalesTrialYear_EmitsActualAndAdditionalMonday()
@@ -143,17 +145,28 @@ public sealed class AustraliaKnownAnswerTests
             .OrderBy(r => r.Date)
             .ToList();
 
-        Assert.HasCount(2, trial, "2026 emits Anzac Day plus an additional Monday");
-        Assert.AreEqual(new DateOnly(2026, 4, 25), trial[0].Date, "Anzac Day stays on Saturday 25 April");
-        Assert.IsFalse(trial[0].IsObserved, "the 25 April occurrence is the actual date");
-        Assert.AreEqual(new DateOnly(2026, 4, 27), trial[1].Date, "additional Monday public holiday");
-        Assert.IsTrue(trial[1].IsObserved, "the additional Monday is observed");
-        Assert.AreEqual("nsw", trial[1].RuleId, "the NSW trial rule shadows the national rule");
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                (new DateOnly(2026, 4, 25), false, "nsw"),  // actual 25 April retained
+                (new DateOnly(2026, 4, 27), true, "nsw"),   // additional observed Monday
+            },
+            trial.Select(r => (r.Date, r.IsObserved, r.RuleId)).ToArray());
+    }
 
+    /// <summary>
+    /// Verifies that outside the New South Wales Anzac Day trial window AU-NSW falls back to the national
+    /// single-occurrence rule, keeping plain 25 April with no substitute. 25 April 2028 is a Tuesday.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_WhenAnzacDayAfterNewSouthWalesTrial_FallsBackToNationalRule()
+    {
         NotableDate afterTrial = SingleForYear("AU-NSW", 2028, "anzac-day");
-        Assert.AreEqual(new DateOnly(2028, 4, 25), afterTrial.Date, "after the trial NSW keeps plain 25 April");
-        Assert.IsFalse(afterTrial.IsObserved, "no substitute after the trial");
-        Assert.AreEqual("au", afterTrial.RuleId, "AU-NSW falls back to the national rule after the trial");
+
+        Assert.AreEqual(
+            (new DateOnly(2028, 4, 25), false, "au"),
+            (afterTrial.Date, afterTrial.IsObserved, afterTrial.RuleId),
+            "AU-NSW falls back to the national rule after the trial");
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/BahaiHolyDayKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/BahaiHolyDayKnownAnswerTests.cs
@@ -91,22 +91,31 @@ public sealed class BahaiHolyDayKnownAnswerTests
     }
 
     /// <summary>
-    /// Verifies that Naw-Ruz always falls on 19, 20 or 21 March (the equinox window) across a multi-decade span, and that
-    /// the Festival of Ridvan preserves its authored twelve-day duration.
+    /// Verifies that Naw-Ruz always falls within the equinox window of 19, 20 or 21 March across the multi-decade span
+    /// 2000-2050.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
-    public void Resolve_NawRuzAcrossDecades_FallsInEquinoxWindow_AndRidvanSpansTwelveDays()
+    public void Resolve_NawRuzAcrossDecades_ShouldFallInEquinoxWindow()
     {
         NotableDateService service = CreateService();
 
-        for (var year = 2000; year <= 2050; year++)
-        {
-            NotableDate nawRuz = CommonCatalogues.ResolveSingle(service, "naw-ruz", year);
-            Assert.AreEqual(3, nawRuz.Date.Month, $"Naw-Ruz {year} fell outside March: {nawRuz.Date:yyyy-MM-dd}");
-            Assert.IsTrue(nawRuz.Date.Day is 19 or 20 or 21, $"Naw-Ruz {year} fell on March {nawRuz.Date.Day}");
-        }
+        DateOnly[] outsideWindow = Enumerable
+            .Range(2000, 51)
+            .Select(year => CommonCatalogues.ResolveSingle(service, "naw-ruz", year).Date)
+            .Where(date => date.Month != 3 || date.Day is not (19 or 20 or 21))
+            .ToArray();
 
-        Assert.AreEqual(12, CommonCatalogues.ResolveSingle(service, "ridvan", 2025).DurationDays);
+        CollectionAssert.AreEqual(Array.Empty<DateOnly>(), outsideWindow);
+    }
+
+    /// <summary>
+    /// Verifies that the Festival of Ridvan preserves its authored twelve-day duration.
+    /// </summary>
+    [TestMethod]
+    [TestCategory("Regression")]
+    public void Resolve_Ridvan_ShouldSpanTwelveDays()
+    {
+        Assert.AreEqual(12, CommonCatalogues.ResolveSingle(CreateService(), "ridvan", 2025).DurationDays);
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CalendarSystemKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CalendarSystemKnownAnswerTests.cs
@@ -56,29 +56,35 @@ public sealed class CalendarSystemKnownAnswerTests
     }
 
     /// <summary>
-    /// Verifies that a multi-day occurrence carries its duration and end date, is returned by a single-day query for a
-    /// day inside its span, and is excluded by a query that falls entirely before or after the span.
+    /// Verifies that a multi-day occurrence is returned by a single-day query for a day inside its span, carrying its
+    /// span start, duration, and end date. Golden Week 2024 spans 29 April to 5 May.
     /// </summary>
     [TestMethod]
-    public void Resolve_MultiDayOccurrence_IsIncludedWhenTheQueryIntersectsTheSpan()
+    public void Resolve_MultiDayOccurrence_WhenQueryInsideSpan_ReturnsOccurrenceWithSpan()
     {
-        NotableDateService service = CreateService();
-
-        var inside = service
+        var inside = CreateService()
             .Resolve(new DateOnly(2024, 5, 2), "XX")
             .Where(r => r.NotableDateId == "golden-week")
             .ToList();
 
         Assert.HasCount(1, inside, "a day inside the span returns the occurrence");
-        Assert.AreEqual(new DateOnly(2024, 4, 29), inside[0].Date, "span start");
-        Assert.AreEqual(7, inside[0].DurationDays, "duration");
-        Assert.AreEqual(new DateOnly(2024, 5, 5), inside[0].EndDate, "span end");
+        Assert.AreEqual(
+            (new DateOnly(2024, 4, 29), 7, new DateOnly(2024, 5, 5)),
+            (inside[0].Date, inside[0].DurationDays, inside[0].EndDate));
+    }
 
-        var before = service.Resolve(new DateOnly(2024, 4, 28), "XX").Count(r => r.NotableDateId == "golden-week");
-        var after = service.Resolve(new DateOnly(2024, 5, 6), "XX").Count(r => r.NotableDateId == "golden-week");
-
-        Assert.AreEqual(0, before, "a day before the span is excluded");
-        Assert.AreEqual(0, after, "a day after the span is excluded");
+    /// <summary>
+    /// Verifies that a multi-day occurrence is excluded by a single-day query that falls entirely before or after its
+    /// span. Golden Week 2024 spans 29 April to 5 May, so 28 April and 6 May are outside it.
+    /// </summary>
+    /// <param name="month">The queried month.</param>
+    /// <param name="day">The queried day of 2024.</param>
+    [TestMethod]
+    [DataRow(4, 28)]  // the day before the span
+    [DataRow(5, 6)]   // the day after the span
+    public void Resolve_MultiDayOccurrence_WhenQueryOutsideSpan_ExcludesOccurrence(int month, int day)
+    {
+        Assert.AreEqual(0, CreateService().Resolve(new DateOnly(2024, month, day), "XX").Count(r => r.NotableDateId == "golden-week"));
     }
 
     /// <summary>
@@ -104,8 +110,10 @@ public sealed class CalendarSystemKnownAnswerTests
 
         IGrouping<int, NotableDate> doubled = doubledYears[0];
         var dates = doubled.Select(r => r.Date).OrderBy(d => d).ToList();
-        Assert.AreEqual(doubled.Key, dates[0].Year, "first occurrence is in the Gregorian year");
-        Assert.AreEqual(doubled.Key, dates[1].Year, "second occurrence is in the same Gregorian year");
+        Assert.AreEqual(
+            (doubled.Key, doubled.Key),
+            (dates[0].Year, dates[1].Year),
+            "both occurrences are in the same Gregorian year");
         Assert.IsGreaterThan(300, dates[1].DayNumber - dates[0].DayNumber, "the two occurrences are about a lunar year apart");
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CollisionResolutionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CollisionResolutionTests.cs
@@ -94,8 +94,7 @@ public sealed class CollisionResolutionTests
         NotableDateService service = new(NotableDateResourceLoader.Load(Document("HighestPriorityOnly")));
         IReadOnlyList<NotableDate> march = service.Resolve(new DateOnly(2025, 3, 3), "XX");
 
-        Assert.HasCount(1, march);
-        Assert.AreEqual("other-day", march[0].NotableDateId);
+        CollectionAssert.AreEqual(new[] { "other-day" }, march.Select(r => r.NotableDateId).ToList());
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CommonResourcesTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CommonResourcesTests.cs
@@ -18,67 +18,100 @@ public sealed class CommonResourcesTests
     /// Verifies that the resolver returns content for a bundled catalogue and <see langword="null" /> for an unknown
     /// name.
     /// </summary>
+    /// <param name="name">The catalogue name to resolve.</param>
+    /// <param name="expectContent">Whether the resolver is expected to return content.</param>
     [TestMethod]
-    public void Resolve_ForBundledCatalogue_ReturnsContentForKnownAndNullForUnknown()
+    [DataRow("global-core", true)]         // bundled catalogue
+    [DataRow("christian-western", true)]   // bundled catalogue
+    [DataRow("no-such-catalogue", false)]  // unknown name
+    public void Resolve_ForBundledCatalogue_ReturnsContentForKnownAndNullForUnknown(string name, bool expectContent)
     {
-        Assert.IsNotNull(CommonNotableDateResources.Resolve("global-core"));
-        Assert.IsNotNull(CommonNotableDateResources.Resolve("christian-western"));
-        Assert.IsNull(CommonNotableDateResources.Resolve("no-such-catalogue"));
+        Assert.AreEqual(expectContent, CommonNotableDateResources.Resolve(name) is not null);
     }
 
     /// <summary>
-    /// Verifies that a territory resource importing the bundled catalogues resolves the shared dates, computes the
-    /// Easter-anchored offsets, and applies the territory's own adjustment and category overrides.
+    /// A territory resource importing the bundled common catalogues and specializing several shared concepts with the
+    /// territory's own scope, category, non-working flag, and weekend adjustments.
+    /// </summary>
+    private const string Region = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.demo">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <AdjustmentPolicies>
+        <AdjustmentPolicy id="sat-to-fri" priority="100">
+          <Trigger type="IfDayOfWeek"><Weekday value="Saturday" /></Trigger>
+          <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
+          <Emission mode="ObservedOnly" reason="Observed Friday" />
+        </AdjustmentPolicy>
+        <AdjustmentPolicy id="sun-to-mon" priority="100">
+          <Trigger type="IfDayOfWeek"><Weekday value="Sunday" /></Trigger>
+          <Action type="MoveToNextWeekday" dayOfWeek="Monday" />
+          <Emission mode="ObservedOnly" reason="Observed Monday" />
+        </AdjustmentPolicy>
+      </AdjustmentPolicies>
+      <Imports>
+        <Import resource="global-core">
+          <Use notableDateRef="new-years-day" territory="ZZ">
+            <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
+          </Use>
+        </Import>
+        <Import resource="christian-western">
+          <Use notableDateRef="easter-sunday" territory="ZZ" />
+          <Use notableDateRef="good-friday" territory="ZZ" category="Religious" nonWorking="false" />
+          <Use notableDateRef="christmas-day" territory="ZZ">
+            <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
+          </Use>
+        </Import>
+      </Imports>
+      <NotableDates />
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Builds a service over the territory <see cref="Region" /> resource resolved against the bundled common catalogues.
+    /// </summary>
+    /// <returns>A service for the region resource.</returns>
+    private static NotableDateService RegionService() =>
+        new(NotableDateResourceLoader.Load(Region, CommonNotableDateResources.Resolver));
+
+    /// <summary>
+    /// Verifies that a territory resource importing the bundled catalogues computes the Easter-anchored offset. Easter
+    /// Sunday 2024 resolves to 31 March.
     /// </summary>
     [TestMethod]
-    public void Import_FromBundledCatalogues_ResolvesSharedDatesWithTerritoryOverrides()
+    public void Import_FromBundledCatalogues_ResolvesEasterAnchoredOffset()
     {
-        const string Region = """
-        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.demo">
-          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
-          <AdjustmentPolicies>
-            <AdjustmentPolicy id="sat-to-fri" priority="100">
-              <Trigger type="IfDayOfWeek"><Weekday value="Saturday" /></Trigger>
-              <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
-              <Emission mode="ObservedOnly" reason="Observed Friday" />
-            </AdjustmentPolicy>
-            <AdjustmentPolicy id="sun-to-mon" priority="100">
-              <Trigger type="IfDayOfWeek"><Weekday value="Sunday" /></Trigger>
-              <Action type="MoveToNextWeekday" dayOfWeek="Monday" />
-              <Emission mode="ObservedOnly" reason="Observed Monday" />
-            </AdjustmentPolicy>
-          </AdjustmentPolicies>
-          <Imports>
-            <Import resource="global-core">
-              <Use notableDateRef="new-years-day" territory="ZZ">
-                <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
-              </Use>
-            </Import>
-            <Import resource="christian-western">
-              <Use notableDateRef="easter-sunday" territory="ZZ" />
-              <Use notableDateRef="good-friday" territory="ZZ" category="Religious" nonWorking="false" />
-              <Use notableDateRef="christmas-day" territory="ZZ">
-                <Adjustments><Adjustment policyRef="sat-to-fri" /><Adjustment policyRef="sun-to-mon" /></Adjustments>
-              </Use>
-            </Import>
-          </Imports>
-          <NotableDates />
-        </NotableDateResource>
-        """;
-
-        NotableDateService service = new(NotableDateResourceLoader.Load(Region, CommonNotableDateResources.Resolver));
         DateRange year2024 = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
-        // Easter Sunday 2024 is 31 March; the imported Good Friday offset resolves to 29 March.
-        Assert.AreEqual(new DateOnly(2024, 3, 31), service.Resolve(year2024, "ZZ").Single(r => r.NotableDateId == "easter-sunday").Date);
-        NotableDate goodFriday = service.Resolve(new DateOnly(2024, 3, 29), "ZZ").Single(r => r.NotableDateId == "good-friday");
-        Assert.AreEqual(NotableDateCategory.Religious, goodFriday.Category, "category override applied");
-        Assert.IsFalse(goodFriday.IsNonWorkingDay, "non-working override applied");
+        Assert.AreEqual(new DateOnly(2024, 3, 31), RegionService().Resolve(year2024, "ZZ").Single(r => r.NotableDateId == "easter-sunday").Date);
+    }
 
-        // New Year's Day 2023 falls on a Sunday; the sun-to-mon override observes it on Monday 2 January.
-        NotableDate newYear = service.Resolve(new DateOnly(2023, 1, 2), "ZZ").Single(r => r.NotableDateId == "new-years-day");
-        Assert.IsTrue(newYear.IsObserved);
-        Assert.AreEqual(new DateOnly(2023, 1, 1), newYear.ActualDate);
+    /// <summary>
+    /// Verifies that a territory resource importing the bundled catalogues applies its category and non-working overrides.
+    /// The imported Good Friday (29 March 2024) carries the territory's Religious category and working-day override.
+    /// </summary>
+    [TestMethod]
+    public void Import_FromBundledCatalogues_AppliesGoodFridayOverrides()
+    {
+        NotableDate goodFriday = RegionService().Resolve(new DateOnly(2024, 3, 29), "ZZ").Single(r => r.NotableDateId == "good-friday");
+
+        Assert.AreEqual(
+            (NotableDateCategory.Religious, false),
+            (goodFriday.Category, goodFriday.IsNonWorkingDay),
+            "category and non-working overrides applied");
+    }
+
+    /// <summary>
+    /// Verifies that a territory resource importing the bundled catalogues applies its own weekend adjustment. New Year's
+    /// Day 2023 (a Sunday) is observed on Monday 2 January, carrying the actual date.
+    /// </summary>
+    [TestMethod]
+    public void Import_FromBundledCatalogues_ObservesNewYearOverride()
+    {
+        NotableDate newYear = RegionService().Resolve(new DateOnly(2023, 1, 2), "ZZ").Single(r => r.NotableDateId == "new-years-day");
+
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2023, 1, 1)),
+            (newYear.IsObserved, newYear.ActualDate));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CustomAdjustmentTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CustomAdjustmentTests.cs
@@ -89,9 +89,9 @@ public sealed class CustomAdjustmentTests
 
         NotableDate match = Single(service, 2025, "moved-holiday");
 
-        Assert.AreEqual(new DateOnly(2025, 1, 10), match.Date);
-        Assert.AreEqual(new DateOnly(2025, 1, 1), match.ActualDate);
-        Assert.IsTrue(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2025, 1, 10), (DateOnly?)new DateOnly(2025, 1, 1), true),
+            (match.Date, match.ActualDate, match.IsObserved));
     }
 
     /// <summary>
@@ -169,9 +169,9 @@ public sealed class CustomAdjustmentTests
 
         NotableDate match = Single(service, 2025, "custom-holiday");
 
-        Assert.AreEqual(new DateOnly(2025, 3, 11), match.Date);
-        Assert.AreEqual(new DateOnly(2025, 3, 1), match.ActualDate);
-        Assert.IsTrue(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2025, 3, 11), (DateOnly?)new DateOnly(2025, 3, 1), true),
+            (match.Date, match.ActualDate, match.IsObserved));
     }
 
     /// <summary>
@@ -184,8 +184,9 @@ public sealed class CustomAdjustmentTests
 
         NotableDate match = Single(service, 2025, "custom-holiday");
 
-        Assert.AreEqual(new DateOnly(2025, 3, 1), match.Date);
-        Assert.AreEqual(new DateOnly(2025, 3, 1), match.ActualDate);
+        Assert.AreEqual(
+            (new DateOnly(2025, 3, 1), (DateOnly?)new DateOnly(2025, 3, 1)),
+            (match.Date, match.ActualDate));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/CustomTriggerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/CustomTriggerTests.cs
@@ -85,9 +85,9 @@ public sealed class CustomTriggerTests
 
         NotableDate match = Single(service, 2024, "custom-trigger-holiday");
 
-        Assert.AreEqual(new DateOnly(2024, 3, 11), match.Date);
-        Assert.AreEqual(new DateOnly(2024, 3, 1), match.ActualDate);
-        Assert.IsTrue(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2024, 3, 11), (DateOnly?)new DateOnly(2024, 3, 1), true),
+            (match.Date, match.ActualDate, match.IsObserved));
     }
 
     /// <summary>
@@ -101,8 +101,9 @@ public sealed class CustomTriggerTests
 
         NotableDate match = Single(service, 2025, "custom-trigger-holiday");
 
-        Assert.AreEqual(new DateOnly(2025, 3, 1), match.Date);
-        Assert.IsFalse(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2025, 3, 1), false),
+            (match.Date, match.IsObserved));
     }
 
     /// <summary>
@@ -115,8 +116,9 @@ public sealed class CustomTriggerTests
 
         NotableDate match = Single(service, 2024, "custom-trigger-holiday");
 
-        Assert.AreEqual(new DateOnly(2024, 3, 1), match.Date);
-        Assert.IsFalse(match.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2024, 3, 1), false),
+            (match.Date, match.IsObserved));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/DateRangeTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/DateRangeTests.cs
@@ -24,41 +24,61 @@ public sealed class DateRangeTests
     /// <summary>
     /// Verifies that a range contains a range fully within its bounds, including an identical range.
     /// </summary>
+    /// <param name="outerStart">The outer range start day.</param>
+    /// <param name="outerEnd">The outer range end day.</param>
+    /// <param name="innerStart">The inner range start day.</param>
+    /// <param name="innerEnd">The inner range end day.</param>
     [TestMethod]
-    public void Contains_WhenInnerWithinOuter_ShouldReturnTrue()
+    [DataRow(1, 10, 3, 7)]    // strictly within
+    [DataRow(1, 10, 1, 10)]   // identical range
+    public void Contains_WhenInnerWithinOuter_ShouldReturnTrue(int outerStart, int outerEnd, int innerStart, int innerEnd)
     {
-        Assert.IsTrue(Range(1, 10).Contains(Range(3, 7)));
-        Assert.IsTrue(Range(1, 10).Contains(Range(1, 10)));
+        Assert.IsTrue(Range(outerStart, outerEnd).Contains(Range(innerStart, innerEnd)));
     }
 
     /// <summary>
     /// Verifies that a range does not contain a range that extends past either bound.
     /// </summary>
+    /// <param name="outerStart">The outer range start day.</param>
+    /// <param name="outerEnd">The outer range end day.</param>
+    /// <param name="innerStart">The inner range start day.</param>
+    /// <param name="innerEnd">The inner range end day.</param>
     [TestMethod]
-    public void Contains_WhenInnerExtendsBeyond_ShouldReturnFalse()
+    [DataRow(3, 7, 1, 10)]    // inner extends past both bounds
+    [DataRow(1, 5, 4, 8)]     // inner extends past the upper bound
+    public void Contains_WhenInnerExtendsBeyond_ShouldReturnFalse(int outerStart, int outerEnd, int innerStart, int innerEnd)
     {
-        Assert.IsFalse(Range(3, 7).Contains(Range(1, 10)));
-        Assert.IsFalse(Range(1, 5).Contains(Range(4, 8)));
+        Assert.IsFalse(Range(outerStart, outerEnd).Contains(Range(innerStart, innerEnd)));
     }
 
     /// <summary>
     /// Verifies that containment is false when either range is not well-formed.
     /// </summary>
+    /// <param name="outerStart">The outer range start day.</param>
+    /// <param name="outerEnd">The outer range end day.</param>
+    /// <param name="innerStart">The inner range start day.</param>
+    /// <param name="innerEnd">The inner range end day.</param>
     [TestMethod]
-    public void Contains_WhenEitherRangeInvalid_ShouldReturnFalse()
+    [DataRow(10, 1, 3, 7)]    // outer range reversed
+    [DataRow(1, 10, 7, 3)]    // inner range reversed
+    public void Contains_WhenEitherRangeInvalid_ShouldReturnFalse(int outerStart, int outerEnd, int innerStart, int innerEnd)
     {
-        Assert.IsFalse(Range(10, 1).Contains(Range(3, 7)));
-        Assert.IsFalse(Range(1, 10).Contains(Range(7, 3)));
+        Assert.IsFalse(Range(outerStart, outerEnd).Contains(Range(innerStart, innerEnd)));
     }
 
     /// <summary>
     /// Verifies that overlapping ranges intersect, regardless of order.
     /// </summary>
+    /// <param name="firstStart">The first range start day.</param>
+    /// <param name="firstEnd">The first range end day.</param>
+    /// <param name="secondStart">The second range start day.</param>
+    /// <param name="secondEnd">The second range end day.</param>
     [TestMethod]
-    public void Intersects_WhenRangesOverlap_ShouldReturnTrue()
+    [DataRow(1, 5, 4, 8)]     // overlap
+    [DataRow(4, 8, 1, 5)]     // overlap with operands swapped
+    public void Intersects_WhenRangesOverlap_ShouldReturnTrue(int firstStart, int firstEnd, int secondStart, int secondEnd)
     {
-        Assert.IsTrue(Range(1, 5).Intersects(Range(4, 8)));
-        Assert.IsTrue(Range(4, 8).Intersects(Range(1, 5)));
+        Assert.IsTrue(Range(firstStart, firstEnd).Intersects(Range(secondStart, secondEnd)));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ExtendedTriggerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ExtendedTriggerTests.cs
@@ -73,18 +73,31 @@ public sealed class ExtendedTriggerTests
         Service.Resolve(new DateRange(new DateOnly(year, 1, 1), new DateOnly(year, 12, 31)), "XX").Single(r => r.NotableDateId == id);
 
     /// <summary>
-    /// Verifies that the leap-year trigger fires only in leap years.
+    /// Verifies that the leap-year trigger fires in a leap year, shifting the observed date back one day. 1 March 2024 is
+    /// observed on 29 February 2024.
     /// </summary>
     [TestMethod]
-    public void IfLeapYear_FiresOnlyInLeapYears()
+    public void IfLeapYear_WhenLeapYear_ShouldFireAndShift()
     {
         NotableDate leap = Single(2024, "march-first");
-        Assert.IsTrue(leap.IsObserved);
-        Assert.AreEqual(new DateOnly(2024, 2, 29), leap.Date);
 
+        Assert.AreEqual(
+            (true, new DateOnly(2024, 2, 29)),
+            (leap.IsObserved, leap.Date));
+    }
+
+    /// <summary>
+    /// Verifies that the leap-year trigger does not fire in a common year, leaving the occurrence on its actual date.
+    /// 1 March 2025 is emitted unobserved.
+    /// </summary>
+    [TestMethod]
+    public void IfLeapYear_WhenCommonYear_ShouldNotFire()
+    {
         NotableDate common = Single(2025, "march-first");
-        Assert.IsFalse(common.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 3, 1), common.Date);
+
+        Assert.AreEqual(
+            (false, new DateOnly(2025, 3, 1)),
+            (common.IsObserved, common.Date));
     }
 
     /// <summary>
@@ -94,8 +107,10 @@ public sealed class ExtendedTriggerTests
     public void IfBeforeFixedDate_FiresWhenEarlier()
     {
         NotableDate match = Single(2025, "jan-fifteen");
-        Assert.IsTrue(match.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 1, 20), match.Date);
+
+        Assert.AreEqual(
+            (true, new DateOnly(2025, 1, 20)),
+            (match.IsObserved, match.Date));
     }
 
     /// <summary>
@@ -105,8 +120,10 @@ public sealed class ExtendedTriggerTests
     public void IfAfterFixedDate_FiresWhenLater()
     {
         NotableDate match = Single(2025, "nov-fifteen");
-        Assert.IsTrue(match.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 11, 18), match.Date);
+
+        Assert.AreEqual(
+            (true, new DateOnly(2025, 11, 18)),
+            (match.IsObserved, match.Date));
     }
 
     /// <summary>
@@ -117,7 +134,9 @@ public sealed class ExtendedTriggerTests
     public void IfNthOccurrenceInMonth_FiresOnTheConfiguredOrdinal()
     {
         NotableDate match = Single(2025, "second-monday");
-        Assert.IsTrue(match.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 6, 10), match.Date);
+
+        Assert.AreEqual(
+            (true, new DateOnly(2025, 6, 10)),
+            (match.IsObserved, match.Date));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/FilterCombinatorTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/FilterCombinatorTests.cs
@@ -146,11 +146,10 @@ public sealed class FilterCombinatorTests
         DateRange range = new(new DateOnly(2022, 12, 25), new DateOnly(2023, 1, 5));
         IReadOnlyList<NotableDate> resolved = CreateService().Resolve(range, "XX", NotableDateFilter.WasAdjusted());
 
-        Assert.IsTrue(resolved.All(r => r.IsObserved));
-        Assert.HasCount(1, resolved);
-        NotableDate observed = resolved[0];
-        Assert.AreEqual("year-end-holiday", observed.NotableDateId);
-        Assert.AreEqual(new DateOnly(2023, 1, 2), observed.Date);
+        // The only emitted occurrence is the observed Year-End Holiday substitute on Monday 2 January 2023.
+        CollectionAssert.AreEqual(
+            new[] { ("year-end-holiday", new DateOnly(2023, 1, 2), true) },
+            resolved.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date, r.IsObserved)).ToArray());
     }
 
     // -----------------------------------------------------------------------------------------------------------
@@ -158,17 +157,22 @@ public sealed class FilterCombinatorTests
     // -----------------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateFilter.And" /> matches an occurrence only when both component filters match.
+    /// Verifies that <see cref="NotableDateFilter.And" /> of a category filter and a non-working filter matches an
+    /// occurrence only when both component filters match.
     /// </summary>
+    /// <param name="category">The occurrence category.</param>
+    /// <param name="isNonWorkingDay">Whether the occurrence is a non-working day.</param>
+    /// <param name="expected">The expected match result.</param>
     [TestMethod]
-    public void Matches_WhenAnd_RequiresBothComponents()
+    [DataRow(NotableDateCategory.PublicHoliday, true, true)]    // both components match
+    [DataRow(NotableDateCategory.PublicHoliday, false, false)]  // non-working component fails
+    [DataRow(NotableDateCategory.Observance, true, false)]      // category component fails
+    public void Matches_WhenAnd_ShouldRequireBothComponents(NotableDateCategory category, bool isNonWorkingDay, bool expected)
     {
         NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday)
             .And(NotableDateFilter.IsNonWorkingDay());
 
-        Assert.IsTrue(filter.Matches(Occurrence(NotableDateCategory.PublicHoliday, isNonWorkingDay: true)));
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.PublicHoliday, isNonWorkingDay: false)));
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.Observance, isNonWorkingDay: true)));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(category, isNonWorkingDay: isNonWorkingDay)));
     }
 
     /// <summary>
@@ -210,17 +214,22 @@ public sealed class FilterCombinatorTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateFilter.Or" /> matches an occurrence when either component filter matches.
+    /// Verifies that <see cref="NotableDateFilter.Or" /> of a category filter and a non-working filter matches an
+    /// occurrence when either component filter matches.
     /// </summary>
+    /// <param name="category">The occurrence category.</param>
+    /// <param name="isNonWorkingDay">Whether the occurrence is a non-working day.</param>
+    /// <param name="expected">The expected match result.</param>
     [TestMethod]
-    public void Matches_WhenOr_AcceptsEitherComponent()
+    [DataRow(NotableDateCategory.Observance, true, true)]       // non-working component matches
+    [DataRow(NotableDateCategory.PublicHoliday, false, true)]   // category component matches
+    [DataRow(NotableDateCategory.Observance, false, false)]     // neither component matches
+    public void Matches_WhenOr_ShouldAcceptEitherComponent(NotableDateCategory category, bool isNonWorkingDay, bool expected)
     {
         NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday)
             .Or(NotableDateFilter.IsNonWorkingDay());
 
-        Assert.IsTrue(filter.Matches(Occurrence(NotableDateCategory.Observance, isNonWorkingDay: true)));
-        Assert.IsTrue(filter.Matches(Occurrence(NotableDateCategory.PublicHoliday, isNonWorkingDay: false)));
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.Observance, isNonWorkingDay: false)));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(category, isNonWorkingDay: isNonWorkingDay)));
     }
 
     /// <summary>
@@ -254,15 +263,19 @@ public sealed class FilterCombinatorTests
     // -----------------------------------------------------------------------------------------------------------
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateFilter.Not" /> inverts the underlying predicate for direct evaluation.
+    /// Verifies that <see cref="NotableDateFilter.Not" /> inverts the underlying category predicate for direct
+    /// evaluation.
     /// </summary>
+    /// <param name="category">The occurrence category.</param>
+    /// <param name="expected">The expected match result after negation.</param>
     [TestMethod]
-    public void Matches_WhenNot_InvertsPredicate()
+    [DataRow(NotableDateCategory.PublicHoliday, false)]  // negated category matches -> false
+    [DataRow(NotableDateCategory.Religious, true)]       // negated category does not match -> true
+    public void Matches_WhenNot_ShouldInvertPredicate(NotableDateCategory category, bool expected)
     {
         NotableDateFilter filter = NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday).Not();
 
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.PublicHoliday)));
-        Assert.IsTrue(filter.Matches(Occurrence(NotableDateCategory.Religious)));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(category)));
     }
 
     /// <summary>
@@ -401,11 +414,27 @@ public sealed class FilterCombinatorTests
     }
 
     /// <summary>
+    /// Provides directly constructed occurrences for the complex-composition matcher, each paired with its expected
+    /// match result against <c>(PublicHoliday OR Observance) AND NonWorking AND tag</c>.
+    /// </summary>
+    /// <returns>A sequence of <c>(string name, NotableDate occurrence, bool expected)</c> rows.</returns>
+    public static IEnumerable<object[]> ComplexCompositionRows()
+    {
+        yield return new object[] { "observance non-working tagged -> match", Occurrence(NotableDateCategory.Observance, isNonWorkingDay: true, tags: ["Public", "Religious"]), true };
+        yield return new object[] { "cultural fails category gate", Occurrence(NotableDateCategory.Cultural, isNonWorkingDay: true, tags: ["Public"]), false };
+        yield return new object[] { "working day fails non-working gate", Occurrence(NotableDateCategory.PublicHoliday, isNonWorkingDay: false, tags: ["Public"]), false };
+    }
+
+    /// <summary>
     /// Verifies that a complex composition <c>(PublicHoliday OR Observance) AND NonWorking AND tag</c> evaluates
     /// correctly over directly constructed occurrences.
     /// </summary>
+    /// <param name="name">A human-readable label for the row.</param>
+    /// <param name="occurrence">The occurrence under evaluation.</param>
+    /// <param name="expected">The expected match result.</param>
     [TestMethod]
-    public void Matches_WhenComplexComposition_EvaluatesCorrectly()
+    [DynamicData(nameof(ComplexCompositionRows))]
+    public void Matches_WhenComplexComposition_ShouldEvaluateCorrectly(string name, NotableDate occurrence, bool expected)
     {
         NotableDateFilter filter = NotableDateFilter.AnyOf(
                 NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday),
@@ -413,8 +442,6 @@ public sealed class FilterCombinatorTests
             .And(NotableDateFilter.IsNonWorkingDay())
             .And(NotableDateFilter.WithTag("Public"));
 
-        Assert.IsTrue(filter.Matches(Occurrence(NotableDateCategory.Observance, isNonWorkingDay: true, tags: ["Public", "Religious"])));
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.Cultural, isNonWorkingDay: true, tags: ["Public"])));
-        Assert.IsFalse(filter.Matches(Occurrence(NotableDateCategory.PublicHoliday, isNonWorkingDay: false, tags: ["Public"])));
+        Assert.AreEqual(expected, filter.Matches(occurrence), name);
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/FilterMatrixTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/FilterMatrixTests.cs
@@ -205,15 +205,24 @@ public sealed class FilterMatrixTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateFilter.WithAnyTag" /> matches an occurrence carrying at least one accepted tag
-    /// and rejects one carrying none.
+    /// Verifies that <see cref="NotableDateFilter.WithAnyTag" /> matches an occurrence carrying at least one accepted tag.
     /// </summary>
     [TestMethod]
-    public void Matches_WhenWithAnyTag_ShouldReflectIntersection()
+    public void Matches_WhenWithAnyTagAndTagIntersects_ShouldReturnTrue()
     {
         var filter = NotableDateFilter.WithAnyTag("Public", "Federal");
 
         Assert.IsTrue(filter.Matches(Occurrence(tags: ["Regional", "Federal"])));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateFilter.WithAnyTag" /> rejects an occurrence carrying none of the accepted tags.
+    /// </summary>
+    [TestMethod]
+    public void Matches_WhenWithAnyTagAndNoTagIntersects_ShouldReturnFalse()
+    {
+        var filter = NotableDateFilter.WithAnyTag("Public", "Federal");
+
         Assert.IsFalse(filter.Matches(Occurrence(tags: ["Christian"])));
     }
 
@@ -233,15 +242,24 @@ public sealed class FilterMatrixTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateFilter.WithAllTags" /> matches an occurrence carrying every required tag and
-    /// rejects one missing any of them.
+    /// Verifies that <see cref="NotableDateFilter.WithAllTags" /> matches an occurrence carrying every required tag.
     /// </summary>
     [TestMethod]
-    public void Matches_WhenWithAllTags_ShouldRequireEveryTag()
+    public void Matches_WhenWithAllTagsAndEveryTagPresent_ShouldReturnTrue()
     {
         var filter = NotableDateFilter.WithAllTags("Public", "Christian");
 
         Assert.IsTrue(filter.Matches(Occurrence(tags: ["Christian", "Public", "Federal"])));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateFilter.WithAllTags" /> rejects an occurrence missing any required tag.
+    /// </summary>
+    [TestMethod]
+    public void Matches_WhenWithAllTagsAndATagMissing_ShouldReturnFalse()
+    {
+        var filter = NotableDateFilter.WithAllTags("Public", "Christian");
+
         Assert.IsFalse(filter.Matches(Occurrence(tags: ["Public"])));
     }
 
@@ -280,13 +298,16 @@ public sealed class FilterMatrixTests
     /// Verifies that <see cref="NotableDateFilter.WithName" /> matches an occurrence whose display name equals the
     /// requested name and rejects a differing name.
     /// </summary>
+    /// <param name="displayName">The display name carried by the occurrence under test.</param>
+    /// <param name="expected">Whether the occurrence is expected to match the requested name.</param>
     [TestMethod]
-    public void Matches_WhenWithName_ShouldReflectNameEquality()
+    [DataRow("Christmas Day", true)]   // exact match
+    [DataRow("Easter Sunday", false)]  // differing name
+    public void Matches_WhenWithName_ShouldReflectNameEquality(string displayName, bool expected)
     {
         var filter = NotableDateFilter.WithName("Christmas Day");
 
-        Assert.IsTrue(filter.Matches(Occurrence(displayName: "Christmas Day")));
-        Assert.IsFalse(filter.Matches(Occurrence(displayName: "Easter Sunday")));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(displayName: displayName)));
     }
 
     /// <summary>
@@ -318,13 +339,16 @@ public sealed class FilterMatrixTests
     /// Verifies that <see cref="NotableDateFilter.WithAnyName" /> matches an occurrence whose display name is one of the
     /// accepted values and rejects one that is not.
     /// </summary>
+    /// <param name="displayName">The display name carried by the occurrence under test.</param>
+    /// <param name="expected">Whether the occurrence is expected to match one of the accepted names.</param>
     [TestMethod]
-    public void Matches_WhenWithAnyName_ShouldReflectMembership()
+    [DataRow("Easter Sunday", true)]  // accepted member
+    [DataRow("Anzac Day", false)]     // not a member
+    public void Matches_WhenWithAnyName_ShouldReflectMembership(string displayName, bool expected)
     {
         var filter = NotableDateFilter.WithAnyName("Christmas Day", "Easter Sunday");
 
-        Assert.IsTrue(filter.Matches(Occurrence(displayName: "Easter Sunday")));
-        Assert.IsFalse(filter.Matches(Occurrence(displayName: "Anzac Day")));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(displayName: displayName)));
     }
 
     /// <summary>
@@ -350,13 +374,16 @@ public sealed class FilterMatrixTests
     /// Verifies that <see cref="NotableDateFilter.WithId" /> matches an occurrence produced by the requested concept id
     /// and rejects one produced by a different concept.
     /// </summary>
+    /// <param name="notableDateId">The concept id carried by the occurrence under test.</param>
+    /// <param name="expected">Whether the occurrence is expected to match the requested id.</param>
     [TestMethod]
-    public void Matches_WhenWithId_ShouldReflectConceptIdentity()
+    [DataRow("christmas-day", true)]  // requested concept
+    [DataRow("boxing-day", false)]    // different concept
+    public void Matches_WhenWithId_ShouldReflectConceptIdentity(string notableDateId, bool expected)
     {
         var filter = NotableDateFilter.WithId("christmas-day");
 
-        Assert.IsTrue(filter.Matches(Occurrence(notableDateId: "christmas-day")));
-        Assert.IsFalse(filter.Matches(Occurrence(notableDateId: "boxing-day")));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(notableDateId: notableDateId)));
     }
 
     /// <summary>
@@ -474,14 +501,19 @@ public sealed class FilterMatrixTests
     /// Verifies that <see cref="NotableDateFilter.InDateRange" /> matches when the start and end coincide and the
     /// occurrence falls on that single day, and rejects an adjacent day.
     /// </summary>
+    /// <param name="year">The emitted year.</param>
+    /// <param name="month">The emitted month.</param>
+    /// <param name="day">The emitted day.</param>
+    /// <param name="expected">Whether the occurrence is expected to match the single-day 15 June 2024 range.</param>
     [TestMethod]
-    public void Matches_WhenInDateRangeStartEqualsEnd_ShouldMatchOnlyThatDay()
+    [DataRow(2024, 6, 15, true)]   // the single day
+    [DataRow(2024, 6, 16, false)]  // adjacent day
+    public void Matches_WhenInDateRangeStartEqualsEnd_ShouldMatchOnlyThatDay(int year, int month, int day, bool expected)
     {
-        DateOnly day = new(2024, 6, 15);
-        var filter = NotableDateFilter.InDateRange(day, day);
+        DateOnly single = new(2024, 6, 15);
+        var filter = NotableDateFilter.InDateRange(single, single);
 
-        Assert.IsTrue(filter.Matches(Occurrence(date: day)));
-        Assert.IsFalse(filter.Matches(Occurrence(date: new DateOnly(2024, 6, 16))));
+        Assert.AreEqual(expected, filter.Matches(Occurrence(date: new DateOnly(year, month, day))));
     }
 
     // -----------------------------------------------------------------------------------------------------------

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/HandlerParametersTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/HandlerParametersTests.cs
@@ -98,8 +98,9 @@ public sealed class HandlerParametersTests
 
         NotableDate observed = service.Resolve(new DateRange(new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 10)), Territory).Single();
 
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 1, 6), observed.Date);
+        Assert.AreEqual(
+            (true, new DateOnly(2025, 1, 6)),
+            (observed.IsObserved, observed.Date));
     }
 
     /// <summary>
@@ -114,8 +115,9 @@ public sealed class HandlerParametersTests
 
         NotableDate observed = service.Resolve(new DateRange(new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 10)), Territory).Single();
 
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2025, 1, 3), observed.Date);
+        Assert.AreEqual(
+            (true, new DateOnly(2025, 1, 3)),
+            (observed.IsObserved, observed.Date));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ImportResolutionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ImportResolutionTests.cs
@@ -51,136 +51,200 @@ public sealed class ImportResolutionTests
     }
 
     /// <summary>
-    /// Verifies that importing every concept of a source brings them in alongside the local concepts, and that the
-    /// source's adjustment policy is merged so the imported Christmas substitute resolves.
+    /// An importing region resource that pulls in every concept of <see cref="Global" /> alongside one local concept.
+    /// </summary>
+    private const string ImportAllRegion = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <Imports><Import resource="global" /></Imports>
+      <NotableDates>
+        <NotableDate id="local-day" displayName="Local Day" category="PublicHoliday" defaultNonWorkingDay="true">
+          <Rules><Rule id="r"><Strategy><Fixed month="June" day="1" /></Strategy></Rule></Rules>
+        </NotableDate>
+      </NotableDates>
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that importing every concept of a source brings them in alongside the local concepts.
     /// </summary>
     [TestMethod]
-    public void Load_WhenImportAll_BringsInSourceConceptsAndPolicies()
+    public void Load_WhenImportAll_BringsInSourceConcepts()
     {
-        const string Region = """
-        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
-          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
-          <Imports><Import resource="global" /></Imports>
-          <NotableDates>
-            <NotableDate id="local-day" displayName="Local Day" category="PublicHoliday" defaultNonWorkingDay="true">
-              <Rules><Rule id="r"><Strategy><Fixed month="June" day="1" /></Strategy></Rule></Rules>
-            </NotableDate>
-          </NotableDates>
-        </NotableDateResource>
-        """;
-
-        NotableDateService service = new(NotableDateResourceLoader.Load(Region, Resolver(("global", Global))));
+        NotableDateService service = new(NotableDateResourceLoader.Load(ImportAllRegion, Resolver(("global", Global))));
 
         var ids = service.Resolve(new DateRange(new DateOnly(2021, 1, 1), new DateOnly(2021, 12, 31)), "XX")
             .Select(r => r.NotableDateId).Distinct().OrderBy(s => s, StringComparer.Ordinal).ToList();
-        CollectionAssert.AreEqual(new[] { "christmas", "easter-sunday", "local-day" }, ids);
 
-        // 25 December 2021 is a Saturday; the imported weekend-roll policy substitutes Monday 27 December.
+        CollectionAssert.AreEqual(new[] { "christmas", "easter-sunday", "local-day" }, ids);
+    }
+
+    /// <summary>
+    /// Verifies that importing every concept of a source also merges the source's adjustment policy, so the imported
+    /// Christmas substitute resolves. 25 December 2021 is a Saturday; the imported weekend-roll substitutes Monday
+    /// 27 December.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenImportAll_MergesSourcePolicies()
+    {
+        NotableDateService service = new(NotableDateResourceLoader.Load(ImportAllRegion, Resolver(("global", Global))));
+
         NotableDate christmas = service.Resolve(new DateOnly(2021, 12, 27), "XX").Single(r => r.NotableDateId == "christmas");
+
         Assert.IsTrue(christmas.IsObserved);
     }
 
     /// <summary>
-    /// Verifies that cherry-picking renames a concept and scopes another to a territory, so the territory-scoped concept
-    /// is absent for other territories.
+    /// A region resource that cherry-picks the global source, scoping Christmas to GB and renaming Easter to <c>easter</c>.
+    /// </summary>
+    private const string CherryPickRegion = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <Imports>
+        <Import resource="global">
+          <Use notableDateRef="christmas" territory="GB" />
+          <Use notableDateRef="easter-sunday" as="easter" />
+        </Import>
+      </Imports>
+      <NotableDates />
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that cherry-picking with a rename and a territory scope makes the scoping territory see both the renamed
+    /// concept and the territory-scoped concept.
     /// </summary>
     [TestMethod]
-    public void Load_WhenCherryPick_AppliesRenameAndTerritory()
+    public void Load_WhenCherryPick_ScopingTerritorySeesRenamedAndScopedConcepts()
     {
-        const string Region = """
-        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
-          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
-          <Imports>
-            <Import resource="global">
-              <Use notableDateRef="christmas" territory="GB" />
-              <Use notableDateRef="easter-sunday" as="easter" />
-            </Import>
-          </Imports>
-          <NotableDates />
-        </NotableDateResource>
-        """;
-
-        NotableDateService service = new(NotableDateResourceLoader.Load(Region, Resolver(("global", Global))));
+        NotableDateService service = new(NotableDateResourceLoader.Load(CherryPickRegion, Resolver(("global", Global))));
         DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
         var britain = service.Resolve(year, "GB").Select(r => r.NotableDateId).Distinct().OrderBy(s => s, StringComparer.Ordinal).ToList();
+
         CollectionAssert.AreEqual(new[] { "christmas", "easter" }, britain, "GB sees the renamed easter and the GB-scoped christmas");
+    }
+
+    /// <summary>
+    /// Verifies that cherry-picking with a territory scope hides the scoped concept from other territories, which see
+    /// only the un-scoped renamed concept.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenCherryPick_OtherTerritorySeesOnlyUnscopedConcept()
+    {
+        NotableDateService service = new(NotableDateResourceLoader.Load(CherryPickRegion, Resolver(("global", Global))));
+        DateRange year = new(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31));
 
         var other = service.Resolve(year, "XX").Select(r => r.NotableDateId).Distinct().ToList();
+
         CollectionAssert.AreEqual(new[] { "easter" }, other, "another territory sees only the un-scoped easter");
     }
 
     /// <summary>
-    /// Verifies that an import use's adjustment override replaces the source rule's adjustments, so the imported
-    /// concept observes the territory's own substitute rather than the source's.
+    /// A region resource that imports the global Christmas for US and overrides its adjustment with a move-to-previous-Friday
+    /// policy.
+    /// </summary>
+    private const string OverrideAdjustmentRegion = """
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <AdjustmentPolicies>
+        <AdjustmentPolicy id="prev-friday" priority="100">
+          <Trigger type="IfWeekend" />
+          <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
+          <Emission mode="ObservedOnly" reason="Observed Friday" />
+        </AdjustmentPolicy>
+      </AdjustmentPolicies>
+      <Imports>
+        <Import resource="global">
+          <Use notableDateRef="christmas" territory="US">
+            <Adjustments><Adjustment policyRef="prev-friday" /></Adjustments>
+          </Use>
+        </Import>
+      </Imports>
+      <NotableDates />
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that an import use's adjustment override observes the imported concept on the territory's own substitute.
+    /// 25 December 2021 is a Saturday; the override moves the observance back to Friday 24 December, carrying the actual
+    /// date.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenUseOverridesAdjustments_ObservesTerritorySubstitute()
+    {
+        NotableDateService service = new(NotableDateResourceLoader.Load(OverrideAdjustmentRegion, Resolver(("global", Global))));
+
+        NotableDate christmas = service.Resolve(new DateOnly(2021, 12, 24), "US").Single(r => r.NotableDateId == "christmas");
+
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2021, 12, 25)),
+            (christmas.IsObserved, christmas.ActualDate));
+    }
+
+    /// <summary>
+    /// Verifies that an import use's adjustment override replaces the source rule's adjustment, so the source weekend-roll
+    /// no longer emits its next-working-day Monday 27 December substitute.
     /// </summary>
     [TestMethod]
     public void Load_WhenUseOverridesAdjustments_ReplacesSourceAdjustment()
     {
-        const string Region = """
-        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
-          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
-          <AdjustmentPolicies>
-            <AdjustmentPolicy id="prev-friday" priority="100">
-              <Trigger type="IfWeekend" />
-              <Action type="MoveToPreviousWeekday" dayOfWeek="Friday" />
-              <Emission mode="ObservedOnly" reason="Observed Friday" />
-            </AdjustmentPolicy>
-          </AdjustmentPolicies>
-          <Imports>
-            <Import resource="global">
-              <Use notableDateRef="christmas" territory="US">
-                <Adjustments><Adjustment policyRef="prev-friday" /></Adjustments>
-              </Use>
-            </Import>
-          </Imports>
-          <NotableDates />
-        </NotableDateResource>
-        """;
+        NotableDateService service = new(NotableDateResourceLoader.Load(OverrideAdjustmentRegion, Resolver(("global", Global))));
 
-        NotableDateService service = new(NotableDateResourceLoader.Load(Region, Resolver(("global", Global))));
-
-        // 25 December 2021 is a Saturday; the override moves the observance back to Friday 24 December rather than the
-        // source weekend-roll's next-working-day Monday 27 December.
-        NotableDate christmas = service.Resolve(new DateOnly(2021, 12, 24), "US").Single(r => r.NotableDateId == "christmas");
-        Assert.IsTrue(christmas.IsObserved);
-        Assert.AreEqual(new DateOnly(2021, 12, 25), christmas.ActualDate);
         Assert.AreEqual(0, service.Resolve(new DateOnly(2021, 12, 27), "US").Count(r => r.NotableDateId == "christmas"), "source weekend-roll replaced");
     }
 
     /// <summary>
-    /// Verifies that two territories importing the same shared concept can each supply their own adjustment override,
-    /// so the shared Christmas observes on different days per territory.
+    /// Builds an importing region resource that scopes the shared Christmas to <paramref name="territory" /> and overrides
+    /// its adjustment with the supplied weekend-substitution policy.
+    /// </summary>
+    /// <param name="territory">The territory the imported Christmas is scoped to.</param>
+    /// <param name="policyId">The adjustment-policy id.</param>
+    /// <param name="action">The adjustment action type.</param>
+    /// <param name="dayOfWeek">The target day of week for the action.</param>
+    /// <returns>The region resource XML.</returns>
+    private static string OverridingRegion(string territory, string policyId, string action, string dayOfWeek) => $$"""
+    <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
+      <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
+      <AdjustmentPolicies>
+        <AdjustmentPolicy id="{{policyId}}" priority="100">
+          <Trigger type="IfWeekend" />
+          <Action type="{{action}}" dayOfWeek="{{dayOfWeek}}" />
+          <Emission mode="ObservedOnly" reason="Observed" />
+        </AdjustmentPolicy>
+      </AdjustmentPolicies>
+      <Imports>
+        <Import resource="global">
+          <Use notableDateRef="christmas" territory="{{territory}}">
+            <Adjustments><Adjustment policyRef="{{policyId}}" /></Adjustments>
+          </Use>
+        </Import>
+      </Imports>
+      <NotableDates />
+    </NotableDateResource>
+    """;
+
+    /// <summary>
+    /// Verifies that a territory importing the shared concept observes it on its own substitute. The shared Christmas
+    /// (Saturday 25 December 2021) rolls back to Friday 24 December under the US move-to-previous-Friday override.
     /// </summary>
     [TestMethod]
-    public void Load_WhenRegionsOverrideAdjustmentsDifferently_EachObservesItsOwn()
+    public void Load_WhenRegionsOverrideAdjustmentsDifferently_UsRollsBackToFriday()
     {
-        static string Make(string territory, string policyId, string action, string dayOfWeek) => $$"""
-        <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.region">
-          <ResolutionPolicy duplicatePolicy="Error" priorityDirection="HigherWins" />
-          <AdjustmentPolicies>
-            <AdjustmentPolicy id="{{policyId}}" priority="100">
-              <Trigger type="IfWeekend" />
-              <Action type="{{action}}" dayOfWeek="{{dayOfWeek}}" />
-              <Emission mode="ObservedOnly" reason="Observed" />
-            </AdjustmentPolicy>
-          </AdjustmentPolicies>
-          <Imports>
-            <Import resource="global">
-              <Use notableDateRef="christmas" territory="{{territory}}">
-                <Adjustments><Adjustment policyRef="{{policyId}}" /></Adjustments>
-              </Use>
-            </Import>
-          </Imports>
-          <NotableDates />
-        </NotableDateResource>
-        """;
+        NotableDateService us = new(NotableDateResourceLoader.Load(OverridingRegion("US", "prev-friday", "MoveToPreviousWeekday", "Friday"), Resolver(("global", Global))));
 
-        NotableDateService us = new(NotableDateResourceLoader.Load(Make("US", "prev-friday", "MoveToPreviousWeekday", "Friday"), Resolver(("global", Global))));
-        NotableDateService gb = new(NotableDateResourceLoader.Load(Make("GB", "next-monday", "MoveToNextWeekday", "Monday"), Resolver(("global", Global))));
-
-        // The shared Christmas (Saturday 25 December 2021) rolls back to Friday in the US and forward to Monday in GB.
         Assert.AreEqual(new DateOnly(2021, 12, 24), us.Resolve(new DateOnly(2021, 12, 24), "US").Single(r => r.NotableDateId == "christmas").Date);
+    }
+
+    /// <summary>
+    /// Verifies that another territory importing the same shared concept observes it on its own substitute. The shared
+    /// Christmas (Saturday 25 December 2021) rolls forward to Monday 27 December under the GB move-to-next-Monday override.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenRegionsOverrideAdjustmentsDifferently_GbRollsForwardToMonday()
+    {
+        NotableDateService gb = new(NotableDateResourceLoader.Load(OverridingRegion("GB", "next-monday", "MoveToNextWeekday", "Monday"), Resolver(("global", Global))));
+
         Assert.AreEqual(new DateOnly(2021, 12, 27), gb.Resolve(new DateOnly(2021, 12, 27), "GB").Single(r => r.NotableDateId == "christmas").Date);
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/IslamicCalendarKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/IslamicCalendarKnownAnswerTests.cs
@@ -44,19 +44,14 @@ public sealed class IslamicCalendarKnownAnswerTests
     [TestCategory("Regression")]
     public void Resolve_WhenLoadingIslamic_ResolvesAllSixObservances()
     {
-        NotableDateService service = CreateService();
-
-        var ids = service
+        var ids = CreateService()
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "XX")
             .Select(r => r.NotableDateId)
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.Contains("ramadan", ids);
-        Assert.Contains("eid-al-fitr", ids);
-        Assert.Contains("eid-al-adha", ids);
-        Assert.Contains("islamic-new-year", ids);
-        Assert.Contains("day-of-ashura", ids);
-        Assert.Contains("mawlid-al-nabi", ids);
+        CollectionAssert.IsSubsetOf(
+            new[] { "ramadan", "eid-al-fitr", "eid-al-adha", "islamic-new-year", "day-of-ashura", "mawlid-al-nabi" },
+            ids.ToArray());
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/JewishCalendarKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/JewishCalendarKnownAnswerTests.cs
@@ -55,20 +55,14 @@ public sealed class JewishCalendarKnownAnswerTests
     [TestCategory("Regression")]
     public void Resolve_WhenLoadingJewish_ResolvesAllSevenHolidays()
     {
-        NotableDateService service = CreateService();
-
-        var ids = service
+        var ids = CreateService()
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "XX")
             .Select(r => r.NotableDateId)
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.Contains("rosh-hashanah", ids);
-        Assert.Contains("yom-kippur", ids);
-        Assert.Contains("sukkot", ids);
-        Assert.Contains("hanukkah", ids);
-        Assert.Contains("purim", ids);
-        Assert.Contains("passover", ids);
-        Assert.Contains("shavuot", ids);
+        CollectionAssert.IsSubsetOf(
+            new[] { "rosh-hashanah", "yom-kippur", "sukkot", "hanukkah", "purim", "passover", "shavuot" },
+            ids.ToArray());
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/JsonIngestionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/JsonIngestionTests.cs
@@ -112,8 +112,9 @@ public sealed class JsonIngestionTests
         NotableDate? match = Single(2023, "new-years-day");
 
         Assert.IsNotNull(match);
-        Assert.IsTrue(match.IsObserved);
-        Assert.AreEqual(new DateOnly(2023, 1, 1), match.ActualDate);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2023, 1, 1)),
+            (match.IsObserved, match.ActualDate));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/LeapYearScenarioTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/LeapYearScenarioTests.cs
@@ -335,9 +335,10 @@ public sealed class LeapYearScenarioTests
             .Resolve(new DateRange(new DateOnly(2020, 2, 1), new DateOnly(2020, 3, 31)), Territory);
 
         NotableDate substitute = Single(results, "leap-day-holiday");
-        Assert.AreEqual(new DateOnly(2020, 3, 2), substitute.Date);
-        Assert.IsTrue(substitute.IsObserved);
-        Assert.AreEqual(new DateOnly(2020, 2, 29), substitute.ActualDate);
+
+        Assert.AreEqual(
+            (new DateOnly(2020, 3, 2), true, (DateOnly?)new DateOnly(2020, 2, 29)),
+            (substitute.Date, substitute.IsObserved, substitute.ActualDate));
     }
 
     /// <summary>
@@ -351,8 +352,10 @@ public sealed class LeapYearScenarioTests
             .Resolve(new DateRange(new DateOnly(2024, 2, 1), new DateOnly(2024, 3, 31)), Territory);
 
         NotableDate match = Single(results, "leap-day-holiday");
-        Assert.AreEqual(new DateOnly(2024, 2, 29), match.Date);
-        Assert.IsFalse(match.IsObserved);
+
+        Assert.AreEqual(
+            (new DateOnly(2024, 2, 29), false),
+            (match.Date, match.IsObserved));
     }
 
     // =====================================================================================================================

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NonWorkingDayTriggerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NonWorkingDayTriggerTests.cs
@@ -90,42 +90,67 @@ public sealed class NonWorkingDayTriggerTests
         new NotableDateService(NotableDateResourceLoader.Load(Xml));
 
     /// <summary>
-    /// Verifies that a non-working holiday colliding with another non-working holiday on a working day fires the
-    /// non-working-day trigger and is observed on the next free working day.
+    /// Verifies that the unadjusted holiday of a colliding pair keeps the contested working day, emitting on its actual
+    /// date. Collide A has no adjustment, so it remains on Thursday 1 January 2026.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenCollidingWithAnotherHoliday_ShouldKeepFirstHolidayOnContestedDay()
+    {
+        IReadOnlyList<NotableDate> thursday = Build().Resolve(new DateOnly(2026, 1, 1), Territory);
+
+        Assert.Contains(n => n.NotableDateId == "collide-a" && !n.IsObserved, thursday, "Collide A on its actual day");
+    }
+
+    /// <summary>
+    /// Verifies that the adjusted holiday of a colliding pair leaves the contested working day, because the non-working-day
+    /// trigger fires when the day is already claimed. Collide B is absent from Thursday 1 January 2026.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenCollidingWithAnotherHoliday_ShouldMoveSecondHolidayOffContestedDay()
+    {
+        IReadOnlyList<NotableDate> thursday = Build().Resolve(new DateOnly(2026, 1, 1), Territory);
+
+        Assert.DoesNotContain(n => n.NotableDateId == "collide-b", thursday, "Collide B moved off the contested day");
+    }
+
+    /// <summary>
+    /// Verifies that the adjusted holiday of a colliding pair is observed on the next free working day, carrying its actual
+    /// date. Collide B (Thursday 1 January 2026) is observed on Friday 2 January.
     /// </summary>
     [TestMethod]
     public void IfNonWorkingDay_WhenCollidingWithAnotherHoliday_ShouldObserveOnNextWorkingDay()
     {
-        INotableDateService service = Build();
+        NotableDate observed = Build().Resolve(new DateOnly(2026, 1, 2), Territory).Single(n => n.NotableDateId == "collide-b");
 
-        // Collide A keeps the contested Thursday; Collide B does not appear on it.
-        IReadOnlyList<NotableDate> thursday = service.Resolve(new DateOnly(2026, 1, 1), Territory);
-        Assert.Contains(n => n.NotableDateId == "collide-a" && !n.IsObserved, thursday, "Collide A on its actual day");
-        Assert.DoesNotContain(n => n.NotableDateId == "collide-b", thursday, "Collide B moved off the contested day");
-
-        // Collide B is observed on the next working day (Friday 2 January).
-        IReadOnlyList<NotableDate> friday = service.Resolve(new DateOnly(2026, 1, 2), Territory);
-        NotableDate observed = friday.Single(n => n.NotableDateId == "collide-b");
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 1), observed.ActualDate);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 1)),
+            (observed.IsObserved, observed.ActualDate));
     }
 
     /// <summary>
-    /// Verifies that the non-working-day trigger fires for a holiday falling on a weekend and moves it to the next
-    /// working day, skipping the weekend.
+    /// Verifies that the non-working-day trigger suppresses the weekend actual date of a holiday emitted observed-only.
+    /// The Saturday 3 January 2026 occurrence does not appear on its actual date.
+    /// </summary>
+    [TestMethod]
+    public void IfNonWorkingDay_WhenHolidayFallsOnWeekend_ShouldSuppressWeekendActual()
+    {
+        Assert.DoesNotContain(
+            n => n.NotableDateId == "weekend-holiday", Build().Resolve(new DateOnly(2026, 1, 3), Territory),
+            "Saturday actual suppressed");
+    }
+
+    /// <summary>
+    /// Verifies that the non-working-day trigger moves a weekend holiday to the next working day, skipping the weekend,
+    /// carrying its actual date. Saturday 3 January 2026 is observed on Monday 5 January.
     /// </summary>
     [TestMethod]
     public void IfNonWorkingDay_WhenHolidayFallsOnWeekend_ShouldObserveOnNextWorkingDay()
     {
-        INotableDateService service = Build();
+        NotableDate observed = Build().Resolve(new DateOnly(2026, 1, 5), Territory).Single(n => n.NotableDateId == "weekend-holiday");
 
-        Assert.DoesNotContain(
-            n => n.NotableDateId == "weekend-holiday", service.Resolve(new DateOnly(2026, 1, 3), Territory),
-            "Saturday actual suppressed");
-
-        NotableDate observed = service.Resolve(new DateOnly(2026, 1, 5), Territory).Single(n => n.NotableDateId == "weekend-holiday");
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 3), observed.ActualDate);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 3)),
+            (observed.IsObserved, observed.ActualDate));
     }
 
     /// <summary>
@@ -137,26 +162,35 @@ public sealed class NonWorkingDayTriggerTests
     {
         NotableDate actual = Build().Resolve(new DateOnly(2026, 1, 8), Territory).Single(n => n.NotableDateId == "lone-working");
 
-        Assert.IsFalse(actual.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 8), actual.Date);
+        Assert.AreEqual(
+            (false, new DateOnly(2026, 1, 8)),
+            (actual.IsObserved, actual.Date));
     }
 
     /// <summary>
-    /// Verifies that the working-day trigger fires for a lone holiday on a working day and shifts it by the configured
-    /// number of days.
+    /// Verifies that the working-day trigger suppresses the actual working-day date of a holiday emitted observed-only.
+    /// The Thursday 15 January 2026 occurrence does not appear on its actual date.
+    /// </summary>
+    [TestMethod]
+    public void IfWorkingDay_WhenHolidayOnWorkingDay_ShouldSuppressActual()
+    {
+        Assert.DoesNotContain(
+            n => n.NotableDateId == "working-shift", Build().Resolve(new DateOnly(2026, 1, 15), Territory),
+            "actual Thursday suppressed by observed-only");
+    }
+
+    /// <summary>
+    /// Verifies that the working-day trigger shifts a lone holiday on a working day by the configured number of days,
+    /// carrying its actual date. Thursday 15 January 2026 is observed two days later on 17 January.
     /// </summary>
     [TestMethod]
     public void IfWorkingDay_WhenHolidayOnWorkingDay_ShouldShiftOccurrence()
     {
-        INotableDateService service = Build();
+        NotableDate observed = Build().Resolve(new DateOnly(2026, 1, 17), Territory).Single(n => n.NotableDateId == "working-shift");
 
-        Assert.DoesNotContain(
-            n => n.NotableDateId == "working-shift", service.Resolve(new DateOnly(2026, 1, 15), Territory),
-            "actual Thursday suppressed by observed-only");
-
-        NotableDate observed = service.Resolve(new DateOnly(2026, 1, 17), Territory).Single(n => n.NotableDateId == "working-shift");
-        Assert.IsTrue(observed.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 15), observed.ActualDate);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 15)),
+            (observed.IsObserved, observed.ActualDate));
     }
 
     /// <summary>
@@ -168,7 +202,8 @@ public sealed class NonWorkingDayTriggerTests
     {
         NotableDate actual = Build().Resolve(new DateOnly(2026, 1, 10), Territory).Single(n => n.NotableDateId == "weekend-no-shift");
 
-        Assert.IsFalse(actual.IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 10), actual.Date);
+        Assert.AreEqual(
+            (false, new DateOnly(2026, 1, 10)),
+            (actual.IsObserved, actual.Date));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAssert.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateAssert.cs
@@ -47,4 +47,18 @@ internal static class NotableDateAssert
         Assert.AreEqual(category, actual.Category, "Category");
         Assert.AreEqual(adjustmentPolicyId, actual.AdjustmentPolicyId, "AdjustmentPolicyId");
     }
+
+    /// <summary>
+    /// Asserts that a resolved occurrence is present and matches the expected notable-date id and emitted date, so that a
+    /// single call captures the identity of one occurrence.
+    /// </summary>
+    /// <param name="occurrence">The resolved occurrence under test, or <see langword="null" /> when none was found.</param>
+    /// <param name="notableDateId">The expected notable-date id.</param>
+    /// <param name="date">The expected emitted date.</param>
+    public static void AssertOccurrence(NotableDate? occurrence, string notableDateId, DateOnly date)
+    {
+        Assert.IsNotNull(occurrence);
+        Assert.AreEqual(date, occurrence.Date, "Date");
+        Assert.AreEqual(notableDateId, occurrence.NotableDateId, "NotableDateId");
+    }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateFilterTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateFilterTests.cs
@@ -93,19 +93,29 @@ public sealed class NotableDateFilterTests
     }
 
     /// <summary>
-    /// Verifies that conjunction keeps only occurrences matching every filter, and disjunction keeps occurrences
-    /// matching either.
+    /// Verifies that conjunction keeps only occurrences matching every filter, so a major-and-public-holiday filter
+    /// keeps the two major public holidays.
     /// </summary>
     [TestMethod]
-    public void Resolve_WhenComposedWithAndOr_AppliesBooleanLogic()
+    public void Resolve_WhenComposedWithAnd_KeepsConjunction()
     {
         NotableDateFilter majorPublicHoliday = NotableDateFilter.WithTag("major")
             .And(NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday));
-        CollectionAssert.AreEqual(new[] { "new-year", "spring-week" }, Resolve(majorPublicHoliday));
 
+        CollectionAssert.AreEqual(new[] { "new-year", "spring-week" }, Resolve(majorPublicHoliday));
+    }
+
+    /// <summary>
+    /// Verifies that disjunction keeps occurrences matching either filter, so a cultural-or-long filter keeps the
+    /// cultural festival and the multi-day span.
+    /// </summary>
+    [TestMethod]
+    public void Resolve_WhenComposedWithOr_KeepsDisjunction()
+    {
         var culturalOrLong = NotableDateFilter.AnyOf(
             NotableDateFilter.ForCategory(NotableDateCategory.Cultural),
             NotableDateFilter.WithMinDuration(2));
+
         CollectionAssert.AreEqual(new[] { "culture-fest", "spring-week" }, Resolve(culturalOrLong));
     }
 
@@ -118,7 +128,8 @@ public sealed class NotableDateFilterTests
         IReadOnlyList<NotableDate> results = CreateService()
             .Resolve(new DateOnly(2023, 2, 3), "XX", NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday));
 
-        Assert.HasCount(1, results);
-        Assert.AreEqual("spring-week", results[0].NotableDateId);
+        CollectionAssert.AreEqual(
+            new[] { "spring-week" },
+            results.Select(r => r.NotableDateId).ToArray());
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateOnlyExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateOnlyExtensionsTests.cs
@@ -34,17 +34,20 @@ public sealed class NotableDateOnlyExtensionsTests
         new NotableDateService(NotableDateResourceLoader.Load(Xml));
 
     /// <summary>
-    /// Verifies that a weekend day, a holiday, and an ordinary weekday are classified correctly. In 2025, 1 January is a
-    /// Wednesday (a non-working holiday), 4 January is a Saturday, and 2 January is an ordinary working day.
+    /// Verifies that a non-working holiday, a weekend day, and an ordinary weekday are each classified correctly. In
+    /// 2025, 1 January is a Wednesday holiday, 4 January is a Saturday, and 2 January is an ordinary working day.
     /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected working-day classification.</param>
     [TestMethod]
-    public void IsWorkingDay_ClassifiesWeekendHolidayAndWeekday()
+    [DataRow(2025, 1, 1, false)]  // Wednesday holiday
+    [DataRow(2025, 1, 4, false)]  // Saturday
+    [DataRow(2025, 1, 2, true)]   // ordinary weekday
+    public void IsWorkingDay_WhenDayIsHolidayWeekendOrWeekday_ShouldReturnExpectedClassification(int year, int month, int day, bool expected)
     {
-        INotableDateService service = Service;
-
-        Assert.IsFalse(new DateOnly(2025, 1, 1).IsWorkingDay(service, "XX"), "1 January holiday");
-        Assert.IsFalse(new DateOnly(2025, 1, 4).IsWorkingDay(service, "XX"), "Saturday");
-        Assert.IsTrue(new DateOnly(2025, 1, 2).IsWorkingDay(service, "XX"), "ordinary weekday");
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsWorkingDay(Service, "XX"));
     }
 
     /// <summary>
@@ -68,27 +71,43 @@ public sealed class NotableDateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that adding working days skips the holiday and weekends.
+    /// Verifies that adding working days forward skips the holiday and weekends. From Tuesday 31 December 2024, three
+    /// working days forward are 2 January (Thursday), 3 January (Friday) and 6 January (Monday).
     /// </summary>
     [TestMethod]
-    public void AddWorkingDays_SkipsNonWorkingDays()
+    public void AddWorkingDays_WhenAddingForward_ShouldSkipNonWorkingDays()
     {
-        // From Tuesday 31 December 2024, three working days: 2 Jan (Thu), 3 Jan (Fri), 6 Jan (Mon).
         Assert.AreEqual(new DateOnly(2025, 1, 6), new DateOnly(2024, 12, 31).AddWorkingDays(3, Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that subtracting working days skips the holiday and weekends. From Monday 6 January 2025, three working
+    /// days back are 3 January (Friday), 2 January (Thursday) and 31 December 2024 (Tuesday).
+    /// </summary>
+    [TestMethod]
+    public void AddWorkingDays_WhenSubtractingBackward_ShouldSkipNonWorkingDays()
+    {
         Assert.AreEqual(new DateOnly(2024, 12, 31), new DateOnly(2025, 1, 6).AddWorkingDays(-3, Service, "XX"));
     }
 
     /// <summary>
-    /// Verifies that the snap helpers move a holiday to the surrounding working days.
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDay" /> moves the 1 January 2025 holiday forward
+    /// to the following working day, Thursday 2 January.
     /// </summary>
     [TestMethod]
-    public void Snap_MovesHolidayToWorkingDay()
+    public void SnapToWorkingDay_WhenHoliday_ShouldReturnFollowingWorkingDay()
     {
-        DateOnly holiday = new(2025, 1, 1);
-        INotableDateService service = Service;
+        Assert.AreEqual(new DateOnly(2025, 1, 2), new DateOnly(2025, 1, 1).SnapToWorkingDay(Service, "XX"));
+    }
 
-        Assert.AreEqual(new DateOnly(2025, 1, 2), holiday.SnapToWorkingDay(service, "XX"));
-        Assert.AreEqual(new DateOnly(2024, 12, 31), holiday.SnapToWorkingDayBackward(service, "XX"));
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDayBackward" /> moves the 1 January 2025 holiday
+    /// backward to the prior working day, Tuesday 31 December 2024.
+    /// </summary>
+    [TestMethod]
+    public void SnapToWorkingDayBackward_WhenHoliday_ShouldReturnPriorWorkingDay()
+    {
+        Assert.AreEqual(new DateOnly(2024, 12, 31), new DateOnly(2025, 1, 1).SnapToWorkingDayBackward(Service, "XX"));
     }
 
     /// <summary>
@@ -105,16 +124,28 @@ public sealed class NotableDateOnlyExtensionsTests
     }
 
     /// <summary>
-    /// Verifies that the date-level notable-date helpers report the holiday.
+    /// Verifies that <see cref="NotableDateOnlyExtensions.IsNotableDate" /> reports the holiday on its day and not on an
+    /// ordinary day. In 2025, 1 January is the holiday and 2 January is an ordinary working day.
+    /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected notable-date classification.</param>
+    [TestMethod]
+    [DataRow(2025, 1, 1, true)]    // holiday
+    [DataRow(2025, 1, 2, false)]   // ordinary day
+    public void IsNotableDate_WhenDayIsHolidayOrOrdinary_ShouldReturnExpected(int year, int month, int day, bool expected)
+    {
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsNotableDate(Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.GetNotableDates" /> returns the holiday occurrence on its day.
     /// </summary>
     [TestMethod]
-    public void GetNotableDates_ReturnsHolidayOnTheDay()
+    public void GetNotableDates_WhenHolidayOnTheDay_ShouldReturnHoliday()
     {
-        INotableDateService service = Service;
-
-        Assert.IsTrue(new DateOnly(2025, 1, 1).IsNotableDate(service, "XX"));
-        Assert.AreEqual("new-years-day", new DateOnly(2025, 1, 1).GetNotableDates(service, "XX").Single().NotableDateId);
-        Assert.IsFalse(new DateOnly(2025, 1, 2).IsNotableDate(service, "XX"));
+        Assert.AreEqual("new-years-day", new DateOnly(2025, 1, 1).GetNotableDates(Service, "XX").Single().NotableDateId);
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateOverrideTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateOverrideTests.cs
@@ -14,19 +14,47 @@ namespace Bodu.Globalization.Calendar;
 public sealed class NotableDateOverrideTests
 {
     /// <summary>
-    /// Verifies that removing the Puerto Rico Constitution Day rule leaves the United States rule intact. (T12)
+    /// Verifies that removing the Puerto Rico Constitution Day rule leaves the sibling United States rule intact. (T12)
     /// </summary>
     [TestMethod]
-    public void Override_RemoveRule_WhenTargetingPuertoRicoConstitutionDay_DoesNotRemoveUnitedStatesRule()
+    public void Override_RemoveRule_WhenTargetingPuertoRicoConstitutionDay_ShouldKeepUnitedStatesRule()
     {
         NotableDateService resolver = new(MinimalNotableDates.LoadWithRemoveOverride());
 
         IReadOnlyList<NotableDate> unitedStates = resolver.Resolve(new DateOnly(2026, 9, 17), "US");
-        Assert.HasCount(1, unitedStates, "United States rule should survive the removal");
-        Assert.AreEqual("us-fixed-sep-17", unitedStates[0].RuleId);
+
+        CollectionAssert.AreEqual(
+            new[] { "us-fixed-sep-17" },
+            unitedStates.Select(r => r.RuleId).ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that the remove override removes the targeted Puerto Rico Constitution Day rule. (T12)
+    /// </summary>
+    [TestMethod]
+    public void Override_RemoveRule_WhenTargetingPuertoRicoConstitutionDay_ShouldRemovePuertoRicoRule()
+    {
+        NotableDateService resolver = new(MinimalNotableDates.LoadWithRemoveOverride());
 
         IReadOnlyList<NotableDate> puertoRico = resolver.Resolve(new DateOnly(2026, 7, 25), "PR");
-        Assert.IsEmpty(puertoRico, "Puerto Rico rule should have been removed");
+
+        Assert.IsEmpty(puertoRico);
+    }
+
+    /// <summary>
+    /// Verifies that patching the Puerto Rico Constitution Day rule's category applies the patched category to the
+    /// Puerto Rico rule. (T13)
+    /// </summary>
+    [TestMethod]
+    public void Override_PatchRule_WhenTargetingPuertoRicoConstitutionDay_ShouldPatchPuertoRicoCategory()
+    {
+        NotableDateService resolver = new(MinimalNotableDates.LoadWithPatchOverride());
+
+        IReadOnlyList<NotableDate> puertoRico = resolver.Resolve(new DateOnly(2026, 7, 25), "PR");
+
+        CollectionAssert.AreEqual(
+            new[] { NotableDateCategory.PublicHoliday },
+            puertoRico.Select(r => r.Category).ToArray());
     }
 
     /// <summary>
@@ -34,16 +62,14 @@ public sealed class NotableDateOverrideTests
     /// rule's category. (T13)
     /// </summary>
     [TestMethod]
-    public void Override_PatchRule_WhenTargetingPuertoRicoConstitutionDay_DoesNotPatchUnitedStatesRule()
+    public void Override_PatchRule_WhenTargetingPuertoRicoConstitutionDay_ShouldLeaveUnitedStatesCategoryUnchanged()
     {
         NotableDateService resolver = new(MinimalNotableDates.LoadWithPatchOverride());
 
-        IReadOnlyList<NotableDate> puertoRico = resolver.Resolve(new DateOnly(2026, 7, 25), "PR");
-        Assert.HasCount(1, puertoRico);
-        Assert.AreEqual(NotableDateCategory.PublicHoliday, puertoRico[0].Category, "patched Puerto Rico category");
-
         IReadOnlyList<NotableDate> unitedStates = resolver.Resolve(new DateOnly(2026, 9, 17), "US");
-        Assert.HasCount(1, unitedStates);
-        Assert.AreEqual(NotableDateCategory.Observance, unitedStates[0].Category, "unchanged United States category");
+
+        CollectionAssert.AreEqual(
+            new[] { NotableDateCategory.Observance },
+            unitedStates.Select(r => r.Category).ToArray());
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateProviderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateProviderTests.cs
@@ -75,7 +75,8 @@ public sealed class NotableDateProviderTests
             provider is null ? null : new[] { provider });
 
     /// <summary>
-    /// Verifies that a provider's occurrence is resolved alongside the resource's authored holiday.
+    /// Verifies that a provider's occurrence is resolved alongside the resource's authored holiday, so the year query
+    /// yields both the authored New Year's Day and the provider's Founders Day.
     /// </summary>
     [TestMethod]
     public void Provider_ContributesOccurrenceAlongsideResource()
@@ -84,13 +85,14 @@ public sealed class NotableDateProviderTests
 
         IReadOnlyList<NotableDate> results = service.Resolve(new DateRange(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31)), Territory);
 
-        Assert.Contains(r => r.NotableDateId == "new-year", results);
-        NotableDate founders = results.Single(r => r.NotableDateId == "founders-day");
-        Assert.AreEqual(new DateOnly(2025, 3, 15), founders.Date);
+        CollectionAssert.AreEqual(
+            new[] { ("new-year", new DateOnly(2025, 1, 1)), ("founders-day", new DateOnly(2025, 3, 15)) },
+            results.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>
-    /// Verifies that a provider occurrence outside the requested range is excluded.
+    /// Verifies that a provider occurrence outside the requested range is excluded, so a January query yields only the
+    /// authored New Year's Day and not the March Founders Day.
     /// </summary>
     [TestMethod]
     public void Provider_OccurrenceOutsideRange_IsExcluded()
@@ -99,24 +101,39 @@ public sealed class NotableDateProviderTests
 
         IReadOnlyList<NotableDate> january = service.Resolve(new DateRange(new DateOnly(2025, 1, 1), new DateOnly(2025, 1, 31)), Territory);
 
-        Assert.DoesNotContain(r => r.NotableDateId == "founders-day", january);
-        Assert.Contains(r => r.NotableDateId == "new-year", january);
+        CollectionAssert.AreEqual(
+            new[] { ("new-year", new DateOnly(2025, 1, 1)) },
+            january.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>
-    /// Verifies that the query filter applies to provider occurrences just as it does to resource occurrences.
+    /// Verifies that an Observance category filter applies to provider occurrences, yielding only the provider's
+    /// Founders Day observance and excluding the authored public holiday.
     /// </summary>
     [TestMethod]
-    public void Provider_OccurrenceRespectsQueryFilter()
+    public void Provider_WhenFilteredByObservance_ShouldYieldOnlyProviderOccurrence()
     {
         INotableDateService service = Build(new FoundersDayProvider(new DateOnly(2025, 3, 15)));
         DateRange year = new(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
 
         IReadOnlyList<NotableDate> observances = service.Resolve(year, Territory, NotableDateFilter.ForCategory(NotableDateCategory.Observance));
-        Assert.Contains(r => r.NotableDateId == "founders-day", observances);
-        Assert.DoesNotContain(r => r.NotableDateId == "new-year", observances);
+
+        CollectionAssert.AreEqual(
+            new[] { ("founders-day", new DateOnly(2025, 3, 15)) },
+            observances.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
+    }
+
+    /// <summary>
+    /// Verifies that a PublicHoliday category filter excludes the provider's Observance occurrence.
+    /// </summary>
+    [TestMethod]
+    public void Provider_WhenFilteredByPublicHoliday_ShouldExcludeProviderOccurrence()
+    {
+        INotableDateService service = Build(new FoundersDayProvider(new DateOnly(2025, 3, 15)));
+        DateRange year = new(new DateOnly(2025, 1, 1), new DateOnly(2025, 12, 31));
 
         IReadOnlyList<NotableDate> holidays = service.Resolve(year, Territory, NotableDateFilter.ForCategory(NotableDateCategory.PublicHoliday));
+
         Assert.DoesNotContain(r => r.NotableDateId == "founders-day", holidays);
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateResourceLoaderTests.cs
@@ -22,8 +22,8 @@ public sealed class NotableDateResourceLoaderTests
     {
         NotableDateResource resource = MinimalNotableDates.Load();
 
-        Assert.HasCount(3, resource.NotableDates, "notable-date count");
-        Assert.AreEqual(5, resource.RuleCount, "rule count");
-        Assert.HasCount(1, resource.AdjustmentPolicies, "adjustment-policy count");
+        Assert.AreEqual(
+            (3, 5, 1),
+            (resource.NotableDates.Count, resource.RuleCount, resource.AdjustmentPolicies.Count));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateServiceTests.cs
@@ -79,22 +79,39 @@ public sealed class NotableDateServiceTests
     }
 
     /// <summary>
-    /// Verifies that single-day and range queries return the same observed New Year's Day result regardless of query
-    /// width. (T05)
+    /// Verifies that a single-day query on the actual Saturday date returns nothing, since the observed-only emission
+    /// suppresses the base occurrence. (T05)
     /// </summary>
     [TestMethod]
-    public void Resolve_NewYearsDay_WhenSingleDayAndRangeQueriesUsed_ReturnsConsistentObservedResult()
+    public void Resolve_NewYearsDay_WhenSingleDayQueryOnActualDate_ReturnsNoResult()
     {
-        NotableDateService resolver = CreateResolver();
+        Assert.IsEmpty(CreateResolver().Resolve(new DateOnly(2022, 1, 1), "AU"));
+    }
 
-        Assert.IsEmpty(resolver.Resolve(new DateOnly(2022, 1, 1), "AU"), "actual-day query");
+    /// <summary>
+    /// Verifies that a single-day query on the observed Monday date returns the observed New Year's Day occurrence.
+    /// (T05)
+    /// </summary>
+    [TestMethod]
+    public void Resolve_NewYearsDay_WhenSingleDayQueryOnObservedDate_ReturnsObservedResult()
+    {
+        IReadOnlyList<NotableDate> observedDay = CreateResolver().Resolve(new DateOnly(2022, 1, 3), "AU");
 
-        IReadOnlyList<NotableDate> observedDay = resolver.Resolve(new DateOnly(2022, 1, 3), "AU");
-        Assert.HasCount(1, observedDay, "observed-day query");
+        Assert.HasCount(1, observedDay);
         Assert.AreEqual(new DateOnly(2022, 1, 3), observedDay[0].Date);
+    }
 
-        IReadOnlyList<NotableDate> range = resolver.Resolve(new DateRange(new DateOnly(2022, 1, 1), new DateOnly(2022, 1, 3)), "AU");
-        Assert.HasCount(1, range, "range query");
+    /// <summary>
+    /// Verifies that a range query spanning the actual and observed dates returns the same observed New Year's Day
+    /// result as the single-day observed query, regardless of query width. (T05)
+    /// </summary>
+    [TestMethod]
+    public void Resolve_NewYearsDay_WhenRangeQuerySpansActualAndObserved_ReturnsObservedResult()
+    {
+        IReadOnlyList<NotableDate> range = CreateResolver()
+            .Resolve(new DateRange(new DateOnly(2022, 1, 1), new DateOnly(2022, 1, 3)), "AU");
+
+        Assert.HasCount(1, range);
         NotableDateAssert.AssertEqual(
             range[0],
             date: new DateOnly(2022, 1, 3),
@@ -217,9 +234,9 @@ public sealed class NotableDateServiceTests
         IReadOnlyList<NotableDate> results = CreateResolver()
             .Resolve(new DateRange(new DateOnly(2026, 7, 1), new DateOnly(2026, 9, 30)), "PR");
 
-        Assert.HasCount(1, results);
-        Assert.AreEqual(new DateOnly(2026, 7, 25), results[0].Date);
-        Assert.AreEqual("pr-fixed-jul-25", results[0].RuleId);
-        Assert.DoesNotContain(r => r.RuleId == "us-fixed-sep-17", results, "US rule must not leak into a PR query");
+        // The PR query must yield exactly the Puerto Rico Constitution Day rule and never the US September rule.
+        CollectionAssert.AreEqual(
+            new[] { ("pr-fixed-jul-25", new DateOnly(2026, 7, 25)) },
+            results.OrderBy(r => r.Date).Select(r => (r.RuleId, r.Date)).ToArray());
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTimeExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTimeExtensionsTests.cs
@@ -96,13 +96,12 @@ public sealed class NotableDateTimeExtensionsTests
 
         DateTime next = start.NextWorkingDay(Service, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 2), DateOnly.FromDateTime(next));
-        Assert.AreEqual(new TimeSpan(14, 30, 0), next.TimeOfDay);
+        Assert.AreEqual(new DateTime(2026, 1, 2, 14, 30, 0, DateTimeKind.Utc), next);
         Assert.AreEqual(DateTimeKind.Utc, next.Kind);
     }
 
     /// <summary>
-    /// Verifies that the holiday is reported as a non-working day.
+    /// Verifies that <see cref="NotableDateTimeExtensions.IsWorkingDay" /> reports the holiday as not a working day.
     /// </summary>
     [TestMethod]
     public void IsWorkingDay_OnHoliday_ShouldBeFalse()
@@ -110,6 +109,16 @@ public sealed class NotableDateTimeExtensionsTests
         DateTime holiday = new(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
 
         Assert.IsFalse(holiday.IsWorkingDay(Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateTimeExtensions.IsNonWorkingDay" /> reports the holiday as a non-working day.
+    /// </summary>
+    [TestMethod]
+    public void IsNonWorkingDay_OnHoliday_ShouldBeTrue()
+    {
+        DateTime holiday = new(2026, 1, 1, 9, 0, 0, DateTimeKind.Utc);
+
         Assert.IsTrue(holiday.IsNonWorkingDay(Service, "XX"));
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTimeOffsetExtensionsTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTimeOffsetExtensionsTests.cs
@@ -43,8 +43,7 @@ public sealed class NotableDateTimeOffsetExtensionsTests
 
         DateTimeOffset next = start.NextWorkingDay(Service, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 2), DateOnly.FromDateTime(next.DateTime));
-        Assert.AreEqual(new TimeSpan(14, 30, 0), next.TimeOfDay);
+        Assert.AreEqual(new DateTimeOffset(2026, 1, 2, 14, 30, 0, TimeSpan.FromHours(5)), next);
         Assert.AreEqual(TimeSpan.FromHours(5), next.Offset);
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTraversalExtensionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/NotableDateTraversalExtensionTests.cs
@@ -308,9 +308,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 6, 15).NextNotableDate(CalendarService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual(new DateOnly(2026, 12, 25), result.Date);
-        Assert.AreEqual("christmas-day", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "christmas-day", new DateOnly(2026, 12, 25));
     }
 
     /// <summary>
@@ -321,9 +319,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 12, 31).NextNotableDate(CalendarService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual(new DateOnly(2027, 1, 1), result.Date);
-        Assert.AreEqual("new-years-day", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "new-years-day", new DateOnly(2027, 1, 1));
     }
 
     /// <summary>
@@ -335,9 +331,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 1, 1).NextNotableDate(CalendarService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual(new DateOnly(2026, 4, 1), result.Date);
-        Assert.AreEqual("festival", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "festival", new DateOnly(2026, 4, 1));
     }
 
     /// <summary>
@@ -350,8 +344,7 @@ public sealed class NotableDateTraversalExtensionTests
 
         NotableDate? result = new DateOnly(2026, 1, 15).NextNotableDate(CalendarService, "XX", filter);
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual("anzac-day", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "anzac-day", new DateOnly(2026, 4, 25));
     }
 
     /// <summary>
@@ -364,9 +357,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 6, 3).NextNotableDate(SpanService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual("holiday", result.NotableDateId);
-        Assert.AreEqual(new DateOnly(2026, 8, 15), result.Date);
+        NotableDateAssert.AssertOccurrence(result, "holiday", new DateOnly(2026, 8, 15));
     }
 
     /// <summary>
@@ -386,9 +377,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 6, 15).PreviousNotableDate(CalendarService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual(new DateOnly(2026, 4, 25), result.Date);
-        Assert.AreEqual("anzac-day", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "anzac-day", new DateOnly(2026, 4, 25));
     }
 
     /// <summary>
@@ -401,9 +390,7 @@ public sealed class NotableDateTraversalExtensionTests
         // Before 1 January 2026 the latest prior occurrence is Christmas Day 2025.
         NotableDate? result = new DateOnly(2026, 1, 1).PreviousNotableDate(CalendarService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual(new DateOnly(2025, 12, 25), result.Date);
-        Assert.AreEqual("christmas-day", result.NotableDateId);
+        NotableDateAssert.AssertOccurrence(result, "christmas-day", new DateOnly(2025, 12, 25));
     }
 
     /// <summary>
@@ -415,9 +402,7 @@ public sealed class NotableDateTraversalExtensionTests
     {
         NotableDate? result = new DateOnly(2026, 6, 3).PreviousNotableDate(SpanService, "XX");
 
-        Assert.IsNotNull(result);
-        Assert.AreEqual("festival", result.NotableDateId);
-        Assert.AreEqual(new DateOnly(2026, 6, 1), result.Date);
+        NotableDateAssert.AssertOccurrence(result, "festival", new DateOnly(2026, 6, 1));
     }
 
     /// <summary>
@@ -432,8 +417,7 @@ public sealed class NotableDateTraversalExtensionTests
 
         DateTime next = start.NextWorkingDay(HolidayService, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 2), DateOnly.FromDateTime(next));
-        Assert.AreEqual(new TimeSpan(14, 30, 0), next.TimeOfDay);
+        Assert.AreEqual(new DateTime(2026, 1, 2, 14, 30, 0, DateTimeKind.Utc), next);
         Assert.AreEqual(DateTimeKind.Utc, next.Kind);
     }
 
@@ -461,8 +445,7 @@ public sealed class NotableDateTraversalExtensionTests
 
         DateTime result = start.AddWorkingDays(3, HolidayService, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 6), DateOnly.FromDateTime(result));
-        Assert.AreEqual(new TimeSpan(6, 0, 0), result.TimeOfDay);
+        Assert.AreEqual(new DateTime(2026, 1, 6, 6, 0, 0, DateTimeKind.Unspecified), result);
         Assert.AreEqual(DateTimeKind.Unspecified, result.Kind);
     }
 
@@ -499,8 +482,7 @@ public sealed class NotableDateTraversalExtensionTests
 
         DateTimeOffset next = start.NextWorkingDay(HolidayService, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 1, 2), DateOnly.FromDateTime(next.DateTime));
-        Assert.AreEqual(new TimeSpan(14, 30, 0), next.TimeOfDay);
+        Assert.AreEqual(new DateTimeOffset(2026, 1, 2, 14, 30, 0, TimeSpan.FromHours(5)), next);
         Assert.AreEqual(TimeSpan.FromHours(5), next.Offset);
     }
 
@@ -516,8 +498,7 @@ public sealed class NotableDateTraversalExtensionTests
 
         DateTimeOffset monday = friday.AddWorkingDays(1, HolidayService, "XX");
 
-        Assert.AreEqual(new DateOnly(2026, 5, 18), DateOnly.FromDateTime(monday.DateTime));
-        Assert.AreEqual(new TimeSpan(9, 30, 0), monday.TimeOfDay);
+        Assert.AreEqual(new DateTimeOffset(2026, 5, 18, 9, 30, 0, TimeSpan.FromHours(-8)), monday);
         Assert.AreEqual(TimeSpan.FromHours(-8), monday.Offset);
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ParserEnumSurfaceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ParserEnumSurfaceTests.cs
@@ -406,7 +406,8 @@ public sealed class ParserEnumSurfaceTests
 
         AdjustmentPolicy policy = NotableDateResourceLoader.Load(xml).AdjustmentPolicies.Single();
 
-        Assert.IsNull(policy.ActionWeekday, "actionWeekday unset");
-        Assert.IsNull(policy.TriggerWeekOrdinal, "triggerWeekOrdinal unset");
+        Assert.AreEqual(
+            ((DayOfWeek?)null, (WeekOrdinal?)null),
+            (policy.ActionWeekday, policy.TriggerWeekOrdinal));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ParserMonthTokenTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ParserMonthTokenTests.cs
@@ -73,11 +73,14 @@ public sealed class ParserMonthTokenTests
                 "rules": [ { "id": "r", "strategy": { "fixed": { "month": 7, "day": 4 } } } ] } ] }
             """));
 
-        Assert.AreEqual(7, xml.Month, "XML month");
-        Assert.AreEqual(4, xml.Day, "XML day");
-        Assert.IsNull(xml.MonthAlias, "XML alias");
-        Assert.AreEqual(7, json.Month, "JSON month");
-        Assert.IsNull(json.MonthAlias, "JSON alias");
+        Assert.AreEqual(
+            (7, 4, (string?)null),
+            (xml.Month, xml.Day, xml.MonthAlias),
+            "XML month/day/alias");
+        Assert.AreEqual(
+            (7, (string?)null),
+            (json.Month, json.MonthAlias),
+            "JSON month/alias");
     }
 
     /// <summary>
@@ -227,8 +230,10 @@ public sealed class ParserMonthTokenTests
 
         FixedDateStrategy strategy = Strategy(NotableDateResourceLoader.Load(xml));
 
-        Assert.AreEqual(13, strategy.Month, "month");
-        Assert.IsNull(strategy.MonthAlias, "alias");
+        Assert.AreEqual(
+            (13, (string?)null),
+            (strategy.Month, strategy.MonthAlias),
+            "month/alias");
     }
 
     /// <summary>
@@ -272,16 +277,26 @@ public sealed class ParserMonthTokenTests
 
     /// <summary>
     /// Verifies that an unrecognised month name on a Gregorian <c>Fixed</c> rule is rejected with the
-    /// <c>BODU-CAL-MONTH</c> diagnostic, in both XML and JSON.
+    /// <c>BODU-CAL-MONTH</c> diagnostic when loaded from XML.
     /// </summary>
     [TestMethod]
-    public void Load_WhenGregorianFixedMonthIsUnknownName_ShouldThrowMonthDiagnostic()
+    public void Load_WhenGregorianFixedMonthIsUnknownName_ForXml_ShouldThrowMonthDiagnostic()
     {
         NotableDateValidationException xmlEx = Assert.ThrowsExactly<NotableDateValidationException>(() =>
         {
             _ = NotableDateResourceLoader.Load(GregorianFixedXml("Smarch"));
         });
 
+        Assert.Contains(d => d.Code == "BODU-CAL-MONTH", xmlEx.Diagnostics, "XML BODU-CAL-MONTH");
+    }
+
+    /// <summary>
+    /// Verifies that an unrecognised month name on a Gregorian <c>Fixed</c> rule is rejected with the
+    /// <c>BODU-CAL-MONTH</c> diagnostic when loaded from JSON.
+    /// </summary>
+    [TestMethod]
+    public void Load_WhenGregorianFixedMonthIsUnknownName_ForJson_ShouldThrowMonthDiagnostic()
+    {
         NotableDateValidationException jsonEx = Assert.ThrowsExactly<NotableDateValidationException>(() =>
         {
             _ = NotableDateResourceLoader.LoadJson(
@@ -292,7 +307,6 @@ public sealed class ParserMonthTokenTests
                 """);
         });
 
-        Assert.Contains(d => d.Code == "BODU-CAL-MONTH", xmlEx.Diagnostics, "XML BODU-CAL-MONTH");
         Assert.Contains(d => d.Code == "BODU-CAL-MONTH", jsonEx.Diagnostics, "JSON BODU-CAL-MONTH");
     }
 

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/PersianCalendarKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/PersianCalendarKnownAnswerTests.cs
@@ -38,23 +38,23 @@ public sealed class PersianCalendarKnownAnswerTests
             .ToList();
 
     /// <summary>
-    /// Verifies that all three Persian observances declared in <c>persian.xml</c> resolve for a representative
-    /// Gregorian year.
+    /// Verifies that each Persian observance declared in <c>persian.xml</c> resolves for a representative Gregorian
+    /// year.
     /// </summary>
+    /// <param name="notableDateId">The notable-date id expected to resolve.</param>
     [TestMethod]
     [TestCategory("Regression")]
-    public void Resolve_WhenLoadingPersian_ResolvesAllThreeObservances()
+    [DataRow("nowruz")]
+    [DataRow("sizdah-bedar")]
+    [DataRow("yalda-night")]
+    public void Resolve_WhenLoadingPersian_ShouldResolveObservance(string notableDateId)
     {
-        NotableDateService service = CreateService();
-
-        var ids = service
+        var ids = CreateService()
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "XX")
             .Select(r => r.NotableDateId)
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.Contains("nowruz", ids);
-        Assert.Contains("sizdah-bedar", ids);
-        Assert.Contains("yalda-night", ids);
+        Assert.Contains(notableDateId, ids);
     }
 
     /// <summary>
@@ -125,10 +125,9 @@ public sealed class PersianCalendarKnownAnswerTests
             List<NotableDate> matches = ResolveForYear(service, "nowruz", year);
 
             Assert.HasCount(1, matches, $"Nowruz unresolved for Gregorian year {year}.");
-            Assert.AreEqual(3, matches[0].Date.Month, $"Nowruz {year} fell outside March: {matches[0].Date:yyyy-MM-dd}.");
             Assert.IsTrue(
-                matches[0].Date.Day is 20 or 21,
-                $"Nowruz {year} fell on March {matches[0].Date.Day} (expected 20 or 21).");
+                matches[0].Date == new DateOnly(year, 3, 20) || matches[0].Date == new DateOnly(year, 3, 21),
+                $"Nowruz {year} fell on {matches[0].Date:yyyy-MM-dd} (expected 20 or 21 March).");
         }
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/RecurrenceCadenceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/RecurrenceCadenceTests.cs
@@ -27,62 +27,77 @@ public sealed class RecurrenceCadenceTests
         new(CalendarSystem.Gregorian, fromYear, null, Array.Empty<string>(), Array.Empty<int>(), Array.Empty<int>(), everyYears, anchorYear);
 
     /// <summary>
-    /// Verifies that a cadence anchored on <c>fromYear</c> applies only on the on-cadence years.
+    /// Verifies that a cadence anchored on <c>fromYear</c> (2024, every four years) applies only on the on-cadence
+    /// years and never below the lower bound.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expected">Whether the cadence applies in that year.</param>
     [TestMethod]
-    public void AppliesTo_EveryFourYearsFromYear_ShouldApplyOnCadenceOnly()
+    [DataRow(2024, true)]
+    [DataRow(2025, false)]
+    [DataRow(2026, false)]
+    [DataRow(2027, false)]
+    [DataRow(2028, true)]
+    [DataRow(2023, false)]  // below fromYear
+    public void AppliesTo_EveryFourYearsFromYear_ShouldApplyOnCadenceOnly(int year, bool expected)
     {
         RuleApplicability a = App(2024, 4, null);
 
-        Assert.IsTrue(a.AppliesTo(Territory, 2024));
-        Assert.IsFalse(a.AppliesTo(Territory, 2025));
-        Assert.IsFalse(a.AppliesTo(Territory, 2026));
-        Assert.IsFalse(a.AppliesTo(Territory, 2027));
-        Assert.IsTrue(a.AppliesTo(Territory, 2028));
-        Assert.IsFalse(a.AppliesTo(Territory, 2023), "below fromYear");
+        Assert.AreEqual(expected, a.AppliesTo(Territory, year));
     }
 
     /// <summary>
-    /// Verifies that a cadence without a lower bound anchors on year zero.
+    /// Verifies that a cadence without a lower bound anchors on year zero, so an every-four-years cadence applies on
+    /// years divisible by four.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expected">Whether the cadence applies in that year.</param>
     [TestMethod]
-    public void AppliesTo_EveryFourYearsWithoutFromYear_ShouldAnchorOnZero()
+    [DataRow(2020, true)]
+    [DataRow(2021, false)]
+    [DataRow(2022, false)]
+    [DataRow(2023, false)]
+    [DataRow(2024, true)]
+    public void AppliesTo_EveryFourYearsWithoutFromYear_ShouldAnchorOnZero(int year, bool expected)
     {
         RuleApplicability a = App(null, 4, null);
 
-        Assert.IsTrue(a.AppliesTo(Territory, 2020));
-        Assert.IsFalse(a.AppliesTo(Territory, 2021));
-        Assert.IsFalse(a.AppliesTo(Territory, 2022));
-        Assert.IsFalse(a.AppliesTo(Territory, 2023));
-        Assert.IsTrue(a.AppliesTo(Territory, 2024));
+        Assert.AreEqual(expected, a.AppliesTo(Territory, year));
     }
 
     /// <summary>
-    /// Verifies that an explicit anchor year sets the cadence phase, including years before the anchor.
+    /// Verifies that an explicit anchor year (2024) sets the cadence phase, including on-cadence years before the
+    /// anchor.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expected">Whether the cadence applies in that year.</param>
     [TestMethod]
-    public void AppliesTo_EveryFourYearsWithExplicitAnchor_ShouldAnchorThere()
+    [DataRow(2024, true)]
+    [DataRow(2028, true)]
+    [DataRow(2020, true)]   // on cadence before the anchor
+    [DataRow(2025, false)]
+    public void AppliesTo_EveryFourYearsWithExplicitAnchor_ShouldAnchorThere(int year, bool expected)
     {
         RuleApplicability a = App(null, 4, 2024);
 
-        Assert.IsTrue(a.AppliesTo(Territory, 2024));
-        Assert.IsTrue(a.AppliesTo(Territory, 2028));
-        Assert.IsTrue(a.AppliesTo(Territory, 2020));
-        Assert.IsFalse(a.AppliesTo(Territory, 2025));
+        Assert.AreEqual(expected, a.AppliesTo(Territory, year));
     }
 
     /// <summary>
-    /// Verifies that a cadence of one (or zero) imposes no restriction, applying every year.
+    /// Verifies that a cadence of one (or zero) imposes no restriction, applying in every year.
     /// </summary>
-    [DataRow(1)]
-    [DataRow(0)]
+    /// <param name="everyYears">The recurrence interval under test.</param>
+    /// <param name="year">The civil year under test.</param>
     [TestMethod]
-    public void AppliesTo_EveryYearsOfOneOrZero_ShouldApplyAnnually(int everyYears)
+    [DataRow(1, 2024)]
+    [DataRow(1, 2025)]
+    [DataRow(0, 2024)]
+    [DataRow(0, 2025)]
+    public void AppliesTo_EveryYearsOfOneOrZero_ShouldApplyAnnually(int everyYears, int year)
     {
         RuleApplicability a = App(null, everyYears, null);
 
-        Assert.IsTrue(a.AppliesTo(Territory, 2024));
-        Assert.IsTrue(a.AppliesTo(Territory, 2025));
+        Assert.IsTrue(a.AppliesTo(Territory, year));
     }
 
     /// <summary>
@@ -100,15 +115,19 @@ public sealed class RecurrenceCadenceTests
     """;
 
     /// <summary>
-    /// Verifies that a quadrennial rule resolves end to end through the service only on its on-cadence years.
+    /// Verifies that a quadrennial rule resolves end to end through the service, emitting one occurrence on its
+    /// on-cadence years and nothing off cadence.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedCount">The expected number of emitted occurrences on 1 July of that year.</param>
     [TestMethod]
-    public void Resolve_QuadrennialRule_ShouldEmitOnlyOnCadenceYears()
+    [DataRow(2024, 1)]  // on cadence
+    [DataRow(2025, 0)]  // off cadence
+    [DataRow(2028, 1)]  // on cadence
+    public void Resolve_QuadrennialRule_ShouldEmitOnlyOnCadenceYears(int year, int expectedCount)
     {
         INotableDateService service = new NotableDateService(NotableDateResourceLoader.Load(Xml));
 
-        Assert.HasCount(1, service.Resolve(new DateOnly(2024, 7, 1), Territory), "2024 on cadence");
-        Assert.IsEmpty(service.Resolve(new DateOnly(2025, 7, 1), Territory), "2025 off cadence");
-        Assert.HasCount(1, service.Resolve(new DateOnly(2028, 7, 1), Territory), "2028 on cadence");
+        Assert.HasCount(expectedCount, service.Resolve(new DateOnly(year, 7, 1), Territory));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ReloadableNotableDateServiceTests.cs
@@ -129,8 +129,10 @@ public sealed class ReloadableNotableDateServiceTests
         provider.Reload(NotableDateResourceLoader.Load(TwoConceptDroppedXml));
 
         IReadOnlyList<NotableDate> after = service.Resolve(Year2025, "XX");
-        Assert.HasCount(1, after);
-        Assert.AreEqual("keep", after[0].NotableDateId);
+
+        CollectionAssert.AreEqual(
+            new[] { ("keep", new DateOnly(2025, 1, 1)) },
+            after.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ResolveBoundaryTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ResolveBoundaryTests.cs
@@ -94,8 +94,9 @@ public sealed class ResolveBoundaryTests
         IReadOnlyList<NotableDate> results = FixedService(7, 4, fromYear: 2026, toYear: 2026)
             .Resolve(new DateRange(new DateOnly(2026, 7, 4), new DateOnly(2026, 7, 4)), Territory);
 
-        Assert.HasCount(1, results);
-        Assert.AreEqual(new DateOnly(2026, 7, 4), results[0].Date);
+        CollectionAssert.AreEqual(
+            new[] { new DateOnly(2026, 7, 4) },
+            results.Select(r => r.Date).ToArray());
     }
 
     /// <summary>
@@ -166,8 +167,9 @@ public sealed class ResolveBoundaryTests
             .Resolve(new DateRange(new DateOnly(9999, 12, 1), DateOnly.MaxValue), Territory);
 
         NotableDate span = Single(results);
-        Assert.AreEqual(new DateOnly(9999, 12, 25), span.Date);
-        Assert.AreEqual(new DateOnly(9999, 12, 31), span.EndDate);
+        Assert.AreEqual(
+            (new DateOnly(9999, 12, 25), new DateOnly(9999, 12, 31)),
+            (span.Date, span.EndDate));
     }
 
     // =====================================================================================================================

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ResolveScenarioTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ResolveScenarioTests.cs
@@ -89,9 +89,9 @@ public sealed class ResolveScenarioTests
     {
         IReadOnlyList<NotableDate> results = ChristmasService().Resolve(new DateOnly(2026, 12, 25), Territory);
 
-        Assert.HasCount(1, results);
-        Assert.AreEqual("christmas-day", results[0].NotableDateId);
-        Assert.AreEqual(new DateOnly(2026, 12, 25), results[0].Date);
+        CollectionAssert.AreEqual(
+            new[] { ("christmas-day", new DateOnly(2026, 12, 25)) },
+            results.Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>
@@ -160,11 +160,16 @@ public sealed class ResolveScenarioTests
         IReadOnlyList<NotableDate> results = NotableDateFixtures.Resolver("resolve-easter.xml")
             .Resolve(new DateRange(new DateOnly(2026, 2, 1), new DateOnly(2026, 4, 30)), "US");
 
-        Assert.AreEqual(new DateOnly(2026, 2, 18), Single(results, "start-of-lent").Date);
-        Assert.AreEqual(new DateOnly(2026, 3, 29), Single(results, "palm-sunday").Date);
-        Assert.AreEqual(new DateOnly(2026, 4, 3), Single(results, "good-friday").Date);
-        Assert.AreEqual(new DateOnly(2026, 4, 5), Single(results, "easter-sunday").Date);
-        Assert.AreEqual(new DateOnly(2026, 4, 6), Single(results, "easter-monday").Date);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                ("start-of-lent", new DateOnly(2026, 2, 18)),
+                ("palm-sunday", new DateOnly(2026, 3, 29)),
+                ("good-friday", new DateOnly(2026, 4, 3)),
+                ("easter-sunday", new DateOnly(2026, 4, 5)),
+                ("easter-monday", new DateOnly(2026, 4, 6)),
+            },
+            results.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     /// <summary>
@@ -177,9 +182,9 @@ public sealed class ResolveScenarioTests
         IReadOnlyList<NotableDate> results = NotableDateFixtures.Resolver("resolve-easter.xml")
             .Resolve(new DateRange(new DateOnly(2026, 3, 25), new DateOnly(2026, 3, 31)), "US");
 
-        Assert.HasCount(1, results);
-        Assert.AreEqual("palm-sunday", results[0].NotableDateId);
-        Assert.AreEqual(new DateOnly(2026, 3, 29), results[0].Date);
+        CollectionAssert.AreEqual(
+            new[] { ("palm-sunday", new DateOnly(2026, 3, 29)) },
+            results.Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     // =====================================================================================================================
@@ -210,8 +215,13 @@ public sealed class ResolveScenarioTests
         IReadOnlyList<NotableDate> results = new NotableDateService(NotableDateResourceLoader.Load(xml))
             .Resolve(new DateRange(new DateOnly(2026, 12, 25), new DateOnly(2026, 12, 27)), Territory);
 
-        Assert.AreEqual(new DateOnly(2026, 12, 25), Single(results, "christmas-day").Date);
-        Assert.AreEqual(new DateOnly(2026, 12, 26), Single(results, "boxing-day").Date);
+        CollectionAssert.AreEqual(
+            new[]
+            {
+                ("christmas-day", new DateOnly(2026, 12, 25)),
+                ("boxing-day", new DateOnly(2026, 12, 26)),
+            },
+            results.OrderBy(r => r.Date).Select(r => (r.NotableDateId, r.Date)).ToArray());
     }
 
     // =====================================================================================================================
@@ -229,9 +239,9 @@ public sealed class ResolveScenarioTests
             .Resolve(new DateRange(new DateOnly(2026, 12, 28), new DateOnly(2027, 1, 10)), Territory);
 
         NotableDate festival = Single(results, "year-end-festival");
-        Assert.AreEqual(new DateOnly(2026, 12, 30), festival.Date);
-        Assert.AreEqual(7, festival.DurationDays);
-        Assert.AreEqual(new DateOnly(2027, 1, 5), festival.EndDate);
+        Assert.AreEqual(
+            (new DateOnly(2026, 12, 30), 7, new DateOnly(2027, 1, 5)),
+            (festival.Date, festival.DurationDays, festival.EndDate));
     }
 
     /// <summary>
@@ -291,8 +301,9 @@ public sealed class ResolveScenarioTests
 
         NotableDate[] festivals = results.Where(n => n.NotableDateId == "year-end-festival").ToArray();
         Assert.HasCount(1, festivals);
-        Assert.AreEqual(new DateOnly(2025, 12, 30), festivals[0].Date);
-        Assert.AreEqual(7, festivals[0].DurationDays);
+        Assert.AreEqual(
+            (new DateOnly(2025, 12, 30), 7),
+            (festivals[0].Date, festivals[0].DurationDays));
     }
 
     /// <summary>
@@ -306,9 +317,9 @@ public sealed class ResolveScenarioTests
             .Resolve(new DateRange(new DateOnly(2026, 6, 1), new DateOnly(2026, 6, 30)), Territory);
 
         NotableDate programme = Single(results, "year-long-programme");
-        Assert.AreEqual(new DateOnly(2026, 1, 1), programme.Date);
-        Assert.AreEqual(365, programme.DurationDays);
-        Assert.AreEqual(new DateOnly(2026, 12, 31), programme.EndDate);
+        Assert.AreEqual(
+            (new DateOnly(2026, 1, 1), 365, new DateOnly(2026, 12, 31)),
+            (programme.Date, programme.DurationDays, programme.EndDate));
     }
 
     // =====================================================================================================================
@@ -416,14 +427,14 @@ public sealed class ResolveScenarioTests
             .Resolve(new DateRange(new DateOnly(2021, 12, 25), new DateOnly(2021, 12, 31)), "AU");
 
         NotableDate christmas = Single(results, "christmas-day");
-        Assert.AreEqual(new DateOnly(2021, 12, 27), christmas.Date);
-        Assert.AreEqual(new DateOnly(2021, 12, 25), christmas.ActualDate);
-        Assert.IsTrue(christmas.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2021, 12, 27), (DateOnly?)new DateOnly(2021, 12, 25), true),
+            (christmas.Date, christmas.ActualDate, christmas.IsObserved));
 
         NotableDate boxing = Single(results, "boxing-day");
-        Assert.AreEqual(new DateOnly(2021, 12, 28), boxing.Date);
-        Assert.AreEqual(new DateOnly(2021, 12, 26), boxing.ActualDate);
-        Assert.IsTrue(boxing.IsObserved);
+        Assert.AreEqual(
+            (new DateOnly(2021, 12, 28), (DateOnly?)new DateOnly(2021, 12, 26), true),
+            (boxing.Date, boxing.ActualDate, boxing.IsObserved));
     }
 
     // =====================================================================================================================

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/RuleApplicabilityTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/RuleApplicabilityTests.cs
@@ -118,15 +118,18 @@ public sealed class RuleApplicabilityTests
     /// Verifies that an <c>ExceptYear</c> inside a <c>fromYear</c>/<c>toYear</c> window is suppressed while the rest of
     /// the window remains applicable.
     /// </summary>
+    /// <param name="year">The Gregorian year being resolved.</param>
+    /// <param name="expected">The expected applicability outcome for the 2020-2030 window excepting 2025.</param>
     [TestMethod]
-    public void AppliesTo_WhenWindowWithExceptYear_ShouldSuppressOnlyThatYear()
+    [DataRow(2024, true)]   // inside window
+    [DataRow(2025, false)]  // excepted year
+    [DataRow(2026, true)]   // inside window
+    [DataRow(2019, false)]  // below window
+    public void AppliesTo_WhenWindowWithExceptYear_ShouldSuppressOnlyThatYear(int year, bool expected)
     {
         RuleApplicability applicability = Years(2020, 2030, exceptYears: [2025]);
 
-        Assert.IsTrue(applicability.AppliesTo("XX", 2024));
-        Assert.IsFalse(applicability.AppliesTo("XX", 2025));
-        Assert.IsTrue(applicability.AppliesTo("XX", 2026));
-        Assert.IsFalse(applicability.AppliesTo("XX", 2019));
+        Assert.AreEqual(expected, applicability.AppliesTo("XX", year));
     }
 
     /// <summary>
@@ -186,14 +189,17 @@ public sealed class RuleApplicabilityTests
     /// <summary>
     /// Verifies that a rule scoped to several territories matches a request against any one of them.
     /// </summary>
+    /// <param name="requested">The requested territory code.</param>
+    /// <param name="expected">Whether the US/AU-scoped rule is expected to match the request.</param>
     [TestMethod]
-    public void MatchesTerritory_WhenMultipleScopes_ShouldMatchAnyListed()
+    [DataRow("US", true)]       // first listed scope
+    [DataRow("AU-NSW", true)]   // subnational of a listed scope
+    [DataRow("CA", false)]      // unlisted scope
+    public void MatchesTerritory_WhenMultipleScopes_ShouldMatchAnyListed(string requested, bool expected)
     {
         RuleApplicability applicability = Territories("US", "AU");
 
-        Assert.IsTrue(applicability.MatchesTerritory("US"));
-        Assert.IsTrue(applicability.MatchesTerritory("AU-NSW"));
-        Assert.IsFalse(applicability.MatchesTerritory("CA"));
+        Assert.AreEqual(expected, applicability.MatchesTerritory(requested));
     }
 
     /// <summary>
@@ -292,22 +298,47 @@ public sealed class RuleApplicabilityTests
     }
 
     /// <summary>
-    /// Verifies that <c>OnlyYear</c> and <c>ExceptYear</c> rules are emitted exactly for the listed and unlisted years
-    /// when resolved through the service.
+    /// Verifies that an <c>OnlyYear</c> rule is emitted exactly for the listed years and suppressed otherwise when
+    /// resolved through the service.
     /// </summary>
+    /// <param name="year">The Gregorian year to resolve.</param>
+    /// <param name="expected">Whether the only-years concept is expected to be emitted.</param>
     [TestMethod]
-    public void Resolve_WhenOnlyAndExceptYears_EmitsAccordingToSets()
+    [DataRow(2024, true)]   // listed
+    [DataRow(2025, false)]  // unlisted
+    [DataRow(2026, true)]   // listed
+    public void Resolve_WhenOnlyYearsRule_EmitsAccordingToSet(int year, bool expected)
     {
-        Assert.IsTrue(Emits("only-years", "XX", 2024));
-        Assert.IsFalse(Emits("only-years", "XX", 2025));
-        Assert.IsTrue(Emits("only-years", "XX", 2026));
+        Assert.AreEqual(expected, Emits("only-years", "XX", year));
+    }
 
-        Assert.IsTrue(Emits("except-2025", "XX", 2024));
-        Assert.IsFalse(Emits("except-2025", "XX", 2025));
+    /// <summary>
+    /// Verifies that an <c>ExceptYear</c> rule is suppressed for the listed year and emitted otherwise when resolved
+    /// through the service.
+    /// </summary>
+    /// <param name="year">The Gregorian year to resolve.</param>
+    /// <param name="expected">Whether the except-2025 concept is expected to be emitted.</param>
+    [TestMethod]
+    [DataRow(2024, true)]   // not excepted
+    [DataRow(2025, false)]  // excepted
+    public void Resolve_WhenExceptYearRule_EmitsAccordingToSet(int year, bool expected)
+    {
+        Assert.AreEqual(expected, Emits("except-2025", "XX", year));
+    }
 
-        Assert.IsTrue(Emits("windowed-except", "XX", 2024));
-        Assert.IsFalse(Emits("windowed-except", "XX", 2025));
-        Assert.IsFalse(Emits("windowed-except", "XX", 2031));
+    /// <summary>
+    /// Verifies that a windowed rule with an <c>ExceptYear</c> is suppressed for the excepted year and for years outside
+    /// the window, and emitted otherwise, when resolved through the service.
+    /// </summary>
+    /// <param name="year">The Gregorian year to resolve.</param>
+    /// <param name="expected">Whether the windowed-except concept is expected to be emitted.</param>
+    [TestMethod]
+    [DataRow(2024, true)]   // inside window, not excepted
+    [DataRow(2025, false)]  // excepted year
+    [DataRow(2031, false)]  // outside window
+    public void Resolve_WhenWindowedExceptRule_EmitsAccordingToSet(int year, bool expected)
+    {
+        Assert.AreEqual(expected, Emits("windowed-except", "XX", year));
     }
 
     /// <summary>
@@ -329,27 +360,31 @@ public sealed class RuleApplicabilityTests
     /// Verifies that a subnational-only rule is emitted for its subdivision but not for the national request, when
     /// resolved through the service.
     /// </summary>
+    /// <param name="territory">The requested territory code.</param>
+    /// <param name="expected">Whether the subnational-nsw concept is expected to be emitted.</param>
     [TestMethod]
-    public void Resolve_WhenSubnationalRule_EmitsOnlyForSubdivision()
+    [DataRow("AU-NSW", true)]  // the scoped subdivision
+    [DataRow("AU", false)]     // the national request
+    public void Resolve_WhenSubnationalRule_EmitsOnlyForSubdivision(string territory, bool expected)
     {
-        Assert.IsTrue(Emits("subnational-nsw", "AU-NSW", 2026));
-        Assert.IsFalse(Emits("subnational-nsw", "AU", 2026));
+        Assert.AreEqual(expected, Emits("subnational-nsw", territory, 2026));
     }
 
     /// <summary>
-    /// Verifies that when a concept carries both a national and a narrower subdivision rule, a subdivision request emits
-    /// only the narrower rule (it shadows the national one) while any other subdivision falls back to the national rule.
+    /// Verifies that when a concept carries both a national and a narrower subdivision rule, the scoped subdivision emits
+    /// the narrower rule (it shadows the national one) while any other subdivision falls back to the national rule.
     /// </summary>
+    /// <param name="territory">The requested subdivision code.</param>
+    /// <param name="expectedRuleId">The rule id expected to win for the request.</param>
     [TestMethod]
-    public void Resolve_WhenTerritoryShadowing_NarrowerRuleShadowsNationalRule()
+    [DataRow("AU-NSW", "nsw")]       // scoped subdivision shadows the national rule
+    [DataRow("AU-VIC", "national")]  // other subdivision falls back to the national rule
+    public void Resolve_WhenTerritoryShadowing_NarrowerRuleShadowsNationalRule(string territory, string expectedRuleId)
     {
         DateRange range = new(new DateOnly(2026, 1, 1), new DateOnly(2026, 12, 31));
-        NotableDateService service = CreateService();
 
-        NotableDate nsw = service.Resolve(range, "AU-NSW").Single(r => r.NotableDateId == "shadowed");
-        Assert.AreEqual("nsw", nsw.RuleId);
+        NotableDate match = CreateService().Resolve(range, territory).Single(r => r.NotableDateId == "shadowed");
 
-        NotableDate vic = service.Resolve(range, "AU-VIC").Single(r => r.NotableDateId == "shadowed");
-        Assert.AreEqual("national", vic.RuleId);
+        Assert.AreEqual(expectedRuleId, match.RuleId);
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/SchemaValidationTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/SchemaValidationTests.cs
@@ -21,8 +21,8 @@ public sealed class SchemaValidationTests
     {
         NotableDateResource resource = NotableDateFixtures.Load("strategies.xml");
 
-        Assert.HasCount(12, resource.NotableDates, "notable-date count");
-        Assert.IsEmpty(resource.AdjustmentPolicies, "adjustment-policy count");
+        // (notable-date count, adjustment-policy count)
+        Assert.AreEqual((12, 0), (resource.NotableDates.Count, resource.AdjustmentPolicies.Count));
     }
 
     /// <summary>
@@ -33,8 +33,8 @@ public sealed class SchemaValidationTests
     {
         NotableDateResource resource = NotableDateFixtures.Load("adjustments.xml");
 
-        Assert.HasCount(10, resource.NotableDates, "notable-date count");
-        Assert.HasCount(10, resource.AdjustmentPolicies, "adjustment-policy count");
+        // (notable-date count, adjustment-policy count)
+        Assert.AreEqual((10, 10), (resource.NotableDates.Count, resource.AdjustmentPolicies.Count));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ScopedRemovalTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ScopedRemovalTests.cs
@@ -76,30 +76,36 @@ public sealed class ScopedRemovalTests
         service.Resolve(date, territory).Count(r => r.NotableDateId == "holiday");
 
     /// <summary>
-    /// Verifies that a PatchRule override excluding a year removes the occurrence for that year alone while leaving
-    /// neighbouring years intact.
+    /// Verifies that a PatchRule override excluding 2025 removes the 1 January occurrence for that year alone while
+    /// leaving neighbouring years intact.
     /// </summary>
+    /// <param name="year">The civil year under test.</param>
+    /// <param name="expectedCount">The expected number of emitted occurrences on 1 January of that year.</param>
     [TestMethod]
-    public void PatchRuleExceptYear_WhenYearExcluded_ShouldRemoveOccurrenceForThatYearOnly()
+    [DataRow(2024, 1)]  // neighbouring year intact
+    [DataRow(2025, 0)]  // excluded year removed
+    [DataRow(2026, 1)]  // neighbouring year intact
+    public void PatchRuleExceptYear_WhenYearExcluded_ShouldRemoveOccurrenceForThatYearOnly(int year, int expectedCount)
     {
         NotableDateService service = new(NotableDateResourceLoader.Load(YearScopedXml));
 
-        Assert.AreEqual(1, Count(service, new DateOnly(2024, 1, 1), "XX"));
-        Assert.AreEqual(0, Count(service, new DateOnly(2025, 1, 1), "XX"));
-        Assert.AreEqual(1, Count(service, new DateOnly(2026, 1, 1), "XX"));
+        Assert.AreEqual(expectedCount, Count(service, new DateOnly(year, 1, 1), "XX"));
     }
 
     /// <summary>
-    /// Verifies that an AddRule override injecting a more-specific suppressing rule removes the occurrence for that
-    /// subterritory alone while leaving the parent and sibling subterritories intact.
+    /// Verifies that an AddRule override injecting a more-specific suppressing rule removes the 26 January 2025
+    /// occurrence for the shadowed subterritory alone while leaving the parent and sibling subterritories intact.
     /// </summary>
+    /// <param name="territory">The requested territory code.</param>
+    /// <param name="expectedCount">The expected number of emitted occurrences for that territory.</param>
     [TestMethod]
-    public void AddRuleSuppressShadow_WhenSubterritoryShadowed_ShouldRemoveOccurrenceForThatTerritoryOnly()
+    [DataRow("AU", 1)]       // national parent intact
+    [DataRow("AU-NSW", 0)]   // shadowed subterritory removed
+    [DataRow("AU-VIC", 1)]   // sibling subterritory intact
+    public void AddRuleSuppressShadow_WhenSubterritoryShadowed_ShouldRemoveOccurrenceForThatTerritoryOnly(string territory, int expectedCount)
     {
         NotableDateService service = new(NotableDateResourceLoader.Load(TerritoryScopedXml));
 
-        Assert.AreEqual(1, Count(service, new DateOnly(2025, 1, 26), "AU"));
-        Assert.AreEqual(0, Count(service, new DateOnly(2025, 1, 26), "AU-NSW"));
-        Assert.AreEqual(1, Count(service, new DateOnly(2025, 1, 26), "AU-VIC"));
+        Assert.AreEqual(expectedCount, Count(service, new DateOnly(2025, 1, 26), territory));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/TerritoryCodeTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/TerritoryCodeTests.cs
@@ -21,10 +21,9 @@ public sealed class TerritoryCodeTests
     {
         var code = TerritoryCode.Parse("AU");
 
-        Assert.AreEqual("AU", code.Country);
-        Assert.IsNull(code.Subdivision);
-        Assert.IsFalse(code.IsSubdivision);
-        Assert.IsFalse(code.IsEmpty);
+        Assert.AreEqual(
+            ("AU", (string?)null, false, false),
+            (code.Country, code.Subdivision, code.IsSubdivision, code.IsEmpty));
     }
 
     /// <summary>
@@ -35,10 +34,9 @@ public sealed class TerritoryCodeTests
     {
         var code = TerritoryCode.Parse("AU-NSW");
 
-        Assert.AreEqual("AU", code.Country);
-        Assert.AreEqual("NSW", code.Subdivision);
-        Assert.IsTrue(code.IsSubdivision);
-        Assert.AreEqual("AU", code.Parent.ToString());
+        Assert.AreEqual(
+            ("AU", (string?)"NSW", true, "AU"),
+            (code.Country, code.Subdivision, code.IsSubdivision, code.Parent.ToString()));
     }
 
     /// <summary>
@@ -93,45 +91,51 @@ public sealed class TerritoryCodeTests
     [TestMethod]
     public void TryParse_WhenInvalid_ShouldReturnFalseAndDefault()
     {
-        Assert.IsFalse(TerritoryCode.TryParse("nope!", out TerritoryCode result));
-        Assert.IsTrue(result.IsEmpty);
+        bool parsed = TerritoryCode.TryParse("nope!", out TerritoryCode result);
+
+        Assert.AreEqual((false, true), (parsed, result.IsEmpty));
     }
 
     /// <summary>
     /// Verifies that <see cref="TerritoryCode.TryParse" /> reports failure for <see langword="null" /> and empty input.
     /// </summary>
+    /// <param name="value">The null or empty input under test.</param>
     [TestMethod]
-    public void TryParse_WhenNullOrEmpty_ShouldReturnFalse()
+    [DataRow(null)]
+    [DataRow("")]
+    public void TryParse_WhenNullOrEmpty_ShouldReturnFalse(string? value)
     {
-        Assert.IsFalse(TerritoryCode.TryParse(null, out _));
-        Assert.IsFalse(TerritoryCode.TryParse(string.Empty, out _));
+        Assert.IsFalse(TerritoryCode.TryParse(value, out _));
     }
 
     /// <summary>
     /// Verifies that a country contains itself and its subdivisions, but a subdivision contains neither its parent nor a
-    /// sibling, and unrelated countries never contain each other.
+    /// sibling, unrelated countries never contain each other, and the empty code neither contains nor is contained by any
+    /// code. A <see langword="null" /> argument denotes the empty (default) <see cref="TerritoryCode" />.
     /// </summary>
+    /// <param name="container">The containing code, or <see langword="null" /> for the default code.</param>
+    /// <param name="contained">The candidate contained code, or <see langword="null" /> for the default code.</param>
+    /// <param name="expected">The expected containment result.</param>
     [TestMethod]
-    public void Contains_ShouldFollowParentChildSemantics()
+    [DataRow("AU", "AU", true)]           // a country contains itself
+    [DataRow("AU", "AU-NSW", true)]       // a country contains its subdivision
+    [DataRow("AU-NSW", "AU-NSW", true)]   // a subdivision contains itself
+    [DataRow("AU-NSW", "AU", false)]      // a subdivision does not contain its parent
+    [DataRow("AU-NSW", "AU-VIC", false)]  // siblings do not contain each other
+    [DataRow("AU", "US", false)]          // unrelated countries
+    [DataRow(null, "AU", false)]          // the default code contains nothing
+    [DataRow("AU", null, false)]          // nothing contains the default code
+    public void Contains_WhenCheckedAgainstParentChild_ShouldFollowSemantics(string? container, string? contained, bool expected)
     {
-        var au = TerritoryCode.Parse("AU");
-        var nsw = TerritoryCode.Parse("AU-NSW");
-        var vic = TerritoryCode.Parse("AU-VIC");
-        var us = TerritoryCode.Parse("US");
+        TerritoryCode containerCode = container is null ? default : TerritoryCode.Parse(container);
+        TerritoryCode containedCode = contained is null ? default : TerritoryCode.Parse(contained);
 
-        Assert.IsTrue(au.Contains(au));
-        Assert.IsTrue(au.Contains(nsw));
-        Assert.IsTrue(nsw.Contains(nsw));
-
-        Assert.IsFalse(nsw.Contains(au));
-        Assert.IsFalse(nsw.Contains(vic));
-        Assert.IsFalse(au.Contains(us));
-        Assert.IsFalse(default(TerritoryCode).Contains(au));
-        Assert.IsFalse(au.Contains(default));
+        Assert.AreEqual(expected, containerCode.Contains(containedCode));
     }
 
     /// <summary>
-    /// Verifies that equality is case-insensitive after normalization and that equal codes share a hash code.
+    /// Verifies that two codes differing only in case are equal after normalization, are not unequal, and share a hash
+    /// code.
     /// </summary>
     [TestMethod]
     public void Equals_WhenSameCodeDifferentCase_ShouldBeEqual()
@@ -139,10 +143,18 @@ public sealed class TerritoryCodeTests
         var a = TerritoryCode.Parse("au-nsw");
         var b = TerritoryCode.Parse("AU-NSW");
 
-        Assert.IsTrue(a == b);
-        Assert.IsFalse(a != b);
-        Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
-        Assert.AreNotEqual(a, TerritoryCode.Parse("AU-VIC"));
+        Assert.AreEqual(
+            (true, false, true),
+            (a == b, a != b, a.GetHashCode() == b.GetHashCode()));
+    }
+
+    /// <summary>
+    /// Verifies that two codes differing in subdivision are not equal.
+    /// </summary>
+    [TestMethod]
+    public void Equals_WhenDifferentSubdivision_ShouldNotBeEqual()
+    {
+        Assert.AreNotEqual(TerritoryCode.Parse("AU-NSW"), TerritoryCode.Parse("AU-VIC"));
     }
 
     /// <summary>
@@ -153,8 +165,7 @@ public sealed class TerritoryCodeTests
     {
         TerritoryCode code = default;
 
-        Assert.AreEqual(string.Empty, code.ToString());
-        Assert.IsTrue(code.IsEmpty);
+        Assert.AreEqual((string.Empty, true), (code.ToString(), code.IsEmpty));
     }
 
     /// <summary>
@@ -171,10 +182,14 @@ public sealed class TerritoryCodeTests
 
     /// <summary>
     /// Verifies that a <see cref="TerritoryCode" /> flows into the string-based resolution surface via its implicit
-    /// conversion and resolves a subdivision-scoped occurrence.
+    /// conversion, resolving a subdivision-scoped occurrence for the matching subdivision and nothing for a sibling.
     /// </summary>
+    /// <param name="territory">The subdivision code passed to the resolver.</param>
+    /// <param name="expectedCount">The expected number of resolved occurrences.</param>
     [TestMethod]
-    public void Resolve_WhenPassedTerritoryCode_ShouldResolveThroughStringSurface()
+    [DataRow("AU-NSW", 1)]  // the scoped subdivision resolves the occurrence
+    [DataRow("AU-VIC", 0)]  // a sibling subdivision resolves nothing
+    public void Resolve_WhenPassedTerritoryCode_ShouldResolveThroughStringSurface(string territory, int expectedCount)
     {
         const string xml = """
         <NotableDateResource xmlns="urn:bodu:globalization:calendar" schemaVersion="1.0" resourceId="data.territory-interop">
@@ -189,8 +204,7 @@ public sealed class TerritoryCodeTests
 
         NotableDateService service = new(NotableDateResourceLoader.Load(xml));
 
-        Assert.HasCount(1, service.Resolve(new DateOnly(2025, 1, 26), TerritoryCode.Parse("AU-NSW")));
-        Assert.IsEmpty(service.Resolve(new DateOnly(2025, 1, 26), TerritoryCode.Parse("AU-VIC")));
+        Assert.HasCount(expectedCount, service.Resolve(new DateOnly(2025, 1, 26), TerritoryCode.Parse(territory)));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/UmmAlQuraCalendarKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/UmmAlQuraCalendarKnownAnswerTests.cs
@@ -45,19 +45,14 @@ public sealed class UmmAlQuraCalendarKnownAnswerTests
     [TestCategory("Regression")]
     public void Resolve_WhenLoadingUmmAlQura_ResolvesAllSixObservances()
     {
-        NotableDateService service = CreateService();
-
-        var ids = service
+        var ids = CreateService()
             .Resolve(new DateRange(new DateOnly(2024, 1, 1), new DateOnly(2024, 12, 31)), "XX")
             .Select(r => r.NotableDateId)
             .ToHashSet(StringComparer.Ordinal);
 
-        Assert.Contains("ramadan", ids);
-        Assert.Contains("eid-al-fitr", ids);
-        Assert.Contains("eid-al-adha", ids);
-        Assert.Contains("islamic-new-year", ids);
-        Assert.Contains("day-of-ashura", ids);
-        Assert.Contains("mawlid-al-nabi", ids);
+        CollectionAssert.IsSubsetOf(
+            new[] { "ramadan", "eid-al-fitr", "eid-al-adha", "islamic-new-year", "day-of-ashura", "mawlid-al-nabi" },
+            ids.ToArray());
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/WorkingDayExtensionMatrixTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/WorkingDayExtensionMatrixTests.cs
@@ -88,17 +88,21 @@ public sealed class WorkingDayExtensionMatrixTests
     }
 
     /// <summary>
-    /// Verifies that a weekend day, a holiday, and an ordinary weekday are classified correctly. In 2026, 1 January is a
-    /// Thursday (a non-working holiday), 3 January is a Saturday, and 2 January is an ordinary working day.
+    /// Verifies that a non-working holiday, a weekend day, and an ordinary weekday are each classified correctly under the
+    /// default Monday-to-Friday working week. In 2026, 1 January is a Thursday holiday, 3 January is a Saturday, and
+    /// 2 January is an ordinary working day.
     /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected working-day classification.</param>
     [TestMethod]
-    public void IsWorkingDay_WhenWeekendHolidayOrWeekday_ShouldClassifyEach()
+    [DataRow(2026, 1, 1, false)]  // Thursday holiday
+    [DataRow(2026, 1, 3, false)]  // Saturday
+    [DataRow(2026, 1, 2, true)]   // ordinary weekday
+    public void IsWorkingDay_WhenDayIsHolidayWeekendOrWeekday_ShouldReturnExpectedClassification(int year, int month, int day, bool expected)
     {
-        INotableDateService service = Service;
-
-        Assert.IsFalse(new DateOnly(2026, 1, 1).IsWorkingDay(service, "XX"), "1 January holiday");
-        Assert.IsFalse(new DateOnly(2026, 1, 3).IsWorkingDay(service, "XX"), "Saturday");
-        Assert.IsTrue(new DateOnly(2026, 1, 2).IsWorkingDay(service, "XX"), "ordinary weekday");
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsWorkingDay(Service, "XX"));
     }
 
     /// <summary>
@@ -134,18 +138,36 @@ public sealed class WorkingDayExtensionMatrixTests
     }
 
     /// <summary>
-    /// Verifies that <see cref="NotableDateOnlyExtensions.IsWeekend(DateOnly, WeekPattern?)" /> reports weekend days
-    /// under the default working week and respects a custom working week.
+    /// Verifies that <see cref="NotableDateOnlyExtensions.IsWeekend(DateOnly, WeekPattern?)" /> reports Saturday and Sunday
+    /// as weekend days, and a weekday as non-weekend, under the default Monday-to-Friday working week.
     /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected weekend classification.</param>
     [TestMethod]
-    public void IsWeekend_WhenDefaultAndCustomWeek_ShouldClassifyByWorkingWeek()
+    [DataRow(2026, 1, 10, true)]   // Saturday is a weekend by default
+    [DataRow(2026, 1, 11, true)]   // Sunday is a weekend by default
+    [DataRow(2026, 1, 5, false)]   // Monday is not a weekend by default
+    public void IsWeekend_WhenDefaultWorkingWeek_ShouldReturnExpectedClassification(int year, int month, int day, bool expected)
     {
-        Assert.IsTrue(new DateOnly(2026, 1, 10).IsWeekend(), "Saturday is a weekend by default");
-        Assert.IsFalse(new DateOnly(2026, 1, 5).IsWeekend(), "Monday is not a weekend by default");
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsWeekend());
+    }
 
-        // Under a Monday-to-Saturday working week, Saturday is a working day and Sunday is the only weekend day.
-        Assert.IsFalse(new DateOnly(2026, 1, 10).IsWeekend(WeekPattern.MondayToSaturday), "Saturday is working in a six-day week");
-        Assert.IsTrue(new DateOnly(2026, 1, 11).IsWeekend(WeekPattern.MondayToSaturday), "Sunday remains a weekend");
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.IsWeekend(DateOnly, WeekPattern?)" /> treats Saturday as a working
+    /// day and Sunday as the sole weekend under a Monday-to-Saturday working week.
+    /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected weekend classification.</param>
+    [TestMethod]
+    [DataRow(2026, 1, 10, false)]  // Saturday is working in a six-day week
+    [DataRow(2026, 1, 11, true)]   // Sunday remains a weekend
+    public void IsWeekend_WhenMondayToSaturdayWeek_ShouldReturnExpectedClassification(int year, int month, int day, bool expected)
+    {
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsWeekend(WeekPattern.MondayToSaturday));
     }
 
     /// <summary>
@@ -209,43 +231,76 @@ public sealed class WorkingDayExtensionMatrixTests
     }
 
     /// <summary>
-    /// Verifies that a working-day input is returned unchanged by every snap helper.
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDay" /> returns a working-day input unchanged.
     /// </summary>
     [TestMethod]
-    public void Snap_WhenInputIsWorkingDay_ShouldReturnInputUnchanged()
+    public void SnapToWorkingDay_WhenInputIsWorkingDay_ShouldReturnInputUnchanged()
     {
         DateOnly input = new(2026, 1, 6);
-        INotableDateService service = Service;
 
-        Assert.AreEqual(input, input.SnapToWorkingDay(service, "XX"));
-        Assert.AreEqual(input, input.SnapToWorkingDayBackward(service, "XX"));
-        Assert.AreEqual(input, input.SnapToNearestWorkingDay(service, "XX"));
+        Assert.AreEqual(input, input.SnapToWorkingDay(Service, "XX"));
     }
 
     /// <summary>
-    /// Verifies that a Saturday snaps forward to the following Monday and backward to the prior Friday.
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDayBackward" /> returns a working-day input unchanged.
     /// </summary>
     [TestMethod]
-    public void SnapToWorkingDay_WhenSaturday_ShouldSnapForwardAndBackward()
+    public void SnapToWorkingDayBackward_WhenInputIsWorkingDay_ShouldReturnInputUnchanged()
     {
-        DateOnly saturday = new(2026, 1, 3);
-        INotableDateService service = Service;
+        DateOnly input = new(2026, 1, 6);
 
-        Assert.AreEqual(new DateOnly(2026, 1, 5), saturday.SnapToWorkingDay(service, "XX"));
-        Assert.AreEqual(new DateOnly(2026, 1, 2), saturday.SnapToWorkingDayBackward(service, "XX"));
+        Assert.AreEqual(input, input.SnapToWorkingDayBackward(Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToNearestWorkingDay" /> returns a working-day input unchanged.
+    /// </summary>
+    [TestMethod]
+    public void SnapToNearestWorkingDay_WhenInputIsWorkingDay_ShouldReturnInputUnchanged()
+    {
+        DateOnly input = new(2026, 1, 6);
+
+        Assert.AreEqual(input, input.SnapToNearestWorkingDay(Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDay" /> snaps a Saturday forward to the following
+    /// Monday.
+    /// </summary>
+    [TestMethod]
+    public void SnapToWorkingDay_WhenSaturday_ShouldReturnFollowingMonday()
+    {
+        Assert.AreEqual(new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 3).SnapToWorkingDay(Service, "XX"));
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="NotableDateOnlyExtensions.SnapToWorkingDayBackward" /> snaps a Saturday backward to the
+    /// prior Friday.
+    /// </summary>
+    [TestMethod]
+    public void SnapToWorkingDayBackward_WhenSaturday_ShouldReturnPriorFriday()
+    {
+        Assert.AreEqual(new DateOnly(2026, 1, 2), new DateOnly(2026, 1, 3).SnapToWorkingDayBackward(Service, "XX"));
     }
 
     /// <summary>
     /// Verifies that the nearest snap chooses the closer side: a Saturday is one day from Friday and snaps backward,
     /// while a Sunday is one day from Monday and snaps forward.
     /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expectedYear">The expected result year.</param>
+    /// <param name="expectedMonth">The expected result month.</param>
+    /// <param name="expectedDay">The expected result day.</param>
     [TestMethod]
-    public void SnapToNearestWorkingDay_WhenWeekend_ShouldChooseCloserSide()
+    [DataRow(2026, 1, 3, 2026, 1, 2)]  // Saturday -> prior Friday
+    [DataRow(2026, 1, 4, 2026, 1, 5)]  // Sunday -> next Monday
+    public void SnapToNearestWorkingDay_WhenWeekend_ShouldChooseCloserSide(int year, int month, int day, int expectedYear, int expectedMonth, int expectedDay)
     {
-        INotableDateService service = Service;
-
-        Assert.AreEqual(new DateOnly(2026, 1, 2), new DateOnly(2026, 1, 3).SnapToNearestWorkingDay(service, "XX"), "Saturday -> prior Friday");
-        Assert.AreEqual(new DateOnly(2026, 1, 5), new DateOnly(2026, 1, 4).SnapToNearestWorkingDay(service, "XX"), "Sunday -> next Monday");
+        Assert.AreEqual(
+            new DateOnly(expectedYear, expectedMonth, expectedDay),
+            new DateOnly(year, month, day).SnapToNearestWorkingDay(Service, "XX"));
     }
 
     /// <summary>
@@ -304,16 +359,23 @@ public sealed class WorkingDayExtensionMatrixTests
     }
 
     /// <summary>
-    /// Verifies that adding working days skips the fixture holiday and the weekend. From Wednesday 31 December 2025,
-    /// three working days are 2 January (Friday), 5 January (Monday) and 6 January (Tuesday).
+    /// Verifies that adding working days forward skips the fixture holiday and the weekend. From Wednesday 31 December 2025,
+    /// three working days forward are 2 January (Friday), 5 January (Monday) and 6 January (Tuesday).
     /// </summary>
     [TestMethod]
-    public void AddWorkingDays_WhenCrossingHolidayAndWeekend_ShouldSkipNonWorkingDays()
+    public void AddWorkingDays_WhenCrossingHolidayAndWeekendForward_ShouldSkipNonWorkingDays()
     {
-        INotableDateService service = Service;
+        Assert.AreEqual(new DateOnly(2026, 1, 6), new DateOnly(2025, 12, 31).AddWorkingDays(3, Service, "XX"));
+    }
 
-        Assert.AreEqual(new DateOnly(2026, 1, 6), new DateOnly(2025, 12, 31).AddWorkingDays(3, service, "XX"));
-        Assert.AreEqual(new DateOnly(2025, 12, 31), new DateOnly(2026, 1, 6).AddWorkingDays(-3, service, "XX"));
+    /// <summary>
+    /// Verifies that subtracting working days skips the fixture holiday and the weekend. From Tuesday 6 January 2026, three
+    /// working days back are 5 January (Monday), 2 January (Friday) and 31 December 2025 (Wednesday).
+    /// </summary>
+    [TestMethod]
+    public void AddWorkingDays_WhenCrossingHolidayAndWeekendBackward_ShouldSkipNonWorkingDays()
+    {
+        Assert.AreEqual(new DateOnly(2025, 12, 31), new DateOnly(2026, 1, 6).AddWorkingDays(-3, Service, "XX"));
     }
 
     /// <summary>
@@ -366,17 +428,20 @@ public sealed class WorkingDayExtensionMatrixTests
     }
 
     /// <summary>
-    /// Verifies that a custom Sunday-to-Thursday working week treats Friday as a non-working day and Sunday as a working
-    /// day. 15 May 2026 is a Friday and 17 May 2026 is a Sunday.
+    /// Verifies that a custom Sunday-to-Thursday working week treats Friday as a non-working day while Sunday and Thursday
+    /// remain working. In 2026, 15 May is a Friday, 17 May is a Sunday and 14 May is a Thursday.
     /// </summary>
+    /// <param name="year">The Gregorian year.</param>
+    /// <param name="month">The month component.</param>
+    /// <param name="day">The day component.</param>
+    /// <param name="expected">The expected working-day classification.</param>
     [TestMethod]
-    public void IsWorkingDay_WhenSundayToThursdayWeek_ShouldTreatFridayAsNonWorking()
+    [DataRow(2026, 5, 15, false)]  // Friday is non-working
+    [DataRow(2026, 5, 17, true)]   // Sunday is working
+    [DataRow(2026, 5, 14, true)]   // Thursday is working
+    public void IsWorkingDay_WhenSundayToThursdayWeek_ShouldReturnExpectedClassification(int year, int month, int day, bool expected)
     {
-        INotableDateService service = Service;
-
-        Assert.IsFalse(new DateOnly(2026, 5, 15).IsWorkingDay(service, "XX", WeekPattern.SundayToThursday), "Friday is non-working");
-        Assert.IsTrue(new DateOnly(2026, 5, 17).IsWorkingDay(service, "XX", WeekPattern.SundayToThursday), "Sunday is working");
-        Assert.IsTrue(new DateOnly(2026, 5, 14).IsWorkingDay(service, "XX", WeekPattern.SundayToThursday), "Thursday is working");
+        Assert.AreEqual(expected, new DateOnly(year, month, day).IsWorkingDay(Service, "XX", WeekPattern.SundayToThursday));
     }
 
     /// <summary>

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/WorkingWeekResolutionTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/WorkingWeekResolutionTests.cs
@@ -50,26 +50,38 @@ public sealed class WorkingWeekResolutionTests
         """));
 
     /// <summary>
-    /// Verifies that under a Sunday-to-Thursday working week a Friday holiday is treated as a weekend occurrence and is
-    /// observed on the following Sunday, skipping the configured Friday and Saturday weekend.
+    /// Verifies that under a Sunday-to-Thursday working week the observed-only emission suppresses the Friday actual
+    /// date, since the configured weekend treats Friday 2 January 2026 as a weekend day.
+    /// </summary>
+    [TestMethod]
+    public void IfWeekend_WhenWorkingWeekIsSundayToThursday_ForFridayHoliday_ShouldSuppressActualDate()
+    {
+        INotableDateService service = Build("workingDays=\"1111100\"");
+
+        Assert.IsEmpty(service.Resolve(new DateOnly(2026, 1, 2), Territory));
+    }
+
+    /// <summary>
+    /// Verifies that under a Sunday-to-Thursday working week a Friday holiday is observed on the following Sunday,
+    /// skipping the configured Friday and Saturday weekend. The substitute lands on Sunday 4 January 2026 carrying the
+    /// 2 January actual date.
     /// </summary>
     [TestMethod]
     public void IfWeekend_WhenWorkingWeekIsSundayToThursday_ForFridayHoliday_ShouldObserveOnFollowingSunday()
     {
         INotableDateService service = Build("workingDays=\"1111100\"");
 
-        Assert.IsEmpty(service.Resolve(new DateOnly(2026, 1, 2), Territory), "Friday actual suppressed");
-
         IReadOnlyList<NotableDate> observed = service.Resolve(new DateOnly(2026, 1, 4), Territory);
+
         Assert.HasCount(1, observed);
-        Assert.IsTrue(observed[0].IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 2), observed[0].ActualDate);
-        Assert.AreEqual(new DateOnly(2026, 1, 4), observed[0].Date);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 2), new DateOnly(2026, 1, 4)),
+            (observed[0].IsObserved, observed[0].ActualDate, observed[0].Date));
     }
 
     /// <summary>
     /// Verifies that under the default Monday-to-Friday working week a Friday holiday is a working-day occurrence, so
-    /// the weekend trigger does not fire and the holiday is emitted on its actual Friday date.
+    /// the weekend trigger does not fire and the holiday is emitted on its actual Friday 2 January 2026 date.
     /// </summary>
     [TestMethod]
     public void IfWeekend_WhenDefaultWorkingWeek_ForFridayHoliday_ShouldEmitActualDate()
@@ -77,11 +89,23 @@ public sealed class WorkingWeekResolutionTests
         INotableDateService service = Build(string.Empty);
 
         IReadOnlyList<NotableDate> actual = service.Resolve(new DateOnly(2026, 1, 2), Territory);
-        Assert.HasCount(1, actual);
-        Assert.IsFalse(actual[0].IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 2), actual[0].Date);
 
-        Assert.IsEmpty(service.Resolve(new DateOnly(2026, 1, 4), Territory), "no observed occurrence emitted");
+        Assert.HasCount(1, actual);
+        Assert.AreEqual(
+            (false, new DateOnly(2026, 1, 2)),
+            (actual[0].IsObserved, actual[0].Date));
+    }
+
+    /// <summary>
+    /// Verifies that under the default Monday-to-Friday working week the Friday holiday emits no observed occurrence on
+    /// the following Sunday, since the weekend trigger never fires.
+    /// </summary>
+    [TestMethod]
+    public void IfWeekend_WhenDefaultWorkingWeek_ForFridayHoliday_ShouldNotEmitObservedOccurrence()
+    {
+        INotableDateService service = Build(string.Empty);
+
+        Assert.IsEmpty(service.Resolve(new DateOnly(2026, 1, 4), Territory));
     }
 
     /// <summary>
@@ -116,9 +140,10 @@ public sealed class WorkingWeekResolutionTests
         """));
 
         IReadOnlyList<NotableDate> observed = service.Resolve(new DateOnly(2026, 1, 5), Territory);
+
         Assert.HasCount(1, observed);
-        Assert.IsTrue(observed[0].IsObserved);
-        Assert.AreEqual(new DateOnly(2026, 1, 3), observed[0].ActualDate);
-        Assert.AreEqual(new DateOnly(2026, 1, 5), observed[0].Date);
+        Assert.AreEqual(
+            (true, (DateOnly?)new DateOnly(2026, 1, 3), new DateOnly(2026, 1, 5)),
+            (observed[0].IsObserved, observed[0].ActualDate, observed[0].Date));
     }
 }

--- a/Bodu.Globalization.Calendar/test/Globalization.Calendar/ZoroastrianCalendarKnownAnswerTests.cs
+++ b/Bodu.Globalization.Calendar/test/Globalization.Calendar/ZoroastrianCalendarKnownAnswerTests.cs
@@ -85,28 +85,33 @@ public sealed class ZoroastrianCalendarKnownAnswerTests
     /// <summary>
     /// Verifies that Zartosht No-Diso (11 Dey) always lands on the 31 December / 1 January boundary of the Gregorian
     /// year. Because that boundary straddles the year end, a given Gregorian year can contain zero, one or two
-    /// occurrences of the swept Persian date; every occurrence resolved across a multi-year span must fall on one of
-    /// those two civil dates.
+    /// occurrences of the swept Persian date; every occurrence resolved across 2023-2027 falls on one of those two civil
+    /// dates.
     /// </summary>
     [TestMethod]
     [TestCategory("Regression")]
     public void Resolve_ZartoshtNoDiso_FallsOnYearBoundary()
     {
         NotableDateService service = CreateService();
-        var occurrences = 0;
 
-        for (var year = 2023; year <= 2027; year++)
-        {
-            foreach (NotableDate occurrence in CommonCatalogues.ResolveForYear(service, "zartosht-no-diso", year))
+        DateOnly[] resolved = Enumerable
+            .Range(2023, 5)
+            .SelectMany(year => CommonCatalogues.ResolveForYear(service, "zartosht-no-diso", year))
+            .Select(occurrence => occurrence.Date)
+            .OrderBy(date => date)
+            .ToArray();
+
+        // Every occurrence lands on the 1 January / 31 December civil boundary; 2025 has none (its 11 Dey anchor fell on
+        // 31 December 2024) while 2024 carries two.
+        CollectionAssert.AreEqual(
+            new[]
             {
-                occurrences++;
-                var landsOnBoundary =
-                    (occurrence.Date.Month == 1 && occurrence.Date.Day == 1) ||
-                    (occurrence.Date.Month == 12 && occurrence.Date.Day == 31);
-                Assert.IsTrue(landsOnBoundary, $"zartosht-no-diso {year} fell on {occurrence.Date:yyyy-MM-dd}");
-            }
-        }
-
-        Assert.IsGreaterThan(0, occurrences, "expected at least one Zartosht No-Diso occurrence across 2023-2027");
+                new DateOnly(2023, 1, 1),
+                new DateOnly(2024, 1, 1),
+                new DateOnly(2024, 12, 31),
+                new DateOnly(2026, 1, 1),
+                new DateOnly(2027, 1, 1),
+            },
+            resolved);
     }
 }

--- a/docs/apidoc/Bodu.Extensions.md
+++ b/docs/apidoc/Bodu.Extensions.md
@@ -30,7 +30,7 @@ This is the single highest-leverage namespace in `Bodu.Core` by surface area. Re
 - <xref:Bodu.Extensions.CalendarQuarterDefinition> — `Fiscal`, `Calendar`.
 - <xref:Bodu.Extensions.DateTimeResolution> — truncation resolution.
 - <xref:Bodu.Extensions.FiscalWeekPattern> — fiscal-week enumeration.
-- <xref:Bodu.Extensions.WeekOfMonthOrdinal> — `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`.
+- <xref:Bodu.Extensions.WeekOrdinal> — `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`.
 
 **Numeric**
 

--- a/docs/apidoc/Bodu.Globalization.Calendar.Algorithms.md
+++ b/docs/apidoc/Bodu.Globalization.Calendar.Algorithms.md
@@ -21,7 +21,7 @@ Every <xref:Bodu.Globalization.Calendar.NotableDateRule> carries exactly one <xr
 
 - <xref:Bodu.Globalization.Calendar.Algorithms.IDateCalculationStrategy> — `DateOnly? Calculate(int year, StrategyResolutionContext context)`. Implemented by every strategy below.
 - <xref:Bodu.Globalization.Calendar.Algorithms.FixedDateStrategy> — a fixed month / day, optionally expressed in a non-Gregorian <xref:Bodu.Globalization.Calendar.CalendarSystem> (a short Hijri month can recur twice in a Gregorian year, so it also exposes `CalculateAll`).
-- <xref:Bodu.Globalization.Calendar.Algorithms.DayOfWeekInMonthStrategy> — the *n*th or last weekday in a month (e.g. fourth Thursday in November), driven by <xref:Bodu.Globalization.Calendar.WeekOrdinal>.
+- <xref:Bodu.Globalization.Calendar.Algorithms.DayOfWeekInMonthStrategy> — the *n*th or last weekday in a month (e.g. fourth Thursday in November), driven by <xref:Bodu.Extensions.WeekOrdinal>.
 - <xref:Bodu.Globalization.Calendar.Algorithms.RelativeWeekdayInMonthStrategy> — a weekday relative to a weekday-in-month anchor (e.g. the Tuesday after the first Monday).
 - <xref:Bodu.Globalization.Calendar.Algorithms.WeekdayNearDateStrategy> — a weekday on / before / after / nearest a fixed date (e.g. the Monday nearest 24 May), driven by <xref:Bodu.Globalization.Calendar.WeekdayProximity>.
 - <xref:Bodu.Globalization.Calendar.Algorithms.OffsetFromRuleStrategy> — a fixed day offset from another rule's occurrence (e.g. Good Friday = Easter Sunday − 2).

--- a/docs/docs/core/concepts.md
+++ b/docs/docs/core/concepts.md
@@ -141,7 +141,7 @@ The `Bodu.Extensions` namespace ships several enums that encode the *shape* of a
 | Type | Encodes |
 |---|---|
 | <xref:Bodu.Extensions.CalendarQuarterDefinition> | The start month of Q1 — `JanuaryToDecember`, `JulyToJune`, `AprilToMarch`, `April6ToApril5` (UK tax year), `March25ToMarch24` (Lady Day), `OctoberToSeptember`, `FebruaryToJanuary`, plus `Custom` for externally defined rules. Drives `FirstDateOfQuarter`, `LastDateOfQuarter`, `Quarter`, `FiscalYear`. |
-| <xref:Bodu.Extensions.WeekOfMonthOrdinal> | The ordinal position of a weekday in a month — `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`. Drives `NthDateOfWeekInMonth` and the recurrence-rule patterns. |
+| <xref:Bodu.Extensions.WeekOrdinal> | The ordinal position of a weekday in a month — `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`. Drives `NthDateOfWeekInMonth` and the recurrence-rule patterns. |
 | <xref:Bodu.Extensions.FiscalWeekPattern> | The 4-4-5 / 4-5-4 / 5-4-4 split for retail-style 13-week fiscal quarters. Each quarter is always 13 weeks; the pattern only affects fiscal-period boundaries inside the quarter. The extra week in a 53-week fiscal year is always appended to the final period of Q4. |
 | <xref:Bodu.WorkingDaysOfWeek> | Named working-week presets — `MondayToFriday`, `MondayToSaturday`, `SaturdayToThursday`, `SaturdayToWednesday`, and others — plus `Custom` for caller-supplied `WeekPattern` schedules. Drives `IsWeekday`, `IsWeekend`, `IsInWorkingWeek`, `NextWeekday`. |
 | <xref:Bodu.Extensions.IWeekendDefinitionProvider> | The injection seam for non-enumerable weekend rules — pass an implementation to override the built-in `WorkingDaysOfWeek` presets when an application needs hybrid, rotating, or domain-specific weekend logic. |

--- a/docs/docs/core/index.md
+++ b/docs/docs/core/index.md
@@ -71,7 +71,7 @@ Date, numeric, span, and array extension methods. Larger surface than the others
 | <xref:Bodu.Extensions.BufferConverter> | Byte / structure conversion helpers. |
 | <xref:Bodu.Extensions.SpanExtensions> | Span-friendly helpers. |
 | <xref:Bodu.Extensions.IComparableExtensions>, <xref:Bodu.Extensions.ComparableHelper> | `Min`, `Max`, `Clamp`, `IsGreaterThan` / `IsGreaterThanOrEqual`. |
-| <xref:Bodu.Extensions.CalendarQuarterDefinition>, <xref:Bodu.WorkingDaysOfWeek>, <xref:Bodu.Extensions.IWeekendDefinitionProvider>, <xref:Bodu.Extensions.FiscalWeekPattern>, <xref:Bodu.Extensions.WeekOfMonthOrdinal> | Calendar-shape enums and injection seams for quarter, weekend, fiscal-week, and week-ordinal computations. |
+| <xref:Bodu.Extensions.CalendarQuarterDefinition>, <xref:Bodu.WorkingDaysOfWeek>, <xref:Bodu.Extensions.IWeekendDefinitionProvider>, <xref:Bodu.Extensions.FiscalWeekPattern>, <xref:Bodu.Extensions.WeekOrdinal> | Calendar-shape enums and injection seams for quarter, weekend, fiscal-week, and week-ordinal computations. |
 
 ### `Bodu.Globalization.Extensions`
 Culture-aware date / calendar helpers built on top of <xref:System.Globalization.DateTimeFormatInfo>.

--- a/docs/guides/calendar/algorithms.md
+++ b/docs/guides/calendar/algorithms.md
@@ -43,7 +43,7 @@ The most common strategy: the same calendar position every year. `month` is a nu
 
 ### `<DayOfWeekInMonth>` — the *n*th weekday in a month
 
-Driven by <xref:Bodu.Globalization.Calendar.WeekOrdinal> (`First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`). `Fifth` yields no occurrence in months that lack a fifth instance; `Last` always selects the final occurrence.
+Driven by <xref:Bodu.Extensions.WeekOrdinal> (`First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`). `Fifth` yields no occurrence in months that lack a fifth instance; `Last` always selects the final occurrence.
 
 ```xml
 <!-- US Thanksgiving — the fourth Thursday in November. -->

--- a/docs/guides/calendar/holiday-patterns.md
+++ b/docs/guides/calendar/holiday-patterns.md
@@ -157,7 +157,7 @@ The full trigger / action / emission catalogue, and the AU/NZ, UK, and US patter
 
 ## Floating weekday-of-month holiday
 
-A holiday defined as the *n*th occurrence of a weekday in a month uses `<DayOfWeekInMonth>` with a <xref:Bodu.Globalization.Calendar.WeekOrdinal> (`First`…`Fifth`, `Last`).
+A holiday defined as the *n*th occurrence of a weekday in a month uses `<DayOfWeekInMonth>` with a <xref:Bodu.Extensions.WeekOrdinal> (`First`…`Fifth`, `Last`).
 
 ```xml
 <NotableDate id="thanksgiving" displayName="Thanksgiving Day" category="PublicHoliday" defaultNonWorkingDay="true">

--- a/docs/guides/calendar/rule-authoring.md
+++ b/docs/guides/calendar/rule-authoring.md
@@ -108,7 +108,7 @@ A one-line example of each:
 <Strategy><Algorithm key="western-easter" /></Strategy>
 ```
 
-`month` accepts either a number (`1`–`12`) or an English month name (`January`). `weekOrdinal` is a <xref:Bodu.Globalization.Calendar.WeekOrdinal> value (`First`…`Fifth`, `Last`); `direction` is a <xref:Bodu.Globalization.Calendar.WeekdayProximity> value (`Before`, `OnOrBefore`, `Nearest`, `OnOrAfter`, `After`). For per-element attribute tables and worked examples see [NotableDateRule and adjustment-policy reference](rule-reference.md); for the `<Algorithm>` key catalogue and custom algorithms see [Date calculation algorithms](algorithms.md).
+`month` accepts either a number (`1`–`12`) or an English month name (`January`). `weekOrdinal` is a <xref:Bodu.Extensions.WeekOrdinal> value (`First`…`Fifth`, `Last`); `direction` is a <xref:Bodu.Globalization.Calendar.WeekdayProximity> value (`Before`, `OnOrBefore`, `Nearest`, `OnOrAfter`, `After`). For per-element attribute tables and worked examples see [NotableDateRule and adjustment-policy reference](rule-reference.md); for the `<Algorithm>` key catalogue and custom algorithms see [Date calculation algorithms](algorithms.md).
 
 ---
 

--- a/docs/guides/calendar/rule-reference.md
+++ b/docs/guides/calendar/rule-reference.md
@@ -122,7 +122,7 @@ An impossible date (e.g. 29 February in a non-leap year) yields no occurrence fo
 |---|---|---|---|
 | `month` | Yes | string | Month number or English month name. |
 | `dayOfWeek` | Yes | day of week | The target weekday. |
-| `weekOrdinal` | Yes | ordinal | <xref:Bodu.Globalization.Calendar.WeekOrdinal>: `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`. |
+| `weekOrdinal` | Yes | ordinal | <xref:Bodu.Extensions.WeekOrdinal>: `First`, `Second`, `Third`, `Fourth`, `Fifth`, `Last`. |
 
 ```xml
 <!-- US Thanksgiving — the fourth Thursday in November. -->


### PR DESCRIPTION
## Summary

Refactors the **Globalization.Calendar** test suite so each test asserts a single observable outcome, replacing tests that bundled multiple independent assertions. The refactor itself changes **tests only — no production code**. (A small DocFX docs fix is also included; see the last section.)

## Rubric applied

Every multi-assertion test across the calendar test projects was triaged and refactored consistently:

- **Same operation over varying inputs** → data-driven `[DataRow]` tables (or `[DynamicData]` where a row carries a non-constant value such as `WeekPattern` or an object graph; where a parameter like `WeekPattern` is a `static readonly` struct, the test is split into one `[DataRow]`-driven test per fixed value rather than forced into an attribute).
- **Distinct operations or scenarios bundled together** (e.g. forward + backward, suppress + emit, "fires on a weekday _and_ not on a weekend") → split into atomic tests, each named for the specific member/scenario.
- **One result object/collection asserted via several properties** (a single outcome) → consolidated into one comparison:
  - a `ValueTuple` comparison for an object's fields, e.g. `Assert.AreEqual((date, durationDays, endDate), (x.Date, x.DurationDays, x.EndDate))`;
  - one `CollectionAssert` over projected `(id, date)` tuples for a whole result set (covering count, content and order in a single assertion);
  - a new `NotableDateAssert.AssertOccurrence(result, id, date)` helper for the recurring `IsNotNull + Date + Id` shape.
- **Left intact** the genuinely tight cases: a value assert plus a `DateTime.Kind`/`DateTimeOffset.Offset` facet that value-equality cannot express, null-guards required before a dereference, reference-identity checks, and `Assert.ThrowsExactly` exception tests (already one logical assertion).

Coverage is **preserved or strengthened** — every split retains all original assertions, and several tuple/collection consolidations now pin additional fields (emitted dates, rule ids) that were previously unchecked. Test naming, `Verifies that …` summaries, `<param>` docs, and tier categories (`Smoke`/`Regression`) follow the repository conventions in `CLAUDE.md`.

## Scope

61 test files changed: 49 in the main `Bodu.Globalization.Calendar` project, 5 in `.Builder`, and one each in `.Plugins`, `.DependencyInjection`, and the Americas/AsiaPacific/Europe/Africa data bundles. A `.gitignore` entry was added for transient Claude Code agent worktrees.

## Verification

All calendar test projects pass at the regression tier, **0 failures**:

| Project | Passed |
|---|---|
| main | 2130 |
| Builder | 54 |
| Americas | 157 |
| AsiaPacific | 104 |
| Europe | 46 |
| Africa | 33 |
| Plugins | 20 |
| DependencyInjection | 6 |

## Also: DocFX cross-reference fix

The `build-docs` check was red on a **pre-existing, master-level** issue unrelated to the test refactor: after the `WeekOfMonthOrdinal` → `WeekOrdinal` rename (the enum now lives in the `Bodu.Extensions` namespace), eight `docs/**` cross-references still pointed at the removed `Bodu.Extensions.WeekOfMonthOrdinal` UID or the wrong-namespace `Bodu.Globalization.Calendar.WeekOrdinal` UID, and DocFX treats those `UidNotFound` warnings as errors. All eight are repointed to `Bodu.Extensions.WeekOrdinal` so the docs build is green.

https://claude.ai/code/session_019mLi9UmJHnzAcDqNhDTnxb