### PR TITLE
Add XML documentation to private methods and internal helpers

### DIFF
--- a/Bodu.Core/src/Buffers/PooledBufferBuilder.cs
+++ b/Bodu.Core/src/Buffers/PooledBufferBuilder.cs
@@ -546,6 +546,11 @@ public sealed class PooledBufferBuilder<T> :
         GrowIfNeeded(minimum);
     }
 
+    /// <summary>
+    /// Ensures the internal buffer can accommodate at least <paramref name="minimum" /> elements, renting a larger
+    /// pooled array and copying the existing contents forward when the current capacity is insufficient.
+    /// </summary>
+    /// <param name="minimum">The minimum total capacity, in elements, the buffer must be able to hold.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void GrowIfNeeded(int minimum)
     {

--- a/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.IndexOf.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.IndexOf.cs
@@ -99,6 +99,16 @@ public static partial class IListExtensions
                 : IndexOfCore(list, predicate, index, count);
     }
 
+    /// <summary>
+    /// Performs the forward scan for the public <c>IndexOf</c> overload once the arguments have been validated,
+    /// returning the position of the first element that satisfies the predicate within the requested range.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in <paramref name="list" />.</typeparam>
+    /// <param name="list">The list to scan.</param>
+    /// <param name="predicate">The condition each element is tested against.</param>
+    /// <param name="index">The zero-based index at which the scan starts.</param>
+    /// <param name="count">The number of elements to examine.</param>
+    /// <returns>The zero-based index of the first matching element; otherwise, <c>-1</c>.</returns>
     private static int IndexOfCore<TSource>(IList<TSource> list, Func<TSource, bool> predicate, int index, int count)
     {
         var end = index + count;

--- a/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.LastIndexOf.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.LastIndexOf.cs
@@ -102,6 +102,16 @@ public static partial class IListExtensions
             : LastIndexOfCore(list, predicate, startIndex, count);
     }
 
+    /// <summary>
+    /// Validates the start index supplied to the backward-search overloads, honoring the convention that a start
+    /// index of <c>-1</c> is the only value permitted for an empty list.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in <paramref name="list" />.</typeparam>
+    /// <param name="list">The list whose size bounds the valid start index.</param>
+    /// <param name="startIndex">The zero-based index at which a backward search would begin.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="startIndex" /> falls outside the valid range for the current list size.
+    /// </exception>
     private static void ValidateLastIndexOfStart<TSource>(IList<TSource> list, int startIndex)
     {
         if (list.Count == 0)
@@ -114,6 +124,16 @@ public static partial class IListExtensions
         }
     }
 
+    /// <summary>
+    /// Performs the backward scan for the public <c>LastIndexOf</c> overload once the arguments have been validated,
+    /// returning the position of the last element that satisfies the predicate within the requested range.
+    /// </summary>
+    /// <typeparam name="TSource">The type of the elements in <paramref name="list" />.</typeparam>
+    /// <param name="list">The list to scan.</param>
+    /// <param name="predicate">The condition each element is tested against.</param>
+    /// <param name="startIndex">The zero-based index at which the scan starts.</param>
+    /// <param name="count">The number of elements to examine.</param>
+    /// <returns>The zero-based index of the last matching element; otherwise, <c>-1</c>.</returns>
     private static int LastIndexOfCore<TSource>(IList<TSource> list, Func<TSource, bool> predicate, int startIndex, int count)
     {
         var end = startIndex - count;

--- a/Bodu.Core/src/WeekPattern.Functions.cs
+++ b/Bodu.Core/src/WeekPattern.Functions.cs
@@ -120,6 +120,11 @@ public partial struct WeekPattern
     /// Parses the format string for use in <see cref="ParseExact" /> or <see cref="TryParseExact" />, throwing
     /// <see cref="FormatException" /> if the format is unrecognized or <see langword="null" />.
     /// </summary>
+    /// <param name="format">The format string to interpret.</param>
+    /// <returns>
+    /// A tuple describing the parsed format: the start-of-week day, the unselected-day placeholder character, and
+    /// whether binary output is requested.
+    /// </returns>
     private static (char? startDay, char? unselectedChar, bool isBinary) ParseFormatForParse(string format)
     {
         ThrowHelper.ThrowIfNull(format);
@@ -132,6 +137,11 @@ public partial struct WeekPattern
     /// Parses the format string for use in <see cref="ToString(string, IFormatProvider)" />, throwing
     /// <see cref="ArgumentException" /> if the format is unrecognized.
     /// </summary>
+    /// <param name="format">The format string to interpret; <see langword="null" /> selects the default.</param>
+    /// <returns>
+    /// A tuple describing the parsed format: the start-of-week day, the unselected-day placeholder character, and
+    /// whether binary output is requested.
+    /// </returns>
     private static (char? startDay, char? unselectedChar, bool isBinary) ParseFormatForToString(string? format)
     {
         format ??= "S";

--- a/Bodu.Core/src/WeekPattern.cs
+++ b/Bodu.Core/src/WeekPattern.cs
@@ -120,6 +120,13 @@ public readonly partial struct WeekPattern : IEnumerable<DayOfWeek>
         : this(Parse(input))
     { }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="WeekPattern" /> struct from a raw day bitmask.
+    /// </summary>
+    /// <param name="value">The day bitmask, where each of the seven low-order bits selects a day of the week.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="value" /> is less than <see cref="MinValue" /> or greater than <see cref="MaxValue" />.
+    /// </exception>
     private WeekPattern(int value)
     {
         ThrowHelper.ThrowIfOutOfRange(value, MinValue, MaxValue);

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Alphanumeric.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Alphanumeric.cs
@@ -145,6 +145,14 @@ internal static class Alphanumeric
         }
     }
 
+    /// <summary>
+    /// Builds the culture-aware error message describing a character that is not valid for a given check-digit
+    /// character set.
+    /// </summary>
+    /// <param name="ch">The offending character.</param>
+    /// <param name="characterSetName">The display name of the character set that rejected the character.</param>
+    /// <param name="validCharacterDescription">A human-readable description of the characters the set permits.</param>
+    /// <returns>The formatted error message.</returns>
     private static string FormatInvalidCharacterMessage(
         char ch,
         string characterSetName,

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iban.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iban.cs
@@ -189,9 +189,26 @@ public sealed class Iban
         _rBban = 0;
     }
 
+    /// <summary>
+    /// Folds a single character into the running ISO 7064 mod-97 remainder, contributing a digit as its value and
+    /// a letter <c>A</c>–<c>Z</c> as the two-digit value <c>10</c>–<c>35</c>.
+    /// </summary>
+    /// <param name="r">The current mod-97 remainder.</param>
+    /// <param name="ch">The character to fold in.</param>
+    /// <returns>The updated mod-97 remainder.</returns>
     private static int FoldChar(int r, char ch) =>
         (uint)(ch - '0') > 9u ? ((r * 100) + ch - 'A' + 10) % 97 : ((r * 10) + (ch - '0')) % 97;
 
+    /// <summary>
+    /// Attempts to fold a single character into the running ISO 7064 mod-97 remainder, accepting digits and the
+    /// letters <c>A</c>–<c>Z</c>.
+    /// </summary>
+    /// <param name="r">The current mod-97 remainder, updated in place when the character is accepted.</param>
+    /// <param name="ch">The character to fold in.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="ch" /> is a valid alphanumeric character and was folded into
+    /// <paramref name="r" />; otherwise, <see langword="false" />.
+    /// </returns>
     private static bool TryFold(ref int r, char ch)
     {
         if ((uint)(ch - '0') <= 9u)

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
@@ -155,6 +155,12 @@ public sealed partial class CrcStandard
         XOrOut = xOrOut;
     }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CrcStandard" /> class from serialized parameter values.
+    /// </summary>
+    /// <param name="info">The store from which the CRC parameters are read.</param>
+    /// <param name="context">The streaming context describing the source of the deserialization.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="info" /> is <see langword="null" />.</exception>
     private CrcStandard(SerializationInfo info, StreamingContext context)
     {
         ThrowHelper.ThrowIfNull(info);

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
@@ -145,6 +145,12 @@ public abstract class Fletcher<TSelf>
     /// <inheritdoc />
     protected override bool ShouldPadFinalBlock() => false;
 
+    /// <summary>
+    /// Writes the least-significant bytes of <paramref name="value" /> into <paramref name="destination" /> in
+    /// big-endian order, emitting exactly as many bytes as the span can hold.
+    /// </summary>
+    /// <param name="value">The value whose low-order bytes are written.</param>
+    /// <param name="destination">The span that receives the big-endian bytes.</param>
     private static void WriteBigEndian(ulong value, Span<byte> destination)
     {
         for (var i = 0; i < destination.Length; i++)

--- a/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
@@ -144,6 +144,11 @@ public sealed class BKDR
     protected override void GetCurrentHashCore(Span<byte> destination) =>
         BinaryPrimitives.WriteUInt32BigEndian(destination, _workingHash);
 
+    /// <summary>
+    /// Validates that the supplied seed is one of the BKDR multipliers supported by this implementation.
+    /// </summary>
+    /// <param name="value">The seed multiplier to validate.</param>
+    /// <exception cref="ArgumentException"><paramref name="value" /> is not a supported BKDR seed.</exception>
     private static void ValidateSeed(uint value)
     {
         if (Array.IndexOf(s_validSeedValues, value) == -1)

--- a/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
@@ -164,6 +164,11 @@ public sealed class Bernstein
     protected override void GetCurrentHashCore(Span<byte> destination) =>
         BinaryPrimitives.WriteUInt32BigEndian(destination, _workingHash);
 
+    /// <summary>
+    /// Folds the supplied bytes into the running hash using the modified Bernstein recurrence
+    /// (<c>hash = hash * 33 ^ b</c>).
+    /// </summary>
+    /// <param name="source">The bytes to incorporate into the hash.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AppendModified(ReadOnlySpan<byte> source)
     {
@@ -176,6 +181,11 @@ public sealed class Bernstein
         _workingHash = v;
     }
 
+    /// <summary>
+    /// Folds the supplied bytes into the running hash using the original Bernstein recurrence
+    /// (<c>hash = hash * 33 + b</c>).
+    /// </summary>
+    /// <param name="source">The bytes to incorporate into the hash.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AppendOriginal(ReadOnlySpan<byte> source)
     {
@@ -188,6 +198,13 @@ public sealed class Bernstein
         _workingHash = v;
     }
 
+    /// <summary>
+    /// Throws a <see cref="CryptographicUnexpectedOperationException" /> if the algorithm has already begun
+    /// consuming input, guarding configuration that may only change before hashing starts.
+    /// </summary>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// The algorithm has already started consuming input.
+    /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfInvalidState() =>
         HashingThrowHelper.ThrowIfAlgorithmAlreadyStarted(_started);

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.32.cs
@@ -251,6 +251,12 @@ public sealed class CityHash32
         return Mix(Mur(c, Mur(b, Mur(a, d))));
     }
 
+    /// <summary>
+    /// Applies the CityHash 32-bit avalanche step to <paramref name="value" />: multiply by <c>C1</c>, rotate the
+    /// result right by 17 bits, then multiply by <c>C2</c>.
+    /// </summary>
+    /// <param name="value">The value to mix.</param>
+    /// <returns>The mixed value.</returns>
     private static uint RotateMix32(uint value)
     {
         unchecked

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
@@ -388,6 +388,14 @@ public abstract class CityHash<T>
         digest.AsSpan(0, HashLengthInBytes).CopyTo(destination);
     }
 
+    /// <summary>
+    /// Validates that <paramref name="hashSize" /> is one of the hash sizes this algorithm supports.
+    /// </summary>
+    /// <param name="hashSize">The requested hash size, in bits.</param>
+    /// <returns>The validated <paramref name="hashSize" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="hashSize" /> is not one of the supported hash sizes.
+    /// </exception>
     private static int ValidateHashSize(int hashSize)
     {
         HashingThrowHelper.ThrowIfInvalidHashSize(hashSize, s_validHashSizes);

--- a/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Elf64.cs
@@ -130,6 +130,13 @@ public sealed class Elf64
     protected override void GetCurrentHashCore(Span<byte> destination) =>
         BinaryPrimitives.WriteUInt64BigEndian(destination, _workingHash);
 
+    /// <summary>
+    /// Throws a <see cref="CryptographicUnexpectedOperationException" /> if the algorithm has already begun
+    /// consuming input, guarding configuration that may only change before hashing starts.
+    /// </summary>
+    /// <exception cref="CryptographicUnexpectedOperationException">
+    /// The algorithm has already started consuming input.
+    /// </exception>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void ThrowIfInvalidState() =>
         HashingThrowHelper.ThrowIfAlgorithmAlreadyStarted(_started);

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
@@ -141,6 +141,14 @@ public abstract class Fnv<TSelf>
         }
     }
 
+    /// <summary>
+    /// Validates that <paramref name="hashSize" /> is one of the FNV hash sizes this implementation supports.
+    /// </summary>
+    /// <param name="hashSize">The requested hash size, in bits.</param>
+    /// <returns>The validated <paramref name="hashSize" />.</returns>
+    /// <exception cref="ArgumentException">
+    /// <paramref name="hashSize" /> is not one of the supported hash sizes.
+    /// </exception>
     private static int ValidateHashSize(int hashSize)
     {
         if (Array.IndexOf(s_validHashSizes, hashSize) == -1)
@@ -157,6 +165,11 @@ public abstract class Fnv<TSelf>
         return hashSize;
     }
 
+    /// <summary>
+    /// Folds the supplied bytes into the running hash using the FNV-1 ordering: multiply by the prime, then XOR
+    /// the byte.
+    /// </summary>
+    /// <param name="source">The bytes to incorporate into the hash.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AppendFnv1(ReadOnlySpan<byte> source)
     {
@@ -171,6 +184,11 @@ public abstract class Fnv<TSelf>
         _workingHash = hash;
     }
 
+    /// <summary>
+    /// Folds the supplied bytes into the running hash using the FNV-1a ordering: XOR the byte, then multiply by
+    /// the prime.
+    /// </summary>
+    /// <param name="source">The bytes to incorporate into the hash.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void AppendFnv1a(ReadOnlySpan<byte> source)
     {

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
@@ -200,6 +200,14 @@ public abstract class MurmurHash3<T>
         digest.AsSpan(0, HashLengthInBytes).CopyTo(destination);
     }
 
+    /// <summary>
+    /// Validates that <paramref name="hashSize" /> is one of the hash sizes this algorithm supports.
+    /// </summary>
+    /// <param name="hashSize">The requested hash size, in bits.</param>
+    /// <returns>The validated <paramref name="hashSize" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="hashSize" /> is not one of the supported hash sizes.
+    /// </exception>
     private static int ValidateHashSize(int hashSize)
     {
         HashingThrowHelper.ThrowIfInvalidHashSize(hashSize, s_validHashSizes);

--- a/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Pearson.cs
@@ -227,6 +227,14 @@ public sealed partial class Pearson
     protected override void GetCurrentHashCore(Span<byte> destination) =>
         _workingHash.AsSpan().CopyTo(destination);
 
+    /// <summary>
+    /// Returns a fresh copy of the 256-byte permutation table associated with the specified Pearson table type.
+    /// </summary>
+    /// <param name="type">The permutation table to retrieve.</param>
+    /// <returns>A new array containing the selected permutation table.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="type" /> is not a defined <see cref="PearsonTableType" /> value.
+    /// </exception>
     private static byte[] GetPermutationTable(PearsonTableType type) => type switch
     {
         PearsonTableType.Pearson => (byte[])s_pearsonTable.Value.Clone(),
@@ -239,6 +247,15 @@ public sealed partial class Pearson
 
     };
 
+    /// <summary>
+    /// Validates that <paramref name="hashSizeBits" /> is within the supported range and a positive multiple of
+    /// eight.
+    /// </summary>
+    /// <param name="hashSizeBits">The requested hash size, in bits.</param>
+    /// <returns>The validated <paramref name="hashSizeBits" />.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// <paramref name="hashSizeBits" /> is outside the supported range or is not a positive multiple of eight.
+    /// </exception>
     private static int ValidateHashSize(int hashSizeBits)
     {
         ThrowHelper.ThrowIfOutOfRange(hashSizeBits, MinHashSizeBits, MaxHashSizeBits);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Argon2.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Argon2.cs
@@ -223,6 +223,9 @@ public abstract class Argon2
     /// <summary>
     /// Parses an Argon2 PHC encoded-hash string into its constituent fields.
     /// </summary>
+    /// <param name="encoded">The Argon2 PHC encoded-hash string to parse.</param>
+    /// <returns>The fields parsed from <paramref name="encoded" />.</returns>
+    /// <exception cref="FormatException"><paramref name="encoded" /> is not a valid Argon2 PHC string.</exception>
     private static Argon2EncodedHash Decode(string encoded)
     {
         var fields = PhcString.SplitFields(encoded);
@@ -254,6 +257,11 @@ public abstract class Argon2
     /// <summary>
     /// Formats an Argon2 PHC encoded-hash string.
     /// </summary>
+    /// <param name="type">The Argon2 variant.</param>
+    /// <param name="p">The Argon2 parameters to encode.</param>
+    /// <param name="salt">The salt bytes.</param>
+    /// <param name="hash">The derived hash (tag) bytes.</param>
+    /// <returns>The Argon2 PHC encoded-hash string.</returns>
     private static string Encode(Argon2Type type, Argon2Parameters p, ReadOnlySpan<byte> salt, ReadOnlySpan<byte> hash)
     {
         var sb = new StringBuilder();
@@ -274,6 +282,11 @@ public abstract class Argon2
     /// <summary>
     /// Parses the comma-separated cost-parameter field (<c>m=..,t=..,p=..[,data=..]</c>).
     /// </summary>
+    /// <param name="field">The comma-separated cost-parameter field.</param>
+    /// <returns>The decoded memory, iterations, parallelism, and optional associated data.</returns>
+    /// <exception cref="FormatException">
+    /// <paramref name="field" /> is malformed or omits a required parameter.
+    /// </exception>
     private static (int Memory, int Iterations, int Parallelism, byte[] Data) ParseCostFields(string field)
     {
         int? memory = null, iterations = null, parallelism = null;
@@ -307,6 +320,8 @@ public abstract class Argon2
     /// <summary>
     /// Parses a non-negative decimal integer, throwing a <see cref="FormatException" /> on failure.
     /// </summary>
+    /// <param name="value">The text to parse.</param>
+    /// <returns>The parsed non-negative integer.</returns>
     private static int ParseInt(string value) =>
         int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var result)
             ? result
@@ -315,6 +330,8 @@ public abstract class Argon2
     /// <summary>
     /// Parses a PHC type name into a variant, throwing a <see cref="FormatException" /> on an unknown name.
     /// </summary>
+    /// <param name="name">The PHC type name (for example, <c>argon2id</c>).</param>
+    /// <returns>The matching <see cref="Argon2Type" />.</returns>
     private static Argon2Type ParseTypeName(string name) => name switch
     {
         "argon2d" => Argon2Type.Argon2d,
@@ -326,6 +343,8 @@ public abstract class Argon2
     /// <summary>
     /// Throws an <see cref="ArgumentException" /> if the salt is shorter than the minimum length.
     /// </summary>
+    /// <param name="salt">The salt whose length is validated.</param>
+    /// <exception cref="ArgumentException"><paramref name="salt" /> is shorter than the minimum length.</exception>
     private static void ThrowIfSaltTooShort(ReadOnlySpan<byte> salt)
     {
         if (salt.Length < MinSaltLength)
@@ -337,6 +356,8 @@ public abstract class Argon2
     /// <summary>
     /// Returns the PHC type name for a variant.
     /// </summary>
+    /// <param name="type">The Argon2 variant.</param>
+    /// <returns>The PHC type name for <paramref name="type" />.</returns>
     private static string TypeName(Argon2Type type) => type switch
     {
         Argon2Type.Argon2d => "argon2d",

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Argon2Core.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Argon2Core.cs
@@ -86,6 +86,11 @@ internal static class Argon2Core
     /// <summary>
     /// Computes the 64-byte pre-hashing digest <c>H0</c> (RFC 9106, Figure 1).
     /// </summary>
+    /// <param name="type">The Argon2 variant being computed.</param>
+    /// <param name="p">The Argon2 parameters describing cost and auxiliary inputs.</param>
+    /// <param name="password">The password bytes.</param>
+    /// <param name="salt">The salt bytes.</param>
+    /// <param name="h0">The destination span that receives the 64-byte <c>H0</c> digest.</param>
     private static void ComputeH0(
         Argon2Type type,
         Argon2Parameters p,
@@ -126,6 +131,10 @@ internal static class Argon2Core
     /// Fills the first two columns of every lane from <c>H0</c> via the variable-length hash <c>H'</c> (RFC 9106,
     /// Figures 3 and 4).
     /// </summary>
+    /// <param name="memory">The full memory matrix, as a flat array of 64-bit words.</param>
+    /// <param name="h0">The 64-byte pre-hashing digest <c>H0</c>.</param>
+    /// <param name="lanes">The number of parallel lanes.</param>
+    /// <param name="laneLength">The number of blocks in each lane.</param>
     private static void InitializeBlocks(ulong[] memory, ReadOnlySpan<byte> h0, int lanes, int laneLength)
     {
         Span<byte> input = stackalloc byte[Argon2Blake2b.MaxDigestBytes + 8];
@@ -149,6 +158,15 @@ internal static class Argon2Core
     /// <summary>
     /// Computes one segment (the intersection of a lane and a slice) of the memory matrix.
     /// </summary>
+    /// <param name="type">The Argon2 variant, which selects data-dependent or data-independent indexing.</param>
+    /// <param name="parameters">The Argon2 parameters describing cost and version.</param>
+    /// <param name="memory">The full memory matrix, as a flat array of 64-bit words.</param>
+    /// <param name="pass">The zero-based pass (iteration) index.</param>
+    /// <param name="slice">The zero-based slice index within the pass.</param>
+    /// <param name="lane">The zero-based lane index being filled.</param>
+    /// <param name="lanes">The total number of lanes.</param>
+    /// <param name="laneLength">The number of blocks in each lane.</param>
+    /// <param name="segmentLength">The number of blocks in each segment.</param>
     private static void FillSegment(
         Argon2Type type,
         Argon2Parameters parameters,
@@ -224,6 +242,9 @@ internal static class Argon2Core
     /// <summary>
     /// Regenerates the Argon2i address block: <c>address = G(ZERO, G(ZERO, input))</c> (RFC 9106, Section 3.4.1.2).
     /// </summary>
+    /// <param name="addressBlock">The block that receives the regenerated pseudo-random addresses.</param>
+    /// <param name="inputBlock">The counter input block; its counter word is incremented in place.</param>
+    /// <param name="zeroBlock">A block of zero words used as the first compression operand.</param>
     private static void NextAddresses(Span<ulong> addressBlock, Span<ulong> inputBlock, ReadOnlySpan<ulong> zeroBlock)
     {
         inputBlock[6]++;
@@ -234,6 +255,14 @@ internal static class Argon2Core
     /// <summary>
     /// Maps the pseudo-random value to a reference-block column within the same lane (RFC 9106, Section 3.4.2).
     /// </summary>
+    /// <param name="pass">The zero-based pass index.</param>
+    /// <param name="slice">The zero-based slice index.</param>
+    /// <param name="index">The zero-based position within the current segment.</param>
+    /// <param name="segmentLength">The number of blocks in each segment.</param>
+    /// <param name="laneLength">The number of blocks in each lane.</param>
+    /// <param name="j1">The low 32 bits of the pseudo-random value driving the mapping.</param>
+    /// <param name="sameLane"><see langword="true" /> when the reference block is taken from the current lane.</param>
+    /// <returns>The column index of the reference block within its lane.</returns>
     private static int ReferenceIndex(
         int pass, int slice, int index, int segmentLength, int laneLength, uint j1, bool sameLane)
     {
@@ -270,6 +299,10 @@ internal static class Argon2Core
     /// Computes the final block as the XOR of the last column across lanes, then emits the tag via <c>H'</c> (RFC 9106,
     /// Figure 7).
     /// </summary>
+    /// <param name="memory">The full memory matrix, as a flat array of 64-bit words.</param>
+    /// <param name="lanes">The number of lanes.</param>
+    /// <param name="laneLength">The number of blocks in each lane.</param>
+    /// <param name="tag">The destination span that receives the final tag.</param>
     private static void Finalize(ulong[] memory, int lanes, int laneLength, Span<byte> tag)
     {
         Span<ulong> c = stackalloc ulong[WordsPerBlock];
@@ -320,6 +353,7 @@ internal static class Argon2Core
     /// Applies the BLAKE2b-based permutation <c>P</c> rowwise then columnwise to a 1024-byte block (RFC 9106, Figures
     /// 15 and 18).
     /// </summary>
+    /// <param name="block">The 128-word (1024-byte) block permuted in place.</param>
     private static void Permute(Span<ulong> block)
     {
         for (var row = 0; row < 8; row++)
@@ -354,6 +388,7 @@ internal static class Argon2Core
     /// <summary>
     /// Applies one BLAKE2b round (eight <c>GB</c> calls) to sixteen 64-bit words.
     /// </summary>
+    /// <param name="v">The sixteen 64-bit words mixed in place.</param>
     private static void Round(Span<ulong> v)
     {
         GB(ref v[0], ref v[4], ref v[8], ref v[12]);
@@ -371,6 +406,10 @@ internal static class Argon2Core
     /// The Argon2 mixing function <c>GB</c> — the BLAKE2b round function augmented with 64-bit multiplications (RFC
     /// 9106, Section 3.6).
     /// </summary>
+    /// <param name="a">The first state word, combined and updated in place.</param>
+    /// <param name="b">The second state word, combined and updated in place.</param>
+    /// <param name="c">The third state word, combined and updated in place.</param>
+    /// <param name="d">The fourth state word, combined and updated in place.</param>
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1107:Code should not contain multiple statements on one line", Justification = "The grouped add / rotate / XOR steps mirror the GB definition and preserve a compact, specification-like layout.")]
     private static void GB(ref ulong a, ref ulong b, ref ulong c, ref ulong d)
     {
@@ -383,6 +422,9 @@ internal static class Argon2Core
     /// <summary>
     /// Computes <c>a + b + 2 * trunc(a) * trunc(b)</c> modulo 2^64, where <c>trunc(x)</c> is the low 32 bits of x.
     /// </summary>
+    /// <param name="x">The first operand.</param>
+    /// <param name="y">The second operand.</param>
+    /// <returns>The value <c>x + y + 2·trunc(x)·trunc(y)</c> modulo 2^64.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static ulong FBlaMka(ulong x, ulong y)
     {
@@ -393,6 +435,9 @@ internal static class Argon2Core
     /// <summary>
     /// Returns the 128-word span of the block at the specified absolute block index.
     /// </summary>
+    /// <param name="memory">The full memory matrix, as a flat array of 64-bit words.</param>
+    /// <param name="blockIndex">The absolute, zero-based block index.</param>
+    /// <returns>The 128-word span backing the requested block.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static Span<ulong> BlockSpan(ulong[] memory, int blockIndex) =>
         memory.AsSpan(blockIndex * WordsPerBlock, WordsPerBlock);
@@ -400,6 +445,8 @@ internal static class Argon2Core
     /// <summary>
     /// Loads a 1024-byte block into 128 little-endian 64-bit words.
     /// </summary>
+    /// <param name="source">The 1024-byte source buffer.</param>
+    /// <param name="block">The destination span of 128 64-bit words.</param>
     private static void LoadBlockLE(ReadOnlySpan<byte> source, Span<ulong> block)
     {
         for (var i = 0; i < WordsPerBlock; i++)
@@ -409,6 +456,8 @@ internal static class Argon2Core
     /// <summary>
     /// Serializes 128 64-bit words into a 1024-byte little-endian block.
     /// </summary>
+    /// <param name="block">The source span of 128 64-bit words.</param>
+    /// <param name="destination">The 1024-byte destination buffer.</param>
     private static void StoreBlockLE(ReadOnlySpan<ulong> block, Span<byte> destination)
     {
         for (var i = 0; i < WordsPerBlock; i++)
@@ -418,6 +467,9 @@ internal static class Argon2Core
     /// <summary>
     /// Writes a 32-bit value in little-endian order and advances the offset.
     /// </summary>
+    /// <param name="destination">The buffer that receives the encoded value.</param>
+    /// <param name="offset">The write offset, advanced by four bytes on return.</param>
+    /// <param name="value">The 32-bit value to write.</param>
     private static void WriteLE32(Span<byte> destination, ref int offset, int value)
     {
         BinaryPrimitives.WriteInt32LittleEndian(destination.Slice(offset, 4), value);
@@ -427,6 +479,9 @@ internal static class Argon2Core
     /// <summary>
     /// Writes a 32-bit length prefix followed by the bytes, advancing the offset.
     /// </summary>
+    /// <param name="destination">The buffer that receives the length prefix and bytes.</param>
+    /// <param name="offset">The write offset, advanced past the written data on return.</param>
+    /// <param name="value">The bytes to write after their 32-bit length prefix.</param>
     private static void WriteLengthPrefixed(Span<byte> destination, ref int offset, ReadOnlySpan<byte> value)
     {
         WriteLE32(destination, ref offset, value.Length);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake3.cs
@@ -386,6 +386,12 @@ public sealed partial class Blake3
     /// Scalar reference implementation of the BLAKE3 compression function used as a fallback on hosts without AVX-512 +
     /// VL support. Implements §2.4 of the BLAKE3 specification directly on a 16-element <see cref="uint" /> array.
     /// </summary>
+    /// <param name="cv">The 8-word input chaining value.</param>
+    /// <param name="blockWords">The 16-word message block.</param>
+    /// <param name="counter">The 64-bit chunk counter.</param>
+    /// <param name="blockLen">The number of input bytes in the block.</param>
+    /// <param name="flags">The BLAKE3 domain-separation flags for the block.</param>
+    /// <returns>The 16-word output state produced by the compression function.</returns>
     [MethodImpl(MethodImplOptions.AggressiveOptimization)]
     private static uint[] CompressScalar(uint[] cv, uint[] blockWords, ulong counter, uint blockLen, uint flags)
     {

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CryptographyThrowHelper.CallerExpression.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CryptographyThrowHelper.CallerExpression.cs
@@ -515,6 +515,12 @@ internal static partial class CryptographyThrowHelper
     /// Returns <see langword="true" /> if <paramref name="sizeBits" /> falls inside any of the ranges supplied by
     /// <paramref name="legalSizes" />.
     /// </summary>
+    /// <param name="sizeBits">The size to test, in bits.</param>
+    /// <param name="legalSizes">The permitted size ranges.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="sizeBits" /> matches one of <paramref name="legalSizes" />;
+    /// otherwise, <see langword="false" />.
+    /// </returns>
     private static bool IsValidSize(int sizeBits, KeySizes[] legalSizes)
     {
         foreach (KeySizes range in legalSizes)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EaxModeTransform.cs
@@ -301,6 +301,11 @@ public sealed class EaxModeTransform
     /// Computes <c>OMAC_K^t(m) = CMAC_K([t]_n ‖ m)</c>, where <c>[t]_n</c> is the integer <paramref name="t" /> encoded
     /// as a full-block big-endian prefix.
     /// </summary>
+    /// <param name="t">
+    /// The single-byte tweak that selects the OMAC domain, encoded as a full-block big-endian prefix.
+    /// </param>
+    /// <param name="m">The message bytes to authenticate.</param>
+    /// <returns>The OMAC tag for <paramref name="m" /> under tweak <paramref name="t" />.</returns>
     private byte[] Omac(byte t, ReadOnlySpan<byte> m)
     {
         var blockSize = _cipher.BlockSize / 8;
@@ -322,6 +327,8 @@ public sealed class EaxModeTransform
     /// <summary>
     /// Computes AES-CMAC of <paramref name="message" /> under the mode's cipher, per RFC 4493.
     /// </summary>
+    /// <param name="message">The message to authenticate.</param>
+    /// <returns>The CMAC tag, one cipher block in length.</returns>
     private byte[] ComputeCmac(ReadOnlySpan<byte> message)
     {
         var blockSize = _cipher.BlockSize / 8;
@@ -407,6 +414,9 @@ public sealed class EaxModeTransform
     /// <paramref name="counter" /> (copied defensively) and XORs it with <paramref name="input" />. The final block may
     /// be partial; remaining keystream bytes are discarded.
     /// </summary>
+    /// <param name="input">The bytes to encrypt or decrypt.</param>
+    /// <param name="output">The span that receives the transformed bytes.</param>
+    /// <param name="counter">The initial counter block; copied defensively and left unmodified.</param>
     private void CtrEncrypt(ReadOnlySpan<byte> input, Span<byte> output, byte[] counter)
     {
         var blockSize = _cipher.BlockSize / 8;
@@ -438,6 +448,7 @@ public sealed class EaxModeTransform
     /// Doubles <paramref name="x" /> in-place in GF(2^128) with big-endian bit order and polynomial x^128 + x^7 + x^2 +
     /// x + 1.
     /// </summary>
+    /// <param name="x">The block doubled in place.</param>
     private static void Dbl(byte[] x)
     {
         var msb = (x[0] & 0x80) != 0;
@@ -454,6 +465,9 @@ public sealed class EaxModeTransform
     /// <summary>
     /// XORs two equally-sized input spans into <paramref name="result" />.
     /// </summary>
+    /// <param name="a">The first input span.</param>
+    /// <param name="b">The second input span.</param>
+    /// <param name="result">The span that receives the XOR of <paramref name="a" /> and <paramref name="b" />.</param>
     private static void Xor(ReadOnlySpan<byte> a, ReadOnlySpan<byte> b, Span<byte> result)
     {
         for (var i = 0; i < result.Length; i++)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmSivModeTransform.cs
@@ -268,6 +268,9 @@ public sealed class GcmSivModeTransform
     /// Derives K_auth (16 bytes) and K_enc (16 bytes) from the master cipher and nonce using four cipher calls per RFC
     /// 8452 Section 4. Input block format: LE32(i) || nonce (4 + 12 = 16 bytes). Take first 8 bytes of each output.
     /// </summary>
+    /// <param name="cipher">The master block cipher keyed with the key-generating key.</param>
+    /// <param name="nonce">The 12-byte nonce.</param>
+    /// <returns>The derived message-authentication key and message-encryption key.</returns>
     private static (byte[] authKey, byte[] encKey) DeriveKeys(IBlockCipher cipher, byte[] nonce)
     {
         var blockSize = cipher.BlockSize / 8;

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Scrypt.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Scrypt.cs
@@ -205,6 +205,8 @@ public sealed class Scrypt
     /// <summary>
     /// Throws an <see cref="ArgumentOutOfRangeException" /> if the requested output length is less than 1.
     /// </summary>
+    /// <param name="length">The requested output length, in bytes.</param>
+    /// <exception cref="ArgumentOutOfRangeException"><paramref name="length" /> is less than 1.</exception>
     private static void ThrowIfInvalidLength(int length)
     {
         // The RFC 7914 upper bound of (2^32 - 1) * 32 always exceeds Array.MaxLength, so only the lower bound is
@@ -219,6 +221,10 @@ public sealed class Scrypt
     /// <summary>
     /// Formats a scrypt PHC encoded-hash string.
     /// </summary>
+    /// <param name="p">The scrypt parameters to encode.</param>
+    /// <param name="salt">The salt bytes.</param>
+    /// <param name="hash">The derived hash bytes.</param>
+    /// <returns>The scrypt PHC encoded-hash string.</returns>
     private static string Encode(ScryptParameters p, ReadOnlySpan<byte> salt, ReadOnlySpan<byte> hash)
     {
         var logN = BitOperations.Log2((uint)p.CostN);
@@ -235,6 +241,9 @@ public sealed class Scrypt
     /// <summary>
     /// Parses a scrypt PHC encoded-hash string into its constituent fields.
     /// </summary>
+    /// <param name="encoded">The scrypt PHC encoded-hash string to parse.</param>
+    /// <returns>The cost parameters, salt, and hash parsed from <paramref name="encoded" />.</returns>
+    /// <exception cref="FormatException"><paramref name="encoded" /> is not a valid scrypt PHC string.</exception>
     private static (int CostN, int BlockSizeR, int Parallelization, byte[] Salt, byte[] Hash) Decode(string encoded)
     {
         var fields = PhcString.SplitFields(encoded);
@@ -274,6 +283,8 @@ public sealed class Scrypt
     /// <summary>
     /// Parses a non-negative decimal integer, throwing a <see cref="FormatException" /> on failure.
     /// </summary>
+    /// <param name="value">The text to parse.</param>
+    /// <returns>The parsed non-negative integer.</returns>
     private static int ParseInt(string value) =>
         int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var result)
             ? result

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ScryptCore.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ScryptCore.cs
@@ -76,6 +76,9 @@ internal static class ScryptCore
     /// <summary>
     /// Applies <c>scryptROMix</c> to a single 128*r-byte block in place (RFC 7914, Section 5).
     /// </summary>
+    /// <param name="block">The 128·r-byte block, as 32-bit words, processed in place.</param>
+    /// <param name="costN">The CPU/memory cost parameter <c>N</c>.</param>
+    /// <param name="blockSizeR">The block-size parameter <c>r</c>.</param>
     private static void ROMix(Span<uint> block, int costN, int blockSizeR)
     {
         var unitWords = block.Length;
@@ -118,6 +121,9 @@ internal static class ScryptCore
     /// <summary>
     /// Applies <c>scryptBlockMix</c>, writing the shuffled result to <paramref name="output" /> (RFC 7914, Section 4).
     /// </summary>
+    /// <param name="input">The 2·r 64-byte input blocks, as 32-bit words.</param>
+    /// <param name="output">The destination that receives the shuffled blocks.</param>
+    /// <param name="blockSizeR">The block-size parameter <c>r</c>.</param>
     private static void BlockMix(ReadOnlySpan<uint> input, Span<uint> output, int blockSizeR)
     {
         var blocks = 2 * blockSizeR;
@@ -142,6 +148,9 @@ internal static class ScryptCore
     /// <summary>
     /// Interprets the last 64-byte block as a little-endian integer (RFC 7914, Section 5).
     /// </summary>
+    /// <param name="block">The block whose final 64-byte sub-block is interpreted.</param>
+    /// <param name="blockSizeR">The block-size parameter <c>r</c>.</param>
+    /// <returns>The little-endian integer value of the final 64-byte sub-block.</returns>
     private static ulong Integerify(ReadOnlySpan<uint> block, int blockSizeR)
     {
         var offset = (2 * blockSizeR - 1) * BlockWords;
@@ -151,6 +160,7 @@ internal static class ScryptCore
     /// <summary>
     /// Applies the Salsa20/8 core in place: <c>B = B + doubleround^4(B)</c> (RFC 7914, Section 3).
     /// </summary>
+    /// <param name="b">The sixteen 32-bit state words transformed in place.</param>
     private static void Salsa20_8(Span<uint> b)
     {
         Span<uint> x = stackalloc uint[BlockWords];
@@ -176,6 +186,10 @@ internal static class ScryptCore
     /// <summary>
     /// Applies the Salsa20 quarter-round to four state words in place.
     /// </summary>
+    /// <param name="a">The first state word, updated in place.</param>
+    /// <param name="b">The second state word, updated in place.</param>
+    /// <param name="c">The third state word, updated in place.</param>
+    /// <param name="d">The fourth state word, updated in place.</param>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     [System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1107:Code should not contain multiple statements on one line", Justification = "The grouped add / rotate / XOR steps mirror the Salsa20 quarter-round definition.")]
     private static void QuarterRound(ref uint a, ref uint b, ref uint c, ref uint d)
@@ -189,6 +203,8 @@ internal static class ScryptCore
     /// <summary>
     /// Converts a little-endian byte buffer into 32-bit words.
     /// </summary>
+    /// <param name="source">The little-endian byte buffer to read.</param>
+    /// <param name="destination">The span that receives the decoded 32-bit words.</param>
     private static void BytesToWordsLE(ReadOnlySpan<byte> source, Span<uint> destination)
     {
         for (var i = 0; i < destination.Length; i++)
@@ -198,6 +214,8 @@ internal static class ScryptCore
     /// <summary>
     /// Converts 32-bit words into a little-endian byte buffer.
     /// </summary>
+    /// <param name="source">The 32-bit words to encode.</param>
+    /// <param name="destination">The span that receives the little-endian bytes.</param>
     private static void WordsToBytesLE(ReadOnlySpan<uint> source, Span<byte> destination)
     {
         for (var i = 0; i < source.Length; i++)

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Twofish.cs
@@ -251,6 +251,11 @@ public sealed class Twofish
         base.Dispose(disposing);
     }
 
+    /// <summary>
+    /// Creates the underlying Twofish block cipher for the specified key.
+    /// </summary>
+    /// <param name="key">The key used to initialize the cipher.</param>
+    /// <returns>A new <see cref="TwofishBlockCipher" /> keyed with <paramref name="key" />.</returns>
     private static TwofishBlockCipher CreateCipher(byte[] key) =>
         new(key);
 

--- a/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodings.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodings.cs
@@ -153,19 +153,26 @@ public static class BinaryEncodings
 
         public string Name => "base16-lower";
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base16.Decode(chars);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base16.Encode(bytes);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base16.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base16.GetEncodedLength(byteCount);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base16.IsValid(source);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base16.TryDecode(source, destination, out bytesWritten);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base16.TryEncode(source, destination, out charsWritten);
     }
@@ -176,19 +183,26 @@ public static class BinaryEncodings
 
         public string Name => "base16-upper";
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base16.Decode(chars);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base16.Encode(bytes, BaseFormattingOptions.UpperCase);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base16.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base16.GetEncodedLength(byteCount, BaseFormattingOptions.UpperCase);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base16.IsValid(source);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base16.TryDecode(source, destination, out bytesWritten);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base16.TryEncode(source, destination, out charsWritten, BaseFormattingOptions.UpperCase);
     }
@@ -197,6 +211,14 @@ public static class BinaryEncodings
     {
         private readonly Base32Variant _variant;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Base32VariantAdapter" /> class.
+        /// </summary>
+        /// <param name="variant">The Base32 variant the adapter delegates to.</param>
+        /// <param name="name">The canonical name surfaced through <see cref="Name" />.</param>
+        /// <param name="description">
+        /// The human-readable description surfaced through <see cref="Description" />.
+        /// </param>
         public Base32VariantAdapter(Base32Variant variant, string name, string description)
         {
             _variant = variant;
@@ -208,19 +230,26 @@ public static class BinaryEncodings
 
         public string Name { get; }
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base32.Decode(chars, _variant);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base32.Encode(bytes, _variant);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base32.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base32.GetEncodedLength(byteCount, _variant);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base32.IsValid(source, _variant);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base32.TryDecode(source, destination, out bytesWritten, _variant);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base32.TryEncode(source, destination, out charsWritten, _variant);
     }
@@ -229,6 +258,14 @@ public static class BinaryEncodings
     {
         private readonly Base58Variant _variant;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Base58VariantAdapter" /> class.
+        /// </summary>
+        /// <param name="variant">The Base58 variant the adapter delegates to.</param>
+        /// <param name="name">The canonical name surfaced through <see cref="Name" />.</param>
+        /// <param name="description">
+        /// The human-readable description surfaced through <see cref="Description" />.
+        /// </param>
         public Base58VariantAdapter(Base58Variant variant, string name, string description)
         {
             _variant = variant;
@@ -240,19 +277,26 @@ public static class BinaryEncodings
 
         public string Name { get; }
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base58.Decode(chars, _variant);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base58.Encode(bytes, _variant);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base58.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base58.GetMaxEncodedLength(byteCount);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base58.IsValid(source, _variant);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base58.TryDecode(source, destination, out bytesWritten, _variant);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base58.TryEncode(source, destination, out charsWritten, _variant);
     }
@@ -261,6 +305,14 @@ public static class BinaryEncodings
     {
         private readonly Base64Variant _variant;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Base64VariantAdapter" /> class.
+        /// </summary>
+        /// <param name="variant">The Base64 variant the adapter delegates to.</param>
+        /// <param name="name">The canonical name surfaced through <see cref="Name" />.</param>
+        /// <param name="description">
+        /// The human-readable description surfaced through <see cref="Description" />.
+        /// </param>
         public Base64VariantAdapter(Base64Variant variant, string name, string description)
         {
             _variant = variant;
@@ -272,19 +324,26 @@ public static class BinaryEncodings
 
         public string Name { get; }
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base64.Decode(chars, _variant);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base64.Encode(bytes, _variant);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base64.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base64.GetEncodedLength(byteCount, _variant);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base64.IsValid(source, _variant);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base64.TryDecode(source, destination, out bytesWritten, _variant);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base64.TryEncode(source, destination, out charsWritten, _variant);
     }
@@ -293,6 +352,14 @@ public static class BinaryEncodings
     {
         private readonly Base85Variant _variant;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Base85VariantAdapter" /> class.
+        /// </summary>
+        /// <param name="variant">The Base85 variant the adapter delegates to.</param>
+        /// <param name="name">The canonical name surfaced through <see cref="Name" />.</param>
+        /// <param name="description">
+        /// The human-readable description surfaced through <see cref="Description" />.
+        /// </param>
         public Base85VariantAdapter(Base85Variant variant, string name, string description)
         {
             _variant = variant;
@@ -304,19 +371,26 @@ public static class BinaryEncodings
 
         public string Name { get; }
 
+        /// <inheritdoc />
         public byte[] Decode(ReadOnlySpan<char> chars) => global::Bodu.Text.Encoding.Base85.Decode(chars, _variant);
 
+        /// <inheritdoc />
         public string Encode(ReadOnlySpan<byte> bytes) => global::Bodu.Text.Encoding.Base85.Encode(bytes, _variant);
 
+        /// <inheritdoc />
         public int GetMaxDecodedLength(int charCount) => global::Bodu.Text.Encoding.Base85.GetMaxDecodedLength(charCount);
 
+        /// <inheritdoc />
         public int GetMaxEncodedLength(int byteCount) => global::Bodu.Text.Encoding.Base85.GetMaxEncodedLength(byteCount, _variant);
 
+        /// <inheritdoc />
         public bool IsValid(ReadOnlySpan<char> source) => global::Bodu.Text.Encoding.Base85.IsValid(source, _variant);
 
+        /// <inheritdoc />
         public bool TryDecode(ReadOnlySpan<char> source, Span<byte> destination, out int bytesWritten) =>
             global::Bodu.Text.Encoding.Base85.TryDecode(source, destination, out bytesWritten, _variant);
 
+        /// <inheritdoc />
         public bool TryEncode(ReadOnlySpan<byte> source, Span<char> destination, out int charsWritten) =>
             global::Bodu.Text.Encoding.Base85.TryEncode(source, destination, out charsWritten, _variant);
     }

--- a/Bodu.Text.Formats/src/Text.Bencode/Bencode.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/Bencode.cs
@@ -239,6 +239,11 @@ public static partial class Bencode
         return true;
     }
 
+    /// <summary>
+    /// Gets the number of ASCII decimal digits required to represent a non-negative integer.
+    /// </summary>
+    /// <param name="value">The non-negative value to measure.</param>
+    /// <returns>The number of decimal digits, which is at least one.</returns>
     private static int GetDecimalDigitCount(int value)
     {
         if (value == 0)
@@ -255,6 +260,14 @@ public static partial class Bencode
         return count;
     }
 
+    /// <summary>
+    /// Computes the exact encoded length of a value, recursing into list items and dictionary entries.
+    /// </summary>
+    /// <param name="value">The value to measure.</param>
+    /// <returns>The exact encoded length, in bytes.</returns>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a recognized bencoded value kind.
+    /// </exception>
     private static int GetEncodedLengthCore(BencodedValue value)
     {
         checked
@@ -275,6 +288,12 @@ public static partial class Bencode
         }
     }
 
+    /// <summary>
+    /// Gets the number of ASCII characters required to represent a signed integer, including the leading minus sign for
+    /// negative values.
+    /// </summary>
+    /// <param name="value">The value to measure.</param>
+    /// <returns>The number of characters, which is at least one.</returns>
     private static int GetIntegerDigitCount(long value)
     {
         if (value == 0)
@@ -294,6 +313,11 @@ public static partial class Bencode
         return count;
     }
 
+    /// <summary>
+    /// Computes the encoded length of a byte string, including its decimal length prefix and the separator.
+    /// </summary>
+    /// <param name="value">The string value to measure.</param>
+    /// <returns>The exact encoded length, in bytes.</returns>
     private static int GetStringEncodedLength(BencodedString value)
     {
         checked
@@ -302,9 +326,26 @@ public static partial class Bencode
         }
     }
 
+    /// <summary>
+    /// Determines whether a byte is an ASCII decimal digit.
+    /// </summary>
+    /// <param name="value">The byte to test.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="value" /> is in the range <c>'0'</c>–<c>'9'</c>; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
     private static bool IsAsciiDigit(byte value) =>
         value is >= (byte)'0' and <= (byte)'9';
 
+    /// <summary>
+    /// Writes the bencoded form of an integer (<c>i</c>&lt;digits&gt;<c>e</c>) into the destination buffer.
+    /// </summary>
+    /// <param name="value">The integer value to encode.</param>
+    /// <param name="destination">The span that receives the encoded bytes.</param>
+    /// <param name="offset">The current write position; advanced past the bytes written on return.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the integer cannot be formatted into the buffer.
+    /// </exception>
     private static void WriteInteger(BencodedInteger value, Span<byte> destination, ref int offset)
     {
         destination[offset++] = IntegerPrefix;
@@ -316,6 +357,15 @@ public static partial class Bencode
         destination[offset++] = EndMarker;
     }
 
+    /// <summary>
+    /// Writes the bencoded form of a byte string (&lt;length&gt;<c>:</c>&lt;bytes&gt;) into the destination buffer.
+    /// </summary>
+    /// <param name="value">The string value to encode.</param>
+    /// <param name="destination">The span that receives the encoded bytes.</param>
+    /// <param name="offset">The current write position; advanced past the bytes written on return.</param>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when the length prefix cannot be formatted into the buffer.
+    /// </exception>
     private static void WriteString(BencodedString value, Span<byte> destination, ref int offset)
     {
         if (!Utf8Formatter.TryFormat(value.Length, destination[offset..], out var bytesWritten))
@@ -328,6 +378,12 @@ public static partial class Bencode
         offset += value.Length;
     }
 
+    /// <summary>
+    /// Writes the bencoded form of a value into the destination buffer, starting at the beginning.
+    /// </summary>
+    /// <param name="value">The value to encode.</param>
+    /// <param name="destination">The span that receives the encoded bytes.</param>
+    /// <returns>The number of bytes written.</returns>
     private static int WriteValue(BencodedValue value, Span<byte> destination)
     {
         var offset = 0;
@@ -335,6 +391,16 @@ public static partial class Bencode
         return offset;
     }
 
+    /// <summary>
+    /// Writes the bencoded form of a value into the destination buffer at the specified position, recursing into list
+    /// items and dictionary entries.
+    /// </summary>
+    /// <param name="value">The value to encode.</param>
+    /// <param name="destination">The span that receives the encoded bytes.</param>
+    /// <param name="offset">The current write position; advanced past the bytes written on return.</param>
+    /// <exception cref="ArgumentOutOfRangeException">
+    /// Thrown when <paramref name="value" /> is not a recognized bencoded value kind.
+    /// </exception>
     private static void WriteValue(BencodedValue value, Span<byte> destination, ref int offset)
     {
         switch (value)
@@ -381,6 +447,11 @@ public static partial class Bencode
         private readonly int _maxDepth;
         private int _depth;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Parser" /> struct.
+        /// </summary>
+        /// <param name="source">The bencoded source bytes to decode.</param>
+        /// <param name="maxDepth">The maximum permitted container nesting depth.</param>
         public Parser(ReadOnlySpan<byte> source, int maxDepth)
         {
             this._source = source;
@@ -391,6 +462,13 @@ public static partial class Bencode
 
         public int Position { get; private set; }
 
+        /// <summary>
+        /// Parses a single bencoded value starting at the current position, dispatching by its leading token.
+        /// </summary>
+        /// <returns>The decoded value.</returns>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the source is exhausted or the current byte does not begin a valid bencoded value.
+        /// </exception>
         public BencodedValue ParseValue()
         {
             if (Position >= _source.Length)
@@ -412,6 +490,12 @@ public static partial class Bencode
             }
         }
 
+        /// <summary>
+        /// Records entry into a list or dictionary and enforces the maximum nesting depth.
+        /// </summary>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the current nesting depth exceeds the configured maximum.
+        /// </exception>
         private void EnterContainer()
         {
             _depth++;
@@ -421,6 +505,13 @@ public static partial class Bencode
                     string.Format(CultureInfo.CurrentCulture, s_nestingTooDeep, _maxDepth));
         }
 
+        /// <summary>
+        /// Parses a dictionary value, verifying that keys are byte strings in strictly ascending bytewise order.
+        /// </summary>
+        /// <returns>The decoded dictionary.</returns>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the dictionary is unterminated, contains a non-string key, or has out-of-order keys.
+        /// </exception>
         private BencodedDictionary ParseDictionary()
         {
             EnterContainer();
@@ -458,6 +549,13 @@ public static partial class Bencode
             }
         }
 
+        /// <summary>
+        /// Parses an integer value, rejecting leading zeros, negative zero, and unterminated or out-of-range values.
+        /// </summary>
+        /// <returns>The decoded integer.</returns>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the integer is malformed, unterminated, or outside the range of <see cref="long" />.
+        /// </exception>
         private BencodedInteger ParseInteger()
         {
             Position++;
@@ -513,6 +611,11 @@ public static partial class Bencode
             return new BencodedInteger(value);
         }
 
+        /// <summary>
+        /// Parses a list value, decoding each contained value until the end marker is reached.
+        /// </summary>
+        /// <returns>The decoded list.</returns>
+        /// <exception cref="BencodeFormatException">Thrown when the list is unterminated.</exception>
         private BencodedList ParseList()
         {
             EnterContainer();
@@ -536,6 +639,13 @@ public static partial class Bencode
             }
         }
 
+        /// <summary>
+        /// Parses a byte string value, reading its decimal length prefix and the following bytes.
+        /// </summary>
+        /// <returns>The decoded byte string.</returns>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the declared length exceeds the remaining input or the length prefix is malformed.
+        /// </exception>
         private BencodedString ParseString()
         {
             var length = ParseStringLength();
@@ -549,6 +659,13 @@ public static partial class Bencode
             return value;
         }
 
+        /// <summary>
+        /// Parses the decimal length prefix of a byte string and consumes the trailing separator.
+        /// </summary>
+        /// <returns>The declared string length, in bytes.</returns>
+        /// <exception cref="BencodeFormatException">
+        /// Thrown when the length is missing, has leading zeros, lacks a separator, or overflows <see cref="int" />.
+        /// </exception>
         private int ParseStringLength()
         {
             if (Position >= _source.Length || !IsAsciiDigit(_source[Position]))

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodedStringComparer.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodedStringComparer.cs
@@ -39,6 +39,9 @@ public sealed class BencodedStringComparer
     : IComparer<BencodedString>
     , IEqualityComparer<BencodedString>
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BencodedStringComparer" /> class.
+    /// </summary>
     private BencodedStringComparer()
     {
     }
@@ -71,6 +74,16 @@ public sealed class BencodedStringComparer
         return hashCode.ToHashCode();
     }
 
+    /// <summary>
+    /// Compares two byte spans using bytewise ordinal ordering, treating the shorter span as ordered before a longer
+    /// span that shares its prefix.
+    /// </summary>
+    /// <param name="x">The first byte span to compare.</param>
+    /// <param name="y">The second byte span to compare.</param>
+    /// <returns>
+    /// A negative value when <paramref name="x" /> sorts before <paramref name="y" />, zero when they are equal, or a
+    /// positive value when <paramref name="x" /> sorts after <paramref name="y" />.
+    /// </returns>
     internal static int CompareBytes(ReadOnlySpan<byte> x, ReadOnlySpan<byte> y)
     {
         var length = Math.Min(x.Length, y.Length);

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedRow.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedRow.cs
@@ -230,6 +230,7 @@ public sealed class DelimitedRow
     /// <summary>
     /// Throws a <see cref="KeyNotFoundException" /> for an absent column header.
     /// </summary>
+    /// <param name="header">The column header name that was not found.</param>
     [DoesNotReturn]
     private static void ThrowHeaderNotFound(string header) =>
         throw new KeyNotFoundException(

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.Parser.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.Parser.cs
@@ -32,6 +32,8 @@ public static partial class DotEnv
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for a duplicate key.
     /// </summary>
+    /// <param name="key">The duplicate key name.</param>
+    /// <param name="lineNumber">The 1-based line number where the duplicate key was found.</param>
     [DoesNotReturn]
     private static void ThrowDuplicateKey(string key, int lineNumber) =>
         throw new DotEnvFormatException(
@@ -40,6 +42,8 @@ public static partial class DotEnv
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an invalid key name.
     /// </summary>
+    /// <param name="key">The offending key text.</param>
+    /// <param name="lineNumber">The 1-based line number where the invalid key was found.</param>
     [DoesNotReturn]
     internal static void ThrowInvalidKey(string key, int lineNumber) =>
         throw new DotEnvFormatException(
@@ -48,6 +52,7 @@ public static partial class DotEnv
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for a malformed entry line.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number of the malformed entry.</param>
     [DoesNotReturn]
     internal static void ThrowMalformedEntry(int lineNumber) =>
         throw new DotEnvFormatException(
@@ -56,6 +61,7 @@ public static partial class DotEnv
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an unterminated double-quoted string.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number on which the unterminated value begins.</param>
     [DoesNotReturn]
     internal static void ThrowUnterminatedDoubleQuote(int lineNumber) =>
         throw new DotEnvFormatException(
@@ -64,6 +70,7 @@ public static partial class DotEnv
     /// <summary>
     /// Throws a <see cref="DotEnvFormatException" /> for an unterminated single-quoted string.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number on which the unterminated value begins.</param>
     [DoesNotReturn]
     internal static void ThrowUnterminatedSingleQuote(int lineNumber) =>
         throw new DotEnvFormatException(
@@ -224,12 +231,22 @@ public static partial class DotEnv
         /// <summary>
         /// Returns <see langword="true" /> when <paramref name="c" /> is a valid key start character.
         /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="c" /> is an ASCII letter or underscore; otherwise,
+        /// <see langword="false" />.
+        /// </returns>
         private static bool IsKeyStart(char c) =>
             c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or '_';
 
         /// <summary>
         /// Returns <see langword="true" /> when <paramref name="c" /> is a valid key continuation character.
         /// </summary>
+        /// <param name="c">The character to test.</param>
+        /// <returns>
+        /// <see langword="true" /> if <paramref name="c" /> is a key start character or an ASCII digit; otherwise,
+        /// <see langword="false" />.
+        /// </returns>
         private static bool IsKeyContinue(char c) =>
             IsKeyStart(c) || (c >= '0' && c <= '9');
 

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvReader.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvReader.cs
@@ -208,6 +208,11 @@ public sealed class DotEnvReader : IDisposable
     /// Commits a successfully parsed entry: publishes its key/value/line, advances the consumed-line counter, and drops
     /// the consumed prefix from the pending buffer.
     /// </summary>
+    /// <param name="key">The parsed entry key.</param>
+    /// <param name="value">The parsed entry value.</param>
+    /// <param name="consumed">The number of characters consumed from the pending buffer.</param>
+    /// <param name="lineDelta">The number of newlines consumed by the entry.</param>
+    /// <param name="keyLineDelta">The number of newlines preceding the key within the consumed span.</param>
     private void Commit(string key, string value, int consumed, int lineDelta, int keyLineDelta)
     {
         _key = key;
@@ -241,12 +246,22 @@ public sealed class DotEnvReader : IDisposable
     /// <summary>
     /// Returns <see langword="true" /> when <paramref name="c" /> may start a key.
     /// </summary>
+    /// <param name="c">The character to test.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="c" /> is an ASCII letter or underscore; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
     private static bool IsKeyStart(char c) =>
         c is >= 'A' and <= 'Z' or >= 'a' and <= 'z' or '_';
 
     /// <summary>
     /// Returns <see langword="true" /> when <paramref name="c" /> may continue a key.
     /// </summary>
+    /// <param name="c">The character to test.</param>
+    /// <returns>
+    /// <see langword="true" /> if <paramref name="c" /> is a key start character or an ASCII digit; otherwise,
+    /// <see langword="false" />.
+    /// </returns>
     private static bool IsKeyContinue(char c) =>
         IsKeyStart(c) || (c >= '0' && c <= '9');
 
@@ -453,6 +468,21 @@ public sealed class DotEnvReader : IDisposable
     /// Parses a double-quoted value (with escape sequences and literal/continuation newlines) starting at the opening
     /// quote. Returns <see cref="ReadResult.NeedMore" /> when the closing quote has not yet been buffered.
     /// </summary>
+    /// <param name="s">The pending input.</param>
+    /// <param name="i">
+    /// The current read offset at the opening quote; advanced past the closing quote on success.
+    /// </param>
+    /// <param name="line">The current line counter; advanced for each newline consumed within the value.</param>
+    /// <param name="isFinal">Whether <paramref name="s" /> is the final block of input.</param>
+    /// <param name="entryLine">The 1-based line number on which the entry begins.</param>
+    /// <param name="value">When an entry is parsed, receives the processed string value.</param>
+    /// <returns>
+    /// <see cref="ReadResult.Entry" /> when the value was parsed; otherwise,
+    /// <see cref="ReadResult.NeedMore" /> when more input is required.
+    /// </returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when the value is unterminated and <paramref name="isFinal" /> is <see langword="true" />.
+    /// </exception>
     private static ReadResult ParseDoubleQuoted(ReadOnlySpan<char> s, ref int i, ref int line, bool isFinal, int entryLine, out string value)
     {
         value = string.Empty;
@@ -546,6 +576,21 @@ public sealed class DotEnvReader : IDisposable
     /// Parses a single-quoted (literal) value starting at the opening quote. The value must close on the same line.
     /// Returns <see cref="ReadResult.NeedMore" /> when the closing quote has not yet been buffered.
     /// </summary>
+    /// <param name="s">The pending input.</param>
+    /// <param name="i">
+    /// The current read offset at the opening quote; advanced past the closing quote on success.
+    /// </param>
+    /// <param name="isFinal">Whether <paramref name="s" /> is the final block of input.</param>
+    /// <param name="entryLine">The 1-based line number on which the entry begins.</param>
+    /// <param name="value">When an entry is parsed, receives the literal string value.</param>
+    /// <returns>
+    /// <see cref="ReadResult.Entry" /> when the value was parsed; otherwise,
+    /// <see cref="ReadResult.NeedMore" /> when more input is required.
+    /// </returns>
+    /// <exception cref="DotEnvFormatException">
+    /// Thrown when the value is unterminated and <paramref name="isFinal" /> is <see langword="true" />, or when a line
+    /// break occurs before the closing quote.
+    /// </exception>
     private static ReadResult ParseSingleQuoted(ReadOnlySpan<char> s, ref int i, bool isFinal, int entryLine, out string value)
     {
         value = string.Empty;
@@ -576,6 +621,17 @@ public sealed class DotEnvReader : IDisposable
     /// Parses an unquoted value, trimming surrounding whitespace and honoring inline comments when enabled. Returns
     /// <see cref="ReadResult.NeedMore" /> when the end of the line has not yet been buffered.
     /// </summary>
+    /// <param name="s">The pending input.</param>
+    /// <param name="i">
+    /// The current read offset at the start of the value; advanced to the end of the line on success.
+    /// </param>
+    /// <param name="isFinal">Whether <paramref name="s" /> is the final block of input.</param>
+    /// <param name="options">The parse options that govern inline-comment handling.</param>
+    /// <param name="value">When an entry is parsed, receives the trimmed value.</param>
+    /// <returns>
+    /// <see cref="ReadResult.Entry" /> when the value was parsed; otherwise,
+    /// <see cref="ReadResult.NeedMore" /> when more input is required.
+    /// </returns>
     private static ReadResult ParseUnquoted(ReadOnlySpan<char> s, ref int i, bool isFinal, DotEnvParseOptions options, out string value)
     {
         value = string.Empty;

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvWriter.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvWriter.cs
@@ -124,6 +124,9 @@ public sealed class DotEnvWriter : IDisposable
     /// Builds the <c>KEY=VALUE</c> line (terminated by a line feed) for one entry, reusing the document formatter's
     /// quoting and escaping rules so streamed output matches <see cref="DotEnv.Format(DotEnvDocument)" />.
     /// </summary>
+    /// <param name="key">The entry key.</param>
+    /// <param name="value">The entry value to format.</param>
+    /// <returns>The formatted <c>KEY=VALUE</c> line, terminated by a line feed.</returns>
     private static string FormatEntry(string key, string value)
     {
         StringBuilder sb = new();

--- a/Bodu.Text.Formats/src/Text.Ini/Ini.Parser.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/Ini.Parser.cs
@@ -30,6 +30,8 @@ public static partial class Ini
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a duplicate key.
     /// </summary>
+    /// <param name="key">The duplicate key name.</param>
+    /// <param name="lineNumber">The 1-based line number where the duplicate key was found.</param>
     [DoesNotReturn]
     private static void ThrowDuplicateKey(string key, int lineNumber) =>
         throw new IniFormatException(
@@ -38,6 +40,8 @@ public static partial class Ini
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a duplicate section name.
     /// </summary>
+    /// <param name="name">The duplicate section name.</param>
+    /// <param name="lineNumber">The 1-based line number where the duplicate section header was found.</param>
     [DoesNotReturn]
     private static void ThrowDuplicateSection(string name, int lineNumber) =>
         throw new IniFormatException(
@@ -47,6 +51,7 @@ public static partial class Ini
     /// Throws an <see cref="IniFormatException" /> when a key appears before the first section header and global
     /// entries are disallowed.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number of the disallowed global key.</param>
     [DoesNotReturn]
     internal static void ThrowGlobalKeyDisallowed(int lineNumber) =>
         throw new IniFormatException(
@@ -55,6 +60,7 @@ public static partial class Ini
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a malformed section header.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number of the malformed section header.</param>
     [DoesNotReturn]
     internal static void ThrowMalformedSectionHeader(int lineNumber) =>
         throw new IniFormatException(
@@ -63,6 +69,7 @@ public static partial class Ini
     /// <summary>
     /// Throws an <see cref="IniFormatException" /> for a property line with an empty key.
     /// </summary>
+    /// <param name="lineNumber">The 1-based line number of the property line with the empty key.</param>
     [DoesNotReturn]
     internal static void ThrowMissingKey(int lineNumber) =>
         throw new IniFormatException(
@@ -294,6 +301,12 @@ public static partial class Ini
         /// </summary>
         private struct SectionBuilder
         {
+            /// <summary>
+            /// Initializes a new instance of the <see cref="SectionBuilder" /> struct.
+            /// </summary>
+            /// <param name="name">The section name.</param>
+            /// <param name="entries">The ordered entry list backing the section.</param>
+            /// <param name="lookup">The case-resolved key lookup backing the section.</param>
             internal SectionBuilder(string name, List<IniEntry> entries, Dictionary<string, IniEntry> lookup)
             {
                 Name = name;


### PR DESCRIPTION
## Summary

This PR adds comprehensive XML documentation (`<summary>`, `<param>`, `<returns>`, `<exception>`) to private methods, internal helpers, and nested types across multiple projects. The changes improve code maintainability and IDE IntelliSense support without altering any runtime behavior.

## Key Changes

- **Bodu.Text.Formats/Bencode.cs**: Documented all private helper methods (`GetDecimalDigitCount`, `GetEncodedLengthCore`, `GetIntegerDigitCount`, `GetStringEncodedLength`, `IsAsciiDigit`, `WriteInteger`, `WriteString`, `WriteValue`) and the nested `Parser` struct with its methods (`ParseValue`, `EnterContainer`, `ParseDictionary`, `ParseInteger`, `ParseList`, `ParseString`).

- **Bodu.Text.Encoding/BinaryEncodings.cs**: Added `/// <inheritdoc />` tags to all interface method implementations in adapter classes (`Base16LowerAdapter`, `Base16UpperAdapter`, `Base32VariantAdapter`, `Base58VariantAdapter`) and documented their constructors.

- **Bodu.Text.Formats/DotEnvReader.cs**: Documented private methods (`Commit`, `IsKeyStart`, `IsKeyContinue`, `ParseDoubleQuoted`, `ParseSingleQuoted`) with parameter and return descriptions.

- **Bodu.Security.Cryptography/Argon2Core.cs**: Documented internal helper methods (`ComputeH0`, `InitializeBlocks`, `FillSegment`, `NextAddresses`, `ReferenceIndex`) with detailed parameter and algorithm descriptions.

- **Bodu.Security.Cryptography/Argon2.cs**: Documented private parsing and encoding methods (`Decode`, `Encode`, `ParseCostParameters`).

- **Bodu.Core/IListExtensions.LastIndexOf.cs**: Documented private validation and core search methods.

- **Bodu.IO.Hashing/Fnv.cs**, **Pearson.cs**, **Bernstein.cs**, **CityHash.cs**, **MurmurHash3.cs**, **Elf64.cs**, **BKDR.cs**: Added documentation to private validation and hash-folding methods.

- **Bodu.IO.Hashing.CheckDigits/Iban.cs**: Documented character-folding helper methods.

- **Bodu.Text.Formats/DotEnv.Parser.cs**, **Ini.Parser.cs**: Documented exception-throwing helper methods.

- **Bodu.Security.Cryptography/Scrypt.cs**, **EaxModeTransform.cs**, **Blake3.cs**: Documented private utility and cryptographic helper methods.

- **Bodu.Text.Formats/BencodedStringComparer.cs**: Documented the private constructor and comparison method.

- **Bodu.Core/WeekPattern.cs**, **WeekPattern.Functions.cs**: Documented constructor and parsing helper methods.

- **Bodu.Core/PooledBufferBuilder.cs**, **Bodu.IO.Hashing.Checksums/CrcStandard.cs**, **Fletcher.cs**, **CityHash.32.cs**, **GcmSivModeTransform.cs**, **DotEnvWriter.cs**, **DelimitedRow.cs**, **CryptographyThrowHelper.CallerExpression.cs**, **Twofish.cs**: Added documentation to remaining private/internal methods and constructors.

## Implementation Details

- All documentation follows the existing Bodu code style conventions with proper `<summary>`, `<param>`, `<returns>`, and `<exception>` tags.
- `/// <inheritdoc />` tags are used consistently for interface implementations to avoid duplication.
- Parameter descriptions include type information and valid ranges where applicable.
- Exception documentation specifies the conditions under which exceptions are thrown.
- No functional changes; this is purely a documentation enhancement pass.

https://claude.ai/code/session_016JcaFxaHqVST95jsJPVk4b