### PR TITLE
docs(toml,bencode): fill remaining XML example gaps and add callbacks guide

### DIFF
--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnDeserialized.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnDeserialized.cs
@@ -14,6 +14,21 @@ namespace Bodu.Text.Bencode.Serialization;
 /// <see cref="OnDeserialized" /> is the last step of deserialization for the instance: it runs after every settable
 /// member and any extension-data entry has been assigned, so it observes the fully materialized object.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class TrackerConfig : IBencodeOnDeserialized
+/// {
+///     public int Port { get; set; }
+///
+///     void IBencodeOnDeserialized.OnDeserialized()
+///     {
+///         if (Port is < 1 or > 65535) throw new InvalidOperationException("Port is out of range.");
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface IBencodeOnDeserialized
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnDeserializing.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnDeserializing.cs
@@ -15,6 +15,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// extension-data entry is assigned. For a type built through a parameterized constructor the instance does not exist
 /// any earlier, so the callback necessarily runs after the constructor has consumed its bound arguments.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class TrackerConfig : IBencodeOnDeserializing
+/// {
+///     public int Port { get; set; }
+///
+///     void IBencodeOnDeserializing.OnDeserializing() =>
+///         Port = 6881;   // the default that survives when the input omits the key
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface IBencodeOnDeserializing
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnSerialized.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnSerialized.cs
@@ -14,6 +14,20 @@ namespace Bodu.Text.Bencode.Serialization;
 /// <see cref="OnSerialized" /> is called after the value's dictionary has been closed, so it observes the completed
 /// write rather than influencing the emitted output.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Snapshot : IBencodeOnSerialized
+/// {
+///     [BencodeIgnore]
+///     public int WriteCount { get; private set; }
+///
+///     void IBencodeOnSerialized.OnSerialized() =>
+///         WriteCount++;   // observes the completed write; the emitted output is unaffected
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface IBencodeOnSerialized
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnSerializing.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode.Serialization/IBencodeOnSerializing.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Bencode.Serialization;
 /// <see cref="OnSerializing" /> is called after a non-<see langword="null" /> value has been selected for writing and
 /// before the opening of its dictionary, so any mutation it performs is reflected in the emitted output.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Snapshot : IBencodeOnSerializing
+/// {
+///     public long SavedAt { get; set; }
+///
+///     void IBencodeOnSerializing.OnSerializing() =>
+///         SavedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();   // stamped before members are written
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface IBencodeOnSerializing
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode/BencodeNamingPolicy.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode/BencodeNamingPolicy.cs
@@ -14,6 +14,15 @@ namespace Bodu.Text.Bencode;
 /// A naming policy applies only when a member does not carry an explicit
 /// <see cref="Bodu.Text.Bencode.Serialization.BencodePropertyNameAttribute" />, which always wins.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// var options = new BencodeSerializerOptions { PropertyNamingPolicy = BencodeNamingPolicy.SnakeCaseLower };
+///
+/// // A MaxRetryCount property now serializes under the dictionary key: 15:max_retry_count
+///]]>
+/// </code>
+/// </example>
 public abstract class BencodeNamingPolicy
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializer.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializer.cs
@@ -29,6 +29,14 @@ namespace Bodu.Text.Bencode;
 /// declaration order of the corresponding members.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// byte[] bytes = BencodeSerializer.Serialize(new Torrent { Name = "demo", PieceLength = 262144 });
+/// Torrent torrent = BencodeSerializer.Deserialize<Torrent>(bytes);
+///]]>
+/// </code>
+/// </example>
 public static class BencodeSerializer
 {
     /// <summary>

--- a/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializerOptions.cs
+++ b/Bodu.Text.Bencode/src/Text.Bencode/BencodeSerializerOptions.cs
@@ -28,6 +28,21 @@ namespace Bodu.Text.Bencode;
 /// a member whose value is <see langword="null" /> is omitted regardless of that setting.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Configure once and reuse across calls; resolved converters are cached on the instance.
+/// var options = new BencodeSerializerOptions
+/// {
+///     PropertyNamingPolicy = BencodeNamingPolicy.SnakeCaseLower,
+///     DefaultIgnoreCondition = BencodeIgnoreCondition.WhenWritingDefault,
+/// };
+/// options.Converters.Add(new BencodeStringEnumConverter(BencodeNamingPolicy.SnakeCaseLower, allowIntegerValues: false));
+///
+/// byte[] bytes = BencodeSerializer.Serialize(value, options);
+///]]>
+/// </code>
+/// </example>
 public sealed class BencodeSerializerOptions
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnDeserialized.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnDeserialized.cs
@@ -14,6 +14,21 @@ namespace Bodu.Text.Toml.Serialization;
 /// <see cref="OnDeserialized" /> is the last step of deserialization for the instance: it runs after every settable
 /// member and any extension-data entry has been assigned, so it observes the fully materialized object.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig : ITomlOnDeserialized
+/// {
+///     public int Port { get; set; }
+///
+///     void ITomlOnDeserialized.OnDeserialized()
+///     {
+///         if (Port is < 1 or > 65535) throw new InvalidOperationException("Port is out of range.");
+///     }
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface ITomlOnDeserialized
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnDeserializing.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnDeserializing.cs
@@ -15,6 +15,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// extension-data entry is assigned. For a type built through a parameterized constructor the instance does not exist
 /// any earlier, so the callback necessarily runs after the constructor has consumed its bound arguments.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class ServerConfig : ITomlOnDeserializing
+/// {
+///     public int Port { get; set; }
+///
+///     void ITomlOnDeserializing.OnDeserializing() =>
+///         Port = 8080;   // the default that survives when the input omits the key
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface ITomlOnDeserializing
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnSerialized.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnSerialized.cs
@@ -14,6 +14,20 @@ namespace Bodu.Text.Toml.Serialization;
 /// <see cref="OnSerialized" /> is called after the value's dictionary has been closed, so it observes the completed
 /// write rather than influencing the emitted output.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Snapshot : ITomlOnSerialized
+/// {
+///     [TomlIgnore]
+///     public int WriteCount { get; private set; }
+///
+///     void ITomlOnSerialized.OnSerialized() =>
+///         WriteCount++;   // observes the completed write; the emitted output is unaffected
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface ITomlOnSerialized
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnSerializing.cs
+++ b/Bodu.Text.Toml/src/Text.Toml.Serialization/ITomlOnSerializing.cs
@@ -14,6 +14,19 @@ namespace Bodu.Text.Toml.Serialization;
 /// <see cref="OnSerializing" /> is called after a non-<see langword="null" /> value has been selected for writing and
 /// before the opening of its dictionary, so any mutation it performs is reflected in the emitted output.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// public sealed class Snapshot : ITomlOnSerializing
+/// {
+///     public DateTime SavedAt { get; set; }
+///
+///     void ITomlOnSerializing.OnSerializing() =>
+///         SavedAt = DateTime.UtcNow;   // stamped before members are written, so it appears in the output
+/// }
+///]]>
+/// </code>
+/// </example>
 public interface ITomlOnSerializing
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml/TomlNamingPolicy.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlNamingPolicy.cs
@@ -14,6 +14,15 @@ namespace Bodu.Text.Toml;
 /// A naming policy applies only when a member does not carry an explicit
 /// <see cref="Bodu.Text.Toml.Serialization.TomlPropertyNameAttribute" />, which always wins.
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// var options = new TomlSerializerOptions { PropertyNamingPolicy = TomlNamingPolicy.SnakeCaseLower };
+///
+/// // A MaxRetryCount property now serializes as: max_retry_count = 5
+///]]>
+/// </code>
+/// </example>
 public abstract class TomlNamingPolicy
 {
     /// <summary>

--- a/Bodu.Text.Toml/src/Text.Toml/TomlSerializer.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlSerializer.cs
@@ -32,10 +32,12 @@ namespace Bodu.Text.Toml;
 /// </para>
 /// </remarks>
 /// <example>
+/// <code language="csharp">
 ///<![CDATA[
 /// string text = TomlSerializer.Serialize(new ServerConfig { Host = "localhost", Port = 8080 });
 /// ServerConfig config = TomlSerializer.Deserialize<ServerConfig>(text);
 ///]]>
+/// </code>
 /// </example>
 public static class TomlSerializer
 {

--- a/Bodu.Text.Toml/src/Text.Toml/TomlSerializerOptions.cs
+++ b/Bodu.Text.Toml/src/Text.Toml/TomlSerializerOptions.cs
@@ -28,6 +28,21 @@ namespace Bodu.Text.Toml;
 /// member whose value is <see langword="null" /> is omitted regardless of that setting.
 /// </para>
 /// </remarks>
+/// <example>
+/// <code language="csharp">
+///<![CDATA[
+/// // Configure once and reuse across calls; resolved converters are cached on the instance.
+/// var options = new TomlSerializerOptions
+/// {
+///     PropertyNamingPolicy = TomlNamingPolicy.SnakeCaseLower,
+///     DefaultIgnoreCondition = TomlIgnoreCondition.WhenWritingDefault,
+/// };
+/// options.Converters.Add(new TomlStringEnumConverter(TomlNamingPolicy.SnakeCaseLower, allowIntegerValues: false));
+///
+/// string text = TomlSerializer.Serialize(config, options);
+///]]>
+/// </code>
+/// </example>
 public sealed class TomlSerializerOptions
 {
     /// <summary>

--- a/docs/guides/serialization/callbacks.md
+++ b/docs/guides/serialization/callbacks.md
@@ -1,0 +1,97 @@
+---
+title: Serialization callbacks
+---
+
+# Serialization callbacks
+
+Both serializers let a type participate in its own serialization lifecycle by implementing one or more callback interfaces. Each format exposes the same four hooks — TOML as <xref:Bodu.Text.Toml.Serialization.ITomlOnSerializing>, <xref:Bodu.Text.Toml.Serialization.ITomlOnSerialized>, <xref:Bodu.Text.Toml.Serialization.ITomlOnDeserializing>, and <xref:Bodu.Text.Toml.Serialization.ITomlOnDeserialized>; Bencode as the like-named `IBencodeOn…` interfaces. The serializer detects the interfaces on the value's type and invokes them at the matching point in the pipeline — no registration or attribute is required.
+
+| Hook | Runs | Typical use |
+|---|---|---|
+| `OnSerializing` | After a non-null value is selected for writing, before its first member is written. | Stamp or derive state that must appear in the output. |
+| `OnSerialized` | After the value's table/dictionary has been closed. | Release or restore state; count or log completed writes. |
+| `OnDeserializing` | After the instance is constructed, before any member is assigned. | Establish defaults that survive omitted keys. |
+| `OnDeserialized` | After every member and any extension data has been assigned. | Validate or finalize the materialized object. |
+
+Each pattern below shows the TOML form; the Bencode form is identical with the `Bencode` prefix.
+
+## Pattern 1 — Apply defaults that survive omitted keys
+
+Member initializers run at construction, but a key present in the input then overwrites them — there is no way to distinguish "key absent" from "key set to the initializer value" after the fact. `OnDeserializing` runs after construction and *before* member assignment, so a value it assigns persists exactly when the input omits the key:
+
+```csharp
+public sealed class ServerConfig : ITomlOnDeserializing
+{
+    public int Port { get; set; }
+
+    void ITomlOnDeserializing.OnDeserializing() =>
+        Port = 8080;
+}
+```
+
+```csharp
+TomlSerializer.Deserialize<ServerConfig>("").Port            // 8080 — key omitted, default survives
+TomlSerializer.Deserialize<ServerConfig>("Port = 9090").Port // 9090 — key present, default overwritten
+```
+
+For a type built through a parameterized constructor the callback necessarily runs after the constructor has consumed its bound arguments — the instance does not exist any earlier.
+
+## Pattern 2 — Validate after deserialization
+
+`OnDeserialized` is the last step of deserialization for the instance, so it observes the fully materialized object — including required members, extension data, and populated collections. Throwing from it fails the deserialization:
+
+```csharp
+public sealed class ServerConfig : ITomlOnDeserialized
+{
+    public int Port { get; set; }
+
+    void ITomlOnDeserialized.OnDeserialized()
+    {
+        if (Port is < 1 or > 65535)
+            throw new InvalidOperationException("Port is out of range.");
+    }
+}
+```
+
+This complements `[TomlRequired]` (which checks presence, not validity): the attribute rejects an absent key, the callback rejects a present-but-invalid value.
+
+## Pattern 3 — Derive state before serialization
+
+`OnSerializing` runs before the value's members are written, so any mutation it performs is reflected in the emitted output. Use it to stamp timestamps, recompute checksums, or normalize state at the moment of writing:
+
+```csharp
+public sealed class Snapshot : ITomlOnSerializing
+{
+    public DateTime SavedAt { get; set; }
+
+    void ITomlOnSerializing.OnSerializing() =>
+        SavedAt = DateTime.UtcNow;
+}
+```
+
+> [!NOTE]
+> Bencode has no native date-time kind, so the Bencode form of this pattern stores a `long` instead — for example `SavedAt = DateTimeOffset.UtcNow.ToUnixTimeSeconds();`.
+
+## Pattern 4 — Observe a completed write
+
+`OnSerialized` runs after the value's table/dictionary has been closed: it observes the completed write rather than influencing the output. Use it to restore state changed by `OnSerializing`, or to track writes:
+
+```csharp
+public sealed class Snapshot : ITomlOnSerialized
+{
+    [TomlIgnore]
+    public int WriteCount { get; private set; }
+
+    void ITomlOnSerialized.OnSerialized() =>
+        WriteCount++;
+}
+```
+
+## Scope and ordering
+
+- The callbacks apply to values written as tables/dictionaries through the object mapping — the path a plain class or struct takes. A value claimed by a scalar converter has no member-writing phase and no callbacks.
+- They fire for nested objects too, innermost completing first on write and on read.
+- Within one instance the order is always construct → `OnDeserializing` → member assignment → `OnDeserialized`, and `OnSerializing` → member writing → `OnSerialized`.
+- The hooks pair naturally: state established in `OnSerializing` can be torn down in `OnSerialized`, and defaults set in `OnDeserializing` can be validated in `OnDeserialized`.
+
+The same four hooks with the same semantics exist for Bencode: <xref:Bodu.Text.Bencode.Serialization.IBencodeOnSerializing>, <xref:Bodu.Text.Bencode.Serialization.IBencodeOnSerialized>, <xref:Bodu.Text.Bencode.Serialization.IBencodeOnDeserializing>, and <xref:Bodu.Text.Bencode.Serialization.IBencodeOnDeserialized>.

--- a/docs/guides/serialization/index.md
+++ b/docs/guides/serialization/index.md
@@ -10,4 +10,5 @@ Practical, task-focused walkthroughs for the two Bodu serializers, **Bodu.Text.B
 - **[Using Bencode](bencode.md)** — `BencodeSerializer`, byte strings, canonical key ordering, and the kinds Bencode cannot represent.
 - **[Mapping attributes](attributes.md)** — rename, ignore, order, require, and capture members with the `[Toml…]` / `[Bencode…]` attribute family.
 - **[Writing converters](converters.md)** — customise a type's shape with `BencodeConverter<T>` / `TomlConverter<T>`, and understand resolution order.
+- **[Serialization callbacks](callbacks.md)** — hook the lifecycle with the `I…OnSerializing` / `I…OnSerialized` / `I…OnDeserializing` / `I…OnDeserialized` interfaces.
 - **[Built-in converter catalog](builtin-converters.md)** — every provisioned converter in both libraries, and how each type is represented in TOML or Bencode.

--- a/docs/guides/toc.yml
+++ b/docs/guides/toc.yml
@@ -312,5 +312,7 @@
       href: serialization/attributes.md
     - name: Writing converters
       href: serialization/converters.md
+    - name: Serialization callbacks
+      href: serialization/callbacks.md
     - name: Built-in converter catalog
       href: serialization/builtin-converters.md


### PR DESCRIPTION
Complete the two-layer documentation approach for the serializer surfaces:
light <example> snippets in the XML docs, fuller worked examples as static
DocFX guide pages.

XML doc additions (both libraries, mirrored):
- BencodeSerializer: add the class-level example its TOML twin already had
- TomlSerializer: wrap the existing example in <code language="csharp"> so
  it renders as a code block like every other example
- Toml/BencodeSerializerOptions: configured-options reuse example
- Toml/BencodeNamingPolicy: options-level policy example with wire output
- All eight I…OnSerializing/Serialized/Deserializing/Deserialized callback
  interfaces: minimal implementation examples

Static guide additions:
- New guides/serialization/callbacks.md covering the lifecycle hooks with
  four worked patterns (defaults for omitted keys, post-read validation,
  derived state before write, observing completed writes) plus scope and
  ordering notes, verified against ObjectConverter
- Wire the page into guides/toc.yml and the serialization guides index

https://claude.ai/code/session_014kuTfsjMUDuDvfqDCc89M6