### PR TITLE
docs: add TOML reference and refresh encoding docs for Base45/Base62/Bech32

### DIFF
--- a/docs/apidoc/Bodu.Text.Bencode.md
+++ b/docs/apidoc/Bodu.Text.Bencode.md
@@ -6,7 +6,7 @@ uid: Bodu.Text.Bencode
 
 ## Purpose
 
-**Bodu.Text.Bencode** decodes and encodes the **Bencode** serialization grammar specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html), the BitTorrent metadata format. It is one of four format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Ini>.
+**Bodu.Text.Bencode** decodes and encodes the **Bencode** serialization grammar specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html), the BitTorrent metadata format. It is one of five format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, <xref:Bodu.Text.Ini>, and <xref:Bodu.Text.Toml>.
 
 Bencode is exposed through the same shape used across the format family: a strongly-typed value tree, a static codec with `Encode` / `Decode` / `TryEncode` / `TryDecode` / `GetEncodedLength` over `ReadOnlySpan<byte>` / `byte[]` / `Stream`, and BEP 3 invariants that the encoder always honours and the parser always enforces. No reflection, no `dynamic`, no schema, no allocations beyond the immutable result graph.
 

--- a/docs/apidoc/Bodu.Text.Delimited.md
+++ b/docs/apidoc/Bodu.Text.Delimited.md
@@ -6,7 +6,7 @@ uid: Bodu.Text.Delimited
 
 ## Purpose
 
-**Bodu.Text.Delimited** parses and emits **delimited** records — CSV, TSV, and other character-separated value documents — using a strongly-typed row model and a static codec with `Parse` / `Format` / `Try*` overloads over `ReadOnlySpan<char>` / `string` / `Stream` / `TextReader` / `TextWriter`. It is one of four format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Ini>.
+**Bodu.Text.Delimited** parses and emits **delimited** records — CSV, TSV, and other character-separated value documents — using a strongly-typed row model and a static codec with `Parse` / `Format` / `Try*` overloads over `ReadOnlySpan<char>` / `string` / `Stream` / `TextReader` / `TextWriter`. It is one of five format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.DotEnv>, <xref:Bodu.Text.Ini>, and <xref:Bodu.Text.Toml>.
 
 ## Key types
 

--- a/docs/apidoc/Bodu.Text.DotEnv.md
+++ b/docs/apidoc/Bodu.Text.DotEnv.md
@@ -6,7 +6,7 @@ uid: Bodu.Text.DotEnv
 
 ## Purpose
 
-**Bodu.Text.DotEnv** parses and emits **.env**-style environment files — `KEY=VALUE` lines with optional quoting, escapes, and comments — using a strongly-typed document model and a static codec with `Parse` / `Format` / `Try*` overloads over `ReadOnlySpan<char>` / `string` / `Stream` / `TextReader` / `TextWriter`. It is one of four format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, and <xref:Bodu.Text.Ini>.
+**Bodu.Text.DotEnv** parses and emits **.env**-style environment files — `KEY=VALUE` lines with optional quoting, escapes, and comments — using a strongly-typed document model and a static codec with `Parse` / `Format` / `Try*` overloads over `ReadOnlySpan<char>` / `string` / `Stream` / `TextReader` / `TextWriter`. It is one of five format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.Ini>, and <xref:Bodu.Text.Toml>.
 
 ## Key types
 

--- a/docs/apidoc/Bodu.Text.Encoding.md
+++ b/docs/apidoc/Bodu.Text.Encoding.md
@@ -6,9 +6,9 @@ uid: Bodu.Text.Encoding
 
 ## Purpose
 
-**Bodu.Text.Encoding** is a focused, allocation-conscious library of **binary-to-text encodings**. It implements the five practical radix encodings .NET applications reach for — **Base16**, **Base32**, **Base64**, **Base58**, **Base85** — and gives each the same modern API shape: span- and UTF-8-friendly overloads, `OperationStatus`-returning streaming methods, length-prediction helpers, validation predicates, and a unified <xref:Bodu.Text.Encoding.IBinaryEncoding> interface that lets code select an encoding at runtime.
+**Bodu.Text.Encoding** is a focused, allocation-conscious library of **binary-to-text encodings**. The five core radix encodings .NET applications reach for — **Base16**, **Base32**, **Base64**, **Base58**, **Base85** — each carry the same modern API shape: span- and UTF-8-friendly overloads, `OperationStatus`-returning streaming methods, length-prediction helpers, validation predicates, and the unified <xref:Bodu.Text.Encoding.IBinaryEncoding> interface that lets code select an encoding at runtime. Alongside them sit three special-purpose encodings — **Base45** (RFC 9285, for QR-code payloads), **Base62** (GMP-style, for compact identifiers), and **Bech32 / Bech32m** (BIP 173 / 350, checksummed addresses with a human-readable part) — plus the convenience wrappers **Base58Check** and **Base64Url**.
 
-The package fills two gaps that <xref:System.Convert> and `System.Buffers.Text.Base64` leave open: **variants** the BCL does not cover (base32hex, Crockford Base32, z-base-32, Base58 Bitcoin / Flickr / Ripple, Ascii85, Z85), and **lenient parsing** / **formatting decoration** — `0x` prefix tolerance, whitespace stripping, byte spacing, line breaks every 64 / 76 characters — for the encodings that benefit from them.
+The package fills two gaps that <xref:System.Convert> and `System.Buffers.Text.Base64` leave open: **variants** the BCL does not cover (base32hex, Crockford Base32, z-base-32, Base58 Bitcoin / Flickr / Ripple, Ascii85, Z85, Base45, Base62, Bech32 / Bech32m), and **lenient parsing** / **formatting decoration** — `0x` prefix tolerance, whitespace stripping, byte spacing, line breaks every 64 / 76 characters — for the encodings that benefit from them.
 
 For structured binary serialization formats with their own framing grammar (Bencode, INI), see the companion `Bodu.Text.Formats` package — namespaces <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Ini>.
 
@@ -21,7 +21,7 @@ For structured binary serialization formats with their own framing grammar (Benc
 
 ## Key types
 
-**Per-encoding static classes (`Bodu.Text.Encoding`)**
+**Core radix encodings (`Bodu.Text.Encoding`)**
 
 - <xref:Bodu.Text.Encoding.Base16> — hexadecimal; 4 bits per symbol; flexible formatting (case, `0x` prefix, line breaks, byte spacing); lenient parsing.
 - <xref:Bodu.Text.Encoding.Base32> — 5 bits per symbol; four variants via <xref:Bodu.Text.Encoding.Base32Variant>: Standard (RFC 4648 §6), HexExtended (RFC 4648 §7), Crockford, ZBase32; padding control.
@@ -29,11 +29,19 @@ For structured binary serialization formats with their own framing grammar (Benc
 - <xref:Bodu.Text.Encoding.Base58> — non-power-of-two radix using big-integer divmod; two variants via <xref:Bodu.Text.Encoding.Base58Variant>: BitcoinFlickr (default), Ripple. Preserves leading zeros.
 - <xref:Bodu.Text.Encoding.Base85> — 4-byte block → 5 chars; two variants via <xref:Bodu.Text.Encoding.Base85Variant>: Ascii85 (Adobe, with `z` shortcut), Z85 (RFC 32 ZeroMQ; 4-byte alignment).
 
+**Special-purpose encodings**
+
+- <xref:Bodu.Text.Encoding.Base45> — RFC 9285; the compact alphanumeric encoding carried inside a QR code's Alphanumeric mode. 45-character alphabet; no padding; not streamable.
+- <xref:Bodu.Text.Encoding.Base62> — GMP-style alphabet `0-9 A-Z a-z`; big-integer divmod; leading zero bytes preserved as leading `0` characters. Suited to short URLs and compact identifiers.
+- <xref:Bodu.Text.Encoding.Bech32> — BIP 173 (Bech32) and BIP 350 (Bech32m); a checksummed base-32 format comprising a human-readable part (HRP), the `1` separator, a 5-bit data part, and a six-symbol error-detecting checksum. The <xref:Bodu.Text.Encoding.Bech32Encoding> enum selects the scheme and is reported on decode.
+- <xref:Bodu.Text.Encoding.Base58Check> — Base58 with the Bitcoin-style four-byte double-SHA-256 checksum appended on encode and verified on decode. The right entry point for address- and key-style payloads.
+- <xref:Bodu.Text.Encoding.Base64Url> — the RFC 4648 §5 URL- and filename-safe Base64 as a first-class type (mirrors `System.Buffers.Text.Base64Url`), with padding omitted by default and a UTF-8 byte path.
+
 **Runtime selection**
 
-- <xref:Bodu.Text.Encoding.IBinaryEncoding> — unified contract for runtime-pluggable encoding choice. `Encode`, `Decode`, `GetEncodedLength`, `GetMaxDecodedLength`, `IsValid`.
-- <xref:Bodu.Text.Encoding.BinaryEncodings> — pre-configured singleton instances (`Base16`, `Base32`, `Base32Crockford`, `Base64`, `Base64UrlSafe`, `Base58`, `Ascii85`, `Z85`, …) plus the `Get(name)` lookup for configuration-driven selection.
-- <xref:Bodu.Text.Encoding.BinaryEncodingExtensions> — fluent extension methods on `byte[]`, `ReadOnlySpan<byte>`, and `string` (`ToBase16String`, `FromBase64String`, …).
+- <xref:Bodu.Text.Encoding.IBinaryEncoding> — unified contract for runtime-pluggable encoding choice. `Encode`, `Decode`, `GetMaxEncodedLength`, `GetMaxDecodedLength`, `IsValid`, `TryEncode`, `TryDecode`, plus `Name` and `Description`.
+- <xref:Bodu.Text.Encoding.BinaryEncodings> — pre-configured singleton instances (`Base16Lower`, `Base16Upper`, `Base32`, `Base32Hex`, `Base32Crockford`, `Base32ZBase32`, `Base45`, `Base58`, `Base58Ripple`, `Base62`, `Base64`, `Base64Mime`, `Base64UrlSafe`, `Ascii85`, `Z85`) plus the `Get(name)` lookup for configuration-driven selection. (Bech32 and Base58Check require an HRP / checksum and so are not surfaced through `IBinaryEncoding`.)
+- <xref:Bodu.Text.Encoding.BinaryEncodingExtensions> — fluent extension methods on `byte[]`, `ReadOnlySpan<byte>`, and `string` (`ToBase16String`, `FromBase64String`, `ToBase64UrlString`, `Encode(IBinaryEncoding)`, …).
 
 **Shared option types**
 
@@ -72,6 +80,22 @@ byte[] payload = Base58.Decode("1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L");
 string ascii85 = Base85.Encode(new byte[] { 0, 0, 0, 0 }, Base85Variant.Ascii85);
 // ascii85 → "z"
 
+// --- Base45: encode a payload for a QR code (RFC 9285) -----------------------
+string qrPayload = Base45.Encode("AB"u8.ToArray());   // → "BB8"
+
+// --- Base62: compact identifier from random bytes ---------------------------
+string shortId = Base62.Encode(RandomNumberGenerator.GetBytes(8));
+
+// --- Bech32m: encode raw bytes under a human-readable part ------------------
+byte[] program = Base16.Decode("751e76e8199196d454941c45d1b3a323f1433bd6");
+string addr = Bech32.EncodeFromBytes("bc", program, Bech32Encoding.Bech32m);   // 8-bit → 5-bit groups
+Bech32.DecodeToBytes(addr, out string hrp, out byte[] data, out Bech32Encoding scheme);
+// hrp → "bc"; data → program; scheme → Bech32Encoding.Bech32m
+
+// --- Base58Check: checksum-protected payload --------------------------------
+string wif = Base58Check.Encode(secret);
+byte[] recovered = Base58Check.Decode(wif);            // verifies, then strips checksum
+
 // --- Runtime selection via IBinaryEncoding ----------------------------------
 IBinaryEncoding encoding = BinaryEncodings.Get("base64-urlsafe");
 string token = encoding.Encode(secret);
@@ -92,6 +116,8 @@ OperationStatus status = Base16.DecodeFromUtf8(
 - **ASCII alphabets / UTF-8 byte path.** Every variant's alphabet is pure ASCII, so the UTF-8 byte form is bit-identical to the character form. The `EncodeToUtf8` / `DecodeFromUtf8` overloads are the natural choice when bytes come from a network or file pipeline — they avoid the allocation of an intermediate `string` or `char[]`.
 - **`OperationStatus` and streaming.** Base16, Base32, and Base64 expose the `System.Buffers`-style `OperationStatus` return convention used by `System.Buffers.Text.Base64`: `Done`, `DestinationTooSmall`, `InvalidData`, and (streaming only, `isFinalBlock: false`) `NeedMoreData`. This makes them safe to drop into chunked stream pipelines without buffering the entire input.
 - **Base58 and Base85 are not streamable.** Base58 needs the entire input for its big-integer divmod; Base85 needs fixed-size block packing. Both surfaces accept `isFinalBlock` for API consistency but ignore the flag — pass the entire input as a single span.
+- **The special-purpose encodings are single-shot.** Base45, Base62, and Bech32 each require the whole input at once (Base45 packs in two/three-character groups, Base62 uses big-integer divmod, Bech32 must compute a checksum over the entire data part), so they expose no `OperationStatus` streaming path. They throw `FormatException` on invalid input and offer `Try*` variants that report failure as `false`.
+- **Bech32 is HRP-aware and checksum-verified.** <xref:Bodu.Text.Encoding.Bech32> encodes and decodes the *whole* string — human-readable part, `1` separator, data, and checksum — rather than a flat byte buffer, which is why it sits outside <xref:Bodu.Text.Encoding.IBinaryEncoding>. Decode reports which scheme (Bech32 vs Bech32m) validated the checksum through an out parameter; the BIP 173 90-character limit is enforced on decode, and `ConvertBits` converts between 8-bit bytes and 5-bit groups. <xref:Bodu.Text.Encoding.Base58Check> likewise verifies its appended four-byte double-SHA-256 checksum on decode and throws on a corrupted string.
 - **Stateless encodings.** Every encoding type is a `static class` with no instance state. There is no lookup-table cache to share across instances (encodings are stateless), no thread-affinity, and no global configuration. The runtime-selection types in <xref:Bodu.Text.Encoding.BinaryEncodings> are pre-configured singletons over the same static APIs.
 - **Decoder strictness.** Decoders are **strict** by default — only the canonical alphabet, padding, and quantum length are accepted — and **lenient** when one or more <xref:Bodu.Text.Encoding.BaseFormatStyles> flags are set: `AllowPrefix` accepts a `0x` / `0X` prefix; `IgnoreWhitespace` strips ASCII space, tab, CR, LF anywhere; `AllowMissingPadding` accepts inputs without trailing `=`. `Decode` throws `FormatException` on validation failure; `TryDecode` returns `false`.
 - **Determinism and portability.** Encoders are deterministic — given a byte sequence and an option set they always produce the same canonical output across platforms and architectures. The `Pearson` family's permutation tables are bit-identical to the published references; the same applies to the BCL-delegated Base64 path.

--- a/docs/apidoc/Bodu.Text.Ini.md
+++ b/docs/apidoc/Bodu.Text.Ini.md
@@ -6,7 +6,7 @@ uid: Bodu.Text.Ini
 
 ## Purpose
 
-**Bodu.Text.Ini** parses and emits **INI**-style configuration documents — section-organised `key = value` lines with optional comments. It is one of four format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, and <xref:Bodu.Text.DotEnv>.
+**Bodu.Text.Ini** parses and emits **INI**-style configuration documents — section-organised `key = value` lines with optional comments. It is one of five format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Toml>.
 
 INI is exposed through the same shape used across the format family: a strongly-typed value tree, a static codec with `Parse` / `Format` / `Load` / `Save` over `ReadOnlySpan<char>` / `string` / `Stream` / `TextReader` / `TextWriter`, and parser invariants the writer always honours and the parser always enforces. The model preserves comments, key order, and section order so round-tripping is byte-faithful under default options.
 

--- a/docs/apidoc/Bodu.Text.Toml.md
+++ b/docs/apidoc/Bodu.Text.Toml.md
@@ -1,0 +1,112 @@
+---
+uid: Bodu.Text.Toml
+---
+
+![Bodu.Text.Toml](~/images/hero-toml.svg)
+
+## Purpose
+
+**Bodu.Text.Toml** parses and emits **TOML** (Tom's Obvious, Minimal Language) documents — the configuration format defined by the [TOML specification](https://toml.io/). It is one of five format namespaces shipped by the **Bodu.Text.Formats** package; see also <xref:Bodu.Text.Bencode>, <xref:Bodu.Text.Delimited>, <xref:Bodu.Text.DotEnv>, and <xref:Bodu.Text.Ini>.
+
+TOML is exposed through a **reader/writer pair** layered under a convenience codec, the shape the package shares with <xref:Bodu.Text.Bencode>: a strongly-typed value tree (<xref:Bodu.Text.Toml.TomlTable> at the root), a <xref:Bodu.Text.Toml.TomlReader> that deserializes text into that model, a <xref:Bodu.Text.Toml.TomlWriter> that serializes it back to canonical TOML, and the static <xref:Bodu.Text.Toml.Toml> façade for one-line `Parse` / `Format`. The grammar covers every TOML value kind — strings (all four forms), integers in four radices, floats (including `inf` / `nan`), booleans, the four RFC 3339 date-time types, arrays, inline tables, standard tables, and arrays of tables.
+
+The reader enforces strict **TOML v1.0.0** by default and opts in to **TOML v1.1.0** grammar additions through <xref:Bodu.Text.Toml.TomlReaderOptions>. The writer always emits constructs valid under both versions.
+
+For EditorConfig-style INI configuration, see <xref:Bodu.Text.Ini>; for binary-to-text encodings (Base16 / Base32 / Base64 / Base58 / Base85) that operate on flat byte sequences without a structural grammar, see the companion <xref:Bodu.Text.Encoding> package.
+
+## Static documentation
+
+- **[Bodu.Text.Formats introduction](~/docs/formats/index.md)** — namespaces, headline types, scenarios.
+- **[Bodu.Text.Formats core concepts](~/docs/formats/concepts.md)** — vocabulary: format vs codec, value vs document, framing tokens, canonical encoding, format exception.
+- **[Bodu.Text.Formats getting started](~/docs/formats/getting-started.md)** — install and minimal samples.
+- **[Parser policies](~/docs/formats/parser-policies.md)** — the `SpecVersion` selector and the line / column / offset diagnostics carried by <xref:Bodu.Text.Toml.TomlFormatException>.
+- **[Using TOML](~/guides/formats/toml.md)** — the reader/writer pair, the value model, spec-version selection, and stream support.
+
+## Key types
+
+- <xref:Bodu.Text.Toml.Toml> — static codec façade. `Parse` / `TryParse` over `ReadOnlySpan<char>`, `Parse` / `ParseAsync` over `Stream` (UTF-8), and `Format` / `FormatAsync` to `string` or `Stream`. Each parse entry point has an overload accepting <xref:Bodu.Text.Toml.TomlReaderOptions>.
+- <xref:Bodu.Text.Toml.TomlReader> — the deserialization half of the pair. Single-pass recursive-descent parser; reads from `ReadOnlySpan<char>`, `string`, `TextReader`, or a UTF-8 `Stream` (sync and async). Unsealed so consumers may inherit read capability without gaining mutation surface.
+- <xref:Bodu.Text.Toml.TomlWriter> — the serialization half. Emits canonical, block-style TOML to a `string`, `TextWriter`, or UTF-8 `Stream` (sync and async).
+- <xref:Bodu.Text.Toml.TomlReaderOptions> — reader configuration. Carries the init-only <xref:Bodu.Text.Toml.TomlReaderOptions.SpecVersion> property; immutable once constructed and safe to share across reads.
+- <xref:Bodu.Text.Toml.TomlSpecVersion> — the spec selector: `V1_0` (default) or `V1_1`.
+- <xref:Bodu.Text.Toml.TomlValue> — abstract base for every value; exposes `Kind` for switch-style dispatch.
+- <xref:Bodu.Text.Toml.TomlValueKind> — `String`, `Integer`, `Float`, `Boolean`, `OffsetDateTime`, `LocalDateTime`, `LocalDate`, `LocalTime`, `Array`, `Table`.
+- <xref:Bodu.Text.Toml.TomlString>, <xref:Bodu.Text.Toml.TomlInteger>, <xref:Bodu.Text.Toml.TomlFloat>, <xref:Bodu.Text.Toml.TomlBoolean> — scalar value types over `string`, `long`, `double`, and `bool`. Immutable; each implements `IEquatable<T>`.
+- <xref:Bodu.Text.Toml.TomlLocalDate>, <xref:Bodu.Text.Toml.TomlLocalTime>, <xref:Bodu.Text.Toml.TomlLocalDateTime>, <xref:Bodu.Text.Toml.TomlOffsetDateTime> — the four RFC 3339 date-time kinds, backed by `DateOnly`, `TimeOnly`, `DateTime` (`Unspecified`), and `DateTimeOffset` respectively.
+- <xref:Bodu.Text.Toml.TomlArray> — an ordered, mutable `IReadOnlyList<TomlValue>`; TOML permits mixed-type elements. `Add` appends.
+- <xref:Bodu.Text.Toml.TomlTable> — an ordered, mutable, case-sensitive map of `string` → <xref:Bodu.Text.Toml.TomlValue>; the document root. `this[key]`, `Add`, `ContainsKey`, `TryGetValue`, `Keys`. Insertion order is preserved for deterministic output.
+- <xref:Bodu.Text.Toml.TomlFormatException> — derives from <xref:Bodu.Text.TextFormatException> (a <xref:System.FormatException>); thrown when the source cannot be interpreted as a valid TOML document. Carries `LineNumber`, `ColumnNumber`, and `Offset`.
+
+## Example
+
+```csharp
+using Bodu.Text.Toml;
+
+// --- Parse a configuration document -----------------------------------------
+TomlTable config = Toml.Parse("""
+    title = "Bodu sample"
+
+    [owner]
+    name = "Tom"
+    dob  = 1979-05-27T07:32:00Z
+
+    [database]
+    ports = [8000, 8001, 8002]
+    enabled = true
+    """);
+
+string title = ((TomlString)config["title"]).Value;               // "Bodu sample"
+
+var owner = (TomlTable)config["owner"];
+string name = ((TomlString)owner["name"]).Value;                  // "Tom"
+DateTimeOffset dob = ((TomlOffsetDateTime)owner["dob"]).Value;
+
+var ports = (TomlArray)((TomlTable)config["database"])["ports"];
+long first = ((TomlInteger)ports[0]).Value;                       // 8000
+
+// --- Switch over the value kind for safe dispatch ---------------------------
+foreach ((string key, TomlValue value) in config)
+{
+    switch (value.Kind)
+    {
+        case TomlValueKind.String:  Console.WriteLine($"{key} = string");  break;
+        case TomlValueKind.Table:   Console.WriteLine($"{key} = table");   break;
+        case TomlValueKind.Array:   Console.WriteLine($"{key} = array");   break;
+    }
+}
+
+// --- Build a document and format it -----------------------------------------
+var doc = new TomlTable
+{
+    ["title"]   = new TomlString("Generated"),
+    ["retries"] = new TomlInteger(3),
+};
+string text = Toml.Format(doc);
+
+// --- Opt in to TOML v1.1.0 grammar ------------------------------------------
+var options = new TomlReaderOptions { SpecVersion = TomlSpecVersion.V1_1 };
+TomlTable v11 = Toml.Parse("greeting = \"\\e[0m\"", options);     // \e escape is v1.1.0
+
+// --- Non-throwing parse for untrusted input ---------------------------------
+if (Toml.TryParse(userInput, out TomlTable? parsed))
+{
+    Use(parsed);
+}
+
+// --- Stream a UTF-8 document asynchronously ---------------------------------
+await using FileStream fs = File.OpenRead("config.toml");
+TomlTable fromStream = await Toml.ParseAsync(fs, cancellationToken);
+```
+
+## Notes
+
+- **Reader/writer pair is the primary surface.** <xref:Bodu.Text.Toml.TomlReader> and <xref:Bodu.Text.Toml.TomlWriter> own deserialization and serialization, mirroring the relationship between `XmlReader` / `XmlWriter` and a document model. The static <xref:Bodu.Text.Toml.Toml> class is a thin convenience façade over shared, stateless reader and writer singletons — reach for it for one-line `Parse` / `Format`, and reach for the pair when you want to configure or reuse a reader.
+- **Spec-version selection.** Parsing defaults to strict **TOML v1.0.0**. Setting <xref:Bodu.Text.Toml.TomlReaderOptions.SpecVersion> to `V1_1` accepts the v1.1.0 additions: `\e` and `\xHH` string escapes, time values without seconds, and multi-line / trailing-comma inline tables. The version affects parsing only — <xref:Bodu.Text.Toml.TomlWriter> always emits output valid under both versions (full `HH:mm:ss` times, standard escapes, single-line inline tables without trailing commas).
+- **Semantic model, not source-preserving.** The value tree records *meaning*, not syntax. A standard `[table]`, an inline `{ }` table, dotted keys, and an array of tables all materialize as <xref:Bodu.Text.Toml.TomlTable> / <xref:Bodu.Text.Toml.TomlArray> instances. A `Parse` → `Format` round trip yields an equal model and canonical text, but it does not reproduce the original layout, comment placement, or whitespace. (Comments are not retained — when comment-preserving round-trips matter, prefer <xref:Bodu.Text.Ini>.)
+- **Canonical writer output.** The writer emits a deterministic block-style document: scalars and non-array-of-tables arrays inline, sub-tables under `[header]` sections, arrays of tables under `[[header]]` sections, keys in insertion order. Cyclic document graphs and keys / string values containing unpaired surrogates are rejected with `InvalidOperationException`.
+- **Ordinal, case-sensitive keys.** <xref:Bodu.Text.Toml.TomlTable> compares keys with ordinal semantics, matching the TOML specification, and preserves insertion order so enumeration and writer output are stable.
+- **Strongly-typed dates.** The four RFC 3339 date-time kinds map onto first-class BCL types — `DateOnly`, `TimeOnly`, `DateTime` (with `DateTimeKind.Unspecified`), and `DateTimeOffset` — so a parsed offset date-time keeps its offset and a local date-time carries no spurious time-zone relation.
+- **UTF-8 streams.** Stream input must be valid UTF-8; a leading byte-order mark is ignored. Stream output is UTF-8 without a BOM. The codec never closes a caller-supplied stream — its lifetime stays with the `using` block that owns it. Character input must consist of valid Unicode scalar values; unpaired surrogates are rejected.
+- **Diagnostics.** <xref:Bodu.Text.Toml.TomlFormatException> derives from <xref:Bodu.Text.TextFormatException>, so a single `catch (TextFormatException)` handles parse failures uniformly across every format in the package. The exception carries a 1-based `LineNumber` and `ColumnNumber` and a 0-based `Offset` pinpointing the failure (each `0` / `null` when the error is not tied to a specific location).
+- **See also:** the [introduction](~/docs/formats/index.md), [core concepts](~/docs/formats/concepts.md), [getting-started](~/docs/formats/getting-started.md), and [parser policies](~/docs/formats/parser-policies.md); the [Using TOML](~/guides/formats/toml.md) guide; and the other formats — [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini).
+```

--- a/docs/apidoc/Bodu.Text.md
+++ b/docs/apidoc/Bodu.Text.md
@@ -9,7 +9,7 @@ uid: Bodu.Text
 The **Bodu.Text** namespace serves two complementary roles:
 
 - It is the home of the **`Bodu.Text` library** — allocation-conscious helpers for the BCL <xref:System.Text.Encoding> itself: zero-ceremony `string`↔`byte[]` conversion, pooled / owned-memory surfaces, byte-order-mark (BOM / preamble) handling, UTF classification, fallback configuration, and chunked transcoding. (These are distinct from the binary-to-text *radix* encodings, which live in [`Bodu.Text.Encoding`](Bodu.Text.Encoding.md).)
-- It also holds the **shared base exception** for the document-format codecs in [`Bodu.Text.Formats`](Bodu.Text.Bencode.md), so callers can catch any format-level parse failure — Bencode, delimited (CSV/TSV), DotEnv, or INI — through a single common type while each codec still throws its own precise subtype.
+- It also holds the **shared base exception** for the document-format codecs in [`Bodu.Text.Formats`](Bodu.Text.Bencode.md), so callers can catch any format-level parse failure — Bencode, delimited (CSV/TSV), DotEnv, INI, or TOML — through a single common type while each codec still throws its own precise subtype.
 
 ## Static documentation
 
@@ -26,7 +26,7 @@ The **Bodu.Text** namespace serves two complementary roles:
 
 **Document-format exceptions**
 
-- <xref:Bodu.Text.TextFormatException> — the abstract base for every format-specific parse exception in the formats library. Concrete subtypes include <xref:Bodu.Text.Bencode.BencodeFormatException>, <xref:Bodu.Text.Delimited.DelimitedFormatException>, <xref:Bodu.Text.DotEnv.DotEnvFormatException>, and <xref:Bodu.Text.Ini.IniFormatException>.
+- <xref:Bodu.Text.TextFormatException> — the abstract base for every format-specific parse exception in the formats library. Concrete subtypes include <xref:Bodu.Text.Bencode.BencodeFormatException>, <xref:Bodu.Text.Delimited.DelimitedFormatException>, <xref:Bodu.Text.DotEnv.DotEnvFormatException>, <xref:Bodu.Text.Ini.IniFormatException>, and <xref:Bodu.Text.Toml.TomlFormatException>.
 
 ## Example
 
@@ -48,4 +48,4 @@ catch (TextFormatException ex)
 ## Notes
 
 - **Catch broad or narrow.** Catch <xref:Bodu.Text.TextFormatException> to handle any document-format failure uniformly, or the concrete subtype when you need format-specific detail.
-- **See also:** the per-format guides — [Bencode](~/guides/formats/bencode.md), [delimited](~/guides/formats/delimited.md), [DotEnv](~/guides/formats/dotenv.md), [INI](~/guides/formats/ini.md).
+- **See also:** the per-format guides — [Bencode](~/guides/formats/bencode.md), [delimited](~/guides/formats/delimited.md), [DotEnv](~/guides/formats/dotenv.md), [INI](~/guides/formats/ini.md), [TOML](~/guides/formats/toml.md).

--- a/docs/docs/formats/concepts.md
+++ b/docs/docs/formats/concepts.md
@@ -10,7 +10,7 @@ For the high-level shape of the library and the encode/decode pipeline diagram, 
 
 ## Format and codec
 
-A **format** is the wire grammar — for now, **Bencode** as specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html). The grammar defines four kinds of value (integer, byte string, list, dictionary), the framing tokens that delimit each kind, and the invariants every encoder must preserve.
+A **format** is the wire grammar. The package ships five — Bencode, Delimited, DotEnv, INI, and TOML — and this page uses **Bencode** (as specified by [BEP 3](https://www.bittorrent.org/beps/bep_0003.html)) as its worked example, because its compact grammar exercises every concept the others reuse. Bencode's grammar defines four kinds of value (integer, byte string, list, dictionary), the framing tokens that delimit each kind, and the invariants every encoder must preserve; the typed-tree, codec, canonicality, and format-exception vocabulary below applies to all five. For the value model unique to each of the other formats — including TOML's tables, arrays, and date-time kinds — see the [per-format guides](../../guides/formats/index.md) and [parser policies](parser-policies.md).
 
 A **codec** is the static façade that exposes encode and decode operations for a format. For Bencode it is <xref:Bodu.Text.Bencode.Bencode> — a single `static partial class` with the recursive writer, the forward-only parser, and the span / array / stream overloads layered around them.
 
@@ -165,5 +165,5 @@ Dictionary keys are ordered and compared by raw byte ordinal — *not* by Unicod
 
 - **[Getting started](getting-started.md)** — install + runnable minimal samples.
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — deep-dive walk-throughs for every concept above.
-- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini).
+- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini), [Toml](xref:Bodu.Text.Toml).
 - **[Introduction](index.md)** — the high-level shape of the library.

--- a/docs/docs/formats/getting-started.md
+++ b/docs/docs/formats/getting-started.md
@@ -162,6 +162,43 @@ catch (BencodeFormatException ex)
 
 `BencodeFormatException` derives from `FormatException` and carries an English-language message that identifies the exact failure mode — *Unterminated bencoded dictionary*, *Bencoded dictionary keys must be unique and sorted by raw byte order*, *The bencoded string length exceeds the available input*, and so on. See [Core concepts](concepts.md#format-exception) for the full list.
 
+### Parse and format TOML
+
+TOML follows a reader/writer shape; the static <xref:Bodu.Text.Toml.Toml> class is the one-line entry point.
+
+```csharp
+using Bodu.Text.Toml;
+
+TomlTable config = Toml.Parse("""
+    title = "Bodu sample"
+
+    [database]
+    ports   = [8000, 8001]
+    enabled = true
+    """);
+
+string title = ((TomlString)config["title"]).Value;            // "Bodu sample"
+var db       = (TomlTable)config["database"];
+bool enabled = ((TomlBoolean)db["enabled"]).Value;             // true
+
+string text = Toml.Format(config);                             // back to canonical TOML
+```
+
+Opt in to TOML v1.1.0 grammar with `TomlReaderOptions`, parse untrusted input with `TryParse`, and stream UTF-8 with `ParseAsync` / `FormatAsync`:
+
+```csharp
+using Bodu.Text.Toml;
+
+var options = new TomlReaderOptions { SpecVersion = TomlSpecVersion.V1_1 };
+TomlTable v11 = Toml.Parse(source, options);
+
+if (Toml.TryParse(userInput, out TomlTable? parsed))
+    Use(parsed);
+
+await using FileStream fs = File.OpenRead("config.toml");
+TomlTable doc = await Toml.ParseAsync(fs, cancellationToken);
+```
+
 ## Round-trip example
 
 ```csharp
@@ -193,4 +230,4 @@ The library passes every positive Known Answer Test vector from BEP 3 in both di
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — per-API deep dives.
 - **[Core concepts](concepts.md)** — vocabulary refresher.
 - **[Introduction](index.md)** — type map and scenario index.
-- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini).
+- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini), [Toml](xref:Bodu.Text.Toml).

--- a/docs/docs/formats/index.md
+++ b/docs/docs/formats/index.md
@@ -4,7 +4,7 @@ title: Bodu.Text.Formats — Introduction
 
 # Bodu.Text.Formats
 
-**Bodu.Text.Formats** decodes and encodes self-framing document formats — formats whose structure is described inline by the bytes themselves, rather than by an external schema. The library ships four format families, each with a strongly-typed value model and a span- and stream-friendly codec:
+**Bodu.Text.Formats** decodes and encodes self-framing document formats — formats whose structure is described inline by the bytes themselves, rather than by an external schema. The library ships five format families, each with a strongly-typed value model and a span- and stream-friendly codec:
 
 | Format | Namespace | Source | Use when |
 |---|---|---|---|
@@ -12,6 +12,7 @@ title: Bodu.Text.Formats — Introduction
 | **Delimited** | <xref:Bodu.Text.Delimited> | [RFC 4180](https://www.rfc-editor.org/rfc/rfc4180) CSV and TSV variants | Row-oriented data interchange, spreadsheet import/export, log lines. |
 | **DotEnv** | <xref:Bodu.Text.DotEnv> | `.env` key/value convention | Process environment configuration, deployment-time secrets, twelve-factor app config. |
 | **INI** | <xref:Bodu.Text.Ini> | Classic INI / EditorConfig | Section/comment-preserving round-trippable configuration documents. Underpins [`Bodu.Text.Configuration`](../text-configuration/index.md). |
+| **TOML** | <xref:Bodu.Text.Toml> | [TOML](https://toml.io/) v1.0.0 / v1.1.0 | Strongly-typed application configuration with tables, arrays, and first-class date-time values. |
 
 Each format exposes the same modern shape: a strongly-typed value tree, a static `Encode` / `Decode` entry point, `Try*` variants that swap exceptions for `bool` results, an explicit `GetEncodedLength` for pre-sizing destinations, and synchronous + asynchronous `Stream` overloads. No reflection, no `dynamic`, no allocations beyond the immutable result graph.
 
@@ -114,11 +115,23 @@ Every format follows the same shape — a static codec, a typed value tree, a fo
 | <xref:Bodu.Text.Ini.IniParseOptions> | Profile presets, escape rules, duplicate-section policy. Shared between read and write paths. |
 | <xref:Bodu.Text.Ini.IniFormatException> | Thrown for malformed headers, entries, or escape sequences. |
 
+### TOML — <xref:Bodu.Text.Toml>
+
+TOML follows a reader/writer shape rather than a single static codec: <xref:Bodu.Text.Toml.TomlReader> and <xref:Bodu.Text.Toml.TomlWriter> own deserialization and serialization, with the static <xref:Bodu.Text.Toml.Toml> class as a convenience façade.
+
+| Type | Purpose |
+|---|---|
+| <xref:Bodu.Text.Toml.Toml> | Static façade — `Parse` / `TryParse` / `Format` over spans, streams, and async, each with a `TomlReaderOptions` overload. |
+| <xref:Bodu.Text.Toml.TomlReader>, <xref:Bodu.Text.Toml.TomlWriter> | The deserialize / serialize pair; the primary surface for configurable or reusable reads and writes. |
+| <xref:Bodu.Text.Toml.TomlTable>, <xref:Bodu.Text.Toml.TomlArray>, <xref:Bodu.Text.Toml.TomlValue> | Ordered, mutable value model. `TomlTable` is the document root; the scalar and date-time subtypes derive from `TomlValue`. |
+| <xref:Bodu.Text.Toml.TomlReaderOptions>, <xref:Bodu.Text.Toml.TomlSpecVersion> | Selects strict TOML v1.0.0 (default) or v1.1.0 grammar. |
+| <xref:Bodu.Text.Toml.TomlFormatException> | Thrown for malformed TOML; carries line, column, and offset. |
+
 ## Where to go next
 
 - **[Core concepts](concepts.md)** — full vocabulary: value vs. document, canonical encoding, framing tokens, byte string vs. text, format exception.
 - **[Getting started](getting-started.md)** — install + minimal samples for `Decode`, `Encode`, `Try*`, and the stream overloads.
 - **[Bodu.Text.Formats guides](../../guides/formats/index.md)** — using each codec, the value models, and stream support.
-- **Per-format guides** — [Bencode](../../guides/formats/bencode.md), [Delimited](../../guides/formats/delimited.md), [DotEnv](../../guides/formats/dotenv.md), [INI](../../guides/formats/ini.md), [Streaming](../../guides/formats/streaming.md), [Value model](../../guides/formats/value-model.md).
-- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini).
+- **Per-format guides** — [Bencode](../../guides/formats/bencode.md), [Delimited](../../guides/formats/delimited.md), [DotEnv](../../guides/formats/dotenv.md), [INI](../../guides/formats/ini.md), [TOML](../../guides/formats/toml.md), [Streaming](../../guides/formats/streaming.md), [Value model](../../guides/formats/value-model.md).
+- **API reference** — per-namespace pages: [Bencode](xref:Bodu.Text.Bencode), [Delimited](xref:Bodu.Text.Delimited), [DotEnv](xref:Bodu.Text.DotEnv), [Ini](xref:Bodu.Text.Ini), [Toml](xref:Bodu.Text.Toml).
 - **For EditorConfig-style configuration layering on `IniDocument`**, see [Bodu.Text.Configuration](../text-configuration/index.md).

--- a/docs/docs/formats/parser-policies.md
+++ b/docs/docs/formats/parser-policies.md
@@ -8,7 +8,7 @@ The `Bodu.Text.Formats` parsers default to **strict** behaviour: anything the gr
 
 ## Common diagnostic surface
 
-Every format-specific exception derives from `TextFormatException`, so a single `catch` block can handle parse failures across Bencode, Delimited, DotEnv, and INI sources:
+Every format-specific exception derives from `TextFormatException`, so a single `catch` block can handle parse failures across Bencode, Delimited, DotEnv, INI, and TOML sources:
 
 ```csharp
 try
@@ -17,14 +17,18 @@ try
 }
 catch (TextFormatException ex)
 {
-    Console.Error.WriteLine($"Parse failed at line {ex.LineNumber}, offset {ex.Offset}: {ex.Message}");
+    Console.Error.WriteLine(
+        $"Parse failed at line {ex.LineNumber}, column {ex.ColumnNumber}, offset {ex.Offset}: {ex.Message}");
 }
 ```
 
 | Property | Meaning |
 |---|---|
 | `LineNumber` | 1-based source line; `0` when the parser cannot identify a line. |
+| `ColumnNumber` | 1-based column within the line; `0` when the column is unknown or the format does not track it. |
 | `Offset` | 0-based byte/character offset from the start of the source; `null` when not tracked. |
+
+The location properties are advisory: each parser populates the fields it can identify. Line-oriented formats report a line (and, where tracked, a column); the byte-offset format (Bencode) reports an offset. TOML reports all three.
 
 ## Delimited
 
@@ -88,6 +92,25 @@ Both `Parse` and `Format` preserve the comment in the resulting document. Set `P
 ## INI
 
 The INI parser has the broadest existing policy surface. See [`DuplicateKeyPolicy`](xref:Bodu.Text.DuplicateKeyPolicy) and [`IniDuplicateSectionBehavior`](xref:Bodu.Text.Ini.IniDuplicateSectionBehavior) for the duplicate-resolution modes, and `IniParseOptions.PreserveComments` for trivia retention.
+
+## TOML
+
+The TOML reader is **strict** and defaults to **TOML v1.0.0**. Its single policy is the specification version, carried by [`TomlReaderOptions.SpecVersion`](xref:Bodu.Text.Toml.TomlReaderOptions.SpecVersion).
+
+| Option | Default | Behaviour |
+|---|---|---|
+| `SpecVersion` | [`TomlSpecVersion.V1_0`](xref:Bodu.Text.Toml.TomlSpecVersion) | Enforce strict TOML v1.0.0. Inline tables must be single-line and free of trailing commas; time values must include seconds; `\e` and `\xHH` escapes are rejected. |
+| | `TomlSpecVersion.V1_1` | Additionally accept the TOML v1.1.0 grammar: `\e` and `\xHH` string escapes, optional seconds in time values, and multi-line / trailing-comma inline tables. |
+
+The version governs **parsing only**. [`TomlWriter`](xref:Bodu.Text.Toml.TomlWriter) always emits output valid under both versions, so a document parsed under v1.1.0 and written back uses only constructs a v1.0.0 reader also accepts.
+
+```csharp
+TomlReaderOptions options = new() { SpecVersion = TomlSpecVersion.V1_1 };
+
+TomlTable document = Toml.Parse(source, options);
+```
+
+[`TomlFormatException`](xref:Bodu.Text.Toml.TomlFormatException) carries the full line, column, and offset of the failure — the column being the diagnostic TOML's character-oriented grammar makes most useful. Beyond the spec version, the reader has no lenient mode: duplicate keys, table redefinition, out-of-range integers, unterminated strings, and unpaired surrogates are always rejected.
 
 ## Migration notes
 

--- a/docs/docs/text-encoding/concepts.md
+++ b/docs/docs/text-encoding/concepts.md
@@ -12,8 +12,9 @@ For the high-level shape of the library and the type map, start with the [introd
 
 ## Encoding and variant
 
-An **encoding** is the family-level concept: Base16, Base32, Base64, Base58, Base85. Each family has a radix (16,
-32, 64, 58, 85) which determines how many bits each output symbol represents.
+An **encoding** is the family-level concept: the five core radices — Base16, Base32, Base64, Base58, Base85 — plus
+the special-purpose Base45, Base62, and Bech32. Each family has a radix (16, 32, 64, 58, 85, 45, 62, 32) which
+determines how many bits each output symbol represents.
 
 A **variant** is a specific choice within an encoding family — typically a different *alphabet* but sometimes
 different padding, line-wrap, or shortcut rules:
@@ -25,6 +26,9 @@ different padding, line-wrap, or shortcut rules:
 | Base64 | `Standard` (RFC 4648 §4), `UrlSafe` (RFC 4648 §5), `Mime` (RFC 2045) |
 | Base58 | `BitcoinFlickr` (default), `Ripple` |
 | Base85 | `Ascii85` (Adobe Tech Note 5045), `Z85` (RFC 32 ZeroMQ) |
+| Base45 | RFC 9285 (single alphabet) |
+| Base62 | GMP-style (single alphabet) |
+| Bech32 | `Bech32` (BIP 173, default), `Bech32m` (BIP 350) — selected by `Bech32Encoding` |
 
 ## Alphabet
 
@@ -42,6 +46,9 @@ Base64 URL-safe:       "A..Za..z0..9-_"             (RFC 4648 §5)
 Base58 Bitcoin/Flickr: "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"  (no 0 O I l)
 Base85 Ascii85:        '!' (33) through 'u' (117)   (Adobe alphabet)
 Base85 Z85:            "0..9a..zA..Z.-:+=^!/*?&<>()[]{}@%$#"  (shell-safe)
+Base45:                "0..9A..Z" + " $%*+-./:"      (45 chars, RFC 9285)
+Base62:                "0..9A..Za..z"               (GMP order: digits, upper, lower)
+Bech32:                "qpzry9x8gf2tvdw0s3jn54khce6mua7l"   (5-bit values 0..31, BIP 173)
 ```
 
 ## Bit packing
@@ -52,8 +59,11 @@ one output symbol.
 
 ![Bit-stream packing — Base16, Base32, Base64](../../images/diagrams/encoding-bit-packing.svg)
 
-Base58 is **not** a power of two: it uses big-integer divmod by 58. Base85 uses **4-byte blocks** packed into a
-32-bit unsigned integer, then divided by 85 four times to emit five characters.
+Base58 is **not** a power of two: it uses big-integer divmod by 58. Base62 works the same way with divmod by 62.
+Base85 uses **4-byte blocks** packed into a 32-bit unsigned integer, then divided by 85 four times to emit five
+characters. Base45 packs each **2-byte group** into a base-45 triple (a trailing single byte becomes 2 characters).
+Bech32 is a 5-bit (base-32) bit-stream like Base32, but wrapped with a human-readable part, a `1` separator, and a
+six-symbol checksum computed over the whole data part.
 
 ## Terminal quantum
 
@@ -171,6 +181,11 @@ that could complete with another chunk.
 > Base58 and Base85 are not streamable: each requires the entire input to be available before decode (Base58 because
 > of big-integer arithmetic, Base85 because of fixed-size block packing). The `isFinalBlock` parameter on those
 > variants is accepted for API consistency but has no behavioural effect.
+>
+> The special-purpose encodings — Base45, Base62, and Bech32 — are likewise single-shot and expose no
+> `OperationStatus` path at all (Base45 packs in fixed groups, Base62 uses big-integer arithmetic, and Bech32 must
+> read the whole string to verify its checksum). They throw `FormatException` on invalid input and offer `Try*`
+> methods that report failure as `false`.
 
 ## IBinaryEncoding interface
 

--- a/docs/docs/text-encoding/getting-started.md
+++ b/docs/docs/text-encoding/getting-started.md
@@ -150,6 +150,59 @@ string ascii85  = data.ToBase85String();
 byte[] backFromHex = hex.FromBase16String();
 ```
 
+### Encode a QR-code payload with Base45
+
+```csharp
+using Bodu.Text.Encoding;
+
+// RFC 9285 — the encoding the EU Digital COVID Certificate carries in a QR code.
+byte[] payload = "Hello!!"u8.ToArray();
+string base45 = Base45.Encode(payload);   // "%69 VD92EX0"
+
+byte[] back = Base45.Decode(base45);
+```
+
+### Generate a compact identifier with Base62
+
+```csharp
+using Bodu.Text.Encoding;
+
+// URL-safe, no special characters — ideal for short links and slugs.
+byte[] random = RandomNumberGenerator.GetBytes(16);
+string id = Base62.Encode(random);
+
+byte[] bytes = Base62.Decode(id);
+```
+
+### Encode an address with Bech32 / Bech32m
+
+```csharp
+using Bodu.Text.Encoding;
+
+// Bech32 carries a human-readable part (HRP), the data, and a checksum together.
+// EncodeFromBytes / DecodeToBytes repack 8-bit bytes to and from the 5-bit data part.
+byte[] program = Base16.Decode("751e76e8199196d454941c45d1b3a323f1433bd6");
+string address = Bech32.EncodeFromBytes("bc", program, Bech32Encoding.Bech32m);
+
+Bech32.DecodeToBytes(address, out string hrp, out byte[] data, out Bech32Encoding scheme);
+// hrp == "bc"; data == program; scheme == Bech32Encoding.Bech32m
+
+// Non-throwing form reports which scheme validated the checksum.
+if (Bech32.TryDecodeToBytes(address, out string? hrp2, out byte[]? data2, out Bech32Encoding scheme2))
+{
+    // hrp2 / data2 are non-null; scheme2 tells Bech32 from Bech32m
+}
+```
+
+### Protect a payload with a checksum (Base58Check)
+
+```csharp
+using Bodu.Text.Encoding;
+
+string encoded = Base58Check.Encode(payload);   // payload + 4-byte double-SHA-256 checksum
+byte[] decoded = Base58Check.Decode(encoded);   // verifies the checksum, then strips it
+```
+
 ## Round-trip example with whitespace tolerance
 
 ```csharp

--- a/docs/docs/text-encoding/index.md
+++ b/docs/docs/text-encoding/index.md
@@ -4,15 +4,17 @@ title: Bodu.Text.Encoding — Introduction
 
 # Bodu.Text.Encoding
 
-**Bodu.Text.Encoding** is a focused, allocation-conscious library of binary-to-text encodings. It implements the
-five practical radix encodings that .NET applications reach for — **Base16**, **Base32**, **Base64**, **Base58**,
-and **Base85** — and gives each one the same modern API shape: span- and UTF-8-friendly overloads,
-`OperationStatus`-returning streaming methods, length-prediction helpers, validation predicates, and a unified
-`IBinaryEncoding` interface that lets code select an encoding at runtime.
+**Bodu.Text.Encoding** is a focused, allocation-conscious library of binary-to-text encodings. The five core radix
+encodings that .NET applications reach for — **Base16**, **Base32**, **Base64**, **Base58**, and **Base85** — each
+carry the same modern API shape: span- and UTF-8-friendly overloads, `OperationStatus`-returning streaming methods,
+length-prediction helpers, validation predicates, and a unified `IBinaryEncoding` interface that lets code select an
+encoding at runtime. Three special-purpose encodings sit alongside them — **Base45** (RFC 9285, QR-code payloads),
+**Base62** (compact identifiers), and **Bech32 / Bech32m** (BIP 173 / 350, checksummed addresses) — plus the
+convenience wrappers **Base58Check** and **Base64Url**.
 
 It fills two gaps that `System.Convert` and `System.Buffers.Text.Base64` leave open:
 
-1. **Variants** the BCL does not cover — base32hex, Crockford Base32, z-base-32, Base58 (Bitcoin / Flickr / Ripple), Ascii85, Z85.
+1. **Variants** the BCL does not cover — base32hex, Crockford Base32, z-base-32, Base58 (Bitcoin / Flickr / Ripple), Ascii85, Z85, Base45, Base62, Bech32 / Bech32m.
 2. **Lenient parsing** and **formatting decoration** — `0x` prefix tolerance, whitespace stripping, byte spacing, line breaks every 64 / 76 characters — for the encodings that benefit from them.
 
 ## Core mental model
@@ -36,10 +38,13 @@ decoration, apply alphabet lookup, then bit-stream unpack / divmod / block expan
 | **Base64** | 6 | 33 % | MIME / SMTP, JWT (URL-safe), TLS certificates, generic binary-in-text |
 | **Base58** | ≈5.86 | ≈37 % | Bitcoin addresses, IPFS CIDs, Solana, NEAR, Stellar, Flickr short URLs |
 | **Base85** | ≈6.41 | 25 % | PDF / PostScript (Ascii85), ZeroMQ keys (Z85), tight ASCII transport |
+| **Base45** | ≈5.49 | 50 % (2 bytes → 3 chars) | QR-code payloads (RFC 9285), EU Digital COVID Certificate |
+| **Base62** | ≈5.95 | ≈35 % | Short URLs, compact identifiers, URL-safe slugs (no special characters) |
+| **Bech32 / Bech32m** | 5 (+ HRP + checksum) | base-32 data + 6-symbol checksum | Bitcoin SegWit addresses, Lightning invoices (BIP 173 / 350) |
 
-## Five entry points, one shape
+## A shared shape
 
-Every encoding type exposes the same public surface:
+Every **core** encoding type (Base16, Base32, Base64, Base58, Base85) exposes the same public surface:
 
 | Member group | Methods |
 |---|---|
@@ -55,6 +60,13 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 `BinaryEncodings` registry: `BinaryEncodings.Base64`, `BinaryEncodings.Base32Crockford`,
 `BinaryEncodings.Z85`, etc.
 
+The **special-purpose** encodings (Base45, Base62, Bech32) share the `Encode` / `Decode` / `TryEncode` / `TryDecode`,
+sizing, and `IsValid` members but omit the `OperationStatus` streaming path — each needs the whole input at once.
+Base45 and Base62 are registered as `BinaryEncodings.Base45` / `BinaryEncodings.Base62`; Bech32 takes a
+human-readable part and verifies a checksum, so it stays outside the flat-byte `IBinaryEncoding` contract.
+See the per-encoding guides — [Base45](../../guides/text-encoding/base45.md), [Base62](../../guides/text-encoding/base62.md),
+and [Bech32](../../guides/text-encoding/bech32.md).
+
 ## Variants at a glance
 
 | Encoding | Variant enum | Variants |
@@ -64,6 +76,9 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 | Base64 | <xref:Bodu.Text.Encoding.Base64Variant> | Standard (RFC 4648 §4), UrlSafe (RFC 4648 §5), Mime (RFC 2045 with 76-char wrap) |
 | Base58 | <xref:Bodu.Text.Encoding.Base58Variant> | BitcoinFlickr (default), Ripple |
 | Base85 | <xref:Bodu.Text.Encoding.Base85Variant> | Ascii85 (Adobe), Z85 (RFC 32 ZeroMQ) |
+| Base45 | (none) | RFC 9285 |
+| Base62 | (none) | GMP-style (`0-9 A-Z a-z`) |
+| Bech32 | <xref:Bodu.Text.Encoding.Bech32Encoding> | Bech32 (BIP 173, default), Bech32m (BIP 350) |
 
 ## Common scenarios
 
@@ -89,6 +104,11 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 | <xref:Bodu.Text.Encoding.Base64> | Base64 — 6 bits per symbol; three variants (Standard, UrlSafe, Mime); delegates inner conversion to BCL for SIMD speed |
 | <xref:Bodu.Text.Encoding.Base58> | Base58 — non-power-of-two radix using big-integer arithmetic; preserves leading zeros |
 | <xref:Bodu.Text.Encoding.Base85> | Base85 — 4-byte block → 5 chars; Ascii85 with <c>z</c> shortcut and partial groups; Z85 with 4-byte alignment |
+| <xref:Bodu.Text.Encoding.Base45> | Base45 — RFC 9285; 2 bytes → 3 chars; QR-code Alphanumeric-mode alphabet; no padding |
+| <xref:Bodu.Text.Encoding.Base62> | Base62 — GMP-style `0-9 A-Z a-z`; big-integer arithmetic; preserves leading zeros |
+| <xref:Bodu.Text.Encoding.Bech32> | Bech32 / Bech32m — HRP + `1` separator + 5-bit data + 6-symbol checksum; scheme via <xref:Bodu.Text.Encoding.Bech32Encoding> |
+| <xref:Bodu.Text.Encoding.Base58Check> | Base58 plus the Bitcoin four-byte double-SHA-256 checksum, verified on decode |
+| <xref:Bodu.Text.Encoding.Base64Url> | RFC 4648 §5 URL-safe Base64 as a first-class type; padding omitted by default; UTF-8 path |
 
 ### Runtime selection
 
@@ -111,4 +131,5 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 - **[Getting started](getting-started.md)** — install + minimal sample per encoding type.
 - **[Bodu.Text.Encoding guides](../../guides/text-encoding/index.md)** — using each encoding, choosing variants, streaming, the `IBinaryEncoding` interface.
 - **[Bodu.Text.Encoding API reference](xref:Bodu.Text.Encoding)** — full type-by-type docs.
-- **For structured binary serialization formats** (Bencode, INI) with their own self-describing grammar, see [Bodu.Text.Formats](../formats/index.md).
+- **Special-purpose guides** — [Base45](../../guides/text-encoding/base45.md) (QR codes), [Base62](../../guides/text-encoding/base62.md) (compact IDs), [Bech32](../../guides/text-encoding/bech32.md) (checksummed addresses).
+- **For structured document formats** (Bencode, INI, TOML) with their own self-describing grammar, see [Bodu.Text.Formats](../formats/index.md).

--- a/docs/guides/formats/index.md
+++ b/docs/guides/formats/index.md
@@ -18,7 +18,11 @@ A bencoded document is a single tree of typed values. **`Bencode`** is the stati
 
 | Namespace | What lives here | Guides |
 |---|---|---|
-| `Bodu.Text.Formats` | Codec entry point (`Bencode`), value model (`BencodedValue` and the four kinds), supporting types (`BencodedStringComparer`, `BencodedValueKind`), and `BencodeFormatException`. | [Using Bencode](bencode.md) · [The BencodedValue model](value-model.md) · [Streams and async I/O](streaming.md) |
+| <xref:Bodu.Text.Bencode> | The `Bencode` codec, the `BencodedValue` model and its four kinds, `BencodedStringComparer`, and `BencodeFormatException`. | [Using Bencode](bencode.md) · [The BencodedValue model](value-model.md) |
+| <xref:Bodu.Text.Delimited> | The `Delimited` codec, `DelimitedDocument` / `DelimitedRow`, the streaming reader / writer, and `DelimitedParseOptions`. | [Using delimited](delimited.md) |
+| <xref:Bodu.Text.DotEnv> | The `DotEnv` codec, `DotEnvDocument` / `DotEnvEntry`, and `DotEnvParseOptions`. | [Using DotEnv](dotenv.md) |
+| <xref:Bodu.Text.Ini> | The `Ini` codec, `IniDocument` / `IniSection` / `IniEntry`, and `IniParseOptions`. | [Using INI](ini.md) |
+| <xref:Bodu.Text.Toml> | The `Toml` façade, the `TomlReader` / `TomlWriter` pair, the `TomlValue` model, `TomlReaderOptions`, and `TomlFormatException`. | [Using TOML](toml.md) |
 
 ## Guides
 
@@ -34,6 +38,26 @@ A bencoded document is a single tree of typed values. **`Bencode`** is the stati
 <div class="bodu-card">
   <h3><a href="value-model.md">The BencodedValue model</a></h3>
   <p>Walk-through of <code>BencodedInteger</code>, <code>BencodedString</code>, <code>BencodedList</code>, and <code>BencodedDictionary</code> — their construction rules, dispatch via <code>BencodedValueKind</code>, and the ordinal <code>BencodedStringComparer</code> that drives dictionary ordering.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="delimited.md">Using delimited (CSV / TSV)</a></h3>
+  <p>The <code>Delimited</code> codec — RFC 4180 quoting, delimiter selection, header handling, the streaming <code>DelimitedReader</code> / <code>DelimitedWriter</code>, and the strictness policies on <code>DelimitedParseOptions</code>.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="dotenv.md">Using DotEnv</a></h3>
+  <p>The <code>DotEnv</code> codec — <code>KEY=VALUE</code> parsing, quoting and escape rules, comment preservation, and duplicate-key policies on <code>DotEnvParseOptions</code>.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="ini.md">Using INI</a></h3>
+  <p>The <code>Ini</code> codec — section / entry model, comment trivia, duplicate-section and duplicate-key policies, and programmatic mutation of the round-trippable <code>IniDocument</code>.</p>
+</div>
+
+<div class="bodu-card">
+  <h3><a href="toml.md">Using TOML</a></h3>
+  <p>The <code>TomlReader</code> / <code>TomlWriter</code> pair and the <code>Toml</code> façade — the typed <code>TomlValue</code> model, tables and arrays, first-class date-time kinds, TOML v1.0.0 / v1.1.0 selection, and stream support.</p>
 </div>
 
 </div>

--- a/docs/guides/formats/toml.md
+++ b/docs/guides/formats/toml.md
@@ -1,0 +1,253 @@
+---
+title: Using TOML
+---
+
+# Using TOML
+
+`Bodu.Text.Toml` reads and writes [TOML](https://toml.io/) — Tom's Obvious, Minimal Language — the configuration
+format whose strongly-typed scalars, tables, arrays, and first-class date-time values make it a popular alternative to
+INI and YAML for application configuration.
+
+TOML follows a **reader/writer** shape rather than a single static codec, mirroring the relationship between
+`XmlReader` / `XmlWriter` and a document model:
+
+- <xref:Bodu.Text.Toml.TomlReader> deserializes text into a <xref:Bodu.Text.Toml.TomlTable> document.
+- <xref:Bodu.Text.Toml.TomlWriter> serializes a `TomlTable` back to canonical TOML.
+- <xref:Bodu.Text.Toml.Toml> is a thin static façade over shared, stateless reader and writer singletons — reach for it for one-line `Parse` / `Format`.
+
+For the vocabulary used below (document, value, codec, format exception) see [Core concepts](../../docs/formats/concepts.md); for the spec-version selector and diagnostics, see [Parser policies](../../docs/formats/parser-policies.md).
+
+## Pattern 1 — parse a configuration document
+
+```csharp
+using Bodu.Text.Toml;
+
+TomlTable config = Toml.Parse("""
+    title = "Bodu sample"
+
+    [owner]
+    name = "Tom"
+    dob  = 1979-05-27T07:32:00Z
+
+    [database]
+    ports   = [8000, 8001, 8002]
+    enabled = true
+    """);
+
+string title = ((TomlString)config["title"]).Value;          // "Bodu sample"
+
+var owner = (TomlTable)config["owner"];
+string name = ((TomlString)owner["name"]).Value;             // "Tom"
+DateTimeOffset dob = ((TomlOffsetDateTime)owner["dob"]).Value;
+
+var database = (TomlTable)config["database"];
+bool enabled = ((TomlBoolean)database["enabled"]).Value;     // true
+var ports    = (TomlArray)database["ports"];
+long first   = ((TomlInteger)ports[0]).Value;                // 8000
+```
+
+`Toml.Parse` returns the root <xref:Bodu.Text.Toml.TomlTable>. Standard `[table]` headers, inline `{ }` tables, dotted
+keys, and arrays of tables all materialise as `TomlTable` / `TomlArray` instances — the model captures meaning, not the
+original syntax.
+
+## Pattern 2 — navigate the value model
+
+Every value derives from <xref:Bodu.Text.Toml.TomlValue> and exposes a <xref:Bodu.Text.Toml.TomlValue.Kind> discriminator. Cast when you know the
+shape, or `switch` on `Kind` for safe dispatch:
+
+```csharp
+using Bodu.Text.Toml;
+
+foreach ((string key, TomlValue value) in config)
+{
+    switch (value.Kind)
+    {
+        case TomlValueKind.String:         Console.WriteLine($"{key} = {((TomlString)value).Value}"); break;
+        case TomlValueKind.Integer:        Console.WriteLine($"{key} = {((TomlInteger)value).Value}"); break;
+        case TomlValueKind.Boolean:        Console.WriteLine($"{key} = {((TomlBoolean)value).Value}"); break;
+        case TomlValueKind.Table:          Console.WriteLine($"{key} = table[{((TomlTable)value).Count}]"); break;
+        case TomlValueKind.Array:          Console.WriteLine($"{key} = array[{((TomlArray)value).Count}]"); break;
+        case TomlValueKind.OffsetDateTime: Console.WriteLine($"{key} = {((TomlOffsetDateTime)value).Value:O}"); break;
+    }
+}
+```
+
+`TomlTable` enumerates as `KeyValuePair<string, TomlValue>` in **insertion order**, and exposes `Count`, `Keys`,
+`ContainsKey`, `TryGetValue`, and a `this[key]` indexer. `TryGetValue` is the safe lookup for an optional key:
+
+```csharp
+if (database.TryGetValue("timeout", out TomlValue? timeout))
+    Use(((TomlInteger)timeout).Value);
+```
+
+### The value kinds
+
+| Kind | Type | `Value` backing type |
+|---|---|---|
+| `String` | <xref:Bodu.Text.Toml.TomlString> | `string` |
+| `Integer` | <xref:Bodu.Text.Toml.TomlInteger> | `long` |
+| `Float` | <xref:Bodu.Text.Toml.TomlFloat> | `double` |
+| `Boolean` | <xref:Bodu.Text.Toml.TomlBoolean> | `bool` |
+| `OffsetDateTime` | <xref:Bodu.Text.Toml.TomlOffsetDateTime> | `DateTimeOffset` |
+| `LocalDateTime` | <xref:Bodu.Text.Toml.TomlLocalDateTime> | `DateTime` (`Unspecified`) |
+| `LocalDate` | <xref:Bodu.Text.Toml.TomlLocalDate> | `DateOnly` |
+| `LocalTime` | <xref:Bodu.Text.Toml.TomlLocalTime> | `TimeOnly` |
+| `Array` | <xref:Bodu.Text.Toml.TomlArray> | `IReadOnlyList<TomlValue>` |
+| `Table` | <xref:Bodu.Text.Toml.TomlTable> | key/value map |
+
+The four RFC 3339 date-time kinds map onto first-class BCL types, so an offset date-time keeps its offset and a local
+date-time carries no spurious time-zone relation.
+
+## Pattern 3 — build a document programmatically
+
+`TomlTable` and `TomlArray` are **mutable** containers. Compose a document with collection initialisers, the indexer,
+or `Add`:
+
+```csharp
+using Bodu.Text.Toml;
+
+var doc = new TomlTable
+{
+    ["title"] = new TomlString("Generated"),
+    ["owner"] = new TomlTable
+    {
+        ["name"] = new TomlString("Tom"),
+        ["dob"]  = new TomlOffsetDateTime(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero)),
+    },
+};
+
+var ports = new TomlArray();
+ports.Add(new TomlInteger(8000));
+ports.Add(new TomlInteger(8001));
+doc.Add("ports", ports);
+```
+
+Keys are case-sensitive and compared with ordinal semantics, matching the TOML specification. `Add` throws
+`ArgumentException` on a duplicate key; the indexer setter adds or replaces.
+
+## Pattern 4 — format to canonical text
+
+```csharp
+using Bodu.Text.Toml;
+
+string text = Toml.Format(doc);
+```
+
+The writer emits a deterministic block-style document: scalars and ordinary arrays inline, sub-tables under
+`[header]` sections, arrays of tables under `[[header]]` sections, keys in insertion order. Because the model records
+semantics rather than syntax, a `Parse` → `Format` round trip yields an **equal model and canonical text** but does
+not reproduce the original layout, comment placement, or whitespace. (TOML comments are not retained — when
+comment-preserving round-trips matter, prefer [INI](ini.md).)
+
+Output uses only constructs valid under **both** TOML v1.0.0 and v1.1.0, so a document parsed under v1.1.0 and written
+back is still accepted by a strict v1.0.0 reader.
+
+## Pattern 5 — non-throwing parse
+
+```csharp
+using Bodu.Text.Toml;
+
+if (Toml.TryParse(source, out TomlTable? document))
+{
+    Configure(document);
+}
+else
+{
+    log.Warn("Malformed TOML input");
+}
+```
+
+`TryParse` returns `false` and sets `document` to `null` on the first parse error rather than raising
+<xref:Bodu.Text.Toml.TomlFormatException>. Use it for untrusted input.
+
+## Pattern 6 — selecting the TOML version
+
+Parsing defaults to strict **TOML v1.0.0**. Pass a <xref:Bodu.Text.Toml.TomlReaderOptions> with
+<xref:Bodu.Text.Toml.TomlReaderOptions.SpecVersion> set to `V1_1` to accept the TOML v1.1.0 grammar additions —
+`\e` and `\xHH` string escapes, optional seconds in time values, and multi-line / trailing-comma inline tables:
+
+```csharp
+using Bodu.Text.Toml;
+
+var options = new TomlReaderOptions { SpecVersion = TomlSpecVersion.V1_1 };
+
+TomlTable document = Toml.Parse(source, options);
+```
+
+Every parse entry point — `Parse`, `TryParse`, `ParseAsync` — has an overload that accepts `TomlReaderOptions`. The
+version governs parsing only; the writer is unaffected.
+
+## Pattern 7 — reuse a configured reader / writer
+
+When you parse many documents under the same options, construct a <xref:Bodu.Text.Toml.TomlReader> once and reuse it
+(readers and writers are stateless and safe to share):
+
+```csharp
+using Bodu.Text.Toml;
+
+var reader = new TomlReader(new TomlReaderOptions { SpecVersion = TomlSpecVersion.V1_1 });
+
+foreach (string path in paths)
+{
+    TomlTable doc = reader.Read(File.ReadAllText(path));
+    Process(doc);
+}
+```
+
+`TomlReader.Read` accepts `ReadOnlySpan<char>`, `string`, a `TextReader`, or a UTF-8 `Stream`; `TomlWriter.Write`
+targets a `string`, `TextWriter`, or UTF-8 `Stream`.
+
+## Pattern 8 — streams and async I/O
+
+Stream input must be valid UTF-8 (a leading BOM is ignored); stream output is UTF-8 without a BOM. The codec never
+closes a caller-supplied stream.
+
+```csharp
+using Bodu.Text.Toml;
+
+await using FileStream input = File.OpenRead("config.toml");
+TomlTable doc = await Toml.ParseAsync(input, cancellationToken);
+
+await using FileStream output = File.Create("out.toml");
+await Toml.FormatAsync(doc, output, cancellationToken);
+```
+
+## Diagnostics
+
+<xref:Bodu.Text.Toml.TomlFormatException> derives from <xref:Bodu.Text.TextFormatException> (itself a
+`FormatException`), so a single `catch` handles parse failures uniformly across every format in the package. The
+exception pinpoints the failure with a 1-based `LineNumber` and `ColumnNumber` and a 0-based `Offset`:
+
+```csharp
+using Bodu.Text;
+using Bodu.Text.Toml;
+
+try
+{
+    TomlTable doc = Toml.Parse(source);
+}
+catch (TomlFormatException ex)
+{
+    Console.Error.WriteLine($"TOML error at line {ex.LineNumber}, column {ex.ColumnNumber}: {ex.Message}");
+}
+```
+
+Beyond the spec version, the reader has no lenient mode — duplicate keys, table redefinition, out-of-range integers,
+unterminated strings, and unpaired surrogates are always rejected.
+
+## When to reach for TOML
+
+| Need | Format |
+|---|---|
+| Typed scalars, nested tables, arrays, first-class dates | **TOML** |
+| Section/comment-preserving round-trip, or `IConfiguration` layering | [INI](ini.md) / [`Bodu.Text.Configuration`](../../docs/text-configuration/index.md) |
+| Flat `KEY=VALUE` environment configuration | [DotEnv](dotenv.md) |
+| Tabular rows | [Delimited](delimited.md) |
+| Canonical structured binary, content addressing | [Bencode](bencode.md) |
+
+## See also
+
+- [Bencode](bencode.md), [Delimited](delimited.md), [DotEnv](dotenv.md), [INI](ini.md) — the other formats in the package.
+- [Streams and async I/O](streaming.md) — the shared stream contract across the codecs.
+- [`Bodu.Text.Toml` API reference](xref:Bodu.Text.Toml)
+- [Parser policies](../../docs/formats/parser-policies.md) — the `SpecVersion` selector and diagnostics.

--- a/docs/guides/text-encoding/base45.md
+++ b/docs/guides/text-encoding/base45.md
@@ -1,0 +1,102 @@
+---
+title: Using Base45
+---
+
+# Using Base45
+
+`Base45` implements the encoding defined by [RFC 9285](https://www.rfc-editor.org/rfc/rfc9285) — the compact
+alphanumeric format designed to carry binary data inside a QR code's **Alphanumeric mode**. Its best-known deployment
+is the EU Digital COVID Certificate (the HCERT payload), but it suits any scenario where bytes must travel through a
+QR code's restricted 45-character symbol set with the smallest possible footprint.
+
+Unlike the bit-stream encodings, Base45 packs **two input bytes into three output characters** (a trailing single
+byte becomes two characters). A 16-bit group `n = a·256 + b` is written as three base-45 digits, least-significant
+first: `c = n % 45`, `d = (n / 45) % 45`, `e = n / 2025`.
+
+```
+input bytes        : 41 42          ("AB")
+                     └── 0x4142 = 16706 ──┐
+                       16706 = 11 + 11·45 + 8·2025
+encoded text       : B  B  8        (c=11 → 'B', d=11 → 'B', e=8 → '8'; least-significant first)
+```
+
+The alphabet is 45 characters: the digits `0-9`, the upper-case letters `A-Z`, and the nine symbols
+`space $ % * + - . / :`.
+
+## Quick reference
+
+```csharp
+using Bodu.Text.Encoding;
+
+// RFC 9285 worked examples
+Base45.Encode("AB"u8.ToArray());        // "BB8"
+Base45.Encode("Hello!!"u8.ToArray());   // "%69 VD92EX0"
+Base45.Encode("base-45"u8.ToArray());   // "UJCLQE7W581"
+
+byte[] back = Base45.Decode("%69 VD92EX0");   // "Hello!!"
+```
+
+## Why Base45 for QR codes
+
+A QR code in Alphanumeric mode stores 11 bits per two characters (5.5 bits/char) drawn from a fixed 45-symbol set.
+Encoding binary as Base64 forces the QR code into the far less dense Byte mode; Base45 keeps it in Alphanumeric mode,
+producing a meaningfully smaller symbol. The 50 % size overhead of Base45 itself is more than repaid by the denser QR
+encoding it unlocks.
+
+## Space is a data character
+
+The space character is part of the Base45 alphabet, so it carries data — it is **not** ignorable whitespace. The
+`IgnoreWhitespace` style strips only tab, carriage return, and line feed; it never strips spaces:
+
+```csharp
+Base45.Decode("%69 VD92EX0");                               // valid — the space is data
+Base45.Decode("%69 VD9\n2EX0", BaseFormatStyles.IgnoreWhitespace);  // newline stripped, then decoded
+```
+
+## Strictness
+
+Base45 is **strict** per RFC 9285. The decoder rejects:
+
+- characters outside the 45-symbol alphabet;
+- a final group of a single character (1, 4, 7, … characters — only 2-character and 3-character terminal groups are legal);
+- a three-character group whose value exceeds `0xFFFF` (would not fit in two bytes);
+- a two-character group whose value exceeds `0xFF`.
+
+```csharp
+Base45.Decode("GGW");   // FormatException — 0x10000, out of 16-bit range
+Base45.Decode("0");     // FormatException — illegal single-character terminal group
+```
+
+`Decode` throws `FormatException` on any of these; `TryDecode` returns `false` instead.
+
+## Span path and sizing
+
+Because Base45 packs in fixed groups, the encoded length is **exact**, not an upper bound:
+
+```csharp
+int chars = Base45.GetEncodedLength(payload.Length);     // exact output length
+Span<char> destination = stackalloc char[chars];
+int written = Base45.Encode(payload, destination);
+
+int maxBytes = Base45.GetMaxDecodedLength(text.Length);  // decode upper bound
+```
+
+Base45 is **not streamable** — it has no `OperationStatus` path. Each call needs the entire input: pass the whole
+payload (encode) or the whole string (decode) as a single span.
+
+## Validation
+
+```csharp
+Base45.IsValid("BB8");        // true
+Base45.IsValid("bb8");        // false — lower case is not in the alphabet
+Base45.IsBase45Digit(' ');    // true  — space is a data symbol
+Base45.IsBase45Digit('a');    // false
+```
+
+`IsValid` returns `true` only for input the strict decoder would accept (subject to any `BaseFormatStyles` you pass).
+
+## Where to go next
+
+- **[Base62 guide](base62.md)** — compact identifiers without QR-specific constraints.
+- **[Base64 guide](base64.md)** — when density matters less than ubiquity.
+- **[`IBinaryEncoding` interface](binary-encodings-interface.md)** — Base45 is registered as `BinaryEncodings.Base45` for runtime selection.

--- a/docs/guides/text-encoding/base62.md
+++ b/docs/guides/text-encoding/base62.md
@@ -1,0 +1,101 @@
+---
+title: Using Base62
+---
+
+# Using Base62
+
+`Base62` encodes binary data with the **GMP-style** alphabet `0-9 A-Z a-z` (digits first, then upper-case, then
+lower-case letters). Like [Base58](base58.md), its radix is **not a power of two**, so it treats the input as a
+big-integer and repeatedly divides by 62 to extract digits. Unlike Base58, it keeps the two visually ambiguous
+characters Base58 drops — Base62 optimises for **density and URL-safety**, not hand-transcription.
+
+Base62 is the natural choice for short URLs, compact record identifiers, and slugs: every character is a letter or
+digit, so the output is URL-safe and shell-safe without any escaping, and the 62-character radix is more compact than
+Base58 while staying free of the `+`, `/`, and `=` that make Base64 awkward in a path segment.
+
+```csharp
+using Bodu.Text.Encoding;
+
+byte[] data = RandomNumberGenerator.GetBytes(16);
+
+string id = Base62.Encode(data);   // e.g. a ~22-character URL-safe identifier
+byte[] back = Base62.Decode(id);   // round-trips exactly
+```
+
+## Alphabet ordering
+
+The alphabet is `0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz` — digit `0` is value 0, `A` is 10,
+`a` is 36. This is the **GMP / base-conversion** ordering, the most widely used Base62 convention. It is *not* the same
+as Base64's alphabet, and the two are not interchangeable.
+
+## Leading zeros
+
+Because Base62 uses big-integer arithmetic, leading zero bytes would normally vanish. The implementation preserves
+them as leading `0` characters (where `0` is `alphabet[0]`), exactly as Base58 preserves leading `1` characters:
+
+| Input bytes | Encoded |
+|---|---|
+| `0x00` | `0` |
+| `0x00 0x00` | `00` |
+| `0x00 0x01` | `01` |
+
+```csharp
+byte[] withZeros = { 0x00, 0x00, 0xDE, 0xAD };
+string encoded = Base62.Encode(withZeros);
+byte[] back = Base62.Decode(encoded);   // back.SequenceEqual(withZeros)
+```
+
+This makes the round trip exact for any byte sequence, including one with a run of leading zeros.
+
+## Lenient parsing
+
+| Flag | Effect |
+|---|---|
+| `BaseFormatStyles.IgnoreWhitespace` | Strip ASCII space / tab / CR / LF anywhere |
+| `BaseFormatStyles.AllowPrefix` | No-op for Base62 |
+| `BaseFormatStyles.AllowMissingPadding` | No-op for Base62 (no padding character) |
+
+```csharp
+byte[] payload = Base62.Decode("  3p Kq9  ", BaseFormatStyles.IgnoreWhitespace);
+```
+
+The decoder otherwise rejects any character outside the 62-symbol alphabet with a `FormatException`; `TryDecode`
+returns `false` instead.
+
+## Span path and sizing
+
+```csharp
+int maxChars = Base62.GetMaxEncodedLength(payload.Length);   // upper bound (data-dependent)
+char[] buffer = new char[maxChars];
+
+int written = Base62.Encode(payload, buffer);
+ReadOnlySpan<char> result = buffer.AsSpan(0, written);
+```
+
+Exact length is data-dependent (it varies with the leading-zero count and the magnitude of the non-zero portion), so
+the library exposes `GetMaxEncodedLength` / `GetMaxDecodedLength` as upper bounds. Base62 uses big-integer arithmetic
+and is therefore **not streamable** — there is no `OperationStatus` path; each call needs the entire input.
+
+## Validation
+
+```csharp
+Base62.IsValid("3pKq9");      // true
+Base62.IsValid("3p+q9");      // false — '+' is not in the alphabet
+Base62.IsBase62Digit('Z');    // true
+Base62.IsBase62Digit('+');    // false
+```
+
+## Base58 or Base62?
+
+| Need | Pick |
+|---|---|
+| Hand-transcribed identifiers (no `0`/`O`/`I`/`l` ambiguity) | [Base58](base58.md) |
+| Blockchain / Bitcoin / IPFS interop | [Base58](base58.md) |
+| Densest URL-safe identifier, machine-to-machine | **Base62** |
+| Built-in checksum on addresses / keys | [Base58Check](base58.md#base58check--checksum-protected-payloads) |
+
+## Where to go next
+
+- **[Base58 guide](base58.md)** — the ambiguity-free sibling, plus `Base58Check`.
+- **[Base64 guide](base64.md)** — when interop with existing Base64 tooling matters more than path-safety.
+- **[`IBinaryEncoding` interface](binary-encodings-interface.md)** — Base62 is registered as `BinaryEncodings.Base62` for runtime selection.

--- a/docs/guides/text-encoding/bech32.md
+++ b/docs/guides/text-encoding/bech32.md
@@ -1,0 +1,134 @@
+---
+title: Using Bech32 and Bech32m
+---
+
+# Using Bech32 and Bech32m
+
+`Bech32` implements the checksummed base-32 format defined by [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki)
+(Bech32) and [BIP 350](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki) (Bech32m). It is best known
+as the encoding of Bitcoin SegWit addresses (`bc1…`) and Lightning BOLT11 invoices, but it is a general-purpose
+encoding for any payload that benefits from a human-readable prefix and strong, position-aware error detection.
+
+Unlike the other encodings in this library, Bech32 is **not** a flat binary-to-text transform. An encoded string has
+four parts:
+
+```
+   bc 1 qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4
+   │  │ │                                  │
+   │  │ │                                  └─ 6-symbol checksum
+   │  │ └─ data part (5-bit groups, drawn from "qpzry9x8gf2tvdw0s3jn54khce6mua7l")
+   │  └─ separator '1'
+   └─ human-readable part (HRP)
+```
+
+Because the HRP and checksum are integral to the string, `Bech32` is modelled on [`Base58Check`](base58.md#base58check--checksum-protected-payloads)
+rather than the [`IBinaryEncoding`](binary-encodings-interface.md) family — it sits outside the runtime registry.
+
+## 5-bit groups vs. 8-bit bytes
+
+The core methods operate on **5-bit data groups** (each value `0`–`31`). Two convenience pairs bridge to ordinary
+bytes, and `ConvertBits` does it by hand:
+
+| Method | Data form |
+|---|---|
+| `Encode(hrp, data, scheme)` / `Decode(...)` | 5-bit groups (values 0–31) |
+| `EncodeFromBytes(hrp, data, scheme)` / `DecodeToBytes(...)` | 8-bit bytes (repacked with `ConvertBits` internally) |
+| `ConvertBits(data, fromBits, toBits, pad)` | manual bit-width conversion |
+
+```csharp
+using Bodu.Text.Encoding;
+
+// Round-trip arbitrary bytes through the byte-oriented pair.
+byte[] payload = { 0xDE, 0xAD, 0xBE, 0xEF };
+string encoded = Bech32.EncodeFromBytes("data", payload, Bech32Encoding.Bech32m);
+
+Bech32.DecodeToBytes(encoded, out string hrp, out byte[] back, out Bech32Encoding scheme);
+// hrp == "data"; back.SequenceEqual(payload); scheme == Bech32Encoding.Bech32m
+```
+
+## Bech32 vs. Bech32m
+
+The two schemes differ only in the checksum constant, which makes a Bech32m string fail a Bech32 checksum and vice
+versa. <xref:Bodu.Text.Encoding.Bech32Encoding> selects the scheme on encode, and the decoder **reports which scheme
+validated** the checksum through an out parameter:
+
+| Scheme | BIP | Use |
+|---|---|---|
+| `Bech32Encoding.Bech32` (default) | BIP 173 | SegWit v0 (`bc1q…`), Lightning invoices |
+| `Bech32Encoding.Bech32m` | BIP 350 | SegWit v1+ / Taproot (`bc1p…`) |
+
+```csharp
+Bech32.Decode("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+    out string hrp, out byte[] data, out Bech32Encoding scheme);
+// scheme == Bech32Encoding.Bech32
+```
+
+## Worked example — a SegWit v0 address
+
+A SegWit address is not a plain byte payload: the data part is a one-symbol **witness version** followed by the
+witness program repacked from 8 bits to 5. Witness v0 uses Bech32; v1+ uses Bech32m.
+
+```csharp
+using Bodu.Text.Encoding;
+
+byte[] program = Base16.Decode("751e76e8199196d454941c45d1b3a323f1433bd6"); // 20-byte HASH160
+
+byte[] groups = Bech32.ConvertBits(program, 8, 5, pad: true)!;   // program → 5-bit groups
+byte[] data = new byte[1 + groups.Length];
+data[0] = 0;                                                     // witness version 0
+groups.CopyTo(data, 1);
+
+string address = Bech32.Encode("bc", data, Bech32Encoding.Bech32);
+// "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4"
+```
+
+## Case handling
+
+Encoded output is always **lower case** (the canonical form). The decoder accepts an all-lower-case or all-upper-case
+string and rejects mixed case per BIP 173; the returned HRP is normalised to lower case.
+
+```csharp
+Bech32.IsValid("BC1QW508D6QEJXTDG4Y5R3ZARVARY0C5XW7KV8F3T4");   // true  (all upper)
+Bech32.IsValid("bc1qw508d6qejxtdg4Y5r3zarvary0c5xw7kv8f3t4");   // false (mixed case)
+```
+
+## The 90-character limit
+
+BIP 173 caps an address at **90 characters**. The decoder enforces this limit; the encoder does **not**, so it can
+produce the longer strings non-address schemes need — Lightning BOLT11 invoices routinely exceed 90 characters.
+
+## HRP rules
+
+The human-readable part must be **non-empty** and contain only US-ASCII characters in the range 33–126. An empty or
+out-of-range HRP throws `ArgumentException` from the encoder; `TryEncode` returns `false`.
+
+## Non-throwing forms
+
+```csharp
+if (Bech32.TryEncode("bc", data, Bech32Encoding.Bech32, out string? encoded))
+{
+    // encoded is non-null
+}
+
+if (Bech32.TryDecodeToBytes(input, out string? hrp, out byte[]? bytes, out Bech32Encoding scheme))
+{
+    // hrp / bytes are non-null; scheme reports Bech32 vs Bech32m
+}
+```
+
+`Decode` / `DecodeToBytes` throw `FormatException` on a bad checksum, mixed case, missing separator, over-length
+input, or an out-of-alphabet character; the `Try*` forms return `false` instead. `Bech32.IsValid` is a shorthand for
+"does this decode without error".
+
+## Sizing
+
+```csharp
+// hrpLength + 1 separator + dataLength + 6 checksum symbols
+int length = Bech32.GetEncodedLength(hrpLength: 2, dataLength: 33);
+```
+
+## Where to go next
+
+- **[Base58 guide](base58.md)** — the legacy Bitcoin address encoding and `Base58Check`.
+- **[Base32 guide](base32.md)** — the plain 5-bit encoding Bech32's data part is built on.
+- **[`IBinaryEncoding` interface](binary-encodings-interface.md)** — the runtime registry for the flat-byte encodings (Bech32 stays outside it).

--- a/docs/guides/text-encoding/index.md
+++ b/docs/guides/text-encoding/index.md
@@ -26,7 +26,10 @@ Base16 / Base32 / Base64, the big-integer arithmetic for Base58, and the 4-byte 
 | **[Base64](base64.md)** | 33 % | Standard, URL-safe, MIME | MIME / SMTP, JWT, certificates, generic binary-in-text |
 | **[Base58](base58.md)** | ≈ 37 % | Bitcoin/Flickr, Ripple | Bitcoin addresses, IPFS CIDs, Solana, Stellar |
 | **[Base85](base85.md)** | 25 % | Ascii85 (Adobe), Z85 (ZeroMQ) | PDF / PostScript, ZeroMQ wire keys |
-| **[`IBinaryEncoding` interface](binary-encodings-interface.md)** | — | every variant above | Runtime-selected encoding choice (config-driven serializers, plugins) |
+| **[Base45](base45.md)** | 50 % | RFC 9285 | QR-code payloads, EU Digital COVID Certificate |
+| **[Base62](base62.md)** | ≈ 35 % | GMP-style | Short URLs, compact identifiers, slugs |
+| **[Bech32](bech32.md)** | data + checksum | Bech32 (BIP 173), Bech32m (BIP 350) | Bitcoin SegWit addresses, Lightning invoices |
+| **[`IBinaryEncoding` interface](binary-encodings-interface.md)** | — | the flat-byte encodings above | Runtime-selected encoding choice (config-driven serializers, plugins) |
 
 ## Choosing between encodings
 
@@ -36,7 +39,11 @@ Base16 / Base32 / Base64, the big-integer arithmetic for Base58, and the 4-byte 
 | Human-readable, spoken aloud | Base32 Crockford or Z-Base-32 |
 | Crypto key / TOTP secret display | Base32 Standard |
 | Hex dump for debugging / forensics | Base16 with `InsertSpacing | InsertLineBreaks` |
-| Bitcoin / blockchain address | Base58 Bitcoin/Flickr |
+| Bitcoin / blockchain address (legacy) | Base58 Bitcoin/Flickr |
+| Bitcoin SegWit / Lightning address | Bech32 / Bech32m |
+| Checksum-protected address or key | Base58Check |
+| Binary inside a QR code | Base45 |
+| Compact URL-safe identifier or slug | Base62 |
 | Embedded in PostScript / PDF | Base85 Ascii85 |
 | Shell-safe binary key transport | Base85 Z85 |
 
@@ -65,5 +72,8 @@ guides drill into the variant-specific options:
 - **[Base64 guide](base64.md)** — Standard / URL-safe / MIME; line wrapping; JWT.
 - **[Base58 guide](base58.md)** — leading zeros, big-integer encoding; Bitcoin/IPFS.
 - **[Base85 guide](base85.md)** — Ascii85 vs Z85; the `z` shortcut; partial-group rules.
+- **[Base45 guide](base45.md)** — RFC 9285; the QR-code payload encoding; group packing and strictness.
+- **[Base62 guide](base62.md)** — GMP-style compact identifiers; leading-zero preservation.
+- **[Bech32 guide](bech32.md)** — Bech32 / Bech32m; HRP, separator, checksum; 5-bit vs 8-bit data.
 - **[`IBinaryEncoding` interface](binary-encodings-interface.md)** — runtime-selected encoding pattern.
 - **[Encoding helpers and BOM detection](encoding-helpers.md)** — `System.Text.Encoding` helpers: `string`↔`byte[]` conversion, preamble/BOM handling, UTF classification, fallbacks, and chunked transcoding.

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -272,6 +272,12 @@
           href: text-encoding/base58.md
         - name: Using Base85 (Ascii85 and Z85)
           href: text-encoding/base85.md
+        - name: Using Base45 (QR codes)
+          href: text-encoding/base45.md
+        - name: Using Base62
+          href: text-encoding/base62.md
+        - name: Using Bech32 and Bech32m
+          href: text-encoding/bech32.md
     - name: Bodu.Text.Encoding — Patterns
       items:
         - name: The IBinaryEncoding interface
@@ -294,6 +300,8 @@
           href: formats/dotenv.md
         - name: Using INI
           href: formats/ini.md
+        - name: Using TOML
+          href: formats/toml.md
     - name: Bodu.Text.Formats — I/O
       items:
         - name: Streams and async I/O

--- a/docs/images/hero-toml.svg
+++ b/docs/images/hero-toml.svg
@@ -1,0 +1,62 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 220" role="img" aria-label="Bodu.Text.Toml — TOML reader and writer over a typed value model">
+  <title>Bodu.Text.Toml</title>
+  <defs>
+    <linearGradient id="tml-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#0F172A"/>
+      <stop offset="1" stop-color="#1E293B"/>
+    </linearGradient>
+  </defs>
+  <rect width="480" height="220" rx="12" fill="url(#tml-bg)"/>
+
+  <!-- Left column: TOML source text -->
+  <g transform="translate(28 30)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11">
+    <rect width="150" height="160" rx="8" fill="#1E293B" stroke="#334155" stroke-width="1.2"/>
+    <rect width="150" height="22" rx="8" fill="#A78BFA"/>
+    <rect y="14" width="150" height="8" fill="#A78BFA"/>
+    <text x="75" y="16" fill="#F8FAFC" text-anchor="middle" font-weight="700" font-size="11">TOML text</text>
+
+    <g fill="#E2E8F0" font-family="'Consolas','Menlo',monospace" font-size="11">
+      <text x="10" y="42">title <tspan fill="#FBBF24">=</tspan> <tspan fill="#60A5FA">"app"</tspan></text>
+      <text x="10" y="64"><tspan fill="#FBBF24">[</tspan>owner<tspan fill="#FBBF24">]</tspan></text>
+      <text x="10" y="80">name <tspan fill="#FBBF24">=</tspan> <tspan fill="#60A5FA">"Tom"</tspan></text>
+      <text x="10" y="96">dob  <tspan fill="#FBBF24">=</tspan> 1979-05-27</text>
+      <text x="10" y="118"><tspan fill="#FBBF24">[</tspan>db<tspan fill="#FBBF24">]</tspan></text>
+      <text x="10" y="134">ports <tspan fill="#FBBF24">=</tspan> <tspan fill="#FBBF24">[</tspan>8000<tspan fill="#FBBF24">]</tspan></text>
+    </g>
+  </g>
+
+  <!-- middle: bidirectional pipeline arrows -->
+  <g transform="translate(186 80)" fill="none" stroke="#60A5FA" stroke-width="2" stroke-linecap="round">
+    <line x1="0" y1="0" x2="104" y2="0"/>
+    <polygon points="104,0 96,-4 96,4" fill="#60A5FA" stroke="none"/>
+    <line x1="104" y1="36" x2="0" y2="36"/>
+    <polygon points="0,36 8,32 8,40" fill="#60A5FA" stroke="none"/>
+  </g>
+  <g transform="translate(186 80)" fill="#60A5FA" font-family="'Consolas','Menlo',monospace" font-size="10" text-anchor="middle">
+    <text x="52" y="-6">read</text>
+    <text x="52" y="56">write</text>
+  </g>
+
+  <!-- Right column: TomlTable value model -->
+  <g transform="translate(310 30)" font-family="'Segoe UI','Helvetica Neue',Arial,sans-serif" font-size="11">
+    <rect width="142" height="160" rx="8" fill="#1E293B" stroke="#334155" stroke-width="1.2"/>
+    <rect width="142" height="22" rx="8" fill="#3B82F6"/>
+    <rect y="14" width="142" height="8" fill="#3B82F6"/>
+    <text x="71" y="16" fill="#F8FAFC" text-anchor="middle" font-weight="700" font-size="11">TomlTable</text>
+
+    <g fill="#E2E8F0" font-family="'Consolas','Menlo',monospace" font-size="11">
+      <text x="10" y="42">table</text>
+      <text x="22" y="58" fill="#60A5FA">title</text>
+      <text x="22" y="74" fill="#60A5FA">owner</text>
+      <text x="34" y="90">  name</text>
+      <text x="34" y="106">  dob</text>
+      <text x="22" y="122" fill="#60A5FA">db</text>
+      <text x="34" y="138">  ports[]</text>
+    </g>
+  </g>
+
+  <!-- bottom note -->
+  <g fill="#94A3B8" font-family="'Consolas','Menlo',monospace" font-size="10">
+    <text x="240" y="206" text-anchor="middle">typed · v1.0 / v1.1 · canonical</text>
+  </g>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ A family of focused primary libraries — collections and utilities, non-cryptog
 <div class="bodu-card">
   <img src="images/hero-text.svg" alt="Bodu.Text.Encoding" />
   <h3>Bodu.Text.Encoding</h3>
-  <p>Binary-to-text encoders for <strong>Base16</strong>, <strong>Base32</strong>, <strong>Base64</strong>, <strong>Base58</strong>, and <strong>Base85</strong> with every common variant — RFC 4648 standard / hex-extended / URL-safe / MIME, Crockford, z-base-32, Bitcoin / Flickr / Ripple, Adobe Ascii85, ZeroMQ Z85. Every encoding exposes the same modern API shape: span- and UTF-8-friendly overloads, <code>OperationStatus</code> streaming methods, length-prediction helpers, validation predicates, plus a unified <code>IBinaryEncoding</code> interface for runtime-pluggable encoding choice.</p>
+  <p>Binary-to-text encoders for <strong>Base16</strong>, <strong>Base32</strong>, <strong>Base64</strong>, <strong>Base58</strong>, and <strong>Base85</strong> with every common variant — RFC 4648 standard / hex-extended / URL-safe / MIME, Crockford, z-base-32, Bitcoin / Flickr / Ripple, Adobe Ascii85, ZeroMQ Z85 — plus <strong>Base45</strong> (RFC 9285 QR codes), <strong>Base62</strong> (compact identifiers), and <strong>Bech32 / Bech32m</strong> (BIP 173 / 350 checksummed addresses). The core encodings share the same modern API shape: span- and UTF-8-friendly overloads, <code>OperationStatus</code> streaming methods, length-prediction helpers, validation predicates, plus a unified <code>IBinaryEncoding</code> interface for runtime-pluggable encoding choice.</p>
   <div class="bodu-card-links">
     <a href="docs/text-encoding/index.md">Introduction</a>
     <a href="guides/text-encoding/index.md">Guides</a>
@@ -89,7 +89,7 @@ A family of focused primary libraries — collections and utilities, non-cryptog
 <div class="bodu-card">
   <img src="images/hero-formats.svg" alt="Bodu.Text.Formats" />
   <h3>Bodu.Text.Formats</h3>
-  <p>Self-framing text and binary document formats with strongly-typed value models and span- and stream-friendly codecs. Ships <strong>Bencode</strong> (BitTorrent BEP 3), <strong>Delimited</strong> (RFC 4180 CSV/TSV with a row-oriented parser), <strong>DotEnv</strong> (<code>.env</code> key/value), and <strong>INI</strong> (round-trippable section/comment-preserving documents). Every format exposes the same modern shape: static <code>Encode</code> / <code>Decode</code> / <code>Try*</code> / <code>GetEncodedLength</code>, an immutable value tree, sync and async <code>Stream</code> overloads, and explicit canonicality enforcement.</p>
+  <p>Self-framing text and binary document formats with strongly-typed value models and span- and stream-friendly codecs. Ships <strong>Bencode</strong> (BitTorrent BEP 3), <strong>Delimited</strong> (RFC 4180 CSV/TSV with a row-oriented parser), <strong>DotEnv</strong> (<code>.env</code> key/value), <strong>INI</strong> (round-trippable section/comment-preserving documents), and <strong>TOML</strong> (v1.0.0 / v1.1.0 with tables, arrays, and first-class date-time values). Every format exposes the same modern shape: static <code>Parse</code> / <code>Format</code> / <code>Try*</code> entry points, typed value models, sync and async <code>Stream</code> overloads, and explicit canonicality enforcement.</p>
   <div class="bodu-card-links">
     <a href="docs/formats/index.md">Introduction</a>
     <a href="guides/formats/index.md">Guides</a>


### PR DESCRIPTION
TOML (Bodu.Text.Toml):
- New API namespace page (docs/apidoc/Bodu.Text.Toml.md) with hero image
- New "Using TOML" guide covering the reader/writer pair, value model,
  v1.0.0/v1.1.0 selection, diagnostics, and streams
- Weave TOML into the Formats introduction, concepts, getting-started,
  and parser-policies pages
- Update format cross-references (four -> five namespaces) and the
  Bodu.Text shared-exception page (TomlFormatException)

Encoding (Bodu.Text.Encoding):
- Document Base45 (RFC 9285), Base62, and Bech32/Bech32m (BIP 173/350)
  in the API page, static docs, and three new per-encoding guides
- Document the Base58Check and Base64Url convenience wrappers
- Correct BinaryEncodings singleton names (Base16Lower/Base16Upper) and
  note the special-purpose encodings omit the OperationStatus path

Also update both guide indexes, the guides TOC, and the landing page.

https://claude.ai/code/session_019ccuTJJn7a2aHTUe29aZpx