### PR TITLE
test: stabilize flaky ElapsedTimeSince_WhenNow timing assertion

### DIFF
--- a/Bodu.Core/test/Extensions/DateTimeExtensionsTests.ElapsedTimeSince.cs
+++ b/Bodu.Core/test/Extensions/DateTimeExtensionsTests.ElapsedTimeSince.cs
@@ -68,9 +68,14 @@ public partial class DateTimeExtensionsTests
 
         TimeSpan elapsed = anchor.ElapsedTimeSince();
 
-        Assert.IsTrue(elapsed.TotalMilliseconds >= 0);
-        Assert.IsTrue(elapsed.TotalMilliseconds < 50,
-            $"Elapsed was {elapsed.TotalMilliseconds:F3}ms, expected < 50ms.");
+        // The elapsed span must be non-negative (the anchor is in the past) and "near zero". A generous upper bound is
+        // used deliberately: the measurement spans real wall-clock time, so on a contended CI host thread scheduling
+        // or a GC pause can stretch the gap well beyond a few milliseconds. The bound still catches gross defects such
+        // as a sign error, a wrong unit, or an incorrect epoch, which would yield negative or minute-scale results.
+        Assert.IsTrue(elapsed.TotalMilliseconds >= 0,
+            $"Elapsed was {elapsed.TotalMilliseconds:F3}ms, expected a non-negative span.");
+        Assert.IsTrue(elapsed.TotalSeconds < 30,
+            $"Elapsed was {elapsed.TotalSeconds:F3}s, expected a near-zero span.");
     }
     /// <summary>
     /// Verifies that <see cref="DateTimeExtensions.ElapsedTimeSince" />, when PastTime, returns <see langword="true" />.


### PR DESCRIPTION
## Problem

CI run [27195670858](https://github.com/bslater/bodu/actions/runs/27195670858/job/80286535080) (push to `master`) failed with exactly **1 failed test** in `Bodu.Core.Test`.

It is a **flaky test, not a regression**: the *same commit* `df273f55` passed on PR #437's CI run ([27195660185](https://github.com/bslater/bodu/actions/runs/27195660185), both checks green), then failed on the master push of that identical commit.

## Root cause

`DateTimeExtensionsTests.ElapsedTimeSince_WhenNow_ShouldReturnNearZero` captured an anchor timestamp, slept 1 ms, then asserted `elapsed.TotalMilliseconds < 50`. That upper bound measures real wall-clock time, which includes things the test cannot control:

- cold-JIT of `ElapsedTimeSince` on first call, *inside* the measured window;
- thread descheduling under the oversubscribed parallel run (`test.runsettings` sets `MaxCpuCount=0`; the workflow runs 8 assemblies on a 4-core runner);
- GC pauses.

So the assertion was effectively testing runtime scheduling latency rather than the method's correctness. It passes on warm/idle machines (all local runs, the PR run) and loses the race on rare CI runs.

The fragile bound was present from the file's first commit (`71b6cfc2`, PR #404) — the file is `<auto-generated />` and was added wholesale in that bulk drop, so this is an authoring/generator defect, not a behavioral change in production code.

## Fix

Relax the upper bound to a generous 30 s that still catches gross defects (a sign/unit/epoch bug yields negative or minute-scale results) while removing the scheduling-induced flakiness. The lower `>= 0` bound is kept.

## Verification

- `ElapsedTimeSince` tests: green across repeated local runs.
- Full `Bodu.Core.Test` suite (24,833 tests): passes locally.
- Opening this PR to exercise the change on CI under the parallel runsettings.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PKGkmzAQZ2KiVadFw9JLZP)_