### PR TITLE
Clarify check-digit family design and relationship to hash algorithms

### DIFF
--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/AlphanumericCheckDigitAlgorithm.cs
@@ -19,9 +19,18 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// <c>'X'</c> sentinel used by ISBN-10 and ISO 7064 MOD 11-2 to represent the check value ten.
 /// </para>
 /// <para>
+/// Like the rest of this family, the type is intentionally separate from the byte-stream oriented
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" /> and does <b>not</b> derive from it. A non-cryptographic
+/// hash produces a fixed-length opaque <em>byte</em> digest over arbitrary input; a check character performs error
+/// detection over a constrained ASCII text alphabet and emits a single <see cref="char" />. The families are kept
+/// distinct by design rather than unified under one base type.
+/// </para>
+/// <para>
 /// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and
-/// <see cref="GetCurrentCheckDigit" /> — mirrors the familiar hash-algorithm idiom. Reading the current check character
-/// is non-destructive and idempotent. Concrete implementations document their empty-body behavior.
+/// <see cref="GetCurrentCheckDigit" /> — will nonetheless feel familiar to anyone who has used a hash algorithm:
+/// input is accumulated, the computation can be restarted, and reading the current check character is non-destructive
+/// and idempotent. That resemblance is incidental convenience, not a shared contract. Concrete implementations document
+/// their empty-body behavior.
 /// </para>
 /// <para>
 /// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
@@ -43,6 +52,9 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// CheckDigitOutputAlphabet outputs = algo.OutputAlphabet;
 ///]]>
 /// </example>
+/// <seealso cref="CheckDigitAlgorithm" />
+/// <seealso cref="MultiCharCheckDigitAlgorithm" />
+/// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />
 public abstract class AlphanumericCheckDigitAlgorithm
 {
     /// <summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/CheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/CheckDigitAlgorithm.cs
@@ -12,16 +12,24 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// <remarks>
 /// <para>
 /// A check-digit algorithm consumes a sequence of decimal digits (<c>'0'</c> to <c>'9'</c>) and yields a single
-/// trailing digit that, when appended to the body, allows the concatenated sequence to be validated. Unlike the
-/// byte-stream oriented <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />, this class operates on
-/// <see cref="char" /> sequences natively and emits a single <see cref="char" /> result — matching the domain of card
-/// numbers, national identifiers, and serial codes on which these algorithms are typically applied.
+/// trailing digit that, when appended to the body, allows the concatenated sequence to be validated — matching the
+/// domain of card numbers, national identifiers, and serial codes on which these algorithms are typically applied.
+/// </para>
+/// <para>
+/// This is a deliberately separate family from the byte-stream oriented
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />, and it does <b>not</b> derive from it. The two serve
+/// different purposes: a non-cryptographic hash produces a fixed-length opaque <em>byte</em> digest over arbitrary
+/// input, whereas a check digit performs error detection over a constrained ASCII text alphabet and emits a single
+/// <see cref="char" /> result. Modeling one as the other would either narrow the hash contract or reduce the check
+/// character to an encoding artifact, so the families are kept distinct by design.
 /// </para>
 /// <para>
 /// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and
-/// <see cref="GetCurrentCheckDigit" /> — mirrors the familiar hash-algorithm idiom. Reading the current check digit is
-/// non-destructive and idempotent. On an empty body every built-in algorithm in this library returns the digit
-/// <c>'0'</c>; concrete implementations document any exception.
+/// <see cref="GetCurrentCheckDigit" /> — will nonetheless feel familiar to anyone who has used a hash algorithm:
+/// <see cref="Append(ReadOnlySpan{char})" /> accumulates input, <see cref="Reset" /> restarts the computation, and
+/// reading the current check digit is non-destructive and idempotent. That resemblance is incidental convenience for
+/// the reader's intuition, not a shared contract. On an empty body every built-in algorithm in this library returns the
+/// digit <c>'0'</c>; concrete implementations document any exception.
 /// </para>
 /// <para>
 /// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
@@ -43,6 +51,9 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// algo.Append("7893729977");
 ///]]>
 /// </example>
+/// <seealso cref="AlphanumericCheckDigitAlgorithm" />
+/// <seealso cref="MultiCharCheckDigitAlgorithm" />
+/// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />
 public abstract class CheckDigitAlgorithm
 {
     /// <summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing.CheckDigits/MultiCharCheckDigitAlgorithm.cs
@@ -18,9 +18,18 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// concrete algorithm accepts via <see cref="InputAlphabet" />.
 /// </para>
 /// <para>
+/// Like the rest of this family, the type is intentionally separate from the byte-stream oriented
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" /> and does <b>not</b> derive from it. A non-cryptographic
+/// hash produces a fixed-length opaque <em>byte</em> digest over arbitrary input; a check code performs error detection
+/// over a constrained ASCII text alphabet and emits a short run of <see cref="char" /> values. The families are kept
+/// distinct by design rather than unified under one base type.
+/// </para>
+/// <para>
 /// The streaming surface — <see cref="Append(ReadOnlySpan{char})" />, <see cref="Reset" />, and the two
-/// <c>GetCurrentCheckDigits</c> overloads — mirrors the familiar hash-algorithm idiom. Reading the current check code
-/// is non-destructive and idempotent. Concrete implementations document their empty-body behavior.
+/// <c>GetCurrentCheckDigits</c> overloads — will nonetheless feel familiar to anyone who has used a hash algorithm:
+/// input is accumulated, the computation can be restarted, and reading the current check code is non-destructive and
+/// idempotent. That resemblance is incidental convenience, not a shared contract. Concrete implementations document
+/// their empty-body behavior.
 /// </para>
 /// <para>
 /// Instances are <b>not</b> thread-safe. Each thread that needs a running check should construct its own instance.
@@ -39,6 +48,9 @@ namespace Bodu.IO.Hashing.CheckDigits;
 /// algo.GetCurrentCheckDigits(check);                   // "82"
 ///]]>
 /// </example>
+/// <seealso cref="CheckDigitAlgorithm" />
+/// <seealso cref="AlphanumericCheckDigitAlgorithm" />
+/// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm" />
 public abstract class MultiCharCheckDigitAlgorithm
 {
     /// <summary>

--- a/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
+++ b/Bodu.IO.Hashing/src/IO.Hashing/BlockNonCryptographicHashAlgorithm.cs
@@ -89,6 +89,13 @@ namespace Bodu.IO.Hashing;
 /// <see cref="System.Security.Cryptography.HashAlgorithm" /> hierarchy instead. Instances are not thread-safe; share
 /// behind explicit synchronization.
 /// </para>
+/// <para>
+/// <strong>Related family.</strong> For error detection over a constrained ASCII text domain — card numbers, account
+/// identifiers, and serial codes — see the separate check-digit family rooted at
+/// <see cref="Bodu.IO.Hashing.CheckDigits.CheckDigitAlgorithm" />. It is intentionally <em>not</em> part of the
+/// <see cref="System.IO.Hashing.NonCryptographicHashAlgorithm" /> hierarchy: it consumes <see cref="char" /> sequences
+/// and emits a <see cref="char" />/<see cref="string" /> check value rather than a byte digest.
+/// </para>
 /// </remarks>
 /// <example>
 ///<![CDATA[
@@ -126,6 +133,7 @@ namespace Bodu.IO.Hashing;
 ///]]>
 /// </example>
 /// <seealso cref="System.IO.Hashing.NonCryptographicHashAlgorithm"/> <seealso cref="IResumableHashAlgorithm"/>
+/// <seealso cref="Bodu.IO.Hashing.CheckDigits.CheckDigitAlgorithm"/>
 public abstract class BlockNonCryptographicHashAlgorithm<T>
     : NonCryptographicHashAlgorithm
     where T : BlockNonCryptographicHashAlgorithm<T>, new()


### PR DESCRIPTION
## Summary

This PR enhances the XML documentation across the check-digit algorithm family to explicitly clarify the intentional design separation from the `System.IO.Hashing.NonCryptographicHashAlgorithm` hierarchy, and to add cross-references between related types.

## Changes

- **CheckDigitAlgorithm.cs**: Expanded remarks to explain why the check-digit family is deliberately separate from `NonCryptographicHashAlgorithm` — the two serve fundamentally different purposes (fixed-length opaque byte digests vs. single-character error detection over constrained ASCII). Clarified that the streaming API surface (`Append`, `Reset`, `GetCurrentCheckDigit`) resembles the hash-algorithm idiom for convenience, not as a shared contract. Added `<seealso>` cross-references to related types.

- **AlphanumericCheckDigitAlgorithm.cs**: Added parallel explanation of the intentional separation from `NonCryptographicHashAlgorithm`, emphasizing the difference between byte digests and single-character check values. Clarified the streaming surface resemblance as incidental convenience. Added `<seealso>` cross-references.

- **MultiCharCheckDigitAlgorithm.cs**: Added matching explanation of the design separation and streaming API resemblance. Added `<seealso>` cross-references to sibling types and the hash algorithm family.

- **BlockNonCryptographicHashAlgorithm.cs**: Added a new "Related family" paragraph in remarks directing readers to the check-digit family as an intentionally separate alternative for error detection over constrained ASCII domains. Added `<seealso>` reference to `CheckDigitAlgorithm`.

## Implementation Details

The documentation changes emphasize that:
1. Check-digit algorithms consume and emit `char` sequences, not byte streams
2. They perform error detection over a constrained alphabet (card numbers, identifiers, serial codes), not general-purpose hashing
3. The streaming API surface is a familiar convenience pattern, not a contract inheritance
4. The families are kept distinct by design to avoid narrowing the hash contract or reducing check characters to encoding artifacts
5. Cross-references help readers navigate between the two families and understand their complementary roles

https://claude.ai/code/session_01SV68VY9L4k9fiBMGw4xmgv