### PR TITLE
docs: fix CheckDigits xref namespace and add Core collection guides

### DIFF
--- a/docs/apidoc/Bodu.Collections.Generic.md
+++ b/docs/apidoc/Bodu.Collections.Generic.md
@@ -14,7 +14,7 @@ Reach for this library when you need a fixed-capacity FIFO queue, a deque with O
 
 - **[Bodu.Core introduction](~/docs/core/index.md)** — namespaces, headline types, scenarios.
 - **[Bodu.Core getting started](~/docs/core/getting-started.md)** — install and minimal samples for the headline types.
-- **[Bodu.Core guides](~/guides/core/index.md)** — recipe-style walk-throughs: [circular buffer](~/guides/core/circular-buffer.md), [deque](~/guides/core/deque.md), [evicting dictionary](~/guides/core/evicting-dictionary.md), [`WeekPattern`](~/guides/core/week-pattern.md).
+- **[Bodu.Core guides](~/guides/core/index.md)** — recipe-style walk-throughs: [choosing a collection](~/guides/core/choosing-a-collection.md), [circular buffer](~/guides/core/circular-buffer.md), [deque](~/guides/core/deque.md), [evicting dictionary](~/guides/core/evicting-dictionary.md), [indexed priority queue](~/guides/core/indexed-priority-queue.md), [indexed and ordered sets](~/guides/core/ordered-sets.md), [multiset](~/guides/core/multiset.md), [multi-value dictionary](~/guides/core/multi-value-dictionary.md), [range-keyed lookups](~/guides/core/range-dictionary.md), [segmented buffer](~/guides/core/segmented-buffer.md), [concurrent collections](~/guides/core/concurrent-collections.md), [`WeekPattern`](~/guides/core/week-pattern.md).
 
 ## Key types
 

--- a/docs/apidoc/Bodu.Financial.DependencyInjection.md
+++ b/docs/apidoc/Bodu.Financial.DependencyInjection.md
@@ -1,0 +1,53 @@
+---
+uid: Bodu.Financial.DependencyInjection
+---
+
+# Bodu.Financial.DependencyInjection
+
+## Purpose
+
+**Bodu.Financial.DependencyInjection** provides the `Microsoft.Extensions.DependencyInjection` integration for [`Bodu.Financial`](Bodu.Financial.md). A single `AddBoduFinancial(...)` call registers the currency-lookup service and returns an <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder> on which you compose the rest of the financial stack — currency lookups, named monetary contexts, exchange-rate providers (timeless and dated), and JSON converters — through chainable `Add*` extension methods.
+
+Bind <xref:Bodu.Financial.DependencyInjection.FinancialOptions> from configuration (JSON policy, unknown-currency policy) by passing an `IConfiguration`, or configure the builder imperatively with a delegate. Direct construction of the underlying `Bodu.Financial` types continues to work for consoles, libraries, and tests that prefer not to bring in `IServiceCollection`.
+
+## Static documentation
+
+- **[Financial dependency injection guide](~/guides/financial/dependency-injection.md)** — the registration surface, builder chaining, options binding, and the currency-resolution activation step.
+
+## Key types
+
+- <xref:Bodu.Financial.DependencyInjection.ServiceCollectionExtensions> — the entry point:
+  - `AddBoduFinancial(IServiceCollection, IConfiguration?, string sectionName)` — registers the currency lookup and binds <xref:Bodu.Financial.DependencyInjection.FinancialOptions> from the named configuration section.
+  - `AddBoduFinancial(IServiceCollection, Action<IFinancialServiceBuilder>)` — the same, with the builder configured imperatively.
+- <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder> — the fluent builder; exposes the underlying `IServiceCollection` via `Services`.
+- <xref:Bodu.Financial.DependencyInjection.FinancialServiceBuilderExtensions> — the chainable composition surface:
+  - `AddCurrencyLookup<TLookup>()` — replace the default <xref:Bodu.Financial.ICurrency> lookup.
+  - `AddMonetaryContext(string name, MonetaryContext context)` — register a named monetary context.
+  - `AddExchangeRateProvider` / `AddDatedExchangeRateProvider` (type-parameter and instance overloads) — register timeless and dated FX providers.
+  - `AddFinancialJson(FinancialJsonPolicy)` — register the `System.Text.Json` converters under the chosen policy.
+- <xref:Bodu.Financial.DependencyInjection.ServiceProviderExtensions> — `UseBoduFinancialCurrencyResolution(IServiceProvider)`, the post-build activation step that wires the resolved currency lookup into the static currency-resolution surface.
+- <xref:Bodu.Financial.DependencyInjection.FinancialOptions> — bound options: `JsonPolicy` and `UnknownCurrency`.
+
+## Minimal sample
+
+```csharp
+using Bodu.Financial.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services.AddBoduFinancial(configure: financial =>
+{
+    financial.AddFinancialJson(FinancialJsonPolicy.Strict);
+    financial.AddDatedExchangeRateProvider<MyRateProvider>();
+});
+
+// After the container is built, activate static currency resolution once:
+app.Services.UseBoduFinancialCurrencyResolution();
+```
+
+To bind options from configuration instead, pass the `IConfiguration`:
+
+```csharp
+builder.Services.AddBoduFinancial(builder.Configuration);   // binds the "Financial" section
+```
+
+See the [Financial dependency injection](~/guides/financial/dependency-injection.md) guide for the full walkthrough.

--- a/docs/apidoc/Bodu.IO.Hashing.CheckDigits.md
+++ b/docs/apidoc/Bodu.IO.Hashing.CheckDigits.md
@@ -17,8 +17,8 @@ uid: Bodu.IO.Hashing.CheckDigits
 **Financial / banking identifiers:**
 
 - <xref:Bodu.IO.Hashing.CheckDigits.AbaRoutingNumber> — ABA routing number (US).
-- <xref:Bodu.IO.Hashing.Checksums.Iban> — IBAN MOD-97.
-- <xref:Bodu.IO.Hashing.Checksums.Lei> — Legal Entity Identifier (ISO 17442).
+- <xref:Bodu.IO.Hashing.CheckDigits.Iban> — IBAN MOD-97.
+- <xref:Bodu.IO.Hashing.CheckDigits.Lei> — Legal Entity Identifier (ISO 17442).
 
 **Retail / GS1:**
 
@@ -26,11 +26,11 @@ uid: Bodu.IO.Hashing.CheckDigits
 
 **Securities:**
 
-- <xref:Bodu.IO.Hashing.Checksums.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Isin>, <xref:Bodu.IO.Hashing.Checksums.Sedol>
+- <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Isin>, <xref:Bodu.IO.Hashing.CheckDigits.Sedol>
 
 **Publishing:**
 
-- <xref:Bodu.IO.Hashing.Checksums.Isbn10>, <xref:Bodu.IO.Hashing.Checksums.Isbn13>
+- <xref:Bodu.IO.Hashing.CheckDigits.Isbn10>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn13>
 
 **Encoded identifiers:**
 
@@ -38,7 +38,7 @@ uid: Bodu.IO.Hashing.CheckDigits
 
 **ISO 7064:**
 
-- <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod97_10>
+- <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod97_10>
 
 ## Example
 

--- a/docs/apidoc/Bodu.IO.Hashing.md
+++ b/docs/apidoc/Bodu.IO.Hashing.md
@@ -40,7 +40,7 @@ Reach for this library when you need a fast, deterministic checksum for error de
 - <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableBuilder> — builds a lookup table from parameters; used by the cache on first miss.
 - <xref:Bodu.IO.Hashing.Checksums.Fletcher16> / <xref:Bodu.IO.Hashing.Checksums.Fletcher32> / <xref:Bodu.IO.Hashing.Checksums.Fletcher64> — twin-accumulator position-dependent checksums.
 - <xref:Bodu.IO.Hashing.Checksums.Adler32> / <xref:Bodu.IO.Hashing.Checksums.Adler32C> / <xref:Bodu.IO.Hashing.Checksums.Adler64> — Adler-32 (canonical zlib), Adler-32C (SIMD), Adler-64.
-- <xref:Bodu.IO.Hashing.Checksums.Iban>, <xref:Bodu.IO.Hashing.Checksums.Isbn10>, <xref:Bodu.IO.Hashing.Checksums.Isbn13>, <xref:Bodu.IO.Hashing.Checksums.Sedol>, <xref:Bodu.IO.Hashing.Checksums.Cusip>, <xref:Bodu.IO.Hashing.Checksums.Lei>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod97_10> — multi-character and alphanumeric identifier checksums.
+- <xref:Bodu.IO.Hashing.CheckDigits.Iban>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn10>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn13>, <xref:Bodu.IO.Hashing.CheckDigits.Sedol>, <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Lei>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod97_10> — multi-character and alphanumeric identifier checksums.
 
 **Check digits — `Bodu.IO.Hashing.CheckDigits`**
 

--- a/docs/apidoc/Bodu.Numerics.Serialization.md
+++ b/docs/apidoc/Bodu.Numerics.Serialization.md
@@ -1,0 +1,42 @@
+---
+uid: Bodu.Numerics.Serialization
+---
+
+# Bodu.Numerics.Serialization
+
+## Purpose
+
+**Bodu.Numerics.Serialization** carries the `System.Text.Json` integration for [`Bodu.Numerics`](Bodu.Numerics.md). It supplies the converters that round-trip <xref:Bodu.Numerics.Fraction`1> and <xref:Bodu.Numerics.Interval`1> to and from JSON, together with a one-call extension that registers them under a chosen policy.
+
+`Fraction<T>` and `Interval<T>` already carry `[JsonConverter]` attributes, so they serialize correctly with the default `JsonSerializerOptions`. Use this namespace when you want to select a non-default wire policy (lenient parsing, or a compact numeric form) across a whole `JsonSerializerOptions` instance.
+
+## Static documentation
+
+- **[Numerics JSON serialization guide](~/guides/numerics/json-serialization.md)** — wire formats, the three policies, and registering the converters.
+
+## Key types
+
+- <xref:Bodu.Numerics.Serialization.NumericsJsonSerializerOptionsExtensions> — `AddNumericsJsonConverters(JsonSerializerOptions, NumericsJsonPolicy)` registers the `Fraction<T>` and `Interval<T>` converter factories on an options instance and returns it for chaining.
+- <xref:Bodu.Numerics.Serialization.NumericsJsonPolicy> — the wire-format selector: `Strict` (default), `Lenient`, and `Compact`.
+- <xref:Bodu.Numerics.Serialization.FractionJsonConverter`1>, <xref:Bodu.Numerics.Serialization.FractionJsonConverterFactory> — converters for `Fraction<T>`; the factory binds the open-generic converter to the concrete `T` at run time.
+- <xref:Bodu.Numerics.Serialization.IntervalJsonConverter`1>, <xref:Bodu.Numerics.Serialization.IntervalJsonConverterFactory> — the equivalent converters for `Interval<T>`.
+
+## Example
+
+```csharp
+using System.Text.Json;
+using Bodu.Numerics;
+using Bodu.Numerics.Serialization;
+
+var options = new JsonSerializerOptions()
+    .AddNumericsJsonConverters(NumericsJsonPolicy.Strict);
+
+string json = JsonSerializer.Serialize(Fraction<int>.Create(8, 15), options);
+Fraction<int> round = JsonSerializer.Deserialize<Fraction<int>>(json, options);
+```
+
+## Notes
+
+- **Default registration is automatic.** Because both value types declare `[JsonConverter]`, they serialize without calling `AddNumericsJsonConverters`. Register explicitly only to change the policy.
+- **Factories bind the generic parameter.** `Fraction<T>` and `Interval<T>` are open generics; the converter *factories* resolve the concrete `T` per request, which is why registration adds the factory rather than a closed converter.
+- **See also:** the [Numerics JSON serialization guide](~/guides/numerics/json-serialization.md) and the [Bodu.Numerics overview](Bodu.Numerics.md).

--- a/docs/apidoc/Bodu.Text.md
+++ b/docs/apidoc/Bodu.Text.md
@@ -1,0 +1,39 @@
+---
+uid: Bodu.Text
+---
+
+# Bodu.Text
+
+## Purpose
+
+The **Bodu.Text** namespace holds the shared base type for the document-format codecs in [`Bodu.Text.Formats`](Bodu.Text.Bencode.md). It exists so that callers can catch any format-level parse failure — Bencode, delimited (CSV/TSV), DotEnv, or INI — through a single common exception type, while each codec still throws its own precise subtype.
+
+## Static documentation
+
+- **[Bodu.Text.Formats overview](~/guides/formats/index.md)** — the document-format codecs and their shared pipeline.
+
+## Key types
+
+- <xref:Bodu.Text.TextFormatException> — the abstract base for every format-specific parse exception in the formats library. Concrete subtypes include <xref:Bodu.Text.Bencode.BencodeFormatException>, <xref:Bodu.Text.Delimited.DelimitedFormatException>, <xref:Bodu.Text.DotEnv.DotEnvFormatException>, and <xref:Bodu.Text.Ini.IniFormatException>.
+
+## Example
+
+```csharp
+using Bodu.Text;
+using Bodu.Text.Ini;
+
+try
+{
+    IniDocument doc = Ini.Decode(text);
+}
+catch (TextFormatException ex)
+{
+    // Catches IniFormatException — and any other Bodu.Text.Formats parse failure.
+    Console.Error.WriteLine(ex.Message);
+}
+```
+
+## Notes
+
+- **Catch broad or narrow.** Catch <xref:Bodu.Text.TextFormatException> to handle any document-format failure uniformly, or the concrete subtype when you need format-specific detail.
+- **See also:** the per-format guides — [Bencode](~/guides/formats/bencode.md), [delimited](~/guides/formats/delimited.md), [DotEnv](~/guides/formats/dotenv.md), [INI](~/guides/formats/ini.md).

--- a/docs/apidoc/Bodu.md
+++ b/docs/apidoc/Bodu.md
@@ -1,0 +1,43 @@
+---
+uid: Bodu
+---
+
+![Bodu.Core](~/images/hero-core.svg)
+
+## Purpose
+
+The root **Bodu** namespace holds the cross-cutting primitives that the rest of `Bodu.Core` — and the wider solution — build on: a day-of-week bitmask value type, the centralized argument-validation helper, and a small pluggable random-number abstraction. These types are namespace-root on purpose: they are used everywhere and carry no sub-domain of their own.
+
+## Static documentation
+
+- **[Bodu.Core introduction](~/docs/core/index.md)** — namespaces, headline types, scenarios.
+- **[`WeekPattern` guide](~/guides/core/week-pattern.md)** — composing, parsing, and enumerating day-of-week sets.
+
+## Key types
+
+- <xref:Bodu.WeekPattern> — an immutable bitmask value type for sets of days of the week. Supports composition (`WeekPattern.Monday | WeekPattern.Wednesday`), bitwise operators, parsing, formatting, and enumeration. See the [`WeekPattern` guide](~/guides/core/week-pattern.md).
+- <xref:Bodu.WorkingDaysOfWeek> — a `[Flags]` enum naming the conventional working-day sets used by the date and calendar extensions.
+- <xref:Bodu.IRandomGenerator> — a minimal abstraction over a random source, so algorithms (shuffles, sampling) can be tested deterministically or swapped between PRNG implementations.
+- <xref:Bodu.XorShiftRandom> — a fast xorshift PRNG that derives from `System.Random`; seedable for reproducible sequences. Drop-in where `Random` is expected, faster where throughput matters and cryptographic strength is *not* required.
+- <xref:Bodu.ThrowHelper> — the centralized argument-validation surface (`ThrowIfNull`, `ThrowIfLessThan`, `ThrowIfGreaterThan`, span/array offset checks, enum-defined checks, …). Public APIs across the solution validate their parameters through these `ThrowIf…` members rather than hand-rolled checks.
+
+## Example
+
+```csharp
+using Bodu;
+
+// Compose and test a day-of-week set.
+WeekPattern weekdays = WeekPattern.Monday | WeekPattern.Tuesday | WeekPattern.Wednesday
+                     | WeekPattern.Thursday | WeekPattern.Friday;
+bool worksSaturday = weekdays.Contains(DayOfWeek.Saturday);   // false
+
+// Deterministic randomness for reproducible tests.
+IRandomGenerator rng = new XorShiftRandom(seed: 12345);
+int roll = rng.Next(1, 7);
+```
+
+## Notes
+
+- **`XorShiftRandom` is not cryptographically secure.** Use `System.Security.Cryptography.RandomNumberGenerator` for security-sensitive randomness.
+- **Validate through `ThrowHelper`.** When contributing public APIs, prefer an existing `ThrowIf…` helper over a hand-written check; add a new helper only when the rule is general-purpose.
+- **See also:** the [`WeekPattern` guide](~/guides/core/week-pattern.md) and the [Bodu.Collections.Generic overview](Bodu.Collections.Generic.md).

--- a/docs/docs/io-hashing/concepts.md
+++ b/docs/docs/io-hashing/concepts.md
@@ -131,13 +131,13 @@ A few high-stakes identifiers use **multi-character** checks — two or more cha
 
 | Identifier | Check length | Alphabet | Algorithm |
 |---|---|---|---|
-| IBAN | 2 digits | Alphanumeric (uppercase) payload, decimal check | <xref:Bodu.IO.Hashing.Checksums.Iban> (ISO 7064 Mod-97-10) |
-| LEI | 2 digits | Alphanumeric (uppercase) payload, decimal check | <xref:Bodu.IO.Hashing.Checksums.Lei> (ISO 7064 Mod-97-10) |
-| ISBN-13 | 1 digit | Decimal | <xref:Bodu.IO.Hashing.Checksums.Isbn13> |
-| ISBN-10 | 1 character (`0`–`9` or `X`) | Decimal payload, `X` permitted as check | <xref:Bodu.IO.Hashing.Checksums.Isbn10> |
-| CUSIP / SEDOL | 1 digit | Alphanumeric | <xref:Bodu.IO.Hashing.Checksums.Cusip>, <xref:Bodu.IO.Hashing.Checksums.Sedol> |
+| IBAN | 2 digits | Alphanumeric (uppercase) payload, decimal check | <xref:Bodu.IO.Hashing.CheckDigits.Iban> (ISO 7064 Mod-97-10) |
+| LEI | 2 digits | Alphanumeric (uppercase) payload, decimal check | <xref:Bodu.IO.Hashing.CheckDigits.Lei> (ISO 7064 Mod-97-10) |
+| ISBN-13 | 1 digit | Decimal | <xref:Bodu.IO.Hashing.CheckDigits.Isbn13> |
+| ISBN-10 | 1 character (`0`–`9` or `X`) | Decimal payload, `X` permitted as check | <xref:Bodu.IO.Hashing.CheckDigits.Isbn10> |
+| CUSIP / SEDOL | 1 digit | Alphanumeric | <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Sedol> |
 
-Multi-character check algorithms live in `Bodu.IO.Hashing.Checksums` alongside the generic ISO 7064 building blocks (<xref:Bodu.IO.Hashing.Checksums.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod97_10>) and share the <xref:Bodu.IO.Hashing.CheckDigits.MultiCharCheckDigitAlgorithm> abstract base.
+Multi-character check algorithms live in `Bodu.IO.Hashing.Checksums` alongside the generic ISO 7064 building blocks (<xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod97_10>) and share the <xref:Bodu.IO.Hashing.CheckDigits.MultiCharCheckDigitAlgorithm> abstract base.
 
 ## Validate vs. compute
 

--- a/docs/docs/io-hashing/getting-started.md
+++ b/docs/docs/io-hashing/getting-started.md
@@ -80,7 +80,7 @@ bool valid = Luhn.IsValid("4539 1488 0343 6467".Replace(" ", ""));
 char digit  = Luhn.ComputeCheckDigit("453914880343646");
 ```
 
-Other check-digit types follow the same `IsValid` / `ComputeCheckDigit` contract. For multi-character checksums, see <xref:Bodu.IO.Hashing.Checksums.Iban>, <xref:Bodu.IO.Hashing.Checksums.Isbn13>, <xref:Bodu.IO.Hashing.Checksums.Cusip>, and <xref:Bodu.IO.Hashing.Checksums.Lei>.
+Other check-digit types follow the same `IsValid` / `ComputeCheckDigit` contract. For multi-character checksums, see <xref:Bodu.IO.Hashing.CheckDigits.Iban>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn13>, <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, and <xref:Bodu.IO.Hashing.CheckDigits.Lei>.
 
 ### Check digit — IBAN (multi-character)
 

--- a/docs/docs/io-hashing/index.md
+++ b/docs/docs/io-hashing/index.md
@@ -49,9 +49,9 @@ Error-detection algorithms with characterized guarantees over specific error pat
 | <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableBuilder> / <xref:Bodu.IO.Hashing.Checksums.CrcLookupTableCache> | — | Shared lookup-table cache so identical CRC parameter sets share a table. |
 | <xref:Bodu.IO.Hashing.Checksums.Fletcher16> / <xref:Bodu.IO.Hashing.Checksums.Fletcher32> / <xref:Bodu.IO.Hashing.Checksums.Fletcher64> | 16 / 32 / 64 bits | Twin-accumulator; catches transpositions a simple sum or XOR misses. |
 | <xref:Bodu.IO.Hashing.Checksums.Adler32> / <xref:Bodu.IO.Hashing.Checksums.Adler32C> / <xref:Bodu.IO.Hashing.Checksums.Adler64> | 32 / 32 / 64 bits | Prime / power-of-two modulus twin accumulator; Adler-32 is the canonical zlib checksum. |
-| <xref:Bodu.IO.Hashing.Checksums.Iban>, <xref:Bodu.IO.Hashing.Checksums.Isbn10>, <xref:Bodu.IO.Hashing.Checksums.Isbn13>, <xref:Bodu.IO.Hashing.Checksums.Sedol>, <xref:Bodu.IO.Hashing.Checksums.Cusip>, <xref:Bodu.IO.Hashing.Checksums.Lei> | Multi-char | Alphanumeric / multi-character identifier checksums. |
-| <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.Checksums.Iso7064Mod97_10> | 1–2 chars | Generic ISO 7064 checksum building blocks for custom alphanumeric schemes. |
-| <xref:Bodu.IO.Hashing.Checksums.CheckDigitInputAlphabet> / <xref:Bodu.IO.Hashing.Checksums.CheckDigitOutputAlphabet> | — | Character-set enums consumed by the alphanumeric check-digit algorithms. |
+| <xref:Bodu.IO.Hashing.CheckDigits.Iban>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn10>, <xref:Bodu.IO.Hashing.CheckDigits.Isbn13>, <xref:Bodu.IO.Hashing.CheckDigits.Sedol>, <xref:Bodu.IO.Hashing.CheckDigits.Cusip>, <xref:Bodu.IO.Hashing.CheckDigits.Lei> | Multi-char | Alphanumeric / multi-character identifier checksums. |
+| <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod11_2>, <xref:Bodu.IO.Hashing.CheckDigits.Iso7064Mod97_10> | 1–2 chars | Generic ISO 7064 checksum building blocks for custom alphanumeric schemes. |
+| <xref:Bodu.IO.Hashing.CheckDigits.CheckDigitInputAlphabet> / <xref:Bodu.IO.Hashing.CheckDigits.CheckDigitOutputAlphabet> | — | Character-set enums consumed by the alphanumeric check-digit algorithms. |
 
 ### `Bodu.IO.Hashing.CheckDigits` — Check digits
 

--- a/docs/guides/core/index.md
+++ b/docs/guides/core/index.md
@@ -12,7 +12,7 @@ If you have not yet installed the package or want the high-level shape of the li
 
 | Namespace | What lives here | Guides |
 |---|---|---|
-| `Bodu.Collections.Generic` | Bounded ring-backed collections — `CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`, `RingBackedCollection<T>` base. | [Circular buffer](circular-buffer.md) · [Deque](deque.md) · [Evicting dictionary](evicting-dictionary.md) |
+| `Bodu.Collections.Generic` | Bounded ring-backed collections, sets, multisets, and range-keyed lookups — `CircularBuffer<T>`, `Deque<T>`, `EvictingDictionary<TKey,TValue>`, `IndexedPriorityQueue<TElement,TPriority>`, `IndexedSet<T>`, `OrderedSet<T>`, `Multiset<T>`, `MultiValueDictionary<TKey,TValue>`, `RangeDictionary<TKey,TValue>`, `RangeSet<T>`, `SegmentedBuffer<T>`, `RingBackedCollection<T>` base. | [Circular buffer](circular-buffer.md) · [Deque](deque.md) · [Evicting dictionary](evicting-dictionary.md) · [Indexed priority queue](indexed-priority-queue.md) · [Indexed and ordered sets](ordered-sets.md) · [Multiset](multiset.md) · [Multi-value dictionary](multi-value-dictionary.md) · [Range-keyed lookups](range-dictionary.md) · [Segmented buffer](segmented-buffer.md) |
 | `Bodu.Collections.Generic.Concurrent` | Thread-safe collection variants — `ConcurrentCircularBuffer<T>`. | (covered in [Circular buffer](circular-buffer.md#pattern-5--concurrent-access-with-concurrentcircularbuffer)) |
 | `Bodu` | Root namespace primitives — `WeekPattern`, `IRandomGenerator`, `XorShiftRandom`, `ThrowHelper`. | [WeekPattern](week-pattern.md) |
 | `Bodu.Buffers` | Pooled buffer infrastructure — `PooledBufferBuilder<T>`. | (no dedicated guide yet — see API reference) |
@@ -38,6 +38,36 @@ If you have not yet installed the package or want the high-level shape of the li
 <div class="bodu-card">
   <h3><a href="evicting-dictionary.md">Evicting dictionary</a></h3>
   <p>Capacity-bounded key-value store with FIFO, LRU, and LFU eviction policies.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="indexed-priority-queue.md">Indexed priority queue</a></h3>
+  <p>Min-heap priority queue with O(1) lookup-by-element and in-place priority updates — for Dijkstra, Prim, and A*.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="ordered-sets.md">Indexed and ordered sets</a></h3>
+  <p>Insertion-ordered unique collections — <code>IndexedSet&lt;T&gt;</code> (unique <code>IList&lt;T&gt;</code>) and <code>OrderedSet&lt;T&gt;</code> (ordered set algebra).</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="multiset.md">Multiset</a></h3>
+  <p>A bag that retains duplicates as multiplicity — frequency counting and multiset algebra (sum, union, intersect, except).</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="multi-value-dictionary.md">Multi-value dictionary</a></h3>
+  <p>One key to many values without the <code>Dictionary&lt;TKey, List&lt;TValue&gt;&gt;</code> boilerplate; the indexer never returns <code>null</code>.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="range-dictionary.md">Range-keyed lookups</a></h3>
+  <p>Half-open interval keys — <code>Range&lt;T&gt;</code>, <code>RangeDictionary&lt;TKey,TValue&gt;</code>, and <code>RangeSet&lt;T&gt;</code> with union / intersect / except.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="segmented-buffer.md">Segmented buffer</a></h3>
+  <p>Append-only buffer that grows in fixed-size segments — avoids the array-doubling copy for streams of unknown length.</p>
 </div>
 
 </div>

--- a/docs/guides/core/multi-value-dictionary.md
+++ b/docs/guides/core/multi-value-dictionary.md
@@ -1,0 +1,119 @@
+---
+title: Multi-value dictionary
+---
+
+# Multi-value dictionary
+
+<xref:Bodu.Collections.Generic.MultiValueDictionary`2> maps each key to an ordered *list* of values — a one-to-many dictionary (a multimap). It removes the boilerplate of the common `Dictionary<TKey, List<TValue>>` pattern: there is no "create the list if the key is missing" dance, the indexer never returns `null`, and value insertion order is preserved per key.
+
+Keys are compared with an `IEqualityComparer<TKey>` supplied at construction.
+
+## Pattern 1 — group values under keys
+
+```csharp
+using Bodu.Collections.Generic;
+
+var byCorrelation = new MultiValueDictionary<string, LogEntry>();
+
+foreach (LogEntry entry in entries)
+    byCorrelation.Add(entry.CorrelationId, entry);   // no pre-check needed
+
+IReadOnlyList<LogEntry> forId = byCorrelation["abc-123"];   // never null
+```
+
+The indexer returns an empty, read-only view when the key is absent — it never throws and never returns `null`, so callers can iterate unconditionally:
+
+```csharp
+foreach (LogEntry e in byCorrelation["missing-key"])   // safe — empty sequence
+    Process(e);
+```
+
+## Pattern 2 — add many values at once
+
+```csharp
+var routes = new MultiValueDictionary<string, string>();
+
+routes.AddRange("GET", new[] { "/users", "/orders", "/health" });
+routes.Add("POST", "/users");
+
+IReadOnlyList<string> gets = routes.GetValues("GET");   // /users, /orders, /health
+```
+
+`GetValues` is equivalent to the indexer; `TryGetValues` returns `false` (and an empty list) when the key is absent, mirroring `Dictionary.TryGetValue`:
+
+```csharp
+if (routes.TryGetValues("DELETE", out IReadOnlyList<string> deletes))
+    Console.WriteLine(deletes.Count);
+```
+
+## Pattern 3 — removing values and keys
+
+```csharp
+bool removedOne = routes.Remove("GET", "/health");  // removes a single value
+bool removedKey = routes.RemoveAll("POST");         // removes the key and all its values
+```
+
+`Remove(key, value)` removes one matching value and returns `false` when the pair is absent; `RemoveAll(key)` drops the key entirely.
+
+## Pattern 4 — membership and counts
+
+```csharp
+bool hasKey   = routes.ContainsKey("GET");                 // true
+bool hasPair  = routes.ContainsValue("GET", "/users");     // true
+
+int totalValues  = routes.Count;       // total values across all keys
+int distinctKeys = routes.KeyCount;    // number of keys
+```
+
+Note the distinction: `Count` is the total number of *values* stored, while `KeyCount` is the number of *keys*.
+
+## Pattern 5 — enumerating
+
+Enumerating the dictionary yields each key paired with its value list:
+
+```csharp
+foreach (KeyValuePair<string, IReadOnlyList<string>> group in routes)
+    Console.WriteLine($"{group.Key}: {group.Value.Count} routes");
+```
+
+To iterate the flat sequence of `(key, value)` pairs — one row per value — use `Flatten`:
+
+```csharp
+foreach (KeyValuePair<string, string> pair in routes.Flatten())
+    Console.WriteLine($"{pair.Key} → {pair.Value}");
+```
+
+The `Keys` collection exposes the distinct keys; `Values` and `ReadOnlyValues` expose the flattened values.
+
+## Pattern 6 — custom key comparison
+
+```csharp
+var headers = new MultiValueDictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+headers.Add("Accept", "text/html");
+headers.Add("accept", "application/json");
+IReadOnlyList<string> accept = headers["ACCEPT"];   // both values, case-insensitive key
+```
+
+## API summary
+
+| Member | Description |
+|---|---|
+| `Add(TKey, TValue)` | Appends a value to the key's list, creating the key if needed. |
+| `AddRange(TKey, IEnumerable<TValue>)` | Appends several values to a key. |
+| `this[TKey]` / `GetValues(TKey)` | Returns the key's values as an `IReadOnlyList<TValue>` (empty, never `null`). |
+| `TryGetValues(TKey, out IReadOnlyList<TValue>)` | Non-throwing lookup. |
+| `Remove(TKey, TValue)` | Removes a single value; returns `false` if absent. |
+| `RemoveAll(TKey)` | Removes a key and all its values. |
+| `ContainsKey(TKey)` / `ContainsValue(TKey, TValue)` | Membership tests. |
+| `Flatten()` | Enumerates `(key, value)` pairs, one per value. |
+| `Keys` / `Values` / `ReadOnlyValues` | The distinct keys and the flattened values. |
+| `Count` | Total number of values across all keys. |
+| `KeyCount` | Number of distinct keys. |
+| `Comparer` | The active key `IEqualityComparer<TKey>`. |
+| `Clear()` | Removes all keys and values. |
+
+## Where to go next
+
+- [Choosing a collection](choosing-a-collection.md) — the full decision guide.
+- [Multiset](multiset.md) — when you need value *counts* rather than value *lists*.
+- [Bodu.Collections.Generic API reference](xref:Bodu.Collections.Generic) — full namespace overview.

--- a/docs/guides/core/multiset.md
+++ b/docs/guides/core/multiset.md
@@ -1,0 +1,107 @@
+---
+title: Multiset
+---
+
+# Multiset
+
+<xref:Bodu.Collections.Generic.Multiset`1> (a *bag*) is a set that retains duplicates as **multiplicity** rather than discarding them. Adding an element that is already present increments its count instead of being rejected. It is the right tool for frequency counting, inventory-style tallies, and multiset algebra (sum, union, intersection, difference) where the number of copies matters.
+
+Equality is governed by an `IEqualityComparer<T>` supplied at construction, so counting can be case-insensitive or structural.
+
+## Pattern 1 — counting occurrences
+
+```csharp
+using Bodu.Collections.Generic;
+
+var words = new Multiset<string>();
+
+foreach (string token in "the cat sat on the mat".Split(' '))
+    words.Add(token);
+
+int the   = words.CountOf("the");   // 2
+int total = words.Count;            // 6 — includes multiplicity
+int kinds = words.DistinctCount;    // 5 — distinct elements only
+```
+
+`Count` reports the total number of elements including duplicates; `DistinctCount` reports the number of *distinct* elements.
+
+## Pattern 2 — adding and removing with explicit multiplicity
+
+```csharp
+var inventory = new Multiset<string>();
+
+inventory.Add("widget", count: 10);   // add ten at once
+inventory.Add("widget");              // now 11
+
+bool removedOne = inventory.Remove("widget");     // removes a single copy → 10
+bool removedAll = inventory.RemoveAll("widget");  // removes every copy → 0, returns true
+```
+
+`Remove` removes a single copy and returns `false` when the element is absent; `RemoveAll` removes every copy of the element at once.
+
+## Pattern 3 — enumerating distinct values and frequencies
+
+```csharp
+var bag = new Multiset<char> { 'a', 'a', 'b', 'c', 'c', 'c' };
+
+foreach (char distinct in bag.Distinct())
+    Console.WriteLine(distinct);                  // a, b, c
+
+foreach (KeyValuePair<char, int> freq in bag.Frequencies())
+    Console.WriteLine($"{freq.Key} × {freq.Value}");  // a × 2, b × 1, c × 3
+```
+
+Enumerating the multiset directly (`foreach (var item in bag)`) yields each element repeated according to its count.
+
+## Pattern 4 — multiset algebra
+
+Multiset operations combine counts rather than just membership. Each returns a new `Multiset<T>`:
+
+```csharp
+var a = new Multiset<int> { 1, 1, 2, 3 };
+var b = new Multiset<int> { 1, 2, 2, 4 };
+
+Multiset<int> sum       = a.Sum(b);       // counts added:   1×3, 2×3, 3×1, 4×1
+Multiset<int> union     = a.Union(b);     // counts max'd:    1×2, 2×2, 3×1, 4×1
+Multiset<int> intersect = a.Intersect(b); // counts min'd:    1×1, 2×1
+Multiset<int> except    = a.Except(b);    // counts subtracted: 1×1, 3×1
+```
+
+| Operation | Resulting count of each element |
+|---|---|
+| `Sum` | sum of the two counts |
+| `Union` | maximum of the two counts |
+| `Intersect` | minimum of the two counts |
+| `Except` | left count minus right count (floored at zero) |
+
+## Pattern 5 — case-insensitive counting
+
+```csharp
+var tally = new Multiset<string>(StringComparer.OrdinalIgnoreCase);
+tally.Add("Error");
+tally.Add("ERROR");
+int errors = tally.CountOf("error");   // 2
+```
+
+## API summary
+
+| Member | Description |
+|---|---|
+| `Add(T)` / `Add(T, int)` | Adds one, or a given count, of an element. |
+| `Remove(T)` | Removes a single copy; returns `false` if absent. |
+| `RemoveAll(T)` | Removes every copy of an element. |
+| `Contains(T)` | Whether the element is present at least once. |
+| `CountOf(T)` | The multiplicity of a specific element. |
+| `Count` | Total element count including duplicates. |
+| `DistinctCount` | Number of distinct elements. |
+| `Distinct()` | Enumerates the distinct elements. |
+| `Frequencies()` | Enumerates `(element, count)` pairs. |
+| `Sum` / `Union` / `Intersect` / `Except` | Multiset algebra returning a new `Multiset<T>`. |
+| `Comparer` | The active `IEqualityComparer<T>`. |
+| `Clear()` / `CopyTo(T[], int)` | Standard collection surface. |
+
+## Where to go next
+
+- [Indexed and ordered sets](ordered-sets.md) — when duplicates should be *rejected* rather than counted.
+- [Choosing a collection](choosing-a-collection.md) — the full decision guide.
+- [Bodu.Collections.Generic API reference](xref:Bodu.Collections.Generic) — full namespace overview.

--- a/docs/guides/core/ordered-sets.md
+++ b/docs/guides/core/ordered-sets.md
@@ -1,0 +1,143 @@
+---
+title: Indexed and ordered sets
+---
+
+# Indexed and ordered sets
+
+`Bodu.Collections.Generic` ships two insertion-ordered, uniqueness-enforcing sets built on the same open-addressing hash engine. They differ only in the surface they expose:
+
+- <xref:Bodu.Collections.Generic.IndexedSet`1> implements `IList<T>` — a list that silently refuses duplicates, with O(1) `Contains`, `IndexOf`, and indexed read **and write**.
+- <xref:Bodu.Collections.Generic.OrderedSet`1> implements `ISet<T>` — the full set-algebra surface (`UnionWith`, `IntersectWith`, …) while preserving insertion order and exposing position only as a read-only index.
+
+Both keep elements in the order they were first added, both reject `null` only when the element type and comparer reject it, and both compare with an `IEqualityComparer<T>` you can supply at construction.
+
+## When to reach for which
+
+| You need… | Reach for |
+|---|---|
+| A `List<T>` that also guarantees uniqueness and O(1) `Contains` | <xref:Bodu.Collections.Generic.IndexedSet`1> |
+| Positional insert / remove / move while staying unique | <xref:Bodu.Collections.Generic.IndexedSet`1> |
+| Set algebra (union / intersect / except) over an ordered set | <xref:Bodu.Collections.Generic.OrderedSet`1> |
+| Subset / superset / overlap relationship tests | <xref:Bodu.Collections.Generic.OrderedSet`1> |
+| An unordered unique set | <xref:System.Collections.Generic.HashSet`1> (BCL) |
+| A thread-safe unique set | <xref:Bodu.Collections.Generic.Concurrent.ConcurrentHashSet`1> |
+
+## IndexedSet&lt;T&gt; — a unique, indexable list
+
+### Pattern 1 — add, reject duplicates, look up by index
+
+```csharp
+using Bodu.Collections.Generic;
+
+var tags = new IndexedSet<string>();
+
+bool addedFirst  = tags.Add("alpha");   // true
+bool addedSecond = tags.Add("beta");    // true
+bool addedDup    = tags.Add("alpha");   // false — already present, order unchanged
+
+int index = tags.IndexOf("beta");       // 1, O(1)
+string at = tags[0];                    // "alpha", O(1)
+bool has  = tags.Contains("alpha");     // true, O(1)
+```
+
+`Add` returns `false` rather than throwing when the element is already present. To add several at once, `AddRange` returns the number of elements actually inserted (duplicates skipped):
+
+```csharp
+int inserted = tags.AddRange(new[] { "beta", "gamma", "delta" }); // 2 — "beta" skipped
+```
+
+### Pattern 2 — positional editing
+
+Because `IndexedSet<T>` is an `IList<T>`, it supports positional mutation. Inserting a value that already exists throws (use `TryInsert` for the non-throwing form), and the indexer setter replaces the element at a position:
+
+```csharp
+var order = new IndexedSet<string> { "first", "third" };
+
+order.Insert(1, "second");          // first, second, third
+bool ok = order.TryInsert(0, "second"); // false — "second" already present
+order.Move(2, 0);                   // third, first, second
+order[0] = "head";                  // replaces "third" at position 0
+order.RemoveAt(2);                  // removes "second"
+```
+
+### Pattern 3 — capacity management
+
+```csharp
+var set = new IndexedSet<int>(capacity: 1024);
+set.EnsureCapacity(4096);   // pre-grow before a known burst
+// … fill …
+set.TrimExcess();           // release unused slots
+```
+
+## OrderedSet&lt;T&gt; — an ordered set with full set algebra
+
+### Pattern 4 — set operations preserve insertion order
+
+```csharp
+using Bodu.Collections.Generic;
+
+var a = new OrderedSet<int> { 1, 2, 3, 4 };
+var b = new OrderedSet<int> { 3, 4, 5, 6 };
+
+a.UnionWith(b);             // 1, 2, 3, 4, 5, 6 (new members appended in b's order)
+a.IntersectWith(b);         // keeps only members also in b
+a.ExceptWith(b);            // removes members found in b
+a.SymmetricExceptWith(b);   // keeps members in exactly one set
+```
+
+### Pattern 5 — relationship tests
+
+```csharp
+var roles  = new OrderedSet<string> { "reader", "writer" };
+var grant  = new OrderedSet<string> { "reader", "writer", "admin" };
+
+bool subset   = roles.IsSubsetOf(grant);        // true
+bool proper   = roles.IsProperSubsetOf(grant);  // true
+bool superset = grant.IsSupersetOf(roles);      // true
+bool overlaps = roles.Overlaps(grant);          // true
+bool equal    = roles.SetEquals(grant);         // false
+```
+
+### Pattern 6 — read-only positional view
+
+`OrderedSet<T>` records insertion order and exposes it through a **read-only** indexer and `IndexOf`; unlike `IndexedSet<T>`, there is no indexer setter or positional `Insert`:
+
+```csharp
+var ordered = new OrderedSet<string> { "x", "y", "z" };
+int pos = ordered.IndexOf("y");   // 1
+string first = ordered[0];        // "x" — read only
+```
+
+## Custom equality
+
+Both types accept an `IEqualityComparer<T>` so uniqueness can be case-insensitive or structural:
+
+```csharp
+var ci = new IndexedSet<string>(StringComparer.OrdinalIgnoreCase);
+ci.Add("Alpha");
+bool dup = ci.Add("ALPHA");   // false — same key under the comparer
+```
+
+## API summary
+
+| Member | `IndexedSet<T>` | `OrderedSet<T>` | Description |
+|---|:--:|:--:|---|
+| `Add(T)` | ✓ | ✓ | Adds; returns `false` if already present. |
+| `AddRange(IEnumerable<T>)` | ✓ | ✓ | Adds many; returns the count actually inserted. |
+| `Contains(T)` | ✓ | ✓ | O(1) membership test. |
+| `IndexOf(T)` | ✓ | ✓ | O(1) position lookup. |
+| `this[int]` | get / set | get | Indexed access (set on `IndexedSet<T>` only). |
+| `Insert` / `TryInsert` / `Move` / `RemoveAt` | ✓ | — | Positional editing. |
+| `Remove(T)` | ✓ | ✓ | Removes by value. |
+| `UnionWith` / `IntersectWith` / `ExceptWith` / `SymmetricExceptWith` | — | ✓ | In-place set algebra. |
+| `IsSubsetOf` / `IsSupersetOf` / `IsProperSubsetOf` / `IsProperSupersetOf` / `Overlaps` / `SetEquals` | — | ✓ | Relationship tests. |
+| `Capacity` / `EnsureCapacity` / `TrimExcess` | ✓ | ✓ | Capacity management. |
+| `Comparer` | ✓ | ✓ | The active `IEqualityComparer<T>`. |
+| `CopyTo` / `ToArray` / `Clear` / `Count` | ✓ | ✓ | Standard collection surface. |
+
+## Where to go next
+
+- [Choosing a collection](choosing-a-collection.md) — the full decision guide.
+- [Multiset](multiset.md) — when duplicates should be *retained* as multiplicity rather than rejected.
+- [Concurrent collections](concurrent-collections.md) — `ConcurrentHashSet<T>` for thread-safe set membership.
+- [Bodu.Collections.Generic API reference](xref:Bodu.Collections.Generic) — full namespace overview.

--- a/docs/guides/core/segmented-buffer.md
+++ b/docs/guides/core/segmented-buffer.md
@@ -1,0 +1,81 @@
+---
+title: Segmented buffer
+---
+
+# Segmented buffer
+
+<xref:Bodu.Collections.Generic.SegmentedBuffer`1> is an append-only collection whose backing store grows in fixed-size **segments** instead of one contiguous array. When a `List<T>` fills up it allocates a new array of double the size and copies every existing element across; `SegmentedBuffer<T>` instead allocates one more segment and leaves the existing elements where they are. That avoids the array-doubling copy and the large-object-heap pressure that comes with very large contiguous buffers, while still offering O(1) indexed access.
+
+Reach for it when you are accumulating a stream of unknown length — caching enumerator results, buffering streamed data, or logging events without knowing the upper bound — and the per-doubling copy of `List<T>` would be costly.
+
+## Pattern 1 — append a stream of unknown length
+
+```csharp
+using Bodu.Collections.Generic;
+
+var buffer = new SegmentedBuffer<int>();   // default segment size
+
+foreach (int value in ReadFromNetwork())
+    buffer.Add(value);
+
+Console.WriteLine(buffer.Count);   // total elements appended
+```
+
+## Pattern 2 — choose a segment size
+
+The segment size is the number of elements per chunk. Pick a larger size for fewer, bigger allocations or a smaller size to bound the per-segment footprint:
+
+```csharp
+// 512 elements per segment.
+var buffer = new SegmentedBuffer<byte>(segmentSize: 512);
+```
+
+The constructor throws <xref:System.ArgumentOutOfRangeException> when `segmentSize` is less than 1.
+
+## Pattern 3 — O(1) indexed access
+
+Even though storage is segmented, element access is O(1): the buffer maps a flat index onto `(segment, offset)` arithmetically. The indexer supports both read and write of any already-populated position:
+
+```csharp
+var buffer = new SegmentedBuffer<string>(segmentSize: 4);
+buffer.Add("a");
+buffer.Add("b");
+
+string first = buffer[0];   // "a"
+buffer[1] = "B";            // overwrite in place
+```
+
+Indexing outside `[0, Count)` throws <xref:System.ArgumentOutOfRangeException> — the indexer never extends the buffer; use `Add` to append.
+
+## Pattern 4 — enumerate in order
+
+```csharp
+var buffer = new SegmentedBuffer<int> { };
+for (int i = 0; i < 1000; i++) buffer.Add(i);
+
+foreach (int value in buffer)
+    Process(value);   // yields elements in insertion order
+```
+
+## When *not* to use it
+
+- If you know the final length up front, a pre-sized `List<T>` or array is simpler and equally fast.
+- If you need removal, insertion at arbitrary positions, or set semantics, choose a different type — `SegmentedBuffer<T>` only appends and overwrites by index.
+- For `ArrayPool<T>`-backed building of a single contiguous result (for example, to hand a `byte[]` to an API), prefer <xref:Bodu.Buffers.PooledBufferBuilder`1>.
+
+## API summary
+
+| Member | Description |
+|---|---|
+| `SegmentedBuffer()` | Creates a buffer with the default segment size. |
+| `SegmentedBuffer(int segmentSize)` | Creates a buffer with the given elements-per-segment. |
+| `Add(T)` | Appends an element, allocating a new segment when the current one fills. |
+| `this[int]` | O(1) read / write of an element at an existing index. |
+| `Count` | The number of elements appended. |
+| `GetEnumerator()` | Enumerates elements in insertion order. |
+
+## Where to go next
+
+- [Choosing a collection](choosing-a-collection.md) — the full decision guide.
+- [Pooled buffer builder](pooled-buffer-builder.md) — `ArrayPool<T>`-backed building of a single contiguous result.
+- [Bodu.Collections.Generic API reference](xref:Bodu.Collections.Generic) — full namespace overview.

--- a/docs/guides/cryptography/aead-modes.md
+++ b/docs/guides/cryptography/aead-modes.md
@@ -251,4 +251,6 @@ On the wire, a failed tag check is indistinguishable from an attack; treat every
 
 - [Encryption basics](encryption-basics.md) — the Key / IV / Tweak / Padding lifecycle for the non-AEAD ciphers.
 - [Cipher block modes](cipher-modes.md) — the five classic non-authenticated modes (ECB / CBC / CFB / OFB / CTR).
+- [Stream ciphers § authenticated stream ciphers](stream-ciphers.md#authenticated-stream-ciphers--poly1305-aead) — the ready-made `XChaCha20Poly1305`, `XSalsa20Poly1305Aead`, and NaCl `secretbox` (`XSalsa20Poly1305`) constructions when you want AEAD over a stream cipher rather than AES.
+- [ASCON AEAD](ascon-aead.md) — lightweight authenticated encryption.
 - API reference: [<xref:Bodu.Security.Cryptography.AesBlockCipher>] · [<xref:Bodu.Security.Cryptography.IAeadBlockCipherModeTransform>] · [<xref:Bodu.Security.Cryptography.Extensions.AeadBlockCipherModeTransformExtensions>].

--- a/docs/guides/cryptography/stream-ciphers.md
+++ b/docs/guides/cryptography/stream-ciphers.md
@@ -115,6 +115,55 @@ Rabbit and HC-128 have no seekable counter — their keystream comes from an evo
 
 HC-128 has a comparatively expensive setup: it warms up two 512-word tables before releasing any keystream. Rabbit's key/IV setup is lighter but still non-trivial. As with Blowfish's key schedule, **do not** build a fresh instance per message under the same key — cache the instance and call `CreateEncryptor()` / `CreateDecryptor()` per message instead.
 
+## Authenticated stream ciphers — Poly1305 AEAD
+
+A raw stream cipher gives you confidentiality but **not** integrity. For authenticated encryption, the library pairs the extended-nonce stream ciphers with Poly1305 in three ready-made constructions. All three derive from the abstract <xref:Bodu.Security.Cryptography.Poly1305AeadTransform> base, take a 256-bit (32-byte) key and a 192-bit (24-byte) extended nonce, produce a 128-bit (16-byte) tag, and emit the wire format `ciphertext ‖ tag`.
+
+| Construction | Stream cipher | Associated data? | Wire / framing |
+|---|---|---|---|
+| <xref:Bodu.Security.Cryptography.XChaCha20Poly1305> | XChaCha20 | Yes | `ciphertext ‖ tag` (RFC 8439-style framing) |
+| <xref:Bodu.Security.Cryptography.XSalsa20Poly1305Aead> | XSalsa20 | Yes | `ciphertext ‖ tag` (RFC 8439-style framing) |
+| <xref:Bodu.Security.Cryptography.XSalsa20Poly1305> | XSalsa20 | **No** (NaCl `secretbox`) | `ciphertext ‖ tag`; libsodium layout via converters |
+
+Each instance is **single-use**: create a fresh instance for every message, because reusing a nonce under the same key destroys both confidentiality and authenticity.
+
+### XChaCha20-Poly1305 with associated data
+
+The span-based `Encrypt` / `Decrypt` on the base return the number of bytes written; the convenience `byte[]` overloads (from `Bodu.Security.Cryptography.Extensions`) allocate the result for you:
+
+```csharp
+using Bodu.Security.Cryptography;
+using Bodu.Security.Cryptography.Extensions;
+
+using var enc = new XChaCha20Poly1305(key, nonce);
+byte[] sealedMsg = enc.Encrypt(plaintext, associatedData: header);   // ciphertext || tag
+
+using var dec = new XChaCha20Poly1305(key, nonce);
+byte[] plain = dec.Decrypt(sealedMsg, associatedData: header);       // throws on tamper
+```
+
+Decryption verifies the tag (and the associated data) before returning; a modified ciphertext, tag, or header fails authentication and throws rather than returning altered plaintext.
+
+### NaCl `secretbox` — XSalsa20-Poly1305
+
+<xref:Bodu.Security.Cryptography.XSalsa20Poly1305> is the classic NaCl/libsodium `secretbox` construction. It does **not** accept associated data — passing any throws <xref:System.ArgumentException>. When you need associated data with XSalsa20, use `XSalsa20Poly1305Aead` instead:
+
+```csharp
+using var box = new XSalsa20Poly1305(key, nonce);
+byte[] sealedMsg = box.Encrypt(plaintext);   // ciphertext || tag, no associated data
+```
+
+This library emits `ciphertext ‖ tag`, whereas libsodium's combined `secretbox` places the tag first (`tag ‖ ciphertext`). Convert between the two layouts with the static helpers when interoperating:
+
+```csharp
+XSalsa20Poly1305.ToLibsodiumCombined(ciphertextThenTag, tagThenCiphertext);
+XSalsa20Poly1305.FromLibsodiumCombined(tagThenCiphertext, ciphertextThenTag);
+```
+
+### In-place operation
+
+The Poly1305 AEAD transforms support exact in-place use — the output span may begin at the same location as the input. Any other partial overlap is rejected with <xref:System.ArgumentException>.
+
 ## Where to go next
 
 - [Encryption basics](encryption-basics.md) — the Key/IV lifecycle shared with the block ciphers.

--- a/docs/guides/financial/dependency-injection.md
+++ b/docs/guides/financial/dependency-injection.md
@@ -1,0 +1,84 @@
+---
+title: Financial dependency injection
+---
+
+# Financial dependency injection
+
+The optional `Bodu.Financial.DependencyInjection` companion package wires the [`Bodu.Financial`](index.md) stack into a `Microsoft.Extensions.DependencyInjection` container. A single `AddBoduFinancial(...)` call registers the currency-lookup service and hands back a fluent <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder> on which you compose currency lookups, named monetary contexts, exchange-rate providers, and JSON converters.
+
+If you are constructing the financial types by hand — in a console app or a test — keep using the `Bodu.Financial` constructors directly; this page is only relevant when you want the host to compose the stack for you.
+
+## Install
+
+```bash
+dotnet add package Bodu.Financial.DependencyInjection
+```
+
+The package depends on `Bodu.Financial` and `Microsoft.Extensions.DependencyInjection.Abstractions`.
+
+## The registration surface
+
+The entry point is <xref:Bodu.Financial.DependencyInjection.ServiceCollectionExtensions>, with two `AddBoduFinancial` overloads. Both register the default <xref:Bodu.Financial.ICurrency> lookup and return an <xref:Bodu.Financial.DependencyInjection.IFinancialServiceBuilder>.
+
+| Method | Registers |
+|---|---|
+| `AddBoduFinancial(IServiceCollection, IConfiguration?, string sectionName = "Financial")` | The currency lookup, and binds <xref:Bodu.Financial.DependencyInjection.FinancialOptions> from the named configuration section. |
+| `AddBoduFinancial(IServiceCollection, Action<IFinancialServiceBuilder> configure)` | The same, with the builder configured imperatively by the delegate. |
+
+## Composing the builder
+
+The chainable methods on <xref:Bodu.Financial.DependencyInjection.FinancialServiceBuilderExtensions> add the rest of the stack:
+
+| Builder method | Effect |
+|---|---|
+| `AddCurrencyLookup<TLookup>()` | Replaces the default currency lookup with your `ICurrencyLookup` implementation. |
+| `AddMonetaryContext(string name, MonetaryContext context)` | Registers a named monetary context (rounding, minor units, formatting). |
+| `AddExchangeRateProvider<TProvider>()` / `AddExchangeRateProvider(provider)` | Registers a timeless <xref:Bodu.Financial.IExchangeRateProvider>, by type or by instance. |
+| `AddDatedExchangeRateProvider<TProvider>()` / `AddDatedExchangeRateProvider(provider)` | Registers a dated <xref:Bodu.Financial.IDatedExchangeRateProvider>. |
+| `AddFinancialJson(FinancialJsonPolicy policy = FinancialJsonPolicy.Strict)` | Registers the `System.Text.Json` converters under the chosen policy. |
+
+```csharp
+using Bodu.Financial.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+
+builder.Services.AddBoduFinancial(configure: financial =>
+{
+    financial
+        .AddFinancialJson(FinancialJsonPolicy.Strict)
+        .AddExchangeRateProvider<MyRateProvider>()
+        .AddDatedExchangeRateProvider<HistoricalRateProvider>();
+});
+```
+
+## Binding options from configuration
+
+Passing an `IConfiguration` binds <xref:Bodu.Financial.DependencyInjection.FinancialOptions> — `JsonPolicy` and `UnknownCurrency` — from the named section (default `"Financial"`):
+
+```jsonc
+// appsettings.json
+{
+  "Financial": {
+    "JsonPolicy": "Strict",
+    "UnknownCurrency": "Throw"
+  }
+}
+```
+
+```csharp
+builder.Services.AddBoduFinancial(builder.Configuration);
+```
+
+## Activating static currency resolution
+
+`Bodu.Financial` exposes a static currency-resolution surface used by parsing and formatting. After the container is built, call <xref:Bodu.Financial.DependencyInjection.ServiceProviderExtensions> `UseBoduFinancialCurrencyResolution` once so the resolved `ICurrencyLookup` backs that static surface:
+
+```csharp
+var app = builder.Build();
+app.Services.UseBoduFinancialCurrencyResolution();
+```
+
+## Where to go next
+
+- [Working with `Money<TCurrency>`](money.md) — the monetary type that the resolved services back.
+- [Working with exchange rates](exchange-rates.md) — the FX provider contracts you register above.
+- [Bodu.Financial.DependencyInjection API reference](xref:Bodu.Financial.DependencyInjection) — full namespace overview.

--- a/docs/guides/financial/index.md
+++ b/docs/guides/financial/index.md
@@ -63,6 +63,9 @@ hand off to `Fraction<BigInteger>` for exact-arithmetic chains via
   one fixed dataset run through every `ExchangeRateDateResolution`
   policy, tolerance window, and the inverse / identity switches, with a
   results matrix showing exactly how each option changes the answer.
+- [Dependency injection](dependency-injection.md) — register the
+  financial stack with `AddBoduFinancial(...)`: currency lookups,
+  monetary contexts, FX providers, JSON converters, and options binding.
 
 ## See also
 

--- a/docs/guides/io-hashing/string-hashes.md
+++ b/docs/guides/io-hashing/string-hashes.md
@@ -19,8 +19,9 @@ A collection of the classic "one-liner" hash functions that appear in textbooks,
 | <xref:Bodu.IO.Hashing.Elf64> | 64 bits | `Seed` (default `0`) | The ELF symbol-table hash, widened to 64 bits. |
 | <xref:Bodu.IO.Hashing.ApHash> | 32 bits | None (seed `0xAAAAAAAA`) | Arash Partow's hash. |
 | <xref:Bodu.IO.Hashing.Pjw32> | 32 bits | None | Peter Weinberger's PJW hash (AT&T compiler). |
+| <xref:Bodu.IO.Hashing.SuperFastHash> | 32 bits | None | Paul Hsieh's SuperFastHash; tuned for short keys. |
 
-All seven derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
+All eight derive from <xref:System.IO.Hashing.NonCryptographicHashAlgorithm?displayProperty=nameWithType>.
 
 ## Pattern 1 — a default-configured hash
 
@@ -109,6 +110,7 @@ hash.Reset();                              // back to the configured seed / init
 
 - **Hashing identifiers inside a compiler or symbol table?** `Pjw32` or `Elf64` — these are the functions you'll meet in the original source.
 - **Quick hash-table function in throwaway code?** `Bernstein` with `UseModifiedAlgorithm = true` is simple, well-known, and distributes reasonably.
+- **Hashing many short keys?** `SuperFastHash` is tuned for short inputs — but it buffers its input, so avoid it for very large streams (use a block-based fingerprint instead).
 - **Hashing user-controlled input?** None of these — reach for <xref:Bodu.Security.Cryptography.SipHash64>.
 - **Reproducing a known published digest from another tool?** Match on algorithm, width, seed, and (for Bernstein) the add-vs-XOR variant.
 

--- a/docs/guides/numerics/index.md
+++ b/docs/guides/numerics/index.md
@@ -37,6 +37,9 @@ that ship in .NET 8+.
   specifiers; what the parser accepts; culture and span surfaces.
 - [Working with `Interval<T>`](interval.md) — endpoint inclusivity,
   set operations, parsing and formatting.
+- [JSON serialization](json-serialization.md) — round-tripping
+  `Fraction<T>` and `Interval<T>` through `System.Text.Json` under the
+  strict, lenient, and compact policies.
 
 ## See also
 

--- a/docs/guides/numerics/json-serialization.md
+++ b/docs/guides/numerics/json-serialization.md
@@ -1,0 +1,64 @@
+---
+title: JSON serialization
+---
+
+# JSON serialization
+
+`Bodu.Numerics.Serialization` round-trips <xref:Bodu.Numerics.Fraction`1> and <xref:Bodu.Numerics.Interval`1> through `System.Text.Json`. Both value types ship with `[JsonConverter]` attributes, so they serialize correctly with the default options out of the box — you only need this namespace when you want to select a non-default wire shape across a whole `JsonSerializerOptions` instance.
+
+## Zero-configuration round-trip
+
+Because the converters are attached at the type level, no setup is required:
+
+```csharp
+using System.Text.Json;
+using Bodu.Numerics;
+
+string json = JsonSerializer.Serialize(Fraction<int>.Create(3, 4));
+Fraction<int> value = JsonSerializer.Deserialize<Fraction<int>>(json);
+```
+
+## Choosing a policy
+
+To change the wire shape, register the converters with a <xref:Bodu.Numerics.Serialization.NumericsJsonPolicy> via `AddNumericsJsonConverters`. A converter registered on `JsonSerializerOptions.Converters` takes precedence over the type-level attribute:
+
+```csharp
+using Bodu.Numerics.Serialization;
+
+var options = new JsonSerializerOptions()
+    .AddNumericsJsonConverters(NumericsJsonPolicy.Compact);
+```
+
+| Policy | `Fraction<T>` shape | `Interval<T>` shape | Use for |
+|---|---|---|---|
+| `Strict` (default) | object `{ "numerator": 3, "denominator": 4 }` | object `{ "lower", "upper", "lowerInclusive", "upperInclusive" }`, or `{ "empty": true }` | Canonical persistence and interchange. |
+| `Lenient` | as `Strict`, plus a top-level string is accepted on read | as `Strict`, plus `"min"`/`"max"` aliases and defaulted inclusivity | Spreadsheet / external-feed ingest. |
+| `Compact` | string `"3/4"` | ISO 31-11 bracket string `"[1, 5)"`, or `"∅"` for empty | Compact payloads where size matters. |
+
+Under `Strict` and `Lenient`, property names compare case-insensitively, duplicate properties are rejected, and unknown properties are ignored. `Lenient` is an *import* convenience — it is not a canonical storage shape; persist with `Strict` or `Compact`.
+
+## Worked example — each policy
+
+```csharp
+var frac = Fraction<int>.Create(8, 15);
+
+// Strict — object form
+// {"numerator":8,"denominator":15}
+
+// Compact — string form
+var compact = new JsonSerializerOptions().AddNumericsJsonConverters(NumericsJsonPolicy.Compact);
+string s = JsonSerializer.Serialize(frac, compact);   // "8/15"
+
+var window = Interval<int>.ClosedOpen(1, 5);
+string i = JsonSerializer.Serialize(window, compact);  // "[1, 5)"
+```
+
+## How the converters resolve the generic parameter
+
+`Fraction<T>` and `Interval<T>` are open generics, so the registered entries are *factories* (<xref:Bodu.Numerics.Serialization.FractionJsonConverterFactory>, <xref:Bodu.Numerics.Serialization.IntervalJsonConverterFactory>) that bind the concrete `T` per request and produce the matching <xref:Bodu.Numerics.Serialization.FractionJsonConverter`1> / <xref:Bodu.Numerics.Serialization.IntervalJsonConverter`1>. You never instantiate the closed converters directly — register the factory (or rely on the type-level attribute) and serialize as normal.
+
+## Where to go next
+
+- [Working with `Fraction<T>`](fraction.md) — the rational type being serialized.
+- [Working with `Interval<T>`](interval.md) — the interval type and its bracket notation.
+- [Bodu.Numerics.Serialization API reference](xref:Bodu.Numerics.Serialization) — full namespace overview.

--- a/docs/guides/text-encoding/base58.md
+++ b/docs/guides/text-encoding/base58.md
@@ -144,14 +144,40 @@ ReadOnlySpan<byte> hash160 = payload.AsSpan(1, 20);
 ReadOnlySpan<byte> checksum = payload.AsSpan(21, 4);
 ```
 
-(Verifying the checksum requires double-SHA256 on the version byte plus HASH160 — see the
-`Bodu.Security.Cryptography` package for the hashing primitives.)
+(The example above decodes the raw payload and leaves checksum verification to the caller. For checksum-protected
+payloads, prefer <xref:Bodu.Text.Encoding.Base58Check> below, which appends and verifies the 4-byte double-hash
+checksum for you.)
 
 ### Round-trip short ID
 
 ```csharp
 byte[] randomBytes = RandomNumberGenerator.GetBytes(8);
 string shortId = Base58.Encode(randomBytes);  // ≈ 11 characters, no ambiguity
+```
+
+## Base58Check — checksum-protected payloads
+
+<xref:Bodu.Text.Encoding.Base58Check> wraps Base58 with the Bitcoin-style 4-byte checksum: `Encode` appends a
+truncated double-hash of the payload, and `Decode` verifies it (throwing on a corrupted string) before returning the
+original bytes. This is the right entry point for address- and key-style payloads where a single mistyped character
+must be rejected rather than silently decoded.
+
+```csharp
+using Bodu.Text.Encoding;
+
+string encoded = Base58Check.Encode(payload);                 // payload + checksum, Base58
+byte[] decoded = Base58Check.Decode(encoded);                 // verifies, then strips the checksum
+
+bool valid = Base58Check.IsValid(encoded);                    // non-throwing validity probe
+```
+
+Like the core type, it offers a span path and explicit sizing, and accepts a `Base58Variant`
+(default `BitcoinFlickr`):
+
+```csharp
+Span<byte> destination = stackalloc byte[Base58Check.GetMaxDecodedLength(encoded.Length)];
+if (Base58Check.TryDecode(encoded, destination, out int written))
+    Use(destination[..written]);
 ```
 
 ## Where to go next

--- a/docs/guides/text-encoding/base64.md
+++ b/docs/guides/text-encoding/base64.md
@@ -84,6 +84,19 @@ byte[] headerBytes = Base64.Decode(
     BaseFormatStyles.AllowMissingPadding);
 ```
 
+### The dedicated `Base64Url` helper
+
+When URL-safe is *all* you need, <xref:Bodu.Text.Encoding.Base64Url> is a focused static class — RFC 4648 §5, unpadded — that skips the variant argument entirely. It offers `string`, span, and UTF-8 surfaces with `Encode` / `Decode` / `EncodeToUtf8` and `GetEncodedLength`:
+
+```csharp
+string token = Base64Url.Encode(payload);              // unpadded URL-safe
+byte[] back  = Base64Url.Decode(token);                // string or ReadOnlySpan<char>
+byte[] utf8  = Base64Url.EncodeToUtf8(payload);        // straight to UTF-8 bytes
+int   length = Base64Url.GetEncodedLength(payload.Length);
+```
+
+Reach for `Base64.Encode(..., Base64Variant.UrlSafe, ...)` when you need the full formatting-options surface (padding control, lenient styles); reach for `Base64Url` when you just want canonical unpadded URL-safe Base64.
+
 ## MIME line wrapping
 
 MIME mandates `\r\n` every 76 characters. The encoder honours this automatically when the variant is `Mime`:

--- a/docs/guides/text-encoding/encoding-helpers.md
+++ b/docs/guides/text-encoding/encoding-helpers.md
@@ -1,0 +1,110 @@
+---
+title: Encoding helpers and BOM detection
+---
+
+# Encoding helpers and BOM detection
+
+Alongside the binary encodings (Base16–Base85), `Bodu.Text.Encoding` ships a set of helpers for working with the BCL <xref:System.Text.Encoding> itself: zero-ceremony `string`↔`byte[]` conversion, allocation-conscious (pooled / owned-memory) surfaces, byte-order-mark (BOM / preamble) handling, UTF classification, fallback configuration, and chunked transcoding. These are the everyday utilities that make `System.Text.Encoding` pleasant to use without hand-rolling preamble logic or `ArrayPool<byte>` plumbing.
+
+Three types make up the surface:
+
+- <xref:Bodu.Text.Encoding.StringEncodingExtensions> — extension methods on `string`.
+- <xref:Bodu.Text.Encoding.EncodingExtensions> — extension methods on `System.Text.Encoding`.
+- <xref:Bodu.Text.Encoding.EncodingDetection> — static BOM-sniffing.
+
+## Converting strings to bytes
+
+`StringEncodingExtensions` removes the `encoding.GetBytes(...)` boilerplate and adds UTF-8 fast paths and preamble-aware variants:
+
+```csharp
+using Bodu.Text.Encoding;
+
+byte[] utf8        = "héllo".ToUtf8Bytes();                       // UTF-8, no BOM
+byte[] utf16       = "héllo".ToBytes(System.Text.Encoding.Unicode);
+byte[] withBom     = "héllo".ToBytesWithPreamble(System.Text.Encoding.Unicode); // BOM prepended
+
+int byteCount      = "héllo".GetUtf8ByteCount();                  // size without allocating
+```
+
+For hot paths, encode straight into a caller-supplied span or an `IBufferWriter<byte>`, or rent the buffer from the pool:
+
+```csharp
+Span<byte> destination = stackalloc byte[64];
+int written = "héllo".EncodeUtf8To(destination);
+
+if ("héllo".TryEncodeUtf8To(destination, out int n)) { /* … */ }
+
+"héllo".WriteUtf8To(bufferWriter);                    // append to a pipeline
+
+using PooledBufferBuilder<byte> pooled = "héllo".GetUtf8BytesPooled();   // ArrayPool-backed
+```
+
+## Byte-order marks (preambles)
+
+`EncodingExtensions` centralizes BOM handling so you never slice preamble bytes by hand:
+
+```csharp
+System.Text.Encoding enc = System.Text.Encoding.UTF8;
+
+bool hasBom   = enc.HasPreamble();
+bool startsBom = enc.StartsWithPreamble(bytes);
+ReadOnlySpan<byte> body = enc.StripPreamble(bytes);          // bytes minus any leading BOM
+string text   = enc.GetStringSkippingPreamble(bytes);        // decode, ignoring a leading BOM
+```
+
+To detect the encoding *from* the bytes, use <xref:Bodu.Text.Encoding.EncodingDetection>:
+
+```csharp
+System.Text.Encoding chosen =
+    EncodingDetection.TryDetectByPreamble(bytes, out System.Text.Encoding? detected)
+        ? detected
+        : System.Text.Encoding.UTF8;     // sensible default when there is no BOM
+```
+
+## Classifying an encoding
+
+```csharp
+enc.IsUtf8();                 // true
+enc.IsAscii();
+enc.IsAnyUtf();               // UTF-8 / UTF-16 / UTF-32, either endianness
+enc.IsUtf16LittleEndian();
+enc.IsUtf32BigEndian();
+```
+
+## Fallback configuration
+
+Switch an encoding between *throwing* on invalid data and *replacing* it, without mutating a shared instance:
+
+```csharp
+System.Text.Encoding strict  = System.Text.Encoding.UTF8.WithExceptionFallbacks();   // throws on malformed input
+System.Text.Encoding lenient = System.Text.Encoding.UTF8.WithReplacementFallbacks(); // substitutes U+FFFD
+```
+
+## Allocation-conscious transcoding
+
+For large or streamed payloads, the owned-memory and chunked surfaces avoid intermediate arrays:
+
+```csharp
+using IMemoryOwner<byte> owner = enc.GetBytesOwner(chars);    // caller disposes
+using PooledBufferBuilder<char> chars = enc.GetCharsPooled(bytes);
+
+// Incremental transcoding with explicit backpressure.
+OperationStatus status = enc.EncodeChunk(charSpan, byteDestination, isFinal: true,
+                                         out int charsRead, out int bytesWritten);
+```
+
+`EncodeChunk` / `DecodeChunk` return an <xref:System.Buffers.OperationStatus> (`Done`, `DestinationTooSmall`, `NeedMoreData`, `InvalidData`) so a caller can drive a pull-based loop and grow the destination as needed.
+
+## API summary
+
+| Type | Highlights |
+|---|---|
+| <xref:Bodu.Text.Encoding.StringEncodingExtensions> | `ToUtf8Bytes` / `ToBytes` / `ToBytesWithPreamble`, `EncodeUtf8To` / `TryEncodeUtf8To`, `WriteUtf8To`, `GetUtf8ByteCount`, pooled variants. |
+| <xref:Bodu.Text.Encoding.EncodingExtensions> | `HasPreamble` / `StripPreamble` / `StartsWithPreamble` / `GetStringSkippingPreamble`, `IsUtf8` / `IsAscii` / `IsAnyUtf` / endianness checks, `WithExceptionFallbacks` / `WithReplacementFallbacks`, owned / pooled buffers, `EncodeChunk` / `DecodeChunk`. |
+| <xref:Bodu.Text.Encoding.EncodingDetection> | `TryDetectByPreamble` — identify an encoding from a leading BOM. |
+
+## Where to go next
+
+- [The IBinaryEncoding interface](binary-encodings-interface.md) — the binary-encoding contract (Base16–Base85).
+- [Bodu.Text.Encoding overview](index.md) — the full namespace map.
+- [Bodu.Text.Encoding API reference](xref:Bodu.Text.Encoding) — full namespace overview.

--- a/docs/guides/text-encoding/index.md
+++ b/docs/guides/text-encoding/index.md
@@ -66,3 +66,4 @@ guides drill into the variant-specific options:
 - **[Base58 guide](base58.md)** — leading zeros, big-integer encoding; Bitcoin/IPFS.
 - **[Base85 guide](base85.md)** — Ascii85 vs Z85; the `z` shortcut; partial-group rules.
 - **[`IBinaryEncoding` interface](binary-encodings-interface.md)** — runtime-selected encoding pattern.
+- **[Encoding helpers and BOM detection](encoding-helpers.md)** — `System.Text.Encoding` helpers: `string`↔`byte[]` conversion, preamble/BOM handling, UTF classification, fallbacks, and chunked transcoding.

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -56,6 +56,8 @@
       href: financial/exchange-types.md
     - name: Exchange-rate lookups (worked dataset)
       href: financial/exchange-rate-lookups.md
+    - name: Dependency injection
+      href: financial/dependency-injection.md
 - name: Bodu.Globalization.Calendar
   items:
     - name: Overview
@@ -162,6 +164,8 @@
       href: numerics/formatting-and-parsing.md
     - name: Working with Interval<T>
       href: numerics/interval.md
+    - name: JSON serialization
+      href: numerics/json-serialization.md
 - name: Bodu.Security.Cryptography
   items:
     - name: Overview

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -16,6 +16,14 @@
           href: core/evicting-dictionary.md
         - name: Indexed priority queue
           href: core/indexed-priority-queue.md
+        - name: Indexed and ordered sets
+          href: core/ordered-sets.md
+        - name: Multiset
+          href: core/multiset.md
+        - name: Multi-value dictionary
+          href: core/multi-value-dictionary.md
+        - name: Segmented buffer
+          href: core/segmented-buffer.md
         - name: Range-keyed lookups
           href: core/range-dictionary.md
     - name: Bodu.Collections.Generic.Concurrent

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -270,6 +270,8 @@
       items:
         - name: The IBinaryEncoding interface
           href: text-encoding/binary-encodings-interface.md
+        - name: Encoding helpers and BOM detection
+          href: text-encoding/encoding-helpers.md
 - name: Bodu.Text.Formats
   items:
     - name: Overview


### PR DESCRIPTION
Fix the docfx build break: check-digit types (Iban, Lei, Isbn10/13,
Cusip, Sedol, Iso7064*, CheckDigit*Alphabet, ...) were cross-referenced
under Bodu.IO.Hashing.Checksums but live in Bodu.IO.Hashing.CheckDigits.
Corrects 16 invalid <xref> uids across the io-hashing intro pages and the
CheckDigits/IO.Hashing apidoc overviews; genuine Checksums.Adler/Fletcher
references are left intact.

Add dedicated guides for the Core collections that previously had only
API-reference coverage: IndexedSet/OrderedSet, Multiset, MultiValueDictionary,
and SegmentedBuffer. Wire them into the guides TOC, the core guides index
(namespace map + cards), and the Bodu.Collections.Generic apidoc overview.