### PR TITLE
Bootstrap .NET 10 SDK and repair dotnet-dnceng plugin on session start

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 # Installs the .NET SDK 10.0 on session start so the agent can run `dotnet
-# build` and `dotnet test` against bodu.slnx. Only runs in the remote Claude
-# Code on the web environment; on a developer's local machine the SDK is
-# expected to be installed already.
+# build` and `dotnet test` against bodu.slnx, and repairs the dotnet-dnceng
+# Claude Code plugin whose upstream manifest currently fails validation (see
+# repair_dnceng_plugin below). Only runs in the remote Claude Code on the web
+# environment; on a developer's local machine the SDK is expected to be
+# installed already.
 #
 # SDK 10.0 is required because the solution uses C# 14 language features (for
 # example the `field` keyword on semi-auto properties). An older SDK such as

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -17,6 +17,39 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
     exit 0
 fi
 
+# ---------------------------------------------------------------------------
+# dotnet-dnceng plugin repair
+#
+# .claude/settings.json registers the dotnet/arcade-skills marketplace and
+# enables its dotnet-dnceng plugin. The upstream plugin manifest currently
+# declares "agents": ["agents/ci-investigator.agent.md"], but Claude Code
+# requires plugin-relative paths to start with "./", so the automatic install
+# at session start fails manifest validation. Patch the cached marketplace
+# clone and install the plugin so its skills load from the next session in
+# this container onward. Idempotent, and a no-op once the manifest is fixed
+# upstream; failures never block session start.
+# ---------------------------------------------------------------------------
+repair_dnceng_plugin() {
+    command -v claude >/dev/null 2>&1 || return 0
+
+    local manifest="$HOME/.claude/plugins/marketplaces/dotnet-arcade-skills/plugins/dotnet-dnceng/plugin.json"
+    [ -f "$manifest" ] || return 0
+
+    if grep -q '"agents/ci-investigator\.agent\.md"' "$manifest"; then
+        sed -i 's#"agents/ci-investigator\.agent\.md"#"./agents/ci-investigator.agent.md"#' "$manifest"
+        echo "[session-start] Patched dotnet-dnceng plugin manifest (agents path lacked ./ prefix)."
+    fi
+
+    if [ ! -d "$HOME/.claude/plugins/cache/dotnet-arcade-skills/dotnet-dnceng" ]; then
+        if claude plugin install dotnet-dnceng@dotnet-arcade-skills >/dev/null 2>&1; then
+            echo "[session-start] Installed dotnet-dnceng plugin; its skills load from the next session."
+        else
+            echo "[session-start] dotnet-dnceng plugin install failed; its skills are unavailable in this container." >&2
+        fi
+    fi
+}
+repair_dnceng_plugin || true
+
 # Fast path: a .NET 10 SDK is already installed. Checking for the 10.x band
 # specifically (rather than merely `dotnet` on PATH) ensures we still upgrade
 # a container image that ships only an older SDK such as 8.0.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "extraKnownMarketplaces": {
+    "dotnet-arcade-skills": {
+      "source": {
+        "source": "github",
+        "repo": "dotnet/arcade-skills"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "dotnet-dnceng@dotnet-arcade-skills": true
+  },
   "hooks": {
     "SessionStart": [
       {

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ See **Test Tiers** below for the category convention each runsettings file appli
 
 ### SDK Bootstrap (Claude Code on the web)
 
-`.claude/hooks/session-start.sh` installs `dotnet-sdk-8.0` from `apt` on session start when running in the remote Claude Code on the web environment (`CLAUDE_CODE_REMOTE=true`). It is idempotent — when `dotnet` is already on `PATH` it exits immediately, so resume / clear / compact sessions pay no extra cost.
+`.claude/hooks/session-start.sh` installs `dotnet-sdk-10.0` from `apt` on session start when running in the remote Claude Code on the web environment (`CLAUDE_CODE_REMOTE=true`). It is idempotent — when a .NET 10 SDK is already installed it exits immediately, so resume / clear / compact sessions pay no extra cost.
 
-Local developer machines are untouched (the hook short-circuits when `CLAUDE_CODE_REMOTE` is unset), and the hook is registered via `.claude/settings.json`.
+The hook also repairs the `dotnet-dnceng` plugin that `.claude/settings.json` enables from the `dotnet/arcade-skills` marketplace (`extraKnownMarketplaces` / `enabledPlugins`): the upstream plugin manifest currently fails Claude Code's path validation (its `agents` entry lacks the required `./` prefix), so the hook patches the cached marketplace clone and installs the plugin. Its skills then load from the next session in the container. The repair is a no-op once the manifest is fixed upstream and can be removed at that point.
+
+Local developer machines are untouched (the hook short-circuits when `CLAUDE_CODE_REMOTE` is unset), and the hook is registered via `.claude/settings.json`. Note for local use: until the upstream manifest fix lands, the plugin install triggered by the project settings may fail validation on a local machine; sessions still work, just without the plugin's skills.
 
 ## Branching and Commits
 


### PR DESCRIPTION
## Summary

Updates the Claude Code session-start hook to install .NET SDK 10.0 (required for C# 14 language features used in the solution) and adds logic to repair the `dotnet-dnceng` plugin from the `dotnet/arcade-skills` marketplace. The hook also registers the marketplace and enables the plugin via `.claude/settings.json`.

## Key Changes

- **`.claude/hooks/session-start.sh`**
  - Updated SDK version from 8.0 to 10.0 in comments and logic
  - Added `repair_dnceng_plugin()` function that:
    - Patches the cached plugin manifest to add the required `./` prefix to the `agents` path (upstream manifest currently fails Claude Code validation)
    - Installs the plugin via `claude plugin install` if not already cached
    - Gracefully handles failures and is idempotent
  - Invokes the repair function at session start (only in remote Claude Code environment)

- **`.claude/settings.json`**
  - Added `extraKnownMarketplaces` configuration to register the `dotnet/arcade-skills` marketplace from `dotnet/arcade-skills` GitHub repo
  - Added `enabledPlugins` to enable `dotnet-dnceng@dotnet-arcade-skills`

- **`CLAUDE.md`**
  - Updated SDK Bootstrap section to reflect .NET 10.0 requirement
  - Documented the plugin repair mechanism and its purpose
  - Added note for local developers about potential plugin install failures until upstream manifest is fixed

## Implementation Details

The plugin repair is defensive and non-blocking:
- Returns early if the `claude` CLI is unavailable or manifest doesn't exist
- Uses `sed` to patch the manifest path in-place (idempotent)
- Attempts plugin install only if not already cached
- All failures are logged but never prevent session start (trailing `|| true`)
- The repair becomes a no-op once the upstream manifest is fixed and can be removed at that point

https://claude.ai/code/session_01Vkpc4MZVz6VhbyjW6kLYxi