### PR TITLE
docs: add TOML and special-purpose encoding diagrams, enrich TOML type docs

### DIFF
--- a/Bodu.Text.Encoding/src/Text.Encoding/Base45.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base45.cs
@@ -12,6 +12,9 @@ namespace Bodu.Text.Encoding;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <img src="../images/diagrams/encoding-special-purpose.svg" alt="Special-purpose encodings. Base45 (RFC 9285) packs each pair of bytes into three characters from the QR-code Alphanumeric-mode alphabet (0-9, A-Z, and nine symbols) with no padding; a trailing odd byte becomes two characters. Base62 uses the GMP-style alphabet 0-9 A-Z a-z and big-integer division by 62, preserving leading zero bytes. Bech32 and Bech32m comprise a human-readable part, the 1 separator, 5-bit data groups, and a six-symbol checksum."/>
+/// </para>
+/// <para>
 /// Base45 encodes each pair of input bytes as a base-45 number written in three characters, and a trailing odd byte as
 /// a two-character base-45 number. Unlike Base64, Base32, and Base16 it uses no padding. The 45-character alphabet is
 /// the Alphanumeric-mode subset of US-ASCII: the digits <c>0-9</c>, the upper-case letters <c>A-Z</c>, and the symbols

--- a/Bodu.Text.Encoding/src/Text.Encoding/Base62.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Base62.cs
@@ -11,6 +11,9 @@ namespace Bodu.Text.Encoding;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <img src="../images/diagrams/encoding-special-purpose.svg" alt="Special-purpose encodings. Base45 (RFC 9285) packs each pair of bytes into three characters from the QR-code Alphanumeric-mode alphabet with no padding. Base62 uses the GMP-style alphabet 0-9 A-Z a-z and big-integer division by 62, preserving leading zero bytes as leading zero characters. Bech32 and Bech32m comprise a human-readable part, the 1 separator, 5-bit data groups, and a six-symbol checksum."/>
+/// </para>
+/// <para>
 /// Base62 is a non-power-of-two radix (radix 62) commonly used for compact, URL-safe identifiers and short links.
 /// Because the radix is not a power of two, encoding is performed with big-integer arithmetic rather than the
 /// bit-stream technique used by Base16, Base32, and Base64.

--- a/Bodu.Text.Encoding/src/Text.Encoding/Bech32.cs
+++ b/Bodu.Text.Encoding/src/Text.Encoding/Bech32.cs
@@ -13,6 +13,9 @@ namespace Bodu.Text.Encoding;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <img src="../images/diagrams/encoding-special-purpose.svg" alt="Special-purpose encodings. Base45 (RFC 9285) packs each pair of bytes into three characters from the QR-code Alphanumeric-mode alphabet with no padding. Base62 uses the GMP-style alphabet 0-9 A-Z a-z and big-integer division by 62. Bech32 and Bech32m (BIP 173 / 350) are not plain binary-to-text encodings: an encoded string is a human-readable part, the 1 separator, 5-bit data groups, and a six-symbol error-detecting checksum."/>
+/// </para>
+/// <para>
 /// Bech32 is not a plain binary-to-text encoding: every encoded string carries an HRP prefix and a checksum, so the
 /// type is modelled on <see cref="Base58Check" /> rather than the <see cref="IBinaryEncoding" /> family. The core
 /// surface operates on 5-bit data groups (each value <c>0</c>–<c>31</c>); use <see cref="ConvertBits" /> — or the

--- a/Bodu.Text.Formats/src/Text.Toml/Toml.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/Toml.cs
@@ -15,6 +15,9 @@ namespace Bodu.Text.Toml;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <img src="../images/diagrams/toml-pipeline.svg" alt="The TOML parse/format pipeline runs in both directions. Parsing takes TOML source text, runs TomlReader to tokenize and apply the grammar, validates the spec rules (the v1.0.0 or v1.1.0 version, no duplicate keys, no table redefinition), and returns a strongly typed TomlTable. Formatting takes a TomlTable, runs TomlWriter to walk the model in insertion order, canonicalizes the layout into block-style tables with inline scalars and arrays, and writes canonical TOML text valid under both spec versions."/>
+/// </para>
+/// <para>
 /// These static helpers exist for ergonomic one-liners; the read/write pair (<see cref="TomlReader" /> and
 /// <see cref="TomlWriter" />) is the primary surface, mirroring the relationship between <c>XmlReader</c> /
 /// <c>XmlWriter</c> and their document model.

--- a/Bodu.Text.Formats/src/Text.Toml/TomlArray.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlArray.cs
@@ -12,6 +12,25 @@ namespace Bodu.Text.Toml;
 /// Represents a TOML array — an ordered, mutable sequence of <see cref="TomlValue" /> elements. TOML permits arrays to
 /// hold elements of differing types.
 /// </summary>
+/// <remarks>
+/// Elements are stored and enumerated in document order, and the array implements <see cref="IReadOnlyList{T}" /> so it
+/// can be indexed and iterated like any list. Because TOML arrays may be heterogeneous, an element's concrete kind is
+/// discovered through <see cref="TomlValue.Kind" /> rather than assumed from its position.
+/// </remarks>
+/// <example>
+///<![CDATA[
+/// // Compose an array, then read elements back by index.
+/// var ports = new TomlArray
+/// {
+///     new TomlInteger(8000),
+///     new TomlInteger(8001),
+/// };
+/// ports.Add(new TomlInteger(8002));
+///
+/// long first = ((TomlInteger)ports[0]).Value;   // 8000
+/// int count  = ports.Count;                      // 3
+///]]>
+/// </example>
 public sealed class TomlArray
     : TomlValue
     , IReadOnlyList<TomlValue>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlBoolean.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlBoolean.cs
@@ -9,6 +9,14 @@ namespace Bodu.Text.Toml;
 /// <summary>
 /// Represents a TOML boolean value.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var enabled = new TomlBoolean(true);
+/// bool value = enabled.Value;                    // true
+///
+/// bool flag = ((TomlBoolean)database["enabled"]).Value;
+///]]>
+/// </example>
 public sealed class TomlBoolean
     : TomlValue
     , IEquatable<TomlBoolean>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlFloat.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlFloat.cs
@@ -9,8 +9,17 @@ using System.Globalization;
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Represents a TOML float value, stored as an IEEE 754 binary64 floating-point number.
+/// Represents a TOML float value, stored as an IEEE 754 binary64 floating-point number. The special values
+/// <c>inf</c>, <c>-inf</c>, and <c>nan</c> are carried as the corresponding <see cref="double" /> values.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var ratio = new TomlFloat(3.14);
+/// double value = ratio.Value;                    // 3.14
+///
+/// var infinity = new TomlFloat(double.PositiveInfinity);   // serializes as "inf"
+///]]>
+/// </example>
 public sealed class TomlFloat
     : TomlValue
     , IEquatable<TomlFloat>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlInteger.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlInteger.cs
@@ -9,8 +9,18 @@ using System.Globalization;
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Represents a TOML integer value, stored as a 64-bit signed integer.
+/// Represents a TOML integer value, stored as a 64-bit signed integer. Decimal, hexadecimal, octal, and binary
+/// literals all parse to the same numeric value.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var port = new TomlInteger(8080);
+/// long value = port.Value;                       // 8080
+///
+/// // 0xFF, 0o17, and 0b1010 literals all yield a TomlInteger.
+/// long first = ((TomlInteger)ports[0]).Value;
+///]]>
+/// </example>
 public sealed class TomlInteger
     : TomlValue
     , IEquatable<TomlInteger>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlLocalDate.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlLocalDate.cs
@@ -9,6 +9,12 @@ namespace Bodu.Text.Toml;
 /// <summary>
 /// Represents a TOML local date — a calendar date without any offset or time-zone relation.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var date = new TomlLocalDate(new DateOnly(1979, 5, 27));
+/// DateOnly value = date.Value;                   // 1979-05-27
+///]]>
+/// </example>
 public sealed class TomlLocalDate
     : TomlValue
     , IEquatable<TomlLocalDate>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlLocalDateTime.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlLocalDateTime.cs
@@ -7,8 +7,16 @@
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Represents a TOML local date-time — a date and time without any offset or time-zone relation.
+/// Represents a TOML local date-time — a date and time without any offset or time-zone relation. The wrapped
+/// <see cref="DateTime" /> always has <see cref="DateTimeKind.Unspecified" /> so it carries no spurious time-zone
+/// relation.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var stamp = new TomlLocalDateTime(new DateTime(1979, 5, 27, 7, 32, 0));
+/// DateTime value = stamp.Value;                  // Kind == Unspecified
+///]]>
+/// </example>
 public sealed class TomlLocalDateTime
     : TomlValue
     , IEquatable<TomlLocalDateTime>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlLocalTime.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlLocalTime.cs
@@ -9,6 +9,12 @@ namespace Bodu.Text.Toml;
 /// <summary>
 /// Represents a TOML local time — a time of day without any offset or time-zone relation.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var time = new TomlLocalTime(new TimeOnly(7, 32, 0));
+/// TimeOnly value = time.Value;                   // 07:32:00
+///]]>
+/// </example>
 public sealed class TomlLocalTime
     : TomlValue
     , IEquatable<TomlLocalTime>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlOffsetDateTime.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlOffsetDateTime.cs
@@ -7,8 +7,15 @@
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Represents a TOML offset date-time — an RFC 3339 instant carrying a time offset.
+/// Represents a TOML offset date-time — an RFC 3339 instant carrying a time offset. Unlike the three local date-time
+/// kinds, it pins the value to an unambiguous point in time.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var dob = new TomlOffsetDateTime(new DateTimeOffset(1979, 5, 27, 7, 32, 0, TimeSpan.Zero));
+/// DateTimeOffset value = dob.Value;              // 1979-05-27T07:32:00+00:00
+///]]>
+/// </example>
 public sealed class TomlOffsetDateTime
     : TomlValue
     , IEquatable<TomlOffsetDateTime>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlString.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlString.cs
@@ -7,8 +7,17 @@
 namespace Bodu.Text.Toml;
 
 /// <summary>
-/// Represents a TOML string value.
+/// Represents a TOML string value. The wrapped text is immutable and compared with ordinal semantics.
 /// </summary>
+/// <example>
+///<![CDATA[
+/// var title = new TomlString("Bodu sample");
+/// string text = title.Value;                  // "Bodu sample"
+///
+/// // Cast a value read from a document back to its concrete kind.
+/// string name = ((TomlString)owner["name"]).Value;
+///]]>
+/// </example>
 public sealed class TomlString
     : TomlValue
     , IEquatable<TomlString>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlTable.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlTable.cs
@@ -28,6 +28,24 @@ namespace Bodu.Text.Toml;
 /// text alongside the model.
 /// </para>
 /// </remarks>
+/// <example>
+///<![CDATA[
+/// // Build a table with a collection initializer, the indexer, or Add.
+/// var owner = new TomlTable
+/// {
+///     ["name"] = new TomlString("Tom"),
+///     ["age"]  = new TomlInteger(45),
+/// };
+///
+/// // Safe lookup of an optional key.
+/// if (owner.TryGetValue("name", out TomlValue? name))
+///     Console.WriteLine(((TomlString)name).Value);   // "Tom"
+///
+/// // Enumerates as KeyValuePair<string, TomlValue> in insertion order.
+/// foreach ((string key, TomlValue value) in owner)
+///     Console.WriteLine($"{key} = {value}");
+///]]>
+/// </example>
 public sealed class TomlTable
     : TomlValue
     , IReadOnlyCollection<KeyValuePair<string, TomlValue>>

--- a/Bodu.Text.Formats/src/Text.Toml/TomlValue.cs
+++ b/Bodu.Text.Formats/src/Text.Toml/TomlValue.cs
@@ -12,6 +12,9 @@ namespace Bodu.Text.Toml;
 /// </summary>
 /// <remarks>
 /// <para>
+/// <img src="../images/diagrams/toml-value-model.svg" alt="The ten TOML value kinds in three groups. The four scalars are TomlString (string), TomlInteger (long), TomlFloat (double), and TomlBoolean (bool). The four RFC 3339 date-time kinds are TomlOffsetDateTime (DateTimeOffset), TomlLocalDateTime (DateTime with Unspecified kind), TomlLocalDate (DateOnly), and TomlLocalTime (TimeOnly). The two containers are TomlArray (an ordered list of TomlValue) and TomlTable (a string-keyed map to TomlValue). Every value derives from TomlValue and reports a TomlValueKind; scalars and date-times are immutable while containers are mutable."/>
+/// </para>
+/// <para>
 /// <see cref="Kind" /> identifies the concrete subclass without forcing a cast, so callers can switch on the kind
 /// before narrowing to a specific type, or pattern-match directly against a concrete subclass such as
 /// <see cref="TomlString" /> or <see cref="TomlTable" />.
@@ -25,6 +28,22 @@ namespace Bodu.Text.Toml;
 /// built-in ones. This guarantees the writer can render every value it is given.
 /// </para>
 /// </remarks>
+/// <example>
+///<![CDATA[
+/// // Dispatch on Kind, then narrow to the concrete type to read its Value.
+/// TomlValue value = config["title"];
+/// string title = value.Kind switch
+/// {
+///     TomlValueKind.String  => ((TomlString)value).Value,
+///     TomlValueKind.Integer => ((TomlInteger)value).Value.ToString(),
+///     _                     => value.ToString(),
+/// };
+///
+/// // Or pattern-match directly against a concrete subclass.
+/// if (config["ports"] is TomlArray ports)
+///     Console.WriteLine($"{ports.Count} ports configured");
+///]]>
+/// </example>
 public abstract class TomlValue
 {
     /// <summary>

--- a/docs/docs/text-encoding/index.md
+++ b/docs/docs/text-encoding/index.md
@@ -60,6 +60,8 @@ For runtime-selected encoding choice, see the **[IBinaryEncoding](../../guides/t
 `BinaryEncodings` registry: `BinaryEncodings.Base64`, `BinaryEncodings.Base32Crockford`,
 `BinaryEncodings.Z85`, etc.
 
+![Special-purpose encodings — Base45 packs byte pairs into three QR-alphabet characters, Base62 uses big-integer divmod over 0-9 A-Z a-z, and Bech32 frames a human-readable part, separator, 5-bit data, and a six-symbol checksum](../../images/diagrams/encoding-special-purpose.svg)
+
 The **special-purpose** encodings (Base45, Base62, Bech32) share the `Encode` / `Decode` / `TryEncode` / `TryDecode`,
 sizing, and `IsValid` members but omit the `OperationStatus` streaming path — each needs the whole input at once.
 Base45 and Base62 are registered as `BinaryEncodings.Base45` / `BinaryEncodings.Base62`; Bech32 takes a

--- a/docs/guides/formats/toml.md
+++ b/docs/guides/formats/toml.md
@@ -15,6 +15,8 @@ TOML follows a **reader/writer** shape rather than a single static codec, mirror
 - <xref:Bodu.Text.Toml.TomlWriter> serializes a `TomlTable` back to canonical TOML.
 - <xref:Bodu.Text.Toml.Toml> is a thin static façade over shared, stateless reader and writer singletons — reach for it for one-line `Parse` / `Format`.
 
+![TOML parse/format pipeline — text through TomlReader to a TomlTable model, and a TomlTable model through TomlWriter back to canonical text](../../images/diagrams/toml-pipeline.svg)
+
 For the vocabulary used below (document, value, codec, format exception) see [Core concepts](../../docs/formats/concepts.md); for the spec-version selector and diagnostics, see [Parser policies](../../docs/formats/parser-policies.md).
 
 ## Pattern 1 — parse a configuration document
@@ -81,6 +83,8 @@ if (database.TryGetValue("timeout", out TomlValue? timeout))
 ```
 
 ### The value kinds
+
+![TOML value model — ten value kinds in three groups (scalars, RFC 3339 date-times, containers) each mapped to its .NET backing type](../../images/diagrams/toml-value-model.svg)
 
 | Kind | Type | `Value` backing type |
 |---|---|---|

--- a/docs/images/diagrams/encoding-special-purpose.svg
+++ b/docs/images/diagrams/encoding-special-purpose.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 300" role="img" aria-labelledby="esp-t esp-d">
+  <title id="esp-t">Special-purpose encodings — Base45, Base62, Bech32</title>
+  <desc id="esp-d">Three special-purpose encodings sit alongside the core radix families. Base45 (RFC 9285) packs each pair of bytes into three characters drawn from the QR-code Alphanumeric-mode alphabet (0-9, A-Z and nine symbols) with no padding; a trailing odd byte becomes two characters. It carries binary payloads inside QR codes and the EU Digital COVID Certificate. Base62 uses the GMP-style alphabet 0-9 A-Z a-z and big-integer division by 62, preserving leading zero bytes as leading zero characters; it produces compact, URL-safe identifiers and short links. Bech32 and Bech32m (BIP 173 / 350) are not plain binary-to-text encodings: an encoded string is a human-readable part, the 1 separator, 5-bit data groups, and a six-symbol error-detecting checksum. They encode Bitcoin SegWit addresses and Lightning invoices.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .name  { font: 700 14px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .ttag  { fill: #94A3B8; font: 700 9px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; letter-spacing: 1px; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.3 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .use   { fill: #CBD5E1; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mono  { font: 700 11px/1 "Consolas","Menlo",monospace; text-anchor: middle; }
+      .c1    { fill: #15262B; stroke: #2DD4BF; stroke-width: 1.5; }
+      .c2    { fill: #20193A; stroke: #A78BFA; stroke-width: 1.5; }
+      .c3    { fill: #2A1B07; stroke: #FBBF24; stroke-width: 1.5; }
+      .box   { fill: #0F172A; stroke: #475569; stroke-width: 1; }
+      .seg-h { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.4; }
+      .seg-s { fill: #1E293B; stroke: #64748B; stroke-width: 1.4; }
+      .seg-d { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.4; }
+      .seg-c { fill: #431407; stroke: #FBBF24; stroke-width: 1.4; }
+    </style>
+    <marker id="esp-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#94A3B8"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="300"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="280" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">Special-purpose encodings — Base45 · Base62 · Bech32</text>
+
+    <!-- ============ Base45 ============ -->
+    <g transform="translate(16 44)">
+      <rect class="c1" width="246" height="216" rx="8"/>
+      <text class="ttag" x="123" y="24">RFC 9285</text>
+      <text class="name" fill="#2DD4BF" x="123" y="44">Base45</text>
+      <line x1="20" y1="56" x2="226" y2="56" stroke="#334155"/>
+
+      <!-- byte-pair → 3 chars -->
+      <rect class="box" x="26"  y="74" width="36" height="24" rx="3"/>
+      <rect class="box" x="64"  y="74" width="36" height="24" rx="3"/>
+      <text class="mono" fill="#E2E8F0" x="44" y="90">b0</text>
+      <text class="mono" fill="#E2E8F0" x="82" y="90">b1</text>
+      <line x1="106" y1="86" x2="132" y2="86" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#esp-a)"/>
+      <rect class="box" x="138" y="74" width="26" height="24" rx="3"/>
+      <rect class="box" x="166" y="74" width="26" height="24" rx="3"/>
+      <rect class="box" x="194" y="74" width="26" height="24" rx="3"/>
+      <text class="mono" fill="#2DD4BF" x="151" y="90">c</text>
+      <text class="mono" fill="#2DD4BF" x="179" y="90">c</text>
+      <text class="mono" fill="#2DD4BF" x="207" y="90">c</text>
+      <text class="mut" x="123" y="118">2 bytes → 3 chars · no padding</text>
+
+      <text class="mono" fill="#E2E8F0" x="123" y="146">{ 0x41, 0x42 }  →  "BB8"</text>
+      <text class="mut" x="123" y="170">alphabet: 0-9 A-Z space $%*+-./:</text>
+      <text class="use" x="123" y="196">QR-code payloads · EU DCC</text>
+    </g>
+
+    <!-- ============ Base62 ============ -->
+    <g transform="translate(277 44)">
+      <rect class="c2" width="246" height="216" rx="8"/>
+      <text class="ttag" x="123" y="24">GMP RADIX-62</text>
+      <text class="name" fill="#C4B5FD" x="123" y="44">Base62</text>
+      <line x1="20" y1="56" x2="226" y2="56" stroke="#334155"/>
+
+      <!-- big-integer divmod -->
+      <rect class="box" x="26" y="74" width="92" height="24" rx="3"/>
+      <text class="mono" fill="#E2E8F0" x="72" y="90">bytes → int</text>
+      <line x1="122" y1="86" x2="148" y2="86" stroke="#94A3B8" stroke-width="1.4" marker-end="url(#esp-a)"/>
+      <rect class="box" x="154" y="74" width="66" height="24" rx="3"/>
+      <text class="mono" fill="#C4B5FD" x="187" y="90">÷ 62</text>
+      <text class="mut" x="123" y="118">big-integer arithmetic, radix 62</text>
+
+      <text class="mono" fill="#E2E8F0" x="123" y="146">0-9  A-Z  a-z</text>
+      <text class="mut" x="123" y="170">leading 0x00 byte → leading '0'</text>
+      <text class="use" x="123" y="196">short URLs · compact IDs · slugs</text>
+    </g>
+
+    <!-- ============ Bech32 ============ -->
+    <g transform="translate(538 44)">
+      <rect class="c3" width="246" height="216" rx="8"/>
+      <text class="ttag" x="123" y="24">BIP 173 / 350</text>
+      <text class="name" fill="#FBBF24" x="123" y="44">Bech32 / Bech32m</text>
+      <line x1="20" y1="56" x2="226" y2="56" stroke="#334155"/>
+
+      <!-- segmented structure: HRP | 1 | data | checksum -->
+      <rect class="seg-h" x="20"  y="74" width="48"  height="26" rx="3"/>
+      <rect class="seg-s" x="68"  y="74" width="18"  height="26" rx="3"/>
+      <rect class="seg-d" x="86"  y="74" width="86"  height="26" rx="3"/>
+      <rect class="seg-c" x="172" y="74" width="54"  height="26" rx="3"/>
+      <text class="mono" fill="#2DD4BF" x="44"  y="91">hrp</text>
+      <text class="mono" fill="#CBD5E1" x="77"  y="91">1</text>
+      <text class="mono" fill="#93C5FD" x="129" y="91">data</text>
+      <text class="mono" fill="#FBBF24" x="199" y="91" style="font-size:9px">checksum</text>
+      <text class="mut" x="123" y="118">5-bit data + 6-symbol checksum</text>
+
+      <text class="mono" fill="#E2E8F0" x="123" y="146">bc1qw508d6...k90wsj</text>
+      <text class="mut" x="123" y="170">lower-case canonical · error-detecting</text>
+      <text class="use" x="123" y="196">SegWit addresses · Lightning</text>
+    </g>
+  </g>
+</svg>

--- a/docs/images/diagrams/toml-pipeline.svg
+++ b/docs/images/diagrams/toml-pipeline.svg
@@ -1,0 +1,110 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 280" role="img" aria-labelledby="tp-t tp-d">
+  <title id="tp-t">TOML parse/format pipeline</title>
+  <desc id="tp-d">The TOML codec follows a reader/writer shape and runs in both directions. Parsing takes TOML source text, runs TomlReader to tokenize and apply the grammar, validates the specification rules (the v1.0.0 or v1.1.0 version, no duplicate keys, no table redefinition, valid UTF-8 with no unpaired surrogates), and returns a strongly typed TomlTable document. Formatting takes a TomlTable document, runs TomlWriter to walk the model in insertion order, canonicalizes the layout into block-style tables with inline scalars and arrays, and writes canonical TOML text that is valid under both spec versions. The static Toml.Parse and Toml.Format helpers are one-line facades over shared reader and writer singletons.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .row   { fill: #2DD4BF; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .rowd  { fill: #A78BFA; font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; }
+      .src   { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .mid   { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .dst   { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .out   { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .wt    { stroke: #2DD4BF; stroke-width: 1.6; fill: none; }
+      .wp    { stroke: #A78BFA; stroke-width: 1.6; fill: none; }
+    </style>
+    <marker id="tpt-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#2DD4BF"/>
+    </marker>
+    <marker id="tpd-a" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 Z" fill="#A78BFA"/>
+    </marker>
+  </defs>
+
+  <rect class="bg" width="820" height="280"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="260" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">TOML parse/format pipeline</text>
+
+    <!-- ===== Top row — PARSE (left-to-right, teal) ===== -->
+    <text class="row" x="20" y="58">PARSE  ▸ Toml.Parse · TomlReader.Read  ·  text → document</text>
+
+    <g transform="translate(20 70)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">TOML text</text>
+      <text class="mut" x="80" y="36">string · span · stream</text>
+    </g>
+
+    <line class="wt" x1="180" y1="93" x2="220" y2="93" marker-end="url(#tpt-a)"/>
+
+    <g transform="translate(220 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">TomlReader</text>
+      <text class="mut" x="80" y="36">tokenize + grammar</text>
+    </g>
+
+    <line class="wt" x1="380" y1="93" x2="420" y2="93" marker-end="url(#tpt-a)"/>
+
+    <g transform="translate(420 70)">
+      <rect class="mid" width="160" height="46" rx="6"/>
+      <text class="lbl" x="80" y="20">Validate spec rules</text>
+      <text class="mut" x="80" y="36">v1.0 / v1.1 · no dup keys</text>
+    </g>
+
+    <line class="wt" x1="580" y1="93" x2="620" y2="93" marker-end="url(#tpt-a)"/>
+
+    <g transform="translate(620 70)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">TomlTable</text>
+      <text class="mut" x="80" y="36">typed value model</text>
+    </g>
+
+    <!-- ===== Middle separator ===== -->
+    <line x1="20" y1="138" x2="780" y2="138" stroke="#334155" stroke-width="1"/>
+
+    <!-- ===== Bottom row — FORMAT (left-to-right, purple) ===== -->
+    <text class="rowd" x="20" y="160">FORMAT  ▸ Toml.Format · TomlWriter.Write  ·  document → text</text>
+
+    <g transform="translate(20 172)">
+      <rect class="src" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="80" y="20">TomlTable</text>
+      <text class="mut" x="80" y="36">authored or parsed</text>
+    </g>
+
+    <line class="wp" x1="180" y1="195" x2="220" y2="195" marker-end="url(#tpd-a)"/>
+
+    <g transform="translate(220 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">TomlWriter</text>
+      <text class="mut" x="80" y="36">walk in insertion order</text>
+    </g>
+
+    <line class="wp" x1="380" y1="195" x2="420" y2="195" marker-end="url(#tpd-a)"/>
+
+    <g transform="translate(420 172)">
+      <rect class="dst" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="80" y="20">Canonicalize</text>
+      <text class="mut" x="80" y="36">block tables · inline arrays</text>
+    </g>
+
+    <line class="wp" x1="580" y1="195" x2="620" y2="195" marker-end="url(#tpd-a)"/>
+
+    <g transform="translate(620 172)">
+      <rect class="out" width="160" height="46" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="80" y="20">TOML text</text>
+      <text class="mut" x="80" y="36">valid under v1.0 &amp; v1.1</text>
+    </g>
+
+    <!-- Footer note -->
+    <text class="mut" x="400" y="244" style="font-size:9.5px">TryParse returns false instead of throwing; a Parse → Format round trip yields an equal model and canonical text, but drops comments and original layout.</text>
+  </g>
+</svg>

--- a/docs/images/diagrams/toml-value-model.svg
+++ b/docs/images/diagrams/toml-value-model.svg
@@ -1,0 +1,120 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 360" role="img" aria-labelledby="tvm-t tvm-d">
+  <title id="tvm-t">TOML value model — ten kinds mapped to .NET types</title>
+  <desc id="tvm-d">Every value in a TOML document derives from TomlValue and reports a TomlValueKind discriminator. The ten kinds fall into three groups. The four scalars are TomlString (backed by string), TomlInteger (long), TomlFloat (double), and TomlBoolean (bool). The four RFC 3339 date-time kinds are TomlOffsetDateTime (DateTimeOffset), TomlLocalDateTime (DateTime with Unspecified kind), TomlLocalDate (DateOnly), and TomlLocalTime (TimeOnly). The two containers are TomlArray (an ordered list of TomlValue) and TomlTable (a key to TomlValue map). Scalar values are immutable; arrays and tables are mutable so a document can be authored programmatically.</desc>
+
+  <defs>
+    <style>
+      .bg    { fill: #0F172A; }
+      .pan   { fill: #1E293B; stroke: #334155; stroke-width: 1; }
+      .hdr   { fill: #111827; stroke: #334155; stroke-width: 1; }
+      .ttl   { fill: #F8FAFC; font: 700 15px/1 "Segoe UI",Arial,sans-serif; }
+      .lbl   { fill: #F8FAFC; font: 700 12px/1 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .mut   { fill: #94A3B8; font: 400 10px/1.25 "Segoe UI",Arial,sans-serif; text-anchor: middle; }
+      .sect  { font: 700 11px/1 "Segoe UI",Arial,sans-serif; text-anchor: start; letter-spacing: 0.5px; }
+      .mono  { font: 700 12px/1 "Consolas","Menlo",monospace; fill: #E2E8F0; text-anchor: middle; }
+      .b1    { fill: #0D3331; stroke: #2DD4BF; stroke-width: 1.5; }
+      .b2    { fill: #1E3A5F; stroke: #60A5FA; stroke-width: 1.5; }
+      .b3    { fill: #2A1B54; stroke: #A78BFA; stroke-width: 1.5; }
+      .b4    { fill: #431407; stroke: #FBBF24; stroke-width: 1.5; }
+      .note  { fill: #15212F; stroke: #334155; stroke-width: 1; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="820" height="360"/>
+
+  <g transform="translate(10 10)">
+    <rect class="pan" width="800" height="340" rx="8"/>
+    <rect class="hdr" width="800" height="30" rx="8"/>
+    <rect class="hdr" y="22" width="800" height="8"/>
+    <text class="ttl" x="16" y="20">TOML value model — ten kinds mapped to .NET types</text>
+
+    <!-- ============ Row 1 — SCALARS ============ -->
+    <text class="sect" fill="#2DD4BF" x="28" y="50">SCALARS</text>
+
+    <g transform="translate(28 56)">
+      <rect class="b1" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="86" y="30">TomlString</text>
+      <text class="mono" x="86" y="50">"hello"</text>
+      <text class="mut" x="86" y="78">string</text>
+    </g>
+
+    <g transform="translate(220 56)">
+      <rect class="b2" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#93C5FD" x="86" y="30">TomlInteger</text>
+      <text class="mono" x="86" y="50">42 · 0xFF · 0b101</text>
+      <text class="mut" x="86" y="78">long</text>
+    </g>
+
+    <g transform="translate(412 56)">
+      <rect class="b3" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="86" y="30">TomlFloat</text>
+      <text class="mono" x="86" y="50">3.14 · inf · nan</text>
+      <text class="mut" x="86" y="78">double</text>
+    </g>
+
+    <g transform="translate(604 56)">
+      <rect class="b4" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="86" y="30">TomlBoolean</text>
+      <text class="mono" x="86" y="50">true · false</text>
+      <text class="mut" x="86" y="78">bool</text>
+    </g>
+
+    <!-- ============ Row 2 — DATE & TIME (RFC 3339) ============ -->
+    <text class="sect" fill="#60A5FA" x="28" y="144">DATE &amp; TIME  ·  RFC 3339</text>
+
+    <g transform="translate(28 150)">
+      <rect class="b1" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="86" y="28">TomlOffsetDateTime</text>
+      <text x="86" y="48" class="mono" style="font-size:10.5px">1979-05-27T07:32Z</text>
+      <text class="mut" x="86" y="78">DateTimeOffset</text>
+    </g>
+
+    <g transform="translate(220 150)">
+      <rect class="b2" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#93C5FD" x="86" y="28">TomlLocalDateTime</text>
+      <text x="86" y="48" class="mono" style="font-size:10.5px">1979-05-27T07:32:00</text>
+      <text class="mut" x="86" y="78">DateTime (Unspecified)</text>
+    </g>
+
+    <g transform="translate(412 150)">
+      <rect class="b3" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#C4B5FD" x="86" y="28">TomlLocalDate</text>
+      <text class="mono" x="86" y="48">1979-05-27</text>
+      <text class="mut" x="86" y="78">DateOnly</text>
+    </g>
+
+    <g transform="translate(604 150)">
+      <rect class="b4" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="86" y="28">TomlLocalTime</text>
+      <text class="mono" x="86" y="48">07:32:00</text>
+      <text class="mut" x="86" y="78">TimeOnly</text>
+    </g>
+
+    <!-- ============ Row 3 — CONTAINERS ============ -->
+    <text class="sect" fill="#A78BFA" x="28" y="238">CONTAINERS  ·  mutable</text>
+
+    <g transform="translate(28 244)">
+      <rect class="b1" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#2DD4BF" x="86" y="30">TomlArray</text>
+      <text class="mono" x="86" y="50">[8000, 8001, 8002]</text>
+      <text class="mut" x="86" y="78">IReadOnlyList&lt;TomlValue&gt;</text>
+    </g>
+
+    <g transform="translate(220 244)">
+      <rect class="b4" width="172" height="52" y="8" rx="6"/>
+      <text class="lbl" fill="#FBBF24" x="86" y="30">TomlTable</text>
+      <text class="mono" x="86" y="50">[owner]  ·  { x = 1 }</text>
+      <text class="mut" x="86" y="78">string key → TomlValue</text>
+    </g>
+
+    <!-- Legend / discriminator note -->
+    <g transform="translate(412 244)">
+      <rect class="note" width="364" height="68" y="8" rx="6"/>
+      <text class="sect" fill="#F8FAFC" x="16" y="30">switch on Kind, or pattern-match a subtype</text>
+      <text class="mut" x="16" y="50" style="text-anchor:start">Every value derives from <tspan fill="#E2E8F0" font-weight="700">TomlValue</tspan> and reports a <tspan fill="#E2E8F0" font-weight="700">TomlValueKind</tspan>.</text>
+      <text class="mut" x="16" y="64" style="text-anchor:start">Scalars and date-times are immutable; containers are mutable.</text>
+    </g>
+
+    <text class="mut" x="400" y="330" style="font-size:9.5px">A [table] header, an inline { } table, dotted keys, and an array-of-tables element all materialize as TomlTable / TomlArray — the model records meaning, not syntax.</text>
+  </g>
+</svg>


### PR DESCRIPTION
Add three on-style SVG diagrams and wire them into both the DocFX
pages and the XML documentation:

- toml-value-model.svg: the ten TOML value kinds grouped into scalars,
  RFC 3339 date-times, and containers, each mapped to its .NET backing
  type. Embedded in TomlValue remarks and the TOML guide.
- toml-pipeline.svg: the TomlReader/TomlWriter parse/format pipeline.
  Embedded in Toml remarks and the TOML guide.
- encoding-special-purpose.svg: the structure of Base45, Base62, and
  Bech32 (the families absent from encoding-families.svg). Embedded in
  the Base45/Base62/Bech32 remarks and the encoding overview page.

Also add consumer-facing <example> blocks (and brief clarifying remarks)
to the TOML container and scalar value types so each public type shows
how it is constructed and read.