### PR TITLE
Standardize XML documentation example comments to use C# syntax

### DIFF
--- a/Bodu.Core/src/Buffers/PooledBufferBuilder.cs
+++ b/Bodu.Core/src/Buffers/PooledBufferBuilder.cs
@@ -27,7 +27,7 @@ namespace Bodu.Buffers;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Accumulate a result of unknown length without per-item array doubling.
+/// // Accumulate a result of unknown length without per-item array doubling.
 /// using var builder = new PooledBufferBuilder<int>(initialCapacity: 256);
 ///
 /// foreach (int value in source)
@@ -35,7 +35,7 @@ namespace Bodu.Buffers;
 ///
 /// ReadOnlySpan<int> span = builder.WrittenSpan;
 /// Console.WriteLine($"Buffered {builder.WrittenCount} values from a pooled buffer of {builder.Capacity}.");
-/// The rented array is returned to ArrayPool<int>.Shared when 'builder' is disposed.
+/// // The rented array is returned to ArrayPool<int>.Shared when 'builder' is disposed.
 ///]]>
 /// </example>
 public sealed class PooledBufferBuilder<T> :

--- a/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.RecursiveSelect.cs
+++ b/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.RecursiveSelect.cs
@@ -50,7 +50,7 @@ public static partial class IEnumerableExtensions
     /// };
     ///
     /// var flattened = root.RecursiveSelect(n => ((Node)n).Children);
-    /// Yields: A, B, C, D
+    /// // Yields: A, B, C, D
     ///]]>
     /// </code>
     /// </example>
@@ -91,7 +91,7 @@ public static partial class IEnumerableExtensions
     /// };
     ///
     /// var names = root.RecursiveSelect(n => ((Node)n).Children, n => ((Node)n).Name);
-    /// Yields: "A", "B", "C", "D"
+    /// // Yields: "A", "B", "C", "D"
     ///]]>
     /// </code>
     /// </example>
@@ -138,7 +138,7 @@ public static partial class IEnumerableExtensions
     /// };
     ///
     /// var labeled = root.RecursiveSelect(n => ((Node)n).Children, (n, i) => $"{i}: {((Node)n).Name}");
-    /// Yields: "0: A", "1: B", "2: C", "3: D"
+    /// // Yields: "0: A", "1: B", "2: C", "3: D"
     ///]]>
     /// </code>
     /// </example>
@@ -186,11 +186,11 @@ public static partial class IEnumerableExtensions
     /// var structured = root.RecursiveSelect(n => ((Node)n).Children,
     ///     (n, i, depth) => new { ((Node)n).Name, Index = i, Depth = depth });
     ///
-    /// Yields:
-    /// { Name = "A", Index = 0, Depth = 0 }
-    /// { Name = "B", Index = 1, Depth = 1 }
-    /// { Name = "C", Index = 2, Depth = 1 }
-    /// { Name = "D", Index = 3, Depth = 0 }
+    /// // Yields:
+    /// // { Name = "A", Index = 0, Depth = 0 }
+    /// // { Name = "B", Index = 1, Depth = 1 }
+    /// // { Name = "C", Index = 2, Depth = 1 }
+    /// // { Name = "D", Index = 3, Depth = 0 }
     ///]]>
     /// </code>
     /// </example>
@@ -247,7 +247,7 @@ public static partial class IEnumerableExtensions
     ///         ? RecursiveSelectControl.YieldAndRecurse
     ///         : RecursiveSelectControl.YieldOnly);
     ///
-    /// Yields: "A", "B", "C", "D"
+    /// // Yields: "A", "B", "C", "D"
     ///]]>
     /// </code>
     /// </example>

--- a/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.cs
+++ b/Bodu.Core/src/Collections.Extensions/IEnumerableExtensions.cs
@@ -33,11 +33,11 @@ namespace Bodu.Collections.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Cheap count when the source already exposes ICollection — falls back to enumeration otherwise.
+/// // Cheap count when the source already exposes ICollection — falls back to enumeration otherwise.
 /// System.Collections.IEnumerable boxed = new ArrayList { 1, 2, 3, 4 };
 /// int count = boxed.CountOrDefault(); // => 4
 ///
-/// Walk a heterogeneous control tree without committing to a generic type.
+/// // Walk a heterogeneous control tree without committing to a generic type.
 /// System.Collections.IEnumerable controls = root.GetChildren();
 /// foreach (object node in controls.RecursiveSelect(c => ((Control)c).GetChildren()))
 ///     Console.WriteLine(node);

--- a/Bodu.Core/src/Collections.Extensions/RecursiveSelectControl.cs
+++ b/Bodu.Core/src/Collections.Extensions/RecursiveSelectControl.cs
@@ -175,77 +175,77 @@ namespace Bodu.Collections.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Common input structure
+/// // Common input structure
 /// var root = new[]
 /// {
 ///     new Node { Name = "A", Children = { new Node { Name = "B" }, new Node { Name = "C" } } },
 ///     new Node { Name = "D" }
 /// };
 /// //
-/// RecursiveSelect using different control values
+/// // RecursiveSelect using different control values
 ///
-/// YieldAndRecurse
+/// // YieldAndRecurse
 /// var all = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.YieldAndRecurse);
-/// Output: A, B, C, D
+/// // Output: A, B, C, D
 ///
-/// SkipOnly
+/// // SkipOnly
 /// var skip = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.SkipOnly);
-/// Output: (empty)
+/// // Output: (empty)
 ///
-/// YieldOnly
+/// // YieldOnly
 /// var yieldOnly = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.YieldOnly);
-/// Output: A, D
+/// // Output: A, D
 ///
-/// RecurseOnly
+/// // RecurseOnly
 /// var recurseOnly = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.RecurseOnly);
-/// Output: B, C
+/// // Output: B, C
 ///
-/// SkipAndRecurse
+/// // SkipAndRecurse
 /// var skipAndRecurse = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.SkipAndRecurse);
-/// Output: B, C
+/// // Output: B, C
 ///
-/// YieldAndBreak
+/// // YieldAndBreak
 /// var yieldAndBreak = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.YieldAndBreak);
-/// Output: A
+/// // Output: A
 ///
-/// SkipAndBreak
+/// // SkipAndBreak
 /// var skipAndBreak = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.SkipAndBreak);
-/// Output: (empty)
+/// // Output: (empty)
 ///
-/// YieldAndExit
+/// // YieldAndExit
 /// var yieldAndExit = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.YieldAndExit);
-/// Output: A
+/// // Output: A
 ///
-/// SkipAndExit
+/// // SkipAndExit
 /// var skipAndExit = root.RecursiveSelect(
 ///     n => n.Children,
 ///     (n, i, d) => n.Name,
 ///     n => RecursiveSelectControl.SkipAndExit);
-/// Output: (empty)
+/// // Output: (empty)
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Leibniz.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.Leibniz.cs
@@ -52,7 +52,7 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Approximate π by summing the first hundred terms whose magnitude is at least 1e-3.
+    /// // Approximate π by summing the first hundred terms whose magnitude is at least 1e-3.
     /// double partial = 0;
     /// foreach (double term in SequenceGenerator.Leibniz(1e-3, 1.1).Take(100))
     ///     partial += term;

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.LookAndSay.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.LookAndSay.cs
@@ -43,12 +43,12 @@ public static partial class SequenceGenerator
     ///<![CDATA[
     /// foreach (string term in SequenceGenerator.LookAndSay(6))
     ///     Console.WriteLine(term);
-    /// => 1
-    /// => 11
-    /// => 21
-    /// => 1211
-    /// => 111221
-    /// => 312211
+    /// // => 1
+    /// // => 11
+    /// // => 21
+    /// // => 1211
+    /// // => 111221
+    /// // => 312211
     ///]]>
     /// </code>
     /// </example>

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.ThueMorse.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.ThueMorse.cs
@@ -36,8 +36,8 @@ public static partial class SequenceGenerator
     ///<![CDATA[
     /// var prefix = SequenceGenerator.ThueMorse(16).ToArray(); // => [0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 0]
     ///
-    /// Convenient as the schedule for a fair turn-taking algorithm:
-    /// player A goes on 0, player B goes on 1.
+    /// // Convenient as the schedule for a fair turn-taking algorithm:
+    /// // player A goes on 0, player B goes on 1.
     ///]]>
     /// </code>
     /// </example>

--- a/Bodu.Core/src/Collections.Extensions/SequenceGenerator.cs
+++ b/Bodu.Core/src/Collections.Extensions/SequenceGenerator.cs
@@ -32,15 +32,15 @@ namespace Bodu.Collections.Extensions;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Fibonacci numbers up to 100 — the value bound, not a fixed count.
+/// // Fibonacci numbers up to 100 — the value bound, not a fixed count.
 /// foreach (long fib in SequenceGenerator.Fibonacci(min: 0, max: 100))
 ///     Console.WriteLine(fib); // 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89
 ///
-/// First five Farey-sequence orders of 1/2 .. 1/1.
+/// // First five Farey-sequence orders of 1/2 .. 1/1.
 /// foreach ((int n, int d) in SequenceGenerator.Farey(order: 5))
 ///     Console.WriteLine($"{n}/{d}");
 ///
-/// Look-and-say from "1": "1", "11", "21", "1211", "111221" ...
+/// // Look-and-say from "1": "1", "11", "21", "1211", "111221" ...
 /// string[] lookAndSay = SequenceGenerator.LookAndSay(count: 5).ToArray();
 ///]]>
 /// </example>

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Batch.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.Batch.cs
@@ -160,14 +160,14 @@ public static partial class IEnumerableExtensions
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Input:  Enumerable.Range(1, 10)
-    /// Batch size: 4
-    /// Selector: (x, i) => $"Item {i}: {x}"
+    /// // Input:  Enumerable.Range(1, 10)
+    /// // Batch size: 4
+    /// // Selector: (x, i) => $"Item {i}: {x}"
     ///
-    /// Expected output:
-    /// Batch 1: "Item 0: 1", "Item 1: 2", "Item 2: 3", "Item 3: 4"
-    /// Batch 2: "Item 4: 5", "Item 5: 6", "Item 6: 7", "Item 7: 8"
-    /// Batch 3: "Item 8: 9", "Item 9: 10"
+    /// // Expected output:
+    /// // Batch 1: "Item 0: 1", "Item 1: 2", "Item 2: 3", "Item 3: 4"
+    /// // Batch 2: "Item 4: 5", "Item 5: 6", "Item 6: 7", "Item 7: 8"
+    /// // Batch 3: "Item 8: 9", "Item 9: 10"
     /// var source = Enumerable.Range(1, 10);
     /// foreach (var batch in source.BatchPooled(4, (x, i) => $"Item {i}: {x}"))
     /// {
@@ -246,13 +246,13 @@ public static partial class IEnumerableExtensions
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Input:  Enumerable.Range(1, 9)
-    /// Batch size: 3
+    /// // Input:  Enumerable.Range(1, 9)
+    /// // Batch size: 3
     ///
-    /// Expected output:
-    /// Batch 1: 1, 2, 3
-    /// Batch 2: 4, 5, 6
-    /// Batch 3: 7, 8, 9
+    /// // Expected output:
+    /// // Batch 1: 1, 2, 3
+    /// // Batch 2: 4, 5, 6
+    /// // Batch 3: 7, 8, 9
     ///
     /// var source = Enumerable.Range(1, 9);
     /// foreach (var batch in source.BatchPooled(3))

--- a/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IEnumerableExtensions.cs
@@ -39,21 +39,21 @@ namespace Bodu.Collections.Generic.Extensions;
 ///<![CDATA[
 /// IEnumerable<int> source = Enumerable.Range(1, 9);
 ///
-/// Chunk into windows of three.
+/// // Chunk into windows of three.
 /// foreach (var window in source.Batch(3))
 ///     Console.WriteLine(string.Join(", ", window));
-/// => 1, 2, 3
-/// => 4, 5, 6
-/// => 7, 8, 9
+/// // => 1, 2, 3
+/// // => 4, 5, 6
+/// // => 7, 8, 9
 ///
-/// Compute count and sum in a single pass.
+/// // Compute count and sum in a single pass.
 /// var (count, sum) = source.Aggregate(
 ///     seed1: 0,
 ///     seed2: 0L,
 ///     func1: (c, _) => c + 1,
 ///     func2: (s, x) => s + x); // => count == 9, sum == 45
 ///
-/// Predicate-style set check using a custom comparer.
+/// // Predicate-style set check using a custom comparer.
 /// bool anyMatch = new[] { "FOO", "bar" }
 ///     .ContainsAny(new[] { "foo", "baz" }, StringComparer.OrdinalIgnoreCase); // => true
 ///]]>

--- a/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.cs
+++ b/Bodu.Core/src/Collections.Generic.Extensions/IListExtensions.cs
@@ -34,14 +34,14 @@ namespace Bodu.Collections.Generic.Extensions;
 ///<![CDATA[
 /// IList<string> items = new List<string> { "alpha", "beta", "gamma", "beta" };
 ///
-/// Predicate-based search.
+/// // Predicate-based search.
 /// int firstBetaIndex = items.IndexOf(s => s.StartsWith("b")); // 1
 ///
-/// Try-style relocation that won't throw on out-of-range indices.
+/// // Try-style relocation that won't throw on out-of-range indices.
 /// if (items.TryMove(oldIndex: 0, newIndex: 2))
 ///     Console.WriteLine(string.Join(", ", items)); // beta, gamma, alpha, beta
 ///
-/// Bulk replacement with a count of changes.
+/// // Bulk replacement with a count of changes.
 /// int replaced = items.ReplaceAll(oldItem: "beta", newItem: "BETA"); // 2
 ///]]>
 /// </example>

--- a/Bodu.Core/src/Collections.Generic/CircularBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic/CircularBuffer.cs
@@ -76,7 +76,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Sliding window of the three most recent samples — overwrite-on-full is the default.
+/// // Sliding window of the three most recent samples — overwrite-on-full is the default.
 /// var window = new CircularBuffer<int>(capacity: 3);
 /// window.Enqueue(1);
 /// window.Enqueue(2);
@@ -84,7 +84,7 @@ namespace Bodu.Collections.Generic;
 /// window.Enqueue(4); // evicts 1; ItemEvicted fires with value 1
 /// Console.WriteLine(window.Peek()); // 2 (oldest remaining)
 ///
-/// Fixed FIFO queue that rejects further pushes when full.
+/// // Fixed FIFO queue that rejects further pushes when full.
 /// var bounded = new CircularBuffer<int>(capacity: 2, allowOverwrite: false);
 /// bounded.Enqueue(10);
 /// bounded.Enqueue(20);

--- a/Bodu.Core/src/Collections.Generic/Deque.cs
+++ b/Bodu.Core/src/Collections.Generic/Deque.cs
@@ -89,14 +89,14 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Growable double-ended queue (the default).
+/// // Growable double-ended queue (the default).
 /// var deque = new Deque<int>();
 /// deque.AddLast(2);
 /// deque.AddFirst(1);
 /// deque.AddLast(3);                  // contents: 1, 2, 3
 /// int head = deque.RemoveFirst();    // 1
 ///
-/// Fixed-capacity queue: rejects adds when full.
+/// // Fixed-capacity queue: rejects adds when full.
 /// var bounded = new Deque<int>(capacity: 8, allowGrow: false);
 /// for (int i = 0; i < 8; i++) bounded.AddLast(i);
 /// bool added = bounded.TryAddLast(8); // false — bounded is full

--- a/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/EvictingDictionary.cs
@@ -41,26 +41,26 @@ namespace Bodu.Collections.Generic;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Create an evicting dictionary with capacity for 2 items using LRU eviction.
+/// // Create an evicting dictionary with capacity for 2 items using LRU eviction.
 /// var cache = new EvictingDictionary<string, int>(capacity: 2, EvictingDictionaryPolicy.LeastRecentlyUsed);
 ///
-/// Add two entries.
+/// // Add two entries.
 /// cache["A"] = 1;
 /// cache["B"] = 2;
 ///
-/// Touch "A" to mark it as recently used.
+/// // Touch "A" to mark it as recently used.
 /// cache.Touch("A");
 ///
-/// Add a third entry; "B" is now the least recently used and will be evicted.
+/// // Add a third entry; "B" is now the least recently used and will be evicted.
 /// cache["C"] = 3;
 ///
-/// Dictionary now contains: { "A": 1, "C": 3 }
+/// // Dictionary now contains: { "A": 1, "C": 3 }
 /// foreach (var kvp in cache)
 ///     Console.WriteLine($"{kvp.Key} = {kvp.Value}");
 ///
-/// Output:
-/// A = 1
-/// C = 3
+/// // Output:
+/// // A = 1
+/// // C = 3
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedPriorityQueue.cs
@@ -47,8 +47,8 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Dijkstra-style relaxation: the tentative cost of each node is its priority, and an improved
-/// path arrives as a re-prioritization rather than a duplicate enqueue.
+/// // Dijkstra-style relaxation: the tentative cost of each node is its priority, and an improved
+/// // path arrives as a re-prioritization rather than a duplicate enqueue.
 /// var queue = new IndexedPriorityQueue<string, int>();
 ///
 /// queue.Enqueue("A", 5);

--- a/Bodu.Core/src/Collections.Generic/IndexedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/IndexedSet.cs
@@ -31,7 +31,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Build a deduplicated playlist that can still be reordered by index.
+/// // Build a deduplicated playlist that can still be reordered by index.
 /// var playlist = new IndexedSet<string>(StringComparer.OrdinalIgnoreCase);
 ///
 /// playlist.Add("Intro");

--- a/Bodu.Core/src/Collections.Generic/MultiValueDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/MultiValueDictionary.cs
@@ -51,7 +51,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Multiple values under a single key — values are retained in insertion order.
+/// // Multiple values under a single key — values are retained in insertion order.
 /// var map = new MultiValueDictionary<string, int>();
 /// map.Add("odd",  1);
 /// map.Add("odd",  3);
@@ -60,11 +60,11 @@ namespace Bodu.Collections.Generic;
 /// Console.WriteLine(map.Count);    // 3 — total key-value entries
 /// Console.WriteLine(map.KeyCount); // 2 — distinct keys
 ///
-/// The indexer returns a live read-only view; absent keys yield an empty list rather than throwing.
+/// // The indexer returns a live read-only view; absent keys yield an empty list rather than throwing.
 /// foreach (int value in map["odd"])
 ///     Console.WriteLine(value);
 ///
-/// Flatten into one KeyValuePair per stored value.
+/// // Flatten into one KeyValuePair per stored value.
 /// foreach (KeyValuePair<string, int> pair in map.Flatten())
 ///     Console.WriteLine($"{pair.Key}: {pair.Value}");
 ///]]>

--- a/Bodu.Core/src/Collections.Generic/Multiset.cs
+++ b/Bodu.Core/src/Collections.Generic/Multiset.cs
@@ -63,7 +63,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Letter-frequency histogram.
+/// // Letter-frequency histogram.
 /// var histogram = new Multiset<char>();
 /// foreach (char c in "mississippi")
 ///     histogram.Add(c);
@@ -75,7 +75,7 @@ namespace Bodu.Collections.Generic;
 /// foreach (KeyValuePair<char, int> kv in histogram.Frequencies())
 ///     Console.WriteLine($"{kv.Key}: {kv.Value}");
 ///
-/// Multiset algebra — combine two histograms without mutating either operand.
+/// // Multiset algebra — combine two histograms without mutating either operand.
 /// var other = new Multiset<char> { 'i', 'i', 's' };
 /// Multiset<char> combined = histogram.Sum(other);
 ///]]>

--- a/Bodu.Core/src/Collections.Generic/OrderedSet.cs
+++ b/Bodu.Core/src/Collections.Generic/OrderedSet.cs
@@ -31,7 +31,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// De-duplicate a stream of tags while keeping the order in which each was first seen.
+/// // De-duplicate a stream of tags while keeping the order in which each was first seen.
 /// var tags = new OrderedSet<string>(StringComparer.OrdinalIgnoreCase);
 /// tags.Add("alpha");
 /// tags.Add("beta");
@@ -41,7 +41,7 @@ namespace Bodu.Collections.Generic;
 /// Console.WriteLine(string.Join(", ", tags)); // alpha, beta, gamma
 /// Console.WriteLine(tags[0]);                 // "alpha" — positional read via IReadOnlyList<T>
 ///
-/// Set algebra returns a new OrderedSet preserving the left operand's order.
+/// // Set algebra returns a new OrderedSet preserving the left operand's order.
 /// var diff = new OrderedSet<string>(tags);
 /// diff.ExceptWith(new[] { "beta" });
 ///]]>

--- a/Bodu.Core/src/Collections.Generic/RangeDictionary.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeDictionary.cs
@@ -29,7 +29,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Tax-bracket lookup: ranges are half-open and must not overlap.
+/// // Tax-bracket lookup: ranges are half-open and must not overlap.
 /// var brackets = new RangeDictionary<decimal, decimal>
 /// {
 ///     {     0m,  18_200m, 0.00m },
@@ -40,7 +40,7 @@ namespace Bodu.Collections.Generic;
 /// if (brackets.TryGetValue(50_000m, out decimal rate))
 ///     Console.WriteLine($"Rate: {rate:P0}"); // Rate: 30%
 ///
-/// Adjacent ranges are allowed; an overlapping insertion throws ArgumentException.
+/// // Adjacent ranges are allowed; an overlapping insertion throws ArgumentException.
 /// brackets.Add(135_000m, 190_000m, 0.37m);
 ///]]>
 /// </example>

--- a/Bodu.Core/src/Collections.Generic/RangeSet.cs
+++ b/Bodu.Core/src/Collections.Generic/RangeSet.cs
@@ -27,7 +27,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Track disjoint blocks of allocated row IDs. Adjacent and overlapping inserts merge automatically.
+/// // Track disjoint blocks of allocated row IDs. Adjacent and overlapping inserts merge automatically.
 /// var allocated = new RangeSet<int>();
 /// allocated.Add(  0,  10);   // [0, 10)
 /// allocated.Add( 20,  30);   // [20, 30)

--- a/Bodu.Core/src/Collections.Generic/RingBackedCollection.cs
+++ b/Bodu.Core/src/Collections.Generic/RingBackedCollection.cs
@@ -79,9 +79,9 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// The common surface is consumed through a concrete derivative — CircularBuffer<T> here.
-/// The same Count, Capacity, IsEmpty, indexer, ToArray, and TrimExcess members are available
-/// on every RingBackedCollection<T> subtype.
+/// // The common surface is consumed through a concrete derivative — CircularBuffer<T> here.
+/// // The same Count, Capacity, IsEmpty, indexer, ToArray, and TrimExcess members are available
+/// // on every RingBackedCollection<T> subtype.
 /// RingBackedCollection<int> ring = new CircularBuffer<int>(capacity: 4);
 /// ((CircularBuffer<int>)ring).Enqueue(10);
 /// ((CircularBuffer<int>)ring).Enqueue(20);

--- a/Bodu.Core/src/Collections.Generic/SegmentedBuffer.cs
+++ b/Bodu.Core/src/Collections.Generic/SegmentedBuffer.cs
@@ -31,7 +31,7 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Buffer a streamed sequence whose length is unknown, then random-access it by index.
+/// // Buffer a streamed sequence whose length is unknown, then random-access it by index.
 /// var buffer = new SegmentedBuffer<int>(segmentSize: 512);
 /// foreach (int value in ReadStream())
 ///     buffer.Add(value);

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Factory.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Factory.cs
@@ -45,7 +45,7 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Adapt an external pull-style API into an IEnumerable<T> pipeline.
+    /// // Adapt an external pull-style API into an IEnumerable<T> pipeline.
     /// IEnumerable<int> randomBytes = SequenceGenerator.Factory(() =>
     /// {
     ///     var rng = new Random(42);

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.NextWhile.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.NextWhile.cs
@@ -48,10 +48,10 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Halving sequence — terminates when the value drops to zero.
+    /// // Halving sequence — terminates when the value drops to zero.
     /// var halves = SequenceGenerator.NextWhile(64, v => v > 0, v => v / 2); // => 64, 32, 16, 8, 4, 2, 1
     ///
-    /// Empty result when the seed already fails the predicate.
+    /// // Empty result when the seed already fails the predicate.
     /// var none = SequenceGenerator.NextWhile(0, v => v > 0, v => v - 1); // => (empty)
     ///]]>
     /// </code>
@@ -113,7 +113,7 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Triangular numbers up to 100: 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91.
+    /// // Triangular numbers up to 100: 0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91.
     /// var triangular = SequenceGenerator.NextWhile(0, v => v <= 100, (v, i) => v + (i + 1));
     ///]]>
     /// </code>
@@ -179,7 +179,7 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Fibonacci numbers below 100, tracked through a (prev, curr) state record.
+    /// // Fibonacci numbers below 100, tracked through a (prev, curr) state record.
     /// var fib = SequenceGenerator.NextWhile(
     ///     initialState: (Prev: 0, Curr: 1),
     ///     conditionHandler: s => s.Curr < 100,

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Range.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Range.cs
@@ -91,7 +91,7 @@ public static partial class SequenceGenerator
     /// foreach (int n in SequenceGenerator.Range(10, 1, -3))
     ///     Console.Write($"{n} "); // => 10 7 4 1
     ///
-    /// Step of zero yields an unbounded sequence — bound it with Take.
+    /// // Step of zero yields an unbounded sequence — bound it with Take.
     /// var heartbeat = SequenceGenerator.Range(42, 0, 0).Take(3); // => 42, 42, 42
     ///]]>
     /// </code>

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.Repeat.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.Repeat.cs
@@ -39,7 +39,7 @@ public static partial class SequenceGenerator
     /// <example>
     /// <code language="csharp">
     ///<![CDATA[
-    /// Generate the first five powers of two by zipping a counter against a constant feed.
+    /// // Generate the first five powers of two by zipping a counter against a constant feed.
     /// var powers = SequenceGenerator.Repeat(2)
     ///     .Zip(SequenceGenerator.Range(0, 4), (b, e) => (long)Math.Pow(b, e)); // => 1, 2, 4, 8, 16
     ///]]>

--- a/Bodu.Core/src/Collections.Generic/SequenceGenerator.cs
+++ b/Bodu.Core/src/Collections.Generic/SequenceGenerator.cs
@@ -34,14 +34,14 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// A counted descending range.
+/// // A counted descending range.
 /// foreach (int n in SequenceGenerator.Range(start: 10, stop: 0, step: -2))
 ///     Console.WriteLine(n); // 10, 8, 6, 4, 2
 ///
-/// A finite repeat.
+/// // A finite repeat.
 /// string[] padding = SequenceGenerator.Repeat("--", count: 3).ToArray();
 ///
-/// A stateful generator producing powers of two while the value fits in a positive int.
+/// // A stateful generator producing powers of two while the value fits in a positive int.
 /// IEnumerable<int> powers = SequenceGenerator.NextWhile(
 ///     initialValue: 1,
 ///     conditionHandler: value => value > 0,

--- a/Bodu.Core/src/Collections.Generic/ShuffleHelpers.cs
+++ b/Bodu.Core/src/Collections.Generic/ShuffleHelpers.cs
@@ -31,12 +31,12 @@ namespace Bodu.Collections.Generic;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Deterministic shuffle of an array — useful for tests and reproducible demos.
+/// // Deterministic shuffle of an array — useful for tests and reproducible demos.
 /// var deck = Enumerable.Range(1, 52).ToArray();
 /// IRandomGenerator rng = new XorShiftRandom(seed: 42);
 /// ShuffleHelpers.Shuffle(deck, rng);
 ///
-/// Sample five cards without replacement using the yield-based overload.
+/// // Sample five cards without replacement using the yield-based overload.
 /// foreach (int card in ShuffleHelpers.ShuffleAndYield(deck, rng, count: 5))
 ///     Console.WriteLine(card);
 ///]]>

--- a/Bodu.Core/src/Extensions/ArrayExtensions.cs
+++ b/Bodu.Core/src/Extensions/ArrayExtensions.cs
@@ -37,13 +37,13 @@ namespace Bodu.Extensions;
 ///<![CDATA[
 /// int[] source = { 1, 2, 3, 4, 5, 6 };
 ///
-/// Reverse only the middle window — in place.
+/// // Reverse only the middle window — in place.
 /// source.Reverse(1, 4); // => source is now { 1, 5, 4, 3, 2, 6 }
 ///
-/// Take a freshly allocated slice using a Range expression.
+/// // Take a freshly allocated slice using a Range expression.
 /// int[] tail = source.Slice(2..); // => { 4, 3, 2, 6 }
 ///
-/// Clear the prefix without touching the tail.
+/// // Clear the prefix without touching the tail.
 /// source.Clear(0, 3); // => source is now { 0, 0, 0, 3, 2, 6 }
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/ComparableHelper.cs
+++ b/Bodu.Core/src/Extensions/ComparableHelper.cs
@@ -39,7 +39,7 @@ namespace Bodu.Extensions;
 /// int? smaller = ComparableHelper.Min(a, b);       // 5 (null is skipped)
 /// int? either  = ComparableHelper.Coalesce(b, a);  // 5
 ///
-/// Custom comparer for reverse-ordered strings.
+/// // Custom comparer for reverse-ordered strings.
 /// string? winner = ComparableHelper.Max("alpha", "beta", StringComparer.OrdinalIgnoreCase); // "beta"
 ///]]>
 /// </example>

--- a/Bodu.Core/src/Extensions/DateOnlyExtensions.cs
+++ b/Bodu.Core/src/Extensions/DateOnlyExtensions.cs
@@ -40,13 +40,13 @@ namespace Bodu.Extensions;
 ///<![CDATA[
 /// var date = new DateOnly(2025, 4, 30);
 ///
-/// Anchor to the first Monday in this month.
+/// // Anchor to the first Monday in this month.
 /// DateOnly firstMonday = date.FirstDateOfWeekInMonth(DayOfWeek.Monday); // => 2025-04-07
 ///
-/// Walk to the previous Friday, even if today is already a Friday.
+/// // Walk to the previous Friday, even if today is already a Friday.
 /// DateOnly priorFriday = date.PreviousDateOfWeek(DayOfWeek.Friday); // => 2025-04-25
 ///
-/// Compute the calendar week within the month using ISO rules.
+/// // Compute the calendar week within the month using ISO rules.
 /// int weekOfMonth = date.WeekOfMonth(CalendarWeekRule.FirstFourDayWeek, DayOfWeek.Monday); // => 5
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/DateTimeExtensions.cs
+++ b/Bodu.Core/src/Extensions/DateTimeExtensions.cs
@@ -46,15 +46,15 @@ namespace Bodu.Extensions;
 ///<![CDATA[
 /// var dt = new DateTime(2025, 4, 30, 14, 35, 0, DateTimeKind.Utc);
 ///
-/// Snap to the start and end of the same day, preserving Kind.
+/// // Snap to the start and end of the same day, preserving Kind.
 /// DateTime startOfDay = dt.StartOfDay(); // 2025-04-30T00:00:00Z
 /// DateTime endOfDay = dt.EndOfDay(); // 2025-04-30T23:59:59.9999999Z
 ///
-/// ISO 8601 week-of-year and matching ISO year.
+/// // ISO 8601 week-of-year and matching ISO year.
 /// int isoWeek = dt.IsoWeekOfYear(); // 18
 /// int isoYear = dt.IsoYear(); // 2025
 ///
-/// Walk to the first Monday strictly after this date.
+/// // Walk to the first Monday strictly after this date.
 /// DateTime nextMonday = dt.NextDateOfWeek(DayOfWeek.Monday); // 2025-05-05T14:35:00Z
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/IComparableExtensions.cs
+++ b/Bodu.Core/src/Extensions/IComparableExtensions.cs
@@ -39,13 +39,13 @@ namespace Bodu.Extensions;
 ///<![CDATA[
 /// int volume = 11;
 ///
-/// Replace explicit min/max calls with a fluent clamp.
+/// // Replace explicit min/max calls with a fluent clamp.
 /// int safeVolume = volume.Clamp(0, 10); // => 10
 ///
-/// Inclusive "between" predicate, ideal in guard clauses.
+/// // Inclusive "between" predicate, ideal in guard clauses.
 /// bool inDecimalDigits = '7'.IsBetween('0', '9'); // => true
 ///
-/// Custom comparer for case-insensitive string ranges.
+/// // Custom comparer for case-insensitive string ranges.
 /// bool inMidAlphabet = "Mango".IsBetween("apple", "orange", StringComparer.OrdinalIgnoreCase); // => true
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/NumericExtensions.cs
+++ b/Bodu.Core/src/Extensions/NumericExtensions.cs
@@ -36,15 +36,15 @@ namespace Bodu.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Swap byte order for big-endian wire encoding.
+/// // Swap byte order for big-endian wire encoding.
 /// uint host = 0x11_22_33_44u;
 /// uint network = host.ReverseBytes(); // => 0x44_33_22_11
 ///
-/// Bit reversal — useful in CRC and DSP code.
+/// // Bit reversal — useful in CRC and DSP code.
 /// byte mask = 0b1011_0001;
 /// byte mirrored = mask.ReverseBits(); // => 0b1000_1101
 ///
-/// Cyclic bit rotation — common in hashing primitives.
+/// // Cyclic bit rotation — common in hashing primitives.
 /// uint rotated = 0x0000_00FFu.RotateBitsLeft(8); // => 0x0000_FF00
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/SpanExtensions.Reverse.cs
+++ b/Bodu.Core/src/Extensions/SpanExtensions.Reverse.cs
@@ -68,7 +68,7 @@ public static partial class SpanExtensions
     ///<![CDATA[
     /// int[] data = { 1, 2, 3, 4, 5 };
     ///
-    /// Reverse a middle section; first and last elements are untouched.
+    /// // Reverse a middle section; first and last elements are untouched.
     /// Span<int> result = data.AsSpan().Reverse(start: 1, length: 3); // [ 1, 4, 3, 2, 5 ]
     ///]]>
     /// </code>

--- a/Bodu.Core/src/Extensions/SpanExtensions.cs
+++ b/Bodu.Core/src/Extensions/SpanExtensions.cs
@@ -35,13 +35,13 @@ namespace Bodu.Extensions;
 ///<![CDATA[
 /// Span<int> buffer = stackalloc int[] { 1, 2, 3, 4, 5, 6 };
 ///
-/// Reverse only the trailing window using a Range.
+/// // Reverse only the trailing window using a Range.
 /// buffer.Reverse(2..); // => buffer is now { 1, 2, 6, 5, 4, 3 }
 ///
-/// Narrow the surface before handing the span to a read-only consumer.
+/// // Narrow the surface before handing the span to a read-only consumer.
 /// ReadOnlySpan<int> view = buffer.AsReadOnly();
 ///
-/// Reverse the full span back to its original ordering.
+/// // Reverse the full span back to its original ordering.
 /// buffer.Reverse(); // => buffer is now { 3, 4, 5, 6, 2, 1 }
 ///]]>
 /// </code>

--- a/Bodu.Core/src/Extensions/StringExtensions.cs
+++ b/Bodu.Core/src/Extensions/StringExtensions.cs
@@ -32,14 +32,14 @@ namespace Bodu.Extensions;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Sanitise then truncate user input for a log line.
+/// // Sanitise then truncate user input for a log line.
 /// string? raw = request?.Title;
 /// string display = raw.TrimToNull()?.CollapseWhitespace().Truncate(80, "…") ?? "(untitled)";
 ///
-/// Build a slug for a URL.
+/// // Build a slug for a URL.
 /// string slug = "Hello, World! — café".ToSlug();   // "hello-world-cafe"
 ///
-/// Round-trip identifiers between conventions.
+/// // Round-trip identifiers between conventions.
 /// string pascal = "user_account_id".ToPascalCase(); // "UserAccountId"
 /// string snake  = "UserAccountId".ToSnakeCase();    // "user_account_id"
 ///]]>

--- a/Bodu.Core/src/Globalization.Extensions/DateTimeFormatInfoExtensions.cs
+++ b/Bodu.Core/src/Globalization.Extensions/DateTimeFormatInfoExtensions.cs
@@ -37,10 +37,10 @@ namespace Bodu.Globalization.Extensions;
 /// var enUs = CultureInfo.GetCultureInfo("en-US").DateTimeFormat;
 ///
 /// DayOfWeek lastInBritain = enGb.LastDayOfWeek();
-/// => DayOfWeek.Sunday (en-GB starts on Monday, so the week ends on Sunday)
+/// // => DayOfWeek.Sunday (en-GB starts on Monday, so the week ends on Sunday)
 ///
 /// DayOfWeek lastInAmerica = enUs.LastDayOfWeek();
-/// => DayOfWeek.Saturday (en-US starts on Sunday, so the week ends on Saturday)
+/// // => DayOfWeek.Saturday (en-US starts on Sunday, so the week ends on Saturday)
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Core/src/IRandomGenerator.cs
+++ b/Bodu.Core/src/IRandomGenerator.cs
@@ -32,7 +32,7 @@ namespace Bodu;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Substitute a deterministic generator in tests.
+/// // Substitute a deterministic generator in tests.
 /// IRandomGenerator rng = new XorShiftRandom(seed: 42);
 /// int dieRoll = rng.Next(6) + 1; // value in [1, 6]
 ///]]>

--- a/Bodu.Core/src/Xml.Linq/XmlNamespaaceResolver.cs
+++ b/Bodu.Core/src/Xml.Linq/XmlNamespaaceResolver.cs
@@ -39,7 +39,7 @@ namespace Bodu.Xml.Linq;
 ///
 /// var ns = new XmlNamespaceResolver(doc.Root!);
 ///
-/// Look up by local name without re-stating the namespace at every call site.
+/// // Look up by local name without re-stating the namespace at every call site.
 /// XElement? book  = ns.Element(doc.Root!, "book");
 /// XElement? title = ns.Element(book!,     "title");
 /// Console.WriteLine(title?.Value); // Foundation

--- a/Bodu.Core/src/XorShiftRandom.cs
+++ b/Bodu.Core/src/XorShiftRandom.cs
@@ -37,7 +37,7 @@ namespace Bodu;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Reproducible shuffle and sample in a test.
+/// // Reproducible shuffle and sample in a test.
 /// var rng = new XorShiftRandom(seed: 1234);
 /// int    roll  = rng.Next(6) + 1;           // value in [1, 6]
 /// double angle = rng.NextDouble() * Math.Tau;

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/ConfigurationOptionsExtensions.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/ConfigurationOptionsExtensions.cs
@@ -33,7 +33,7 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Strongly-typed options bound to the "Logging" section produced by AddBoduConfigurationFile.
+/// // Strongly-typed options bound to the "Logging" section produced by AddBoduConfigurationFile.
 /// public sealed class LoggingOptions
 /// {
 ///     public string Level { get; init; } = "Information";
@@ -43,16 +43,16 @@ namespace Bodu.Extensions.Configuration.Text;
 /// var builder = WebApplication.CreateBuilder(args);
 /// builder.Configuration.AddBoduConfigurationFile("appsettings.boduconfig");
 ///
-/// Bind by section name against the configuration root.
+/// // Bind by section name against the configuration root.
 /// builder.Services.AddConfigurationOptions<LoggingOptions>(
 ///     builder.Configuration,
 ///     sectionName: "Logging");
 ///
-/// Or bind a pre-resolved section directly.
+/// // Or bind a pre-resolved section directly.
 /// IConfigurationSection logging = builder.Configuration.GetSection("Logging");
 /// builder.Services.AddConfigurationOptions<LoggingOptions>(logging);
 ///
-/// Consumed via constructor injection.
+/// // Consumed via constructor injection.
 /// public sealed class HomeController(IOptions<LoggingOptions> options) { /* options.Value.Level */ }
 ///]]>
 /// </example>

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationExtensions.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationExtensions.cs
@@ -64,16 +64,16 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// 1. Canonical ASP.NET / Generic Host registration in Program.cs.
+/// // 1. Canonical ASP.NET / Generic Host registration in Program.cs.
 /// var builder = WebApplication.CreateBuilder(args);
 /// builder.Configuration
 ///     .AddBoduConfigurationFile("appsettings.boduconfig", optional: true, reloadOnChange: true)
 ///     .AddBoduConfigurationFile("appsettings.boduconfig", targetPath: "src/Foo.cs"); // path-aware view
 ///
-/// 2. Convention discovery — probes .boduconfig, then bodu.config.
+/// // 2. Convention discovery — probes .boduconfig, then bodu.config.
 /// builder.Configuration.AddBoduConfiguration(optional: true, reloadOnChange: true);
 ///
-/// 3. Lambda overload — pin every option, including parse/resolve behaviour.
+/// // 3. Lambda overload — pin every option, including parse/resolve behaviour.
 /// builder.Configuration.AddBoduConfigurationFile(source =>
 /// {
 ///     source.Path           = "app.boduconfig";
@@ -87,11 +87,11 @@ namespace Bodu.Extensions.Configuration.Text;
 ///     };
 /// });
 ///
-/// 4. In-memory stream — handy in unit tests.
+/// // 4. In-memory stream — handy in unit tests.
 /// using var ms = new MemoryStream(Encoding.UTF8.GetBytes("[*]\nLogging:Level=Debug\n"));
 /// builder.Configuration.AddBoduConfigurationStream(ms);
 ///
-/// 5. Pre-parsed document — share one parse across multiple builders.
+/// // 5. Pre-parsed document — share one parse across multiple builders.
 /// ConfigurationDocument doc = ConfigurationDocument.Parse(text);
 /// builder.Configuration.AddBoduConfigurationDocument(doc, targetPath: "src/Foo.cs");
 ///]]>

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationProvider.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationProvider.cs
@@ -27,7 +27,7 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Diagnostic introspection: locate the Bodu provider after the configuration root has been built.
+/// // Diagnostic introspection: locate the Bodu provider after the configuration root has been built.
 /// IConfigurationRoot root = builder.Build();
 /// TextConfigurationProvider? bodu = root.Providers
 ///     .OfType<TextConfigurationProvider>()

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationSource.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextConfigurationSource.cs
@@ -30,7 +30,7 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Typical lambda registration via the IConfigurationBuilder extension.
+/// // Typical lambda registration via the IConfigurationBuilder extension.
 /// builder.Configuration.AddBoduConfigurationFile(source =>
 /// {
 ///     source.Path           = "app.boduconfig";
@@ -40,7 +40,7 @@ namespace Bodu.Extensions.Configuration.Text;
 ///     source.ParseOptions   = ConfigurationParseOptions.Strict;
 /// });
 ///
-/// Direct construction — for example, in a custom builder host.
+/// // Direct construction — for example, in a custom builder host.
 /// var source = new TextConfigurationSource
 /// {
 ///     Path           = "app.boduconfig",

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextStreamConfigurationProvider.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextStreamConfigurationProvider.cs
@@ -28,7 +28,7 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Diagnostic introspection: locate the Bodu stream provider after the configuration root has been built.
+/// // Diagnostic introspection: locate the Bodu stream provider after the configuration root has been built.
 /// IConfigurationRoot root = builder.Build();
 /// TextStreamConfigurationProvider? bodu = root.Providers
 ///     .OfType<TextStreamConfigurationProvider>()

--- a/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextStreamConfigurationSource.cs
+++ b/Bodu.Extensions.Configuration.Text/src/Extensions.Configuration.Text/TextStreamConfigurationSource.cs
@@ -30,7 +30,7 @@ namespace Bodu.Extensions.Configuration.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Test-time configuration from an in-memory string.
+/// // Test-time configuration from an in-memory string.
 /// const string ConfigText = """
 ///     [*]
 ///     Logging:Level = Debug

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AbaRoutingNumber.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AbaRoutingNumber.cs
@@ -31,13 +31,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 8-digit body.
+/// // Single-call computation against the 8-digit body.
 /// char check = AbaRoutingNumber.Compute("01100001");   // '5'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = AbaRoutingNumber.IsValid("011000015");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new AbaRoutingNumber();
 /// algo.Append("01100001");
 /// char d = algo.GetCurrentCheckDigit();                // '5'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithm.cs
@@ -32,13 +32,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Use a concrete derivative through the abstract surface — ISIN accepts a mix of
-/// ASCII letters (the country code) and digits.
+/// // Use a concrete derivative through the abstract surface — ISIN accepts a mix of
+/// // ASCII letters (the country code) and digits.
 /// AlphanumericCheckDigitAlgorithm algo = new Isin();
 /// algo.Append("US037833100");                          // Apple Inc.
 /// char check = algo.GetCurrentCheckDigit();            // '5'
 ///
-/// Inspect the declared alphabets for input validation upstream.
+/// // Inspect the declared alphabets for input validation upstream.
 /// CheckDigitInputAlphabet  inputs  = algo.InputAlphabet;
 /// CheckDigitOutputAlphabet outputs = algo.OutputAlphabet;
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/CheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/CheckDigitAlgorithm.cs
@@ -32,12 +32,12 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Use a concrete derivative through the abstract surface.
+/// // Use a concrete derivative through the abstract surface.
 /// CheckDigitAlgorithm algo = new Luhn();
 /// algo.Append("7992739871");
 /// char check = algo.GetCurrentCheckDigit();   // '3'
 ///
-/// Reset between independent computations.
+/// // Reset between independent computations.
 /// algo.Reset();
 /// algo.Append('1');
 /// algo.Append("7893729977");

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Code39Mod43.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Code39Mod43.cs
@@ -35,13 +35,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Code39Mod43.Compute("CODE39");   // 'W'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Code39Mod43.IsValid("CODE39W");      // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Code39Mod43();
 /// algo.Append("CODE39");
 /// char d = algo.GetCurrentCheckDigit();          // 'W'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Crockford32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Crockford32.cs
@@ -36,13 +36,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Crockford32.Compute("16J");   // 'D'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Crockford32.IsValid("16JD");      // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Crockford32();
 /// algo.Append("16J");
 /// char d = algo.GetCurrentCheckDigit();       // 'D'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Cusip.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Cusip.cs
@@ -32,13 +32,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Apple Inc. — CUSIP body "03783310".
+/// // Apple Inc. — CUSIP body "03783310".
 /// char check = Cusip.Compute("03783310");   // '0'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Cusip.IsValid("037833100");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Cusip();
 /// algo.Append("03783310");
 /// char d = algo.GetCurrentCheckDigit();     // '0'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Damm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Damm.cs
@@ -29,13 +29,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Damm.Compute("572");   // '4'
 ///
-/// Full-sequence validation — equivalent to checking that the final interim is zero.
+/// // Full-sequence validation — equivalent to checking that the final interim is zero.
 /// bool ok = Damm.IsValid("5724");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Damm();
 /// algo.Append("572");
 /// char d = algo.GetCurrentCheckDigit(); // '4'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean13.cs
@@ -27,13 +27,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 12-digit body.
+/// // Single-call computation against the 12-digit body.
 /// char check = Ean13.Compute("501234567890");   // '0'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Ean13.IsValid("5012345678900");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Ean13();
 /// algo.Append("501234567890");
 /// char d = algo.GetCurrentCheckDigit();         // '0'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean8.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Ean8.cs
@@ -26,13 +26,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 7-digit body.
+/// // Single-call computation against the 7-digit body.
 /// char check = Ean8.Compute("7351353");   // '7'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Ean8.IsValid("73513537");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Ean8();
 /// algo.Append("7351353");
 /// char d = algo.GetCurrentCheckDigit();   // '7'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gtin14.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gtin14.cs
@@ -26,13 +26,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 13-digit body.
+/// // Single-call computation against the 13-digit body.
 /// char check = Gtin14.Compute("1061414100041");   // '5'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Gtin14.IsValid("10614141000415");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Gtin14();
 /// algo.Append("1061414100041");
 /// char d = algo.GetCurrentCheckDigit();           // '5'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gumm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Gumm.cs
@@ -38,13 +38,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Gumm.Compute("236");   // '9'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Gumm.IsValid("2369");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Gumm();
 /// algo.Append("236");
 /// char d = algo.GetCurrentCheckDigit();   // '9'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iban.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iban.cs
@@ -35,13 +35,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation — body is the country code followed by the BBAN.
+/// // Single-call computation — body is the country code followed by the BBAN.
 /// string check = Iban.Compute("GBWEST12345698765432");   // "82"
 ///
-/// Full-sequence validation against the complete IBAN.
+/// // Full-sequence validation against the complete IBAN.
 /// bool ok = Iban.IsValid("GB82WEST12345698765432");      // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Iban();
 /// algo.Append("GBWEST12345698765432");
 /// string code = algo.GetCurrentCheckDigits();            // "82"

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isbn10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isbn10.cs
@@ -28,14 +28,14 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Two contrasting bodies — the second exercises the 'X' sentinel.
+/// // Two contrasting bodies — the second exercises the 'X' sentinel.
 /// char check    = Isbn10.Compute("030640615");   // '2'
 /// char checkX   = Isbn10.Compute("043942089");   // 'X'  (sentinel for value ten)
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Isbn10.IsValid("043942089X");        // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Isbn10();
 /// algo.Append("030640615");
 /// char d = algo.GetCurrentCheckDigit();          // '2'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isbn13.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isbn13.cs
@@ -30,13 +30,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 12-digit body.
+/// // Single-call computation against the 12-digit body.
 /// char check = Isbn13.Compute("978030640615");   // '7'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Isbn13.IsValid("9780306406157");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Isbn13();
 /// algo.Append("978030640615");
 /// char d = algo.GetCurrentCheckDigit();          // '7'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isin.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Isin.cs
@@ -32,13 +32,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Apple Inc. — country code US, body "US037833100".
+/// // Apple Inc. — country code US, body "US037833100".
 /// char check = Isin.Compute("US037833100");   // '5'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Isin.IsValid("US0378331005");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Isin();
 /// algo.Append("US037833100");
 /// char d = algo.GetCurrentCheckDigit();       // '5'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iso7064Mod11_2.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iso7064Mod11_2.cs
@@ -31,13 +31,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against a decimal body.
+/// // Single-call computation against a decimal body.
 /// char check = Iso7064Mod11_2.Compute("0794");   // '0'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Iso7064Mod11_2.IsValid("07940");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Iso7064Mod11_2();
 /// algo.Append("0794");
 /// char d = algo.GetCurrentCheckDigit();          // '0'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iso7064Mod97_10.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Iso7064Mod97_10.cs
@@ -34,13 +34,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation — returns the two-digit check as a string.
+/// // Single-call computation — returns the two-digit check as a string.
 /// string check = Iso7064Mod97_10.Compute("794");   // "44"
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Iso7064Mod97_10.IsValid("79444");      // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Iso7064Mod97_10();
 /// algo.Append("794");
 /// string code = algo.GetCurrentCheckDigits();      // "44"

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Lei.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Lei.cs
@@ -28,13 +28,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 18-character body.
+/// // Single-call computation against the 18-character body.
 /// string check = Lei.Compute("54930084UKLVMY22DS");   // "16"
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Lei.IsValid("54930084UKLVMY22DS16");      // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Lei();
 /// algo.Append("54930084UKLVMY22DS");
 /// string code = algo.GetCurrentCheckDigits();         // "16"

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Luhn.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Luhn.cs
@@ -35,13 +35,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Luhn.Compute("7992739871");   // '3'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Luhn.IsValid("79927398713");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Luhn();
 /// algo.Append("7992739871");
 /// char d = algo.GetCurrentCheckDigit();      // '3'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithm.cs
@@ -31,7 +31,7 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Use a concrete derivative through the abstract surface — IBAN emits a two-digit check.
+/// // Use a concrete derivative through the abstract surface — IBAN emits a two-digit check.
 /// MultiCharCheckDigitAlgorithm algo = new Iban();
 /// algo.Append("GBWEST12345698765432");                 // country code + BBAN
 ///

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Sedol.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Sedol.cs
@@ -31,13 +31,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 6-character body (consonants and digits only).
+/// // Single-call computation against the 6-character body (consonants and digits only).
 /// char check = Sedol.Compute("B0WNLY");   // '7'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Sedol.IsValid("B0WNLY7");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Sedol();
 /// algo.Append("B0WNLY");
 /// char d = algo.GetCurrentCheckDigit();   // '7'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/UpcA.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/UpcA.cs
@@ -26,13 +26,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against the 11-digit body.
+/// // Single-call computation against the 11-digit body.
 /// char check = UpcA.Compute("03600029145");   // '2'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = UpcA.IsValid("036000291452");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new UpcA();
 /// algo.Append("03600029145");
 /// char d = algo.GetCurrentCheckDigit();       // '2'

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Verhoeff.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/Verhoeff.cs
@@ -29,13 +29,13 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Single-call computation against an in-memory body.
+/// // Single-call computation against an in-memory body.
 /// char check = Verhoeff.Compute("236");   // '3'
 ///
-/// Full-sequence validation.
+/// // Full-sequence validation.
 /// bool ok = Verhoeff.IsValid("2363");     // true
 ///
-/// Streaming use when the body is built up incrementally.
+/// // Streaming use when the body is built up incrementally.
 /// var algo = new Verhoeff();
 /// algo.Append("236");
 /// char d = algo.GetCurrentCheckDigit();   // '3'

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32.cs
@@ -51,7 +51,7 @@ namespace Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// zlib-compatible Adler-32 of a deflate payload.
+/// // zlib-compatible Adler-32 of a deflate payload.
 /// var adler = new Adler32();
 /// byte[] checksum = adler.ComputeHash(deflateBlock);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32Base.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32Base.cs
@@ -23,8 +23,8 @@ namespace Bodu.IO.Hashing.Checksums;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete derivative — the shared 32-bit finalization layout
-/// is identical across every Adler32Base subclass.
+/// // Consume through a concrete derivative — the shared 32-bit finalization layout
+/// // is identical across every Adler32Base subclass.
 /// Adler32Base hash = new Adler32();                 // modulus 65521 (the canonical Adler-32)
 /// hash.Append("Wikipedia"u8);
 /// byte[] digest = hash.GetCurrentHash();            // 0x11E60398 in big-endian byte order

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler32C.cs
@@ -50,7 +50,7 @@ namespace Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// SIMD-friendly Adler variant for high-throughput internal pipelines.
+/// // SIMD-friendly Adler variant for high-throughput internal pipelines.
 /// var adler = new Adler32C();
 /// byte[] checksum = adler.ComputeHash(largeBlock);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64Base.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.Adler64Base.cs
@@ -20,8 +20,8 @@ namespace Bodu.IO.Hashing.Checksums;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete derivative — the shared 64-bit finalization layout
-/// is identical across every Adler64Base subclass.
+/// // Consume through a concrete derivative — the shared 64-bit finalization layout
+/// // is identical across every Adler64Base subclass.
 /// Adler64Base hash = new Adler64();
 /// hash.Append("Wikipedia"u8);
 /// byte[] digest = hash.GetCurrentHash();   // big-endian (B << 32) | A

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Adler.cs
@@ -48,7 +48,7 @@ namespace Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// zlib-compatible Adler-32 of a deflate payload.
+/// // zlib-compatible Adler-32 of a deflate payload.
 /// var adler = new Adler32();
 /// byte[] checksum = adler.ComputeHash(deflateBlock);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Crc.cs
@@ -90,18 +90,18 @@ namespace Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 1. Standard PKZIP / Ethernet CRC-32 of a buffer.
+/// // 1. Standard PKZIP / Ethernet CRC-32 of a buffer.
 /// var crc32 = new Crc(CrcStandard.CRC32_ISOHDLC);
 /// byte[] digest = crc32.ComputeHash(File.ReadAllBytes("payload.bin"));
 ///
-/// 2. Modbus RTU — different polynomial/init/reflect choices, same engine.
+/// // 2. Modbus RTU — different polynomial/init/reflect choices, same engine.
 /// var modbus = new Crc(CrcStandard.CRC16_MODBUS);
 /// modbus.Append(frameHeader);
 /// modbus.Append(framePayload);
 /// byte[] frameCrc = modbus.GetCurrentHash(); // non-destructive snapshot
 ///
-/// 3. Resumption — fold an appended log segment into yesterday's digest without re-reading
-/// the original bytes.
+/// // 3. Resumption — fold an appended log segment into yesterday's digest without re-reading
+/// // the original bytes.
 /// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
 /// byte[] updated = resumable.ComputeHashFrom(digest, File.ReadAllBytes("payload.appended.bin"));
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableBuilder.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableBuilder.cs
@@ -40,15 +40,15 @@ namespace Bodu.IO.Hashing.Checksums;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Build the lookup table for CRC-32/ISO-HDLC (the canonical CRC-32 used by Ethernet, PKZIP, gzip).
+/// // Build the lookup table for CRC-32/ISO-HDLC (the canonical CRC-32 used by Ethernet, PKZIP, gzip).
 /// CrcStandard isoHdlc = CrcStandard.CRC32_ISOHDLC;
 /// ulong[] table = CrcLookupTableBuilder.BuildLookupTable(
 ///     size:       isoHdlc.Size,        // 32
 ///     polynomial: isoHdlc.Polynomial,  // 0x04C11DB7
 ///     reflectIn:  isoHdlc.ReflectIn);  // true
 ///
-/// table has 256 entries; each value is masked to 32 bits and suitable for
-/// direct XOR into the running CRC register.
+/// // table has 256 entries; each value is masked to 32 bits and suitable for
+/// // direct XOR into the running CRC register.
 /// Console.WriteLine(table[0xFF]); // 0x...  the precomputed contribution for byte 0xFF
 ///]]>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcLookupTableCache.cs
@@ -39,10 +39,10 @@ namespace Bodu.IO.Hashing.Checksums;
 ///<![CDATA[
 /// using Bodu.IO.Hashing.Checksums;
 ///
-/// Most callers do not interact with the cache directly — Crc resolves it through Crc.GlobalCache.
+/// // Most callers do not interact with the cache directly — Crc resolves it through Crc.GlobalCache.
 /// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
 ///
-/// Use a scoped cache for an isolated test, then restore the default.
+/// // Use a scoped cache for an isolated test, then restore the default.
 /// CrcLookupTableCache previous = Crc.GlobalCache;
 /// try
 /// {

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/CrcStandard.cs
@@ -83,18 +83,18 @@ namespace Bodu.IO.Hashing.Checksums;
 ///<![CDATA[
 /// using Bodu.IO.Hashing.Checksums;
 ///
-/// 1. Direct named accessor — most callers want exactly this.
+/// // 1. Direct named accessor — most callers want exactly this.
 /// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
 ///
-/// 2. Data-driven look-up — pick the variant from a configuration value.
+/// // 2. Data-driven look-up — pick the variant from a configuration value.
 /// CrcStandards configured = Enum.Parse<CrcStandards>(config["CrcVariant"]);
 /// var configuredCrc = new Crc(CrcStandard.Get(configured));
 ///
-/// 3. Look-up by alias — accept legacy or vendor names supplied by users.
+/// // 3. Look-up by alias — accept legacy or vendor names supplied by users.
 /// CrcStandard pkzip = CrcStandard.FromName("PKZIP");      // same instance as CRC32_ISOHDLC
 /// CrcStandard ccitt = CrcStandard.FromName("CRC-CCITT");  // resolves to CRC16_KERMIT
 ///
-/// 4. Custom variant (not in the RevEng catalogue): a 12-bit CRC with bespoke parameters.
+/// // 4. Custom variant (not in the RevEng catalogue): a 12-bit CRC with bespoke parameters.
 /// var custom = new CrcStandard(
 ///     name:         "CRC-12/MY-SPEC",
 ///     size:         12,

--- a/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Checksums/Fletcher.cs
@@ -46,7 +46,7 @@ namespace Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Checksums;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 32-bit Fletcher checksum of a packet payload.
+/// // 32-bit Fletcher checksum of a packet payload.
 /// var fletcher = new Fletcher32();
 /// byte[] checksum = fletcher.ComputeHash(payload);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.Extensions/NonCryptographicHashAlgorithmExtensions.cs
@@ -72,15 +72,15 @@ namespace Bodu.IO.Hashing.Extensions;
 /// using System.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 1. One-shot hash of a byte buffer using xxHash64.
+/// // 1. One-shot hash of a byte buffer using xxHash64.
 /// var xx = new XxHash64();
 /// byte[] digest = xx.ComputeHash(File.ReadAllBytes("payload.bin"));
 ///
-/// 2. Stream-hash a large file without loading it into memory.
+/// // 2. Stream-hash a large file without loading it into memory.
 /// using FileStream fs = File.OpenRead("payload.bin"); 
 /// byte[] streamDigest = xx.ComputeHash(fs);
 ///
-/// 3. Verify a downloaded artefact against an expected hex digest, without throwing on a malformed string.
+/// // 3. Verify a downloaded artefact against an expected hex digest, without throwing on a malformed string.
 /// var crc = new Crc32();
 /// if (crc.TryVerifyHash(File.ReadAllBytes("artefact.zip"), expectedHex: "deadbeef"))
 ///     Console.WriteLine("artefact verified");

--- a/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BKDR.cs
@@ -43,7 +43,7 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// Default seed (131); appropriate for short identifier keys.
+/// // Default seed (131); appropriate for short identifier keys.
 /// var bkdr = new BKDR();
 /// byte[] digest = bkdr.ComputeHash(System.Text.Encoding.UTF8.GetBytes("Identifier"));
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Bernstein.cs
@@ -47,11 +47,11 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// Default djb2 with the canonical 5381 seed.
+/// // Default djb2 with the canonical 5381 seed.
 /// var djb2 = new Bernstein();
 /// byte[] digest = djb2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
 ///
-/// XOR-modified djb2a, generally better distribution.
+/// // XOR-modified djb2a, generally better distribution.
 /// var djb2a = new Bernstein { UseModifiedAlgorithm = true };
 /// byte[] digestA = djb2a.ComputeHash(System.Text.Encoding.UTF8.GetBytes("symbol"));
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
@@ -92,8 +92,8 @@ namespace Bodu.IO.Hashing;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Sketch of a derived block hash. The base class drives buffering and snapshotting; the
-/// derived type only expresses how a single block mutates the accumulator.
+/// // Sketch of a derived block hash. The base class drives buffering and snapshotting; the
+/// // derived type only expresses how a single block mutates the accumulator.
 /// public sealed class MyBlockHash : BlockNonCryptographicHashAlgorithm<MyBlockHash>
 /// {
 ///     private uint _state;

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.128.cs
@@ -67,7 +67,7 @@ namespace Bodu.IO.Hashing;
 ///
 /// var city = new CityHash128();
 /// byte[] fingerprint = city.ComputeHash(blob);
-/// fingerprint = [low 64 bits || high 64 bits], each little-endian.
+/// // fingerprint = [low 64 bits || high 64 bits], each little-endian.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/CityHash.cs
@@ -59,12 +59,12 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 64-bit fingerprint of a content blob — typical use case.
+/// // 64-bit fingerprint of a content blob — typical use case.
 /// var city = new CityHash64();
 /// byte[] fingerprint = city.ComputeHash(blob);
 ///
-/// Stream-hash a moderately sized file.
-/// Note: CityHash buffers fully — prefer Crc / xxHash for very large streams.
+/// // Stream-hash a moderately sized file.
+/// // Note: CityHash buffers fully — prefer Crc / xxHash for very large streams.
 /// using FileStream fs = File.OpenRead("payload.bin");
 /// byte[] streamDigest = city.ComputeHash(fs);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/Fnv.cs
@@ -61,7 +61,7 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// Pick a width and variant; FNV-1a is the recommended default.
+/// // Pick a width and variant; FNV-1a is the recommended default.
 /// var fnv = new Fnv1a64();
 /// byte[] digest = fnv.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user@example.com"));
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/IResumableHashAlgorithm.cs
@@ -65,18 +65,18 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Checksums;
 ///
-/// 1. Compute a baseline digest of a file's first segment.
+/// // 1. Compute a baseline digest of a file's first segment.
 /// var crc = new Crc(CrcStandard.CRC32_ISOHDLC);
 /// crc.Append(File.ReadAllBytes("part-1.bin"));
 /// byte[] digest1 = crc.GetCurrentHash();
 ///
-/// 2. Hours (or processes) later, fold an additional segment into the same
-/// digest using only `digest1`.
+/// // 2. Hours (or processes) later, fold an additional segment into the same
+/// // digest using only `digest1`.
 /// var resumable = (IResumableHashAlgorithm)new Crc(CrcStandard.CRC32_ISOHDLC);
 /// byte[] digest2 = resumable.ComputeHashFrom(digest1, File.ReadAllBytes("part-2.bin"));
 ///
-/// 3. Same result as if both segments had been appended in one session — without
-/// holding the running state.
+/// // 3. Same result as if both segments had been appended in one session — without
+/// // holding the running state.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.128.cs
@@ -64,11 +64,11 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 128-bit fingerprint of a content blob.
+/// // 128-bit fingerprint of a content blob.
 /// var m = new MurmurHash3_128();
 /// byte[] fingerprint = m.ComputeHash(blob);
 ///
-/// Custom seed to isolate a second hash family for cuckoo / bloom-filter use.
+/// // Custom seed to isolate a second hash family for cuckoo / bloom-filter use.
 /// var m2 = new MurmurHash3_128(seed: 0xC2B2AE35u);
 ///]]>
 /// </code>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.32.cs
@@ -62,11 +62,11 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// Default seed, suitable for an in-memory hash table.
+/// // Default seed, suitable for an in-memory hash table.
 /// var m = new MurmurHash3_32();
 /// byte[] digest = m.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
 ///
-/// Custom seed for a second, independent hash family (useful in bloom filters).
+/// // Custom seed for a second, independent hash family (useful in bloom filters).
 /// var m2 = new MurmurHash3_32(seed: 0x9E3779B1u);
 /// byte[] digest2 = m2.ComputeHash(System.Text.Encoding.UTF8.GetBytes("hash-table-key"));
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/MurmurHash3.cs
@@ -56,11 +56,11 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// 32-bit hash, default seed, suitable for in-memory hash tables.
+/// // 32-bit hash, default seed, suitable for in-memory hash tables.
 /// var m32 = new MurmurHash3_32();
 /// uint h32 = BinaryPrimitives.ReadUInt32LittleEndian(m32.ComputeHash(keyBytes));
 ///
-/// 128-bit hash, custom seed for shard isolation across services.
+/// // 128-bit hash, custom seed for shard isolation across services.
 /// var m128 = new MurmurHash3_128(seed: 0xC2B2AE35u);
 /// byte[] fingerprint = m128.ComputeHash(payload);
 ///]]>

--- a/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/SuperFastHash.cs
@@ -45,7 +45,7 @@ namespace Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing;
 /// using Bodu.IO.Hashing.Extensions;
 ///
-/// Suited to short keys; avoid for multi-megabyte streams (the input is fully buffered).
+/// // Suited to short keys; avoid for multi-megabyte streams (the input is fully buffered).
 /// var sfh = new SuperFastHash();
 /// byte[] digest = sfh.ComputeHash(System.Text.Encoding.UTF8.GetBytes("short-key"));
 ///]]>

--- a/Bodu.Numerics/src/Numerics/Fraction.cs
+++ b/Bodu.Numerics/src/Numerics/Fraction.cs
@@ -42,14 +42,14 @@ namespace Bodu.Numerics;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Construct from components; the value is reduced to canonical form on creation.
+/// // Construct from components; the value is reduced to canonical form on creation.
 /// Fraction<int> oneHalf = new Fraction<int>(2, 4);   // 1/2
 /// Fraction<int> oneThird = new Fraction<int>(1, 3);
 ///
-/// Exact arithmetic through the operators.
+/// // Exact arithmetic through the operators.
 /// Fraction<int> sum = oneHalf + oneThird;            // 5/6
 ///
-/// Parse and format round-trip through the invariant "numerator/denominator" form.
+/// // Parse and format round-trip through the invariant "numerator/denominator" form.
 /// Fraction<int> parsed = Fraction<int>.Parse("3/8");
 /// string text = parsed.ToString();                   // "3/8"
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/AeadBlockCipherModeTransformExtensions.cs
@@ -77,15 +77,15 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// byte[] nonce = RandomNumberGenerator.GetBytes(12);
 /// byte[] header = Encoding.UTF8.GetBytes("v=1;msg=42");
 ///
-/// 1. Encrypt with associated data; receive ciphertext + tag in a single buffer.
+/// // 1. Encrypt with associated data; receive ciphertext + tag in a single buffer.
 /// using IAeadBlockCipherModeTransform enc = new GcmModeTransform(key, nonce);
 /// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header);
 ///
-/// 2. Decrypt and verify in one call. A tampered tag or header throws CryptographicException.
+/// // 2. Decrypt and verify in one call. A tampered tag or header throws CryptographicException.
 /// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(key, nonce);
 /// byte[] recovered = dec.Decrypt(sealed_, associatedData: header);
 ///
-/// 3. Same shape with a different mode — Ascon, EAX, GCM-SIV all interchange behind IAeadBlockCipherModeTransform.
+/// // 3. Same shape with a different mode — Ascon, EAX, GCM-SIV all interchange behind IAeadBlockCipherModeTransform.
 /// using IAeadBlockCipherModeTransform enc2 = new AsconAead128(key, nonce);
 /// byte[] sealedAscon = enc2.Encrypt(plaintext);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/HashAlgorithmExtensions.cs
@@ -75,16 +75,16 @@ namespace Bodu.Security.Cryptography.Extensions;
 ///
 /// using var sha = SHA256.Create();
 ///
-/// 1. Verify a UTF-8 string against an expected digest, throwing if anything is wrong.
+/// // 1. Verify a UTF-8 string against an expected digest, throwing if anything is wrong.
 /// byte[] expected =
 ///     Convert.FromHexString("dffd6021bb2bd5b0af676290809ec3a53191dd81c7f70a4b28688a362182986f");
 /// bool match = sha.VerifyHash("Hello, World!", Encoding.UTF8, expected);
 ///
-/// 2. Stream-verify a downloaded file against a hex digest, without throwing on malformed hex.
+/// // 2. Stream-verify a downloaded file against a hex digest, without throwing on malformed hex.
 /// using FileStream fs = File.OpenRead("payload.bin");
 /// bool ok = sha.TryVerifyHash(fs, expectedHex: "ba7816bf...");
 ///
-/// 3. Cancellable async verification of a network stream against a known digest.
+/// // 3. Cancellable async verification of a network stream against a known digest.
 /// await using Stream net = response.Content.ReadAsStream();
 /// bool verified = await sha.VerifyHashAsync(net, expected, cancellationToken);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/ICryptoTransformExtensions.cs
@@ -74,17 +74,17 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// aes.Key = key;
 /// aes.IV = iv;
 ///
-/// 1. One-shot encrypt of a span into a new byte[].
+/// // 1. One-shot encrypt of a span into a new byte[].
 /// using ICryptoTransform encryptor = aes.CreateEncryptor();
 /// byte[] ciphertext = encryptor.Transform(plaintext.AsSpan());
 ///
-/// 2. Stream-encrypt a large file end to end with a 64 KiB buffer.
+/// // 2. Stream-encrypt a large file end to end with a 64 KiB buffer.
 /// using FileStream src = File.OpenRead("plain.bin");
 /// using FileStream dst = File.Create("cipher.bin");
 /// using ICryptoTransform e2 = aes.CreateEncryptor();
 /// int written = e2.Transform(src, dst, bufferSize: 64 * 1024);
 ///
-/// 3. Cancellable async stream transform, e.g. when piping HTTP content.
+/// // 3. Cancellable async stream transform, e.g. when piping HTTP content.
 /// using ICryptoTransform e3 = aes.CreateEncryptor();
 /// await e3.TransformAsync(networkStream, output, bufferSize: 16 * 1024, cancellationToken);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/SymmetricAlgorithmExtensions.cs
@@ -69,16 +69,16 @@ namespace Bodu.Security.Cryptography.Extensions;
 /// aes.Key = key;
 /// aes.IV = iv;
 ///
-/// 1. One-shot encrypt of an in-memory span; one-shot decrypt back.
+/// // 1. One-shot encrypt of an in-memory span; one-shot decrypt back.
 /// byte[] ciphertext = aes.Encrypt(plaintext.AsSpan());
 /// byte[] roundTrip = aes.Decrypt(ciphertext);
 ///
-/// 2. Stream-encrypt a large file with the default 80 KiB buffer.
+/// // 2. Stream-encrypt a large file with the default 80 KiB buffer.
 /// using FileStream src = File.OpenRead("plain.bin");
 /// using FileStream dst = File.Create("cipher.bin");
 /// int bytesWritten = aes.Encrypt(src, dst);
 ///
-/// 3. Validate caller-supplied key material without catching CryptographicException.
+/// // 3. Validate caller-supplied key material without catching CryptographicException.
 /// if (!aes.TryCreateDecryptor(suppliedKey, suppliedIv, out ICryptoTransform? decryptor))
 ///     return BadRequest("invalid key/iv combination");
 /// using (decryptor) { /* … decrypt with the validated transform … */ }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography.Extensions/TweakableSymmetricAlgorithmExtensions.cs
@@ -55,12 +55,12 @@ namespace Bodu.Security.Cryptography.Extensions;
 ///
 /// using TweakableSymmetricAlgorithm tf = new Threefish256();
 ///
-/// 1. Validate user-supplied key/IV/tweak without catching CryptographicException.
+/// // 1. Validate user-supplied key/IV/tweak without catching CryptographicException.
 /// if (!tf.TryCreateEncryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? encryptor))
 ///     return BadRequest("invalid key, iv, or tweak");
 /// using (encryptor) { /* … encrypt with the validated transform … */ }
 ///
-/// 2. Round-trip pairing — same try-pattern shape for the decryptor.
+/// // 2. Round-trip pairing — same try-pattern shape for the decryptor.
 /// if (tf.TryCreateDecryptor(suppliedKey, suppliedIv, suppliedTweak, out ICryptoTransform? decryptor))
 /// {
 ///     using (decryptor) { /* … decrypt … */ }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AesBlockCipher.cs
@@ -33,7 +33,7 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Encrypt a single 16-byte block (typically used indirectly via an AEAD mode transform).
+/// // Encrypt a single 16-byte block (typically used indirectly via an AEAD mode transform).
 /// byte[] key = RandomNumberGenerator.GetBytes(16);
 /// using var cipher = new AesBlockCipher(key);
 /// Span<byte> block = stackalloc byte[16];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Ansix923Padding.cs
@@ -32,7 +32,7 @@ namespace Bodu.Security.Cryptography;
 /// IPaddingStrategy padding = new Ansix923Padding();
 /// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
 ///
-/// padded ends with N-1 zero bytes followed by a single byte holding N.
+/// // padded ends with N-1 zero bytes followed by a single byte holding N.
 /// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconAead128.cs
@@ -103,8 +103,8 @@ namespace Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography.Extensions;
 ///
-/// Most callers should reach for the AeadBlockCipherModeTransformExtensions helpers,
-/// which size the output buffer and return a single freshly allocated array.
+/// // Most callers should reach for the AeadBlockCipherModeTransformExtensions helpers,
+/// // which size the output buffer and return a single freshly allocated array.
 /// using IAeadBlockCipherModeTransform enc = new AsconAead128(key, nonce);
 /// byte[] sealed_ = enc.Encrypt(plaintext, associatedData: header);
 /// using IAeadBlockCipherModeTransform dec = new AsconAead128(key, nonce);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/AsconXof.cs
@@ -77,18 +77,18 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete derivative — produce a 32-byte digest from "hello".
+/// // Consume through a concrete derivative — produce a 32-byte digest from "hello".
 /// using var xof = new AsconXof128();
 /// xof.Absorb("hello"u8);
 ///
 /// byte[] digest = new byte[32];
 /// xof.Squeeze(digest);
 ///
-/// Squeeze additional output of any length — the XOF can produce as many bytes as needed.
+/// // Squeeze additional output of any length — the XOF can produce as many bytes as needed.
 /// byte[] more = new byte[64];
 /// xof.Squeeze(more);
 ///
-/// Reuse the instance for a new message via Initialize.
+/// // Reuse the instance for a new message via Initialize.
 /// xof.Initialize();
 /// xof.Absorb("world"u8);
 /// xof.Squeeze(digest);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2b.cs
@@ -71,11 +71,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Unkeyed hash
+/// // Unkeyed hash
 /// using var blake2b = new Blake2b(512);
 /// byte[] digest = blake2b.ComputeHash(message);
 ///
-/// Keyed MAC (BLAKE2b-MAC-512)
+/// // Keyed MAC (BLAKE2b-MAC-512)
 /// using var mac = new Blake2b(512) { Key = myKey };
 /// byte[] tag = mac.ComputeHash(message);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blake2s.cs
@@ -70,11 +70,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Unkeyed hash
+/// // Unkeyed hash
 /// using var blake2s = new Blake2s(256);
 /// byte[] digest = blake2s.ComputeHash(message);
 ///
-/// Keyed MAC (BLAKE2s-MAC-256)
+/// // Keyed MAC (BLAKE2s-MAC-256)
 /// using var mac = new Blake2s(256) { Key = myKey };
 /// byte[] tag = mac.ComputeHash(message);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockCipherTransform.cs
@@ -65,23 +65,23 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Most consumers never touch BlockCipherTransform directly — it is surfaced as the
-/// ICryptoTransform returned by every Bodu SymmetricAlgorithm. Typical usage:
+/// // Most consumers never touch BlockCipherTransform directly — it is surfaced as the
+/// // ICryptoTransform returned by every Bodu SymmetricAlgorithm. Typical usage:
 /// using SymmetricAlgorithm alg = new Twofish();
 /// alg.GenerateKey();
 /// alg.GenerateIV();
 /// alg.Mode    = CipherMode.CBC;
 /// alg.Padding = PaddingMode.PKCS7;
 ///
-/// CreateEncryptor returns a BlockCipherTransform under the hood — a one-shot
-/// ICryptoTransform that pairs the block cipher with the configured mode and padding.
+/// // CreateEncryptor returns a BlockCipherTransform under the hood — a one-shot
+/// // ICryptoTransform that pairs the block cipher with the configured mode and padding.
 /// using ICryptoTransform encryptor = alg.CreateEncryptor();
 /// using var output = new MemoryStream();
 /// using (var cs = new CryptoStream(output, encryptor, CryptoStreamMode.Write))
 ///     cs.Write(plaintext, 0, plaintext.Length);
 /// byte[] ciphertext = output.ToArray();
 ///
-/// Reuse requires a fresh transform — BlockCipherTransform.CanReuseTransform is false.
+/// // Reuse requires a fresh transform — BlockCipherTransform.CanReuseTransform is false.
 ///]]>
 /// </example>
 /// <seealso cref="IBlockCipher"/> <seealso cref="IBlockCipherModeTransform"/> <seealso cref="IPaddingStrategy"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BlockHashAlgorithm.cs
@@ -57,11 +57,11 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete derivative — the base class drives buffering and finalization.
+/// // Consume through a concrete derivative — the base class drives buffering and finalization.
 /// using HashAlgorithm hash = new Tiger();      // 512-bit block, 192-bit digest
 /// byte[] digest = hash.ComputeHash("hello"u8.ToArray());
 ///
-/// Or feed input incrementally via the standard streaming surface.
+/// // Or feed input incrementally via the standard streaming surface.
 /// using HashAlgorithm streaming = new Tiger();
 /// streaming.TransformBlock(buffer1, 0, buffer1.Length, null, 0);
 /// streaming.TransformBlock(buffer2, 0, buffer2.Length, null, 0);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Blowfish.cs
@@ -70,7 +70,7 @@ namespace Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography.Extensions;
 ///
-/// Legacy interop only.
+/// // Legacy interop only.
 /// using var blowfish = new Blowfish();
 /// blowfish.Key = legacyKeyMaterial; // 4–56 bytes
 /// blowfish.IV = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/BufferedBlockHashAlgorithm.cs
@@ -20,8 +20,8 @@ namespace Bodu.Security.Cryptography;
 /// </typeparam>
 /// <example>
 ///<![CDATA[
-/// Consume a concrete derivative through the standard HashAlgorithm contract — the base
-/// class drives the residual buffer and the block-aligned compression loop for you.
+/// // Consume a concrete derivative through the standard HashAlgorithm contract — the base
+/// // class drives the residual buffer and the block-aligned compression loop for you.
 /// using HashAlgorithm hash = new Blake2b();      // DeferredFinalBlockHashAlgorithm<T>
 /// byte[] digest1 = hash.ComputeHash("hello"u8.ToArray());
 ///

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CamelliaBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CamelliaBlockCipher.cs
@@ -59,7 +59,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Camellia SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Camellia SymmetricAlgorithm wrapper.
 /// byte[] key = new byte[16];   // 128, 192, or 256 bits
 /// RandomNumberGenerator.Fill(key);
 ///
@@ -71,7 +71,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[16];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso href="https://www.rfc-editor.org/rfc/rfc3713">RFC 3713 — A Description of the Camellia Encryption Algorithm

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CbcModeTransform.cs
@@ -44,7 +44,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CBC instead of using this directly.
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CBC instead of using this directly.
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 /// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
 /// IBlockCipherModeTransform cbc = new CbcModeTransform(cipher, iv);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CfbModeTransform.cs
@@ -43,7 +43,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CFB instead of using this directly.
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CFB instead of using this directly.
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 /// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8);
 /// IBlockCipherModeTransform cfb = new CfbModeTransform(cipher, iv);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtrModeTransform.cs
@@ -48,16 +48,16 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTR instead of using this directly.
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTR instead of using this directly.
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 ///
-/// Initial counter is typically `nonce || zero-counter`; the nonce must never repeat under one key.
+/// // Initial counter is typically `nonce || zero-counter`; the nonce must never repeat under one key.
 /// byte[] initialCounter = BuildInitialCounter(nonce);
 /// IBlockCipherModeTransform ctr = new CtrModeTransform(cipher, initialCounter);
 /// byte[] ciphertext = new byte[plaintext.Length];
 /// int written = ctr.Transform(plaintext, ciphertext, encrypt: true);
 ///
-/// The same call shape decrypts: encrypt: true / encrypt: false produce identical results.
+/// // The same call shape decrypts: encrypt: true / encrypt: false produce identical results.
 ///]]>
 /// </code>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CtsModeTransform.cs
@@ -57,12 +57,12 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTS instead of using this directly.
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.CTS instead of using this directly.
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 /// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8);
 /// IBlockCipherModeTransform cts = new CtsModeTransform(cipher, iv);
 ///
-/// CTS preserves length: plaintext.Length == ciphertext.Length, no padding required.
+/// // CTS preserves length: plaintext.Length == ciphertext.Length, no padding required.
 /// byte[] ciphertext = new byte[plaintext.Length];
 /// int written = cts.Transform(plaintext, ciphertext, encrypt: true);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/CubeHash.cs
@@ -63,7 +63,7 @@ namespace Bodu.Security.Cryptography;
 ///<![CDATA[
 /// using Bodu.Security.Cryptography;
 ///
-/// Default parameters: 512-bit output, 32-byte input block, 16/16/32 rounds.
+/// // Default parameters: 512-bit output, 32-byte input block, 16/16/32 rounds.
 /// using var cube = new CubeHash();
 /// byte[] digest = cube.ComputeHash(message);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DeferredFinalBlockHashAlgorithm.cs
@@ -20,12 +20,12 @@ namespace Bodu.Security.Cryptography;
 /// </typeparam>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete BLAKE-family derivative — the base class defers the final
-/// block until HashFinal so the compression call can carry isFinal: true.
+/// // Consume through a concrete BLAKE-family derivative — the base class defers the final
+/// // block until HashFinal so the compression call can carry isFinal: true.
 /// using HashAlgorithm hash = new Blake3();
 /// byte[] digest = hash.ComputeHash("hello"u8.ToArray());
 ///
-/// Streaming use — the deferral remains transparent across TransformBlock calls.
+/// // Streaming use — the deferral remains transparent across TransformBlock calls.
 /// using HashAlgorithm streaming = new Blake2s();
 /// streaming.TransformBlock(buffer1, 0, buffer1.Length, null, 0);
 /// streaming.TransformBlock(buffer2, 0, buffer2.Length, null, 0);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/DelegateHashAlgorithmFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/DelegateHashAlgorithmFactory.cs
@@ -33,16 +33,16 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Wrap a delegate via the static helper — the call site reads more naturally than the
-/// constructor and avoids the trailing generic-type repetition.
+/// // Wrap a delegate via the static helper — the call site reads more naturally than the
+/// // constructor and avoids the trailing generic-type repetition.
 /// IHashAlgorithmFactory<SipHash64> factory = HashAlgorithmFactory.From(() =>
 ///     new SipHash64 { Key = sharedKey });
 ///
-/// Resolve and use — the factory hands out a freshly-keyed instance each time.
+/// // Resolve and use — the factory hands out a freshly-keyed instance each time.
 /// using SipHash64 hash = factory.Create();
 /// byte[] digest = hash.ComputeHash("hello"u8.ToArray());
 ///
-/// Or construct directly when the field type needs to be the concrete factory.
+/// // Or construct directly when the field type needs to be the concrete factory.
 /// var concreteFactory = new DelegateHashAlgorithmFactory<Tiger>(() => new Tiger
 /// {
 ///     HashingVariant = TigerHashingVariant.Tiger2,

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/EcbModeTransform.cs
@@ -42,8 +42,8 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should reach for SymmetricAlgorithm.Mode = ECB instead of constructing this directly.
-/// Direct use is appropriate only inside larger primitives (e.g. wide-block constructions, KDFs).
+/// // Most callers should reach for SymmetricAlgorithm.Mode = ECB instead of constructing this directly.
+/// // Direct use is appropriate only inside larger primitives (e.g. wide-block constructions, KDFs).
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 /// IBlockCipherModeTransform ecb = new EcbModeTransform(cipher);
 /// byte[] ciphertext = new byte[plaintext.Length];

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/GcmModeTransform.cs
@@ -94,7 +94,7 @@ namespace Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography.Extensions;
 ///
 /// using IBlockCipher cipher = new AesBlockCipher(key);
-/// GCM takes the 96-bit (12-byte) nonce directly — J0 is derived internally as nonce || 0x00000001.
+/// // GCM takes the 96-bit (12-byte) nonce directly — J0 is derived internally as nonce || 0x00000001.
 /// using IAeadBlockCipherModeTransform gcm = new GcmModeTransform(cipher, nonce);
 /// byte[] sealed_ = gcm.Encrypt(plaintext, associatedData: header);
 /// using IAeadBlockCipherModeTransform dec = new GcmModeTransform(cipher, nonce);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmFactory.cs
@@ -31,11 +31,11 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// 1. Bare SHA-256 factory.
+/// // 1. Bare SHA-256 factory.
 /// IHashAlgorithmFactory<SHA256> sha256 = HashAlgorithmFactory.From(() => SHA256.Create());
 /// byte[] digest = HashAlgorithmHelper.HashData(sha256, payload);
 ///
-/// 2. Configured keyed-hash factory — applied consistently every time the consumer constructs an instance.
+/// // 2. Configured keyed-hash factory — applied consistently every time the consumer constructs an instance.
 /// IHashAlgorithmFactory<SipHash64> sip = HashAlgorithmFactory.From(() => new SipHash64 { Key = sessionKey });
 /// byte[] tag = HashAlgorithmHelper.HashData(sip, message);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/HashAlgorithmHelper.cs
@@ -35,7 +35,7 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Configured SipHash-2-4 factory; the configuration applies to every call to HashData.
+/// // Configured SipHash-2-4 factory; the configuration applies to every call to HashData.
 /// var factory = HashAlgorithmFactory.From(() => new SipHash64
 /// {
 ///     Key = key,

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso10126Padding.cs
@@ -30,7 +30,7 @@ namespace Bodu.Security.Cryptography;
 ///<![CDATA[
 /// using Bodu.Security.Cryptography;
 ///
-/// Legacy interop only — padding bytes are random; only the final length byte is validated.
+/// // Legacy interop only — padding bytes are random; only the final length byte is validated.
 /// IPaddingStrategy padding = new Iso10126Padding();
 /// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
 /// byte[] recovered = padding.Unpad(padded, blockSize: 128);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Iso7816_4Padding.cs
@@ -34,7 +34,7 @@ namespace Bodu.Security.Cryptography;
 /// IPaddingStrategy padding = new Iso7816_4Padding();
 /// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
 ///
-/// padded ends with 0x80 followed by zero or more 0x00 bytes.
+/// // padded ends with 0x80 followed by zero or more 0x00 bytes.
 /// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedBlockHashAlgorithm.cs
@@ -38,14 +38,14 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Consume through a concrete keyed derivative — Poly1305 needs a 32-byte one-time key.
+/// // Consume through a concrete keyed derivative — Poly1305 needs a 32-byte one-time key.
 /// byte[] key = new byte[32];
 /// RandomNumberGenerator.Fill(key);
 ///
 /// using var mac = new Poly1305 { Key = key };
 /// byte[] tag = mac.ComputeHash("message"u8.ToArray());
 ///
-/// SipHash takes a 16-byte key and is the standard hash-table keyed primitive.
+/// // SipHash takes a 16-byte key and is the standard hash-table keyed primitive.
 /// byte[] sipKey = new byte[16];
 /// RandomNumberGenerator.Fill(sipKey);
 ///

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/KeyedDeferredFinalBlockHashAlgorithm.cs
@@ -44,14 +44,14 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// BLAKE2b in keyed MAC mode — the key is optional and may be up to MaximumKeySize bits.
+/// // BLAKE2b in keyed MAC mode — the key is optional and may be up to MaximumKeySize bits.
 /// byte[] key = new byte[32];
 /// RandomNumberGenerator.Fill(key);
 ///
 /// using var mac = new Blake2b { Key = key };
 /// byte[] tag = mac.ComputeHash("message"u8.ToArray());
 ///
-/// Or use the same type unkeyed for a plain BLAKE2b digest.
+/// // Or use the same type unkeyed for a plain BLAKE2b digest.
 /// using var digest = new Blake2b();
 /// byte[] hash = digest.ComputeHash("message"u8.ToArray());
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/MerkleTreeHash.cs
@@ -79,7 +79,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// SHA-256 leaves, 4 KiB blocks, fan-out of 4.
+/// // SHA-256 leaves, 4 KiB blocks, fan-out of 4.
 /// using var merkle = new MerkleTreeHash(
 ///     algorithmFactory: () => SHA256.Create(),
 ///     blockSize: 4096,

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/NoPadding.cs
@@ -29,7 +29,7 @@ namespace Bodu.Security.Cryptography;
 ///<![CDATA[
 /// using Bodu.Security.Cryptography;
 ///
-/// Caller guarantees that `plaintext.Length` is a multiple of the block size.
+/// // Caller guarantees that `plaintext.Length` is a multiple of the block size.
 /// IPaddingStrategy padding = new NoPadding();
 /// byte[] aligned = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes; throws if not aligned
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/OfbModeTransform.cs
@@ -44,7 +44,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.OFB instead of using this directly.
+/// // Most callers should set SymmetricAlgorithm.Mode = CipherBlockMode.OFB instead of using this directly.
 /// using IBlockCipher cipher = new AesBlockCipher(key);
 /// byte[] iv = RandomNumberGenerator.GetBytes(cipher.BlockSize / 8); // unique per message
 /// IBlockCipherModeTransform ofb = new OfbModeTransform(cipher, iv);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/PaddingFactory.cs
@@ -28,17 +28,17 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// BCL-standard padding mode — covers PKCS7, Zeros, None, ANSI X.923, ISO 10126.
+/// // BCL-standard padding mode — covers PKCS7, Zeros, None, ANSI X.923, ISO 10126.
 /// IPaddingStrategy pkcs7 = PaddingFactory.Create(PaddingMode.PKCS7);
 ///
-/// Extended padding mode — adds ISO/IEC 7816-4 ("one-and-zeros") used by smart cards and SHA-3.
+/// // Extended padding mode — adds ISO/IEC 7816-4 ("one-and-zeros") used by smart cards and SHA-3.
 /// IPaddingStrategy iso7816 = PaddingFactory.Create(PaddingModeKind.ISO7816_4);
 ///
-/// Apply on encryption.
+/// // Apply on encryption.
 /// byte[] padded = pkcs7.Pad(plaintext, blockSizeBits: 128);
 ///
-/// Remove on decryption — Unpad validates the trailer and throws CryptographicException
-/// if the padding is malformed.
+/// // Remove on decryption — Unpad validates the trailer and throws CryptographicException
+/// // if the padding is malformed.
 /// byte[] stripped = pkcs7.Unpad(decrypted, blockSizeBits: 128);
 ///]]>
 /// </example>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ParallelMerkleTreeHash.cs
@@ -104,7 +104,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// SHA-256 leaves, 64 KiB blocks, fan-out of 4 — a typical large-content configuration.
+/// // SHA-256 leaves, 64 KiB blocks, fan-out of 4 — a typical large-content configuration.
 /// using var merkle = new ParallelMerkleTreeHash(
 ///     algorithmFactory: () => SHA256.Create(),
 ///     blockSize: 64 * 1024,

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Pkcs7Padding.cs
@@ -37,7 +37,7 @@ namespace Bodu.Security.Cryptography;
 /// IPaddingStrategy padding = new Pkcs7Padding();
 /// byte[] padded = padding.Pad(plaintext, blockSize: 128); // 128 bits = 16 bytes
 ///
-/// padded.Length is a multiple of 16; the trailing N bytes each equal N.
+/// // padded.Length is a multiple of 16; the trailing N bytes each equal N.
 /// byte[] recovered = padding.Unpad(padded, blockSize: 128);
 ///]]>
 /// </code>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Poly1305.cs
@@ -82,7 +82,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// The 32-byte key MUST be unique per message — typically derived from a stream cipher's keystream.
+/// // The 32-byte key MUST be unique per message — typically derived from a stream cipher's keystream.
 /// byte[] oneTimeKey = DerivePoly1305KeyFromChaCha20(sessionKey, nonce);
 /// using var poly = new Poly1305 { Key = oneTimeKey };
 /// byte[] tag = poly.ComputeHash(message);

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent.cs
@@ -30,7 +30,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Use a concrete wide-block variant — Serpent-256 over a CTR mode.
+/// // Use a concrete wide-block variant — Serpent-256 over a CTR mode.
 /// using TweakableSymmetricAlgorithm alg = new Serpent256();
 /// alg.GenerateKey();
 /// alg.GenerateIV();
@@ -42,8 +42,8 @@ namespace Bodu.Security.Cryptography;
 /// using (var cs = new CryptoStream(cipherText, encryptor, CryptoStreamMode.Write))
 ///     cs.Write(plaintext, 0, plaintext.Length);
 ///
-/// For standard, externally vetted Serpent use Serpent128 instead — the wide-block variants
-/// are experimental and not interoperable with reference Serpent implementations.
+/// // For standard, externally vetted Serpent use Serpent128 instead — the wide-block variants
+/// // are experimental and not interoperable with reference Serpent implementations.
 ///]]>
 /// </example>
 public abstract class Serpent

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128Cipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Serpent128Cipher.cs
@@ -31,7 +31,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Serpent128 SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Serpent128 SymmetricAlgorithm wrapper.
 /// byte[] key = new byte[32];   // 128, 192, or 256 bits — Serpent pads shorter keys to 256
 /// RandomNumberGenerator.Fill(key);
 ///
@@ -43,7 +43,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[16];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso cref="Serpent128"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.1024.cs
@@ -28,7 +28,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Serpent1024 SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Serpent1024 SymmetricAlgorithm wrapper.
 /// byte[] key   = new byte[128];   // 1024-bit key
 /// byte[] tweak = new byte[16];    // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -42,7 +42,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[128];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso cref="Serpent1024"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.256.cs
@@ -28,7 +28,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Serpent256 SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Serpent256 SymmetricAlgorithm wrapper.
 /// byte[] key   = new byte[32];   // 256-bit key
 /// byte[] tweak = new byte[16];   // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -42,7 +42,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[32];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso cref="Serpent256"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SerpentBlockCipher.512.cs
@@ -28,7 +28,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Serpent512 SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Serpent512 SymmetricAlgorithm wrapper.
 /// byte[] key   = new byte[64];   // 512-bit key
 /// byte[] tweak = new byte[16];   // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -42,7 +42,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[64];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso cref="Serpent512"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Shake.cs
@@ -84,11 +84,11 @@ namespace Bodu.Security.Cryptography;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// SHAKE128 producing 256-bit output.
+/// // SHAKE128 producing 256-bit output.
 /// using var shake = new Shake(256, 128);
 /// byte[] digest = shake.ComputeHash(Encoding.UTF8.GetBytes("hello"));
 ///
-/// SHAKE256 producing 512-bit output.
+/// // SHAKE256 producing 512-bit output.
 /// using var shake256 = new Shake(512, 256);
 /// byte[] longer = shake256.ComputeHash(message);
 ///]]>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SipHash.64.cs
@@ -60,7 +60,7 @@ namespace Bodu.Security.Cryptography;
 ///<![CDATA[
 /// using Bodu.Security.Cryptography;
 ///
-/// 16-byte secret key — keep it private to your process; SipHash assumes attackers cannot guess it.
+/// // 16-byte secret key — keep it private to your process; SipHash assumes attackers cannot guess it.
 /// byte[] hashTableKey = RandomNumberGenerator.GetBytes(16);
 /// using var sip = new SipHash64 { Key = hashTableKey };
 /// byte[] tag = sip.ComputeHash(System.Text.Encoding.UTF8.GetBytes("user-supplied-key"));

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SivModeTransform.cs
@@ -72,7 +72,7 @@ namespace Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography.Extensions;
 ///
-/// SIV uses a doubled key: first half drives the MAC, second half drives CTR encryption.
+/// // SIV uses a doubled key: first half drives the MAC, second half drives CTR encryption.
 /// using IBlockCipher s2v = new AesBlockCipher(macKey);
 /// using IBlockCipher ctr = new AesBlockCipher(encKey);
 /// byte[] iv = new byte[s2v.BlockSize / 8]; // ignored by SIV — present for interface compatibility

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Skipjack.cs
@@ -68,7 +68,7 @@ namespace Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 /// using Bodu.Security.Cryptography.Extensions;
 ///
-/// Legacy interop only — do not use Skipjack to protect new data.
+/// // Legacy interop only — do not use Skipjack to protect new data.
 /// using var skipjack = new Skipjack();
 /// skipjack.Key = legacyKeyMaterial; // exactly 10 bytes
 /// skipjack.IV = RandomNumberGenerator.GetBytes(8); // matches the 64-bit block

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/SkipjackBlockCipher.cs
@@ -57,8 +57,8 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. Skipjack is a legacy 80-bit-key cipher — use only for legacy
-/// compatibility, never for new systems.
+/// // Direct single-block use. Skipjack is a legacy 80-bit-key cipher — use only for legacy
+/// // compatibility, never for new systems.
 /// byte[] key = new byte[10];   // 80-bit key
 /// RandomNumberGenerator.Fill(key);
 ///
@@ -70,7 +70,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[8];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/Threefish.cs
@@ -58,7 +58,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Use the recommended general-purpose variant — Threefish-512 over a CTR mode.
+/// // Use the recommended general-purpose variant — Threefish-512 over a CTR mode.
 /// using TweakableSymmetricAlgorithm alg = new Threefish512();
 /// alg.GenerateKey();
 /// alg.GenerateIV();

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.1024.cs
@@ -29,7 +29,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use — most callers should prefer the Threefish1024 SymmetricAlgorithm.
+/// // Direct single-block use — most callers should prefer the Threefish1024 SymmetricAlgorithm.
 /// byte[] key   = new byte[128];   // 1024-bit key
 /// byte[] tweak = new byte[16];    // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -43,7 +43,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[128];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.256.cs
@@ -29,7 +29,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use — most callers should prefer the Threefish256 SymmetricAlgorithm.
+/// // Direct single-block use — most callers should prefer the Threefish256 SymmetricAlgorithm.
 /// byte[] key   = new byte[32];   // 256-bit key
 /// byte[] tweak = new byte[16];   // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -43,7 +43,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[32];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/ThreefishBlockCipher.512.cs
@@ -29,7 +29,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use — most callers should prefer the Threefish512 SymmetricAlgorithm.
+/// // Direct single-block use — most callers should prefer the Threefish512 SymmetricAlgorithm.
 /// byte[] key   = new byte[64];   // 512-bit key
 /// byte[] tweak = new byte[16];   // 128-bit tweak
 /// RandomNumberGenerator.Fill(key);
@@ -43,7 +43,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[64];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso href="../guides/cryptography/composing-primitives.html">Composing primitives — direct use vs.

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TweakableSymmetricAlgorithm.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TweakableSymmetricAlgorithm.cs
@@ -47,17 +47,17 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Construct via a concrete derivative — Threefish is the production tweakable cipher family.
+/// // Construct via a concrete derivative — Threefish is the production tweakable cipher family.
 /// using TweakableSymmetricAlgorithm alg = new Threefish256();
 /// alg.GenerateKey();
 /// alg.GenerateIV();
 /// alg.GenerateTweak();      // unique to TweakableSymmetricAlgorithm — supplies the per-message tweak
 ///
-/// CreateEncryptor / CreateDecryptor accept the additional tweak argument.
+/// // CreateEncryptor / CreateDecryptor accept the additional tweak argument.
 /// using ICryptoTransform encryptor = alg.CreateEncryptor(alg.Key, alg.IV, alg.Tweak);
 /// using ICryptoTransform decryptor = alg.CreateDecryptor(alg.Key, alg.IV, alg.Tweak);
 ///
-/// The companion try-pattern wrappers gate over user-supplied keying material.
+/// // The companion try-pattern wrappers gate over user-supplied keying material.
 /// if (alg.TryCreateEncryptor(userKey, userIv, userTweak, out ICryptoTransform? safe))
 /// {
 ///     using (safe) { /* encrypt */ }

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/TwofishBlockCipher.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/TwofishBlockCipher.cs
@@ -25,7 +25,7 @@ namespace Bodu.Security.Cryptography;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Direct single-block use. For most workloads prefer the Twofish SymmetricAlgorithm wrapper.
+/// // Direct single-block use. For most workloads prefer the Twofish SymmetricAlgorithm wrapper.
 /// byte[] key = new byte[32];   // 128, 192, or 256 bits
 /// RandomNumberGenerator.Fill(key);
 ///
@@ -37,7 +37,7 @@ namespace Bodu.Security.Cryptography;
 ///
 /// byte[] roundtrip = new byte[16];
 /// cipher.Decrypt(ciphertext, roundtrip);
-/// roundtrip equals plaintext
+/// // roundtrip equals plaintext
 ///]]>
 /// </example>
 /// <seealso cref="Twofish"/>

--- a/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
+++ b/Bodu.Security.Cryptography/src/Security.Cryptography/XtsModeTransform.cs
@@ -63,7 +63,7 @@ namespace Bodu.Security.Cryptography;
 /// using System.Security.Cryptography;
 /// using Bodu.Security.Cryptography;
 ///
-/// XTS uses two independent keys — Key1 for data, Key2 for the tweak. Never share keys.
+/// // XTS uses two independent keys — Key1 for data, Key2 for the tweak. Never share keys.
 /// using IBlockCipher data = new AesBlockCipher(key1);
 /// using IBlockCipher tweak = new AesBlockCipher(key2);
 /// byte[] sectorNumber = BitConverter.GetBytes((long)42); // little-endian sector number, padded to block size

--- a/Bodu.Test/test/Test/TestHelpers.GenerateIncrementalByteSequence.cs
+++ b/Bodu.Test/test/Test/TestHelpers.GenerateIncrementalByteSequence.cs
@@ -39,7 +39,7 @@ public static partial class TestHelpers
     /// <example>
     /// <code>
     /// byte[] bytes = GenerateIncrementalByteSequence(0x10, 4);
-    /// Produces: { 0x10, 0x11, 0x12, 0x13 }
+    /// // Produces: { 0x10, 0x11, 0x12, 0x13 }
     /// </code>
     /// </example>
     public static byte[] GenerateIncrementalByteSequence(byte start, int count)
@@ -83,7 +83,7 @@ public static partial class TestHelpers
     /// <example>
     /// <code>
     /// byte[] bytes = GenerateRepeatingIncrementalByteSequence(0xFE, 4);
-    /// Produces: { 0xFE, 0xFF, 0x00, 0x01 }
+    /// // Produces: { 0xFE, 0xFF, 0x00, 0x01 }
     /// </code>
     /// </example>
     public static byte[] GenerateRepeatingIncrementalByteSequence(byte start, int count)

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDiagnostic.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDiagnostic.cs
@@ -27,7 +27,7 @@ namespace Bodu.Text.Configuration;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Surface every diagnostic the reader produced and tag any errors for caller attention.
+/// // Surface every diagnostic the reader produced and tag any errors for caller attention.
 /// foreach (ConfigurationDiagnostic d in result.Diagnostics)
 /// {
 ///     Console.WriteLine(d); // "Warning DuplicateKey at line 12, column 3: ..."
@@ -35,7 +35,7 @@ namespace Bodu.Text.Configuration;
 ///         hasErrors = true;
 /// }
 ///
-/// Build one directly — useful when a host integrates Bodu diagnostics into its own pipeline.
+/// // Build one directly — useful when a host integrates Bodu diagnostics into its own pipeline.
 /// var diag = new ConfigurationDiagnostic(
 ///     ConfigurationDiagnosticSeverity.Warning,
 ///     ConfigurationDiagnosticCode.UnknownKey,

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocument.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationDocument.cs
@@ -37,12 +37,12 @@ namespace Bodu.Text.Configuration;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse and resolve a configuration file for a specific target path.
+/// // Parse and resolve a configuration file for a specific target path.
 /// ConfigurationDocument doc  = ConfigurationDocument.Parse(text);
 /// ConfigurationView     view = doc.Resolve("src/Foo.cs");
 /// int indent = view.GetInt32("format:indent:size", 4);
 ///
-/// Collect every diagnostic instead of failing on the first issue.
+/// // Collect every diagnostic instead of failing on the first issue.
 /// var opts = new ConfigurationParseOptions
 /// {
 ///     Profile        = ConfigurationProfile.Bodu,

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationKey.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationKey.cs
@@ -29,14 +29,14 @@ namespace Bodu.Text.Configuration;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Default mapping — split on '.' and ':', case-insensitive comparison.
+/// // Default mapping — split on '.' and ':', case-insensitive comparison.
 /// var k1 = new ConfigurationKey("Logging.Level.Default");
 /// var k2 = new ConfigurationKey("logging:level:default");
 /// Console.WriteLine(k1 == k2);              // True — same segment sequence under the default comparer
 /// Console.WriteLine(k1.Path);               // "Logging:Level:Default"
 /// Console.WriteLine(string.Join(",", k1.Segments)); // "Logging,Level,Default"
 ///
-/// Case-sensitive parsing for hosts that distinguish 'Foo' from 'foo'.
+/// // Case-sensitive parsing for hosts that distinguish 'Foo' from 'foo'.
 /// var opts = new ConfigurationKeyOptions { CaseSensitive = true };
 /// var k3   = new ConfigurationKey("Foo:Bar", opts);
 /// var k4   = new ConfigurationKey("foo:bar", opts);

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationPattern.cs
@@ -66,12 +66,12 @@ namespace Bodu.Text.Configuration;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Compile once, match many times.
+/// // Compile once, match many times.
 /// ConfigurationPattern csFiles = ConfigurationPattern.Compile("**/*.cs");
 /// Console.WriteLine(csFiles.IsMatch("src/Foo.cs"));     // true
 /// Console.WriteLine(csFiles.IsMatch("docs/notes.md"));  // false
 ///
-/// Alternation + numeric range.
+/// // Alternation + numeric range.
 /// ConfigurationPattern markup = ConfigurationPattern.Compile("**/*.{md,mdx,txt}");
 /// ConfigurationPattern logs   = ConfigurationPattern.Compile("logs/run-{1..99}.log");
 ///]]>

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationProfile.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationProfile.cs
@@ -80,7 +80,7 @@ namespace Bodu.Text.Configuration;
 /// <example>
 /// <code language="csharp">
 ///<![CDATA[
-/// Start from the profile closest to the desired behaviour, then override only what differs.
+/// // Start from the profile closest to the desired behaviour, then override only what differs.
 /// ConfigurationParseOptions options = ConfigurationParseOptions.For(ConfigurationProfile.Strict);
 /// ConfigurationDocument document = ConfigurationDocument.Parse(text, options);
 ///]]>

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationSourceLocation.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationSourceLocation.cs
@@ -33,7 +33,7 @@ namespace Bodu.Text.Configuration;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Construct a location pointing at a specific span on line 12.
+/// // Construct a location pointing at a specific span on line 12.
 /// var loc = new ConfigurationSourceLocation(
 ///     lineNumber:   12,
 ///     linePosition: 5,
@@ -41,7 +41,7 @@ namespace Bodu.Text.Configuration;
 ///     path:         "app.ini");
 /// Console.WriteLine(loc);   // "app.ini(12,5): length 8"
 ///
-/// Surface from a parse exception in editor-style form.
+/// // Surface from a parse exception in editor-style form.
 /// try { ConfigurationDocument.Parse(text); }
 /// catch (ConfigurationParseException ex)
 /// {

--- a/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationView.cs
+++ b/Bodu.Text.Configuration/src/Text.Configuration/ConfigurationView.cs
@@ -36,14 +36,14 @@ namespace Bodu.Text.Configuration;
 /// IniDocument           doc  = ConfigurationDocument.Parse(text);
 /// ConfigurationView view = doc.Resolve("src/Foo.cs");
 ///
-/// Indexer lookup — colon and dotted forms are equivalent.
+/// // Indexer lookup — colon and dotted forms are equivalent.
 /// string? level = view["logging:level:default"];
 /// string? alt   = view["logging.level.default"]; // same value
 ///
-/// Typed convenience accessors on the view.
+/// // Typed convenience accessors on the view.
 /// int indent = view.GetInt32("format:indent:size", fallback: 4);
 ///
-/// Enumeration yields canonical colon-delimited keys.
+/// // Enumeration yields canonical colon-delimited keys.
 /// foreach (KeyValuePair<string, string?> kv in view)
 ///     Console.WriteLine($"{kv.Key} = {kv.Value}");
 ///]]>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base16.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base16.cs
@@ -28,15 +28,15 @@ namespace Bodu.Text.Encoding;
 ///<![CDATA[
 /// byte[] data = { 0xDE, 0xAD, 0xBE, 0xEF };
 ///
-/// Canonical lower-case hex.
+/// // Canonical lower-case hex.
 /// string lower = Base16.Encode(data);                                           // "deadbeef"
 ///
-/// Upper-case with the "0x" prefix and byte spacing — useful for diagnostic output.
+/// // Upper-case with the "0x" prefix and byte spacing — useful for diagnostic output.
 /// string pretty = Base16.Encode(data, BaseFormattingOptions.UpperCase
 ///                                    | BaseFormattingOptions.IncludePrefix
 ///                                    | BaseFormattingOptions.InsertSpacing);    // "0xDE AD BE EF"
 ///
-/// Lenient decoding — accepts the "0x" prefix and embedded whitespace.
+/// // Lenient decoding — accepts the "0x" prefix and embedded whitespace.
 /// byte[] roundtrip = Base16.Decode(pretty,
 ///     BaseFormatStyles.AllowPrefix | BaseFormatStyles.IgnoreWhitespace);
 ///]]>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base32.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base32.cs
@@ -27,16 +27,16 @@ namespace Bodu.Text.Encoding;
 ///<![CDATA[
 /// byte[] data = "hello"u8.ToArray();
 ///
-/// RFC 4648 Standard Base32 (default).
+/// // RFC 4648 Standard Base32 (default).
 /// string standard = Base32.Encode(data);                                      // "NBSWY3DP"
 ///
-/// Crockford Base32 — human-friendly alphabet, no padding.
+/// // Crockford Base32 — human-friendly alphabet, no padding.
 /// string crockford = Base32.Encode(data, Base32Variant.Crockford);
 ///
-/// RFC 4648 base32hex — preserves sort order with binary keys.
+/// // RFC 4648 base32hex — preserves sort order with binary keys.
 /// string base32hex = Base32.Encode(data, Base32Variant.HexExtended);
 ///
-/// Round-trip.
+/// // Round-trip.
 /// byte[] roundtrip = Base32.Decode(standard);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base45.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base45.cs
@@ -27,11 +27,11 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Encode an arbitrary byte payload for inclusion in a QR code.
+/// // Encode an arbitrary byte payload for inclusion in a QR code.
 /// byte[] data = { 0x41, 0x42 };
 /// string encoded = Base45.Encode(data);          // "BB8"
 ///
-/// Round-trip.
+/// // Round-trip.
 /// byte[] roundtrip = Base45.Decode(encoded);      // { 0x41, 0x42 }
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base58.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base58.cs
@@ -29,14 +29,14 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Bitcoin/Flickr Base58 (default) — leading zero bytes encode as leading '1' characters.
+/// // Bitcoin/Flickr Base58 (default) — leading zero bytes encode as leading '1' characters.
 /// byte[] data = { 0x00, 0xDE, 0xAD, 0xBE, 0xEF };
 /// string encoded = Base58.Encode(data);
 ///
-/// Ripple alphabet — a permutation used by the XRP ledger.
+/// // Ripple alphabet — a permutation used by the XRP ledger.
 /// string ripple = Base58.Encode(data, Base58Variant.Ripple);
 ///
-/// Round-trip.
+/// // Round-trip.
 /// byte[] roundtrip = Base58.Decode(encoded);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base58Check.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base58Check.cs
@@ -26,14 +26,14 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Build a Bitcoin P2PKH address: 0x00 version byte + 20-byte hash160.
+/// // Build a Bitcoin P2PKH address: 0x00 version byte + 20-byte hash160.
 /// byte[] payload = new byte[21];
 /// payload[0] = 0x00;                                          // mainnet version
 /// hash160.CopyTo(payload.AsSpan(1));                          // 20-byte RIPEMD-160(SHA-256(pubkey))
 ///
 /// string address = Base58Check.Encode(payload);               // "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2" (example)
 ///
-/// Decoder verifies the trailing checksum and strips it; throws on mismatch.
+/// // Decoder verifies the trailing checksum and strips it; throws on mismatch.
 /// byte[] decoded = Base58Check.Decode(address);               // 21 bytes — original version + hash160
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base64.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base64.cs
@@ -30,16 +30,16 @@ namespace Bodu.Text.Encoding;
 ///<![CDATA[
 /// byte[] data = "hello"u8.ToArray();
 ///
-/// RFC 4648 Standard Base64 (default).
+/// // RFC 4648 Standard Base64 (default).
 /// string standard = Base64.Encode(data);                                       // "aGVsbG8="
 ///
-/// URL-safe alphabet, no padding — the form used by JWT and OAuth tokens.
+/// // URL-safe alphabet, no padding — the form used by JWT and OAuth tokens.
 /// string urlSafe  = Base64.Encode(data, Base64Variant.UrlSafe);                // "aGVsbG8"
 ///
-/// MIME variant — wraps every 76 characters with CRLF.
+/// // MIME variant — wraps every 76 characters with CRLF.
 /// string mime     = Base64.Encode(longerPayload, Base64Variant.Mime);
 ///
-/// Round-trip.
+/// // Round-trip.
 /// byte[] roundtrip = Base64.Decode(standard);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base64Url.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base64Url.cs
@@ -20,11 +20,11 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Encode a JWT segment — URL-safe alphabet, no padding.
+/// // Encode a JWT segment — URL-safe alphabet, no padding.
 /// byte[] header   = "{\"alg\":\"HS256\",\"typ\":\"JWT\"}"u8.ToArray();
 /// string segment  = Base64Url.Encode(header);                                  // "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
 ///
-/// Decoder accepts inputs both with and without trailing '=' padding.
+/// // Decoder accepts inputs both with and without trailing '=' padding.
 /// byte[] roundtrip = Base64Url.Decode(segment);
 /// byte[] padded    = Base64Url.Decode("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9==");
 ///]]>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base85.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base85.cs
@@ -37,17 +37,17 @@ namespace Bodu.Text.Encoding;
 ///<![CDATA[
 /// byte[] data = "hello world"u8.ToArray();
 ///
-/// Adobe Ascii85 (default) — the form used by PostScript and PDF, with the 'z' shortcut for all-zero groups.
+/// // Adobe Ascii85 (default) — the form used by PostScript and PDF, with the 'z' shortcut for all-zero groups.
 /// string ascii85 = Base85.Encode(data);
 ///
-/// Wrap the output in the Adobe <~ ... ~> delimiter pair.
+/// // Wrap the output in the Adobe <~ ... ~> delimiter pair.
 /// string delimited = Base85.Encode(data, BaseFormattingOptions.IncludePrefix);
 ///
-/// ZeroMQ Z85 — shell-safe alphabet; the input must be a multiple of four bytes.
+/// // ZeroMQ Z85 — shell-safe alphabet; the input must be a multiple of four bytes.
 /// byte[] padded = "hello wor"u8.ToArray();    // 9 bytes — pad to 12 before encoding
 /// string z85    = Base85.Encode(padded.AsSpan(0, 8), Base85Variant.Z85);
 ///
-/// Round-trip.
+/// // Round-trip.
 /// byte[] roundtrip = Base85.Decode(ascii85);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/BaseFormattingOptions.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/BaseFormattingOptions.cs
@@ -24,16 +24,16 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Compact lower-case hex (the default Base16 form).
+/// // Compact lower-case hex (the default Base16 form).
 /// string compact = Base16.Encode(data);
 ///
-/// Diagnostic-friendly: upper case, "0x" prefix, single-space byte groups.
+/// // Diagnostic-friendly: upper case, "0x" prefix, single-space byte groups.
 /// string diagnostic = Base16.Encode(data,
 ///     BaseFormattingOptions.UpperCase
 ///     | BaseFormattingOptions.IncludePrefix
 ///     | BaseFormattingOptions.InsertSpacing);
 ///
-/// Padding-free Base64 — produces the same output as Base64Url.Encode.
+/// // Padding-free Base64 — produces the same output as Base64Url.Encode.
 /// string unpadded = Base64.Encode(data, BaseFormattingOptions.OmitPadding);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/Bech32.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Bech32.cs
@@ -26,11 +26,11 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Encode 5-bit data groups under a human-readable prefix.
+/// // Encode 5-bit data groups under a human-readable prefix.
 /// byte[] data = { 0x00, 0x01, 0x02 };                 // already 5-bit values
 /// string encoded = Bech32.Encode("abc", data);        // "abc1..." with a Bech32 checksum
 ///
-/// Decode and recover the parts.
+/// // Decode and recover the parts.
 /// Bech32.Decode(encoded, out string hrp, out byte[] groups, out Bech32Encoding scheme);
 ///]]>
 /// </example>

--- a/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodingExtensions.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodingExtensions.cs
@@ -29,16 +29,16 @@ namespace Bodu.Text.Encoding;
 ///<![CDATA[
 /// byte[] data = "hello"u8.ToArray();
 ///
-/// Direct shortcuts — discoverable from IntelliSense via the byte[] receiver.
+/// // Direct shortcuts — discoverable from IntelliSense via the byte[] receiver.
 /// string hex     = data.ToBase16String();                  // "68656c6c6f"
 /// string base32  = data.ToBase32String();                  // "NBSWY3DP"
 /// string base64  = data.ToBase64String();                  // "aGVsbG8="
 /// string base58  = data.ToBase58String();                  // "Cn8eVZg"
 ///
-/// Round-trip via the matching FromBase*String extension.
+/// // Round-trip via the matching FromBase*String extension.
 /// byte[] roundtrip = base64.FromBase64String();
 ///
-/// Generic dispatch via IBinaryEncoding for runtime-selected encodings.
+/// // Generic dispatch via IBinaryEncoding for runtime-selected encodings.
 /// IBinaryEncoding chosen = BinaryEncodings.Get(appConfig["encoding"] ?? "base64");
 /// string encoded = data.Encode(chosen);
 /// byte[] decoded = encoded.Decode(chosen);

--- a/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodings.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/BinaryEncodings.cs
@@ -24,7 +24,7 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Pre-bound singleton — no allocation per call.
+/// // Pre-bound singleton — no allocation per call.
 /// IBinaryEncoding hex    = BinaryEncodings.Base16Upper;
 /// IBinaryEncoding jwt    = BinaryEncodings.Base64UrlSafe;
 /// IBinaryEncoding bitcoin = BinaryEncodings.Base58;
@@ -32,7 +32,7 @@ namespace Bodu.Text.Encoding;
 /// string encoded = jwt.Encode(payload);
 /// byte[] decoded = jwt.Decode(encoded);
 ///
-/// Look up by name — accepts canonical names and well-known aliases.
+/// // Look up by name — accepts canonical names and well-known aliases.
 /// IBinaryEncoding fromConfig = BinaryEncodings.Get(appConfig["encoding"] ?? "base64");
 /// IBinaryEncoding fromAlias  = BinaryEncodings.Get("hex");           // same as Base16Lower
 ///]]>

--- a/Bodu.Text.Encoding/src/Text.Encoding/IBinaryEncoding.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/IBinaryEncoding.cs
@@ -25,11 +25,11 @@ namespace Bodu.Text.Encoding;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Pick an encoding at runtime from configuration.
+/// // Pick an encoding at runtime from configuration.
 /// string             configured = appConfig["encoding"];                     // e.g. "base64-urlsafe"
 /// IBinaryEncoding    encoding   = BinaryEncodings.Get(configured);
 ///
-/// Use the same call shape regardless of which variant was chosen.
+/// // Use the same call shape regardless of which variant was chosen.
 /// string encoded = encoding.Encode(payload);
 /// byte[] decoded = encoding.Decode(encoded);
 ///

--- a/Bodu.Text.Formats/src/Text.Bencode/Bencode.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/Bencode.cs
@@ -52,7 +52,7 @@ namespace Bodu.Text.Bencode;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse a BitTorrent-style dictionary and inspect a known field.
+/// // Parse a BitTorrent-style dictionary and inspect a known field.
 /// byte[] payload = File.ReadAllBytes("example.torrent");
 /// BencodedValue root = Bencode.Parse(payload);
 ///
@@ -63,7 +63,7 @@ namespace Bodu.Text.Bencode;
 ///     Console.WriteLine(url.GetUtf8String());
 /// }
 ///
-/// Round-trip: encode the value back to bytes.
+/// // Round-trip: encode the value back to bytes.
 /// int length = Bencode.GetFormattedLength(root);
 /// byte[] reencoded = Bencode.Format(root);
 ///]]>

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodeExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodeExtensions.cs
@@ -22,7 +22,7 @@ namespace Bodu.Text.Bencode;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse and round-trip via the receiver-typed extensions.
+/// // Parse and round-trip via the receiver-typed extensions.
 /// byte[] payload = File.ReadAllBytes("example.torrent");
 /// BencodedValue root = payload.ParseBencode();
 /// byte[] reencoded = root.FormatBencode();

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodedDictionary.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodedDictionary.cs
@@ -31,7 +31,7 @@ namespace Bodu.Text.Bencode;
 ///     KeyValuePair.Create(BencodedString.FromUtf8("piece length"), (BencodedValue)new BencodedInteger(262144)),
 /// });
 ///
-/// UTF-8 convenience overload.
+/// // UTF-8 convenience overload.
 /// if (dict.TryGetValue("announce", out BencodedValue url))
 ///     Console.WriteLine(((BencodedString)url).GetUtf8String());
 ///

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodedString.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodedString.cs
@@ -25,11 +25,11 @@ namespace Bodu.Text.Bencode;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Construct from raw bytes or from a UTF-8 string.
+/// // Construct from raw bytes or from a UTF-8 string.
 /// var hash  = new BencodedString(infoHashBytes);
 /// var label = BencodedString.FromUtf8("comment");
 ///
-/// Inspect the payload — Bytes for raw, GetUtf8String only when text is expected.
+/// // Inspect the payload — Bytes for raw, GetUtf8String only when text is expected.
 /// ReadOnlySpan<byte> raw  = hash.Bytes.Span;
 /// string             text = label.GetUtf8String();   // "comment"
 ///]]>

--- a/Bodu.Text.Formats/src/Text.Bencode/BencodedStringComparer.cs
+++ b/Bodu.Text.Formats/src/Text.Bencode/BencodedStringComparer.cs
@@ -32,7 +32,7 @@ namespace Bodu.Text.Bencode;
 /// };
 ///
 /// Array.Sort(keys, BencodedStringComparer.Ordinal);
-/// keys is now ordered { announce, comment, info } — bytewise ASCII order.
+/// // keys is now ordered { announce, comment, info } — bytewise ASCII order.
 ///]]>
 /// </example>
 public sealed class BencodedStringComparer

--- a/Bodu.Text.Formats/src/Text.Delimited/Delimited.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/Delimited.cs
@@ -46,7 +46,7 @@ namespace Bodu.Text.Delimited;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse a CSV document with a header row (the default).
+/// // Parse a CSV document with a header row (the default).
 /// DelimitedDocument doc = Delimited.Parse("""
 ///     name,age,city
 ///     Ada,42,London
@@ -56,7 +56,7 @@ namespace Bodu.Text.Delimited;
 /// foreach (DelimitedRow row in doc.Rows)
 ///     Console.WriteLine($"{row["name"]} ({row.GetInt32("age")}) — {row["city"]}");
 ///
-/// TSV without a header.
+/// // TSV without a header.
 /// DelimitedDocument tsv = Delimited.Parse(source, new DelimitedParseOptions
 /// {
 ///     Delimiter  = '\t',

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedExtensions.cs
@@ -22,7 +22,7 @@ namespace Bodu.Text.Delimited;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse a CSV document and round-trip back to text via the receiver-typed extensions.
+/// // Parse a CSV document and round-trip back to text via the receiver-typed extensions.
 /// DelimitedDocument doc = "name,age\nAda,42".ParseDelimited();
 /// string text = doc.FormatDelimited();
 ///]]>

--- a/Bodu.Text.Formats/src/Text.Delimited/DelimitedParseOptions.cs
+++ b/Bodu.Text.Formats/src/Text.Delimited/DelimitedParseOptions.cs
@@ -24,10 +24,10 @@ namespace Bodu.Text.Delimited;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Strict RFC 4180 CSV with a header row.
+/// // Strict RFC 4180 CSV with a header row.
 /// DelimitedDocument csv = Delimited.Parse(text);
 ///
-/// Tab-separated, no header, allow # comments.
+/// // Tab-separated, no header, allow # comments.
 /// var tsv = new DelimitedParseOptions
 /// {
 ///     Delimiter         = '\t',

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnv.cs
@@ -60,7 +60,7 @@ namespace Bodu.Text.DotEnv;
 /// foreach (DotEnvEntry entry in doc.Entries)
 ///     Environment.SetEnvironmentVariable(entry.Key, entry.Value);
 ///
-/// Direct lookup is O(1).
+/// // Direct lookup is O(1).
 /// string port = doc["PORT"];   // "8080"
 ///]]>
 /// </example>

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvDocument.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvDocument.cs
@@ -26,14 +26,14 @@ namespace Bodu.Text.DotEnv;
 ///<![CDATA[
 /// DotEnvDocument doc = DotEnv.Parse(text);
 ///
-/// Direct lookup — throws KeyNotFoundException when the key is missing.
+/// // Direct lookup — throws KeyNotFoundException when the key is missing.
 /// string apiKey = doc["API_KEY"];
 ///
-/// TryGetValue for optional keys.
+/// // TryGetValue for optional keys.
 /// if (doc.TryGetValue("LOG_LEVEL", out string? level))
 ///     Console.WriteLine($"Log level: {level}");
 ///
-/// Walk every entry in source order.
+/// // Walk every entry in source order.
 /// foreach (DotEnvEntry entry in doc.Entries)
 ///     Console.WriteLine($"{entry.Key}={entry.Value}");
 ///]]>

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvExtensions.cs
@@ -21,7 +21,7 @@ namespace Bodu.Text.DotEnv;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse and round-trip via the receiver-typed extensions.
+/// // Parse and round-trip via the receiver-typed extensions.
 /// DotEnvDocument doc = "PORT=8080\nHOST=localhost".ParseDotEnv();
 /// string text = doc.FormatDotEnv();
 ///]]>

--- a/Bodu.Text.Formats/src/Text.DotEnv/DotEnvParseOptions.cs
+++ b/Bodu.Text.Formats/src/Text.DotEnv/DotEnvParseOptions.cs
@@ -22,10 +22,10 @@ namespace Bodu.Text.DotEnv;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Default behaviour — wide compatibility with .env conventions.
+/// // Default behaviour — wide compatibility with .env conventions.
 /// DotEnvDocument doc = DotEnv.Parse(text);
 ///
-/// Strict ingest: reject duplicate keys and disallow inline comments.
+/// // Strict ingest: reject duplicate keys and disallow inline comments.
 /// var options = new DotEnvParseOptions
 /// {
 ///     DuplicateKeyBehavior = DuplicateKeyPolicy.Disallowed,

--- a/Bodu.Text.Formats/src/Text.Ini/Ini.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/Ini.cs
@@ -46,7 +46,7 @@ namespace Bodu.Text.Ini;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse a document and read a typed value out of a known section.
+/// // Parse a document and read a typed value out of a known section.
 /// IniDocument doc = Ini.Parse("""
 ///     [database]
 ///     host=localhost
@@ -57,10 +57,10 @@ namespace Bodu.Text.Ini;
 /// string host  = db["host"];
 /// int    port  = db.GetInt32("port", fallback: 5432);
 ///
-/// Round-trip: emit the document back to a string.
+/// // Round-trip: emit the document back to a string.
 /// string text = Ini.Format(doc);
 ///
-/// Dialect override: case-sensitive section names.
+/// // Dialect override: case-sensitive section names.
 /// IniDocument strict = Ini.Parse(source, new IniParseOptions { CaseSensitiveSections = true });
 ///]]>
 /// </example>

--- a/Bodu.Text.Formats/src/Text.Ini/IniDocument.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniDocument.cs
@@ -24,14 +24,14 @@ namespace Bodu.Text.Ini;
 ///<![CDATA[
 /// IniDocument doc = Ini.Parse(text);
 ///
-/// Walk every named section.
+/// // Walk every named section.
 /// foreach (IniSection section in doc.Sections)
 ///     Console.WriteLine($"[{section.Name}] — {section.Entries.Count} entries");
 ///
-/// Read the global section (keys that appeared before any header).
+/// // Read the global section (keys that appeared before any header).
 /// IniSection global = doc.GlobalSection;
 ///
-/// Indexer lookup by section name.
+/// // Indexer lookup by section name.
 /// if (doc.TryGetSection("database", out IniSection? db))
 ///     Console.WriteLine(db!["host"]);
 ///]]>

--- a/Bodu.Text.Formats/src/Text.Ini/IniEntry.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniEntry.cs
@@ -28,14 +28,14 @@ namespace Bodu.Text.Ini;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Build a section programmatically and format it back to text.
+/// // Build a section programmatically and format it back to text.
 /// var doc = new IniDocument();
 /// IniSection db = doc.GetOrAddSection("database");
 /// db.SetEntry("host", "localhost");
 /// IniEntry port = db.SetEntry("port", "5432");
 /// port.InlineComment = new IniComment('#', " default Postgres port");
 ///
-/// Key and Value are immutable; replace the value via SetEntry.
+/// // Key and Value are immutable; replace the value via SetEntry.
 /// db.SetEntry("port", "5433");
 ///
 /// string text = Ini.Format(doc);

--- a/Bodu.Text.Formats/src/Text.Ini/IniExtensions.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniExtensions.cs
@@ -21,11 +21,11 @@ namespace Bodu.Text.Ini;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Parse and round-trip via the receiver-typed extensions.
+/// // Parse and round-trip via the receiver-typed extensions.
 /// IniDocument doc = "[database]\nhost=localhost".ParseIni();
 /// string text = doc.FormatIni();
 ///
-/// Non-throwing variant.
+/// // Non-throwing variant.
 /// if (source.ParseIni() is { Sections.Count: > 0 } parsed) { /* ... */ }
 ///]]>
 /// </example>

--- a/Bodu.Text.Formats/src/Text.Ini/IniSection.cs
+++ b/Bodu.Text.Formats/src/Text.Ini/IniSection.cs
@@ -27,15 +27,15 @@ namespace Bodu.Text.Ini;
 ///<![CDATA[
 /// IniSection db = doc["database"];
 ///
-/// Indexer lookup throws KeyNotFoundException when the key is missing.
+/// // Indexer lookup throws KeyNotFoundException when the key is missing.
 /// string host = db["host"];
 ///
-/// TryGetValue + typed accessors with fallbacks for optional keys.
+/// // TryGetValue + typed accessors with fallbacks for optional keys.
 /// int port = db.GetInt32("port", fallback: 5432);
 /// if (db.TryGetValue("password", out string? password))
 ///     Console.WriteLine($"Password length: {password.Length}");
 ///
-/// Walk the entries in source order.
+/// // Walk the entries in source order.
 /// foreach (IniEntry entry in db.Entries)
 ///     Console.WriteLine($"{entry.Key} = {entry.Value}");
 ///]]>

--- a/Bodu.Text/src/Text/EncodingDetection.cs
+++ b/Bodu.Text/src/Text/EncodingDetection.cs
@@ -48,7 +48,7 @@ namespace Bodu.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Read a file's leading bytes and decode using the detected encoding, falling back to UTF-8.
+/// // Read a file's leading bytes and decode using the detected encoding, falling back to UTF-8.
 /// byte[] bytes = File.ReadAllBytes(path);
 ///
 /// System.Text.Encoding encoding =

--- a/Bodu.Text/src/Text/EncodingExtensions.Chunked.cs
+++ b/Bodu.Text/src/Text/EncodingExtensions.Chunked.cs
@@ -42,7 +42,7 @@ public static partial class EncodingExtensions
     /// </exception>
     /// <example>
     ///<![CDATA[
-    /// Encode a long string into a buffer writer one chunk at a time.
+    /// // Encode a long string into a buffer writer one chunk at a time.
     /// ReadOnlySpan<char> source = text.AsSpan();
     /// System.Text.Encoder encoder = System.Text.Encoding.UTF8.GetEncoder();
     ///

--- a/Bodu.Text/src/Text/EncodingExtensions.Encoding.Fallback.cs
+++ b/Bodu.Text/src/Text/EncodingExtensions.Encoding.Fallback.cs
@@ -15,7 +15,7 @@ public static partial class EncodingExtensions
     /// </summary>
     /// <example>
     ///<![CDATA[
-    /// Configure a single call-site to fail fast on bad input without mutating the global default.
+    /// // Configure a single call-site to fail fast on bad input without mutating the global default.
     /// System.Text.Encoding strictAscii = System.Text.Encoding.ASCII.WithExceptionFallbacks();
     /// try
     /// {

--- a/Bodu.Text/src/Text/EncodingExtensions.Encoding.Pool.cs
+++ b/Bodu.Text/src/Text/EncodingExtensions.Encoding.Pool.cs
@@ -201,12 +201,12 @@ public static partial class EncodingExtensions
     /// </exception>
     /// <example>
     ///<![CDATA[
-    /// Encode into a pooled buffer, hand the written span to a downstream consumer, then dispose to
-    /// return the rented array.
+    /// // Encode into a pooled buffer, hand the written span to a downstream consumer, then dispose to
+    /// // return the rented array.
     /// using PooledBufferBuilder<byte> pooled = System.Text.Encoding.UTF8.GetBytesPooled("hello");
     /// ReadOnlySpan<byte> bytes = pooled.WrittenSpan;
     /// downstream.Process(bytes);
-    /// Disposed at the end of the using scope — the underlying byte[] returns to ArrayPool<byte>.Shared.
+    /// // Disposed at the end of the using scope — the underlying byte[] returns to ArrayPool<byte>.Shared.
     ///]]>
     /// </example>
     public static PooledBufferBuilder<byte> GetBytesPooled(

--- a/Bodu.Text/src/Text/EncodingExtensions.cs
+++ b/Bodu.Text/src/Text/EncodingExtensions.cs
@@ -38,15 +38,15 @@ namespace Bodu.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Encode a chunk of UTF-16 text to UTF-8 bytes via the span receiver.
+/// // Encode a chunk of UTF-16 text to UTF-8 bytes via the span receiver.
 /// ReadOnlySpan<char> chars = "héllo".AsSpan();
 /// byte[] utf8 = chars.ToUtf8Bytes();
 ///
-/// Round-trip via the encoding receiver, using the pooled builder for zero unnecessary allocations.
+/// // Round-trip via the encoding receiver, using the pooled builder for zero unnecessary allocations.
 /// using PooledBufferBuilder<byte> pooled = System.Text.Encoding.UTF8.GetBytesPooled(chars);
 /// ReadOnlySpan<byte> encoded = pooled.WrittenSpan;
 ///
-/// Detect a UTF-8 byte-order-mark and decode the remainder.
+/// // Detect a UTF-8 byte-order-mark and decode the remainder.
 /// if (System.Text.Encoding.UTF8.StartsWithPreamble(encoded))
 ///     encoded = System.Text.Encoding.UTF8.StripPreamble(encoded);
 ///

--- a/Bodu.Text/src/Text/StringEncodingExtensions.GetUtf8BytesPooled.cs
+++ b/Bodu.Text/src/Text/StringEncodingExtensions.GetUtf8BytesPooled.cs
@@ -25,8 +25,8 @@ public static partial class StringEncodingExtensions
     /// </exception>
     /// <example>
     ///<![CDATA[
-    /// Encode a large JSON document to UTF-8 without a permanent allocation, then hand the
-    /// pooled buffer to a network writer before disposal returns the array to the pool.
+    /// // Encode a large JSON document to UTF-8 without a permanent allocation, then hand the
+    /// // pooled buffer to a network writer before disposal returns the array to the pool.
     /// using PooledBufferBuilder<byte> pooled = jsonText.GetUtf8BytesPooled();
     /// await socket.SendAsync(pooled.WrittenMemory, SocketFlags.None);
     ///]]>

--- a/Bodu.Text/src/Text/StringEncodingExtensions.ToUtf8Bytes.cs
+++ b/Bodu.Text/src/Text/StringEncodingExtensions.ToUtf8Bytes.cs
@@ -18,7 +18,7 @@ public static partial class StringEncodingExtensions
     /// </exception>
     /// <example>
     ///<![CDATA[
-    /// Convert a configuration value to UTF-8 bytes for hashing.
+    /// // Convert a configuration value to UTF-8 bytes for hashing.
     /// byte[] payload = "client-secret".ToUtf8Bytes();
     /// byte[] hash    = SHA256.HashData(payload);
     ///]]>

--- a/Bodu.Text/src/Text/StringEncodingExtensions.cs
+++ b/Bodu.Text/src/Text/StringEncodingExtensions.cs
@@ -23,15 +23,15 @@ namespace Bodu.Text;
 /// </remarks>
 /// <example>
 ///<![CDATA[
-/// Fluent encoding of a string variable.
+/// // Fluent encoding of a string variable.
 /// byte[] utf8       = "héllo".ToUtf8Bytes();
 /// byte[] withBom    = "héllo".ToBytesWithPreamble(new System.Text.UTF8Encoding(true));
 ///
-/// Pool-backed encoding for a network send.
+/// // Pool-backed encoding for a network send.
 /// using PooledBufferBuilder<byte> pooled = jsonPayload.GetUtf8BytesPooled();
 /// await socket.SendAsync(pooled.WrittenMemory, SocketFlags.None);
 ///
-/// Pipeline integration.
+/// // Pipeline integration.
 /// "key=value\n".WriteUtf8To(pipeWriter);
 ///]]>
 /// </example>


### PR DESCRIPTION
## Summary

This change standardizes XML documentation example code blocks across the entire codebase to use proper C# comment syntax (`//`) for inline comments within `<![CDATA[…]]>` sections, rather than leaving comments as bare text. This improves code clarity and ensures examples are syntactically valid C# that can be copy-pasted directly.

## Changes Made

- **Affected files**: 150+ source files across all projects (Bodu.Core, Bodu.Numerics, Bodu.IO.Hashing, Bodu.Security.Cryptography, Bodu.Text.*, Bodu.Extensions.Configuration.Text, Bodu.Globalization.Calendar, Bodu.Financial, and test infrastructure)
- **Pattern**: Converted bare text comments in XML doc examples to proper C# line comments (`//`)
  - Example: `/// Common input structure` → `/// // Common input structure`
  - Example: `/// Output: A, B, C, D` → `/// // Output: A, B, C, D`
  - Example: `/// Expected output:` → `/// // Expected output:`

## Implementation Details

- All changes are purely documentation-focused; no functional code modifications
- Maintains the existing `<![CDATA[…]]>` wrapper structure for code examples
- Ensures example code blocks are now syntactically correct C# that developers can directly copy and compile
- Improves consistency across the entire documentation suite, making examples more professional and easier to follow

https://claude.ai/code/session_01Hwz8SmJcMavwdnERTfUUpS