### PR TITLE
docs(toml,bencode): add XML <example> snippets to converter and attribute types

### DIFF
--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConstructorAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConstructorAttribute.cs
@@ -14,6 +14,24 @@ namespace Bodu.Text.Bencode.Serialization;
 /// When no constructor carries this attribute, the serializer uses a public parameterless constructor when one exists,
 /// otherwise the single declared constructor, otherwise the constructor with the most parameters.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Endpoint
+/// {
+///     [BencodeConstructor]
+///     public Endpoint(string host, int port) => (Host, Port) = (host, port);
+///
+///     public Endpoint(Uri uri) : this(uri.Host, uri.Port) { }
+///
+///     public string Host { get; }
+///     public int Port { get; }
+/// }
+///
+/// // Deserialization instantiates Endpoint through the marked constructor.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
 public sealed class BencodeConstructorAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterAttribute.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// The referenced type must derive from <see cref="BencodeConverter" /> and declare a public parameterless constructor.
 /// Applied to a member, the converter governs that member only; applied to a type, it governs every use of the type.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Package
+/// {
+///     [BencodeConverter(typeof(VersionConverter))]
+///     public Version Version { get; set; } = new(1, 2, 3);
+/// }
+///
+/// // VersionConverter governs the member, writing the byte string 5:1.2.3.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(
     AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum,
     AllowMultiple = false,

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterFactory.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterFactory.cs
@@ -19,6 +19,21 @@ namespace Bodu.Text.Bencode.Serialization;
 /// <see cref="CreateConverter" /> to obtain the converter for the specific closed type being serialized. A factory is
 /// never asked to read or write a value itself.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class StackConverterFactory : BencodeConverterFactory
+/// {
+///     public override bool CanConvert(Type typeToConvert) =>
+///         typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Stack<>);
+///
+///     public override BencodeConverter CreateConverter(Type typeToConvert, BencodeSerializerOptions options) =>
+///         (BencodeConverter)Activator.CreateInstance(
+///             typeof(StackConverter<>).MakeGenericType(typeToConvert.GetGenericArguments()[0]))!;
+/// }
+///]]>
+/// </code>
+/// </example>
 public abstract class BencodeConverterFactory
     : BencodeConverter
 {

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterOfT.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeConverterOfT.cs
@@ -15,16 +15,18 @@ namespace Bodu.Text.Bencode.Serialization;
 /// </summary>
 /// <typeparam name="T">The type the converter handles.</typeparam>
 /// <example>
+/// <code language="csharp">
 ///<![CDATA[
-/// public sealed class BooleanConverter : BencodeConverter<bool>
+/// public sealed class VersionConverter : BencodeConverter<Version>
 /// {
-///     public override bool Read(ref Utf8BencodeReader reader, Type typeToConvert, BencodeSerializerOptions options) =>
-///         reader.GetInt64() != 0;
+///     public override Version Read(ref Utf8BencodeReader reader, Type typeToConvert, BencodeSerializerOptions options) =>
+///         Version.Parse(reader.GetString());
 ///
-///     public override void Write(Utf8BencodeWriter writer, bool value, BencodeSerializerOptions options) =>
-///         writer.WriteInteger(value ? 1 : 0);
+///     public override void Write(Utf8BencodeWriter writer, Version value, BencodeSerializerOptions options) =>
+///         writer.WriteString(value.ToString());
 /// }
 ///]]>
+/// </code>
 /// </example>
 public abstract class BencodeConverter<T>
     : BencodeConverter

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeExtensionDataAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeExtensionDataAttribute.cs
@@ -23,6 +23,21 @@ namespace Bodu.Text.Bencode.Serialization;
 /// position automatically.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig
+/// {
+///     public int Port { get; set; }
+///
+///     [BencodeExtensionData]
+///     public Dictionary<string, BencodeNode>? Extra { get; set; }
+/// }
+///
+/// // Keys that map to no member land in Extra and are written back on serialization.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class BencodeExtensionDataAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeIgnoreAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeIgnoreAttribute.cs
@@ -10,6 +10,22 @@ namespace Bodu.Text.Bencode.Serialization;
 /// Excludes a property or field from Bencode serialization, either unconditionally or under the condition given by
 /// <see cref="Condition" />.
 /// </summary>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Account
+/// {
+///     [BencodeIgnore]
+///     public string? Secret { get; set; }
+///
+///     [BencodeIgnore(Condition = BencodeIgnoreCondition.WhenWritingNull)]
+///     public string? Comment { get; set; }
+/// }
+///
+/// // Secret is never written; Comment is written only when it is non-null.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class BencodeIgnoreAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeIncludeAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeIncludeAttribute.cs
@@ -17,6 +17,22 @@ namespace Bodu.Text.Bencode.Serialization;
 /// visibility. Public fields participate only when this attribute is applied or
 /// <see cref="BencodeSerializerOptions.IncludeFields" /> is enabled; non-public fields are never surfaced.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Counter
+/// {
+///     [BencodeInclude]
+///     public int Total { get; private set; }
+///
+///     [BencodeInclude]
+///     public int Retries;
+/// }
+///
+/// // Both members round-trip, despite the non-public setter and the field.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class BencodeIncludeAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeNamingPolicyAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeNamingPolicyAttribute.cs
@@ -16,6 +16,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// <see cref="BencodePropertyNameAttribute" /> is unaffected, since that attribute always takes precedence over any
 /// naming policy.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [BencodeNamingPolicy(BencodeKnownNamingPolicy.SnakeCaseLower)]
+/// public sealed class RetryPolicy
+/// {
+///     public int MaxRetryCount { get; set; } = 5;
+/// }
+///
+/// // Serializes under the key "max_retry_count": d15:max_retry_counti5ee
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
 public sealed class BencodeNamingPolicyAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeNumberEnumConverter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeNumberEnumConverter.cs
@@ -18,6 +18,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// itself, or register it on <see cref="BencodeSerializerOptions.Converters" />. It exposes a public parameterless
 /// constructor so it can be used through the converter attribute.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class WorkItem
+/// {
+///     [BencodeConverter(typeof(BencodeNumberEnumConverter<Priority>))]
+///     public Priority Priority { get; set; }
+/// }
+///
+/// // Priority.High (underlying value 2) serializes as the integer i2e.
+///]]>
+/// </code>
+/// </example>
 public sealed class BencodeNumberEnumConverter<TEnum>
     : BencodeConverterFactory
     where TEnum : struct, Enum

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeObjectCreationHandlingAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeObjectCreationHandlingAttribute.cs
@@ -16,6 +16,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// the type that does not carry its own attribute. A member-level attribute takes precedence over a type-level one, and
 /// both take precedence over the options-level default.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Pipeline
+/// {
+///     [BencodeObjectCreationHandling(BencodeObjectCreationHandling.Populate)]
+///     public List<string> Steps { get; } = new() { "restore" };
+/// }
+///
+/// // Deserialized entries are appended to the existing list instead of replacing it.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class BencodeObjectCreationHandlingAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodePropertyNameAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodePropertyNameAttribute.cs
@@ -10,6 +10,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// Specifies the dictionary key used for a property or field when it is serialized to Bencode, overriding the member's
 /// CLR name and any configured naming policy.
 /// </summary>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Profile
+/// {
+///     [BencodePropertyName("display-name")]
+///     public string DisplayName { get; set; } = "Ada";
+/// }
+///
+/// // Serializes as the dictionary entry: 12:display-name3:Ada
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class BencodePropertyNameAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodePropertyOrderAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodePropertyOrderAttribute.cs
@@ -16,6 +16,23 @@ namespace Bodu.Text.Bencode.Serialization;
 /// ascending key order when a dictionary is closed, this order governs the sequence in which members are presented to
 /// the writer rather than the final on-the-wire order.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Manifest
+/// {
+///     [BencodePropertyOrder(2)]
+///     public string Name { get; set; } = "demo";
+///
+///     [BencodePropertyOrder(1)]
+///     public int Version { get; set; } = 3;
+/// }
+///
+/// // Version is presented to the writer first, but the closed dictionary is still
+/// // emitted in canonical key order: d4:Name4:demo7:Versioni3ee
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class BencodePropertyOrderAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeRequiredAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeRequiredAttribute.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// the member must appear in the Bencode dictionary being read, otherwise a
 /// <see cref="BencodeSerializationException" /> is thrown.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig
+/// {
+///     [BencodeRequired]
+///     public string Host { get; set; } = string.Empty;
+/// }
+///
+/// // Deserializing input without a "Host" key throws BencodeSerializationException.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class BencodeRequiredAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumConverter.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumConverter.cs
@@ -18,6 +18,16 @@ namespace Bodu.Text.Bencode.Serialization;
 /// it to a single enumeration. Two constructors are provided: a parameterless form that applies no naming policy and
 /// accepts integers on read, and a form that takes an explicit naming policy and integer-handling flag.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// var options = new BencodeSerializerOptions();
+/// options.Converters.Add(new BencodeStringEnumConverter(BencodeNamingPolicy.SnakeCaseLower, allowIntegerValues: false));
+///
+/// // Status.OnHold now serializes as the byte string 7:on_hold.
+///]]>
+/// </code>
+/// </example>
 public sealed class BencodeStringEnumConverter
     : BencodeConverterFactory
 {

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumConverterOfT.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumConverterOfT.cs
@@ -19,6 +19,20 @@ namespace Bodu.Text.Bencode.Serialization;
 /// a <see cref="BencodeConverterAttribute" /> on a member, property, or the enumeration itself, because it exposes a
 /// public parameterless constructor and applies to a single enumeration type.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [BencodeConverter(typeof(BencodeStringEnumConverter<Status>))]
+/// public enum Status
+/// {
+///     Active,
+///     OnHold,
+/// }
+///
+/// // Status.OnHold serializes as the byte string 6:OnHold.
+///]]>
+/// </code>
+/// </example>
 public sealed class BencodeStringEnumConverter<TEnum>
     : BencodeConverterFactory
     where TEnum : struct, Enum

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumMemberNameAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeStringEnumMemberNameAttribute.cs
@@ -21,6 +21,22 @@ namespace Bodu.Text.Bencode.Serialization;
 /// Bencode serialization attribute family.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [BencodeConverter(typeof(BencodeStringEnumConverter<Status>))]
+/// public enum Status
+/// {
+///     Active,
+///
+///     [BencodeStringEnumMemberName("on-hold")]
+///     OnHold,
+/// }
+///
+/// // Status.OnHold serializes as the byte string 7:on-hold.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
 public sealed class BencodeStringEnumMemberNameAttribute
     : BencodeAttribute

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeUnmappedMemberHandlingAttribute.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/BencodeUnmappedMemberHandlingAttribute.cs
@@ -15,6 +15,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// default for that type. A type with an extension-data member still captures unmapped keys into that member regardless
 /// of this setting.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [BencodeUnmappedMemberHandling(BencodeUnmappedMemberHandling.Disallow)]
+/// public sealed class StrictConfig
+/// {
+///     public int Port { get; set; }
+/// }
+///
+/// // Input containing a key that maps to no member throws BencodeSerializationException.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
 public sealed class BencodeUnmappedMemberHandlingAttribute
     : BencodeAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConstructorAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConstructorAttribute.cs
@@ -14,6 +14,24 @@ namespace Bodu.Text.Toml.Serialization;
 /// When no constructor carries this attribute, the serializer uses a public parameterless constructor when one exists,
 /// otherwise the single declared constructor, otherwise the constructor with the most parameters.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Endpoint
+/// {
+///     [TomlConstructor]
+///     public Endpoint(string host, int port) => (Host, Port) = (host, port);
+///
+///     public Endpoint(Uri uri) : this(uri.Host, uri.Port) { }
+///
+///     public string Host { get; }
+///     public int Port { get; }
+/// }
+///
+/// // Deserialization instantiates Endpoint through the marked constructor.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Constructor, AllowMultiple = false, Inherited = false)]
 public sealed class TomlConstructorAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterAttribute.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// The referenced type must derive from <see cref="TomlConverter" /> and declare a public parameterless constructor.
 /// Applied to a member, the converter governs that member only; applied to a type, it governs every use of the type.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Package
+/// {
+///     [TomlConverter(typeof(VersionConverter))]
+///     public Version Version { get; set; } = new(1, 2, 3);
+/// }
+///
+/// // VersionConverter governs the member: Version = "1.2.3"
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(
     AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum,
     AllowMultiple = false,

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterFactory.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterFactory.cs
@@ -19,6 +19,21 @@ namespace Bodu.Text.Toml.Serialization;
 /// <see cref="CreateConverter" /> to obtain the converter for the specific closed type being serialized. A factory is
 /// never asked to read or write a value itself.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class StackConverterFactory : TomlConverterFactory
+/// {
+///     public override bool CanConvert(Type typeToConvert) =>
+///         typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Stack<>);
+///
+///     public override TomlConverter CreateConverter(Type typeToConvert, TomlSerializerOptions options) =>
+///         (TomlConverter)Activator.CreateInstance(
+///             typeof(StackConverter<>).MakeGenericType(typeToConvert.GetGenericArguments()[0]))!;
+/// }
+///]]>
+/// </code>
+/// </example>
 public abstract class TomlConverterFactory
     : TomlConverter
 {

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterOfT.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlConverterOfT.cs
@@ -15,16 +15,18 @@ namespace Bodu.Text.Toml.Serialization;
 /// </summary>
 /// <typeparam name="T">The type the converter handles.</typeparam>
 /// <example>
+/// <code language="csharp">
 ///<![CDATA[
-/// public sealed class BooleanConverter : TomlConverter<bool>
+/// public sealed class VersionConverter : TomlConverter<Version>
 /// {
-///     public override bool Read(ref TomlDocumentReader reader, Type typeToConvert, TomlSerializerOptions options) =>
-///         reader.GetInt64() != 0;
+///     public override Version Read(ref TomlDocumentReader reader, Type typeToConvert, TomlSerializerOptions options) =>
+///         Version.Parse(reader.GetString());
 ///
-///     public override void Write(Utf8TomlWriter writer, bool value, TomlSerializerOptions options) =>
-///         writer.WriteInteger(value ? 1 : 0);
+///     public override void Write(Utf8TomlWriter writer, Version value, TomlSerializerOptions options) =>
+///         writer.WriteString(value.ToString());
 /// }
 ///]]>
+/// </code>
 /// </example>
 public abstract class TomlConverter<T>
     : TomlConverter

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlExtensionDataAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlExtensionDataAttribute.cs
@@ -23,6 +23,21 @@ namespace Bodu.Text.Toml.Serialization;
 /// On serialization the captured entries are written alongside the type's other members in document order.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig
+/// {
+///     public int Port { get; set; }
+///
+///     [TomlExtensionData]
+///     public Dictionary<string, TomlNode>? Extra { get; set; }
+/// }
+///
+/// // Keys that map to no member land in Extra and are written back on serialization.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class TomlExtensionDataAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlIgnoreAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlIgnoreAttribute.cs
@@ -10,6 +10,22 @@ namespace Bodu.Text.Toml.Serialization;
 /// Excludes a property or field from TOML serialization, either unconditionally or under the condition given by
 /// <see cref="Condition" />.
 /// </summary>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Account
+/// {
+///     [TomlIgnore]
+///     public string? Secret { get; set; }
+///
+///     [TomlIgnore(Condition = TomlIgnoreCondition.WhenWritingNull)]
+///     public string? Comment { get; set; }
+/// }
+///
+/// // Secret is never written; Comment is written only when it is non-null.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class TomlIgnoreAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlIncludeAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlIncludeAttribute.cs
@@ -17,6 +17,22 @@ namespace Bodu.Text.Toml.Serialization;
 /// visibility. Public fields participate only when this attribute is applied or
 /// <see cref="TomlSerializerOptions.IncludeFields" /> is enabled; non-public fields are never surfaced.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Counter
+/// {
+///     [TomlInclude]
+///     public int Total { get; private set; }
+///
+///     [TomlInclude]
+///     public int Retries;
+/// }
+///
+/// // Both members round-trip, despite the non-public setter and the field.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class TomlIncludeAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlNamingPolicyAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlNamingPolicyAttribute.cs
@@ -15,6 +15,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// on <see cref="TomlNamingPolicy" />. A member that carries an explicit <see cref="TomlPropertyNameAttribute" /> is
 /// unaffected, since that attribute always takes precedence over any naming policy.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [TomlNamingPolicy(TomlKnownNamingPolicy.SnakeCaseLower)]
+/// public sealed class RetryPolicy
+/// {
+///     public int MaxRetryCount { get; set; } = 5;
+/// }
+///
+/// // Serializes as: max_retry_count = 5
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
 public sealed class TomlNamingPolicyAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlNumberEnumConverter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlNumberEnumConverter.cs
@@ -18,6 +18,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// or register it on <see cref="TomlSerializerOptions.Converters" />. It exposes a public parameterless constructor so
 /// it can be used through the converter attribute.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class WorkItem
+/// {
+///     [TomlConverter(typeof(TomlNumberEnumConverter<Priority>))]
+///     public Priority Priority { get; set; }
+/// }
+///
+/// // Priority.High (underlying value 2) serializes as: Priority = 2
+///]]>
+/// </code>
+/// </example>
 public sealed class TomlNumberEnumConverter<TEnum>
     : TomlConverterFactory
     where TEnum : struct, Enum

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlObjectCreationHandlingAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlObjectCreationHandlingAttribute.cs
@@ -16,6 +16,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// the type that does not carry its own attribute. A member-level attribute takes precedence over a type-level one, and
 /// both take precedence over the options-level default.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Pipeline
+/// {
+///     [TomlObjectCreationHandling(TomlObjectCreationHandling.Populate)]
+///     public List<string> Steps { get; } = new() { "restore" };
+/// }
+///
+/// // Deserialized entries are appended to the existing list instead of replacing it.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface | AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class TomlObjectCreationHandlingAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlPropertyNameAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlPropertyNameAttribute.cs
@@ -10,6 +10,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// Specifies the dictionary key used for a property or field when it is serialized to TOML, overriding the member's CLR
 /// name and any configured naming policy.
 /// </summary>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Profile
+/// {
+///     [TomlPropertyName("display-name")]
+///     public string DisplayName { get; set; } = "Ada";
+/// }
+///
+/// // Serializes as: display-name = "Ada"
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class TomlPropertyNameAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlPropertyOrderAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlPropertyOrderAttribute.cs
@@ -15,6 +15,24 @@ namespace Bodu.Text.Toml.Serialization;
 /// and otherwise keep their declaration order. Because the TOML writer preserves the order in which members are
 /// presented, this order governs the on-the-wire sequence of the table's key/value lines.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Manifest
+/// {
+///     [TomlPropertyOrder(2)]
+///     public string Name { get; set; } = "demo";
+///
+///     [TomlPropertyOrder(1)]
+///     public int Version { get; set; } = 3;
+/// }
+///
+/// // Emitted with Version first:
+/// // Version = 3
+/// // Name = "demo"
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false, Inherited = true)]
 public sealed class TomlPropertyOrderAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlRequiredAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlRequiredAttribute.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// the member must appear in the TOML table being read, otherwise a <see cref="TomlSerializationException" /> is
 /// thrown.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig
+/// {
+///     [TomlRequired]
+///     public string Host { get; set; } = string.Empty;
+/// }
+///
+/// // Deserializing input without a "Host" key throws TomlSerializationException.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field, AllowMultiple = false)]
 public sealed class TomlRequiredAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumConverter.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumConverter.cs
@@ -18,6 +18,16 @@ namespace Bodu.Text.Toml.Serialization;
 /// single enumeration. Two constructors are provided: a parameterless form that applies no naming policy and accepts
 /// integers on read, and a form that takes an explicit naming policy and integer-handling flag.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// var options = new TomlSerializerOptions();
+/// options.Converters.Add(new TomlStringEnumConverter(TomlNamingPolicy.SnakeCaseLower, allowIntegerValues: false));
+///
+/// // Status.OnHold now serializes as the TOML string "on_hold".
+///]]>
+/// </code>
+/// </example>
 public sealed class TomlStringEnumConverter
     : TomlConverterFactory
 {

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumConverterOfT.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumConverterOfT.cs
@@ -19,6 +19,20 @@ namespace Bodu.Text.Toml.Serialization;
 /// <see cref="TomlConverterAttribute" /> on a member, property, or the enumeration itself, because it exposes a public
 /// parameterless constructor and applies to a single enumeration type.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [TomlConverter(typeof(TomlStringEnumConverter<Status>))]
+/// public enum Status
+/// {
+///     Active,
+///     OnHold,
+/// }
+///
+/// // Status.OnHold serializes as the TOML string "OnHold".
+///]]>
+/// </code>
+/// </example>
 public sealed class TomlStringEnumConverter<TEnum>
     : TomlConverterFactory
     where TEnum : struct, Enum

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumMemberNameAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlStringEnumMemberNameAttribute.cs
@@ -21,6 +21,22 @@ namespace Bodu.Text.Toml.Serialization;
 /// serialization attribute family.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [TomlConverter(typeof(TomlStringEnumConverter<Status>))]
+/// public enum Status
+/// {
+///     Active,
+///
+///     [TomlStringEnumMemberName("on-hold")]
+///     OnHold,
+/// }
+///
+/// // Status.OnHold serializes as the TOML string "on-hold".
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Field, AllowMultiple = false)]
 public sealed class TomlStringEnumMemberNameAttribute
     : TomlAttribute

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlUnmappedMemberHandlingAttribute.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/TomlUnmappedMemberHandlingAttribute.cs
@@ -15,6 +15,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// default for that type. A type with an extension-data member still captures unmapped keys into that member regardless
 /// of this setting.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// [TomlUnmappedMemberHandling(TomlUnmappedMemberHandling.Disallow)]
+/// public sealed class StrictConfig
+/// {
+///     public int Port { get; set; }
+/// }
+///
+/// // Input containing a key that maps to no member throws TomlSerializationException.
+///]]>
+/// </code>
+/// </example>
 [AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
 public sealed class TomlUnmappedMemberHandlingAttribute
     : TomlAttribute

--- a/docs/guides/serialization/attributes.md
+++ b/docs/guides/serialization/attributes.md
@@ -1,0 +1,234 @@
+---
+title: Mapping attributes
+---
+
+# Mapping attributes
+
+Both serializers expose the same attribute family for shaping how a type maps to the wire: every TOML attribute derives <xref:Bodu.Text.Toml.Serialization.TomlAttribute> and every Bencode attribute derives <xref:Bodu.Text.Bencode.Serialization.BencodeAttribute>. The two families mirror each other exactly — each pattern below shows the TOML form and its output; the Bencode form is the same shape with the `Bencode` prefix, with the wire form noted where it differs in an interesting way.
+
+## Pattern 1 — Rename a member
+
+<xref:Bodu.Text.Toml.Serialization.TomlPropertyNameAttribute> pins the serialized key for one member, beating any naming policy:
+
+```csharp
+public sealed class Profile
+{
+    [TomlPropertyName("display-name")]
+    public string DisplayName { get; set; } = "Ada";
+}
+```
+
+```toml
+display-name = "Ada"
+```
+
+Bencode (`[BencodePropertyName("display-name")]`) writes the dictionary entry `12:display-name3:Ada`.
+
+## Pattern 2 — Apply a naming policy per type
+
+<xref:Bodu.Text.Toml.Serialization.TomlNamingPolicyAttribute> overrides the options-level `PropertyNamingPolicy` for one type:
+
+```csharp
+[TomlNamingPolicy(TomlKnownNamingPolicy.SnakeCaseLower)]
+public sealed class RetryPolicy
+{
+    public int MaxRetryCount { get; set; } = 5;
+}
+```
+
+```toml
+max_retry_count = 5
+```
+
+A member carrying `[TomlPropertyName]` is unaffected — the explicit name always wins. `TomlKnownNamingPolicy.Unspecified` defers back to the options.
+
+## Pattern 3 — Exclude members
+
+<xref:Bodu.Text.Toml.Serialization.TomlIgnoreAttribute> drops a member unconditionally, or under a condition:
+
+```csharp
+public sealed class Account
+{
+    public string Name { get; set; } = "svc";
+
+    [TomlIgnore]
+    public string? Secret { get; set; }
+
+    [TomlIgnore(Condition = TomlIgnoreCondition.WhenWritingNull)]
+    public string? Comment { get; set; }
+}
+```
+
+```toml
+Name = "svc"
+```
+
+`Secret` is never written; `Comment` appears only when non-null. `WhenWritingDefault` extends the rule to default value-type values.
+
+## Pattern 4 — Force a member in
+
+<xref:Bodu.Text.Toml.Serialization.TomlIncludeAttribute> binds non-public property accessors and surfaces public fields without turning on `IncludeFields` for the whole options:
+
+```csharp
+public sealed class Counter
+{
+    [TomlInclude]
+    public int Total { get; private set; }
+
+    [TomlInclude]
+    public int Retries;
+}
+```
+
+Both members now round-trip — the private setter is assigned on read, and the field participates like a property, following the same naming, ordering, ignore, required, and converter rules.
+
+## Pattern 5 — Control write order
+
+<xref:Bodu.Text.Toml.Serialization.TomlPropertyOrderAttribute> reorders the emitted key/value lines; members without the attribute default to order zero and keep declaration order:
+
+```csharp
+public sealed class Manifest
+{
+    [TomlPropertyOrder(2)]
+    public string Name { get; set; } = "demo";
+
+    [TomlPropertyOrder(1)]
+    public int Version { get; set; } = 3;
+}
+```
+
+```toml
+Version = 3
+Name = "demo"
+```
+
+> [!NOTE]
+> In Bencode the attribute governs only the order members are *presented to the writer* — the writer re-sorts dictionary entries into canonical ascending key order when the dictionary closes, so the example above still emits `d4:Name4:demo7:Versioni3ee` regardless of `[BencodePropertyOrder]`.
+
+## Pattern 6 — Require a key
+
+<xref:Bodu.Text.Toml.Serialization.TomlRequiredAttribute> makes deserialization fail when the key is absent, with the same effect as declaring the member with the C# `required` keyword:
+
+```csharp
+public sealed class ServerConfig
+{
+    [TomlRequired]
+    public string Host { get; set; } = string.Empty;
+}
+
+// Input without a "Host" key throws TomlSerializationException.
+```
+
+## Pattern 7 — Pick the deserialization constructor
+
+When a type declares more than one constructor, <xref:Bodu.Text.Toml.Serialization.TomlConstructorAttribute> resolves the ambiguity:
+
+```csharp
+public sealed class Endpoint
+{
+    [TomlConstructor]
+    public Endpoint(string host, int port) => (Host, Port) = (host, port);
+
+    public Endpoint(Uri uri) : this(uri.Host, uri.Port) { }
+
+    public string Host { get; }
+    public int Port { get; }
+}
+```
+
+Without the attribute the serializer prefers a public parameterless constructor, then a single declared constructor, then the constructor with the most parameters.
+
+## Pattern 8 — Capture unknown keys
+
+<xref:Bodu.Text.Toml.Serialization.TomlExtensionDataAttribute> designates one member that collects every key that maps to no other member, and writes the collected entries back out on serialization:
+
+```csharp
+public sealed class ServerConfig
+{
+    public int Port { get; set; }
+
+    [TomlExtensionData]
+    public Dictionary<string, TomlNode>? Extra { get; set; }
+}
+```
+
+The member must be a `TomlObject` or an `(I)Dictionary<string, TomlNode>` (Bencode: `BencodeObject` / `(I)Dictionary<string, BencodeNode>`), and a type may declare at most one.
+
+## Pattern 9 — Reject unknown keys
+
+<xref:Bodu.Text.Toml.Serialization.TomlUnmappedMemberHandlingAttribute> chooses, per type, between skipping a key that maps to no member (the default) and failing:
+
+```csharp
+[TomlUnmappedMemberHandling(TomlUnmappedMemberHandling.Disallow)]
+public sealed class StrictConfig
+{
+    public int Port { get; set; }
+}
+
+// Input containing an unrecognised key throws TomlSerializationException.
+```
+
+A type with an extension-data member (Pattern 8) still captures unmapped keys into that member regardless of this setting.
+
+## Pattern 10 — Populate instead of replace
+
+<xref:Bodu.Text.Toml.Serialization.TomlObjectCreationHandlingAttribute> controls whether deserialization replaces a member's value with a fresh instance or populates the instance already held — useful for get-only collection properties:
+
+```csharp
+public sealed class Pipeline
+{
+    [TomlObjectCreationHandling(TomlObjectCreationHandling.Populate)]
+    public List<string> Steps { get; } = new() { "restore" };
+}
+```
+
+Deserialized entries are appended to the existing list instead of replacing it. The attribute applies to a member or a whole type; member beats type, and both beat the options-level `PreferredObjectCreationHandling`.
+
+## Pattern 11 — Choose a converter
+
+<xref:Bodu.Text.Toml.Serialization.TomlConverterAttribute> selects the converter for a member, or for every use of a type:
+
+```csharp
+public sealed class Package
+{
+    [TomlConverter(typeof(VersionConverter))]
+    public Version Version { get; set; } = new(1, 2, 3);
+}
+```
+
+```toml
+Version = "1.2.3"
+```
+
+The referenced type must derive from the format's converter base and expose a public parameterless constructor. Writing converters — including the factory pattern and resolution order — is covered in [Writing converters](converters.md).
+
+## Pattern 12 — Name enum members
+
+<xref:Bodu.Text.Toml.Serialization.TomlStringEnumMemberNameAttribute> renames an individual enumeration member when the enum is serialized by name:
+
+```csharp
+[TomlConverter(typeof(TomlStringEnumConverter<Status>))]
+public enum Status
+{
+    Active,
+
+    [TomlStringEnumMemberName("on-hold")]
+    OnHold,
+}
+```
+
+```toml
+Status = "on-hold"
+```
+
+The attribute applies only to by-name serialization (the default enum handling, or an explicit string-enum converter); it is a no-op when the enum is written as an integer.
+
+## Precedence at a glance
+
+When several settings could govern the same member, the closest one wins:
+
+1. a member-level attribute (`[TomlPropertyName]`, `[TomlIgnore]`, `[TomlConverter]`, `[TomlObjectCreationHandling]`, …);
+2. a type-level attribute (`[TomlNamingPolicy]`, `[TomlConverter]`, `[TomlUnmappedMemberHandling]`, `[TomlObjectCreationHandling]`);
+3. the serializer options (`PropertyNamingPolicy`, `Converters`, `UnmappedMemberHandling`, `PreferredObjectCreationHandling`, `IncludeFields`).
+
+The same ladder applies to the `Bencode` family.

--- a/docs/guides/serialization/bencode.md
+++ b/docs/guides/serialization/bencode.md
@@ -41,7 +41,7 @@ var options = new BencodeSerializerOptions
 
 Naming policies cover `CamelCase`, `SnakeCaseLower` / `SnakeCaseUpper`, and `KebabCaseLower` / `KebabCaseUpper`. Pin a single member's name with `[BencodePropertyName("…")]`, which always wins over the policy.
 
-Properties are mapped by default; public fields join in when `IncludeFields` is set on the options, or individually with `[BencodeInclude]` on the field. Fields follow the same naming-policy, ignore, required, and converter rules as properties.
+Properties are mapped by default; public fields join in when `IncludeFields` is set on the options, or individually with `[BencodeInclude]` on the field. Fields follow the same naming-policy, ignore, required, and converter rules as properties. The full attribute family is catalogued in [Mapping attributes](attributes.md).
 
 ## Pattern 4 — Handle the kinds Bencode cannot represent
 

--- a/docs/guides/serialization/converters.md
+++ b/docs/guides/serialization/converters.md
@@ -4,9 +4,9 @@ title: Writing converters
 
 # Writing converters
 
-A converter customises how a single type is read and written: derive `TomlConverter<T>` (<xref:Bodu.Text.Toml.Serialization.TomlConverter`1>) or `BencodeConverter<T>` (<xref:Bodu.Text.Bencode.Serialization.BencodeConverter`1>), and read or write tokens through the format's `Utf8…Reader` and `Utf8…Writer`.
+A converter customises how a single type is read and written: derive `TomlConverter<T>` (<xref:Bodu.Text.Toml.Serialization.TomlConverter`1>) or `BencodeConverter<T>` (<xref:Bodu.Text.Bencode.Serialization.BencodeConverter`1>), and read or write values through the format's reader and writer. A TOML converter reads through <xref:Bodu.Text.Toml.Reader.TomlDocumentReader> and writes through <xref:Bodu.Text.Toml.Writer.Utf8TomlWriter>; a Bencode converter reads through <xref:Bodu.Text.Bencode.Reader.Utf8BencodeReader> and writes through <xref:Bodu.Text.Bencode.Writer.Utf8BencodeWriter>.
 
-Because each library is self-contained, a converter is written against one format's reader/writer. The pattern is identical across the two; only the prefix differs.
+Because each library is self-contained, a converter is written against one format's reader/writer. The pattern is identical across the two; only the prefix and the reader/writer types differ.
 
 ## Pattern 1 — Convert a value type
 
@@ -19,7 +19,7 @@ using Bodu.Text.Toml.Writer;
 
 public sealed class PointConverter : TomlConverter<Point>
 {
-    public override Point Read(ref Utf8TomlReader reader, Type typeToConvert, TomlSerializerOptions options)
+    public override Point Read(ref TomlDocumentReader reader, Type typeToConvert, TomlSerializerOptions options)
     {
         string[] parts = reader.GetString().Split(',');
         return new Point(int.Parse(parts[0]), int.Parse(parts[1]));
@@ -30,7 +30,7 @@ public sealed class PointConverter : TomlConverter<Point>
 }
 ```
 
-The Bencode equivalent derives `BencodeConverter<Point>` and takes `ref Utf8BencodeReader` / `Utf8BencodeWriter` — the same shape with the `Bencode` prefix.
+The Bencode equivalent derives `BencodeConverter<Point>` and takes `ref Utf8BencodeReader` / `Utf8BencodeWriter` — the same shape with the `Bencode` prefix and that format's reader/writer pair.
 
 ## Pattern 2 — Register it
 
@@ -64,6 +64,20 @@ The first match wins, and the result is cached on the options.
 
 To convert an open generic (say, every `Money<TCurrency>`), derive `TomlConverterFactory` (<xref:Bodu.Text.Toml.Serialization.TomlConverterFactory>) — or `BencodeConverterFactory` (<xref:Bodu.Text.Bencode.Serialization.BencodeConverterFactory>) — return `true` from `CanConvert` for the family, and build the concrete converter in `CreateConverter`. This is the same pattern the built-in nullable, enum, collection, and dictionary converters use.
 
+```csharp
+public sealed class MoneyConverterFactory : TomlConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert) =>
+        typeToConvert.IsGenericType && typeToConvert.GetGenericTypeDefinition() == typeof(Money<>);
+
+    public override TomlConverter CreateConverter(Type typeToConvert, TomlSerializerOptions options) =>
+        (TomlConverter)Activator.CreateInstance(
+            typeof(MoneyConverter<>).MakeGenericType(typeToConvert.GetGenericArguments()[0]))!;
+}
+```
+
+The factory itself never reads or writes a value: the serializer calls `CanConvert` to decide whether the factory applies, then `CreateConverter` once per closed type and caches the result. `MoneyConverter<T>` here is an ordinary `TomlConverter<Money<T>>` written as in Pattern 1. The Bencode factory is the same shape with the `Bencode` prefix.
+
 ## Pattern 5 — Map a type the format cannot represent
 
 Some BCL types have no native form in a format and are rejected unless a converter maps them: Booleans, floating-point, and date-times in **Bencode**; `decimal` and `TimeSpan` in **TOML**. A converter bridges the gap — for example, writing a `bool` as a Bencode integer:
@@ -85,4 +99,42 @@ public sealed class BoolAsIntConverter : BencodeConverter<bool>
 
 ## Built-in enum converters
 
-For enums you usually do not need a hand-written converter. Each library ships a string-enum converter (member names) and a number-enum converter; reference them from a `[…Converter]` attribute on a member, property, or the enumeration itself.
+For enums you usually do not need a hand-written converter. Each library ships a string-enum converter (member names) and a number-enum converter; reference them from a `[…Converter]` attribute on a member, property, or the enumeration itself, or register one on the options.
+
+On the enumeration itself, use the generic string-enum form (<xref:Bodu.Text.Toml.Serialization.TomlStringEnumConverter`1> / <xref:Bodu.Text.Bencode.Serialization.BencodeStringEnumConverter`1>), optionally renaming individual members:
+
+```csharp
+[TomlConverter(typeof(TomlStringEnumConverter<Status>))]
+public enum Status
+{
+    Active,
+
+    [TomlStringEnumMemberName("on-hold")]
+    OnHold,
+}
+
+// Status.OnHold serializes as: Status = "on-hold"
+```
+
+On a single member, the generic number-enum form (<xref:Bodu.Text.Toml.Serialization.TomlNumberEnumConverter`1> / <xref:Bodu.Text.Bencode.Serialization.BencodeNumberEnumConverter`1>) writes the underlying value instead:
+
+```csharp
+public sealed class WorkItem
+{
+    [TomlConverter(typeof(TomlNumberEnumConverter<Priority>))]
+    public Priority Priority { get; set; }
+}
+
+// Priority.High (underlying value 2) serializes as: Priority = 2
+```
+
+To cover *every* enumeration in one registration, add the non-generic string-enum factory (<xref:Bodu.Text.Toml.Serialization.TomlStringEnumConverter> / <xref:Bodu.Text.Bencode.Serialization.BencodeStringEnumConverter>) to the options, optionally with a naming policy:
+
+```csharp
+var options = new TomlSerializerOptions();
+options.Converters.Add(new TomlStringEnumConverter(TomlNamingPolicy.SnakeCaseLower, allowIntegerValues: false));
+
+// Status.OnHold now serializes as "on_hold" everywhere.
+```
+
+The generic forms expose a public parameterless constructor, which is what makes them usable from a `[…Converter]` attribute; the non-generic factory is the options-level, all-enums form. There is no non-generic number-enum converter.

--- a/docs/guides/serialization/index.md
+++ b/docs/guides/serialization/index.md
@@ -8,4 +8,5 @@ Practical, task-focused walkthroughs for the two Bodu serializers, **Bodu.Text.B
 
 - **[Using TOML](toml.md)** — `TomlSerializer`, the type mapping, spec-version selection, the DOMs, and streams.
 - **[Using Bencode](bencode.md)** — `BencodeSerializer`, byte strings, canonical key ordering, and the kinds Bencode cannot represent.
+- **[Mapping attributes](attributes.md)** — rename, ignore, order, require, and capture members with the `[Toml…]` / `[Bencode…]` attribute family.
 - **[Writing converters](converters.md)** — customise a type's shape with `BencodeConverter<T>` / `TomlConverter<T>`, and understand resolution order.

--- a/docs/guides/serialization/toml.md
+++ b/docs/guides/serialization/toml.md
@@ -52,7 +52,7 @@ var options = new TomlSerializerOptions
 
 Naming policies cover `CamelCase`, `SnakeCaseLower` / `SnakeCaseUpper`, and `KebabCaseLower` / `KebabCaseUpper`. Pin a single member's name with `[TomlPropertyName("…")]`, which always wins over the policy. Start from a scenario preset by constructing the options from <xref:Bodu.Text.Toml.TomlSerializerDefaults> (for example `TomlSerializerDefaults.Web`).
 
-Properties are mapped by default; public fields join in when `IncludeFields` is set on the options, or individually with `[TomlInclude]` on the field. Fields follow the same naming-policy, ordering, ignore, required, and converter rules as properties — including `[TomlPropertyOrder]`, which reorders the emitted lines.
+Properties are mapped by default; public fields join in when `IncludeFields` is set on the options, or individually with `[TomlInclude]` on the field. Fields follow the same naming-policy, ordering, ignore, required, and converter rules as properties — including `[TomlPropertyOrder]`, which reorders the emitted lines. The full attribute family is catalogued in [Mapping attributes](attributes.md).
 
 ## Pattern 4 — Select the spec version
 

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -308,5 +308,7 @@
       href: serialization/toml.md
     - name: Using Bencode
       href: serialization/bencode.md
+    - name: Mapping attributes
+      href: serialization/attributes.md
     - name: Writing converters
       href: serialization/converters.md


### PR DESCRIPTION
Add consumer-focused <example> blocks to the public attribute family
(12 per library) and the converter surface (TomlConverter<T>/factory and
the enum converter factories, plus Bencode twins). Normalize the existing
TomlConverter<T>/BencodeConverter<T> examples to the canonical
<code language="csharp"> + CDATA shape and replace the bool-as-int body
with a Version converter that is idiomatic for both formats.

https://claude.ai/code/session_01SVj8HSsn3Un7diXSrNx6kA