### PR TITLE
Fix TOML test build break from merged refactor/encoding-PR collision

### DIFF
--- a/Bodu.Text.Formats/test/Text.Toml/Conformance/TomlConformanceTests.cs
+++ b/Bodu.Text.Formats/test/Text.Toml/Conformance/TomlConformanceTests.cs
@@ -46,11 +46,35 @@ public sealed class TomlConformanceTests
     };
 
     /// <summary>
+    /// The reader options that select the TOML v1.1.0 profile, under which the consolidated corpus is exercised so that
+    /// the documents v1.1.0 newly accepts (optional seconds, multi-line inline tables, the <c>\e</c> and <c>\xHH</c>
+    /// escapes) parse rather than fail.
+    /// </summary>
+    private static readonly TomlReaderOptions s_v11 = new() { SpecVersion = TomlSpecVersion.V1_1 };
+
+    /// <summary>
+    /// The valid and invalid case names the TOML v1.0.0 manifest lists.
+    /// </summary>
+    private static readonly (HashSet<string> Valid, HashSet<string> Invalid) s_manifestV10 = LoadManifest("toml-test-files-1.0.0.txt");
+
+    /// <summary>
+    /// The valid and invalid case names the TOML v1.1.0 manifest lists.
+    /// </summary>
+    private static readonly (HashSet<string> Valid, HashSet<string> Invalid) s_manifestV11 = LoadManifest("toml-test-files-1.1.0.txt");
+
+    /// <summary>
     /// Provides the valid conformance cases.
     /// </summary>
     /// <returns>One <see cref="ConformanceCase" /> per valid document.</returns>
     public static IEnumerable<object[]> ValidCases() =>
         LoadCases("toml-test-valid.json", includeExpected: true);
+
+    /// <summary>
+    /// Provides the valid cases that belong to the TOML v1.0.0 suite — the documents a strict v1.0.0 parser must accept.
+    /// </summary>
+    /// <returns>One <see cref="ConformanceCase" /> per v1.0.0-valid document.</returns>
+    public static IEnumerable<object[]> ValidCasesV10() =>
+        ValidCases().Where(row => s_manifestV10.Valid.Contains(((ConformanceCase)row[0]).Name));
 
     /// <summary>
     /// Provides the invalid conformance cases, excluding those relaxed by TOML v1.1.0.
@@ -71,7 +95,7 @@ public sealed class TomlConformanceTests
     [DynamicData(nameof(ValidCases), DynamicDataDisplayName = nameof(KatDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(KatDisplayName))]
     public void Valid_WhenParsed_ShouldMatchExpectedModel(ConformanceCase testCase)
     {
-        TomlTable document = Toml.Parse(testCase.Toml);
+        TomlTable document = Toml.Parse(testCase.Toml, s_v11);
         JsonNode actual = TomlTestEncoder.Encode(document);
         JsonNode expected = JsonNode.Parse(testCase.Expected!)!;
 
@@ -87,7 +111,7 @@ public sealed class TomlConformanceTests
     [DynamicData(nameof(InvalidCases), DynamicDataDisplayName = nameof(KatDisplayName.GetDisplayName), DynamicDataDisplayNameDeclaringType = typeof(KatDisplayName))]
     public void Invalid_WhenParsed_ShouldThrowTomlFormatException(ConformanceCase testCase)
     {
-        Assert.ThrowsExactly<TomlFormatException>(() => Toml.Parse(testCase.Toml), $"Conformance case '{testCase.Name}' should have been rejected.");
+        Assert.ThrowsExactly<TomlFormatException>(() => Toml.Parse(testCase.Toml, s_v11), $"Conformance case '{testCase.Name}' should have been rejected.");
     }
 
     /// <summary>
@@ -115,6 +139,40 @@ public sealed class TomlConformanceTests
         }
 
         return rows;
+    }
+
+    /// <summary>
+    /// Loads a vendored <c>files-toml-&lt;version&gt;</c> manifest into the sets of valid and invalid case names it
+    /// lists, keyed the same way as the corpus (the path under <c>valid/</c> or <c>invalid/</c> without the
+    /// <c>.toml</c> extension). The accompanying <c>.json</c> expected-value entries are ignored.
+    /// </summary>
+    /// <param name="resourceSuffix">The trailing portion of the embedded manifest resource name.</param>
+    /// <returns>The valid and invalid case-name sets.</returns>
+    private static (HashSet<string> Valid, HashSet<string> Invalid) LoadManifest(string resourceSuffix)
+    {
+        var valid = new HashSet<string>(StringComparer.Ordinal);
+        var invalid = new HashSet<string>(StringComparer.Ordinal);
+
+        Assembly assembly = typeof(TomlConformanceTests).Assembly;
+        var resourceName = Array.Find(assembly.GetManifestResourceNames(), n => n.EndsWith(resourceSuffix, StringComparison.Ordinal))
+            ?? throw new InvalidOperationException($"Embedded manifest resource '{resourceSuffix}' was not found.");
+
+        using Stream stream = assembly.GetManifestResourceStream(resourceName)!;
+        using StreamReader reader = new(stream);
+        string? line;
+        while ((line = reader.ReadLine()) is not null)
+        {
+            line = line.Trim();
+            if (!line.EndsWith(".toml", StringComparison.Ordinal))
+                continue;
+
+            if (line.StartsWith("valid/", StringComparison.Ordinal))
+                valid.Add(line["valid/".Length..^".toml".Length]);
+            else if (line.StartsWith("invalid/", StringComparison.Ordinal))
+                invalid.Add(line["invalid/".Length..^".toml".Length]);
+        }
+
+        return (valid, invalid);
     }
 
     /// <summary>
@@ -160,6 +218,30 @@ public sealed class TomlConformanceTests
     }
 
     /// <summary>
+    /// Verifies that every vendored corpus case is classified by at least one version manifest, so no document is
+    /// silently excluded from the manifest-gated suites when the corpus or manifests are re-vendored.
+    /// </summary>
+    [TestMethod]
+    public void Manifest_WhenLoaded_ShouldClassifyEveryCorpusCase()
+    {
+        foreach (object[] row in ValidCases())
+        {
+            var name = ((ConformanceCase)row[0]).Name;
+            Assert.IsTrue(
+                s_manifestV10.Valid.Contains(name) || s_manifestV11.Valid.Contains(name),
+                $"Valid corpus case '{name}' is not listed in any toml-test version manifest.");
+        }
+
+        foreach (object[] row in LoadCases("toml-test-invalid.json", includeExpected: false))
+        {
+            var name = ((ConformanceCase)row[0]).Name;
+            Assert.IsTrue(
+                s_manifestV10.Invalid.Contains(name) || s_manifestV11.Invalid.Contains(name),
+                $"Invalid corpus case '{name}' is not listed in any toml-test version manifest.");
+        }
+    }
+
+    /// <summary>
     /// Verifies the reverse of <see cref="Manifest_WhenLoaded_ShouldClassifyEveryCorpusCase" />: every case a version
     /// manifest lists is vendored in the consolidated corpus, except the byte-level <c>invalid/encoding/*</c> cases that
     /// cannot be represented as JSON strings (see the README). This fails when a manifest entry silently loses its
@@ -194,9 +276,6 @@ public sealed class TomlConformanceTests
         name.StartsWith("encoding/", StringComparison.Ordinal);
 
     /// <summary>
-    /// Loads a vendored <c>files-toml-&lt;version&gt;</c> manifest into the set of valid and invalid case names it
-    /// lists, keyed the same way as the corpus (the path under <c>valid/</c> or <c>invalid/</c> without the
-    /// <c>.toml</c> extension). The accompanying <c>.json</c> expected-value entries are ignored.
     /// Compares two tagged-JSON scalar leaves by type and value semantics.
     /// </summary>
     /// <param name="caseName">The conformance case name, for diagnostics.</param>

--- a/Bodu.Text.Formats/test/Text.Toml/TomlStreamTests.cs
+++ b/Bodu.Text.Formats/test/Text.Toml/TomlStreamTests.cs
@@ -16,6 +16,18 @@ public sealed class TomlStreamTests
 {
     private const string Sample = "title = \"x\"\n\n[server]\nhost = \"localhost\"\nport = 8080\n";
 
+    /// <summary>
+    /// Provides streams whose bytes are not valid UTF-8 and therefore must be rejected.
+    /// </summary>
+    /// <returns>One named byte sequence per row.</returns>
+    public static IEnumerable<object[]> InvalidUtf8Cases()
+    {
+        yield return ["lone-continuation", new byte[] { 0x80 }];
+        yield return ["overlong-slash", new byte[] { 0xC0, 0xAF }];
+        yield return ["encoded-surrogate", new byte[] { 0xED, 0xA0, 0x80 }];
+        yield return ["above-unicode-range", new byte[] { 0xF4, 0x90, 0x80, 0x80 }];
+    }
+
     [TestMethod]
     public void FormatThenParse_WhenUsingStreams_ShouldRoundTrip()
     {


### PR DESCRIPTION
The TOML test-suite refactor consolidated the conformance tests to a
single v1.1.0 run and deleted the per-version manifest infrastructure
(s_manifestV10/V11, LoadManifest, ValidCasesV10) and the InvalidUtf8Cases
stream data source. The later encoding-validation PR was branched before
that refactor and re-introduced consumers of those symbols (the writer
conformance test, the reverse manifest drift guard, and the async invalid
UTF-8 stream tests). The merge kept the consumers without the definitions,
so Bodu.Text.Formats.Test failed to compile (CS0117 ValidCasesV10, CS0103
InvalidUtf8Cases). The undefined s_manifestV10/V11 references were masked
because the attribute-level errors abort compilation before method-body
binding.

Restore the dropped plumbing so the encoding PR's tests work as intended:

- Re-add s_manifestV10/V11 + LoadManifest and the manifest-filtered
  ValidCasesV10 source the writer conformance test consumes.
- Re-add the forward drift guard Manifest_WhenLoaded_ShouldClassifyEvery
  CorpusCase, restoring the cref its reverse counterpart references and
  completing the corpus<->manifest correspondence check in both directions.
- Re-add the InvalidUtf8Cases data source for the stream UTF-8 tests.
- Fix a doc comment that merged LoadManifest's summary into
  AssertScalarEquivalent during the bad merge.

Also parse the consolidated corpus under the v1.1.0 profile. The refactor
introduced the s_invalidSkip list of cases v1.1.0 relaxed to valid but
still parsed with the v1.0.0 default, so the v1.1-only valid documents in
the corpus (optional seconds, multi-line inline tables, \e/\xHH escapes)
would fail at runtime. These are Regression-tier tests, excluded from the
default BVT run, which is why only the compile error surfaced.

https://claude.ai/code/session_01HMutGfbfZJ1fvF9jAAVgZP